### PR TITLE
[13.4-stable] Fix ISO generation from a host with different architecture from target (fixes arm64 ISO generation from x86_64 hosts)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -789,7 +789,7 @@ $(INSTALLER).raw: $(INSTALLER_IMG) $(EFI_PART) $(BOOT_PART) $(CONFIG_IMG) $(BSP_
 	$(QUIET): $@: Succeeded
 
 $(INSTALLER).iso: $(INSTALLER_TAR) $(BSP_IMX_PART) | $(INSTALLER)
-	./tools/makeiso.sh $< $@ installer
+	DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG) ./tools/makeiso.sh $< $@ installer
 	$(QUIET): $@: Succeeded
 
 $(INSTALLER).net: $(INSTALLER).iso $(EFI_PART) $(INITRD_IMG) $(CONFIG_IMG) | $(INSTALLER)

--- a/tools/makeiso.sh
+++ b/tools/makeiso.sh
@@ -2,6 +2,19 @@
 
 [ -n "$DEBUG" ] && set -x
 
+if [ -z "$DOCKER_ARCH_TAG" ] ; then
+  case $(uname -m) in
+    x86_64) ARCH=amd64
+      ;;
+    aarch64) ARCH=arm64
+      ;;
+    *) echo "Unsupported architecture $(uname -m). Exiting" && exit 1
+      ;;
+  esac
+else
+  ARCH="${DOCKER_ARCH_TAG}"
+fi
+
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
 PATH="$EVE/build-tools/bin:$PATH"
 INSTALLER_TAR="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
@@ -15,4 +28,4 @@ fi
 
 : > "$ISO"
 # shellcheck disable=SC2086
-cat $INSTALLER_TAR | docker run -i --rm -e DEBUG="$DEBUG" -e VOLUME_LABEL=EVEISO -v "$ISO:/output.iso" "$MKIMAGE_TAG" $3
+cat $INSTALLER_TAR | docker run -i --platform "linux/${ARCH}" --rm -e DEBUG="$DEBUG" -e VOLUME_LABEL=EVEISO -v "$ISO:/output.iso" "$MKIMAGE_TAG" $3


### PR DESCRIPTION
Backport of https://github.com/lf-edge/eve/pull/4592