### PR TITLE
[13.4-stable] eve: Fix override configuration for ISO image generator

### DIFF
--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -162,6 +162,9 @@ do_installer_raw() {
 create_installer_iso() {
   mkdir -p /installer_root
   unsquashfs -f -d /installer_root /bits/installer.img 1>&2
+  if [ -e /bits/config.img ]; then
+      cp /bits/config.img /installer_root/
+  fi
   tar -C /installer_root -cf - . | VOLUME_LABEL=EVEISO /make-efi installer
   rm -rf /installer_root
 }


### PR DESCRIPTION
Backport of PR https://github.com/lf-edge/eve/pull/4608