### PR TITLE
set MediaType in BlobStatus from VerifyImageStatus

### DIFF
--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -424,6 +424,7 @@ func lookupOrCreateBlobStatus(ctx *volumemgrContext, blobSha string) *types.Blob
 			State:                  vs.State,
 			Path:                   vs.FileLocation,
 			Size:                   uint64(vs.Size),
+			MediaType:              vs.MediaType,
 			CurrentSize:            vs.Size,
 			TotalSize:              vs.Size,
 			Progress:               100,

--- a/pkg/pillar/types/blob.go
+++ b/pkg/pillar/types/blob.go
@@ -95,7 +95,7 @@ func (status BlobStatus) LogCreate(logBase *base.LogObject) {
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("datastoreid-uuids", uuids).
 		AddField("size-int64", status.Size).
-		AddField("blobtype-string", status.MediaType).
+		AddField("mediatype", status.MediaType).
 		AddField("refcount-int64", status.RefCount).
 		AddField("has-verifier-ref-bool", status.HasVerifierRef).
 		AddField("has-downloader-ref-bool", status.HasDownloaderRef).
@@ -116,6 +116,7 @@ func (status BlobStatus) LogModify(logBase *base.LogObject, old interface{}) {
 		oldStatus.Size != status.Size {
 
 		logObject.CloneAndAddField("state", status.State.String()).
+			AddField("mediatype", status.MediaType).
 			AddField("refcount-int64", status.RefCount).
 			AddField("size-int64", status.Size).
 			AddField("has-verifier-ref-bool", status.HasVerifierRef).
@@ -145,6 +146,7 @@ func (status BlobStatus) LogDelete(logBase *base.LogObject) {
 	logObject := base.EnsureLogObject(logBase, base.BlobStatusLogType, status.RelativeURL,
 		nilUUID, status.LogKey())
 	logObject.CloneAndAddField("state", status.State.String()).
+		AddField("mediatype", status.MediaType).
 		AddField("refcount-int64", status.RefCount).
 		AddField("size-int64", status.Size).
 		AddField("has-verifier-ref-bool", status.HasVerifierRef).

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -41,6 +41,7 @@ func (config VerifyImageConfig) LogCreate(logBase *base.LogObject) {
 		return
 	}
 	logObject.CloneAndAddField("refcount-int64", config.RefCount).
+		AddField("mediatype", config.MediaType).
 		AddField("expired-bool", config.Expired).
 		Noticef("VerifyImage config create")
 }
@@ -58,6 +59,7 @@ func (config VerifyImageConfig) LogModify(logBase *base.LogObject, old interface
 		oldConfig.Expired != config.Expired {
 
 		logObject.CloneAndAddField("refcount-int64", config.RefCount).
+			AddField("mediatype", config.MediaType).
 			AddField("expired-bool", config.Expired).
 			AddField("old-refcount-int64", oldConfig.RefCount).
 			AddField("old-expired-bool", oldConfig.Expired).
@@ -74,6 +76,7 @@ func (config VerifyImageConfig) LogDelete(logBase *base.LogObject) {
 	logObject := base.EnsureLogObject(logBase, base.VerifyImageConfigLogType, config.Name,
 		nilUUID, config.LogKey())
 	logObject.CloneAndAddField("refcount-int64", config.RefCount).
+		AddField("mediatype", config.MediaType).
 		AddField("expired-bool", config.Expired).
 		Noticef("VerifyImage config delete")
 
@@ -116,6 +119,7 @@ func (status VerifyImageStatus) LogCreate(logBase *base.LogObject) {
 		return
 	}
 	logObject.CloneAndAddField("state", status.State.String()).
+		AddField("mediatype", status.MediaType).
 		AddField("refcount-int64", status.RefCount).
 		AddField("expired-bool", status.Expired).
 		AddField("size-int64", status.Size).
@@ -139,6 +143,7 @@ func (status VerifyImageStatus) LogModify(logBase *base.LogObject, old interface
 		oldStatus.FileLocation != status.FileLocation {
 
 		logObject.CloneAndAddField("state", status.State.String()).
+			AddField("mediatype", status.MediaType).
 			AddField("refcount-int64", status.RefCount).
 			AddField("expired-bool", status.Expired).
 			AddField("size-int64", status.Size).
@@ -169,6 +174,7 @@ func (status VerifyImageStatus) LogDelete(logBase *base.LogObject) {
 	logObject := base.EnsureLogObject(logBase, base.VerifyImageStatusLogType, status.Name,
 		nilUUID, status.LogKey())
 	logObject.CloneAndAddField("state", status.State.String()).
+		AddField("mediatype", status.MediaType).
 		AddField("refcount-int64", status.RefCount).
 		AddField("expired-bool", status.Expired).
 		AddField("size-int64", status.Size).


### PR DESCRIPTION
This change is an attempt to fix https://github.com/lf-edge/eve/issues/4510.

This doesn't necessarily fix the bug, but should facilitate further debugging by adding more relevant logs.
Also it sets the `MediaType` field of `BlobStatus` when created from `VerifyImageStatus`.