### PR TITLE
Fix dhcpcd arguments for static IP config

### DIFF
--- a/pkg/pillar/dpcreconciler/genericitems/dhcpcd.go
+++ b/pkg/pillar/dpcreconciler/genericitems/dhcpcd.go
@@ -59,8 +59,8 @@ func (c Dhcpcd) Equal(other depgraph.Item) bool {
 	// Consider two DHCP configs as equal if they result in the same set of arguments for dhcpcd.
 	// This avoids unnecessary restarts of dhcpcd (when e.g. going from override to zedagent DPC).
 	configurator := &DhcpcdConfigurator{}
-	op1, args1 := configurator.dhcpcdArgs(c.DhcpConfig)
-	op2, args2 := configurator.dhcpcdArgs(c2.DhcpConfig)
+	op1, args1 := configurator.DhcpcdArgs(c.DhcpConfig)
+	op2, args2 := configurator.DhcpcdArgs(c2.DhcpConfig)
 	if op1 != op2 || len(args1) != len(args2) {
 		return false
 	}
@@ -151,7 +151,7 @@ func (c *DhcpcdConfigurator) Create(ctx context.Context, item depgraph.Item) err
 		}
 
 		// Prepare input arguments for dhcpcd.
-		op, args := c.dhcpcdArgs(config)
+		op, args := c.DhcpcdArgs(config)
 
 		// Start DHCP client.
 		if c.dhcpcdExists(client.AdapterIfName) {
@@ -275,7 +275,9 @@ func (c *DhcpcdConfigurator) NeedsRecreate(oldItem, newItem depgraph.Item) (recr
 	return true
 }
 
-func (c *DhcpcdConfigurator) dhcpcdArgs(config types.DhcpConfig) (op string, args []string) {
+// DhcpcdArgs returns command line arguments for dhcpcd corresponding to the given
+// DHCP config. The method is exported only for the purpose of unit testing.
+func (c *DhcpcdConfigurator) DhcpcdArgs(config types.DhcpConfig) (op string, args []string) {
 	switch config.Dhcp {
 	case types.DhcpTypeClient:
 		op = "--request"
@@ -327,9 +329,9 @@ func (c *DhcpcdConfigurator) dhcpcdArgs(config types.DhcpConfig) (op string, arg
 		if config.NTPServers != nil {
 			for _, ntpServer := range config.NTPServers {
 				args = append(args, "--static", fmt.Sprintf("ntp_servers=%s", ntpServer))
-				args = append(args, extras...)
 			}
 		}
+		args = append(args, extras...)
 	}
 
 	return op, args

--- a/pkg/pillar/dpcreconciler/genericitems/dhcpcd_test.go
+++ b/pkg/pillar/dpcreconciler/genericitems/dhcpcd_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package genericitems_test
 
 import (
@@ -6,6 +9,7 @@ import (
 
 	configitems "github.com/lf-edge/eve/pkg/pillar/dpcreconciler/genericitems"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
 )
 
 func TestDhcpcdEqual(t *testing.T) {
@@ -137,6 +141,96 @@ func TestDhcpcdEqual(t *testing.T) {
 		if test.item1.Equal(test.item2) != test.expEqual {
 			t.Errorf("TEST CASE \"%s\" FAILED - Equal() returned: %t, expected: %t",
 				test.name, test.item1.Equal(test.item2), test.expEqual)
+		}
+	}
+}
+
+func TestDhcpcdArgs(t *testing.T) {
+	t.Parallel()
+	type test struct {
+		name    string
+		config  types.DhcpConfig
+		expOp   string
+		expArgs []string
+	}
+	var tests = []test{
+		{
+			name: "DHCP client for IPv4 only",
+			config: types.DhcpConfig{
+				Dhcp: types.DhcpTypeClient,
+				Type: types.NetworkTypeIpv4Only,
+			},
+			expOp:   "--request",
+			expArgs: []string{"-f", "/dhcpcd.conf", "--noipv4ll", "--ipv4only", "-b", "-t", "0"},
+		},
+		{
+			name: "DHCP client for IPv4 only with zero gateway",
+			config: types.DhcpConfig{
+				Dhcp:    types.DhcpTypeClient,
+				Type:    types.NetworkTypeIpv4Only,
+				Gateway: net.IP{0, 0, 0, 0},
+			},
+			expOp:   "--request",
+			expArgs: []string{"-f", "/dhcpcd.conf", "--noipv4ll", "--ipv4only", "-b", "-t", "0", "--nogateway"},
+		},
+		{
+			name: "DHCP client for IPv6 only",
+			config: types.DhcpConfig{
+				Dhcp: types.DhcpTypeClient,
+				Type: types.NetworkTypeIpv6Only,
+			},
+			expOp:   "--request",
+			expArgs: []string{"-f", "/dhcpcd.conf", "--ipv6only", "-b", "-t", "0"},
+		},
+		{
+			name: "DHCP client for dual stack",
+			config: types.DhcpConfig{
+				Dhcp: types.DhcpTypeClient,
+				Type: types.NetworkTypeDualStack,
+			},
+			expOp:   "--request",
+			expArgs: []string{"-f", "/dhcpcd.conf", "--noipv4ll", "-b", "-t", "0"},
+		},
+		{
+			name: "Static IPv4 config",
+			config: types.DhcpConfig{
+				Dhcp:       types.DhcpTypeStatic,
+				AddrSubnet: "192.168.1.44/24",
+				Gateway:    net.IP{192, 168, 1, 1},
+				DomainName: "mydomain",
+				NTPServers: []string{"192.168.1.1", "10.10.12.13"},
+				DNSServers: []net.IP{net.ParseIP("8.8.8.8")},
+				Type:       types.NetworkTypeIpv4Only, // irrelevant
+			},
+			expOp: "--static",
+			expArgs: []string{"ip_address=192.168.1.44/24", "--static", "routers=192.168.1.1",
+				"--static", "domain_name=mydomain", "--static", "domain_name_servers=8.8.8.8",
+				"--static", "ntp_servers=192.168.1.1", "--static", "ntp_servers=10.10.12.13",
+				"-f", "/dhcpcd.conf", "-b", "-t", "0"},
+		},
+		{
+			name: "Static IPv4 config with unspecified gateway",
+			config: types.DhcpConfig{
+				Dhcp:       types.DhcpTypeStatic,
+				AddrSubnet: "192.168.1.44/24",
+				DomainName: "mydomain",
+				NTPServers: []string{"192.168.1.1", "10.10.12.13"},
+				DNSServers: []net.IP{net.ParseIP("8.8.8.8")},
+				Type:       types.NetworkTypeIpv4Only, // irrelevant
+			},
+			expOp: "--static",
+			expArgs: []string{"ip_address=192.168.1.44/24",
+				"--static", "domain_name=mydomain", "--static", "domain_name_servers=8.8.8.8",
+				"--static", "ntp_servers=192.168.1.1", "--static", "ntp_servers=10.10.12.13",
+				"-f", "/dhcpcd.conf", "-b", "-t", "0", "--nogateway"},
+		},
+	}
+	configurator := configitems.DhcpcdConfigurator{}
+	for _, test := range tests {
+		op, args := configurator.DhcpcdArgs(test.config)
+		if op != test.expOp || !generics.EqualLists(args, test.expArgs) {
+			t.Errorf("TEST CASE \"%s\" FAILED - DhcpcdArgs() returned: %s %v, "+
+				"expected: %s %v", test.name, op, args, test.expOp, test.expArgs)
 		}
 	}
 }


### PR DESCRIPTION
Commit bcb650f93 (`pillar: enhance NTP server handling`) introduced a bug in `DhcpcdConfigurator` (EVE version `14.0.0`), where certain arguments for `dhcpcd` may be unintentionally omitted in static IP configurations.

Specifically, the configuration file option (`-f`), background execution (`-b`), and infinite timeout (`-t 0`) may be missing. As a result, if `dhcpcd` starts while the network cable is unplugged, it will timeout after 30 seconds (default timeout) and exit. Consequently, even after the cable is reconnected, `dhcpcd` will no longer be running to apply the static IP.