### PR TITLE
Remove perl from installer image.

### DIFF
--- a/pkg/installer/Dockerfile
+++ b/pkg/installer/Dockerfile
@@ -40,7 +40,7 @@ ENV BUILD_PKGS mkinitfs grep patch make coreutils musl-dev gcc g++ perl \
     cryptsetup-dev go lddtree git
 ENV PKGS mtools dosfstools libarchive-tools sgdisk e2fsprogs util-linux \
     squashfs-tools coreutils tar dmidecode smartmontools libaio libaio-dev \
-    perl glib zlib libusb curl xz pciutils usbutils hdparm ncurses-dev jq \
+    glib zlib libusb curl xz pciutils usbutils hdparm ncurses-dev jq \
     wireless-tools libxrandr eudev-libs sudo fio iperf3 sysstat \
     lm-sensors acpi iw libdrm hwinfo dhclient e2fsprogs-extra \
     libgcc pixman libvncserver musl-utils \


### PR DESCRIPTION
perl was part of PKGS, i.e. it was available both during build and during the final image. But perl is not needed in the final image. Removes it.

As a comparison, I created both images on x86_64 with `docker build`, then `docker create`, then `docker export` to see what the tarred up filesystem size is without compression:

```
131M    /tmp/installer-post.tar
165M    /tmp/installer-pre.tar
```

So this PR saves 34MB from the installer container and final installer image. In installer raw, it is squashfs, so it matters somewhat less, but for the ISO, this saved 34MB out of the ~800MB of the total, or just under 5%. Not bad for removing a single word from the Dockerfile.