### PR TITLE
github/workflows: Publish arm64 platform variant images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,12 +22,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: arm64-secure
-            arch: arm64
           - os: ubuntu-22.04
             arch: amd64
+            platform: "generic"
+          - os: arm64-secure
+            arch: arm64
+            platform: "generic"
+          - os: arm64-secure
+            arch: arm64
+            platform: "nvidia-jp5"
+          - os: arm64-secure
+            arch: arm64
+            platform: "nvidia-jp6"
           - os: ubuntu-latest
             arch: riscv64
+            platform: "generic"
     steps:
       - name: Starting Report
         run: |
@@ -73,7 +82,7 @@ jobs:
           # sadly, our build sometimes times out on network access
           # and running out of disk space: re-trying for 3 times
           for i in 1 2 3; do
-             if make -e V=1 LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
+             if make -e V=1 PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
                 SUCCESS=true
                 break
              else
@@ -111,16 +120,24 @@ jobs:
       matrix:
         arch: [arm64, amd64]
         hv: [kvm, xen]
+        platform: ["generic"]
         include:
           - arch: riscv64
             hv: mini
+            platform: "generic"
+          - arch: arm64
+            hv: kvm
+            platform: "nvidia-jp5"
+          - arch: arm64
+            hv: kvm
+            platform: "nvidia-jp6"
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/actions/run-make
         with:
-          command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push eve"
+          command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push eve"
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
       - uses: ./.github/actions/run-make


### PR DESCRIPTION
## Description

Currently the following packages are published with dedicated tags for arm64 platform variants:

* pkg/nvidia
* pkg/fw
* eve container built with "make eve"

For instance, the pkg/nvidia will be tagged like the following:

* lfedge/eve-nvidia:14.4.0-nvidia-jp5
* lfedge/eve-nvidia:14.4.0-nvidia-jp6

However, since only PLATFORM=generic is considered while publishing images, the other variants (e.g., nvidia-jp6) are not being taking into account, letting some images unpublished.

This PR adds the arm64 platform variants to the publish workflow in order to publish all required images.

## Tests

This PR was partially tested using local registry and self-hosted runners on my repo: https://github.com/rene/eve/actions/runs/13892409970

The matrix is working and I can also see the variants for a tag that I pushed to test (14.4.1). However, too many changes are needed to check the full cycle of eve image publishing, so we will get full results only when merging this PR.

```sh
curl -s http://localhost:5001/v2/lfedge/eve-nvidia/tags/list | jq
```

```json
{
  "name": "lfedge/eve-nvidia",
  "tags": [
    "latest-arm64",
    "14.4.1-nvidia-jp6",
    "14.4.1-nvidia-jp6-arm64",
    "14.4.1-nvidia-jp5-arm64",
    "14.4.1-nvidia-jp5",
    "d87f8292cf66d41663ef6dda502e5aa265c1242b-nvidia-jp5-arm64",
    "snapshot-arm64",
    "snapshot",
    "latest",
    "d87f8292cf66d41663ef6dda502e5aa265c1242b-nvidia-jp5"
  ]
}
```

PS: I will provide updates here if I manage to perform more tests locally.