### PR TITLE
tools: Fix tag for eve-mkimage-iso-efi

### DIFF
--- a/tools/makeiso.sh
+++ b/tools/makeiso.sh
@@ -18,7 +18,7 @@ fi
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
 PATH="$EVE/build-tools/bin:$PATH"
 INSTALLER_TAR="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
-MKIMAGE_TAG="$(linuxkit pkg show-tag "$EVE/pkg/mkimage-iso-efi")"
+MKIMAGE_TAG="$(linuxkit pkg show-tag "$EVE/pkg/mkimage-iso-efi")-${ARCH}"
 ISO="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
 
 if [ ! -f "$INSTALLER_TAR" ] || [ $# -lt 2 ]; then


### PR DESCRIPTION
Commit ee15f4d2d1438b605b58febb7c002d34c1f04072 introduced changes to fetch the eve-mkimage-iso-efi container for the right target architecture, the fix was needed to generate ISO images for arm64. However, the ARCH prefix was missing for the linuxkit pkg tag resolution. This commit adds the ARCH prefix just as it's done in the tools/parse-pkgs.sh script.

PS: I just figured out this error now because I was changing the pkg/mkimage-iso-efi and it turns out the tag was missing.