### PR TITLE
Fix flow-logging config removal

### DIFF
--- a/pkg/pillar/nireconciler/linux_acl.go
+++ b/pkg/pillar/nireconciler/linux_acl.go
@@ -508,7 +508,7 @@ func (r *LinuxNIReconciler) getIntendedACLRootChains() dg.Graph {
 
 func (r *LinuxNIReconciler) withFlowlog() bool {
 	for _, ni := range r.nis {
-		if ni.config.EnableFlowlog {
+		if !ni.deleted && ni.config.EnableFlowlog {
 			return true
 		}
 	}


### PR DESCRIPTION
When the last NI with flow-logging enabled is being deleted, `LinuxNIReconciler` should remove all config items used solely for the flow logging purposes (e.g. the `blackhole` dummy interface). However, due to a bug in the `withFlowlog()` method this was not the case. The method would return `true` even when the remaining non-deleted NIs had all flow logging disabled.