### PR TITLE
docs: Fix security warnings pointed by dependabot

### DIFF
--- a/docs/mkdocs/prepare_mkdocs.py
+++ b/docs/mkdocs/prepare_mkdocs.py
@@ -18,7 +18,8 @@ else:
 
 # Regex
 reLinks  = re.compile(r'\[([^\]]+)\]\(([^)]+)\)')
-reURL    = re.compile(r'[A-Za-z0-9]+://[A-Za-z0-9%-_]+(/[A-Za-z0-9%-_])*(#|\\?)[A-Za-z0-9%-_&=]*')
+# pylint: disable-next=line-too-long
+reURL    = re.compile(r'^(https?|ftp):\/\/([A-Za-z0-9-]+\.)+[A-Za-z]{2,6}(:\d+)?(\/[A-Za-z0-9-._~:?#[\]@!$&\'()*+,;=\/]*)?$')
 reMAIL   = re.compile(r'mailto:.*')
 reANCHOR = re.compile(r'^#.*')
 

--- a/docs/mkdocs/requirements.txt
+++ b/docs/mkdocs/requirements.txt
@@ -1,2 +1,2 @@
-jinja2<3.1.0
+jinja2>=3.1.6
 mkdocs==1.3.1


### PR DESCRIPTION
This PR fixes some warnings pointed out by dependabot. It's only related to documentation, nothing critical, still good to fix:

- Bump up jinja2 version
- Improve regex for URLs