### PR TITLE
Bump Alpine version to 3.16.9 - Part 0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,7 @@ $(DOCKERFILE_FROM_CHECKER): $(DOCKERFILE_FROM_CHECKER_DIR)/*.go $(DOCKERFILE_FRO
 # this next section checks that the FROM hashes for any image in any dockerfile anywhere here are consistent.
 # For example, one Dockerfile has foo:abc and the next has foo:def, it will flag them.
 # These are the packages that we are ignoring for now
-IGNORE_DOCKERFILE_HASHES_PKGS=alpine installer
+IGNORE_DOCKERFILE_HASHES_PKGS=alpine installer cross-compilers
 IGNORE_DOCKERFILE_HASHES_EVE_TOOLS=bpftrace-compiler
 
 IGNORE_DOCKERFILE_DOT_GO_DIR=$(shell find .go/ -name Dockerfile -exec echo "-i {}" \;)

--- a/pkg/alpine/mirrors/3.16/community
+++ b/pkg/alpine/mirrors/3.16/community
@@ -1,3 +1,4 @@
+bcc
 bcc-dev
 cereal
 cni-plugins

--- a/pkg/cross-compilers/Dockerfile
+++ b/pkg/cross-compilers/Dockerfile
@@ -1,8 +1,8 @@
-FROM lfedge/eve-alpine:591df01e581889c3027514c8a91feaca1c8ad49f as build-base
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build-base
 ENV BUILD_PKGS abuild curl tar make linux-headers patch g++ git gcc ncurses-dev autoconf file sudo
 RUN eve-alpine-deploy.sh
 
-ENV ALPINE_VERSION 3.16.2
+ENV ALPINE_VERSION 3.16.9
 ENV APORTS /home/builder/aports
 
 # setting up building account and output directory
@@ -47,7 +47,7 @@ FROM build-base as build-armhf
 # we do not support cross-compilers for riscv64 host
 # as gcc-gnat is not available on riscv64
 # we cannot build cross-compilers without additional patches
-FROM lfedge/eve-alpine:591df01e581889c3027514c8a91feaca1c8ad49f as build-riscv64
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build-riscv64
 
 # hadolint ignore=DL3006
 FROM build-${TARGETARCH} as build


### PR DESCRIPTION
As expected, PR https://github.com/lf-edge/eve/pull/4704 is taking excessive time for build and run tests, so let's break the Alpine 3.16.9 update into two parts: This PR will bump pkg/alpine (with the missing packages inside) and will bump pkg/cross-compilers, which is a heavy package that take long time for build.

Once this PR is merged, then PR https://github.com/lf-edge/eve/pull/4704 will be updated to use the new images, taking less time to build.