### PR TITLE
Set volumeStatus.FileLocation to PVC name for kubevirt eve

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -318,8 +318,13 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext, wdName string) {
 func createOrUpdateAppDiskMetrics(ctx *volumemgrContext, volumeStatus *types.VolumeStatus) error {
 	log.Functionf("createOrUpdateAppDiskMetrics(%s, %s)", volumeStatus.VolumeID, volumeStatus.FileLocation)
 	if volumeStatus.FileLocation == "" {
-		// Nothing we can do? XXX can we retrieve size from CAS?
-		return nil
+		if !ctx.hvTypeKube {
+			// Nothing we can do? XXX can we retrieve size from CAS?
+			return nil
+		} else {
+			// Kubevirt eve volumes have no location on /persist, they are PVCs
+			volumeStatus.FileLocation = volumeStatus.GetPVCName()
+		}
 	}
 	actualSize, maxSize, diskType, dirtyFlag, err := volumehandlers.GetVolumeHandler(log, ctx, volumeStatus).GetVolumeDetails()
 	if err != nil {


### PR DESCRIPTION
VolumeStatus of FileLocation may not be set for volumes in kubevirt eve since they are PVCs. They will not have a explicit path under /persist/. Set the filelocation to PVC name. Which will be used by the volumehandler to get volume details.

This will fix the app disk metrics.