### PR TITLE
[12.0-stable] fix: github/workflows/eden.yml: Fix the job name

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -19,14 +19,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  get-run-id:
+  get_run_id:
     if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     outputs:
-      result: ${{ steps.get-run-id.outputs.result }}
+      run_id: ${{ steps.get_run_id.outputs.run_id }}
     steps:
       - name: Get run ID for the artifact upload
-        id: get-run-id
+        id: get_run_id
         uses: actions/github-script@v7
         with:
           script: |
@@ -46,10 +46,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Report Run ID  # useful for debugging
-        run: echo "Run ID is ${{ steps.get-run-id.outputs.result }}"
+        run: echo "Run ID is ${{ steps.get_run_id.outputs.run_id }}"
 
   test_suite_pr:
-    needs: get-run-id
+    needs: get_run_id
     strategy:
       fail-fast: false
       # we do not really need a matrix, as we only do amd64/kvm,

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -20,31 +20,42 @@ concurrency:
 
 jobs:
   get_run_id:
-    if: github.event.review.state == 'approved'
+    if: ${{ github.event.review.state == 'approved' }}
     runs-on: ubuntu-latest
     outputs:
       run_id: ${{ steps.get_run_id.outputs.run_id }}
     steps:
+      - name: Get the GitHub context
+        run: echo "github context is $GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+      - name: Print the head SHA
+        run: |
+          echo ${{ github.event.pull_request.head.sha }}
+      - name: Print pull request url
+        run: |
+          echo ${{ github.event.pull_request._links.self.href }}
       - name: Get run ID for the artifact upload
         id: get_run_id
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { data } = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'build.yml',
-              head_sha: context.payload.pull_request.head.sha,
-              status: 'success'
-            });
-            if (data == null || data.workflow_runs.length == 0) {
-                throw new Error('No successful runs found');
-            }
-            const runId = data.workflow_runs[0].id; // Assuming the first one is the latest successful run
-            return runId;
-          result-encoding: string
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RESPONSE=$(curl -s -L "https://api.github.com/repos/${{ github.repository }}/actions/workflows/build.yml/runs?head_sha=${{ github.event.pull_request.head.sha }}&status=success" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json")
+          # Check if RESPONSE is empty
+          if [ -z "$RESPONSE" ]; then
+            echo "API call returned no response."
+            exit 1
+          fi
+          RUN_ID=$(echo $RESPONSE | jq -r '.workflow_runs[0].id')
+          # Check if the RUN_ID is empty
+          if [ "$RUN_ID" == "null" ] || [ -z "$RUN_ID" ]; then
+            echo "No successful runs found"
+            exit 1
+          fi
+          echo $RUN_ID
+          echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
       - name: Report Run ID  # useful for debugging
         run: echo "Run ID is ${{ steps.get_run_id.outputs.run_id }}"
 


### PR DESCRIPTION
The platform variants are not back ported to the 12.0-stable branch, so the PR for Eden cannot be directly back ported. This PR addresses the job name and ID to ensure the artifact names are correctly passed to Eden.