### PR TITLE
fix: Remove AMD and NVIDIA from the build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,11 @@ jobs:
           - os: buildjet-4vcpu-ubuntu-2204-arm
             arch: amd64
           - os: buildjet-4vcpu-ubuntu-2004
-            platform: arm64
+            arch: arm64
+          - arch: amd64
+            platform: nvidia-jp5
+          - arch: amd64
+            platform: nvidia-jp6
     steps:
       - name: Starting Report
         run: |


### PR DESCRIPTION
A minor variable issue to ignore the cross compilation for AMD and ARM