### PR TITLE
Fix installer to work with the OnLogic FR201 device

### DIFF
--- a/pkg/installer/install
+++ b/pkg/installer/install
@@ -336,8 +336,8 @@ ln -s /bits/* ${ARTIFACTS_DIR} 2>/dev/null
 # and now a few measures of last resort - make sure the ${ARTIFACTS_DIR}/* we need exist, or else
 # symlink to the root filesystem
 [ -e ${ROOTFS_IMG} ] || { echo "ERROR: no rootfs.img found"; exit 1; }
-[ -e ${EFI_DIR} ] || ln -s /root/EFI ${EFI_DIR}
-[ -e ${BOOT_DIR} ] || ln -s /uboot/boot ${BOOT_DIR}
+[ -d ${EFI_DIR} ] || ln -s /root/EFI ${EFI_DIR}
+[ -d ${BOOT_DIR} ] || ln -s /uboot/boot ${BOOT_DIR}
 
 # finally lets see if we were given any overrides
 for i in rootfs config persist; do

--- a/pkg/installer/install
+++ b/pkg/installer/install
@@ -139,6 +139,19 @@ mount_part() {
    mount "$@" "/dev/$ID" "$TARGET"
 }
 
+# Find EFI partition and copy files
+copy_native_efi() {
+    EFI_PART=$(lsblk -anl -o "NAME,PARTLABEL" | grep "EFI System" | awk '{print $1}' | sed "s#.*#/dev/&#")
+    if [ -n "$EFI_PART" ]; then
+        # EFI partition was found, copy files
+        mkdir -p "$BOOT_DIR"
+        mkdir /tmp/_EFI
+        mount "$EFI_PART" /tmp/_EFI
+        cp -r /tmp/_EFI/* "$BOOT_DIR"/
+        umount /tmp/_EFI
+    fi
+}
+
 # collect_black_box FOLDER_TO_PUT_BLACK_BOX
 collect_black_box() {
    lsblk > "$1/lsblk.txt"
@@ -324,6 +337,9 @@ tr ' ' '\012' < "$CMDLINEFILE" | sed -ne '/^eve_install_server=/s#^.*=##p' > $IN
 if [ ! -s $INSTALL_SERVER_FILE ]; then
    logmsg "EVE install server : $(cat $INSTALL_SERVER_FILE)"
 fi
+
+# Try to copy EFI files from the EFI partition of the installer device
+copy_native_efi
 
 # if there's something in /bits -- that's the ultimate source
 # before we do, let's list what we have, for the log


### PR DESCRIPTION
# Overview

This PR provides two changes in the installer script: one small fix and an additional functional to make installer work with the OnLogic FR201 device.

## Commits

### installer: Copy bootloader files from the installer device EFI partition
    
The installer script (within the installer container) look for EFI files under /parts/boot. Currently this directory it's not being populated at all, so the installer script will just create a link for the files from u-boot container (mounted at /uboot/boot). For default installations there is no issues on this behavior. However, for the OnLogic FR201 device, the workflow to produce an installer image is the following:

1. Create the installer raw image
2. Flash the installer image to an USB Stick
3. Change the config.txt file of the EFI partition in the USB Stick to enable the options for the FR201 device
4. Boot the USB Stick into the device
    
For this particular case, the config.txt from the EFI partition of the USB Stick (installer device) must be copied to the destination EFI partition of the target storage device (eMMC or SSD). However, the default config.txt (from the u-boot container) is copied and the device is not able to boot.
    
This commits adds a function to search for the EFI partition and copy the files to /parts/boot, so the installer script will install these files instead of the default ones from u-boot container. In this way, changes in the config.txt of the installer USB Stick will reflect in the target device.

### installer: Fix directory checking
    
Fix the test command argument to check for directories `-d` instead of regular file (`-e`).
    
