### PR TITLE
Fix crash in pillar if NTP FQDN is an empty string

### DIFF
--- a/pkg/pillar/devicenetwork/dns.go
+++ b/pkg/pillar/devicenetwork/dns.go
@@ -76,7 +76,7 @@ func ResolveWithSrcIP(domain string, dnsServerIP net.IP, srcIP net.IP) ([]DNSRes
 	dialer := net.Dialer{LocalAddr: &sourceUDPAddr}
 	dnsClient := dns.Client{Dialer: &dialer}
 	msg := dns.Msg{}
-	if domain[len(domain)-1] != '.' {
+	if !strings.HasSuffix(domain, ".") {
 		domain = domain + "."
 	}
 	msg.SetQuestion(domain, dns.TypeA)

--- a/pkg/pillar/devicenetwork/dns_test.go
+++ b/pkg/pillar/devicenetwork/dns_test.go
@@ -285,3 +285,15 @@ func TestResolveCacheWrap(t *testing.T) {
 		t.Fatalf("resolver func should have been called twice because different src IPs, but called=%d", called)
 	}
 }
+
+func FuzzResolveWithSrcIP(f *testing.F) {
+	f.Fuzz(func(t *testing.T,
+		domain string,
+		dnsServer string,
+		src string,
+	) {
+		dnsServerIP := net.ParseIP(dnsServer)
+		srcIP := net.ParseIP(src)
+		devicenetwork.ResolveWithSrcIP(domain, dnsServerIP, srcIP)
+	})
+}


### PR DESCRIPTION
Under some conditions e.g. when set from Monitor TUI NTP FQDN can be an empty string which causes a crash

pillar;panic: runtime error: index out of range -1]

pillar;goroutine 170248 [running]:
pillar;github.com/lf-edge/eve/pkg/pillar/devicenetwork.ResolveWithSrcIP({0x0, 0x0}, {0xc002631950, 0x10, 0x10}, {0xc002631960, 0x10, 0x10}) pillar;  /pillar/devicenetwork/dns.go:79 +0x4d4
pillar;github.com/lf-edge/eve/pkg/pillar/devicenetwork.ResolveCacheWrap.func1({0x0, 0x0}, {0xc002631950, 0x10, 0x10}, {0xc002631960, 0x10, 0x10}) pillar;  /pillar/devicenetwork/dns.go:122 +0x1ca
pillar;github.com/lf-edge/eve/pkg/pillar/devicenetwork.ResolveWithPortsLambda.func1({0xc002631950, 0x10, 0x10}, {0xc002631960, 0x10, 0x10}) pillar;  /pillar/devicenetwork/dns.go:198 +0x17b
pillar;created by github.com/lf-edge/eve/pkg/pillar/devicenetwork.ResolveWithPortsLambda pillar;  /pillar/devicenetwork/dns.go:182 +0x98a