### PR TITLE
eve: installer: Add rootwait by default

### DIFF
--- a/pkg/eve/installer/grub_installer.cfg
+++ b/pkg/eve/installer/grub_installer.cfg
@@ -1,8 +1,4 @@
 function installer_submenus {
-   menuentry 'force rootdelay for slow USB controllers' {
-      set_global dom0_extra_args "$dom0_extra_args rootdelay=30"
-   }
-
    menuentry 'do NOT install - collect black box instead' {
       set_global dom0_cmdline "$dom0_cmdline eve_blackbox"
    }
@@ -53,7 +49,7 @@ install_part="$cmddevice"
 cat -s boot_uid "($install_part)/boot/.uuid"
 set_global rootfs_title_suffix "-installer"
 set_global do_extra_submenus "installer_submenus"
-set_global dom0_extra_args "getty"
+set_global dom0_extra_args "getty rootwait"
 set_global eve_flavor kvm
 
 # to handle the case where the rootfs is on a CD/ISO with a label


### PR DESCRIPTION
We have experiencing issues with installer due to USB Sticks that take a few seconds to get detected by the system, leading to "rootfs not found" errors. This commit adds "rootwait" parameter by default, so the kernel will wait until root file system is available. The only drawback is that kernel can wait indefinitely in case of a real failure, but this should be easily noticed during the installer process. The old behavior can also be easily configured by overriding dom0_extra_args.

By using rootwait, doesn't make sense to keep the optional entry with rootdelay option, so it's removed.