### PR TITLE
dom0-ztools: add 'monitor' to EVESERVICES in cgroup init script.

### DIFF
--- a/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
@@ -9,7 +9,7 @@ hv=`cat /run/eve-hv-type`
 default_cgroup_cpus_limit=1
 
 default_cgroup_memory_limit=838860800 #800M
-EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd memlogd memory-monitor debug"
+EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd memlogd memory-monitor debug monitor"
 
 #Increase memory limits temporarily for kubevirt type only.
 case $hv in


### PR DESCRIPTION
Ensure the TUI monitor service is handled equally with other EVE services by adding it to the EVESERVICES list in the cgroup initialization script. This change ensures that the monitor service receives the same memory limits and resource constraints as other system services.