### PR TITLE
Missing flags to mark install complete.

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -844,6 +844,7 @@ if [ ! -f /var/lib/all_components_initialized ]; then
                 continue
         fi
         logmsg "longhorn ready"
+        touch /var/lib/longhorn_initialized
 
         #
         # Descheduler
@@ -922,6 +923,7 @@ else
                 fi
                 if [ ! -e /var/lib/longhorn_configured ]; then
                         longhorn_post_install_config
+                        touch /var/lib/longhorn_configured
                 fi
         fi
 fi


### PR DESCRIPTION
/var/lib/longhorn_initialized for lh install complete 
/var/lib/longhorn_configured for lh post settings