### PR TITLE
Fix ISO generation from a host with different architecture from target (fixes arm64 ISO generation from x86_64 hosts)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -822,7 +822,7 @@ $(INSTALLER).raw: $(INSTALLER_IMG) $(EFI_PART) $(BOOT_PART) $(CONFIG_IMG) $(BSP_
 	$(QUIET): $@: Succeeded
 
 $(INSTALLER).iso: $(INSTALLER_TAR) $(BSP_IMX_PART) | $(INSTALLER)
-	./tools/makeiso.sh $< $@ installer
+	DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG) ./tools/makeiso.sh $< $@ installer
 	$(QUIET): $@: Succeeded
 
 $(INSTALLER).net: $(INSTALLER).iso $(EFI_PART) $(INITRD_IMG) $(CONFIG_IMG) | $(INSTALLER)

--- a/tools/makeiso.sh
+++ b/tools/makeiso.sh
@@ -2,6 +2,19 @@
 
 [ -n "$DEBUG" ] && set -x
 
+if [ -z "$DOCKER_ARCH_TAG" ] ; then
+  case $(uname -m) in
+    x86_64) ARCH=amd64
+      ;;
+    aarch64) ARCH=arm64
+      ;;
+    *) echo "Unsupported architecture $(uname -m). Exiting" && exit 1
+      ;;
+  esac
+else
+  ARCH="${DOCKER_ARCH_TAG}"
+fi
+
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
 PATH="$EVE/build-tools/bin:$PATH"
 INSTALLER_TAR="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
@@ -15,4 +28,4 @@ fi
 
 : > "$ISO"
 # shellcheck disable=SC2086
-cat $INSTALLER_TAR | docker run -i --rm -e DEBUG="$DEBUG" -e VOLUME_LABEL=EVEISO -v "$ISO:/output.iso" "$MKIMAGE_TAG" $3
+cat $INSTALLER_TAR | docker run -i --platform "linux/${ARCH}" --rm -e DEBUG="$DEBUG" -e VOLUME_LABEL=EVEISO -v "$ISO:/output.iso" "$MKIMAGE_TAG" $3


### PR DESCRIPTION
## Description

The `tools/makeiso.sh` script runs the `pkg/mkimage-iso-efi` container to generate the ISO image. Inside the script that generates the image there is the following code (https://github.com/lf-edge/eve/blob/master/pkg/mkimage-iso-efi/make-efi#L65):

```sh
if [ ! -e boot/initrd.img ]; then
   # all of the things we need to make a simple initrd
   mkdir -p /tmp/initrd
   (cd /tmp/initrd
   mkdir -p bin lib sbin etc proc sys newroot
   cp /initrd.sh init
   cp /bin/busybox bin/
   cp /lib/ld-musl* lib/
   /bin/busybox --install -s /tmp/initrd/bin
   find . | cpio -H newc -o | gzip > /tmp/initrd.img)
   mv /tmp/initrd.img boot/initrd.img
fi
```

This code generates the initial ramdisk when boot/initrd.img file is not provided. However, `makeiso.sh` doesn't consider the target architecture to run the container, leading to a broken initrd.img image when generating the ISO from a host with different architecture. This issue was notice while building an ISO image for arm64 from a x86_64 host. Binaries for x86_64 are copied to the initrd.img for arm64.

This PR fixes this issue by running the `pkg/mkimage-iso-efi` container for the target architecture. The same approach used by `tools/parse-pkgs.sh` to get the target architecture is introduced for `makeiso.sh`.