### PR TITLE
installer: Fix root_dev() for correct INVENTORY mounting

### DIFF
--- a/pkg/installer/install
+++ b/pkg/installer/install
@@ -99,7 +99,7 @@ root_dev() {
    local MAJOR
    local MINOR
    local DEV
-   if [ -L /dev/root ] ; then
+   if [ -L /dev/root ] || [ -b /dev/root ] ; then
       DEV=$(readlink -f /dev/root)
       MAJOR=$(( 0x$(stat -c '%t' "$DEV") + 0 ))
       MINOR=$(( 0x$(stat -c '%T' "$DEV") + 0 ))

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -276,7 +276,7 @@ for BLK_DEVICE in $BLK_DEVICES; do
 done
 
 #Recording SMART details to a file
-if [ -L /dev/root ] ; then
+if [ -L /dev/root ] || [ -b /dev/root ] ; then
   DEV_TO_CHECK_SMART=/dev/root
 else
   DEV_TO_CHECK_SMART=$(grep -m 1 /persist < /proc/mounts | cut -d ' ' -f 1)


### PR DESCRIPTION
root_dev() function in the installer script checks for the root device in /dev/root, considering that this file will be always a symbolic link, which is not true for some platforms, such as in some NVIDIA devices, where /dev/root it's just a regular file block device. For these cases, INVENTORY partition will not be found and /persist/installer will be used instead. This commit fixes this issue by checking if /dev/root is a symbolic link or a file block device.