### PR TITLE
Update monitor TUI to v0.2.0

### DIFF
--- a/pkg/monitor/Dockerfile
+++ b/pkg/monitor/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG MONITOR_RS_VERSION=v0.1.2
+ARG MONITOR_RS_VERSION=v0.2.0
 ARG RUST_VERSION=lfedge/eve-rust:1.80.1
 FROM --platform=$BUILDPLATFORM ${RUST_VERSION} AS toolchain-base
 ARG TARGETARCH


### PR DESCRIPTION
**NOTE:** depends on https://github.com/lf-edge/eve/pull/4536

 386ecef Version 0.2.0
 e638477 Display application version in the top right corner
 1be7d9a Add GIT_VERSION in the log
 2151fdf Add build.rs to set GIT_VERSION cargo env variable
 46e2c75 Reduce log level for annoying message from dmesg task
 402a966 Rework panic and log handling
 35f93df Fix NTP server parsing
 850b788 Fix network interfaces are not displayed if MAC is null
 948d440 Remove verbose log