### PR TITLE
newlog: add filter, dedup and counter functions

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -70,8 +70,8 @@
 | memory-monitor.enabled | boolean | false | Enable external memory monitoring and memory pressure events handling |
 | debug.tui.loglevel | string | info | Set log level for EVE Text UI (TUI) monitor. Possible values are "OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE" and are case insensitive
 | log.dedup.window.size | integer | 0 | The size of the log deduplicator's sliding window (in number of messages). See logging [docs](LOGGING.md#log-filtering-counting-and-deduplication) for details. If the window size is set to 0 (default), no deduplication is performed. |
-| log.count.filenames | string | "" | Comma-separated list of log's filenames to be counted and logged once instead of logging them every time. Example `/my-pkg/main.go:123,/other-pkg/code.go:42`. See logging [docs](LOGGING.md#log-filtering-counting-and-deduplication) for details. |
-| log.filter.filenames | string | "" | Comma-separated list of log's filenames to be filtered out. Example `/my-pkg/main.go:123,/other-pkg/code.go:42`. See logging [docs](LOGGING.md#log-filtering-counting-and-deduplication) for details. |
+| log.count.filenames | string | "" | Comma-separated list of log's filenames to be counted and logged once instead of logging them every time. Example `/my-pkg/main.go:123,/other-pkg/code.go:42`. Empty string `""` doesn't filter anything out, however a single comma `","` will filter out all entries that don't have a filename field set (e.g. logs not coming from components written in Golang). See logging [docs](LOGGING.md#log-filtering-counting-and-deduplication) for details. |
+| log.filter.filenames | string | "" | Comma-separated list of log's filenames to be filtered out. Example `/my-pkg/main.go:123,/other-pkg/code.go:42`. Empty string `""` doesn't filter anything out, however a single comma `","` will filter out all entries that don't have a filename field set (e.g. logs not coming from components written in Golang). See logging [docs](LOGGING.md#log-filtering-counting-and-deduplication) for details. |
 
 ## Log levels
 

--- a/pkg/newlog/cmd/counter.go
+++ b/pkg/newlog/cmd/counter.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync/atomic"
+
+	"github.com/lf-edge/eve-api/go/logs"
+)
+
+var (
+	// logsToCount is a list of Filename fields (src file + line number) of log entries that should be counted.
+	logsToCount atomic.Value
+
+	counterSuppressedLogs = 0
+)
+
+func countLogsInFile(file *os.File) map[string]int {
+	logCounter := make(map[string]int)
+	for _, logSrcLine := range logsToCount.Load().([]string) {
+		logCounter[logSrcLine] = 0
+	}
+	preScanner := bufio.NewScanner(file)
+	for preScanner.Scan() {
+		var logEntry logs.LogEntry
+		// we ignore the errors here, they might be coming from non-json lines like the metadata line
+		_ = json.Unmarshal(preScanner.Bytes(), &logEntry)
+
+		if currentCount, ok := logCounter[logEntry.Filename]; ok {
+			logCounter[logEntry.Filename] = currentCount + 1
+		}
+	}
+	if err := preScanner.Err(); err != nil {
+		log.Errorf("Error scanning file for log occurrence count: %v", err)
+	}
+	if _, err := file.Seek(0, 0); err != nil {
+		log.Errorf("Failed to reset file pointer: %v", err)
+	}
+	return logCounter
+}
+
+// addLogCount updates the log entry with a count tag based on the occurrence count
+// provided in the filterMap, and manages suppression of duplicate log entries.
+// It returns true if the log entry should be included in the output and false if it should be suppressed.
+func addLogCount(logEntry *logs.LogEntry, filterMap map[string]int) bool {
+	count, ok := filterMap[logEntry.Filename]
+	if !ok {
+		return true
+	}
+
+	if count == 0 {
+		// the count was already included in another entry
+		counterSuppressedLogs++
+		return false
+	}
+
+	if count == 1 {
+		// no need to add additional count field if there is only one occurrence
+		return true
+	}
+
+	if logEntry.Tags == nil {
+		logEntry.Tags = make(map[string]string)
+	}
+	logEntry.Tags["count"] = fmt.Sprint(count)
+
+	// mark the log entry as counted
+	filterMap[logEntry.Filename] = 0
+
+	return true
+}

--- a/pkg/newlog/cmd/dedup.go
+++ b/pkg/newlog/cmd/dedup.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"container/ring"
+	"encoding/json"
+	"sync/atomic"
+
+	"github.com/lf-edge/eve-api/go/logs"
+)
+
+var dedupWindowSize atomic.Uint32
+
+func init() {
+	dedupWindowSize.Store(0)
+}
+
+type containsMsg struct {
+	Msg string `json:"msg"`
+}
+
+var numDedupedLogs = 0
+
+// dedupLogEntry returns a boolean indicating whether the log entry should be used and the updated queue.
+// It can be used to deduplicate logs based on the content of a file
+func dedupLogEntry(logEntry *logs.LogEntry, seen map[string]uint64, queue *ring.Ring) (bool, *ring.Ring) {
+	useEntry := true
+
+	// No queue means no deduplication.
+	if queue == nil {
+		return useEntry, queue
+	}
+
+	dedupField := ""
+	// If logEntry.content is a valid JSON, extract the field "msg" from it.
+	if logEntry.Content != "" {
+		var content containsMsg
+		err := json.Unmarshal([]byte(logEntry.Content), &content)
+		if err == nil && content.Msg != "" {
+			dedupField = content.Msg
+		} else {
+			dedupField = logEntry.Content
+		}
+	}
+
+	// If the file hasn't appeared in the last bufferSize logs, forward it.
+	if _, ok := seen[dedupField]; ok && logEntry.Severity == "error" {
+		useEntry = false
+		log.Tracef("Deduped log id %d because of the log id %d\n", logEntry.Msgid, seen[dedupField])
+		numDedupedLogs++
+	} else {
+		useEntry = true
+	}
+
+	// Remove the oldest log from the window.
+	if oldest := queue.Value; oldest != nil {
+		delete(seen, oldest.(string))
+	}
+
+	// Add the current log to the window.
+	queue.Value = dedupField
+	seen[dedupField] = logEntry.Msgid
+
+	return useEntry, queue.Next()
+}

--- a/pkg/newlog/cmd/dedup_test.go
+++ b/pkg/newlog/cmd/dedup_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bufio"
+	"compress/gzip"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/lf-edge/eve-api/go/logs"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+func TestDoMoveCompressFile(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	logFileInfo := fileChanInfo{
+		tmpfile:   "../testdata/collect/dev.log.keep.397634723",
+		isApp:     false,
+		notUpload: false, // treat as if it was uploaded to see how the filtering measures work
+	}
+
+	logger.SetLevel(logrus.TraceLevel)
+	ps := pubsub.New(&pubsub.EmptyDriver{}, logger, log)
+
+	// FILTERING PARAMS:
+	filenameFilter.Store(map[string]struct{}{
+		// "/pillar/types/zedroutertypes.go:1079": {},
+	})
+	logsToCount.Store([]string{
+		"/pillar/types/zedroutertypes.go:1079",
+	})
+	dedupWindowSize.Store(100)
+
+	// set uploadDevDir to a local path
+	uploadDevDir = "/tmp"
+
+	compressedFiles := doMoveCompressFile(ps, logFileInfo)
+	g.Expect(len(compressedFiles)).To(gomega.Equal(1))
+
+	t.Logf("filterSuppressedLogs: %d", filterSuppressedLogs)
+	t.Logf("counterSuppressedLogs: %d", counterSuppressedLogs)
+	t.Logf("Total num deduped logs: %d", numDedupedLogs)
+
+	// Now let's count how many log entries are missing from the compressed file
+	var missingMsgidCount int
+	var expectedMsgID uint64
+	for _, filePath := range compressedFiles {
+		f, err := os.Open(filePath)
+		if err != nil {
+			t.Errorf("failed to open compressed file %q: %v", filePath, err)
+			continue
+		}
+		defer f.Close()
+
+		gr, err := gzip.NewReader(f)
+		if err != nil {
+			t.Errorf("failed to create gzip reader for %q: %v", filePath, err)
+			continue
+		}
+		defer gr.Close()
+
+		scanner := bufio.NewScanner(gr)
+		for scanner.Scan() {
+			var entry logs.LogEntry
+			if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+				t.Errorf("failed to unmarshal JSON from %q: %v", filePath, err)
+				continue
+			}
+			if entry.Msgid != expectedMsgID && expectedMsgID != 0 {
+				missingMsgidCount += int(entry.Msgid - expectedMsgID)
+			}
+			expectedMsgID = entry.Msgid + 1
+		}
+		if err := scanner.Err(); err != nil {
+			t.Errorf("scanner error for %q: %v", filePath, err)
+		}
+	}
+
+	t.Logf("Total number of log entries with missing msgid: %d", missingMsgidCount)
+
+	g.Expect(missingMsgidCount).To(gomega.Equal(filterSuppressedLogs+counterSuppressedLogs+numDedupedLogs), "The number of missing msgid entries should match the sum of filterSuppressedLogs, counterSuppressedLogs, and numDedupedLogs")
+}
+
+func BenchmarkDoMoveCompressFile(b *testing.B) {
+	logFileInfo := fileChanInfo{
+		tmpfile: "../testdata/collect/dev.log.keep.397634723",
+		isApp:   false,
+	}
+
+	ps := pubsub.New(&pubsub.EmptyDriver{}, logger, log)
+
+	b.Run("only compression", func(b *testing.B) {
+		logFileInfo.notUpload = true // filtering and deduplication are only applied to the logs to be uploaded
+		// set keepSentDir to a local path
+		keepSentDir = "/tmp"
+
+		// Report memory allocations.
+		b.ReportAllocs()
+
+		// Run the benchmark.
+		for b.Loop() {
+			doMoveCompressFile(ps, logFileInfo)
+		}
+	})
+
+	b.Run("filtering and deduplication does nothing", func(b *testing.B) {
+		logFileInfo.notUpload = false // filtering and deduplication are only applied to the logs to be uploaded
+		// set uploadDevDir to a local path
+		uploadDevDir = "/tmp"
+
+		// FILTERING PARAMS:
+		filenameFilter.Store(map[string]struct{}{
+			// "/pillar/types/zedroutertypes.go:1079": {},
+		})
+		logsToCount.Store([]string{
+			// "/pillar/types/zedroutertypes.go:1079",
+		})
+		dedupWindowSize.Store(0)
+
+		// Report memory allocations.
+		b.ReportAllocs()
+
+		// Run the benchmark.
+		for b.Loop() {
+			doMoveCompressFile(ps, logFileInfo)
+		}
+
+		b.Logf("filterSuppressedLogs: %d", filterSuppressedLogs)
+		b.Logf("counterSuppressedLogs: %d", counterSuppressedLogs)
+		b.Logf("Total num deduped logs: %d", numDedupedLogs)
+	})
+
+	b.Run("filtering and deduplication does something", func(b *testing.B) {
+		logFileInfo.notUpload = false // filtering and deduplication are only applied to the logs to be uploaded
+		// set uploadDevDir to a local path
+		uploadDevDir = "/tmp"
+
+		// FILTERING PARAMS:
+		filenameFilter.Store(map[string]struct{}{
+			"/pillar/types/zedroutertypes.go:1079": {},
+		})
+		logsToCount.Store([]string{
+			"/pillar/types/zedroutertypes.go:1079",
+		})
+		dedupWindowSize.Store(100)
+
+		// Report memory allocations.
+		b.ReportAllocs()
+
+		// Run the benchmark.
+		for b.Loop() {
+			doMoveCompressFile(ps, logFileInfo)
+		}
+
+		b.Logf("filterSuppressedLogs: %d", filterSuppressedLogs)
+		b.Logf("counterSuppressedLogs: %d", counterSuppressedLogs)
+		b.Logf("Total num deduped logs: %d", numDedupedLogs)
+	})
+}

--- a/pkg/newlog/cmd/filter.go
+++ b/pkg/newlog/cmd/filter.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"sync/atomic"
+
+	"github.com/lf-edge/eve-api/go/logs"
+)
+
+var (
+	filenameFilter atomic.Value // map[string]struct{}, where key is the filename+line number of the source code that generated the log
+
+	filterSuppressedLogs = 0
+)
+
+// filterOut checks if the log entry should be filtered out
+// based on the filename or severity + function name
+func filterOut(l *logs.LogEntry) bool {
+	if _, ok := filenameFilter.Load().(map[string]struct{})[l.Filename]; ok {
+		filterSuppressedLogs++
+		return true
+	}
+
+	return false
+}

--- a/pkg/newlog/cmd/newlogd.go
+++ b/pkg/newlog/cmd/newlogd.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"container/ring"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -377,6 +378,11 @@ func main() {
 		case tmpLogfileInfo := <-movefileChan:
 			// handle logfile to gzip conversion work
 			doMoveCompressFile(&ps, tmpLogfileInfo)
+			// done gzip conversion, get rid of the temp log file in collect directory
+			err = os.Remove(tmpLogfileInfo.tmpfile)
+			if err != nil {
+				log.Fatal("doMoveCompressFile: remove file failed", err)
+			}
 
 		case panicBuf := <-panicFileChan:
 			// save panic stack into files
@@ -585,6 +591,29 @@ func handleGlobalConfigImp(ctxArg interface{}, key string, statusArg interface{}
 		// parse kernel remote log level
 		kernelRemotePrioStr := gcp.GlobalValueString(types.KernelRemoteLogLevel)
 		atomic.StoreUint32(&kernelRemotePrio, parseSyslogLogLevel(kernelRemotePrioStr))
+
+		// set log deduplication and filtering settings
+		dedupWindowSize.Store(gcp.GlobalValueInt(types.LogDedupWindowSize))
+		log.Functionf("handleGlobalConfigModify: set dedupWindowSize to %d", dedupWindowSize.Load())
+
+		// parse a comma separated list of log filenames to count
+		var filenamesToCount []string
+		if gcp.GlobalValueString(types.LogFilenamesToCount) != "" {
+			filenamesToCount = strings.Split(gcp.GlobalValueString(types.LogFilenamesToCount), ",")
+		}
+		logsToCount.Store(filenamesToCount)
+		log.Functionf("handleGlobalConfigModify: gonna count the logs from the following lines %v", filenamesToCount)
+
+		// parse a comma separated list of log filenames to filter
+		newFilenameFilter := make(map[string]struct{})
+		if gcp.GlobalValueString(types.LogFilenamesToFilter) != "" {
+			for filename := range strings.SplitSeq(gcp.GlobalValueString(types.LogFilenamesToFilter), ",") {
+				newFilenameFilter[filename] = struct{}{}
+			}
+		}
+		filenameFilter.Store(newFilenameFilter)
+		log.Functionf("handleGlobalConfigModify: gonna filter out the logs from the following lines %v", newFilenameFilter)
+
 	}
 	log.Tracef("handleGlobalConfigModify done for %s, fastupload enabled %v", key, enableFastUpload)
 }
@@ -1355,7 +1384,9 @@ func getOldestLog() (*logs.LogEntry, error) {
 	return &entry, nil
 }
 
-func doMoveCompressFile(ps *pubsub.PubSub, tmplogfileInfo fileChanInfo) {
+func doMoveCompressFile(ps *pubsub.PubSub, tmplogfileInfo fileChanInfo) []string {
+	var writtenFiles []string
+
 	isApp := tmplogfileInfo.isApp
 	dirName, appuuid := getFileInfo(tmplogfileInfo)
 
@@ -1373,21 +1404,34 @@ func doMoveCompressFile(ps *pubsub.PubSub, tmplogfileInfo fileChanInfo) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer iFile.Close()
+
+	// first we go through the file and count the number of occurrences of the selected log entries
+	var logCounter map[string]int
+	var seen map[string]uint64
+	var queue *ring.Ring
+	if dirName == uploadDevDir {
+		if len(logsToCount.Load().([]string)) != 0 {
+			logCounter = countLogsInFile(iFile)
+			log.Functionf("Counted log occurrences while compressing %s to %s: %v", tmplogfileInfo.tmpfile, outfile, logCounter)
+		}
+
+		// for deduplicator
+		// 'seen' counts occurrences of each file in the current window.
+		seen = make(map[string]uint64)
+		// 'queue' holds the file fields of the last bufferSize logs.
+		queue = ring.New(int(dedupWindowSize.Load()))
+	}
+
 	scanner := bufio.NewScanner(iFile)
 	// check if we cannot scan
 	// check valid json header for device log we will use later
 	if !scanner.Scan() || (!isApp && !json.Valid(scanner.Bytes())) {
-		_ = iFile.Close()
-		err = fmt.Errorf("doMoveCompressFile: can't get metadata on first line, remove %s", tmplogfileInfo.tmpfile)
-		log.Error(err)
+		log.Errorf("doMoveCompressFile: can't get metadata on first line, remove %s", tmplogfileInfo.tmpfile)
 		if scanner.Err() != nil {
 			log.Error(scanner.Err())
 		}
-		err = os.Remove(tmplogfileInfo.tmpfile)
-		if err != nil {
-			log.Fatal("doMoveCompressFile: remove file failed", err)
-		}
-		return
+		return nil
 	}
 
 	// assign the metadata in the first line of the logfile
@@ -1416,11 +1460,37 @@ func doMoveCompressFile(ps *pubsub.PubSub, tmplogfileInfo fileChanInfo) {
 			log.Errorf("doMoveCompressFile: found broken line: %s", string(newLine))
 			continue
 		}
+
+		if dirName == uploadDevDir {
+			if len(filenameFilter.Load().(map[string]struct{})) != 0 || len(logCounter) != 0 || dedupWindowSize.Load() != 0 {
+				var logEntry logs.LogEntry
+				if err := json.Unmarshal(newLine, &logEntry); err != nil {
+					continue // we don't care about the error here
+				}
+				var useEntry bool
+				if useEntry = !filterOut(&logEntry); !useEntry {
+					continue
+				}
+				if useEntry = addLogCount(&logEntry, logCounter); !useEntry {
+					continue
+				}
+				if useEntry, queue = dedupLogEntry(&logEntry, seen, queue); !useEntry {
+					continue
+				}
+				newLine, err = json.Marshal(&logEntry)
+				if err != nil {
+					log.Errorf("doMoveCompressFile: failed to marshal logEntry: %v", err)
+					continue
+				}
+			}
+		}
+
 		// assume that next line is incompressible to be safe
 		// note: bytesWritten may be updated eventually because of gzip implementation
 		// potentially we cannot account maxGzipFileSize less than windowsize of gzip 32768
 		if underlayWriter.bytesWritten+gzipFileFooter+int64(len(newLine)) >= maxGzipFileSize {
 			newSize += finalizeGzipToOutTempFile(gw, oTmpFile, outfile)
+			writtenFiles = append(writtenFiles, outfile)
 			logmetrics.NumBreakGZipFile++
 			fileID++
 			outfile = gzipFileNameGet(isApp, timeNowNum+fileID, dirName, appuuid, tmplogfileInfo.notUpload)
@@ -1435,6 +1505,7 @@ func doMoveCompressFile(ps *pubsub.PubSub, tmplogfileInfo fileChanInfo) {
 		log.Fatal("doMoveCompressFile: reading file failed", scanner.Err())
 	}
 	newSize += finalizeGzipToOutTempFile(gw, oTmpFile, outfile)
+	writtenFiles = append(writtenFiles, outfile)
 	fileID++
 
 	// store variable to check for the new file name generator
@@ -1449,12 +1520,7 @@ func doMoveCompressFile(ps *pubsub.PubSub, tmplogfileInfo fileChanInfo) {
 		logmetrics.DevMetrics.NumGZipBytesWrite += uint64(newSize)
 	}
 
-	_ = iFile.Close()
-	// done gzip conversion, get rid of the temp log file in collect directory
-	err = os.Remove(tmplogfileInfo.tmpfile)
-	if err != nil {
-		log.Fatal("doMoveCompressFile: remove file failed", err)
-	}
+	return writtenFiles
 }
 
 func calculateGzipSizes(size int64) {
@@ -1483,7 +1549,7 @@ func prepareGzipToOutTempFile(gzipDirName string, fHdr fileChanInfo, now time.Ti
 	// open output file
 	oTmpFile, err := os.CreateTemp(gzipDirName, tmpPrefix)
 	if err != nil {
-		log.Fatal("prepareGzipToOutTempFile: create tmp file failed ", err)
+		log.Fatal("prepareGzipToOutTempFile: create tmp file failed: ", err)
 	}
 
 	writer := &countingWriter{

--- a/pkg/newlog/cmd/newlogd_test.go
+++ b/pkg/newlog/cmd/newlogd_test.go
@@ -16,6 +16,7 @@ import (
 func init() {
 	logger, log = agentlog.Init(agentName)
 }
+
 func TestGzipParsing(t *testing.T) {
 	t.Parallel()
 	g := NewWithT(t)

--- a/pkg/newlog/cmd/newlogd_test.go
+++ b/pkg/newlog/cmd/newlogd_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega"
 )
 
 func init() {
@@ -19,17 +19,17 @@ func init() {
 
 func TestGzipParsing(t *testing.T) {
 	t.Parallel()
-	g := NewWithT(t)
+	g := gomega.NewWithT(t)
 
 	// Test the gzip parsing function
 	keepSentDir = "../testdata/keepSentQueue"
 	oldestLogEntry, err := getOldestLog()
 
-	g.Expect(err).To(BeNil())
-	g.Expect(oldestLogEntry).NotTo(BeNil())
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(oldestLogEntry).NotTo(gomega.BeNil())
 	t.Logf("latestLogEntry: %v\n", oldestLogEntry)
 
-	g.Expect(oldestLogEntry.Content).To(Equal("memlogd started"))
+	g.Expect(oldestLogEntry.Content).To(gomega.Equal("memlogd started"))
 
 	logmetrics.OldestSavedDeviceLog = time.Unix(
 		oldestLogEntry.Timestamp.Seconds, int64(oldestLogEntry.Timestamp.Nanos))
@@ -38,7 +38,7 @@ func TestGzipParsing(t *testing.T) {
 
 func TestGetTimestampFromGzipName(t *testing.T) {
 	t.Parallel()
-	g := NewWithT(t)
+	g := gomega.NewWithT(t)
 
 	comparisonMap := map[string]time.Time{
 		"app.8ce1cc69-e1bb-4fe3-9613-e3eb1c5f5c4d.log.1731935033496.gz": time.Unix(0, 1731935033496*int64(time.Millisecond)),
@@ -49,21 +49,21 @@ func TestGetTimestampFromGzipName(t *testing.T) {
 
 	keepSentDir = "../testdata/keepSentQueue"
 	files, err := os.ReadDir(keepSentDir)
-	g.Expect(err).To(BeNil())
+	g.Expect(err).To(gomega.BeNil())
 
 	for _, file := range files {
 		if file.IsDir() {
 			continue
 		}
 		timestamp, err := types.GetTimestampFromGzipName(file.Name())
-		g.Expect(err).To(BeNil())
-		g.Expect(timestamp).To(Equal(comparisonMap[file.Name()]))
+		g.Expect(err).To(gomega.BeNil())
+		g.Expect(timestamp).To(gomega.Equal(comparisonMap[file.Name()]))
 	}
 }
 
 func TestFindMovePrevLogFiles(t *testing.T) {
 	t.Parallel()
-	g := NewWithT(t)
+	g := gomega.NewWithT(t)
 
 	collectDir = "../testdata/collect"
 
@@ -76,7 +76,7 @@ func TestFindMovePrevLogFiles(t *testing.T) {
 	movefileChan := make(chan fileChanInfo, 5)
 	findMovePrevLogFiles(movefileChan)
 
-	g.Eventually(movefileChan).Should(HaveLen(3))
+	g.Eventually(movefileChan).Should(gomega.HaveLen(3))
 
 	var file1, file2, file3 fileChanInfo
 	select {
@@ -106,8 +106,8 @@ func TestFindMovePrevLogFiles(t *testing.T) {
 
 	for _, file := range files {
 		expectedNotUpload, exists := expectedFiles[file.tmpfile]
-		g.Expect(exists).To(BeTrue())
-		g.Expect(file.notUpload).To(Equal(expectedNotUpload))
+		g.Expect(exists).To(gomega.BeTrue())
+		g.Expect(file.notUpload).To(gomega.Equal(expectedNotUpload))
 
 		getFileInfo(file)
 	}
@@ -115,7 +115,7 @@ func TestFindMovePrevLogFiles(t *testing.T) {
 
 func TestGetFileInfo(t *testing.T) {
 	t.Parallel()
-	g := NewWithT(t)
+	g := gomega.NewWithT(t)
 
 	tests := []struct {
 		name          string
@@ -169,8 +169,8 @@ func TestGetFileInfo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dirName, appuuid := getFileInfo(tt.fileChanInfo)
-			g.Expect(dirName).To(Equal(tt.expectedDir))
-			g.Expect(appuuid).To(Equal(tt.expectedAppID))
+			g.Expect(dirName).To(gomega.Equal(tt.expectedDir))
+			g.Expect(appuuid).To(gomega.Equal(tt.expectedAppID))
 		})
 	}
 }

--- a/pkg/newlog/go.mod
+++ b/pkg/newlog/go.mod
@@ -1,7 +1,6 @@
 module github.com/lf-edge/eve/pkg/newlog
 
-go 1.23
-toolchain go1.24.1
+go 1.24.1
 
 require (
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible
@@ -9,7 +8,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/lf-edge/eve-api/go v0.0.0-20250310225738-c77ab6f8c73a
 	github.com/lf-edge/eve-tools/runtimemetrics/go v0.0.0-20250320220227-713ea9d6c6d2
-	github.com/lf-edge/eve/pkg/pillar v0.0.0-20250327141430-f040d3437112
+	github.com/lf-edge/eve/pkg/pillar v0.0.0-20250403232224-ee02f7ed9974
 	github.com/onsi/gomega v1.29.0
 	github.com/sirupsen/logrus v1.9.3
 )

--- a/pkg/newlog/go.sum
+++ b/pkg/newlog/go.sum
@@ -1340,8 +1340,8 @@ github.com/lf-edge/eve-tools/runtimemetrics/go v0.0.0-20250320220227-713ea9d6c6d
 github.com/lf-edge/eve-tools/runtimemetrics/go v0.0.0-20250320220227-713ea9d6c6d2/go.mod h1:l5jh2deQzJnZ7gW4F7dvzJcLRlkYBgFjcHs+eBnBUxo=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d h1:tUBb9M6u42LXwHAYHyh22wJeUUQlTpDkXwRXalpRqbo=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d/go.mod h1:Nn3juMJJ1G8dyHOebdZyS4jOB/fuxAd5fIajBaWjHr8=
-github.com/lf-edge/eve/pkg/pillar v0.0.0-20250327141430-f040d3437112 h1:8UkacfP5qQR0CQfyYbDSjOxKEksUnEm7VoqsESHPXvc=
-github.com/lf-edge/eve/pkg/pillar v0.0.0-20250327141430-f040d3437112/go.mod h1:qHx+C/9HT8xEWXVnhZeNZ+PevVMnNlB0W2IjDzishYk=
+github.com/lf-edge/eve/pkg/pillar v0.0.0-20250403232224-ee02f7ed9974 h1:5wDvqWIXvFE1dChqFjUffjL/+xmCqGfeeClt4zMKq/A=
+github.com/lf-edge/eve/pkg/pillar v0.0.0-20250403232224-ee02f7ed9974/go.mod h1:qHx+C/9HT8xEWXVnhZeNZ+PevVMnNlB0W2IjDzishYk=
 github.com/linuxkit/linuxkit/src/cmd/linuxkit v0.0.0-20240507172735-6d37353ca1ee h1:ASS39H/5OkVqkGSOR2xtcIsu3EZH4aDQOKhE1OfazUo=
 github.com/linuxkit/linuxkit/src/cmd/linuxkit v0.0.0-20240507172735-6d37353ca1ee/go.mod h1:UMA/+cd1QZElFCZAhuGv0TEEdWP9AgcRSXSI6S+r/KA=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=

--- a/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/containerd/containerd.go
+++ b/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/containerd/containerd.go
@@ -148,7 +148,7 @@ func (client *Client) CloseClient() error {
 	}
 	if err := client.ctrdClient.Close(); err != nil {
 		err = fmt.Errorf("CloseClient: exception while closing containerd client. %v", err.Error())
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return err
 	}
 	client.ctrdClient = nil

--- a/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/types/cipherinfotypes.go
+++ b/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/types/cipherinfotypes.go
@@ -146,4 +146,6 @@ type EncryptionBlock struct {
 	CellularNetPassword string
 	ProtectedUserData   string
 	ClusterToken        string
+	User                zcommon.EncryptionBlockUser
+	EncryptedData       string
 }

--- a/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/types/global.go
+++ b/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/types/global.go
@@ -308,6 +308,14 @@ const (
 	// FmlCustomResolution global setting key
 	FmlCustomResolution GlobalSettingKey = "app.fml.resolution"
 
+	// Log filtering and dedupliction
+	// LogDedupWindowSize is a measure of how many log entries are saved to search for duplicates
+	LogDedupWindowSize GlobalSettingKey = "log.dedup.window.size"
+	// LogFilenamesToCount a comma-separated list of log filenames to count
+	LogFilenamesToCount GlobalSettingKey = "log.count.filenames"
+	// LogFilenamesToFilter a comma-separated list of log filenames to filter
+	LogFilenamesToFilter GlobalSettingKey = "log.filter.filenames"
+
 	// DisableDHCPAllOnesNetMask option is deprecated and has no effect.
 	// Zedrouter no longer uses the all-ones netmask as it adds unnecessary complexity,
 	// causes confusion for some applications, and is no longer required for any EVE
@@ -1029,6 +1037,11 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddStringItem(KernelRemoteLogLevel, "info", validateSyslogKernelLevel)
 	configItemSpecMap.AddStringItem(FmlCustomResolution, FmlResolutionUnset, blankValidator)
 	configItemSpecMap.AddStringItem(TUIMonitorLogLevel, "info", blankValidator)
+
+	// Log deduplication and filtering settings
+	configItemSpecMap.AddIntItem(LogDedupWindowSize, 0, 0, 0xFFFFFFFF)
+	configItemSpecMap.AddStringItem(LogFilenamesToCount, "", blankValidator)
+	configItemSpecMap.AddStringItem(LogFilenamesToFilter, "", blankValidator)
 
 	// Add Agent Settings
 	configItemSpecMap.AddAgentSettingStringItem(LogLevel, "info", validateLogLevel)

--- a/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/types/zedmanagertypes.go
@@ -27,10 +27,12 @@ type UUIDandVersion struct {
 type SnapshotType int32
 
 const (
-	// SnapshotTypeUnspecified is the default value, and should not be used in practice
+	// SnapshotTypeUnspecified is the default value, and means no snapshot should be taken
 	SnapshotTypeUnspecified SnapshotType = 0
 	// SnapshotTypeAppUpdate is used when the snapshot is created as a result of an app update
 	SnapshotTypeAppUpdate SnapshotType = 1
+	// SnapshotTypeImmediate is used when the snapshot is created immediately
+	SnapshotTypeImmediate SnapshotType = 2
 )
 
 func (s SnapshotType) String() string {
@@ -39,6 +41,8 @@ func (s SnapshotType) String() string {
 		return "SnapshotTypeUnspecified"
 	case SnapshotTypeAppUpdate:
 		return "SnapshotTypeAppUpdate"
+	case SnapshotTypeImmediate:
+		return "SnapshotTypeImmediate"
 	default:
 		return fmt.Sprintf("Unknown SnapshotType %d", s)
 	}
@@ -49,6 +53,8 @@ func (s SnapshotType) ConvertToInfoSnapshotType() info.SnapshotType {
 	switch s {
 	case SnapshotTypeAppUpdate:
 		return info.SnapshotType_SNAPSHOT_TYPE_APP_UPDATE
+	case SnapshotTypeImmediate:
+		return info.SnapshotType_SNAPSHOT_TYPE_IMMEDIATE
 	default:
 		return info.SnapshotType_SNAPSHOT_TYPE_UNSPECIFIED
 	}
@@ -234,6 +240,18 @@ func (config AppInstanceConfig) Key() string {
 	return config.UUIDandVersion.UUID.String()
 }
 
+// SnapshotWhen describes when a snapshot should be taken, see info below
+type SnapshotWhen uint8
+
+const (
+	// NoSnapshotTake indicated no snapshot should be taken, f.e. because it already exists.
+	NoSnapshotTake SnapshotWhen = iota
+	// SnapshotImmediate indicates whether a snapshot should be taken immediately.
+	SnapshotImmediate
+	// SnapshotOnUpgrade indicates whether a snapshot should be taken during the app instance update.
+	SnapshotOnUpgrade
+)
+
 // SnapshottingStatus contains the snapshot information for the app instance.
 type SnapshottingStatus struct {
 	// MaxSnapshots indicates the maximum number of snapshots to be kept for the app instance.
@@ -246,8 +264,8 @@ type SnapshottingStatus struct {
 	SnapshotsToBeDeleted []SnapshotDesc
 	// PreparedVolumesSnapshotConfigs contains the list of snapshots to be triggered for the app instance.
 	PreparedVolumesSnapshotConfigs []VolumesSnapshotConfig
-	// SnapshotOnUpgrade indicates whether a snapshot should be taken during the app instance update.
-	SnapshotOnUpgrade bool
+	// SnapshotTakenType indicates if and when a snapshot should be taken
+	SnapshotTakenType SnapshotWhen
 	// HasRollbackRequest indicates whether there are any rollback requests for the app instance.
 	// Set to true when a rollback is requested by controller, set to false when the rollback is triggered.
 	HasRollbackRequest bool

--- a/pkg/newlog/vendor/modules.txt
+++ b/pkg/newlog/vendor/modules.txt
@@ -321,7 +321,7 @@ github.com/lf-edge/eve-tools/runtimemetrics/go/nestedappinstancemetrics
 # github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d
 ## explicit; go 1.20
 github.com/lf-edge/eve/pkg/kube/cnirpc
-# github.com/lf-edge/eve/pkg/pillar v0.0.0-20250327141430-f040d3437112
+# github.com/lf-edge/eve/pkg/pillar v0.0.0-20250403232224-ee02f7ed9974
 ## explicit; go 1.23
 github.com/lf-edge/eve/pkg/pillar/agentlog
 github.com/lf-edge/eve/pkg/pillar/base


### PR DESCRIPTION
Newlog will have 3 ways to reduce the amount of logs:
- filter: filter logs out based on the source code line that produced them
- counter: count the number of logs produced by a specific source code line. Add that number to the first occurance of the log and remove the rest
- deduplicator (for errors only): record the last X errors in a sliding window and remove duplicates

The benchmarking of the newlogd with the new features is in the dedup_test.go file. It shows that CPU and RAM usage increase by a factor of 3 when the features are enabled. So they can be disabled by setting the deduplication window size to 0 and not providing anything to the filter and counter functions.