### PR TITLE
Include proper iso volume label when running docker run eve installer_iso

### DIFF
--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -162,7 +162,7 @@ do_installer_raw() {
 create_installer_iso() {
   mkdir -p /installer_root
   unsquashfs -f -d /installer_root /bits/installer.img 1>&2
-  tar -C /installer_root -cf - . | /make-efi installer
+  tar -C /installer_root -cf - . | VOLUME_LABEL=EVEISO /make-efi installer
   rm -rf /installer_root
 }
 


### PR DESCRIPTION
The mkimage-iso-efi can override the default iso volume label based on the env variable VOLUME_LABEL. We use this when we call tools/makeiso.sh to set the label to EVEISO. The installer in turn looks for this label to find its installer iso to use for installs. This label-setting did not, however, get carried over to eve/runme.sh, which means that `docker run lfedge/eve installer_iso` creates an iso with the wrong volume label, and thus install fails.

This fixes it so that it sets the volume label correctly.