### PR TITLE
Fix boot sequence to prioritize previously active applications.

### DIFF
--- a/pkg/pillar/activeapp/activeapp.go
+++ b/pkg/pillar/activeapp/activeapp.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package activeapp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// CreateLocalAppActiveFile creates the local file that indicates the app instance is active
+func CreateLocalAppActiveFile(log *base.LogObject, appUUID string) {
+	// Construct the file path as "<LocalActiveAppConfigDir>/<appUUID>.json".
+	filePath := filepath.Join(types.LocalActiveAppConfigDir, appUUID+".json")
+
+	// Ensure that the base directory exists.
+	if err := os.MkdirAll(types.LocalActiveAppConfigDir, 0700); err != nil {
+		log.Errorf("Failed to create directory %s: %v", types.LocalActiveAppConfigDir, err)
+		return
+	}
+
+	// Create (or truncate) an empty file.
+	f, err := os.Create(filePath)
+	if err != nil {
+		log.Errorf("Failed to create active file %s: %v", filePath, err)
+		return
+	}
+	defer f.Close()
+
+	log.Noticef("Created empty JSON file: %s", filePath)
+}
+
+// DelLocalAppActiveFile deletes the local file that indicates the app instance is active
+func DelLocalAppActiveFile(log *base.LogObject, appUUID string) {
+	filePath := filepath.Join(types.LocalActiveAppConfigDir, appUUID+".json")
+	if err := os.Remove(filePath); err != nil {
+		log.Errorf("Failed to remove a file %s: %v", filePath, err)
+	}
+}
+
+// LoadActiveAppInstanceUUIDs reads all JSON files from the specified directory,
+// extracts the UUID from each filename (by removing the ".json" extension),
+// and returns a slice of UUIDs.
+func LoadActiveAppInstanceUUIDs(log *base.LogObject) ([]string, error) {
+	// Read all directory entries using os.ReadDir.
+	entries, err := os.ReadDir(types.LocalActiveAppConfigDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var uuids []string
+	// Iterate over all entries found.
+	for _, entry := range entries {
+		// We only care about files (not subdirectories) with a .json extension.
+		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".json" {
+			// Remove the .json extension to get the UUID.
+			uuid := strings.TrimSuffix(entry.Name(), ".json")
+			log.Noticef("Found active app instance UUID: %s", uuid)
+			uuids = append(uuids, uuid)
+		}
+	}
+
+	return uuids, nil
+}

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -105,6 +105,7 @@ type domainContext struct {
 	pubProcessMetric       pubsub.Publication
 	pubCipherBlockStatus   pubsub.Publication
 	pubCapabilities        pubsub.Publication
+	subNodeAgentStatus     pubsub.Subscription
 	cipherMetrics          *cipher.AgentMetrics
 	createSema             *sema.Semaphore
 	GCComplete             bool
@@ -310,6 +311,23 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		log.Fatal(err)
 	}
 	domainCtx.pubCapabilities = capabilitiesInfoPub
+
+	// Look for nodeagent status
+	subNodeAgentStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:   "nodeagent",
+		MyAgentName: agentName,
+		TopicImpl:   types.NodeAgentStatus{},
+		Activate:    false,
+		Persistent:  false,
+		Ctx:         &domainCtx,
+		WarningTime: warningTime,
+		ErrorTime:   errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	domainCtx.subNodeAgentStatus = subNodeAgentStatus
+	subNodeAgentStatus.Activate()
 
 	// Look for controller certs which will be used for decryption
 	subControllerCert, err := ps.NewSubscription(pubsub.SubscriptionOptions{
@@ -662,6 +680,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	for {
 		select {
+		case change := <-subNodeAgentStatus.MsgChan():
+			subNodeAgentStatus.ProcessChange(change)
+
 		case change := <-subControllerCert.MsgChan():
 			subControllerCert.ProcessChange(change)
 
@@ -790,6 +811,27 @@ func unpublishCipherBlockStatus(ctx *domainContext, key string) {
 		return
 	}
 	pub.Unpublish(key)
+}
+
+func createLocalAppActiveFile(appUUID string) {
+	// Construct the file path as "<LocalActiveAppConfigDir>/<appUUID>.json".
+	filePath := filepath.Join(types.LocalActiveAppConfigDir, appUUID+".json")
+
+	// Ensure that the base directory exists.
+	if err := os.MkdirAll(types.LocalActiveAppConfigDir, 0700); err != nil {
+		log.Errorf("Failed to create directory %s: %v", types.LocalActiveAppConfigDir, err)
+		return
+	}
+
+	// Create (or truncate) an empty file.
+	f, err := os.Create(filePath)
+	if err != nil {
+		log.Errorf("Failed to create active file %s: %v", filePath, err)
+		return
+	}
+	defer f.Close()
+
+	log.Functionf("Created empty JSON file: %s", filePath)
 }
 
 func xenCfgFilename(appNum int) string {
@@ -1263,6 +1305,14 @@ func lookupDomainStatus(ctx *domainContext, key string) *types.DomainStatus {
 	}
 	status := st.(types.DomainStatus)
 	return &status
+}
+
+// Delete the local file that indicates the app instance is active
+func delLocalAppActiveFile(appUUID string) {
+	filePath := filepath.Join(types.LocalActiveAppConfigDir, appUUID+".json")
+	if err := os.Remove(filePath); err != nil {
+		log.Errorf("Failed to remove a file %s: %v", filePath, err)
+	}
 }
 
 // lookupDomainStatusByUUID ignores the version part of the key
@@ -1880,6 +1930,9 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 	}
 
 	status.Activated = true
+	// create a new json file in the filesystem for the specific VM.
+	createLocalAppActiveFile(status.UUIDandVersion.UUID.String())
+
 	log.Functionf("doActivateTail(%v) done for %s",
 		status.UUIDandVersion, status.DisplayName)
 }
@@ -2021,6 +2074,16 @@ func doCleanup(ctx *domainContext, status *types.DomainStatus) {
 		status)
 	status.IoAdapterList = nil
 	publishDomainStatus(ctx, status)
+
+	// Remove the boot file for the app instance unless the device is currently rebooting/shutting down.
+	items := ctx.subNodeAgentStatus.GetAll()
+	for _, st := range items {
+		if agentStatus, ok := st.(types.NodeAgentStatus); ok {
+			if !agentStatus.DeviceReboot && !agentStatus.DevicePoweroff && !agentStatus.DeviceShutdown {
+				delLocalAppActiveFile(status.UUIDandVersion.UUID.String())
+			}
+		}
+	}
 
 	log.Functionf("doCleanup(%v) done for %s",
 		status.UUIDandVersion, status.DisplayName)

--- a/pkg/pillar/cmd/zedagent/localinfo.go
+++ b/pkg/pillar/cmd/zedagent/localinfo.go
@@ -400,12 +400,21 @@ func addLocalAppConfig(ctx *getconfigContext, appInstance *types.AppInstanceConf
 	}
 }
 
+// Delete the local file that indicates the app instance is active
+func delLocalAppActiveFile(appUUID string) {
+	filePath := filepath.Join(types.LocalActiveAppConfigDir, appUUID+".json")
+	if err := os.Remove(filePath); err != nil {
+		log.Errorf("Failed to remove a file %s: %v", filePath, err)
+	}
+}
+
 // Delete all local config for this application.
 // ctx.sideController should be locked!
 func delLocalAppConfig(ctx *getconfigContext, appUUID string) {
 	delete(ctx.sideController.localCommands.AppCommands, appUUID)
 	delete(ctx.sideController.localCommands.AppCounters, appUUID)
 	persistLocalCommands(ctx.sideController.localCommands)
+	delLocalAppActiveFile(appUUID)
 }
 
 // Add config submitted for the volume via local profile server.

--- a/pkg/pillar/cmd/zedagent/localinfo.go
+++ b/pkg/pillar/cmd/zedagent/localinfo.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/lf-edge/eve-api/go/info"
 	"github.com/lf-edge/eve-api/go/profile"
+	"github.com/lf-edge/eve/pkg/pillar/activeapp"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
@@ -400,21 +401,13 @@ func addLocalAppConfig(ctx *getconfigContext, appInstance *types.AppInstanceConf
 	}
 }
 
-// Delete the local file that indicates the app instance is active
-func delLocalAppActiveFile(appUUID string) {
-	filePath := filepath.Join(types.LocalActiveAppConfigDir, appUUID+".json")
-	if err := os.Remove(filePath); err != nil {
-		log.Errorf("Failed to remove a file %s: %v", filePath, err)
-	}
-}
-
 // Delete all local config for this application.
 // ctx.sideController should be locked!
 func delLocalAppConfig(ctx *getconfigContext, appUUID string) {
 	delete(ctx.sideController.localCommands.AppCommands, appUUID)
 	delete(ctx.sideController.localCommands.AppCounters, appUUID)
 	persistLocalCommands(ctx.sideController.localCommands)
-	delLocalAppActiveFile(appUUID)
+	activeapp.DelLocalAppActiveFile(log, appUUID)
 }
 
 // Add config submitted for the volume via local profile server.

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -634,7 +634,8 @@ var appinstancePrevConfigHash []byte
 
 func parseAppInstanceConfig(getconfigCtx *getconfigContext,
 	config *zconfig.EdgeDevConfig) {
-
+	// This checks if the configuration that we get from the server has changed.
+	// if not, we will leave the function. Else we will try to create the Apps.
 	Apps := config.GetApps()
 	h := sha256.New()
 	for _, a := range Apps {
@@ -654,7 +655,8 @@ func parseAppInstanceConfig(getconfigCtx *getconfigContext,
 
 	devUUIDStr := config.GetId().Uuid
 
-	// First look for deleted ones
+	// First look for deleted ones. Look for Apps that exists on EVE OS, but not in the config
+	// file from the server. If yes, we will remove the App from the EVE OS.
 	items := getconfigCtx.pubAppInstanceConfig.GetAll()
 	for uuidStr := range items {
 		found := false

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/lf-edge/eve/pkg/pillar/activeapp"
 	"github.com/lf-edge/eve/pkg/pillar/hypervisor"
 	uuid "github.com/satori/go.uuid"
 
@@ -189,7 +190,7 @@ func doUpdate(ctx *zedmanagerContext,
 	// Check if the App is low priority.
 	// Load the UUIDs of the apps that were previously (before the reboot) in the ACTIVE state.
 	var hasPriority bool
-	activeAppsUUIDs, err := loadActiveAppInstanceUUIDs()
+	activeAppsUUIDs, err := activeapp.LoadActiveAppInstanceUUIDs(log)
 	if err != nil {
 		log.Warningf("checkLowPriorityApps: failed to load active app instance UUIDs: %v", err)
 		activeAppsUUIDs = []string{} // Fallback to an empty list

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -12,12 +12,11 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/lf-edge/eve/pkg/pillar/activeapp"
 	"github.com/lf-edge/eve/pkg/pillar/agentbase"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
@@ -616,7 +615,7 @@ func checkDelayedStartApps(ctx *zedmanagerContext) {
 // If all the High priority apps are running or the timeout has expired, then
 // we can start the Low priority apps.
 func checkLowPriorityApps(ctx *zedmanagerContext) {
-	activeAppsUUIDs, err := loadActiveAppInstanceUUIDs()
+	activeAppsUUIDs, err := activeapp.LoadActiveAppInstanceUUIDs(log)
 	if err != nil {
 		log.Warningf("checkLowPriorityApps: failed to load active app instance UUIDs: %v", err)
 		activeAppsUUIDs = []string{} // Fallback to an empty list
@@ -1145,31 +1144,6 @@ func handleCreate(ctxArg interface{}, key string,
 		config.UUIDandVersion, config.DisplayName)
 
 	handleCreateAppInstanceStatus(ctx, config)
-}
-
-// loadActiveAppInstanceUUIDs reads all JSON files from the specified directory,
-// extracts the UUID from each filename (by removing the ".json" extension),
-// and returns a slice of UUIDs.
-func loadActiveAppInstanceUUIDs() ([]string, error) {
-	// Read all directory entries using os.ReadDir.
-	entries, err := os.ReadDir(types.LocalActiveAppConfigDir)
-	if err != nil {
-		return nil, err
-	}
-
-	var uuids []string
-	// Iterate over all entries found.
-	for _, entry := range entries {
-		// We only care about files (not subdirectories) with a .json extension.
-		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".json" {
-			// Remove the .json extension to get the UUID.
-			uuid := strings.TrimSuffix(entry.Name(), ".json")
-			log.Noticef("Found active app instance UUID: %s", uuid)
-			uuids = append(uuids, uuid)
-		}
-	}
-
-	return uuids, nil
 }
 
 func handleCreateAppInstanceStatus(ctx *zedmanagerContext, config types.AppInstanceConfig) {

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -141,6 +141,9 @@ const (
 	OVMFSettingsTemplate = "/usr/lib/xen/boot/OVMF_VARS.fd"
 	// CustomOVMFSettingsDir - directory for custom OVMF settings (for different resolutions)
 	CustomOVMFSettingsDir = "/hostfs/etc/ovmf"
+
+	// LocalActiveAppConfigDir - directory to put JSON of the apps that are running.
+	LocalActiveAppConfigDir = "/persist/vault/active-app-instance-config/"
 )
 
 var (

--- a/pkg/pillar/types/zedmanagertypes.go
+++ b/pkg/pillar/types/zedmanagertypes.go
@@ -298,7 +298,9 @@ type AppInstanceStatus struct {
 	State          SwState
 	MissingNetwork bool // If some Network UUID not found
 	MissingMemory  bool // Waiting for memory
-
+	// NoBootPriority indicates whether the application instance has no boot priority set.
+	// If true, the application instance will not be prioritized during the boot process.
+	NoBootPriority bool
 	// All error strings across all steps and all StorageStatus
 	// ErrorAndTimeWithSource provides SetError, SetErrrorWithSource, etc
 	ErrorAndTimeWithSource


### PR DESCRIPTION
Due to multiple applications competing for memory and insufficient memory on EVE, some applications are active while others enter an error state. After a reboot, the boot sequence can change, causing different applications to become active and shutting down others. This commit fixes the issue by ensuring that the applications which were previously active now start with priority after the reboot.