### PR TITLE
grub: Fix console option for Onlogic FR201 device

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -269,7 +269,7 @@ function set_arm64_baremetal {
       smbios -t 1 -s 5 --set smb_product
       if [ "$smb_product" = "FR201" ]; then
          set_to_existing_file devicetree /boot/dtb/broadcom/bcm2711-rpi-cm4-fr201.dtb
-         set_global dom0_console "console=ttyS0,115200 console=tty0 earlycon=tty0"
+         set_global dom0_console "console=ttyS0,115200 console=tty1 earlycon=tty1"
          set_global dom0_platform_tweaks "eve_install_disk=mmcblk0 eve_persist_disk=sdb"
       fi
    fi


### PR DESCRIPTION
Set default consoles to tty1 instead of tty0, so getty won't start in the default console and clashes with TUI Monitor.

Kudos to @rucoder that figured out the issue :+1: 

PS: Other devices must be fixed as well, this PR focus only on the FR201 first (where the fix was tested).