### PR TITLE
Make mkimage-iso-efi able to build for other architectures

### DIFF
--- a/pkg/mkimage-iso-efi/Dockerfile
+++ b/pkg/mkimage-iso-efi/Dockerfile
@@ -1,3 +1,10 @@
+# to have access to packages for alternate arches
+# hadolint ignore=DL3029
+FROM --platform=linux/amd64 lfedge/eve-alpine:591df01e581889c3027514c8a91feaca1c8ad49f AS build-amd64
+# hadolint ignore=DL3029
+FROM --platform=linux/arm64 lfedge/eve-alpine:591df01e581889c3027514c8a91feaca1c8ad49f AS build-arm64
+
+# the one we build is our local
 FROM lfedge/eve-alpine:591df01e581889c3027514c8a91feaca1c8ad49f AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools xorriso mkinitfs squashfs-tools
@@ -14,6 +21,12 @@ RUN if ! grep -q -w /sbin/nlplug-findfs  /out/etc/mkinitfs/features.d/base.files
         echo "/sbin/nlplug-findfs" >> /out/etc/mkinitfs/features.d/base.files; \
     fi
 RUN echo /bin/grep >> /out/etc/mkinitfs/features.d/base.files
+
+# for alternate architectures
+COPY --from=build-amd64 /bin/busybox /out/arch/amd64/bin/
+COPY --from=build-amd64 /lib/ld-musl* /out/arch/amd64/lib/
+COPY --from=build-arm64 /bin/busybox /out/arch/arm64/bin/
+COPY --from=build-arm64 /lib/ld-musl* /out/arch/arm64/lib/
 
 FROM scratch
 COPY --from=build /out /

--- a/pkg/mkimage-iso-efi/README.md
+++ b/pkg/mkimage-iso-efi/README.md
@@ -8,6 +8,12 @@ In addition, the following will be created:
 1. An El Torito compliant FAT32 image that can be booted by UEFI firmware.
 1. An `initrd.img` that can be used to boot the kernel and mount the ISO filesystem.
 
+The `initrd.img` will be for the architecture on which you are running, for example linux/amd64. If you wish to
+build for another architecture, do one of the following:
+
+* `docker run --platform <other-platform>`, e.g. `docker run --platform linux/arm64` while on `linux/amd64`
+* pass the target architecture as `TARGETARCH` environment variable, e.g. `docker run -e TARGETARCH=arm64` while on `linux/amd64`
+
 ## Usage
 
 ### Input

--- a/pkg/mkimage-iso-efi/make-efi
+++ b/pkg/mkimage-iso-efi/make-efi
@@ -76,14 +76,23 @@ if [ -n "$VOLUME_LABEL" ]; then
    VOL_LABEL="-V $VOLUME_LABEL"
 fi
 
+# we copy over to the initrd the image for the appropriate architecture. If none provided, use ours.
+CPBASE=
+if [ -n "$TARGETARCH" ]; then
+       # canonicalize the architecture
+       [ "$TARGETARCH" = "x86_64" ] && TARGETARCH="amd64"
+       [ "$TARGETARCH" = "aarch64" ] && TARGETARCH="arm64"
+       CPBASE=/arch/${TARGETARCH}
+fi
+
 if [ ! -e boot/initrd.img ]; then
    # all of the things we need to make a simple initrd
    mkdir -p /tmp/initrd
    (cd /tmp/initrd
    mkdir -p bin lib sbin etc proc sys newroot
    cp /initrd.sh init
-   cp /bin/busybox bin/
-   cp /lib/ld-musl* lib/
+   cp "${CPBASE}"/bin/busybox bin/
+   cp "${CPBASE}"/lib/ld-musl* lib/
    /bin/busybox --install -s /tmp/initrd/bin
    find . | cpio -H newc -o | gzip > /tmp/initrd.img)
    mv /tmp/initrd.img boot/initrd.img


### PR DESCRIPTION
mkimage-iso-efi does everything arch-agnostic, except for if it needs to install an initrd. In that case, it copies busybox and lib*musl* from its _local_ run, which is whatever architecture it runs on.

This adds the necessary binaries for arm64 and amd64 to all builds from the alpine base, and then calculates which one to install by the env var ARCH. If ARCH is not set, it then uses the local arch.

Also updates the README.

See discussion on #4662 

cc @rene 