### PR TITLE
Makefile: Add platform variant to eve container's TAG and rootfs version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,12 @@ ifeq ($(DEV),y)
 	DEV_TAG:=-dev
 endif
 
+ifeq ($(PLATFORM),generic)
+TAGPLAT=
+else
+TAGPLAT=$(PLATFORM)
+endif
+
 # ROOTFS_VERSION used to construct the installer directory
 # set this to the current tag only if we are building from a tag
 ROOTFS_VERSION:=$(if $(findstring snapshot,$(REPO_TAG)),$(EVE_SNAPSHOT_VERSION)-$(REPO_BRANCH)-$(REPO_SHA)$(REPO_DIRTY_TAG)$(DEV_TAG),$(REPO_TAG))
@@ -108,6 +114,9 @@ ROOTFS_VERSION:=$(if $(findstring snapshot,$(REPO_TAG)),$(EVE_SNAPSHOT_VERSION)-
 #if KERNEL_TAG is set, append it to the ROOTFS_VERSION but replace docker.io/lfedge/eve-kernel:eve-kernel- part with k-
 SHORT_KERNEL_TAG=$(subst docker.io/lfedge/eve-kernel:eve-kernel-,k-,$(KERNEL_TAG))
 ROOTFS_VERSION:=$(if $(SHORT_KERNEL_TAG),$(ROOTFS_VERSION)-$(SHORT_KERNEL_TAG),$(ROOTFS_VERSION))
+
+# For non-generic platforms, include the variant to the rootfs version
+ROOTFS_VERSION:=$(if $(TAGPLAT),$(ROOTFS_VERSION)-$(TAGPLAT),$(ROOTFS_VERSION))
 
 HOSTARCH:=$(subst aarch64,arm64,$(subst x86_64,amd64,$(shell uname -m)))
 # by default, take the host architecture as the target architecture, but can override with `make ZARCH=foo`
@@ -883,7 +892,7 @@ eve: $(INSTALLER) $(EVE_ARTIFACTS) current $(RUNME) $(BUILD_YML) | $(BUILD_DIR)
 	$(PARSE_PKGS) pkg/eve/Dockerfile.in > $|/Dockerfile
 	$(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) $(LINUXKIT_ORG_TARGET) --platforms linux/$(ZARCH) --hash-path $(CURDIR) --hash $(ROOTFS_VERSION)-$(HV) --docker $(if $(strip $(EVE_REL)),--release) $(EVE_REL)$(if $(strip $(EVE_REL)),-$(HV)) $(FORCE_BUILD) $|
 	$(QUIET)if [ -n "$(EVE_REL)" ] && [ $(HV) = $(HV_DEFAULT) ]; then \
-	   $(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) $(LINUXKIT_ORG_TARGET) --platforms linux/$(ZARCH) --hash-path $(CURDIR) --hash $(EVE_REL)-$(HV) --docker --release $(EVE_REL) $(FORCE_BUILD) $| ;\
+	   $(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) $(LINUXKIT_ORG_TARGET) --platforms linux/$(ZARCH) --hash-path $(CURDIR) --hash $(EVE_REL)-$(if $(TAGPLAT),$(TAGPLAT)-)$(HV) --docker --release $(EVE_REL) $(FORCE_BUILD) $| ;\
 	fi
 	$(QUIET): $@: Succeeded
 


### PR DESCRIPTION
In order to push the eve container for different variants, we must set different TAGs. Following the same approach for pkg/fw and pkg/nvidia, this commit adds the platform variant to the eve container's TAG when building for non-generic platforms. Nothing changes for generic (and specially x86) platforms.

Additionally, EVE-OS images must be differentiated across platform variants, so a remote controller can provide the same version for different platforms, e.g., generic, nvidia-jp5, nvidia-jp6. The platform variant is also added to the rootfs version (except for the default 'generic' platform).

The new TAG scheme changes from:

`<HASH/EVE_RELEASE>-<HV>-<ARCH>`

To:

`<HASH/EVE_RELEASE>-<PLATFORM_VARIANT>-<HV>-<ARCH>`

The PLATFORM variant is added right after the hash/release in order to keep the tuple `<HV>-<ARCH>`, keeping compatibilty with any script/tool that expects this kind of tag.