### PR TITLE
grub: Add rootdelay for FR201 device

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -270,7 +270,7 @@ function set_arm64_baremetal {
       if [ "$smb_product" = "FR201" ]; then
          set_to_existing_file devicetree /boot/dtb/broadcom/bcm2711-rpi-cm4-fr201.dtb
          set_global dom0_console "console=ttyS0,115200 console=tty1 earlycon=tty1"
-         set_global dom0_platform_tweaks "eve_install_disk=mmcblk0 eve_persist_disk=sdb"
+         set_global dom0_platform_tweaks "eve_install_disk=mmcblk0 eve_persist_disk=sdb rootdelay=10"
       fi
    fi
    if [ "$smb_vendor" = "Huawei" ]; then


### PR DESCRIPTION
Some variants of FR201 device don't have an eMMC, so the whole EVE must be installed in the NVMe disk, which is connected through an USB M.2 internal adapter. When booting from USB storage, we need to add a rootdelay option so kernel can wait for the USB device (during boot) in order to mount the root file system.