### PR TITLE
WIP: deduplicate and filter logs

### DIFF
--- a/pkg/newlog/cmd/counter.go
+++ b/pkg/newlog/cmd/counter.go
@@ -3,12 +3,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/lf-edge/eve-api/go/logs"
 )
 
 // logsToCount is a list of Filename fields (src file + line number) of log entries that should be counted.
-var logsToCount []string
+var logsToCount atomic.Value
 
 // countLogOccurances checks if the log entries should be merged into a single entry with a counter of occurances.
 // If so it increments the counter for that log entry. It returns true if the log entry

--- a/pkg/newlog/cmd/counter.go
+++ b/pkg/newlog/cmd/counter.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/lf-edge/eve-api/go/logs"
+)
+
+// logsToCount is a list of Filename fields (src file + line number) of log entries that should be counted.
+var logsToCount []string
+
+// countLogOccurances checks if the log entries should be merged into a single entry with a counter of occurances.
+// If so it increments the counter for that log entry. It returns true if the log entry
+// should be kept in the logs file (log's first occurance) and false otherwise.
+func countLogOccurances(line []byte, filterMap map[string]int) error {
+	var logEntry logs.LogEntry
+	if err := json.Unmarshal(line, &logEntry); err != nil {
+		return err
+	}
+
+	if currentCount, ok := filterMap[logEntry.Filename]; ok {
+		filterMap[logEntry.Filename] = currentCount + 1
+	}
+
+	return nil
+}
+
+// addLogCount adds the count of the log entry to the log entry and returns the log entry as a byte array.
+// If the log entry is not supposed to be counted, it's returned without any changes.
+// If the log entry count was already included in another entry, the function returns nil, meaning the log entry should be skipped (not written to the logs file).
+func addLogCount(logEntry *logs.LogEntry, filterMap map[string]int) bool {
+	if count, ok := filterMap[logEntry.Filename]; !ok {
+		return true
+	} else {
+		if count == 0 {
+			// the count was already included in another entry
+			return false
+		}
+
+		if count == 1 {
+			// no need to add additional count field if there is only one occurance
+			return true
+		}
+
+		if logEntry.Tags == nil {
+			logEntry.Tags = make(map[string]string)
+		}
+		logEntry.Tags["count"] = fmt.Sprint(count)
+
+		// mark the log entry as counted
+		filterMap[logEntry.Filename] = 0
+
+		return true
+	}
+}

--- a/pkg/newlog/cmd/dedup.go
+++ b/pkg/newlog/cmd/dedup.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const bufferSize = 100
+
+type ContainsMsg struct {
+	Msg string `json:"msg"`
+}
+
+func deduplicateLogs(in <-chan inputEntry, out chan<- inputEntry) {
+	// 'seen' counts occurrences of each file in the current window.
+	seen := make(map[string]string)
+	// 'queue' holds the file fields of the last bufferSize logs.
+	queue := make([]string, bufferSize)
+
+	newElementIdx := 0
+	bufferFull := false
+
+	for logEntry := range in {
+		dedupField := ""
+		msgid := logEntry.appUUID // the field is set artificially for testing - CHANGE AFTER TESTING!!!
+		// If logEntry.content is a valid JSON, extract the field "msg" from it.
+		if logEntry.content != "" {
+			var content ContainsMsg
+			err := json.Unmarshal([]byte(logEntry.content), &content)
+			if err == nil && content.Msg != "" {
+				dedupField = content.Msg
+			} else {
+				dedupField = logEntry.content
+			}
+		}
+
+		if bufferFull {
+			oldest := queue[newElementIdx]
+			delete(seen, oldest)
+		}
+
+		// If the file hasn't appeared in the last bufferSize logs, forward it.
+		if _, ok := seen[dedupField]; !ok || logEntry.severity != "error" {
+			out <- logEntry
+		} else {
+			fmt.Printf("Deduped %s because of %s\n", msgid, seen[dedupField])
+		}
+
+		// Add the current log to the window.
+		queue[newElementIdx] = dedupField
+		seen[dedupField] = msgid
+
+		// increment the index
+		newElementIdx++
+		// Maintain the window size: if it exceeds bufferSize, remove the oldest log.
+		if newElementIdx == bufferSize {
+			newElementIdx = 0
+			bufferFull = true
+		}
+	}
+
+	close(out)
+}

--- a/pkg/newlog/cmd/dedup.go
+++ b/pkg/newlog/cmd/dedup.go
@@ -22,7 +22,6 @@ func deduplicateLogs(in <-chan inputEntry, out chan<- inputEntry) {
 
 	for logEntry := range in {
 		dedupField := ""
-		msgid := logEntry.appUUID // the field is set artificially for testing - CHANGE AFTER TESTING!!!
 		// If logEntry.content is a valid JSON, extract the field "msg" from it.
 		if logEntry.content != "" {
 			var content ContainsMsg
@@ -38,7 +37,7 @@ func deduplicateLogs(in <-chan inputEntry, out chan<- inputEntry) {
 		if _, ok := seen[dedupField]; !ok || logEntry.severity != "error" {
 			out <- logEntry
 		} else {
-			fmt.Printf("Deduped %s because of %s\n", msgid, seen[dedupField])
+			fmt.Printf("Deduped log at %s because of the log at %s\n", logEntry.timestamp, seen[dedupField])
 			numDedupedLogs++
 			if numDedupedLogs%10 == 0 {
 				fmt.Printf("Deduped %d logs\n", numDedupedLogs)
@@ -52,7 +51,7 @@ func deduplicateLogs(in <-chan inputEntry, out chan<- inputEntry) {
 
 		// Add the current log to the window.
 		queue.Value = dedupField
-		seen[dedupField] = msgid
+		seen[dedupField] = logEntry.timestamp
 
 		// Move the window.
 		queue = queue.Next()

--- a/pkg/newlog/cmd/dedup.go
+++ b/pkg/newlog/cmd/dedup.go
@@ -12,6 +12,8 @@ type ContainsMsg struct {
 	Msg string `json:"msg"`
 }
 
+var numDedupedLogs = 0
+
 func deduplicateLogs(in <-chan inputEntry, out chan<- inputEntry) {
 	// 'seen' counts occurrences of each file in the current window.
 	seen := make(map[string]string)
@@ -37,6 +39,10 @@ func deduplicateLogs(in <-chan inputEntry, out chan<- inputEntry) {
 			out <- logEntry
 		} else {
 			fmt.Printf("Deduped %s because of %s\n", msgid, seen[dedupField])
+			numDedupedLogs++
+			if numDedupedLogs%10 == 0 {
+				fmt.Printf("Deduped %d logs\n", numDedupedLogs)
+			}
 		}
 
 		// Remove the oldest log from the window.

--- a/pkg/newlog/cmd/dedup_test.go
+++ b/pkg/newlog/cmd/dedup_test.go
@@ -197,7 +197,9 @@ func TestLogFiltering(t *testing.T) {
 	defer oFile.Close()
 
 	// FILTERING PARAMS:
-	filenameFilter["/pillar/evetpm/tpm.go:346"] = nil
+	filenameFilter.Store(map[string]any{
+		"/pillar/types/zedroutertypes.go:1079": nil,
+	})
 	logsToCount.Store([]string{
 		"/pillar/types/zedroutertypes.go:1079",
 	})

--- a/pkg/newlog/cmd/dedup_test.go
+++ b/pkg/newlog/cmd/dedup_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestDeduplicateLogs(t *testing.T) {
 	// Create channels
-	totalLogs := bufferSize + 50
+	totalLogs := int(dedupWindowSize.Load() + 50)
 	in := make(chan inputEntry, totalLogs)
 	distinctLogs := 75
 	out := make(chan inputEntry, distinctLogs)
@@ -227,7 +227,7 @@ func TestLogFiltering(t *testing.T) {
 	// 'seen' counts occurrences of each file in the current window.
 	seen = make(map[string]uint64)
 	// 'queue' holds the file fields of the last bufferSize logs.
-	queue = ring.New(bufferSize)
+	queue = ring.New(int(dedupWindowSize.Load()))
 
 	// now we go through the file again and deduplicate the logs
 	scanner := bufio.NewScanner(iFile)

--- a/pkg/newlog/cmd/dedup_test.go
+++ b/pkg/newlog/cmd/dedup_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/lf-edge/eve-api/go/logs"
+)
+
+func TestDeduplicateLogs(t *testing.T) {
+	// Create channels
+	totalLogs := bufferSize + 50
+	in := make(chan inputEntry, totalLogs)
+	distinctLogs := 75
+	out := make(chan inputEntry, distinctLogs)
+
+	// Start deduplicateLogs in a goroutine.
+	go deduplicateLogs(in, out)
+
+	for i := range totalLogs {
+		// Use 50 distinct messages
+		entry := inputEntry{content: "msg" + strconv.Itoa(i%distinctLogs), severity: "error", appUUID: strconv.Itoa(i)}
+		in <- entry
+	}
+	close(in)
+
+	// Collect output logs.
+	var results []inputEntry
+	for entry := range out {
+		results = append(results, entry)
+	}
+
+	if len(results) != distinctLogs {
+		t.Fatalf("expected %d output logs, got %d", distinctLogs, len(results))
+	}
+
+	for i := range distinctLogs {
+		expectedMessage := "msg" + strconv.Itoa(i)
+		if results[i].content != expectedMessage {
+			t.Errorf("at output index %d: expected %q, got %q", i, expectedMessage, results[i].content)
+		}
+	}
+}
+
+func TestDedupWithLocalFile(t *testing.T) {
+	// Create a channel to send the log entry to deduplicateLogs
+	in := make(chan inputEntry, 10)
+	out := make(chan inputEntry, 10)
+
+	// Start deduplicateLogs in a goroutine.
+	go deduplicateLogs(in, out)
+
+	go func() {
+		// Read local log file
+		file, err := os.Open("/home/paul/eve-info/eve-info-v33-2025-03-03-15-44-57/all_logs")
+		if err != nil {
+			panic(err)
+		}
+		defer file.Close()
+
+		// Read lines from the gzip file
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				t.Error(err)
+				continue
+			}
+
+			var entry logs.LogEntry
+			if err = json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+				t.Error(err)
+				continue
+			}
+
+			in <- inputEntry{
+				severity:  entry.Severity,
+				source:    entry.Source,
+				content:   entry.Content,
+				pid:       entry.Iid,
+				filename:  entry.Filename,
+				function:  entry.Function,
+				timestamp: entry.Timestamp.String(),
+				appUUID:   fmt.Sprint(entry.Msgid),
+			}
+		}
+		close(in)
+	}()
+
+	file, err := os.OpenFile(filepath.Join("/home/paul/eve-info/eve-info-v33-2025-03-03-15-44-57/deduped_logs"), os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+
+	expectedMsgId := 1
+	fmt.Println("msgid's of deduplicated logs:")
+	for entry := range out {
+		timeS, _ := getPtypeTimestamp(entry.timestamp)
+		msgid, _ := strconv.Atoi(entry.appUUID)
+		mapLog := logs.LogEntry{
+			Severity:  entry.severity,
+			Source:    entry.source,
+			Content:   entry.content,
+			Iid:       entry.pid,
+			Filename:  entry.filename,
+			Function:  entry.function,
+			Timestamp: timeS,
+			Msgid:     uint64(msgid),
+		}
+		for msgid > expectedMsgId {
+			fmt.Println(expectedMsgId) // the msg with this id was deduplicated
+			expectedMsgId++
+		}
+		expectedMsgId = msgid + 1
+
+		mapJentry, _ := json.Marshal(&mapLog)
+		logline := string(mapJentry) + "\n"
+		_, err = file.WriteString(logline)
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestMsgFieldExtraction(t *testing.T) {
+	contentStr := "{\"file\":\"/pillar/zedcloud/zedcloudmetric.go:86\",\"func\":\"github.com/lf-edge/eve/pkg/pillar/zedcloud.(*AgentMetrics).RecordFailure\",\"level\":\"info\",\"msg\":\"EVENT: failed to access https://zedcloud.alpha.zededa.net/api/v2/edgedevice/id/91a44d75-0bfe-466b-acfe-0b91d2033c15/metrics\",\"pid\":2162,\"source\":\"zedagent\",\"time\":\"2025-03-03T15:36:18.530126869Z\"}"
+
+	var content ContainsMsg
+	json.Unmarshal([]byte(contentStr), &content)
+	if content.Msg != "EVENT: failed to access https://zedcloud.alpha.zededa.net/api/v2/edgedevice/id/91a44d75-0bfe-466b-acfe-0b91d2033c15/metrics" {
+		t.Errorf("expected %q, got %q", "EVENT: failed to access https://zedcloud.alpha.zededa.net/api/v2/edgedevice/id/91a44d75-0bfe-466b-acfe-0b91d2033c15/metrics", content.Msg)
+	}
+}

--- a/pkg/newlog/cmd/dedup_test.go
+++ b/pkg/newlog/cmd/dedup_test.go
@@ -91,7 +91,7 @@ func TestDedupWithLocalFile(t *testing.T) {
 		close(in)
 	}()
 
-	file, err := os.OpenFile(filepath.Join("/home/paul/eve-info/eve-info-v33-2025-03-03-15-44-57/deduped_logs"), os.O_CREATE|os.O_WRONLY, 0644)
+	file, err := os.OpenFile("/home/paul/eve-info/eve-info-v33-2025-03-03-15-44-57/deduped_logs", os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		panic(err)
 	}
@@ -125,6 +125,8 @@ func TestDedupWithLocalFile(t *testing.T) {
 			t.Error(err)
 		}
 	}
+
+	t.Logf("Total num deduped logs: %d", numDedupedLogs)
 }
 
 func TestMsgFieldExtraction(t *testing.T) {

--- a/pkg/newlog/cmd/dedup_test.go
+++ b/pkg/newlog/cmd/dedup_test.go
@@ -198,16 +198,16 @@ func TestLogFiltering(t *testing.T) {
 
 	// FILTERING PARAMS:
 	filenameFilter["/pillar/evetpm/tpm.go:346"] = nil
-	logsToCount = []string{
+	logsToCount.Store([]string{
 		"/pillar/types/zedroutertypes.go:1079",
-	}
+	})
 
 	// first we go through the file and count the number of occurrences of the selected log entries
 	var logCounter map[string]int
 	var seen map[string]uint64
 	var queue *ring.Ring
 	logCounter = make(map[string]int)
-	for _, logSrcLine := range logsToCount {
+	for _, logSrcLine := range logsToCount.Load().([]string) {
 		logCounter[logSrcLine] = 0
 	}
 	preScanner := bufio.NewScanner(iFile)

--- a/pkg/newlog/cmd/filter.go
+++ b/pkg/newlog/cmd/filter.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"slices"
+
+	"github.com/lf-edge/eve-api/go/logs"
+)
+
+var (
+	// those structures need to support concurrency since they will be set in a different goroutine
+	filenameFilter            = make(map[string]any)      // map[filename+line]nothing
+	severityAndFunctionFilter = make(map[string][]string) // map[function]severities
+)
+
+// filterOut checks if the log entry should be filtered out
+// based on the filename or severity + function name
+func filterOut(l *logs.LogEntry) bool {
+	if _, ok := filenameFilter[l.Filename]; ok {
+		return false
+	}
+
+	if severityList, ok := severityAndFunctionFilter[l.Function]; ok {
+		if slices.Contains(severityList, l.Severity) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/newlog/cmd/filter.go
+++ b/pkg/newlog/cmd/filter.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"slices"
 	"sync/atomic"
 
 	"github.com/lf-edge/eve-api/go/logs"
@@ -17,14 +16,16 @@ var (
 // based on the filename or severity + function name
 func filterOut(l *logs.LogEntry) bool {
 	if _, ok := filenameFilter.Load().(map[string]any)[l.Filename]; ok {
-		return false
+		return true
 	}
 
 	if severityList, ok := severityAndFunctionFilter[l.Function]; ok {
-		if slices.Contains(severityList, l.Severity) {
-			return false
+		for _, severity := range severityList {
+			if severity == l.Severity {
+				return true
+			}
 		}
 	}
 
-	return true
+	return false
 }

--- a/pkg/newlog/cmd/filter.go
+++ b/pkg/newlog/cmd/filter.go
@@ -2,20 +2,21 @@ package main
 
 import (
 	"slices"
+	"sync/atomic"
 
 	"github.com/lf-edge/eve-api/go/logs"
 )
 
 var (
 	// those structures need to support concurrency since they will be set in a different goroutine
-	filenameFilter            = make(map[string]any)      // map[filename+line]nothing
+	filenameFilter            atomic.Value                // map[filename+line]nothing
 	severityAndFunctionFilter = make(map[string][]string) // map[function]severities
 )
 
 // filterOut checks if the log entry should be filtered out
 // based on the filename or severity + function name
 func filterOut(l *logs.LogEntry) bool {
-	if _, ok := filenameFilter[l.Filename]; ok {
+	if _, ok := filenameFilter.Load().(map[string]any)[l.Filename]; ok {
 		return false
 	}
 

--- a/pkg/newlog/cmd/newlogd.go
+++ b/pkg/newlog/cmd/newlogd.go
@@ -568,6 +568,9 @@ func handleGlobalConfigImp(ctxArg interface{}, key string, statusArg interface{}
 
 		// set log deduplication and filtering settings
 		dedupWindowSize.Store(gcp.GlobalValueInt(types.LogDedupWindowSize))
+
+		// parse a comma separated list of log filenames to count
+		logsToCount.Store(strings.Split(gcp.GlobalValueString(types.LogFilenamesToCount), ","))
 	}
 	log.Tracef("handleGlobalConfigModify done for %s, fastupload enabled %v", key, enableFastUpload)
 }
@@ -1266,7 +1269,7 @@ func doMoveCompressFile(ps *pubsub.PubSub, tmplogfileInfo fileChanInfo) {
 	var queue *ring.Ring
 	if dirName == uploadDevDir {
 		logCounter = make(map[string]int)
-		for _, logSrcLine := range logsToCount {
+		for _, logSrcLine := range logsToCount.Load().([]string) {
 			logCounter[logSrcLine] = 0
 		}
 		preScanner := bufio.NewScanner(iFile)

--- a/pkg/newlog/cmd/newlogd.go
+++ b/pkg/newlog/cmd/newlogd.go
@@ -571,6 +571,15 @@ func handleGlobalConfigImp(ctxArg interface{}, key string, statusArg interface{}
 
 		// parse a comma separated list of log filenames to count
 		logsToCount.Store(strings.Split(gcp.GlobalValueString(types.LogFilenamesToCount), ","))
+
+		// parse a comma separated list of log filenames to filter
+		newFilenameFilter := make(map[string]any)
+		filenamesToFilter := strings.Split(gcp.GlobalValueString(types.LogFilenamesToFilter), ",")
+		for _, filename := range filenamesToFilter {
+			newFilenameFilter[filename] = nil
+		}
+		filenameFilter.Store(newFilenameFilter)
+
 	}
 	log.Tracef("handleGlobalConfigModify done for %s, fastupload enabled %v", key, enableFastUpload)
 }

--- a/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/types/global.go
+++ b/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/types/global.go
@@ -302,6 +302,10 @@ const (
 	// FmlCustomResolution global setting key
 	FmlCustomResolution GlobalSettingKey = "app.fml.resolution"
 
+	// Log filtering and dedupliction
+	// LogDedupWindowSize is a measure of how many log entries are saved to search for duplicates
+	LogDedupWindowSize GlobalSettingKey = "log.dedup.window.size"
+
 	// DisableDHCPAllOnesNetMask option is deprecated and has no effect.
 	// Zedrouter no longer uses the all-ones netmask as it adds unnecessary complexity,
 	// causes confusion for some applications, and is no longer required for any EVE
@@ -995,6 +999,9 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddStringItem(SyslogRemoteLogLevel, "info", validateSyslogKernelLevel)
 	configItemSpecMap.AddStringItem(KernelRemoteLogLevel, "info", validateSyslogKernelLevel)
 	configItemSpecMap.AddStringItem(FmlCustomResolution, FmlResolutionUnset, blankValidator)
+
+	// Log deduplication and filtering settings
+	configItemSpecMap.AddIntItem(LogDedupWindowSize, 100, 0, 0xFFFFFFFF)
 
 	// Add Agent Settings
 	configItemSpecMap.AddAgentSettingStringItem(LogLevel, "info", validateLogLevel)

--- a/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/types/global.go
+++ b/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/types/global.go
@@ -307,6 +307,8 @@ const (
 	LogDedupWindowSize GlobalSettingKey = "log.dedup.window.size"
 	// LogFilenamesToCount a comma-separated list of log filenames to count
 	LogFilenamesToCount GlobalSettingKey = "log.count.filenames"
+	// LogFilenamesToFilter a comma-separated list of log filenames to filter
+	LogFilenamesToFilter GlobalSettingKey = "log.filter.filenames"
 
 	// DisableDHCPAllOnesNetMask option is deprecated and has no effect.
 	// Zedrouter no longer uses the all-ones netmask as it adds unnecessary complexity,
@@ -1005,6 +1007,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	// Log deduplication and filtering settings
 	configItemSpecMap.AddIntItem(LogDedupWindowSize, 100, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddStringItem(LogFilenamesToCount, "", blankValidator)
+	configItemSpecMap.AddStringItem(LogFilenamesToFilter, "", blankValidator)
 
 	// Add Agent Settings
 	configItemSpecMap.AddAgentSettingStringItem(LogLevel, "info", validateLogLevel)

--- a/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/types/global.go
+++ b/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/types/global.go
@@ -305,6 +305,8 @@ const (
 	// Log filtering and dedupliction
 	// LogDedupWindowSize is a measure of how many log entries are saved to search for duplicates
 	LogDedupWindowSize GlobalSettingKey = "log.dedup.window.size"
+	// LogFilenamesToCount a comma-separated list of log filenames to count
+	LogFilenamesToCount GlobalSettingKey = "log.count.filenames"
 
 	// DisableDHCPAllOnesNetMask option is deprecated and has no effect.
 	// Zedrouter no longer uses the all-ones netmask as it adds unnecessary complexity,
@@ -1002,6 +1004,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 
 	// Log deduplication and filtering settings
 	configItemSpecMap.AddIntItem(LogDedupWindowSize, 100, 0, 0xFFFFFFFF)
+	configItemSpecMap.AddStringItem(LogFilenamesToCount, "", blankValidator)
 
 	// Add Agent Settings
 	configItemSpecMap.AddAgentSettingStringItem(LogLevel, "info", validateLogLevel)

--- a/pkg/pillar/cmd/loguploader/loguploader.go
+++ b/pkg/pillar/cmd/loguploader/loguploader.go
@@ -880,8 +880,7 @@ func sendToCloud(ctx *loguploaderContext, data []byte, iter int, fName string, f
 		}
 	}
 	if err != nil {
-		log.Errorf("sendToCloud: %d bytes, file %s failed: %v", size, fName, err)
-		return serviceUnavailable, fmt.Errorf("sendToCloud: failed to send")
+		return serviceUnavailable, fmt.Errorf("sendToCloud: %d bytes, file %s failed: %v", size, fName, err)
 	}
 	log.Tracef("sendToCloud: Sent %d bytes, file %s to %s", size, fName, logsURL)
 	return serviceUnavailable, nil

--- a/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
+++ b/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
@@ -190,13 +190,10 @@ func getVolumeStatusByLocation(location string) (*types.VolumeStatus, error) {
 		}
 		volumeIDAndGeneration = keyAndFormat[0]
 		ok := false
-		log.Noticef("getVolumeStatusByLocation: parsing format from location %s", location)
-		log.Noticef("getVolumeStatusByLocation: found format %s", keyAndFormat[1])
 		parsedFormat, ok = zconfig.Format_value[strings.ToUpper(keyAndFormat[1])]
 		if !ok {
 			return nil, fmt.Errorf("found unknown format volume %s", location)
 		}
-		log.Noticef("getVolumeStatusByLocation: the format as digit %d", parsedFormat)
 		volumeIDAndGeneration = strings.ReplaceAll(volumeIDAndGeneration, "#", ".")
 	}
 
@@ -221,7 +218,7 @@ func getVolumeStatusByLocation(location string) (*types.VolumeStatus, error) {
 		ContentFormat:     zconfig.Format(parsedFormat),
 		FileLocation:      location,
 	}
-	log.Noticef("getVolumeStatusByLocation: found volume %s, content format %s", location, vs.ContentFormat)
+	log.Functionf("getVolumeStatusByLocation: found volume %s, content format %s", location, vs.ContentFormat)
 	return &vs, nil
 }
 

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -309,6 +309,8 @@ const (
 	// Log filtering and dedupliction
 	// LogDedupWindowSize is a measure of how many log entries are saved to search for duplicates
 	LogDedupWindowSize GlobalSettingKey = "log.dedup.window.size"
+	// LogFilenamesToCount a comma-separated list of log filenames to count
+	LogFilenamesToCount GlobalSettingKey = "log.count.filenames"
 
 	// DisableDHCPAllOnesNetMask option is deprecated and has no effect.
 	// Zedrouter no longer uses the all-ones netmask as it adds unnecessary complexity,
@@ -1027,6 +1029,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 
 	// Log deduplication and filtering settings
 	configItemSpecMap.AddIntItem(LogDedupWindowSize, 100, 0, 0xFFFFFFFF)
+	configItemSpecMap.AddStringItem(LogFilenamesToCount, "", blankValidator)
 
 	// Add Agent Settings
 	configItemSpecMap.AddAgentSettingStringItem(LogLevel, "info", validateLogLevel)

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -306,6 +306,10 @@ const (
 	// FmlCustomResolution global setting key
 	FmlCustomResolution GlobalSettingKey = "app.fml.resolution"
 
+	// Log filtering and dedupliction
+	// LogDedupWindowSize is a measure of how many log entries are saved to search for duplicates
+	LogDedupWindowSize GlobalSettingKey = "log.dedup.window.size"
+
 	// DisableDHCPAllOnesNetMask option is deprecated and has no effect.
 	// Zedrouter no longer uses the all-ones netmask as it adds unnecessary complexity,
 	// causes confusion for some applications, and is no longer required for any EVE
@@ -1020,6 +1024,9 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddStringItem(SyslogRemoteLogLevel, "info", validateSyslogKernelLevel)
 	configItemSpecMap.AddStringItem(KernelRemoteLogLevel, "info", validateSyslogKernelLevel)
 	configItemSpecMap.AddStringItem(FmlCustomResolution, FmlResolutionUnset, blankValidator)
+
+	// Log deduplication and filtering settings
+	configItemSpecMap.AddIntItem(LogDedupWindowSize, 100, 0, 0xFFFFFFFF)
 
 	// Add Agent Settings
 	configItemSpecMap.AddAgentSettingStringItem(LogLevel, "info", validateLogLevel)

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -311,6 +311,8 @@ const (
 	LogDedupWindowSize GlobalSettingKey = "log.dedup.window.size"
 	// LogFilenamesToCount a comma-separated list of log filenames to count
 	LogFilenamesToCount GlobalSettingKey = "log.count.filenames"
+	// LogFilenamesToFilter a comma-separated list of log filenames to filter
+	LogFilenamesToFilter GlobalSettingKey = "log.filter.filenames"
 
 	// DisableDHCPAllOnesNetMask option is deprecated and has no effect.
 	// Zedrouter no longer uses the all-ones netmask as it adds unnecessary complexity,
@@ -1030,6 +1032,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	// Log deduplication and filtering settings
 	configItemSpecMap.AddIntItem(LogDedupWindowSize, 100, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddStringItem(LogFilenamesToCount, "", blankValidator)
+	configItemSpecMap.AddStringItem(LogFilenamesToFilter, "", blankValidator)
 
 	// Add Agent Settings
 	configItemSpecMap.AddAgentSettingStringItem(LogLevel, "info", validateLogLevel)


### PR DESCRIPTION
This PR introduces log deduplication and filtering components to newlogd. The operations are performed as the logs are being compressed before sending them to the controller. The controller can configure which logs to filter out and which to count or deduplicate.

THIS IMPLEMENTATION IS STILL UNDER DEVELOPMENT & TESTING, PLEASE DON'T REVIEW OR MERGE!