### PR TITLE
Propagate Windows license to the VMs

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -704,6 +704,7 @@ func parseAppInstanceConfig(getconfigCtx *getconfigContext,
 		appInstance.Service = cfgApp.Service
 		appInstance.CloudInitVersion = cfgApp.CloudInitVersion
 		appInstance.FixedResources.CPUsPinned = cfgApp.Fixedresources.PinCpu
+		appInstance.FixedResources.EnableOemWinLicenseKey = cfgApp.Fixedresources.EnableOemWinLicenseKey
 
 		// Parse the snapshot related fields
 		if cfgApp.Snapshot != nil {

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -648,7 +648,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext, dest destinationBitset) {
 	// device returns a runtime error. Similarly, we only support enforced application network
 	// interface order for the KVM hypervisor. If enabled for application deployed under Xen
 	// or Kubevirt hypervisor, EVE returns error and the application will not be started.
-	ReportDeviceInfo.ApiCapability = info.APICapability_API_CAPABILITY_NTPS_FQDN
+	ReportDeviceInfo.ApiCapability = info.APICapability_API_CAPABILITY_WIN_LIC_PASSTHROUGH
 
 	// Report if there is a local override of profile
 	if ctx.getconfigCtx.sideController.currentProfile !=

--- a/pkg/pillar/hypervisor/containerd.go
+++ b/pkg/pillar/hypervisor/containerd.go
@@ -358,3 +358,7 @@ func (ctx ctrdContext) VirtualTPMTerminate(domainName string, wp *types.Watchdog
 func (ctx ctrdContext) VirtualTPMTeardown(domainName string, wp *types.WatchdogParam) error {
 	return fmt.Errorf("not implemented")
 }
+
+func (ctx ctrdContext) OemWindowsLicenseKeySetup(wlk *types.OemWindowsLicenseKeyInfo) error {
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -1723,6 +1723,10 @@ func (ctx kubevirtContext) VirtualTPMTeardown(domainName string, wp *types.Watch
 	return fmt.Errorf("not implemented")
 }
 
+func (ctx kubevirtContext) OemWindowsLicenseKeySetup(wlk *types.OemWindowsLicenseKeyInfo) error {
+	return fmt.Errorf("not implemented")
+}
+
 // save the node-name to context map for later retrieval
 func saveMyNodeUUID(ctx *kubevirtContext, nodeName string) {
 	if len(ctx.nodeNameMap) == 0 {

--- a/pkg/pillar/hypervisor/null.go
+++ b/pkg/pillar/hypervisor/null.go
@@ -183,3 +183,7 @@ func (ctx nullContext) VirtualTPMTerminate(domainName string, wp *types.Watchdog
 func (ctx nullContext) VirtualTPMTeardown(domainName string, wp *types.WatchdogParam) error {
 	return fmt.Errorf("not implemented")
 }
+
+func (ctx nullContext) OemWindowsLicenseKeySetup(wlk *types.OemWindowsLicenseKeyInfo) error {
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/pillar/hypervisor/win.go
+++ b/pkg/pillar/hypervisor/win.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package hypervisor
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+)
+
+// getWindowsLicenseACPIPath returns the path to the ACPI tables that contain
+// the Windows license information.
+func getWindowsLicenseACPIPath() []string {
+	collectedLicenses := []string{}
+	// check for both MSDM and SLIC tables, SLIC is deprecated but we should
+	// look for it in case older versions of Windows are being used.
+	windowsLicenseTables := []string{"MSDM", "SLIC"}
+	acpiTablePath := "/sys/firmware/acpi/tables"
+
+	for _, table := range windowsLicenseTables {
+		sysfsPath := filepath.Join(acpiTablePath, table)
+		if _, err := os.Stat(sysfsPath); err != nil {
+			logrus.Infof("error while checkin %s table : %v", table, err)
+			continue
+		}
+
+		collectedLicenses = append(collectedLicenses, sysfsPath)
+	}
+
+	return collectedLicenses
+}

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -896,3 +896,7 @@ func (ctx xenContext) VirtualTPMTerminate(domainName string, wp *types.WatchdogP
 func (ctx xenContext) VirtualTPMTeardown(domainName string, wp *types.WatchdogParam) error {
 	return fmt.Errorf("not implemented")
 }
+
+func (ctx xenContext) OemWindowsLicenseKeySetup(wlk *types.OemWindowsLicenseKeyInfo) error {
+	return fmt.Errorf("not implemented")
+}


### PR DESCRIPTION
TODO : 

- [x] Test on a real HW with windows license
- [x] Take https://github.com/lf-edge/eve-api/pull/85 changes
- [x] add config to control which vm gets the license
- [x] remove TODOs and clean up

## Testing 
So far I can confirm that things work, I can read my injected ACPI table and SMBIOS inside a Ubuntu VM, running on top of EVE : 

```
dc32ca59-4b27-4ea8-9482-3e7175a3d041:~# eve list-app-consoles
PID	APP-UUID				CONS-TYPE	CONS-ID
---	--------				---------	---------
27944	27719702-c7fd-4d2f-af78-672cafb1b9b2	VM		27719702-c7fd-4d2f-af78-672cafb1b9b2.1.1/cons
dc32ca59-4b27-4ea8-9482-3e7175a3d041:~# eve attach-app-console 27719702-c7fd-4d2f-af78-672cafb1b9b2.1.1/cons
[12:58:58.047] tio v1.37
[12:58:58.047] Press ctrl-t q to quit
[12:58:58.047] Connected

Ubuntu-Instance login: ubuntu
Password:
Welcome to Ubuntu 24.04 LTS (GNU/Linux 6.8.0-39-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/pro

 System information as of Mon Feb 10 12:59:04 UTC 2025

  System load:  0.33              Processes:               148
  Usage of /:   70.9% of 2.35GB   Users logged in:         0
  Memory usage: 12%               IPv4 address for enp3s0: 10.1.0.128
  Swap usage:   0%

Expanded Security Maintenance for Applications is not enabled.

251 updates can be applied immediately.
73 of these updates are standard security updates.
To see these additional updates run: apt list --upgradable

Enable ESM Apps to receive additional future security updates.
See https://ubuntu.com/esm or run: sudo pro status



The programs included with the Ubuntu system are free software;
ubuntu@Ubuntu-Instance:~$ ls -al /sys/firmware/acpi/tables/
total 0
drwxr-xr-x 4 root root    0 Feb 10 13:00 .
drwxr-xr-x 5 root root    0 Feb 10 13:00 ..
-r-------- 1 root root  144 Feb 10 13:00 APIC
-r-------- 1 root root  160 Feb 10 13:00 DMAR
-r-------- 1 root root 8220 Feb 10 13:00 DSDT
-r-------- 1 root root  244 Feb 10 13:00 FACP
-r-------- 1 root root   64 Feb 10 13:00 FACS
-r-------- 1 root root   60 Feb 10 13:00 MCFG
-r-------- 1 root root   85 Feb 10 13:00 MSDM
-r-------- 1 root root  374 Feb 10 13:00 SLIC
-r-------- 1 root root   76 Feb 10 13:00 TPM2
-r-------- 1 root root   40 Feb 10 13:00 WAET
drwxr-xr-x 2 root root    0 Feb 10 13:00 data
drwxr-xr-x 2 root root    0 Feb 10 13:00 dynamic
ubuntu@Ubuntu-Instance:~$ sudo xxd /sys/firmware/acpi/tables/MSDM
00000000: 4d53 444d 5500 0000 03c6 4c45 4e4f 564f  MSDMU.....LENOVO
00000010: 5450 2d47 3220 2020 5025 0000 5054 4c20  TP-G2   P%..PTL
00000020: 0200 0000 0100 0000 0000 0000 0100 0000  ................
00000030: 0000 0000 1d00 0000 4237 4e43 392d 5643  ........B7NC9-VC
00000040: 4846 502d 4451 3936 4b2d 5437 504d 472d  HFP-DQ96K-T7PMG-
00000050: 5252 4448 32                             RRDH2
ubuntu@Ubuntu-Instance:~$
[13:01:59.638] Disconnected
dc32ca59-4b27-4ea8-9482-3e7175a3d041:~# xxd /persist/msWindowsLicenceStore/MSDM
00000000: 4d53 444d 5500 0000 03c6 4c45 4e4f 564f  MSDMU.....LENOVO
00000010: 5450 2d47 3220 2020 5025 0000 5054 4c20  TP-G2   P%..PTL
00000020: 0200 0000 0100 0000 0000 0000 0100 0000  ................
00000030: 0000 0000 1d00 0000 4237 4e43 392d 5643  ........B7NC9-VC
00000040: 4846 502d 4451 3936 4b2d 5437 504d 472d  HFP-DQ96K-T7PMG-
00000050: 5252 4448 32                             RRDH2
dc32ca59-4b27-4ea8-9482-3e7175a3d041:~#
```

I get the same Product ID in Windows 11 too : 

<img width="1262" alt="image" src="https://github.com/user-attachments/assets/2709dcb6-d9eb-43d7-b750-0f31cb735be7" />


Tested on HW with valid embedded Windows License : 
```
ssh -i ~/.ssh/id_rsa root@0.0.0.0 -p 9001
EVE is Edge Virtualization Engine

Take a look around and don't forget to use eve(1).
~ # 
~ # 
~ # 
~ # eve version
0.0.0-windows.lic.propagate-fd03077b-dirty-2025-02-19.10.50-kvm-amd64
~ # logread -f | grep guest

BdsDxe: loading Boot0001 "UEFI Misc Device" from PciRoot(0x0)/Pci(0x4,0x0)/Pci(0x0,0x0)
2025-03-07T10:22:29.20336594Z;guest_vm-a6303a6f-3628-417e-9c9d-21db356bbbf8.9.1;BdsDxe: loading Boot0001 "UEFI Misc Device" from PciRoot(0x0)/Pci(0x4,0x0)/Pci(0x0,0x0)
2025-03-07T10:22:29.239023113Z;guest_vm-a6303a6f-3628-417e-9c9d-21db356bbbf8.9.1;BdsDxe: starting Boot0001 "UEFI Misc Device" from PciRoot(0x0)/Pci(0x4,0x0)/Pci(0x0,0x0)
2025-03-07T10:22:29.249892161Z;guest_vm-a6303a6f-3628-417e-9c9d-21db356bbbf8.9.1;BdsDxe: starting Boot0001 "UEFI Misc Device" from PciRoot(0x0)/Pci(0x4,0x0)/Pci(0x0,0x0)
```
![image](https://github.com/user-attachments/assets/52123c55-435a-4981-b78f-b688dc1f367a)
