### PR TITLE
nvidia: Bumps libc binary to stable version

### DIFF
--- a/pkg/nvidia/Dockerfile
+++ b/pkg/nvidia/Dockerfile
@@ -88,9 +88,9 @@ RUN make && mkdir -p dist/ && cp nvfanctrl dist/
 
 # Get and extract ldconfig for glibc, this tool runs over the rootfs of the
 # application container, like CUDA application containers (glibc based).
-ADD http://ports.ubuntu.com/ubuntu-ports/pool/main/g/glibc/libc-bin_2.31-0ubuntu9.16_arm64.deb /
+ADD http://ports.ubuntu.com/ubuntu-ports/pool/main/g/glibc/libc-bin_2.31-0ubuntu9_arm64.deb /
 RUN mkdir -p /ldconfig-bin && \
-    dpkg -x /libc-bin_2.31-0ubuntu9.16_arm64.deb /ldconfig && \
+    dpkg -x /libc-bin_2.31-0ubuntu9_arm64.deb /ldconfig && \
     cp /ldconfig/sbin/ldconfig.real /ldconfig-bin/ldconfig-glibc
 
 # Copy udev rules


### PR DESCRIPTION
The libc package 9.16 was marked as "superseded" in favor of version 9.17 and removed from Ubuntu official repositories. This commit bumps the package to stable version 9 so it won't change the download link between security updates.