### PR TITLE
[13.4-stable] Fix vm unknown state

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -60,9 +60,10 @@ const (
 	ciDirname  = runDirname + "/cloudinit" // For cloud-init images
 
 	// Time limits for event loop handlers
-	errorTime     = 3 * time.Minute
-	warningTime   = 40 * time.Second
-	casClientType = "containerd"
+	errorTime           = 3 * time.Minute
+	warningTime         = 40 * time.Second
+	casClientType       = "containerd"
+	unknownStateRetries = 10
 )
 
 // Really a constant
@@ -1784,7 +1785,23 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 	status.VifList = checkIfEmu(status.VifList)
 
 	status.State = types.RUNNING
-	domainID, state, err := hyper.Task(status).Info(status.DomainName)
+	var state types.SwState
+	// If status is unknown, get info again for some retries and if it will not be activated return error.
+	for retry := 0; retry < unknownStateRetries; retry++ {
+		ctx.ps.StillRunning(agentName, warningTime, errorTime)
+		domainID, state, err = hyper.Task(status).Info(status.DomainName)
+		if err != nil || state != types.UNKNOWN {
+			break
+		}
+		log.Warnf("doActivateTail(%v) for %s: state is UNKNOWN, retry %d", status.UUIDandVersion, status.DisplayName, retry)
+		time.Sleep(2 * time.Second)
+	}
+
+	// if the state is still unknown after the retries we set an error, because we
+	// cannot guarantee that the domain is running.
+	if state == types.UNKNOWN && err == nil {
+		err = fmt.Errorf("The domain state is still unknown after %d retries", unknownStateRetries)
+	}
 
 	if err != nil {
 		// Immediate failure treat as above
@@ -1811,6 +1828,7 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 			status.DomainId, status.BootTime.Format(time.RFC3339Nano),
 			status.Key())
 	}
+
 	status.Activated = true
 	log.Functionf("doActivateTail(%v) done for %s",
 		status.UUIDandVersion, status.DisplayName)

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -513,6 +513,9 @@ func (client *Client) CtrContainerInfo(ctx context.Context, name string) (int, i
 		return 0, 0, "", fmt.Errorf("CtrContainerInfo: couldn't determine task status for container %s: %v", name, err)
 	}
 
+	if stat.Status == "unknown" {
+		logrus.Infof("CtrContainerInfo: PID of the task in container %s is %d, exit code is %d, status is %s and the task object (%v)", name, int(t.Pid()), int(stat.ExitStatus), stat.Status, t)
+	}
 	return int(t.Pid()), int(stat.ExitStatus), string(stat.Status), nil
 }
 


### PR DESCRIPTION
Backport of #4559

Keep the applications alive when getting UNKNOWN state from the containerd tasks.