### PR TITLE
[WIP] Avoid unnecessary test restarts on PR approval. [DO NOT MERGE]

### DIFF
--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -60,8 +60,50 @@ jobs:
           echo "${{ env.workflow_files_modified }}"
           echo "workflow_files_modified=${{ env.workflow_files_modified }}" >> $GITHUB_OUTPUT
 
+  check_existing_workflow:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check_status.outputs.should_run }}
+    steps:
+      - name: Check if workflow is currently running
+        id: check_status
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          PR_SHA="${{ github.event.pull_request.head.sha }}"
+
+          # Fetch running workflows for this PR
+          RUNNING_WORKFLOWS=$(curl -s -L \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/actions/runs?head_sha=$PR_SHA&status=in_progress")
+
+          if echo "$RUNNING_WORKFLOWS" | jq -e '.workflow_runs | length > 0' > /dev/null; then
+            echo "Another workflow is already running. Exiting."
+            echo "should_run=false" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          # Fetch latest completed run for this PR
+          COMPLETED_RUN=$(curl -s -L \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/actions/runs?head_sha=$PR_SHA&status=completed" | jq '.workflow_runs[0]')
+
+          LAST_STATUS=$(echo "$COMPLETED_RUN" | jq -r '.conclusion')
+
+          if [[ "$LAST_STATUS" == "failure" ]] || [[ "$LAST_STATUS" == "cancelled" ]]; then
+            echo "Last workflow failed or was cancelled. Running tests again."
+            echo "should_run=true" >> $GITHUB_ENV
+          else
+            echo "No failed or cancelled workflows. Skipping test run."
+            echo "should_run=false" >> $GITHUB_ENV
+          fi
+
   get_run_id:
-    if: ${{ github.event.review.state == 'approved' && needs.check_md_wf_files.outputs.only_md == 'false' && needs.check_md_wf_files.outputs.workflow_files_modified == 'false' }}
+    if: needs.check_existing_workflow.outputs.should_run == 'true' && needs.check_md_wf_files.outputs.only_md == 'false' && needs.check_md_wf_files.outputs.workflow_files_modified == 'false'
     runs-on: ubuntu-latest
     needs: check_md_wf_files
     outputs:

--- a/.github/workflows/eden.yml
+++ b/.github/workflows/eden.yml
@@ -103,7 +103,7 @@ jobs:
           fi
 
   get_run_id:
-    if: needs.check_existing_workflow.outputs.should_run == 'true' && needs.check_md_wf_files.outputs.only_md == 'false' && needs.check_md_wf_files.outputs.workflow_files_modified == 'false'
+    if: needs.check_existing_workflow.outputs.should_run == 'true' && needs.check_md_wf_files.outputs.only_md == 'false'
     runs-on: ubuntu-latest
     needs: check_md_wf_files
     outputs:

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -146,6 +146,7 @@ var hyper hypervisor.Hypervisor // Current hypervisor
 var logger *logrus.Logger
 var log *base.LogObject
 
+// Run is the main entry point for domainmgr
 func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int { //nolint:gocyclo
 	logger = loggerArg
 	log = logArg
@@ -491,7 +492,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	log.Noticef("processed GlobalConfig")
+	log.Noticef("processed GlobalConfig!")
 
 	capabilitiesSent := false
 	capabilitiesTicker := time.NewTicker(5 * time.Second)


### PR DESCRIPTION
Added a new `check_existing_workflow` job to prevent restarting tests if a workflow is already running. This job checks for active test runs and only triggers a new one if no workflow is in progress and the last completed test run failed or was canceled.

Modified `get_run_id` to depend on
`check_existing_workflow.outputs.should_run`, ensuring tests only start when needed. This avoids redundant test executions on repeated approvals while still allowing re-runs if previous tests failed.