### PR TITLE
Convert ISO installer rootfs to squashfs image

### DIFF
--- a/pkg/eve/installer/grub_installer.cfg
+++ b/pkg/eve/installer/grub_installer.cfg
@@ -60,6 +60,6 @@ if [ "$rootlabel" = "EVEISO" ]; then
       set_global rootfs_root "/installer.iso"
    else
       set_global initrd "/boot/initrd.img" # add a simple custom initrd that will find the CD based on the label on the next line
-      set_global rootfs_root "LABEL=$rootlabel"
+      set_global rootfs_root "LABEL=$rootlabel rootimg=/rootfs_installer.img"
    fi
 fi

--- a/pkg/mkimage-iso-efi/Dockerfile
+++ b/pkg/mkimage-iso-efi/Dockerfile
@@ -1,6 +1,6 @@
 FROM lfedge/eve-alpine:591df01e581889c3027514c8a91feaca1c8ad49f AS build
 
-ENV PKGS dosfstools libarchive-tools binutils mtools xorriso mkinitfs
+ENV PKGS dosfstools libarchive-tools binutils mtools xorriso mkinitfs squashfs-tools
 RUN eve-alpine-deploy.sh
 
 RUN echo "mtools_skip_check=1" >> /out/etc/mtools.conf

--- a/pkg/mkimage-iso-efi/make-efi
+++ b/pkg/mkimage-iso-efi/make-efi
@@ -18,10 +18,24 @@ copy() {
 # We could do this in /tmp, but it might be really big, and for cases where
 # /tmp is tmpfs, that might use up a lot of memory
 #
+ROOTFS=/var/efi-rootfs
+mkdir -p $ROOTFS
+cd $ROOTFS
+bsdtar xzf -
+
+# Create and change to a working directory for the ISO image
 TMPDIR=/var/efiparts-$$
 mkdir -p $TMPDIR
 cd $TMPDIR
-bsdtar xzf -
+
+# Some files must also be present at the rootfs of the boot device
+cp -r ${ROOTFS}/EFI .
+cp -r ${ROOTFS}/boot .
+mkdir -p ./etc
+cp -r ${ROOTFS}/etc/eve-release ./etc/
+
+# Build a squashfs image for the installer rootfs
+mksquashfs $ROOTFS rootfs_installer.img -noappend -comp xz -no-recovery
 
 # create a ISO with a EFI boot partition
 # Stuff it into a FAT filesystem, making it as small as possible.  511KiB


### PR DESCRIPTION
## Description

This PR converts the rootfs of the ISO installer image to a squashfs image. The rootfs image of the installer is generated by linuxkit and packaged into a tarball that later on is fully extracted to compose the root of the ISO image. This approach has some major drawbacks:

1. It increases the size of the ISO image
2. It fails to work with flashing tools such as Rufus because these tools will format the target USB installer stick as FAT32, which  has several issues to work as a rootfs, such as the lack of file permissions support.

### How the current implementation works?

1. ISO boots, loads the kernel + initramdisk
2. Initrd script performs initial operations (basic mounts, etc)
3. Initrd script finds/wait for the installer device (e.g. USB Stick)
4. Initrd script mounts the installer device
5. Initrd script performs a switch_root to the installer device
6. After the switch_root, /sbin/init (linuxkit) from installer device is executed and the installation process will begin

### How it works with this PR?

The workflow is pretty much the same, the only difference is that the installer rootfs will be packed into a single image to be present at the installer device:

1. ISO boots, loads the kernel + initramdisk
2. Initrd script performs initial operations (basic mounts, etc)
3. Initrd script finds/wait for the installer device (e.g. USB Stick)
4. Initrd script mounts the installer device
5. **Initrd finds the installer rootfs squashfs image in the installer device**
6. **Initrd mounts the rootfs squashfs image** 
7. Initrd script performs a switch_root to the rootfs installer image
8. After the switch_root, /sbin/init (linuxkit) from installer device image is executed and the installation process will begin

## Improvements

1. Image size reduces from 723MB to **438MB** !
2. Flashing ISO with tools like Rufus it works

## Tests

This PR was tested on:

1. QEMU
2. Real PC installed through iLO as a virtual ISO media
3. Real PC installed through an USB Stick flashed with Rufus tool



