### PR TITLE
Installer UI cannot remove disks for persist parition

### DIFF
--- a/pkg/installer/src/utils.rs
+++ b/pkg/installer/src/utils.rs
@@ -88,15 +88,32 @@ pub fn save_config_value(c: &mut Cursive, k: &str, v: &str, m: bool) -> crate::e
     Ok(())
 }
 
-pub fn edit_config_value(c: &mut Cursive, k: &str, v: &str) -> crate::error::Result<()> {
+pub fn add_config_value(c: &mut Cursive, k: &str, v: &str) -> crate::error::Result<()> {
     let mut s: GlobalState = c.take_user_data().unwrap();
-    let mut vedit = s.data.map.get(k).unwrap().clone();
-    if vedit == "_____" {
-        vedit = v.to_string();
+    let mut vadd = s.data.map.get(k).cloned().unwrap_or_default();
+    if vadd == "_____" {
+        vadd = v.to_string();
     } else {
-        vedit = vedit + "," + v;
+        vadd = vadd + "," + v;
     }
-    s.data.map.insert(k.to_string(), vedit);
+    s.data.map.insert(k.to_string(), vadd);
+    c.set_user_data(s);
+    Ok(())
+}
+
+pub fn remove_config_value(c: &mut Cursive, k: &str, v: &str) -> crate::error::Result<()> {
+    let mut s: GlobalState = c.take_user_data().unwrap();
+    let mut vremove: String = s.data.map.get(k).cloned().unwrap_or_default()
+        .split(',')
+        .filter(|&d| d != v) // Remove matching device
+        .collect::<Vec<&str>>() // Collect filtered items into Vec
+        .join(","); // Join them back with ','
+
+    if vremove == "" { // If we removed all devices we return to the init value
+        vremove = "_____".to_string()
+    }
+
+    s.data.map.insert(k.to_string(), vremove);
     c.set_user_data(s);
     Ok(())
 }

--- a/pkg/installer/src/views/pdev.rs
+++ b/pkg/installer/src/views/pdev.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use crate::{
     data::{PERSIST_DISK},
     herr,
-    utils::{get_block_devices, edit_config_value},
+    utils::{get_block_devices, add_config_value, remove_config_value},
 };
 
 use cursive::{
@@ -35,7 +35,9 @@ pub fn get_pdev(map: HashMap<String, String>) -> PDEVView {
         let dev = d.clone();
         let mut c = Checkbox::new().on_change(move |s, checked | {
             if checked {
-                herr!(s, edit_config_value, PERSIST_DISK, &dev);
+                herr!(s, add_config_value, PERSIST_DISK, &dev);
+            } else if !checked {
+                herr!(s, remove_config_value, PERSIST_DISK, &dev);
             }
         });
         if pdevs.contains(&d.as_str()) {


### PR DESCRIPTION
- Added a utility function for removing devices when selecting the persist partition
- Added conditional in the view for persist partition to remove or add a disk when selecting the persist partition