### PR TITLE
[13.4-stable] Add missing FW package to installer

### DIFF
--- a/images/installer.yml.in
+++ b/images/installer.yml.in
@@ -10,6 +10,7 @@ init:
   - linuxkit/memlogd:1ded209c4cc10aa8de2099f4156164b59df14e3c
   - GRUB_TAG
   - DOM0ZTOOLS_TAG
+  - FW_TAG
 onboot:
   - name: sysctl
     image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee


### PR DESCRIPTION
Backport of #4559 

- ucode.img is loaded from this package
- we may need FW to even start the installer on some HW 

WARNING: the ISO image is 802MB!!!!

Signed-off-by: Mikhail Malyshev <mike.malyshev@gmail.com>
(cherry picked from commit 54304ff2d2b2abea7e8e47cedb63fc0a472ccd1b)