### PR TITLE
Don't include logs by default in collect-info.sh

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -463,6 +463,11 @@ find /sys/kernel/security -name "tpm*" | while read -r TPM; do
     fi
 done
 
+if [ -c /dev/tpm0 ]; then
+    echo "- TPM getcap"
+    eve exec vtpm tpm2 getcap handles-persistent > "$DIR/handles-persistent.txt"
+fi
+
 if [ -n "$GET_LOGS_DAYS" ]; then
     mkdir -p "$LOG_TMP_DIR"
     # Find and link log files from /persist/newlog modified in the last GET_LOGS_DAYS days
@@ -472,6 +477,7 @@ elif [ "$GET_LOGS" -eq 1 ]; then
     ln -s /persist/newlog "$DIR/persist-newlog"
 fi
 
+ln -s /persist/certs        "$DIR/persist-certs"
 ln -s /persist/status       "$DIR/persist-status"
 ln -s /persist/log          "$DIR/persist-log"
 [ -d /persist/kubelog ] && ln -s /persist/kubelog "$DIR/persist-kubelog"


### PR DESCRIPTION
This change makes the collect-info.sh script not tar logs by default. Instead the logs are only included if the user specifies one of the two flags:
* -l to include all logs from /persist/newlog
* -t <days> to include the logs from the last <days> days

The reason for this is the that EVE already sends logs to the controller, so there is not always a need to include all the logs in the tar ball. This makes the tar balls generated by collect-info easier to handle.