### PR TITLE
fix: allow ICMP echo-requests only for traffic destined to EVE

### DIFF
--- a/pkg/pillar/dpcreconciler/linux.go
+++ b/pkg/pillar/dpcreconciler/linux.go
@@ -1780,12 +1780,12 @@ func (r *LinuxDpcReconciler) getIntendedFilterRules(gcp types.ConfigItemValueMap
 	}
 	inputV4Rules = append(inputV4Rules, dhcpRule)
 
-	// Allow all ICMP traffic to enter the device from outside.
+	// Allow ICMP echo request to enter the device from outside.
 	icmpRule := iptables.Rule{
-		RuleLabel:   "Allow ICMP",
-		MatchOpts:   []string{"-p", "icmp"},
+		RuleLabel:   "Allow ICMP echo request",
+		MatchOpts:   []string{"-p", "icmp", "--icmp-type", "echo-request"},
 		Target:      "ACCEPT",
-		Description: "Allow ICMP traffic to enter the device from outside",
+		Description: "Allow ICMP echo request to enter the device from outside",
 	}
 	inputV4Rules = append(inputV4Rules, icmpRule)
 	icmpV6Rule := icmpRule // copy


### PR DESCRIPTION
- Allow only ICMP type 8 (echo-request) and not general ICMP traffic for ingress traffic towards EVE. This makes the firewall more strict on the type of ICMP traffic allowed for improved security. 