### PR TITLE
Make memory monitor configurable and disable it by default

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -67,7 +67,7 @@
 | goroutine.leak.detection.keep.stats.hours | integer (hours) | 24 | Amount of hours to keep the stats for leak detection. We keep more stats than the check window to be able to react to settings with a bigger check window via configuration. |
 | goroutine.leak.detection.cooldown.minutes | integer (minutes) | 5 | Cooldown period in minutes after the leak detection is triggered. During this period, no stack traces are collected; only warning messages are logged. |
 | kubevirt.drain.timeout | integer | 24 | hours to allow kubernetes to drain a node |
-| memory-monitor.enabled | boolean | true | Enable external memory monitoring and memory pressure events handling |
+| memory-monitor.enabled | boolean | false | Enable external memory monitoring and memory pressure events handling |
 
 ## Log levels
 

--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -67,6 +67,7 @@
 | goroutine.leak.detection.keep.stats.hours | integer (hours) | 24 | Amount of hours to keep the stats for leak detection. We keep more stats than the check window to be able to react to settings with a bigger check window via configuration. |
 | goroutine.leak.detection.cooldown.minutes | integer (minutes) | 5 | Cooldown period in minutes after the leak detection is triggered. During this period, no stack traces are collected; only warning messages are logged. |
 | kubevirt.drain.timeout | integer | 24 | hours to allow kubernetes to drain a node |
+| memory-monitor.enabled | boolean | true | Enable external memory monitoring and memory pressure events handling |
 
 ## Log levels
 

--- a/pkg/memory-monitor/README.md
+++ b/pkg/memory-monitor/README.md
@@ -190,6 +190,10 @@ This setup allows you to toggle memory monitoring on and off, which can be
 especially useful if you suspect that the memory monitor's handler script might
 be consuming excessive CPU or memory resources.
 
+As the memory monitor is a new component in the EVE system, and very few
+real-world testing was done with it, is important to be on the safe side, so we
+disable the memory monitor by default. It can be enabled by the user if needed.
+
 ## Internals of the build and startup process
 
 To deploy the memory monitor to the EVE system, we create a corresponding

--- a/pkg/memory-monitor/README.md
+++ b/pkg/memory-monitor/README.md
@@ -177,6 +177,19 @@ The tool than creates the output files in `/persist/memory-monitor/output`.
 The persistent storage is mounted to the container, so the output files are
 available in the host system.
 
+### Enabling memory monitor
+
+By default, the memory monitor is disabled: its container starts automatically
+with the EVE boot but remains paused. To activate memory monitoring, set the
+global configuration option `memory-monitor.enabled` to `true`. When Pillar
+receives this update, it simply resumes the paused container. Conversely, if
+you need to disable it again, setting the option to `false` will pause the
+container.
+
+This setup allows you to toggle memory monitoring on and off, which can be
+especially useful if you suspect that the memory monitor's handler script might
+be consuming excessive CPU or memory resources.
+
 ## Internals of the build and startup process
 
 To deploy the memory monitor to the EVE system, we create a corresponding

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -358,6 +358,9 @@ const (
 	// IsTimeout
 	// IsTooManyRequests
 	KubevirtDrainSkipK8sAPINotReachableTimeout GlobalSettingKey = "kubevirt.drain.skip.k8sapinotreachable.timeout"
+
+	// MemoryMonitorEnabled : Enable memory monitor
+	MemoryMonitorEnabled GlobalSettingKey = "memory-monitor.enabled"
 )
 
 // AgentSettingKey - keys for per-agent settings
@@ -1002,6 +1005,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddBoolItem(EnableARPSnoop, true)
 	configItemSpecMap.AddBoolItem(WwanQueryVisibleProviders, false)
 	configItemSpecMap.AddBoolItem(NetworkLocalLegacyMACAddress, false)
+	configItemSpecMap.AddBoolItem(MemoryMonitorEnabled, true)
 
 	// Add TriState Items
 	configItemSpecMap.AddTriStateItem(NetworkFallbackAnyEth, TS_DISABLED)

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -1005,7 +1005,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddBoolItem(EnableARPSnoop, true)
 	configItemSpecMap.AddBoolItem(WwanQueryVisibleProviders, false)
 	configItemSpecMap.AddBoolItem(NetworkLocalLegacyMACAddress, false)
-	configItemSpecMap.AddBoolItem(MemoryMonitorEnabled, true)
+	configItemSpecMap.AddBoolItem(MemoryMonitorEnabled, false)
 
 	// Add TriState Items
 	configItemSpecMap.AddTriStateItem(NetworkFallbackAnyEth, TS_DISABLED)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -200,6 +200,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		EnableARPSnoop,
 		WwanQueryVisibleProviders,
 		NetworkLocalLegacyMACAddress,
+		MemoryMonitorEnabled,
 		// TriState Items
 		NetworkFallbackAnyEth,
 		MaintenanceMode,


### PR DESCRIPTION
This PR introduces a way to enable or disable the memory monitor dynamically through the global configuration option `memory-monitor.enabled`. Since the memory monitor is a new component with limited real-world testing, it is disabled by default to ensure system stability. Users can enable it manually if needed.

The changes include:

* Adding `memory-monitor.enabled` to the global config and updating handling logic to pause or resume the memory monitor container accordingly.
* Updating documentation to describe how to use the new option.
* Setting the default value of `memory-monitor.enabled` to false so the memory monitor starts in a paused state unless explicitly enabled.

This ensures that the system remains stable while allowing users to experiment with the memory monitor when needed.