### PR TITLE
mkimage-iso-efi: Do not follow symbolic links

### DIFF
--- a/pkg/mkimage-iso-efi/make-efi
+++ b/pkg/mkimage-iso-efi/make-efi
@@ -75,11 +75,9 @@ if [ ! -e boot/initrd.img ]; then
    mv /tmp/initrd.img boot/initrd.img
 fi
 
-# pay attention to the -f option: it follows symlinks which is exactly
-# what we need for installer construction but could be dangerous in the
-# generic case for this container
+# shellcheck disable=SC2086
 xorriso -as mkisofs \
-        -m rootfs-\* -f -R -e boot.img -hide boot.img -hide boot.catalog -no-emul-boot ${VOL_LABEL} -o /tmp/disk.iso .
+        -m rootfs-\* -R -e boot.img -hide boot.img -hide boot.catalog -no-emul-boot ${VOL_LABEL} -o /tmp/disk.iso .
 copy /tmp/disk.iso /output.iso
 
 # How to build a VHDX. Commented out because we are currently not using it


### PR DESCRIPTION
The option -f is passed to xorriso, following symbolic links and increasing the final image size. This commit removes this option so symbolic links are treat as it should be.

~Marking this PR as draft because apparently it doesn't help to reduce the size too much.... in anycase I can see that symlinks are not followed anymore...~