### PR TITLE
pillar: Add passed-through devices to cgroups device list as well

### DIFF
--- a/pkg/pillar/containerd/oci.go
+++ b/pkg/pillar/containerd/oci.go
@@ -421,7 +421,16 @@ func (s *ociSpec) UpdateWithIoBundles(config *types.DomainConfig, aa *types.Assi
 			logrus.Errorf("could not retrieve information about device file %s", dev)
 			continue
 		}
+		// Add to device + cgroups list
 		s.Linux.Devices = append(s.Linux.Devices, ociDev)
+		cgrDev := &specs.LinuxDeviceCgroup{
+			Allow:  true,
+			Type:   ociDev.Type,
+			Major:  &ociDev.Major,
+			Minor:  &ociDev.Minor,
+			Access: "rwm",
+		}
+		s.Linux.Resources.Devices = append(s.Linux.Resources.Devices, *cgrDev)
 	}
 	return nil
 }


### PR DESCRIPTION
When passingthrough a device to a Reduced Isolated container, the file device is added only to the device list in the OCI spec. However, in order to allow full access to the device, it must also be added to the cgroups device list.

The error was observed while passingthrough a webcam to a Reduced Isolated container. The gst-launch application returned the following error:

```
Setting pipeline to PAUSED ...
ERROR: from element /GstPipeline:pipeline0/GstV4l2Src:v4l2src0: Could not open device '/dev/video0' for reading and writing. Additional debug info:
../sys/v4l2/v4l2_calls.c(627): gst_v4l2_open (): /GstPipeline:pipeline0/GstV4l2Src:v4l2src0: system error: Operation not permitted
ERROR: pipeline doesn't want to preroll.
```

With the fix provided in this PR, the application started to work.

Kudos to @cshari-zededa for reporting and help debugging this issue....