### PR TITLE
github/workflows: Remove imx8mp platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,12 +114,6 @@ jobs:
           - arch: arm64
             hv: kvm
             platform: "nvidia-jp6"
-          - arch: arm64
-            hv: kvm
-            platform: "imx8mp_pollux"
-          - arch: arm64
-            hv: kvm
-            platform: "imx8mp_epc_r3720"
         exclude:
           - arch: arm64
             hv: kubevirt


### PR DESCRIPTION
This commit removes the imx8mp platforms from the build.yml file. 

This prevents build failures caused by the missing Linux kit cache for IMX8MP platforms, as we are not publishing the IMX8MP variants to Docker Hub.