### PR TITLE
github/workflows: Build packages for NVIDIA platform variants(amd and arm)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,13 +20,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [buildjet-4vcpu-ubuntu-2204-arm, buildjet-4vcpu-ubuntu-2004]
+        arch: [arm64, amd64]
+        platform: [generic, nvidia-jp5, nvidia-jp6]
         include:
-          - os: buildjet-4vcpu-ubuntu-2204-arm
-            arch: arm64
-          - os: buildjet-4vcpu-ubuntu-2004
-            arch: amd64
           - os: buildjet-4vcpu-ubuntu-2004
             arch: riscv64
+            platform: generic
+        exclude:
+          - os: buildjet-4vcpu-ubuntu-2204-arm
+            arch: amd64
+          - os: buildjet-4vcpu-ubuntu-2004
+            platform: arm64
     steps:
       - name: Starting Report
         run: |
@@ -71,9 +76,9 @@ jobs:
         with:
           path: ~/.linuxkit/cache
           key: linuxkit-${{ matrix.arch }}-${{ github.event.pull_request.head.sha }}
-      - name: Build packages
+      - name: Build packages ${{ matrix.os }} for ${{ matrix.platform }}
         run: |
-          make V=1 PRUNE=1 ZARCH=${{ matrix.arch }} pkgs
+          make V=1 PRUNE=1 PLATFORM=${{ matrix.platform }} ZARCH=${{ matrix.arch }} pkgs
       - name: Post package report
         run: |
           echo Disk usage


### PR DESCRIPTION
The eve job occasionally encounters issues when building the NVIDIA variants, which may be caused by the type of runners being used.

This PR builds packages for the NVIDIA platform variants and also includes the AMD variant, as discussed with @rene , for potential future use. The eve job will then reference the packages from the cache.


Reference PR: https://github.com/lf-edge/eve/pull/4562

Execution matrix table:

OS | Architecture | Platform | Included/Excluded
-- | -- | -- | --
buildjet-4vcpu-ubuntu-2204-arm | arm64 | generic | ✅ Included
buildjet-4vcpu-ubuntu-2204-arm | arm64 | nvidia-jp5 | ✅ Included
buildjet-4vcpu-ubuntu-2204-arm | arm64 | nvidia-jp6 | ✅ Included
buildjet-4vcpu-ubuntu-2204-arm | amd64 | generic | ❌ Excluded
buildjet-4vcpu-ubuntu-2204-arm | amd64 | nvidia-jp5 | ❌ Excluded
buildjet-4vcpu-ubuntu-2204-arm | amd64 | nvidia-jp6 | ❌ Excluded
buildjet-4vcpu-ubuntu-2004 | amd64 | generic | ✅ Included
buildjet-4vcpu-ubuntu-2004 | amd64 | nvidia-jp5 | ✅ Included
buildjet-4vcpu-ubuntu-2004 | amd64 | nvidia-jp6 | ✅ Included
buildjet-4vcpu-ubuntu-2004 | arm64 | generic | ❌ Excluded
buildjet-4vcpu-ubuntu-2004 | arm64 | nvidia-jp5 | ❌ Excluded
buildjet-4vcpu-ubuntu-2004 | arm64 | nvidia-jp6 | ❌ Excluded
buildjet-4vcpu-ubuntu-2004 | riscv64 | generic | ✅ Included