### PR TITLE
github/workflows/assets.yml: switch to builjet runners to upload assets

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -21,7 +21,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   create_release:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     outputs:
       release_id: ${{ steps.create_release.outputs.release_id }}
       upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -46,7 +46,7 @@ jobs:
           echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
           echo "upload_url=$upload_url" >> "$GITHUB_OUTPUT"
   build:
-    runs-on: ubuntu-24.04
+    runs-on: buildjet-4vcpu-ubuntu-2204
     needs: create_release
     strategy:
       fail-fast: false


### PR DESCRIPTION
The runner available from GitHub Actions encounters an OOM error while uploading assets.

We've switched to Buildjet runners for asset uploads instead.