### PR TITLE
Allow old IoUSB devices for config.enable.usb

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1396,7 +1396,7 @@ func usbControllersWithoutPCIReserve(ioBundles []types.IoBundle) map[string][]*t
 	usbControllerGroups := make(map[string][]*types.IoBundle) // assigngrp -> iobundle
 
 	for i, ioBundle := range ioBundles {
-		if ioBundle.Type != types.IoUSBController {
+		if !ioBundle.IsUSBController() {
 			continue
 		}
 

--- a/pkg/pillar/cmd/domainmgr/domainmgr_test.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr_test.go
@@ -595,7 +595,7 @@ func TestConfigEnableUsbUpdatePortAndPciBackIoBundle(t *testing.T) {
 		IoBundleList: []types.IoBundle{
 			{
 				Phylabel:        "IoUSB",
-				Type:            types.IoUSB,
+				Type:            types.IoUSBController,
 				KeepInHost:      false,
 				AssignmentGroup: "1",
 				PciLong:         "00:01",

--- a/pkg/pillar/cmd/watcher/watcher_test.go
+++ b/pkg/pillar/cmd/watcher/watcher_test.go
@@ -406,7 +406,7 @@ func TestGoroutinesMonitorUpdateParamsKeepStatsDecrease(t *testing.T) {
 	// Check if the log output contains the expected messages
 	for _, expectedMsg := range expectedMsgs {
 		if !strings.Contains(string(output), expectedMsg) {
-			t.Errorf("Expected log output to contain '%s'", expectedMsg)
+			t.Errorf("Expected log output to contain '%s', but got '%s'", expectedMsg, output)
 		}
 	}
 }

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -427,7 +427,7 @@ func (ctx kubevirtContext) CreateReplicaVMIConfig(domainName string, config type
 			}
 			if ib.PciLong != "" {
 				logrus.Infof("Adding PCI device <%v>\n", ib.PciLong)
-				tap := pciDevice{pciLong: ib.PciLong, ioType: ib.Type}
+				tap := pciDevice{ioBundle: *ib}
 				pciAssignments = addNoDuplicatePCI(pciAssignments, tap)
 			}
 		}

--- a/pkg/pillar/hypervisor/kvm_test.go
+++ b/pkg/pillar/hypervisor/kvm_test.go
@@ -1095,7 +1095,7 @@ func domainConfigAndAssignableAdapters(dcl []types.DiskConfig) (types.DomainConf
 		IoAdapterList: []types.IoAdapter{
 			{Type: types.IoNetEth, Name: "eth0"},
 			{Type: types.IoCom, Name: "COM1"},
-			{Type: types.IoUSB, Name: "USB1"},
+			{Type: types.IoUSBDevice, Name: "USB1"},
 		},
 	}
 
@@ -1119,7 +1119,7 @@ func domainConfigAndAssignableAdapters(dcl []types.DiskConfig) (types.DomainConf
 				UsedByUUID:      config.UUIDandVersion.UUID,
 			},
 			{
-				Type:            types.IoUSB,
+				Type:            types.IoUSBDevice,
 				AssignmentGroup: "USB1",
 				Phylabel:        "USB1:1",
 				UsbAddr:         "1:1",
@@ -2942,7 +2942,7 @@ func TestPCIAddressAllocator(t *testing.T) {
 		},
 		{
 			pciLong: "0000:00:15.0",
-			ioType:  types.IoUSB,
+			ioType:  types.IoUSBController,
 		},
 		{
 			pciLong: "0000:06:00.2",

--- a/pkg/pillar/hypervisor/kvm_test.go
+++ b/pkg/pillar/hypervisor/kvm_test.go
@@ -2832,20 +2832,28 @@ func expectedMultifunctionDevice() string {
 func TestPCIAssignmentsTemplateFillMultifunctionDevice(t *testing.T) {
 	pciAssignments := []pciDevice{
 		{
-			pciLong: "0000:00:0a.0",
-			ioType:  0,
+			ioBundle: types.IoBundle{
+				PciLong: "0000:00:0a.0",
+				Type:    0,
+			},
 		},
 		{
-			pciLong: "0000:00:0d.0",
-			ioType:  0,
+			ioBundle: types.IoBundle{
+				PciLong: "0000:00:0d.0",
+				Type:    0,
+			},
 		},
 		{
-			pciLong: "0000:00:0b.0",
-			ioType:  0,
+			ioBundle: types.IoBundle{
+				PciLong: "0000:00:0b.0",
+				Type:    0,
+			},
 		},
 		{
-			pciLong: "0000:00:0d.2",
-			ioType:  0,
+			ioBundle: types.IoBundle{
+				PciLong: "0000:00:0d.2",
+				Type:    0,
+			},
 		},
 	}
 
@@ -2873,20 +2881,28 @@ func TestPCIAssignmentsTemplateFillMultifunctionDevice(t *testing.T) {
 func TestConvertToMultifunctionPCIDevices(t *testing.T) {
 	pciAssignments := []pciDevice{
 		{
-			pciLong: "0000:00:0d.0",
-			ioType:  0,
+			ioBundle: types.IoBundle{
+				PciLong: "0000:00:0d.0",
+				Type:    0,
+			},
 		},
 		{
-			pciLong: "0000:00:aa.8",
-			ioType:  0,
+			ioBundle: types.IoBundle{
+				PciLong: "0000:00:aa.8",
+				Type:    0,
+			},
 		},
 		{
-			pciLong: "0000:00:0d.2",
-			ioType:  0,
+			ioBundle: types.IoBundle{
+				PciLong: "0000:00:0d.2",
+				Type:    0,
+			},
 		},
 		{
-			pciLong: "0000:00:0d.f",
-			ioType:  0,
+			ioBundle: types.IoBundle{
+				PciLong: "0000:00:0d.f",
+				Type:    0,
+			},
 		},
 	}
 
@@ -2898,7 +2914,7 @@ func TestConvertToMultifunctionPCIDevices(t *testing.T) {
 
 	t.Log(mds)
 	for i, pci := range []string{"0000:00:0d.0", "0000:00:0d.2", "0000:00:0d.f"} {
-		functionPCIDev := mds["0000:00:0d"].devs[i].pciLong
+		functionPCIDev := mds["0000:00:0d"].devs[i].ioBundle.PciLong
 		if functionPCIDev != pci {
 			t.Logf("expected %s got %s", pci, functionPCIDev)
 			t.Fail()
@@ -2936,26 +2952,36 @@ func TestPCIAddressAllocator(t *testing.T) {
 	}
 	pciAssignments := []pciDevice{
 		{
-			pciLong:      "0000:06:00.0",
-			ioType:       types.IoNetEth,
+			ioBundle: types.IoBundle{
+				PciLong: "0000:06:00.0",
+				Type:    types.IoNetEth,
+			},
 			netIntfOrder: 2,
 		},
 		{
-			pciLong: "0000:00:15.0",
-			ioType:  types.IoUSBController,
+			ioBundle: types.IoBundle{
+				PciLong: "0000:00:15.0",
+				Type:    types.IoUSBController,
+			},
 		},
 		{
-			pciLong: "0000:06:00.2",
-			ioType:  types.IoOther,
+			ioBundle: types.IoBundle{
+				PciLong: "0000:06:00.2",
+				Type:    types.IoOther,
+			},
 		},
 		{
-			pciLong:      "0000:06:00.1",
-			ioType:       types.IoNetEth,
+			ioBundle: types.IoBundle{
+				PciLong: "0000:06:00.1",
+				Type:    types.IoNetEth,
+			},
 			netIntfOrder: 3,
 		},
 		{
-			pciLong:      "0000:08:00.0",
-			ioType:       types.IoNetWWAN,
+			ioBundle: types.IoBundle{
+				PciLong: "0000:08:00.0",
+				Type:    types.IoNetWWAN,
+			},
 			netIntfOrder: 0,
 		},
 	}

--- a/pkg/pillar/hypervisor/pci_test.go
+++ b/pkg/pillar/hypervisor/pci_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,7 +39,7 @@ func TestPCIReadResources(t *testing.T) {
 	}
 
 	// Instantiate the PCI device and call readResources()
-	pciDev := pciDevice{pciLong: "0000:00:1f.0"}
+	pciDev := pciDevice{ioBundle: types.IoBundle{PciLong: "0000:00:1f.0"}}
 	resources, err := pciDev.readResources(tempDir)
 
 	// Assertions

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -413,7 +413,7 @@ func (ctx xenContext) CreateDomConfig(domainName string,
 			short := types.PCILongToShort(pa.pciLong)
 			// USB controller are subject to legacy USB support from
 			// some BIOS. Use relaxed to get past that.
-			if pa.ioType == types.IoUSB {
+			if pa.ioType == types.IoUSBController {
 				cfg = cfg + fmt.Sprintf("'%s,rdm_policy=relaxed'",
 					short)
 			} else {

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -381,7 +381,7 @@ func (ctx xenContext) CreateDomConfig(domainName string,
 					domainName)
 			}
 			if ib.PciLong != "" {
-				tap := pciDevice{pciLong: ib.PciLong, ioType: ib.Type}
+				tap := pciDevice{ioBundle: *ib}
 				pciAssignments = addNoDuplicatePCI(pciAssignments, tap)
 			}
 			if ib.Irq != "" && config.VirtualizationMode == types.PV {
@@ -410,10 +410,10 @@ func (ctx xenContext) CreateDomConfig(domainName string,
 			if i != 0 {
 				cfg = cfg + ", "
 			}
-			short := types.PCILongToShort(pa.pciLong)
+			short := types.PCILongToShort(pa.ioBundle.PciLong)
 			// USB controller are subject to legacy USB support from
 			// some BIOS. Use relaxed to get past that.
-			if pa.ioType == types.IoUSBController {
+			if pa.ioBundle.Type == types.IoUSBController {
 				cfg = cfg + fmt.Sprintf("'%s,rdm_policy=relaxed'",
 					short)
 			} else {

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -413,7 +413,7 @@ func (ctx xenContext) CreateDomConfig(domainName string,
 			short := types.PCILongToShort(pa.ioBundle.PciLong)
 			// USB controller are subject to legacy USB support from
 			// some BIOS. Use relaxed to get past that.
-			if pa.ioBundle.Type == types.IoUSBController {
+			if pa.ioBundle.IsUSBController() {
 				cfg = cfg + fmt.Sprintf("'%s,rdm_policy=relaxed'",
 					short)
 			} else {

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -210,6 +210,21 @@ type VfInfo struct {
 // Really a constant
 var nilUUID = uuid.UUID{}
 
+// IsUSBController checks if the IoBundle is a USB controller, including when using the deprecated type IoUSB
+func (ib IoBundle) IsUSBController() bool {
+	if ib.Type == IoUSBController {
+		return true
+	}
+
+	// let's assume that if no usbaddr and no usbproduct is set, that it is a USB controller
+	// we cannot check for PciLong as there are USB controllers out there that are not connected via PCI
+	if ib.Type == IoUSB && ib.UsbAddr == "" && ib.UsbProduct == "" {
+		return true
+	}
+
+	return false
+}
+
 // HasAdapterChanged - We store each Physical Adapter using the IoBundle object.
 // Compares IoBundle with Physical adapter and returns if they are the Same
 // or the Physical Adapter has changed.

--- a/pkg/pillar/types/assignableadapters_test.go
+++ b/pkg/pillar/types/assignableadapters_test.go
@@ -251,7 +251,7 @@ var aa2 = AssignableAdapters{
 			PciLong:         "0000:f8:00.1",
 		},
 		{
-			Type:            IoUSB,
+			Type:            IoUSBController,
 			Phylabel:        "USB0",
 			Logicallabel:    "USB0",
 			AssignmentGroup: "USB-A",
@@ -259,7 +259,7 @@ var aa2 = AssignableAdapters{
 			PciLong:         "0000:f0:15.0",
 		},
 		{
-			Type:            IoUSB,
+			Type:            IoUSBController,
 			Phylabel:        "USB1",
 			Logicallabel:    "USB1",
 			AssignmentGroup: "USB-A",
@@ -267,7 +267,7 @@ var aa2 = AssignableAdapters{
 			PciLong:         "0000:f0:15.0",
 		},
 		{
-			Type:            IoUSB,
+			Type:            IoUSBController,
 			Phylabel:        "USB2",
 			Logicallabel:    "USB2",
 			AssignmentGroup: "USB-A",
@@ -275,7 +275,7 @@ var aa2 = AssignableAdapters{
 			PciLong:         "0000:f0:15.0",
 		},
 		{
-			Type:            IoUSB,
+			Type:            IoUSBController,
 			Phylabel:        "USB3",
 			Logicallabel:    "USB3",
 			AssignmentGroup: "USB-A",
@@ -283,7 +283,7 @@ var aa2 = AssignableAdapters{
 			PciLong:         "0000:f0:15.0",
 		},
 		{
-			Type:            IoUSB,
+			Type:            IoUSBController,
 			Phylabel:        "USB4",
 			Logicallabel:    "USB4",
 			AssignmentGroup: "USB-A",
@@ -291,7 +291,7 @@ var aa2 = AssignableAdapters{
 			PciLong:         "0000:f0:15.0",
 		},
 		{
-			Type:            IoUSB,
+			Type:            IoUSBController,
 			Phylabel:        "USB5",
 			Logicallabel:    "USB5",
 			AssignmentGroup: "USB-A",
@@ -299,7 +299,7 @@ var aa2 = AssignableAdapters{
 			PciLong:         "0000:f0:15.0",
 		},
 		{
-			Type:            IoUSB,
+			Type:            IoUSBController,
 			Phylabel:        "USB-C",
 			Logicallabel:    "USB6",
 			AssignmentGroup: "USB-C",


### PR DESCRIPTION
IoUsb should not be used anymore in favor of IoUsbController and IoUsbDevice 
but let's still be backwards compatible and make an intelligent guess whether a device or a controller was meant

