### PR TITLE
Fix deleted app is displayed in halted state

### DIFF
--- a/pkg/pillar/cmd/monitor/messages.go
+++ b/pkg/pillar/cmd/monitor/messages.go
@@ -30,7 +30,6 @@ func (ctx *monitor) isOnboarded() (bool, uuid.UUID) {
 }
 
 func (ctx *monitor) getAppSummary() types.AppInstanceSummary {
-	// send the network status to the server
 	sub := ctx.subscriptions["AppSummary"]
 	if item, err := sub.Get("global"); err == nil {
 		appSummary := item.(types.AppInstanceSummary)
@@ -61,7 +60,6 @@ func (ctx *monitor) sendNodeStatus() {
 }
 
 func (ctx *monitor) getAppInstancesStatus() []types.AppInstanceStatus {
-	// send the network status to the server
 	sub := ctx.subscriptions["AppStatus"]
 	items := sub.GetAll()
 	apps := make([]types.AppInstanceStatus, 0)
@@ -84,12 +82,11 @@ func (ctx *monitor) getZedAgentStatus() types.ZedAgentStatus {
 }
 
 func (ctx *monitor) sendAppsList() {
-	// send the node status to the server
+	// send the application list to the client
+	// empty list is allowed
 	appStatus := ctx.getAppInstancesStatus()
-	if len(appStatus) > 0 {
-		apps := appInstancesStatus{
-			Apps: appStatus,
-		}
-		ctx.IPCServer.sendIpcMessage("AppsList", apps)
+	apps := appInstancesStatus{
+		Apps: appStatus,
 	}
+	ctx.IPCServer.sendIpcMessage("AppsList", apps)
 }

--- a/pkg/pillar/cmd/monitor/subscriptions.go
+++ b/pkg/pillar/cmd/monitor/subscriptions.go
@@ -106,6 +106,9 @@ func handleAppInstanceStatusModify(ctxArg interface{}, key string,
 
 func handleAppInstanceStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
+	ctx := ctxArg.(*monitor)
+	// send updated status for all apps to detect deleted apps
+	ctx.sendAppsList()
 }
 
 func handleAppInstanceStatusUpdate(statusArg interface{}, ctxArg interface{}) {


### PR DESCRIPTION
If the App is deleted its AppInstanceStatus is unpublished. We should Update the list of active apps in monitor app as well