### PR TITLE
Makefile: Remove old cross-compiling warning message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,6 @@ export ZARCH
 CROSS ?=
 ifneq ($(HOSTARCH),$(ZARCH))
 CROSS = 1
-$(warning "WARNING: We are assembling an $(ZARCH) image on $(HOSTARCH). Things may break.")
 endif
 
 DOCKER_ARCH_TAG=$(ZARCH)


### PR DESCRIPTION
This commits removes an old warning message when doing cross-compiling. Our build system is mature enough to perform cross-compilation well and it has been tested a lot. Let's get rid of this message.