### PR TITLE
GitHub Actions: bump runners ubuntu version to latest available

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -6,7 +6,7 @@
 # to "emulated" arm64 side on the amd64 runner.
 #
 # The trick we play is that we keep it as a matrix job still, but we make
-# it use the same GitHub provided x86 ubuntu-20.04 runners. The runner that
+# it use the same GitHub provided x86 ubuntu-24.04 runners. The runner that
 # gets to unpack arm64 artifacts does so with the help of binfmt-support and
 # qemu-user-static
 
@@ -46,7 +46,7 @@ jobs:
           echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
           echo "upload_url=$upload_url" >> "$GITHUB_OUTPUT"
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: create_release
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,17 +20,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [buildjet-4vcpu-ubuntu-2204-arm, buildjet-4vcpu-ubuntu-2004]
+        os: [buildjet-4vcpu-ubuntu-2204-arm, buildjet-4vcpu-ubuntu-2204]
         arch: [arm64, amd64]
         platform: [generic, nvidia-jp5, nvidia-jp6]
         include:
-          - os: buildjet-4vcpu-ubuntu-2004
+          - os: buildjet-4vcpu-ubuntu-2204
             arch: riscv64
             platform: generic
         exclude:
           - os: buildjet-4vcpu-ubuntu-2204-arm
             arch: amd64
-          - os: buildjet-4vcpu-ubuntu-2004
+          - os: buildjet-4vcpu-ubuntu-2204
             arch: arm64
           - arch: amd64
             platform: nvidia-jp5
@@ -94,7 +94,7 @@ jobs:
 
   eve:
     needs: packages  # all packages for all platforms must be built first
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: buildjet-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/buildondemand.yml
+++ b/.github/workflows/buildondemand.yml
@@ -28,9 +28,9 @@ jobs:
         include:
           - os: buildjet-4vcpu-ubuntu-2204-arm
             arch: arm64
-          - os: buildjet-4vcpu-ubuntu-2004
+          - os: buildjet-4vcpu-ubuntu-2204
             arch: amd64
-          - os: buildjet-4vcpu-ubuntu-2004
+          - os: buildjet-4vcpu-ubuntu-2204
             arch: riscv64
     steps:
       - name: Starting Report
@@ -84,7 +84,7 @@ jobs:
     needs: packages  # all packages for all platforms must be built first
     # Only run for the default branch
     if: github.ref_name == github.event.repository.default_branch
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: buildjet-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check-docker-hashes-consistency.yml
+++ b/.github/workflows/check-docker-hashes-consistency.yml
@@ -22,7 +22,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -20,7 +20,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           - os: arm64-secure
             arch: arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             arch: amd64
           - os: ubuntu-latest
             arch: riscv64

--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -16,7 +16,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   yetus:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Accoring to [1] Ubuntu 20.04 runners in GitHub will be fully unsuppoerted by 2025-04-01. This commit bumps GitHub-provided runners to latest available Ubuntu 24.04 and BuildJet-provided runners are updated to latest available Ubuntu 22.04

I am not changing runners to latest because fixed version guarantees stability of packages across workflow runs

[1] - https://github.com/actions/runner-images/issues/11101