### PR TITLE
Remove qemu from installer

### DIFF
--- a/pkg/installer/Dockerfile
+++ b/pkg/installer/Dockerfile
@@ -44,7 +44,7 @@ ENV PKGS mtools dosfstools libarchive-tools sgdisk e2fsprogs util-linux \
     wireless-tools libxrandr eudev-libs sudo fio iperf3 sysstat \
     lm-sensors acpi iw libdrm hwinfo dhclient e2fsprogs-extra \
     libgcc pixman libvncserver musl-utils \
-    qemu-system-x86_64 tpm2-tss-dev tpm2-tss-esys tpm2-tss-fapi tpm2-tss-rc \
+    tpm2-tss-dev tpm2-tss-esys tpm2-tss-fapi tpm2-tss-rc \
     kmod-libs tpm2-tss-sys tpm2-tss-tctildr tpm2-abrmd libblkid cryptsetup-libs
 RUN eve-alpine-deploy.sh
 

--- a/pkg/installer/verify
+++ b/pkg/installer/verify
@@ -58,27 +58,10 @@ do
    fi
 done
 
-if false; # Temporarily commented out
-then
-   # Testing qemu and passthrough
-   qemu_exec=/usr/bin/qemu-system-$(uname -m)
-   machine=$($qemu_exec -machine help | awk '{if (NR==2) print $1}')
-   $qemu_exec -m 1024 -smp 2 -display none -serial mon:stdio -global ICH9-LPC.noreboot=false \
-      -watchdog-action reset -rtc base=utc,clock=rt -machine "$machine" -cpu SandyBridge \
-      -drive file=/ubuntu-22.04-minimal-cloudimg-amd64.img,format=qcow2 &
-
-   # shellcheck disable=SC2181
-   if [ "$?" -eq 0 ]; then
-      kill %1
-      echo "start VM success" > "$REPORT/guest-checks.log"
-      echo "Start of an edge application successful" >> "$REPORT/summary.log";
-   else
-      echo "start VM failed" > "$REPORT/guest-checks.log"
-      echo "Start of an edge application failed" >> "$REPORT/summary.log";
-   fi
-fi
-
-echo "start VM test unavailable" > "$REPORT/guest-checks.log"
+# There used to be a VM test here, using qemu, and ubuntu-22.04-minimal-cloud.img. It was commented out for a long time as of this writing.
+# The installer image does not have qemu (~40MB) or the listed ubuntu-22.04 file (~287MB) installed.
+# If they are needed, add qemu to the Dockerfile, as well as downloading the .img, but think long
+# and hard if the size is needed. Look for alternatives. You can find the actual script code for the test from older commits.
 
 tpm2_pcrread >> "$REPORT/summary.log"
 


### PR DESCRIPTION
Installer installs qemu, but the code that references it in `verify` script is commented out. This means that 5+% of the installer image, as qemu, is unnecessary. In addition, the booted ubuntu file is not in the image. Removing qemu as it is unused. If we ever deem it worthwhile to use that space and enable it, it can be added back.