### PR TITLE
Makefile: do not check hash consistency for pkg/installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,7 @@ $(DOCKERFILE_FROM_CHECKER): $(DOCKERFILE_FROM_CHECKER_DIR)/*.go $(DOCKERFILE_FRO
 # this next section checks that the FROM hashes for any image in any dockerfile anywhere here are consistent.
 # For example, one Dockerfile has foo:abc and the next has foo:def, it will flag them.
 # These are the packages that we are ignoring for now
-IGNORE_DOCKERFILE_HASHES_PKGS=alpine
+IGNORE_DOCKERFILE_HASHES_PKGS=alpine installer
 IGNORE_DOCKERFILE_HASHES_EVE_TOOLS=bpftrace-compiler
 
 IGNORE_DOCKERFILE_HASHES_PKGS_ARGS=$(foreach pkg,$(IGNORE_DOCKERFILE_HASHES_PKGS),-i pkg/$(pkg)/Dockerfile)


### PR DESCRIPTION
Add pkg/installer to the hash consistent checker exceptions since keep same rust compiler for both pkg/installer and pkg/monitor is not strictly needed in this case. It can be removed later if they get in sync again.