### PR TITLE
Compose sbom from packages rather than building fresh each build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -771,20 +771,11 @@ collected_sources_info:
 
 $(SBOM): $(ROOTFS_TAR) | $(INSTALLER)
 	$(QUIET): $@: Begin
-	$(eval TMP_ROOTDIR := $(shell mktemp -d))
-	# this is a bit of a hack, but we need to extract the rootfs tar to a directory, and it fails if
-	# we try to extract character devices, block devices or pipes, so we just exclude the dir.
-	# when syft supports reading straight from a tar archive with duplicate entries,
-	# this all can go away, and we can read the rootfs.tar
-	# see https://github.com/anchore/syft/issues/1400
-	#
 	# the ROOTFS_TAR includes extended PAX headers, which GNU tar does not support.
 	# It does not break, but logs two lines of warnings for each file, which is a lot.
 	# For BSD tar, no need to do anything; for GNU tar, need to add `--warning=no-unknown-keyword`
 	$(eval TAR_OPTS = $(shell tar --version | grep -qi 'GNU tar' && echo --warning=no-unknown-keyword || echo))
-	tar $(TAR_OPTS) -xf $< -C $(TMP_ROOTDIR) --exclude "dev/*"
-	docker run -v $(TMP_ROOTDIR):/rootdir:ro -v $(CURDIR)/.syft.yaml:/syft.yaml:ro $(SYFT_IMAGE) -c /syft.yaml --base-path /rootdir /rootdir > $@
-	rm -rf $(TMP_ROOTDIR)
+	tar $(TAR_OPTS) -xf $< -O sbom.spdx.json > $@
 	$(QUIET): $@: Succeeded
 
 $(GOSOURCES):

--- a/tools/makerootfs.sh
+++ b/tools/makerootfs.sh
@@ -24,9 +24,8 @@ do_image() {
     ARCHARG="--arch ${arch}"
   fi
   : > "$IMAGE"
-  # sbom disabled for now; will be re-enabled later
   # shellcheck disable=SC2086
-  linuxkit build --no-sbom --docker ${ARCHARG} -o - "$ymlfile" | docker run -i --rm -v /dev:/dev --privileged -v "$IMAGE:/rootfs.img" "${MKROOTFS_TAG}"
+  linuxkit build --docker ${ARCHARG} -o - "$ymlfile" | docker run -i --rm -v /dev:/dev --privileged -v "$IMAGE:/rootfs.img" "${MKROOTFS_TAG}"
 }
 
 # mode 1 - generate tarfile from yml and save
@@ -42,13 +41,11 @@ do_tar() {
     ARCHARG="--arch ${arch}"
   fi
   if [ -z "$updatetar" ] || [ ! -e "${tarfile}" ]; then
-    # sbom disabled for now; will be re-enabled later
     # shellcheck disable=SC2086
-    linuxkit build --no-sbom --docker ${ARCHARG} --o "${tarfile}" "$ymlfile"
+    linuxkit build --docker ${ARCHARG} --o "${tarfile}" "$ymlfile"
   else
-    # sbom disabled for now; will be re-enabled later
     # shellcheck disable=SC2086
-    linuxkit build --no-sbom --docker ${ARCHARG} --o "${tarfile}.new" --input-tar "${tarfile}"  "$ymlfile"
+    linuxkit build --docker ${ARCHARG} --o "${tarfile}.new" --input-tar "${tarfile}"  "$ymlfile"
     newmd5=$(md5sum "${tarfile}.new" | awk '{print $1}')
     oldmd5=$(md5sum "${tarfile}" | awk '{print $1}')
     # Don't touch the modification time if files are equal. Crucial for Makefile.


### PR DESCRIPTION
Historically, we created the sbom for eve by creating the whole rootfs.tar, opening it up, scanning it, and saving the sbom file. Two years ago, with commit 6a21af0afb11c9501a8b6ab480f272d662a56999, we added native buildkit sbom generation to each package. That should have made it possible to just compose the sbom from the components rather than scan afresh, a long and slower process. For reasons forgotten, we never enabled that, instead continuing to scan.

This commit removes the `--no-sbom` from the eve rootfs.tar build, and uses the generated sbom for the separate artifact.

This is the completion of the (long forgotten) #3592 , which should have had this one added.

We need to do two things to make sure this is ready:

* compare 2 sboms, one from the current way and one from the new way, and make sure nothing is missing
* look at `.syft.yml` config in this repository, see if anything in there needs to be provided to individual packages

It is possible that this one is ready to go in right now; it also is possible that we need to make multiple package changes and pushes before we merge it.