### PR TITLE
nvidia: Fix script and udev for Jetpack 5

### DIFF
--- a/pkg/nvidia/scripts/jp5/nv-init.sh
+++ b/pkg/nvidia/scripts/jp5/nv-init.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2024 Zededa, Inc.
+# Copyright (c) 2024-2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 VENDOR="/opt/vendor/nvidia"
@@ -22,11 +22,13 @@ udevadm info -a -p /devices/gpu.0
 modprobe nvidia
 modprobe nvidia_modeset
 
-# Enforces add for framebuffer and nvidia modules, so we have /dev/fb0 and
-# /dev/nvidiactrl even when there is no monitor connected to the display
-# port. These devices must be present because they are on the CDI spec.
+# Enforces add for framebuffer and nvidia modules, so we have /dev/fb0,
+# /dev/nvidiactrl and /dev/tegra_dc_1 even when there is no monitor connected
+# to the display port. These devices must be present because they are on the
+# CDI spec.
 echo "add" > /sys/module/fb/uevent 2> /dev/null
 echo "add" > /sys/module/nvidia/uevent 2> /dev/null
+echo "add" > /sys/devices/platform/host1x/uevent 2> /dev/null
 
 # Start FAN controller detached from terminal
 if [ -f "$FANCTRL" ]; then

--- a/pkg/nvidia/udev/jp5/rules.d/90-eve-nvidia.rules
+++ b/pkg/nvidia/udev/jp5/rules.d/90-eve-nvidia.rules
@@ -1,12 +1,14 @@
 # EVE-OS udev rules for NVIDIA Jetson Xavier and Orin platforms
 
-# Ensure fb0 file device to be present in the system (otherwise OCI spec will fail)
+# Ensure fb0 and fb1 file devices to be present in the system (otherwise OCI spec will fail)
 KERNEL=="fb", RUN+="/bin/mknod -m 660 /dev/fb0 c %M 0"
+KERNEL=="fb", RUN+="/bin/mknod -m 660 /dev/fb1 c %M 1"
 
 # NVIDIA modules
 KERNEL=="nvidia", RUN+="/bin/mknod -m 660 /dev/nvidiactl c 195 255"
 KERNEL=="nvidia", RUN+="/bin/mknod -m 660 /dev/nvidia0 c 195 0"
 KERNEL=="nvidia_modeset", RUN+="/bin/mknod -m 660 /dev/nvidia-modeset c %M %m"
+DRIVER=="host1x", RUN+="/bin/mknod -m 660 /dev/tegra_dc_1 c %M 1"
 
 # Set SD card read_ahead_kb to 2048 (taken from Jetpack)
 KERNEL=="mmcblk[0-9]", SUBSYSTEMS=="mmc", ACTION=="add|change", ATTR{bdi/read_ahead_kb}="2048"


### PR DESCRIPTION
The second framebuffer device (/dev/fb1) and the /dev/tegra_dc_1 are not initialized by default on the Siemens IPC520A device, so let's add some rules to enforce the creation of these files on Jetpack 5.x.