### PR TITLE
[13.4-stable] grub: Disable boot measurement for installer

### DIFF
--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -121,7 +121,9 @@ function set_rootfs_root {
    if [ -z "$rootfs_root" ]; then
       probe -s root_type --fs $root # do NOT try to probe netfs for part-uuid; grub crashes
       if [ "$root_type" != "netfs" ]; then
-         measurefs $root --pcr 13
+         if [ "$rootfs_title_suffix" != "-installer" ]; then
+             measurefs $root --pcr 13
+         fi
          probe --set partuuid --part-uuid $root
          set_global rootfs_root "PARTUUID=$partuuid"
       fi


### PR DESCRIPTION
## Description
Backport of https://github.com/lf-edge/eve/pull/4568

This speeds up a lot the boot of installer, so it makes sense to backport.

## Original PR
This commit disables the boot measurement for the installer in order to speed up the boot process.