### PR TITLE
Always enable bridge iptables for kubernetes networking

### DIFF
--- a/pkg/pillar/nireconciler/linux_config.go
+++ b/pkg/pillar/nireconciler/linux_config.go
@@ -368,9 +368,11 @@ func (r *LinuxNIReconciler) getIntendedGlobalState() dg.Graph {
 
 func (r *LinuxNIReconciler) getIntendedHostSysctl() linux.Sysctl {
 	var bridgeCallIptables, bridgeCallIp6tables bool
-	if r.withFlowlog() {
+	if r.withKubernetesNetworking || r.withFlowlog() {
 		// Enforce the use of iptables in order to get conntrack entry
 		// created for every flow, which is then used to obtain flow metadata.
+		// Enabling iptables for bridges is also required for Flannel CNI to ensure
+		// the iptables-based implementation of Kubernetes services functions correctly.
 		bridgeCallIptables = true
 		bridgeCallIp6tables = true
 		return linux.Sysctl{


### PR DESCRIPTION
Flannel CNI requires iptables to be enabled for bridges, otherwise NAT will not work when accessing a Kubernetes service where the endpoint is on the local node.
Some references:
- https://github.com/kelseyhightower/kubernetes-the-hard-way/issues/561
- https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/guides/flannel.md

This means that the recently added performance optimization, disabling iptables for bridges when ACLs allow everything (see commit 38ab4b71), must be disabled for Kubevirt-EVE.