### PR TITLE
Use new mkimage-iso-efi that automatically uses initrd binaries from tar stream

### DIFF
--- a/tools/makeiso.sh
+++ b/tools/makeiso.sh
@@ -2,23 +2,10 @@
 
 [ -n "$DEBUG" ] && set -x
 
-if [ -z "$DOCKER_ARCH_TAG" ] ; then
-  case $(uname -m) in
-    x86_64) ARCH=amd64
-      ;;
-    aarch64) ARCH=arm64
-      ;;
-    *) echo "Unsupported architecture $(uname -m). Exiting" && exit 1
-      ;;
-  esac
-else
-  ARCH="${DOCKER_ARCH_TAG}"
-fi
-
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
 PATH="$EVE/build-tools/bin:$PATH"
 INSTALLER_TAR="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
-MKIMAGE_TAG="$(linuxkit pkg show-tag "$EVE/pkg/mkimage-iso-efi")-${ARCH}"
+MKIMAGE_TAG="$(linuxkit pkg show-tag "$EVE/pkg/mkimage-iso-efi")"
 ISO="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
 
 if [ ! -f "$INSTALLER_TAR" ] || [ $# -lt 2 ]; then
@@ -28,4 +15,4 @@ fi
 
 : > "$ISO"
 # shellcheck disable=SC2086
-cat $INSTALLER_TAR | docker run -i --platform "linux/${ARCH}" --rm -e DEBUG="$DEBUG" -e VOLUME_LABEL=EVEISO -v "$ISO:/output.iso" "$MKIMAGE_TAG" $3
+cat $INSTALLER_TAR | docker run -i --rm -e DEBUG="$DEBUG" -e VOLUME_LABEL=EVEISO -v "$ISO:/output.iso" "$MKIMAGE_TAG" $3


### PR DESCRIPTION
mkimage-iso-efi recently was updated to be architecture-safe. It builds initrd using binaries from the tar stream, so the arch always matches up. This takes advantage of it.

@rene this kind of changes your last PR, so if you think this is less clean or not as good, comment here and I will remove this.