### PR TITLE
Edge-Node Clustering miscellaneous bug fixes

### DIFF
--- a/pkg/kube/cluster-utils.sh
+++ b/pkg/kube/cluster-utils.sh
@@ -43,6 +43,16 @@ check_log_file_size() {
                 fi
                 # keep the original log file's attributes
                 cp -p "$K3S_LOG_DIR/$1" "$K3S_LOG_DIR/$1.1"
+                # Check if the argument passed is "$K3s_LOG_FILE", sometimes the k3s is
+                # not releasing the file descriptor, so truncate the file may not
+                # take effect. Signal a HUP signal to that.
+                if [ "$1" = "$K3s_LOG_FILE" ]; then
+                        k3s_pid=$(pgrep -f "k3s server")
+                        if [ -n "$k3s_pid" ]; then
+                                kill -HUP "$k3s_pid"
+                                logmsg "Sent HUP signal to k3s server before truncate k3s.log size"
+                        fi
+                fi
                 truncate -s 0 "$K3S_LOG_DIR/$1"
                 logmsg "k3s logfile $1, size $currentSize rotate"
         fi

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -159,6 +159,9 @@ func parseConfig(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig,
 			parseContentInfoConfig(getconfigCtx, config)
 			parseVolumeConfig(getconfigCtx, config)
 			parseEvConfig(getconfigCtx, config)
+			// several service are waiting this NodeInfo at startup, either if we don't
+			// have apps, need to parse this config first
+			parseEdgeNodeInfo(getconfigCtx, config)
 
 			// We have handled the volumes, so we can now process the app instances. But we need to check if
 			// we are in the middle of a baseOS upgrade, and if so, we need to skip processing the app instances.
@@ -176,8 +179,6 @@ func parseConfig(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig,
 			parseAppInstanceConfig(getconfigCtx, config)
 
 			parseDisksConfig(getconfigCtx, config)
-
-			parseEdgeNodeInfo(getconfigCtx, config)
 
 			parsePatchEnvelopes(getconfigCtx, config)
 		}

--- a/pkg/pillar/cmd/zedkube/clusterstatus.go
+++ b/pkg/pillar/cmd/zedkube/clusterstatus.go
@@ -370,8 +370,6 @@ func (z *zedkube) clusterAppIDHandler(w http.ResponseWriter, r *http.Request) {
 				log.Errorf("clusterAppIDHandler: error reading response from %s: %v", host, err)
 				continue
 			}
-
-			// Replace outermost { and } with [ and ] in remoteAppInfoJSON
 			combinedJSON = combinedJSON + "," + strings.TrimSuffix(string(remoteAppInfoJSON), "\n")
 		}
 	}

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -38,6 +38,12 @@ var (
 	log    *base.LogObject
 )
 
+// GetKubePodsError is used to check and handle get kube pods error
+type GetKubePodsError struct {
+	getKubePodsErrorTime    time.Time
+	processedErrorCondition bool
+}
+
 type zedkube struct {
 	agentbase.AgentBase
 	globalConfig             *types.ConfigItemValueMap
@@ -78,6 +84,7 @@ type zedkube struct {
 	electionStopCh           chan struct{}
 	statusServer             *http.Server
 	statusServerWG           sync.WaitGroup
+	getKubePodsError         GetKubePodsError
 	drainOverrideTimer       *time.Timer
 
 	// Config Properties for Drain


### PR DESCRIPTION
- handle the ENC App Status and cluster reachable conditions and with error message status
- fix an issue in checkAppsStatus() of using staled oldStatus{}
- in multiple applications case, the there is a bug since now we changed the logic to not always publish the ENClusterAppStatus, need to use the correct oldStatus for the application
- fix the token rotation failure and waitfor cluster status bug and fix a bug in waiting for bootstrap server status, we can fall into the 'else' condition and get a wrong cert
- if not all-pods-ready, not printing the misleading 'applying node labels' message, instead log the 'Not all pods are ready'
- handle the case convert to single-node and immediately back to cluster-mode again. we need towait for the bootstrap 'cluster' status before moving on
- try to fix an issue of 'k3s.log' file rotation not taking effect once a while. the file size can not be truncated. Add a HUP signal before truncate the file