### PR TITLE
[GH actions] Add OSV-Scanner GitHub Actions workflow for vulnerability scanning

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,42 @@
+---
+# Copyright (c) 2025, Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: OSV-Scanner
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - "master"
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-stable"
+    paths-ignore:
+      - '**/*.md'
+      - '.github/**'
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches:
+      - "master"
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-stable"
+    paths-ignore:
+      - '**/*.md'
+  schedule:
+    - cron: "12 12 * * 1"
+
+permissions:
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
+  # Read commit contents
+  contents: read
+
+jobs:
+  scan-scheduled:
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@e994fd8ab13fe1394942045f5945cd39c6c2d68e"  # v1.9.2
+
+  scan-pr:
+    if: ${{ github.event_name == 'pull_request'}}
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@e994fd8ab13fe1394942045f5945cd39c6c2d68e"  # v1.9.2


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to integrate OSV-Scanner for security scanning. The workflow is configured to run on pull requests, scheduled events, and pushes to the master branch. 

Key changes:

* [`.github/workflows/osv-scanner.yml`](diffhunk://#diff-cffe33bb0ffb2810cb2ba28b35e9fb9ebef98fd615b71ef50305846fa8ba0e00R1-R41): Added a new workflow file to configure OSV-Scanner for security scanning on pull requests, scheduled events, and pushes to the master branch. The workflow includes permissions setup and job definitions for both scheduled scans and pull request scans.