### PR TITLE
volumemgr: allow OCI registry fallback datastores

### DIFF
--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -33,8 +33,11 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 		}
 
 		if status.IsOCIRegistry {
-			if len(status.DatastoreIDList) > 1 {
-				err := fmt.Sprintf("doUpdateContentTree(%s) name %s: OCI registry along with the fallback datastores list is not supported",
+			// An OCI registry datastore can be combined with fallback
+			// datastores, but only if all of them are OCI registries too.
+			// Mixing OCI and non-OCI datastores is not supported.
+			if !status.AllDatastoresAreOCIRegistry() {
+				err := fmt.Sprintf("doUpdateContentTree(%s) name %s: mixing OCI registry with non-OCI (fallback) datastores is not supported",
 					status.Key(), status.DisplayName)
 				log.Error(err)
 				status.SetErrorDescription(types.ErrorDescription{Error: err})

--- a/pkg/pillar/types/contenttreetypes.go
+++ b/pkg/pillar/types/contenttreetypes.go
@@ -159,6 +159,20 @@ func (status ContentTreeStatus) IsContainer() bool {
 	return status.Format == zconfig.Format_CONTAINER
 }
 
+// AllDatastoresAreOCIRegistry returns true if every datastore backing this
+// content tree is an OCI registry. Mixing an OCI registry with non-OCI
+// (fallback) datastores is not supported, so this is used to reject such
+// combinations. Note that this relies on DatastoreTypesList being fully
+// populated, i.e. AllDatastoresResolved is true.
+func (status ContentTreeStatus) AllDatastoresAreOCIRegistry() bool {
+	for _, dsType := range status.DatastoreTypesList {
+		if dsType != zconfig.DsType_DsContainerRegistry.String() {
+			return false
+		}
+	}
+	return true
+}
+
 // ReferenceID get the image reference ID
 func (status ContentTreeStatus) ReferenceID() string {
 

--- a/pkg/pillar/types/contenttreetypes_test.go
+++ b/pkg/pillar/types/contenttreetypes_test.go
@@ -25,6 +25,33 @@ func TestContentTreeStatusIsContainer(t *testing.T) {
 	assert.False(t, s.IsContainer())
 }
 
+// ContentTreeStatus.AllDatastoresAreOCIRegistry
+
+func TestContentTreeStatusAllDatastoresAreOCIRegistry(t *testing.T) {
+	oci := zconfig.DsType_DsContainerRegistry.String()
+	other := zconfig.DsType_DsHttp.String()
+
+	// No datastores resolved yet: vacuously true.
+	s := ContentTreeStatus{}
+	assert.True(t, s.AllDatastoresAreOCIRegistry())
+
+	// Single OCI registry.
+	s.DatastoreTypesList = []string{oci}
+	assert.True(t, s.AllDatastoresAreOCIRegistry())
+
+	// Multiple OCI registries (OCI + OCI fallbacks) is allowed.
+	s.DatastoreTypesList = []string{oci, oci}
+	assert.True(t, s.AllDatastoresAreOCIRegistry())
+
+	// Mixing OCI and non-OCI datastores is not allowed.
+	s.DatastoreTypesList = []string{oci, other}
+	assert.False(t, s.AllDatastoresAreOCIRegistry())
+
+	// Only non-OCI datastores.
+	s.DatastoreTypesList = []string{other, other}
+	assert.False(t, s.AllDatastoresAreOCIRegistry())
+}
+
 // ContentTreeStatus.ReferenceID
 
 func TestContentTreeStatusReferenceID(t *testing.T) {


### PR DESCRIPTION
A content tree backed by an OCI registry was rejected whenever it referenced more than one datastore. That check assumed an OCI registry can only ever be the single datastore, but the real constraint is narrower: the download path already passes the whole datastore list on as fallbacks, so multiple OCI registries work fine. The only combination that is genuinely unsupported is mixing an OCI registry with non-OCI datastores.

This reworks the check to reject only that mixed case (per @eriknordmark's review suggestion), so a list of OCI registry fallback datastores is accepted as intended. A new `ContentTreeStatus.AllDatastoresAreOCIRegistry()` helper enforces the all-or-none-OCI rule, with unit-test coverage.

For the original (overly conservative) restriction see commit 34ae2287ea6d916e3218a8d84773c69577e0cd3e.