### PR TITLE
Make parsing log filenames future-proof

### DIFF
--- a/pkg/pillar/cmd/volumemgr/sizemgmt.go
+++ b/pkg/pillar/cmd/volumemgr/sizemgmt.go
@@ -85,7 +85,7 @@ func getRemainingDiskSpace(ctxPtr *volumemgrContext) (uint64, error) {
 // Everything in /persist except these directories/datasets counts
 // as EVE overhead.
 // Note that we also exclude /persist/newlog here since it maintains its own
-// size limit (GlobalValueInt(types.LogRemainToSendMBytes)) the caller
+// size limit (GlobalValueInt(types.MaxGzipLogMBytesInPersist)) the caller
 // needs to consider as EVE overhead.
 var excludeDirs = append(types.AppPersistPaths, types.NewlogDir)
 

--- a/pkg/pillar/diskmetrics/usage.go
+++ b/pkg/pillar/diskmetrics/usage.go
@@ -204,7 +204,7 @@ func Dom0DiskReservedSize(log *base.LogObject, globalConfig *types.ConfigItemVal
 		(float64(dom0MinDiskUsagePercent) * 0.01))
 	staticMaxDom0DiskSize := uint64(globalConfig.GlobalValueInt(
 		types.Dom0DiskUsageMaxBytes))
-	newlogReserved := uint64(globalConfig.GlobalValueInt(types.LogRemainToSendMBytes))
+	newlogReserved := uint64(globalConfig.GlobalValueInt(types.MaxGzipLogMBytesInPersist))
 	// Always leave space for /persist/newlogd
 	maxDom0DiskSize := newlogReserved
 	// Select the larger of the current overhead usage and the configured

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -209,8 +209,8 @@ const (
 	AppContainerStatsInterval GlobalSettingKey = "timer.appcontainer.stats.interval"
 	// VaultReadyCutOffTime global setting key
 	VaultReadyCutOffTime GlobalSettingKey = "timer.vault.ready.cutoff"
-	// LogRemainToSendMBytes Max gzip log files remain on device to be sent in Mbytes
-	LogRemainToSendMBytes GlobalSettingKey = "newlog.gzipfiles.ondisk.maxmegabytes"
+	// MaxGzipLogMBytesInPersist Max size of gzip log files in persist in Mbytes
+	MaxGzipLogMBytesInPersist GlobalSettingKey = "newlog.gzipfiles.ondisk.maxmegabytes"
 
 	// ForceFallbackCounter global setting key
 	ForceFallbackCounter = "force.fallback.counter"
@@ -972,8 +972,8 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 		eveMemoryLimitInMiB, 0xFFFFFFFF)
 	// Limit manual vmm overhead override to 1 PiB
 	configItemSpecMap.AddIntItem(VmmMemoryLimitInMiB, 0, 0, uint32(1024*1024*1024))
-	// LogRemainToSendMBytes - Default is 2 Gbytes, minimum is 10 Mbytes
-	configItemSpecMap.AddIntItem(LogRemainToSendMBytes, 2048, 10, 0xFFFFFFFF)
+	// MaxGzipLogMBytesInPersist - Default is 2 Gbytes, minimum is 10 Mbytes
+	configItemSpecMap.AddIntItem(MaxGzipLogMBytesInPersist, 2048, 10, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(DownloadMaxPortCost, 0, 0, 255)
 	configItemSpecMap.AddIntItem(BlobDownloadMaxRetries, 5, 1, 10)
 

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -175,7 +175,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		Dom0DiskUsageMaxBytes,
 		StorageZfsReserved,
 		ForceFallbackCounter,
-		LogRemainToSendMBytes,
+		MaxGzipLogMBytesInPersist,
 		DownloadMaxPortCost,
 		BlobDownloadMaxRetries,
 		KubevirtDrainTimeout,

--- a/pkg/pillar/types/newlogtypes_test.go
+++ b/pkg/pillar/types/newlogtypes_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+)
+
+func TestGetTimestampFromFileName(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	tests := []struct {
+		name      string
+		filename  string
+		wantTime  time.Time
+		wantError bool
+	}{
+		{
+			name:      "Valid timestamp in filename",
+			filename:  "dev.log.1731491904032.gz",
+			wantTime:  time.Unix(0, 1731491904032*int64(time.Millisecond)),
+			wantError: false,
+		},
+		{
+			name:      "Valid timestamp in regular filename",
+			filename:  "dev.log.1731491904032",
+			wantTime:  time.Unix(0, 1731491904032*int64(time.Millisecond)),
+			wantError: false,
+		},
+		{
+			name:      "Valid timestamp with UUID",
+			filename:  "app.8ce1cc69-e1bb-4fe3-9613-e3eb1c5f5c4d.log.1731935033496.gz",
+			wantTime:  time.Unix(0, 1731935033496*int64(time.Millisecond)),
+			wantError: false,
+		},
+		{
+			name:      "Two timestamps in filename",
+			filename:  "dev.log.1731935033496.123.gz",
+			wantTime:  time.Unix(0, 1731935033496*int64(time.Millisecond)),
+			wantError: false,
+		},
+		{
+			name:      "Invalid timestamp in filename",
+			filename:  "dev.log.invalidtimestamp.gz",
+			wantTime:  time.Time{},
+			wantError: true,
+		},
+		{
+			name:      "No timestamp in filename",
+			filename:  "dev.log.gz",
+			wantTime:  time.Time{},
+			wantError: true,
+		},
+		{
+			name:      "Old timestamp (short format) in filename",
+			filename:  "dev.log.123.gz",
+			wantTime:  time.Unix(0, 123*int64(time.Millisecond)),
+			wantError: false,
+		},
+		{
+			name:      "Old timestamp (long format) in filename",
+			filename:  "dev.log.0000000000123.gz",
+			wantTime:  time.Unix(0, 123*int64(time.Millisecond)),
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // create a new variable to hold the value of tt to avoid being overwritten by the next iteration (needed until Go 1.23)
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotTime, err := GetTimestampFromFileName(tt.filename)
+			if tt.wantError {
+				g.Expect(err).To(gomega.HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(gotTime).To(gomega.Equal(tt.wantTime))
+			}
+		})
+	}
+}
+
+func FuzzGetTimestampFromFileName(f *testing.F) {
+	testcases := []string{
+		"dev.log.1731491904032.gz",
+		"app.8ce1cc69-e1bb-4fe3-9613-e3eb1c5f5c4d.log.1731935033496.gz",
+		"dev.log.invalidtimestamp.gz",
+		"dev.log.gz",
+		"dev.log.123456789012.gz",
+		"dev.log.1234567890123456.gz",
+	}
+
+	for _, tc := range testcases {
+		f.Add(tc)
+	}
+
+	f.Fuzz(func(t *testing.T, filename string) {
+		_, _ = GetTimestampFromFileName(filename)
+	})
+}
+
+func TestGetUUIDFromFileName(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	tests := []struct {
+		name      string
+		filename  string
+		wantUUID  string
+		wantError bool
+	}{
+		{
+			name:      "Valid UUID in filename",
+			filename:  "app.8ce1cc69-e1bb-4fe3-9613-e3eb1c5f5c4d.log.1731935033496.gz",
+			wantUUID:  "8ce1cc69-e1bb-4fe3-9613-e3eb1c5f5c4d",
+			wantError: false,
+		},
+		{
+			name:      "Valid UUID in regular filename",
+			filename:  "app.8ce1cc69-e1bb-4fe3-9613-e3eb1c5f5c4d.log.1731935033496",
+			wantUUID:  "8ce1cc69-e1bb-4fe3-9613-e3eb1c5f5c4d",
+			wantError: false,
+		},
+		{
+			name:      "Valid UUID with timestamp",
+			filename:  "app.123e4567-e89b-12d3-a456-426614174000.log.1731935033496.gz",
+			wantUUID:  "123e4567-e89b-12d3-a456-426614174000",
+			wantError: false,
+		},
+		{
+			name:      "No UUID in filename",
+			filename:  "dev.log.1731491904032.gz",
+			wantUUID:  "",
+			wantError: true,
+		},
+		{
+			name:      "Invalid UUID in filename",
+			filename:  "app.invalid-uuid-string.log.1731935033496.gz",
+			wantUUID:  "",
+			wantError: true,
+		},
+		{
+			name:      "UUID at the end of filename",
+			filename:  "app.log.1731935033496.8ce1cc69-e1bb-4fe3-9613-e3eb1c5f5c4d.gz",
+			wantUUID:  "8ce1cc69-e1bb-4fe3-9613-e3eb1c5f5c4d",
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // create a new variable to hold the value of tt to avoid being overwritten by the next iteration (needed until Go 1.23)
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotUUID, err := GetUUIDFromFileName(tt.filename)
+			if tt.wantError {
+				g.Expect(err).To(gomega.HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(gotUUID).To(gomega.Equal(tt.wantUUID))
+			}
+		})
+	}
+}
+
+func FuzzGetUUIDFromFileName(f *testing.F) {
+	testcases := []string{
+		"app.8ce1cc69-e1bb-4fe3-9613-e3eb1c5f5c4d.log.1731935033496.gz",
+		"app.123e4567-e89b-12d3-a456-426614174000.log.1731935033496.gz",
+		"dev.log.1731491904032.gz",
+		"app.invalid-uuid-string.log.1731935033496.gz",
+		"app.log.1731935033496.8ce1cc69-e1bb-4fe3-9613-e3eb1c5f5c4d.gz",
+	}
+
+	for _, tc := range testcases {
+		f.Add(tc)
+	}
+
+	f.Fuzz(func(t *testing.T, filename string) {
+		_, _ = GetUUIDFromFileName(filename)
+	})
+}


### PR DESCRIPTION
Main commit is a8725c77d437b9aa412848f6e6b359d8569e26cc. Instead of relying on a certain structure of log filenames, we should just  use regexp to look for timestamps or UUIDs - this way the filename structure can change in the future, but it will still be backwards compatible with our filename parsing logic.

This PR contains the changes for pillar. In a later PR those changes will also be applied to newlog and edge-view.