### PR TITLE
Increase eve rootfs partition size to 1G for kubevirt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,12 +379,12 @@ endif
 # The rootfs partition size is set to 512MB after 10.2.0 release (see commit 719b4d516)
 # Before 10.2.0 it was 300MB. We must maintain compatibility with older versions so rootfs size cannot exceed 300MB.
 # kubevirt and nvidia are not affected by this limitation because there no installation of kubevirt prior to 10.2.0
-# Nethertheless lets check for ROOTFS_MAXSIZE_MB not exceeding 450MB for kubevirt and ARM and 270MB for x86_64
+# Nevertheless lets check for ROOTFS_MAXSIZE_MB not exceeding 900MB for kubevirt, 450MB for NVIDIA based platforms (arm64) and 270MB for x86_64 and other arm64 platforms
 # That helps in catching image size increases earlier than at later stage.
 # We are currently filtering out a few packages from bulk builds since they are not getting published in Docker HUB
 ifeq ($(HV),kubevirt)
         PKGS_$(ZARCH)=$(shell find pkg -maxdepth 1 -type d | grep -Ev "eve|alpine|sources$$")
-        ROOTFS_MAXSIZE_MB=450
+        ROOTFS_MAXSIZE_MB=900
 else
         #kube container will not be in non-kubevirt builds
         PKGS_$(ZARCH)=$(shell find pkg -maxdepth 1 -type d | grep -Ev "eve|alpine|sources|kube|external-boot-image$$")

--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -100,6 +100,16 @@ EFI_PART_SIZE=$((36 * 1024 * 1024))
 # Warning: free space and rellocate all tables if image has
 # Warning: been bloated.
 ROOTFS_PART_SIZE_MIN=$((512 * 1024 * 1024))
+# For kubevirt eve lets set partition size to 1GB
+# Check if file /root/etc/eve-hv-type exists.
+# make-raw will be called twice during compilation and during installation.
+# The eve-hv-type file will be present only during installation.
+if [ -f /root/etc/eve-hv-type ]; then
+   eve_flavor=$(cat /root/etc/eve-hv-type)
+   if [ "$eve_flavor" = "kubevirt" ]; then
+      ROOTFS_PART_SIZE_MIN=$((1 * 1024 * 1024 * 1024))
+   fi
+fi
 # conf partition size in bytes
 CONF_PART_SIZE=$((1024 * 1024))
 # installer inventory partition size in bytes


### PR DESCRIPTION
For kubevirt eve we will create partition of 5GB each (IMGA and IMGB)
During build we verify if the rootfs size reached 4.5GB and terminate build. 
This will help us catch the image size increase ahead of reaching the actual limit.