### PR TITLE
gh: disable slurping in curl

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -124,7 +124,7 @@ jobs:
             upload_response=$(curl -s -X POST \
               -H "Authorization: Bearer $GITHUB_TOKEN" \
               -H "Content-Type: application/octet-stream" \
-              --data-binary @"assets/$new_name" \
+              -T "assets/$new_name" \
               "$UPLOAD_URL?name=$new_name")
             if echo "$upload_response" | jq -e .id > /dev/null; then
               echo "$file_name uploaded successfully."


### PR DESCRIPTION
curl --data-binary reads in the whole file first before sending it
see also: https://github.com/curl/curl/issues/1385#issuecomment-291442642