### PR TITLE
Publish info and metrics also for L2-only ports

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -339,10 +339,6 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	// Only report stats for the ports in DeviceNetworkStatus
 	for _, p := range deviceNetworkStatus.Ports {
 		var metric *types.NetworkMetric
-		if !p.IsL3Port {
-			// metrics for ports from lower layers are not reported
-			continue
-		}
 		if p.IfName == "" {
 			// Cannot associate metrics with the port until interface name is known.
 			continue

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -1001,10 +1001,6 @@ func encodeSystemAdapterInfo(ctx *zedagentContext) *info.SystemAdapterInfo {
 
 		dps.Ports = make([]*info.DevicePort, len(dpc.Ports))
 		for j, p := range dpc.Ports {
-			if !p.IsL3Port {
-				// info for ports from lower layers is not published
-				continue
-			}
 			if i == dpcl.CurrentIndex {
 				// For the currently used DPC we publish the status (DeviceNetworkStatus).
 				portStatus := deviceNetworkStatus.LookupPortByLogicallabel(p.Logicallabel)


### PR DESCRIPTION
It was decided that it makes sense to publish info and metrics also for ports which do not have Network assigned (without `SystemAdapter` in `EdgeDevConfig`) but still are used by VLANs or LAGs. For example, user may configure `vlan-10` and `vlan-20` for `eth0`, use one of the VLAN sub-interfaces for management, the other for apps, while not using `eth0` directly with any network or network instance. Still it makes sense for EVE to collect and publish metrics and status information for the VLAN parent interface.
Note that NICs which are not used directly, only through VLANs/LAGs, still have `NetworkPortStatus` entry inside `DeviceNetworkStatus`, but `IsL3Port` attribute is set to false.