### PR TITLE
[13.4-stable] Avoid nil dereference in baseosmgr

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -68,7 +68,7 @@ func installDownloadedObjects(ctx *baseOsMgrContext, uuidStr, finalObjDir string
 
 	if status == nil {
 		return changed, proceed, fmt.Errorf("installDownloadedObjects(%s) cannot found contentTree %s",
-			uuidStr, status.ContentID)
+			uuidStr, contentID)
 	}
 
 	if status.State == types.LOADED {


### PR DESCRIPTION
- avoid nil dereference

Signed-off-by: Mikhail Malyshev <mike.malyshev@gmail.com>
(cherry picked from commit 6bac1ef8b37cc5c21463abc2413a010d9b06cdac)