### PR TITLE
alpine: Make a new bootstrap to update to 3.16.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -914,7 +914,7 @@ cache-export-docker-load: $(LINUXKIT)
 	rm -rf ${TARFILE}
 
 %-cache-export-docker-load: $(LINUXKIT)
-	$(eval IMAGE_TAG := $(shell $(MAKE) $*-show-tag))
+	$(eval IMAGE_TAG := $(shell $(LINUXKIT) pkg show-tag --canonical pkg/$*))
 	$(eval CACHE_CONTENT := $(shell $(LINUXKIT) cache ls 2>&1))
 	$(if $(filter $(IMAGE_TAG),$(CACHE_CONTENT)),$(MAKE) cache-export-docker-load IMAGE=$(IMAGE_TAG),@echo "Missing image $(IMAGE_TAG) in cache")
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
 
 # you are not supposed to tweak these variables -- they are effectively R/O
 HV_DEFAULT=kvm
-GOVER ?= 1.20.1
+GOVER ?= 1.24.1
 PKGBASE=github.com/lf-edge/eve
 GOMODULE=$(PKGBASE)/pkg/pillar
 GOTREE=$(CURDIR)/pkg/pillar
@@ -491,13 +491,14 @@ $(DOCKERFILE_FROM_CHECKER): $(DOCKERFILE_FROM_CHECKER_DIR)/*.go $(DOCKERFILE_FRO
 IGNORE_DOCKERFILE_HASHES_PKGS=alpine installer
 IGNORE_DOCKERFILE_HASHES_EVE_TOOLS=bpftrace-compiler
 
+IGNORE_DOCKERFILE_DOT_GO_DIR=$(shell find .go/ -name Dockerfile -exec echo "-i {}" \;)
 IGNORE_DOCKERFILE_HASHES_PKGS_ARGS=$(foreach pkg,$(IGNORE_DOCKERFILE_HASHES_PKGS),-i pkg/$(pkg)/Dockerfile)
 IGNORE_DOCKERFILE_HASHES_EVE_TOOLS_ARGS=$(foreach tool,$(IGNORE_DOCKERFILE_HASHES_EVE_TOOLS),$(addprefix -i ,$(shell find eve-tools/$(tool) -path '*/vendor' -prune -o -name Dockerfile -print)))
 
 .PHONY: check-docker-hashes-consistency
 check-docker-hashes-consistency: $(DOCKERFILE_FROM_CHECKER)
 	@echo "Checking Dockerfiles for inconsistencies"
-	$(DOCKERFILE_FROM_CHECKER) ./ $(IGNORE_DOCKERFILE_HASHES_PKGS_ARGS) $(IGNORE_DOCKERFILE_HASHES_EVE_TOOLS_ARGS)
+	$(DOCKERFILE_FROM_CHECKER) ./ $(IGNORE_DOCKERFILE_HASHES_PKGS_ARGS) $(IGNORE_DOCKERFILE_HASHES_EVE_TOOLS_ARGS) $(IGNORE_DOCKERFILE_DOT_GO_DIR)
 
 yetus:
 	@echo Running yetus
@@ -760,8 +761,8 @@ ifeq ($(ROOTFS_FORMAT),squash)
 endif
 	$(QUIET): $@: Succeeded
 
-$(GET_DEPS):
-	$(MAKE) -C $(GET_DEPS_DIR) GOOS=$(LOCAL_GOOS)
+$(GET_DEPS): $(GOBUILDER)
+	$(QUIET)$(DOCKER_GO) "make" $(GET_DEPS_DIR)
 
 sbom_info:
 	@echo "$(SBOM)"

--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -1,12 +1,18 @@
-# image was bootstraped using FROM lfedge/eve-alpine-base:fad44e3702708a8d044663a20fd98d933dddb41e AS cache
+# image was bootstraped using FROM lfedge/eve-alpine-base:353bf866797f6e60f91cbe1b00c439634adfcf13 AS cache
 # to update please see https://github.com/lf-edge/eve/blob/master/docs/BUILD.md#how-to-update-eve-alpine-package
-FROM lfedge/eve-alpine:43c5a193374e44350e27fad7ad6fe28a929109b5 AS cache
+FROM lfedge/eve-alpine-base:353bf866797f6e60f91cbe1b00c439634adfcf13 AS cache
+
+FROM lfedge/eve-alpine:b96ae7c5b776702cdc7596e3722e40cc0d353ad7 AS cache-riscv64
+FROM cache AS cache-amd64
+FROM cache AS cache-arm64
+# hadolint ignore=DL3006
+FROM cache-${TARGETARCH} AS cache-build
 
 ARG ALPINE_VERSION=3.16
 # this is only needed once, when this package
 # is rebased on the new version of Alpine and
 # you have to have FROM alpine:x.y.z above:
-# RUN apk update && apk upgrade -a
+RUN apk update && apk upgrade -a
 
 # Copy Dockerfile so we can include it in the hash
 COPY Dockerfile abuild.conf /etc/
@@ -14,6 +20,7 @@ COPY mirrors /tmp/mirrors/
 COPY build-cache.sh /bin/
 
 # install abuild for signing (which requires gcc as well)
+# hadolint ignore=DL3018
 RUN apk add --no-cache abuild gcc sudo
 
 # install a new key into /etc/apk/keys
@@ -42,9 +49,9 @@ RUN apk update
 
 FROM lfedge/eve-alpine:591df01e581889c3027514c8a91feaca1c8ad49f AS compactor
 
-COPY --from=cache /etc/apk/repositories* /etc/apk/
-COPY --from=cache /etc/apk/keys /etc/apk/keys/
-COPY --from=cache /mirror /mirror/
+COPY --from=cache-build /etc/apk/repositories* /etc/apk/
+COPY --from=cache-build /etc/apk/keys /etc/apk/keys/
+COPY --from=cache-build /mirror /mirror/
 COPY eve-alpine-deploy.sh go-compile.sh /bin/
 
 RUN apk update && apk upgrade -a

--- a/pkg/alpine/build-cache.sh
+++ b/pkg/alpine/build-cache.sh
@@ -8,9 +8,9 @@ bail() {
 
 [ "$#" -gt 2 ] || bail "Usage: $0 <alpine version> <path to the cache> [packages...]"
 
-ALPINE_VERSION=$1
-
-if [ "$ALPINE_VERSION" != "edge" ]; then
+if echo "$1" | grep -q edge; then
+  ALPINE_VERSION=$1
+else
   ALPINE_VERSION=v$1
 fi
 

--- a/pkg/alpine/mirrors/3.16/community
+++ b/pkg/alpine/mirrors/3.16/community
@@ -3,8 +3,8 @@ cereal
 cni-plugins
 fio
 fmt
-hwinfo-libs
 hwinfo
+hwinfo-libs
 i2c-tools
 i2c-tools-dev
 iw
@@ -12,6 +12,7 @@ json-glib
 json-glib-dev
 libbpf
 libbpf-dev
+libgudev
 libgudev-dev
 libproc
 librados
@@ -26,6 +27,7 @@ libvirt-lxc
 libvirt-qemu
 libvncserver
 libvncserver-dev
+libx86emu
 pahole
 perf
 pkgconf
@@ -63,8 +65,8 @@ tpm2-tss-rc
 tpm2-tss-sys
 tpm2-tss-tcti-cmd
 tpm2-tss-tcti-device
+tpm2-tss-tctildr
 tpm2-tss-tcti-mssim
 tpm2-tss-tcti-pcap
 tpm2-tss-tcti-swtpm
-tpm2-tss-tctildr
 yq


### PR DESCRIPTION
## Description

This is the second step towards the bump of Alpine to 3.16.9. Package pkg/alpine-base was built with the minirootfs of 3.16.9 version.

This commit uses the latest pkg/alpine-base as the base image and provides the changes to build pkg/alpine bumping it to 3.16.9. Once this package is published, it can be used as the base image for itself (pkg/alpine).

PS: Changes are only applied to amd64 and arm64. Another base image (without changes) is used for riscv64.

## Notes

The build actions for arm64 were failing due to the lack of go on the arm64 runners, which was leading `get-deps` to not run. Thus, the dependency of pkg/alpine-base by pkg/alpine was not detected. This could be easily fixed by using our Go builder container to build `get-deps`. However, doing so just broke `cache-export-docker-load` target, but the fix is also provided in this PR.