### PR TITLE
fix: volumemgr: update VRS every time VS changes

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlevolumeref.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolumeref.go
@@ -91,14 +91,17 @@ func handleVolumeRefModify(ctxArg interface{}, key string,
 	vs := ctx.LookupVolumeStatus(config.VolumeKey())
 	if vs != nil {
 		if needUpdateVol {
-			doUpdateVol(ctx, vs)
+			changed, _ := doUpdateVol(ctx, vs)
+			if changed {
+				publishVolumeStatus(ctx, vs)
+				updateVolumeRefStatus(ctx, vs)
+				if err := createOrUpdateAppDiskMetrics(ctx, vs); err != nil {
+					log.Errorf("handleVolumeRefModify(%s): exception while publishing diskmetric. %s",
+						status.Key(), err.Error())
+				}
+			}
 		}
 		updateVolumeStatusRefCount(ctx, vs)
-		publishVolumeStatus(ctx, vs)
-		if err := createOrUpdateAppDiskMetrics(ctx, vs); err != nil {
-			log.Errorf("handleVolumeRefModify(%s): exception while publishing diskmetric. %s",
-				status.Key(), err.Error())
-		}
 	}
 	log.Functionf("handleVolumeRefModify(%s) Done", key)
 }
@@ -167,6 +170,8 @@ func unpublishVolumeRefStatus(ctx *volumemgrContext, key string) {
 }
 
 func updateVolumeRefStatus(ctx *volumemgrContext, vs *types.VolumeStatus) {
+
+	log.Functionf("updateVolumeRefStatus(%s)", vs.Key())
 	sub := ctx.subVolumeRefConfig
 	items := sub.GetAll()
 	for _, st := range items {
@@ -217,4 +222,5 @@ func updateVolumeRefStatus(ctx *volumemgrContext, vs *types.VolumeStatus) {
 			publishVolumeRefStatus(ctx, status)
 		}
 	}
+	log.Functionf("updateVolumeRefStatus(%s) Done", vs.Key())
 }


### PR DESCRIPTION
This is the only place in the code base where volume ref status was not updated after volume status was potentially changed, which led to some changes in volumes to being seen by edge apps.