### PR TITLE
Add code for volume detachment during failover

### DIFF
--- a/pkg/pillar/cmd/zedkube/applogs.go
+++ b/pkg/pillar/cmd/zedkube/applogs.go
@@ -22,6 +22,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// If DeletionTimestamp is not null, the pod is terminating.
+func isPodTerminating(pod corev1.Pod) bool {
+	return pod.ObjectMeta.DeletionTimestamp != nil
+}
+
 // collect App logs from pods which covers both containers and virt-launcher pods
 func (z *zedkube) collectAppLogs() {
 	sub := z.subAppInstanceConfig
@@ -141,10 +146,9 @@ func (z *zedkube) checkAppsStatus() {
 
 	var oldStatus *types.ENClusterAppStatus
 	for _, item := range items {
+		var foundPod bool
 		aiconfig := item.(types.AppInstanceConfig)
-		if !aiconfig.IsDesignatedNodeID { // if not for cluster app, skip
-			continue
-		}
+
 		encAppStatus := types.ENClusterAppStatus{
 			AppUUID:    aiconfig.UUIDandVersion.UUID,
 			IsDNidNode: aiconfig.IsDesignatedNodeID,
@@ -154,13 +158,26 @@ func (z *zedkube) checkAppsStatus() {
 		for _, pod := range pods.Items {
 			contVMIName := "virt-launcher-" + contName
 			log.Functionf("checkAppsStatus: pod %s, cont %s", pod.Name, contName)
-			if strings.HasPrefix(pod.Name, contName) || strings.HasPrefix(pod.Name, contVMIName) {
+			foundVMIPod := strings.HasPrefix(pod.Name, contVMIName)
+			if strings.HasPrefix(pod.Name, contName) || foundVMIPod {
+				if isPodTerminating(pod) {
+					// This is the old copy on the failed node, ignore it.
+					// Next in the list should be a new copy in 'Scheduling'
+					log.Noticef("Pod:%s is terminating onNode:%s deletionTime:%v",
+						pod.Name, pod.Spec.NodeName, pod.ObjectMeta.DeletionTimestamp)
+					continue
+				}
 				if pod.Spec.NodeName == z.nodeName {
 					encAppStatus.ScheduledOnThisNode = true
 				}
 				if pod.Status.Phase == corev1.PodRunning {
 					encAppStatus.StatusRunning = true
 				}
+				if foundVMIPod {
+					encAppStatus.AppIsVMI = true
+					encAppStatus.AppKubeName, _ = base.GetVMINameFromVirtLauncher(pod.Name)
+				}
+				foundPod = true
 				break
 			}
 		}
@@ -174,10 +191,60 @@ func (z *zedkube) checkAppsStatus() {
 		}
 		log.Functionf("checkAppsStatus: devname %s, pod (%d) status %+v, old %+v", z.nodeName, len(pods.Items), encAppStatus, oldStatus)
 
+		// If this is first time after zedkube started (oldstatus is nil) and I am DNid and the app is not shceduled
+		// on this node. This condition is seen for two reasons
+		// 1) We just got appinstanceconfig and domainmgr did not get chance to start it yet, timing issue, zedkube checked first
+		// 2) We are checking after app failover to other node, either this node network failed and came back or this just got rebooted
+
+		if oldStatus == nil && !encAppStatus.ScheduledOnThisNode && encAppStatus.IsDNidNode && !foundPod {
+			log.Noticef("checkAppsStatus: app not yet scheduled on this node %v", encAppStatus)
+			continue
+		}
+
 		// Publish if there is a status change
-		if oldStatus == nil || oldStatus.IsDNidNode != encAppStatus.IsDNidNode ||
-			oldStatus.ScheduledOnThisNode != encAppStatus.ScheduledOnThisNode || oldStatus.StatusRunning != encAppStatus.StatusRunning {
+		if oldStatus == nil || oldStatus.ScheduledOnThisNode != encAppStatus.ScheduledOnThisNode || oldStatus.StatusRunning != encAppStatus.StatusRunning {
 			log.Functionf("checkAppsStatus: status differ, publish")
+			// If app scheduled on this node, could happen for 3 reasons.
+			// 1) I am designated node.
+			// 2) I am not designated node but failover happened.
+			// 3) I am designated node but this is failback after failover.
+			// Get the list of volumes referenced by this app and delete the volume attachments from previous node.
+			// We need to do that because longhorn volumes are RWO and only one node can attach to those volumes.
+			// This will ensure at any given time only one node can write to those volumes, avoids corruptions.
+			// Basically if app is scheduled on this node, no other node should have volumeattachments.
+			// This is our fencing mechanism.
+			if encAppStatus.ScheduledOnThisNode {
+				for _, vol := range aiconfig.VolumeRefConfigList {
+					pvcName := fmt.Sprintf("%s-pvc-%d", vol.VolumeID.String(), vol.GenerationCounter)
+					// Get the PV name for this PVC
+					pv, err := kubeapi.GetPVFromPVC(pvcName, log)
+					if err != nil {
+						log.Errorf("Error getting PV from PVC %v", err)
+						continue
+					}
+
+					va, remoteNodeName, err := kubeapi.GetVolumeAttachmentFromPV(pv, log)
+					if err != nil {
+						log.Errorf("Error getting volumeattachment PV %s err %v", pv, err)
+						continue
+					}
+					// If no volumeattachment found, continue
+					if va == "" {
+						continue
+					}
+
+					// Delete the attachment if not on this node.
+					if remoteNodeName != z.nodeName {
+						log.Noticef("Deleting volumeattachment %s on remote node %s", va, remoteNodeName)
+						err = kubeapi.DeleteVolumeAttachment(va, log)
+						if err != nil {
+							log.Errorf("Error deleting volumeattachment %s from PV %v", va, err)
+							continue
+						}
+					}
+
+				}
+			}
 			z.pubENClusterAppStatus.Publish(aiconfig.Key(), encAppStatus)
 		}
 	}


### PR DESCRIPTION
This is commit brings in a missing code during recent merges from POC branch.

1) Fence the longhorn volumes by detaching from the failed node and attaching to new node happens automatically during failover and failback.
2) Explicitly check for terminating status of pod and ignore such pods. Just checking for scheduled status is not good enough since terminating pods are still scheduled on a node.
3) Handle a timing issue where zedkube sees appinstanceconfig before domainmgr.