### PR TITLE
mkimage-iso-efi should always build for architecture of its tar input stream

### DIFF
--- a/pkg/mkimage-iso-efi/Dockerfile
+++ b/pkg/mkimage-iso-efi/Dockerfile
@@ -1,10 +1,3 @@
-# to have access to packages for alternate arches
-# hadolint ignore=DL3029
-FROM --platform=linux/amd64 lfedge/eve-alpine:591df01e581889c3027514c8a91feaca1c8ad49f AS build-amd64
-# hadolint ignore=DL3029
-FROM --platform=linux/arm64 lfedge/eve-alpine:591df01e581889c3027514c8a91feaca1c8ad49f AS build-arm64
-
-# the one we build is our local
 FROM lfedge/eve-alpine:591df01e581889c3027514c8a91feaca1c8ad49f AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools xorriso mkinitfs squashfs-tools
@@ -21,12 +14,6 @@ RUN if ! grep -q -w /sbin/nlplug-findfs  /out/etc/mkinitfs/features.d/base.files
         echo "/sbin/nlplug-findfs" >> /out/etc/mkinitfs/features.d/base.files; \
     fi
 RUN echo /bin/grep >> /out/etc/mkinitfs/features.d/base.files
-
-# for alternate architectures
-COPY --from=build-amd64 /bin/busybox /out/arch/amd64/bin/
-COPY --from=build-amd64 /lib/ld-musl* /out/arch/amd64/lib/
-COPY --from=build-arm64 /bin/busybox /out/arch/arm64/bin/
-COPY --from=build-arm64 /lib/ld-musl* /out/arch/arm64/lib/
 
 FROM scratch
 COPY --from=build /out /

--- a/pkg/mkimage-iso-efi/README.md
+++ b/pkg/mkimage-iso-efi/README.md
@@ -8,11 +8,8 @@ In addition, the following will be created:
 1. An El Torito compliant FAT32 image that can be booted by UEFI firmware.
 1. An `initrd.img` that can be used to boot the kernel and mount the ISO filesystem.
 
-The `initrd.img` will be for the architecture on which you are running, for example linux/amd64. If you wish to
-build for another architecture, do one of the following:
-
-* `docker run --platform <other-platform>`, e.g. `docker run --platform linux/arm64` while on `linux/amd64`
-* pass the target architecture as `TARGETARCH` environment variable, e.g. `docker run -e TARGETARCH=arm64` while on `linux/amd64`
+The `initrd.img` will be for the architecture of the input filesystem tar stream. All executables placed in the initrd, if
+needed, will be taken from the tar.
 
 ## Usage
 

--- a/pkg/mkimage-iso-efi/make-efi
+++ b/pkg/mkimage-iso-efi/make-efi
@@ -76,23 +76,14 @@ if [ -n "$VOLUME_LABEL" ]; then
    VOL_LABEL="-V $VOLUME_LABEL"
 fi
 
-# we copy over to the initrd the image for the appropriate architecture. If none provided, use ours.
-CPBASE=
-if [ -n "$TARGETARCH" ]; then
-       # canonicalize the architecture
-       [ "$TARGETARCH" = "x86_64" ] && TARGETARCH="amd64"
-       [ "$TARGETARCH" = "aarch64" ] && TARGETARCH="arm64"
-       CPBASE=/arch/${TARGETARCH}
-fi
-
 if [ ! -e boot/initrd.img ]; then
    # all of the things we need to make a simple initrd
    mkdir -p /tmp/initrd
    (cd /tmp/initrd
    mkdir -p bin lib sbin etc proc sys newroot
    cp /initrd.sh init
-   cp "${CPBASE}"/bin/busybox bin/
-   cp "${CPBASE}"/lib/ld-musl* lib/
+   cp "${ROOTFS}"/bin/busybox bin/
+   cp "${ROOTFS}"/lib/ld-musl* lib/
    /bin/busybox --install -s /tmp/initrd/bin
    find . | cpio -H newc -o | gzip > /tmp/initrd.img)
    mv /tmp/initrd.img boot/initrd.img


### PR DESCRIPTION
Previously, mkimage-iso-efi would take the tar as is, but insert initrd for its local platform, which made no sense. An earlier commit in #4665 fixed it so you could specify TARGETARCH. Thus, if running on am64 and your tar is arm64, you could force it to build for arm64 via TARGETARCH=arm64. That works, but even that is too complex.

There is no reason *ever* to build the initrd for anything other than the architecture _of the input tar stream_. Rather than trying to use local arch, or have the user signal it with an env var, this just takes the arch of the tar stream and uses it.

mkimage-iso-efi always will build the initrd for the architecture of the input stream. Much cleaner and simpler.

Kudos to @rene , who thought of this nice one.