### PR TITLE
github/workflows: Added the platform suffix to the linuxkit cache.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.linuxkit/cache
-          key: linuxkit-${{ matrix.arch }}-${{ github.event.pull_request.head.sha }}
+          key: linuxkit-${{ matrix.arch }}-${{ github.event.pull_request.head.sha }}-${{ matrix.platform }}
       - name: Build packages ${{ matrix.os }} for ${{ matrix.platform }}
         run: |
           make V=1 PRUNE=1 PLATFORM=${{ matrix.platform }} ZARCH=${{ matrix.arch }} pkgs
@@ -165,7 +165,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.linuxkit/cache
-          key: linuxkit-amd64-${{ github.event.pull_request.head.sha }}
+          key: linuxkit-amd64-${{ github.event.pull_request.head.sha }}-${{ matrix.platform }}
           fail-on-cache-miss: true
       - name: load images we need from linuxkit cache into docker
         run: |
@@ -181,7 +181,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.linuxkit/cache
-          key: linuxkit-${{ matrix.arch }}-${{ github.event.pull_request.head.sha }}
+          key: linuxkit-${{ matrix.arch }}-${{ github.event.pull_request.head.sha }}-${{ matrix.platform }}
           fail-on-cache-miss: true
       - name: set environment
         env:


### PR DESCRIPTION
Packages built for different platforms are stored in a shared cache based on the architecture.  

This PR introduces platform-specific cache suffixes for EVE, ensuring it retrieves the correct cache. This prevents build failures caused by architecture-dependent dependencies.