### PR TITLE
Fix non-constant format string in call to log.Errorf etc

### DIFF
--- a/pkg/pillar/cas/containerd.go
+++ b/pkg/pillar/cas/containerd.go
@@ -260,19 +260,19 @@ func (c *containerdCAS) IngestBlob(ctx context.Context, blobs ...types.BlobStatu
 		case blobFile == "" && len(blob.Content) == 0:
 			err = fmt.Errorf("IngestBlob(%s): both blobFile and blobContent empty %s",
 				blob.Sha256, blobFile)
-			logrus.Errorf(err.Error())
+			logrus.Error(err.Error())
 			return loadedBlobs, err
 		case blobFile != "" && len(blob.Content) != 0:
 			err = fmt.Errorf("IngestBlob(%s): both blobFile and blobContent provided, cannot pick, %s",
 				blob.Sha256, blobFile)
-			logrus.Errorf(err.Error())
+			logrus.Error(err.Error())
 			return loadedBlobs, err
 		case blobFile != "":
 			fileReader, err := os.Open(blobFile)
 			if err != nil {
 				err = fmt.Errorf("IngestBlob(%s): could not open blob file for reading at %s: %+s",
 					blob.Sha256, blobFile, err.Error())
-				logrus.Errorf(err.Error())
+				logrus.Error(err.Error())
 				return loadedBlobs, err
 			}
 			defer fileReader.Close()
@@ -290,7 +290,7 @@ func (c *containerdCAS) IngestBlob(ctx context.Context, blobs ...types.BlobStatu
 			if err != nil {
 				err = fmt.Errorf("IngestBlob(%s): could not read data at %s: %+s",
 					blob.Sha256, blobFile, err.Error())
-				logrus.Errorf(err.Error())
+				logrus.Error(err.Error())
 				return loadedBlobs, err
 			}
 			// create a new reader for the content.WriteBlob
@@ -299,7 +299,7 @@ func (c *containerdCAS) IngestBlob(ctx context.Context, blobs ...types.BlobStatu
 			if err := json.Unmarshal(data, &index); err != nil {
 				err = fmt.Errorf("IngestBlob(%s): could not parse index at %s: %+s",
 					blob.Sha256, blobFile, err.Error())
-				logrus.Errorf(err.Error())
+				logrus.Error(err.Error())
 				return loadedBlobs, err
 			}
 			indexHash = sha
@@ -309,7 +309,7 @@ func (c *containerdCAS) IngestBlob(ctx context.Context, blobs ...types.BlobStatu
 			if err != nil {
 				err = fmt.Errorf("IngestBlob(%s): could not read data at %s: %+s",
 					blob.Sha256, blobFile, err.Error())
-				logrus.Errorf(err.Error())
+				logrus.Error(err.Error())
 				return loadedBlobs, err
 			}
 			// create a new reader for the content.WriteBlob
@@ -319,7 +319,7 @@ func (c *containerdCAS) IngestBlob(ctx context.Context, blobs ...types.BlobStatu
 			if err := json.Unmarshal(data, &mfst); err != nil {
 				err = fmt.Errorf("IngestBlob(%s): could not parse manifest at %s: %+s",
 					blob.Sha256, blobFile, err.Error())
-				logrus.Errorf(err.Error())
+				logrus.Error(err.Error())
 				return loadedBlobs, err
 			}
 			manifests = append(manifests, &mfst)
@@ -333,7 +333,7 @@ func (c *containerdCAS) IngestBlob(ctx context.Context, blobs ...types.BlobStatu
 		if err := c.ctrdClient.CtrWriteBlob(ctx, sha, blob.Size, r); err != nil {
 			err = fmt.Errorf("IngestBlob(%s): could not load blob file into containerd at %s: %+s",
 				blob.Sha256, blobFile, err.Error())
-			logrus.Errorf(err.Error())
+			logrus.Error(err.Error())
 			return loadedBlobs, err
 		}
 		logrus.Infof("IngestBlob(%s): Loaded the blob successfully", blob.Sha256)
@@ -352,7 +352,7 @@ func (c *containerdCAS) IngestBlob(ctx context.Context, blobs ...types.BlobStatu
 		}
 		if err := c.UpdateBlobInfo(info); err != nil {
 			err = fmt.Errorf("IngestBlob(%s): could not update labels on index: %v", info.Digest, err.Error())
-			logrus.Errorf(err.Error())
+			logrus.Error(err.Error())
 			return loadedBlobs, err
 		}
 	}
@@ -373,7 +373,7 @@ func (c *containerdCAS) IngestBlob(ctx context.Context, blobs ...types.BlobStatu
 			if err := c.UpdateBlobInfo(info); err != nil {
 				err = fmt.Errorf("IngestBlob(%s): could not update labels on manifest: %v",
 					info.Digest, err.Error())
-				logrus.Errorf(err.Error())
+				logrus.Error(err.Error())
 				return loadedBlobs, err
 			}
 		}
@@ -611,7 +611,7 @@ func (c *containerdCAS) CreateSnapshotForImage(snapshotID, reference string) err
 	if err := c.ctrdClient.UnpackClientImage(clientImageObj); err != nil {
 		err = fmt.Errorf("CreateSnapshotForImage: could not unpack clientImageObj %s: %+s",
 			clientImageObj.Name(), err.Error())
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return err
 	}
 
@@ -681,7 +681,7 @@ func (c *containerdCAS) PrepareContainerRootDir(rootPath, reference, _ string) e
 	snapshotID := containerd.GetSnapshotID(rootPath)
 	if err := c.CreateSnapshotForImage(snapshotID, reference); err != nil {
 		err = fmt.Errorf("PrepareContainerRootDir: Could not create snapshot %s. %w", snapshotID, err)
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return err
 	}
 
@@ -690,33 +690,33 @@ func (c *containerdCAS) PrepareContainerRootDir(rootPath, reference, _ string) e
 	if err != nil {
 		err = fmt.Errorf("PrepareContainerRootDir: exception while fetching image config for reference %s: %s",
 			reference, err.Error())
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return err
 	}
 	clientImageSpecJSON, err := json.MarshalIndent(clientImageSpec, "", "    ")
 	if err != nil {
 		err = fmt.Errorf("PrepareContainerRootDir: Could not build json of image: %v. %v",
 			reference, err.Error())
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return err
 	}
 
 	if err := os.MkdirAll(rootPath, 0766); err != nil {
 		err = fmt.Errorf("PrepareContainerRootDir: Exception while creating rootPath dir. %w", err)
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return err
 	}
 	ociConfPath := filepath.Join(rootPath, imageConfigFilename)
 	if err := fileutils.WriteRename(ociConfPath, clientImageSpecJSON); err != nil {
 		err = fmt.Errorf("PrepareContainerRootDir: Exception while writing image info to %s. %w",
 			ociConfPath, err)
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return err
 	}
 	if err := os.Chmod(ociConfPath, 0666); err != nil {
 		err = fmt.Errorf("PrepareContainerRootDir: Exception while setting permissions on %s. %w",
 			ociConfPath, err)
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return err
 	}
 	logrus.Infof("written image config for reference %s. content: %s", reference, string(clientImageSpecJSON))
@@ -911,7 +911,7 @@ func (c *containerdCAS) IngestBlobsAndCreateImage(reference string, root types.B
 	if err != nil {
 		err = fmt.Errorf("IngestBlobsAndCreateImage: Unable load blobs for reference %s. "+
 			"Exception while creating lease: %v", reference, err.Error())
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return nil, err
 	}
 	// deleting the lease means that containerd will be free to GC any blob that doesn't have a tag
@@ -920,7 +920,7 @@ func (c *containerdCAS) IngestBlobsAndCreateImage(reference string, root types.B
 	loadedBlobs, err := c.IngestBlob(newCtxWithLease, blobs...)
 	if err != nil {
 		err = fmt.Errorf("IngestBlobsAndCreateImage: Exception while loading blobs into CAS: %v", err.Error())
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return nil, err
 	}
 	rootBlobSha := fmt.Sprintf("%s:%s", digest.SHA256, strings.ToLower(root.Sha256))
@@ -931,7 +931,7 @@ func (c *containerdCAS) IngestBlobsAndCreateImage(reference string, root types.B
 		if err := c.CreateImage(reference, mediaType, rootBlobSha); err != nil {
 			err = fmt.Errorf("IngestBlobsAndCreateImage: could not create reference %s with rootBlob %s: %v",
 				reference, rootBlobSha, err.Error())
-			logrus.Errorf(err.Error())
+			logrus.Error(err.Error())
 			return nil, err
 		}
 	} else if err != nil {
@@ -943,7 +943,7 @@ func (c *containerdCAS) IngestBlobsAndCreateImage(reference string, root types.B
 		if err := c.ReplaceImage(reference, mediaType, rootBlobSha); err != nil {
 			err = fmt.Errorf("IngestBlobsAndCreateImage: could not update reference %s with rootBlob %s: %v",
 				reference, rootBlobSha, err.Error())
-			logrus.Errorf(err.Error())
+			logrus.Error(err.Error())
 			return nil, err
 		}
 	}
@@ -1036,7 +1036,7 @@ func getImageConfig(c *containerdCAS, reference string) (*ocispec.Image, error) 
 	imageParentHash, err := c.GetImageHash(reference)
 	if err != nil {
 		err = fmt.Errorf("getImageConfig: exception while fetching reference hash of %s: %s", reference, err.Error())
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return nil, err
 	}
 
@@ -1048,14 +1048,14 @@ func getImageConfig(c *containerdCAS, reference string) (*ocispec.Image, error) 
 	if err != nil {
 		err = fmt.Errorf("getImageConfig: exception while reading blob %s for reference %s: %s",
 			imageParentHash, reference, err.Error())
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return nil, err
 	}
 	blobData, err := io.ReadAll(blobReader)
 	if err != nil {
 		err = fmt.Errorf("getImageConfig: could not read blobdata %s for reference %s: %+s",
 			imageParentHash, reference, err.Error())
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return nil, err
 	}
 
@@ -1067,7 +1067,7 @@ func getImageConfig(c *containerdCAS, reference string) (*ocispec.Image, error) 
 		if err := json.Unmarshal(blobData, &manifests); err != nil {
 			err = fmt.Errorf("getImageConfig: could not read imageManifest %s for reference %s: %+s",
 				imageParentHash, reference, err.Error())
-			logrus.Errorf(err.Error())
+			logrus.Error(err.Error())
 			return nil, err
 		}
 	} else {
@@ -1079,7 +1079,7 @@ func getImageConfig(c *containerdCAS, reference string) (*ocispec.Image, error) 
 				if err != nil {
 					err = fmt.Errorf("getImageConfig: exception while reading manifest blob %s for reference %s: %s",
 						m.Digest.String(), reference, err.Error())
-					logrus.Errorf(err.Error())
+					logrus.Error(err.Error())
 					return nil, err
 				}
 				// Step 3.1.3: Read the manifest data
@@ -1087,13 +1087,13 @@ func getImageConfig(c *containerdCAS, reference string) (*ocispec.Image, error) 
 				if err != nil {
 					err = fmt.Errorf("getImageConfig: could not parsr manifestBlob %s for reference %s: %+s",
 						m.Digest.String(), reference, err.Error())
-					logrus.Errorf(err.Error())
+					logrus.Error(err.Error())
 					return nil, err
 				}
 				if err := json.Unmarshal(blobData, &manifests); err != nil {
 					err = fmt.Errorf("getImageConfig: could not parse manifestBlob %s for reference %s: %+s",
 						m.Digest.String(), reference, err.Error())
-					logrus.Errorf(err.Error())
+					logrus.Error(err.Error())
 					return nil, err
 				}
 				break
@@ -1107,20 +1107,20 @@ func getImageConfig(c *containerdCAS, reference string) (*ocispec.Image, error) 
 	if err != nil {
 		err = fmt.Errorf("getImageConfig: exception while reading config blob %s for reference %s: %s",
 			configHash, reference, err.Error())
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return nil, err
 	}
 	blobData, err = io.ReadAll(blobReader)
 	if err != nil {
 		err = fmt.Errorf("getImageConfig: could not read config blobdata %s for reference %s: %+s",
 			configHash, reference, err.Error())
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return nil, err
 	}
 	if err := json.Unmarshal(blobData, &imageConfig); err != nil {
 		err = fmt.Errorf("getImageConfig: could not parse configBlob %s for reference %s: %+s",
 			configHash, reference, err.Error())
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return nil, err
 	}
 	return &imageConfig, nil

--- a/pkg/pillar/cipher/handlecipher.go
+++ b/pkg/pillar/cipher/handlecipher.go
@@ -108,7 +108,7 @@ func decryptCipherBlockWithECDH(ctx *DecryptCipherContext,
 	edgeNodeCert := lookupEdgeNodeCert(ctx, cipherContext.EdgeNodeCertKey())
 	if edgeNodeCert == nil {
 		errStr := fmt.Sprint("Edge Node Certificate get fail")
-		ctx.Log.Errorf(errStr)
+		ctx.Log.Error(errStr)
 		return []byte{}, errors.New(errStr)
 	}
 	switch cipherContext.EncryptionScheme {

--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -4,6 +4,7 @@
 package baseosmgr
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -115,7 +116,7 @@ func installDownloadedObject(ctx *baseOsMgrContext, contentID uuid.UUID, finalOb
 			contentID)
 		log.Errorln(errStr)
 		ctsPtr.SetErrorWithSource(errStr, types.ContentTreeStatus{}, time.Now())
-		return changed, proceed, fmt.Errorf(errStr)
+		return changed, proceed, errors.New(errStr)
 	}
 
 	// check if we have a result
@@ -124,7 +125,7 @@ func installDownloadedObject(ctx *baseOsMgrContext, contentID uuid.UUID, finalOb
 		log.Functionf("installDownloadedObject(%s): InstallWorkResult found", contentID)
 		if wres.Error != nil {
 			err := fmt.Errorf("installDownloadedObject(%s): InstallWorkResult error, exception while installing: %v", contentID, wres.Error)
-			log.Errorf(err.Error())
+			log.Error(err.Error())
 			return changed, proceed, err
 		}
 		changed = true

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -1111,7 +1111,7 @@ func printProxy(ctx *diagContext, port types.NetworkPortStatus,
 			pacFile, err := base64.StdEncoding.DecodeString(port.ProxyConfig.Pacfile)
 			if err != nil {
 				errStr := fmt.Sprintf("Decoding proxy file failed: %s", err)
-				log.Errorf(errStr)
+				log.Error(errStr)
 			} else {
 				ctx.ph.Print("INFO: %s: PAC file:\n%s\n",
 					ifname, pacFile)

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -998,7 +998,7 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 			// the only remedy is an explicit user action (delete, restart, etc.)
 			if domainStatus == types.BROKEN {
 				err := fmt.Errorf("one of the %s tasks has crashed (%v)", status.Key(), err)
-				log.Errorf(err.Error())
+				log.Error(err.Error())
 				status.SetErrorNow("one of the application's tasks has crashed - please restart application instance")
 				status.State = types.BROKEN
 			} else {
@@ -1499,7 +1499,7 @@ func doAssignIoAdaptersToDomain(ctx *domainContext, config types.DomainConfig,
 			}
 			// Also checked in reserveAdapters. Check here in case there was a late error.
 			if !ib.Error.Empty() {
-				return fmt.Errorf(ib.Error.String())
+				return errors.New(ib.Error.String())
 			}
 			if ib.UsbAddr != "" {
 				log.Functionf("Assigning %s (%s) to %s",

--- a/pkg/pillar/cmd/msrv/handlers.go
+++ b/pkg/pillar/cmd/msrv/handlers.go
@@ -161,7 +161,7 @@ func (msrv *Msrv) handleOpenStack() func(http.ResponseWriter, *http.Request) {
 		if anConfig.MetaDataType != types.MetaDataOpenStack {
 			errorLine := fmt.Sprintf("no MetaDataOpenStack for %s",
 				anStatus.Key())
-			msrv.Log.Tracef(errorLine)
+			msrv.Log.Trace(errorLine)
 			http.Error(w, errorLine, http.StatusNotFound)
 			return
 		}
@@ -291,7 +291,7 @@ func (msrv *Msrv) handleLocationInfo() func(http.ResponseWriter, *http.Request) 
 		resp, err := json.Marshal(locInfo)
 		if err != nil {
 			msg := fmt.Sprintf("Failed to marshal location info: %v", err)
-			msrv.Log.Errorf(msg)
+			msrv.Log.Error(msg)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
@@ -325,7 +325,7 @@ func (msrv *Msrv) handleWWANStatus() func(http.ResponseWriter, *http.Request) {
 		resp, err := json.Marshal(status)
 		if err != nil {
 			msg := fmt.Sprintf("Failed to marshal WWAN status: %v", err)
-			msrv.Log.Errorf(msg)
+			msrv.Log.Error(msg)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
@@ -347,7 +347,7 @@ func (msrv *Msrv) handleWWANMetrics() func(http.ResponseWriter, *http.Request) {
 		resp, err := json.Marshal(metrics)
 		if err != nil {
 			msg := fmt.Sprintf("Failed to marshal WWAN metrics: %v", err)
-			msrv.Log.Errorf(msg)
+			msrv.Log.Error(msg)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
@@ -371,7 +371,7 @@ func (msrv *Msrv) handleSigner(zedcloudCtx *zedcloud.ZedCloudContext) func(http.
 		payload, err := io.ReadAll(io.LimitReader(r.Body, SignerMaxSize+1))
 		if err != nil {
 			msg := fmt.Sprintf("signerHandler: ReadAll failed: %v", err)
-			msrv.Log.Errorf(msg)
+			msrv.Log.Error(msg)
 			http.Error(w, msg, http.StatusInternalServerError)
 			return
 		}
@@ -379,7 +379,7 @@ func (msrv *Msrv) handleSigner(zedcloudCtx *zedcloud.ZedCloudContext) func(http.
 		if binary.Size(payload) > SignerMaxSize {
 			msg := fmt.Sprintf("signerHandler: size exceeds limit. Expected <= %v",
 				SignerMaxSize)
-			msrv.Log.Errorf(msg)
+			msrv.Log.Error(msg)
 			http.Error(w, msg, http.StatusBadRequest)
 			return
 		}
@@ -388,7 +388,7 @@ func (msrv *Msrv) handleSigner(zedcloudCtx *zedcloud.ZedCloudContext) func(http.
 		if anStatus == nil {
 			msg := fmt.Sprintf("signerHandler: no AppNetworkStatus for %s",
 				remoteIP.String())
-			msrv.Log.Errorf(msg)
+			msrv.Log.Error(msg)
 			http.Error(w, msg, http.StatusForbidden)
 			return
 		}
@@ -397,7 +397,7 @@ func (msrv *Msrv) handleSigner(zedcloudCtx *zedcloud.ZedCloudContext) func(http.
 			bytes.NewBuffer(payload), false)
 		if err != nil {
 			msg := fmt.Sprintf("Failed to AddAuthentication: %v", err)
-			msrv.Log.Errorf(msg)
+			msrv.Log.Error(msg)
 			http.Error(w, msg, http.StatusInternalServerError)
 			return
 		}
@@ -424,7 +424,7 @@ func (msrv *Msrv) handleDiag() func(http.ResponseWriter, *http.Request) {
 		if anStatus == nil {
 			msg := fmt.Sprintf("diagHandler: no AppNetworkStatus for %s",
 				remoteIP.String())
-			msrv.Log.Errorf(msg)
+			msrv.Log.Error(msg)
 			http.Error(w, msg, http.StatusForbidden)
 			return
 		}
@@ -440,7 +440,7 @@ func (msrv *Msrv) handleDiag() func(http.ResponseWriter, *http.Request) {
 			DiagMaxSize+1)
 		if err != nil {
 			msg := fmt.Sprintf("diagHandler: read: %v", err)
-			msrv.Log.Errorf(msg)
+			msrv.Log.Error(msg)
 			http.Error(w, msg, http.StatusInternalServerError)
 			return
 		}
@@ -448,7 +448,7 @@ func (msrv *Msrv) handleDiag() func(http.ResponseWriter, *http.Request) {
 		if len(b) > DiagMaxSize {
 			msg := fmt.Sprintf("diagHandler: size exceeds limit. Expected <= %v",
 				DiagMaxSize)
-			msrv.Log.Errorf(msg)
+			msrv.Log.Error(msg)
 			http.Error(w, msg, http.StatusInternalServerError)
 			return
 		}
@@ -869,7 +869,7 @@ func (msrv *Msrv) handleNetworkStatusMetrics() func(http.ResponseWriter, *http.R
 		resp, err := json.Marshal(devList)
 		if err != nil {
 			msg := fmt.Sprintf("Failed to marshal network status and metrics: %v", err)
-			msrv.Log.Errorf(msg)
+			msrv.Log.Error(msg)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}

--- a/pkg/pillar/cmd/nodeagent/handlebaseos.go
+++ b/pkg/pillar/cmd/nodeagent/handlebaseos.go
@@ -34,7 +34,7 @@ func doZbootBaseOsInstallationComplete(ctxPtr *nodeagentContext,
 		}
 		infoStr := fmt.Sprintf("NORMAL: baseos-update(%s) to EVE version %s reboot",
 			key, newVersion)
-		log.Functionf(infoStr)
+		log.Function(infoStr)
 		scheduleNodeOperation(ctxPtr, infoStr, types.BootReasonUpdate,
 			types.DeviceOperationReboot)
 	}

--- a/pkg/pillar/cmd/nodeagent/handletimers.go
+++ b/pkg/pillar/cmd/nodeagent/handletimers.go
@@ -63,7 +63,7 @@ func handleFallbackOnCloudDisconnect(ctxPtr *nodeagentContext) {
 	if timePassed > fallbackLimit {
 		errStr := fmt.Sprintf("Exceeded fallback outage for cloud connectivity %d by %d seconds; rebooting\n",
 			fallbackLimit, timePassed-fallbackLimit)
-		log.Errorf(errStr)
+		log.Error(errStr)
 		scheduleNodeOperation(ctxPtr, errStr, types.BootReasonFallback,
 			types.DeviceOperationReboot)
 	} else {
@@ -80,7 +80,7 @@ func handleResetOnCloudDisconnect(ctxPtr *nodeagentContext) {
 	if timePassed > resetLimit {
 		errStr := fmt.Sprintf("Exceeded outage for cloud connectivity %d by %d seconds; rebooting\n",
 			resetLimit, timePassed-resetLimit)
-		log.Errorf(errStr)
+		log.Error(errStr)
 		scheduleNodeOperation(ctxPtr, errStr, types.BootReasonDisconnect,
 			types.DeviceOperationReboot)
 	} else {
@@ -127,7 +127,7 @@ func handleRebootOnVaultLocked(ctxPtr *nodeagentContext) {
 			// fail the upgrade by rebooting now
 			errStr := fmt.Sprintf("Exceeded time for vault to be ready %d by %d seconds, rebooting",
 				vaultCutOffTime, timePassed-vaultCutOffTime)
-			log.Errorf(errStr)
+			log.Error(errStr)
 			scheduleNodeOperation(ctxPtr, errStr, types.BootReasonVaultFailure,
 				types.DeviceOperationReboot)
 		} else {

--- a/pkg/pillar/cmd/upgradeconverter/persistlayout.go
+++ b/pkg/pillar/cmd/upgradeconverter/persistlayout.go
@@ -26,7 +26,7 @@ func convertPersistVolumes(ctxPtr *ucContext) error {
 		// This error always happens on first boot of a device.
 		// In that case there is nothing to convert.
 		errStr := fmt.Sprintf("No checkpoint file in %s", checkpointFile)
-		log.Errorf(errStr)
+		log.Error(errStr)
 		return errors.New(errStr)
 	}
 	latch, err := inhaleLatch(ctxPtr.ps) // XXX override dir in pubsub?

--- a/pkg/pillar/cmd/verifier/pubsub/handlers.go
+++ b/pkg/pillar/cmd/verifier/pubsub/handlers.go
@@ -117,7 +117,7 @@ func handleCreate(ctx *VerifierContext,
 
 	if config.FileLocation == "" {
 		err := fmt.Errorf("handleCreate: verifyImageConfig: %s has empty fileLocation", config.ImageSha256)
-		ctx.log.Errorf(err.Error())
+		ctx.log.Error(err.Error())
 		cerr := fmt.Sprintf("%v", err)
 		updateVerifyErrStatus(ctx, &status, cerr)
 		return

--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -495,7 +495,7 @@ func unpublishBlobStatus(ctx *volumemgrContext, blobs ...*types.BlobStatus) {
 			if err := ctx.casClient.RemoveBlob(cas.CheckAndCorrectBlobHash(blob.Sha256)); err != nil {
 				err := fmt.Errorf("unpublishBlobStatus: Exception while removing loaded blob %s: %s",
 					blob.Sha256, err.Error())
-				log.Errorf(err.Error())
+				log.Error(err.Error())
 			}
 		}
 

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -232,7 +232,7 @@ func AddBlobsToContentTreeStatus(ctx *volumemgrContext, status *types.ContentTre
 		if blobStatus == nil {
 			err := fmt.Errorf("AddBlobsToContentTreeStatus(%s): No BlobStatus found for blobHash: %s",
 				status.ContentID.String(), blobSha)
-			log.Errorf(err.Error())
+			log.Error(err.Error())
 			return err
 		}
 		// Adding a blob to ContentTreeStatus and incrementing the refcount of that blob should be atomic as
@@ -257,7 +257,7 @@ func RemoveAllBlobsFromContentTreeStatus(ctx *volumemgrContext, status *types.Co
 		if blobStatus == nil {
 			err := fmt.Errorf("RemoveAllBlobsFromContentTreeStatus(%s): No BlobStatus found for blobHash: %s",
 				status.ContentID.String(), blobSha)
-			log.Errorf(err.Error())
+			log.Error(err.Error())
 			continue
 		}
 		RemoveRefFromBlobStatus(ctx, blobStatus)

--- a/pkg/pillar/cmd/volumemgr/handlesnapshot.go
+++ b/pkg/pillar/cmd/volumemgr/handlesnapshot.go
@@ -37,7 +37,7 @@ func createSnapshot(ctx *volumemgrContext, config *types.VolumesSnapshotConfig) 
 		if volumeStatus == nil {
 			errDesc := types.ErrorDescription{}
 			errDesc.Error = fmt.Sprintf("createSnapshot: volume %s not found", volumeID.String())
-			log.Errorf(errDesc.Error)
+			log.Error(errDesc.Error)
 			volumesSnapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
 			return volumesSnapshotStatus
 		}
@@ -46,7 +46,7 @@ func createSnapshot(ctx *volumemgrContext, config *types.VolumesSnapshotConfig) 
 		if err != nil {
 			errDesc := types.ErrorDescription{}
 			errDesc.Error = fmt.Sprintf("createSnapshot: failed to create snapshot for %s, %s", volumeID.String(), err.Error())
-			log.Errorf(errDesc.Error)
+			log.Error(errDesc.Error)
 			volumesSnapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
 			return volumesSnapshotStatus
 		}
@@ -59,7 +59,7 @@ func createSnapshot(ctx *volumemgrContext, config *types.VolumesSnapshotConfig) 
 	if err != nil {
 		errDesc := types.ErrorDescription{}
 		errDesc.Error = fmt.Sprintf("handleVolumesSnapshotConfigCreate: failed to serialize snapshot status for %s, %s", config.SnapshotID, err.Error())
-		log.Errorf(errDesc.Error)
+		log.Error(errDesc.Error)
 		volumesSnapshotStatus.SetErrorWithSourceAndDescription(errDesc, types.VolumesSnapshotStatus{})
 	}
 	return volumesSnapshotStatus

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -389,28 +389,28 @@ func quantifyChanges(config types.VolumeConfig,
 	if config.ContentID != status.ContentID {
 		str := fmt.Sprintf("ContentID changed from %s to %s for %s",
 			status.ContentID, config.ContentID, config.DisplayName)
-		log.Functionf(str)
+		log.Function(str)
 		needRegeneration = true
 		regenerationReason += str + "\n"
 	}
 	if config.VolumeContentOriginType != status.VolumeContentOriginType {
 		str := fmt.Sprintf("VolumeContentOriginType changed from %v to %v for %s",
 			status.VolumeContentOriginType, config.VolumeContentOriginType, config.DisplayName)
-		log.Functionf(str)
+		log.Function(str)
 		needRegeneration = true
 		regenerationReason += str + "\n"
 	}
 	if config.MaxVolSize != status.MaxVolSize {
 		str := fmt.Sprintf("MaxVolSize changed from %d to %d for %s",
 			status.MaxVolSize, config.MaxVolSize, config.DisplayName)
-		log.Functionf(str)
+		log.Function(str)
 		needRegeneration = true
 		regenerationReason += str + "\n"
 	}
 	if config.ReadOnly != status.ReadOnly {
 		str := fmt.Sprintf("ReadOnly changed from %v to %v for %s",
 			status.ReadOnly, config.ReadOnly, config.DisplayName)
-		log.Functionf(str)
+		log.Function(str)
 		needRegeneration = true
 		regenerationReason += str + "\n"
 	}

--- a/pkg/pillar/cmd/volumemgr/oci.go
+++ b/pkg/pillar/cmd/volumemgr/oci.go
@@ -28,27 +28,27 @@ func resolveIndex(ctx *volumemgrContext, blob *types.BlobStatus) (*v1.Descriptor
 		reader, err := ctx.casClient.ReadBlob(ctrdCtx, blobHash)
 		if err != nil {
 			err = fmt.Errorf("resolveIndex(%s): Exception while reading blob: %v", blob.Sha256, err)
-			log.Errorf(err.Error())
+			log.Error(err.Error())
 			return nil, err
 		}
 		index, err = v1.ParseIndexManifest(reader)
 		if err != nil && err != io.EOF {
 			err = fmt.Errorf("resolveIndex(%s): Exception while parsing Index from cas: %v", blob.Sha256, err)
-			log.Errorf(err.Error())
+			log.Error(err.Error())
 			return nil, err
 		}
 	} else {
 		fileReader, err := os.Open(blob.Path)
 		if err != nil {
 			err = fmt.Errorf("resolveIndex(%s): failed to open file %s: %v", blob.Sha256, blob.Path, err)
-			log.Errorf(err.Error())
+			log.Error(err.Error())
 			return nil, err
 		}
 		index, err = v1.ParseIndexManifest(fileReader)
 		if err != nil && err != io.EOF {
 			err = fmt.Errorf("resolveIndex(%s): Exception while parsing Index from %s: %v",
 				blob.Sha256, blob.Path, err)
-			log.Errorf(err.Error())
+			log.Error(err.Error())
 			return nil, err
 		}
 		defer fileReader.Close()
@@ -80,27 +80,27 @@ func resolveManifestChildren(ctx *volumemgrContext, blob *types.BlobStatus) (int
 		reader, err := ctx.casClient.ReadBlob(ctrdCtx, blobHash)
 		if err != nil {
 			err = fmt.Errorf("resolveManifestChildren(%s): Exception while reading blob: %v", blob.Sha256, err)
-			log.Errorf(err.Error())
+			log.Error(err.Error())
 			return 0, nil, err
 		}
 		manifest, err = v1.ParseManifest(reader)
 		if err != nil && err != io.EOF {
 			err = fmt.Errorf("resolveManifestChildren(%s): Exception while parsing Index from cas: %v", blob.Sha256, err)
-			log.Errorf(err.Error())
+			log.Error(err.Error())
 			return 0, nil, err
 		}
 	} else {
 		fileReader, err := os.Open(blob.Path)
 		if err != nil {
 			err = fmt.Errorf("resolveManifestChildren(%s): failed to open file %s: %v", blob.Sha256, blob.Path, err)
-			log.Errorf(err.Error())
+			log.Error(err.Error())
 			return 0, nil, err
 		}
 		manifest, err = v1.ParseManifest(fileReader)
 		if err != nil && err != io.EOF {
 			err = fmt.Errorf("resolveManifestChildren(%s): Exception while parsing Index from %s: %v",
 				blob.Sha256, blob.Path, err)
-			log.Errorf(err.Error())
+			log.Error(err.Error())
 			return 0, nil, err
 		}
 		defer fileReader.Close()

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -36,7 +36,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			if len(status.DatastoreIDList) > 1 {
 				err := fmt.Sprintf("doUpdateContentTree(%s) name %s: OCI registry along with the fallback datastores list is not supported",
 					status.Key(), status.DisplayName)
-				log.Errorf(err)
+				log.Error(err)
 				status.SetErrorDescription(types.ErrorDescription{Error: err})
 				changed = true
 				return changed, false
@@ -130,7 +130,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			if status.ContentSha256 == "" {
 				err := fmt.Sprintf("doUpdateContentTree(%s) name %s: no content sha256 defined",
 					status.Key(), status.DisplayName)
-				log.Errorf(err)
+				log.Error(err)
 				status.SetErrorDescription(types.ErrorDescription{Error: err})
 				changed = true
 				return changed, false
@@ -331,7 +331,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			if err != nil {
 				err = fmt.Errorf("doUpdateContentTree(%s): Exception while getting manifest and config for bare blob: %s",
 					status.ContentID, err.Error())
-				log.Errorf(err.Error())
+				log.Error(err.Error())
 				status.SetErrorWithSource(err.Error(), types.ContentTreeStatus{}, time.Now())
 				return changed, false
 			}
@@ -405,7 +405,7 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			log.Functionf("doUpdateContentTree(%s): IngestWorkResult found", status.Key())
 			if wres.Error != nil {
 				err := fmt.Errorf("doUpdateContentTree(%s): IngestWorkResult error, exception while loading blobs into CAS: %v", status.Key(), wres.Error)
-				log.Errorf(err.Error())
+				log.Error(err.Error())
 				status.SetErrorWithSource(err.Error(), types.ContentTreeStatus{}, wres.ErrorTime)
 				changed = true
 				return changed, false

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -324,7 +324,7 @@ func requestCertsByURL(ctx *zedagentContext, certURL string, desc string,
 	}
 
 	if err := zedcloud.ValidateProtoContentType(certURL, rv.HTTPResp); err != nil {
-		log.Errorf("getCertsFromController: resp header error")
+		log.Error("getCertsFromController: resp header error")
 		return false
 	}
 	if len(rv.RespContents) > 0 {
@@ -370,7 +370,7 @@ func requestCertsByURL(ctx *zedagentContext, certURL string, desc string,
 	// write the signing cert to file
 	if err := zedcloud.SaveServerSigningCert(zedcloudCtx, signingCertBytes); err != nil {
 		errStr := fmt.Sprintf("%v", err)
-		log.Errorf("getCertsFromController: " + errStr)
+		log.Error("getCertsFromController: " + errStr)
 		return false
 	}
 

--- a/pkg/pillar/cmd/zedagent/handlecipherconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecipherconfig.go
@@ -119,7 +119,7 @@ func parseCipherBlock(ctx *getconfigContext, key string, cfgCipherBlock *zcommon
 	if len(cipherBlock.CipherData) == 0 ||
 		len(cipherBlock.CipherContextID) == 0 {
 		errStr := fmt.Sprintf("%s, block contains incomplete data", key)
-		log.Errorf(errStr)
+		log.Error(errStr)
 		cipherBlock.SetErrorNow(errStr)
 		return cipherBlock
 	}

--- a/pkg/pillar/cmd/zedagent/parsepatchenvelopes.go
+++ b/pkg/pillar/cmd/zedagent/parsepatchenvelopes.go
@@ -5,6 +5,7 @@ package zedagent
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"crypto/sha256"
@@ -48,7 +49,7 @@ func parsePatchEnvelopesImpl(ctx *getconfigContext, config *zconfig.EdgeDevConfi
 			if err != nil {
 				msg := fmt.Sprintf("Failed to compose binary blob for patch envelope %v", err)
 				peInfo.Errors = append(peInfo.Errors, msg)
-				log.Errorf(msg)
+				log.Error(msg)
 				return
 			}
 		}
@@ -109,7 +110,7 @@ func addBinaryBlobToPatchEnvelope(pe *types.PatchEnvelopeInfo, artifact *zconfig
 		return nil
 	}
 
-	return fmt.Errorf("Unknown EveBinaryArtifact format")
+	return errors.New("Unknown EveBinaryArtifact format")
 }
 
 // cacheInlineBinaryArtifact stores inline artifact as file and

--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -7,6 +7,7 @@ package zedmanager
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -396,7 +397,7 @@ func moveSnapshotToAvailable(status *types.AppInstanceStatus, volumesSnapshotSta
 	if err != nil {
 		errStr := fmt.Sprintf("moveSnapshotToAvailable: Failed to serialize snapshot instance status: %s", err)
 		log.Error(errStr)
-		return fmt.Errorf(errStr)
+		return errors.New(errStr)
 	}
 	// Add to AvailableSnapshots
 	status.SnapStatus.AvailableSnapshots = append(status.SnapStatus.AvailableSnapshots, *snapToBeMoved)

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -1419,7 +1419,7 @@ func quantifyChanges(config types.AppInstanceConfig, oldConfig types.AppInstance
 		str := fmt.Sprintf("number of volume ref changed from %d to %d",
 			len(oldConfig.VolumeRefConfigList),
 			len(config.VolumeRefConfigList))
-		log.Functionf(str)
+		log.Function(str)
 		needPurge = true
 		purgeReason += str + "\n"
 	} else {
@@ -1441,7 +1441,7 @@ func quantifyChanges(config types.AppInstanceConfig, oldConfig types.AppInstance
 		str := fmt.Sprintf("number of AppNetAdapter changed from %d to %d",
 			len(oldConfig.AppNetAdapterList),
 			len(config.AppNetAdapterList))
-		log.Functionf(str)
+		log.Function(str)
 		needPurge = true
 		purgeReason += str + "\n"
 	} else {
@@ -1450,21 +1450,21 @@ func quantifyChanges(config types.AppInstanceConfig, oldConfig types.AppInstance
 			if old.AppMacAddr.String() != uc.AppMacAddr.String() {
 				str := fmt.Sprintf("AppMacAddr changed from %v to %v",
 					old.AppMacAddr, uc.AppMacAddr)
-				log.Functionf(str)
+				log.Function(str)
 				needPurge = true
 				purgeReason += str + "\n"
 			}
 			if !old.AppIPAddr.Equal(uc.AppIPAddr) {
 				str := fmt.Sprintf("AppIPAddr changed from %v to %v",
 					old.AppIPAddr, uc.AppIPAddr)
-				log.Functionf(str)
+				log.Function(str)
 				needPurge = true
 				purgeReason += str + "\n"
 			}
 			if old.Network != uc.Network {
 				str := fmt.Sprintf("Network changed from %v to %v",
 					old.Network, uc.Network)
-				log.Functionf(str)
+				log.Function(str)
 				needPurge = true
 				purgeReason += str + "\n"
 			}
@@ -1477,14 +1477,14 @@ func quantifyChanges(config types.AppInstanceConfig, oldConfig types.AppInstance
 	if !cmp.Equal(config.IoAdapterList, oldConfig.IoAdapterList) {
 		str := fmt.Sprintf("IoAdapterList changed: %v",
 			cmp.Diff(oldConfig.IoAdapterList, config.IoAdapterList))
-		log.Functionf(str)
+		log.Function(str)
 		needPurge = true
 		purgeReason += str + "\n"
 	}
 	if !cmp.Equal(config.FixedResources, oldConfig.FixedResources) {
 		str := fmt.Sprintf("FixedResources changed: %v",
 			cmp.Diff(oldConfig.FixedResources, config.FixedResources))
-		log.Functionf(str)
+		log.Function(str)
 		needRestart = true
 		restartReason += str + "\n"
 	}

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -148,7 +148,7 @@ func (client *Client) CloseClient() error {
 	}
 	if err := client.ctrdClient.Close(); err != nil {
 		err = fmt.Errorf("CloseClient: exception while closing containerd client. %v", err.Error())
-		logrus.Errorf(err.Error())
+		logrus.Error(err.Error())
 		return err
 	}
 	client.ctrdClient = nil

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -1648,7 +1648,8 @@ func (ctx KvmContext) CreateDomConfig(domainName string,
 	}
 	// Set pciDeviceID and pciBridgeID for every item in pciAssignments and virtualNetworks.
 	if err = addrAllocator.allocate(); err != nil {
-		return logError(err.Error())
+		logrus.Error(err.Error())
+		return err
 	}
 
 	// Render virtual network interfaces.
@@ -1657,7 +1658,8 @@ func (ctx KvmContext) CreateDomConfig(domainName string,
 	}
 	err = virtNetworksFiller.do(virtualNetworks, config.VirtualizationMode)
 	if err != nil {
-		return logError(err.Error())
+		logrus.Error(err.Error())
+		return err
 	}
 
 	// Render PCI assignments.

--- a/pkg/pillar/pubsub/reverse/publish.go
+++ b/pkg/pillar/pubsub/reverse/publish.go
@@ -24,7 +24,7 @@ func Publish(log *base.LogObject, agent string, data interface{}) error {
 
 	if _, err := os.Stat(sockName); err != nil {
 		err := fmt.Errorf("publish(%s): exception while check socket. %s", sockName, err.Error())
-		log.Errorf(err.Error())
+		log.Error(err.Error())
 		return err
 	}
 
@@ -32,7 +32,7 @@ func Publish(log *base.LogObject, agent string, data interface{}) error {
 	if err != nil {
 		err := fmt.Errorf("publish(%s): exception while marshalling data. %s",
 			sockName, err.Error())
-		log.Errorf(err.Error())
+		log.Error(err.Error())
 		return err
 	}
 
@@ -40,7 +40,7 @@ func Publish(log *base.LogObject, agent string, data interface{}) error {
 	if err != nil {
 		err := fmt.Errorf("publish(%s): exception while dialing socket. %s",
 			sockName, err.Error())
-		log.Errorf(err.Error())
+		log.Error(err.Error())
 		return err
 	}
 	defer conn.Close()
@@ -48,7 +48,7 @@ func Publish(log *base.LogObject, agent string, data interface{}) error {
 	if _, err := conn.Write(byteData); err != nil {
 		err := fmt.Errorf("publish(%s): exception while writing data to the socket. %s",
 			sockName, err.Error())
-		log.Errorf(err.Error())
+		log.Error(err.Error())
 		return err
 	}
 	return nil

--- a/pkg/pillar/types/assignableadapters_test.go
+++ b/pkg/pillar/types/assignableadapters_test.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -497,8 +498,8 @@ func alternativeCheckBadUSBBundlesImpl(bundles []IoBundle) {
 			}
 
 			if errStr != "" {
-				bundles[i].Error.Append(fmt.Errorf(errStr))
-				bundles[j].Error.Append(fmt.Errorf(errStr))
+				bundles[i].Error.Append(errors.New(errStr))
+				bundles[j].Error.Append(errors.New(errStr))
 			}
 		}
 	}

--- a/pkg/pillar/utils/deserialize.go
+++ b/pkg/pillar/utils/deserialize.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"io"
@@ -48,8 +49,8 @@ func validateFields(dataMap map[string]interface{}, expectedFields map[string]bo
 		if _, ok := dataMap[k]; !ok {
 			if criticalFields[k] {
 				errMsg := fmt.Sprintf("Critical field %s missing in stored data in %s", k, filename)
-				log.Errorf(errMsg)
-				return fmt.Errorf(errMsg)
+				log.Error(errMsg)
+				return errors.New(errMsg)
 			}
 			log.Warnf("Missing field %s in stored data in %s", k, filename)
 		}

--- a/pkg/pillar/volumehandlers/containerhandler.go
+++ b/pkg/pillar/volumehandlers/containerhandler.go
@@ -4,6 +4,7 @@
 package volumehandlers
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -51,7 +52,7 @@ func (handler *volumeHandlerContainer) CreateVolume() (string, error) {
 	if ctStatus == nil {
 		err := fmt.Errorf("createContainerVolume: Unable to find contentTreeStatus %s for Volume %s",
 			handler.status.ContentID.String(), handler.status.Key())
-		handler.log.Errorf(err.Error())
+		handler.log.Error(err.Error())
 		return fileLocation, err
 	}
 	// First blob in the list will be a root Blob
@@ -59,7 +60,7 @@ func (handler *volumeHandlerContainer) CreateVolume() (string, error) {
 	if rootBlobStatus == nil {
 		err := fmt.Errorf("createContainerVolume: Unable to find root BlobStatus %s for Volume %s",
 			ctStatus.Blobs[0], handler.status.Key())
-		handler.log.Errorf(err.Error())
+		handler.log.Error(err.Error())
 		return fileLocation, err
 	}
 	if err := handler.volumeManager.GetCasClient().PrepareContainerRootDir(fileLocation, handler.status.ReferenceName, cas.CheckAndCorrectBlobHash(rootBlobStatus.Sha256)); err != nil {
@@ -95,27 +96,27 @@ func (handler *volumeHandlerContainer) Populate() (bool, error) {
 func (handler *volumeHandlerContainer) CreateSnapshot() (interface{}, time.Time, error) {
 	//TODO implement me
 	errStr := fmt.Sprintf("CreateSnapshot not implemented for container volumes")
-	handler.log.Errorf(errStr)
+	handler.log.Error(errStr)
 	timeCreated := time.Time{}
-	return "", timeCreated, fmt.Errorf(errStr)
+	return "", timeCreated, errors.New(errStr)
 }
 
 func (handler *volumeHandlerContainer) RollbackToSnapshot(snapshotMeta interface{}) error {
 	//TODO implement me
 	errStr := fmt.Sprintf("RollbackToSnapshot not implemented for container volumes")
-	handler.log.Errorf(errStr)
-	return fmt.Errorf(errStr)
+	handler.log.Error(errStr)
+	return errors.New(errStr)
 }
 
 func (handler *volumeHandlerContainer) DeleteSnapshot(snapshotMeta interface{}) error {
 	//TODO implement me
 	errStr := fmt.Sprintf("DeleteSnapshot not implemented for container volumes")
-	handler.log.Errorf(errStr)
-	return fmt.Errorf(errStr)
+	handler.log.Error(errStr)
+	return errors.New(errStr)
 }
 
 func (handler *volumeHandlerContainer) GetAllDataSets() ([]types.ImgInfo, error) {
 	errStr := fmt.Sprintf("GetAllDataSets not implemented for container volumes")
-	handler.log.Errorf(errStr)
-	return nil, fmt.Errorf(errStr)
+	handler.log.Error(errStr)
+	return nil, errors.New(errStr)
 }

--- a/pkg/pillar/volumehandlers/csihandler.go
+++ b/pkg/pillar/volumehandlers/csihandler.go
@@ -333,6 +333,6 @@ func (handler *volumeHandlerCSI) DeleteSnapshot(snapshotMeta interface{}) error 
 
 func (handler *volumeHandlerCSI) GetAllDataSets() ([]types.ImgInfo, error) {
 	errStr := fmt.Sprintf("GetAllDataSets not implemented for container volumes")
-	handler.log.Errorf(errStr)
-	return nil, fmt.Errorf(errStr)
+	handler.log.Error(errStr)
+	return nil, errors.New(errStr)
 }

--- a/pkg/pillar/volumehandlers/filehandler.go
+++ b/pkg/pillar/volumehandlers/filehandler.go
@@ -256,6 +256,6 @@ func (handler *volumeHandlerFile) DeleteSnapshot(snapshotMeta interface{}) error
 
 func (handler *volumeHandlerFile) GetAllDataSets() ([]types.ImgInfo, error) {
 	errStr := fmt.Sprintf("GetAllDataSets not implemented for file volumes")
-	handler.log.Errorf(errStr)
-	return nil, fmt.Errorf(errStr)
+	handler.log.Error(errStr)
+	return nil, errors.New(errStr)
 }

--- a/pkg/pillar/volumehandlers/zvolhandler.go
+++ b/pkg/pillar/volumehandlers/zvolhandler.go
@@ -195,13 +195,13 @@ func (handler *volumeHandlerZVol) DestroyVolume() (string, error) {
 			if err := tgt.VHostDeleteIBlock(tgt.GetNaaSerial(serial)); err != nil {
 				errStr := fmt.Sprintf("Error deleting vhost for %s, error=%v",
 					handler.status.Key(), err)
-				handler.log.Warnf(errStr)
+				handler.log.Warn(errStr)
 			}
 		}
 		if err := tgt.TargetDeleteIBlock(handler.status.Key()); err != nil {
 			errStr := fmt.Sprintf("Error deleting target for %s, error=%v",
 				handler.status.Key(), err)
-			handler.log.Warnf(errStr)
+			handler.log.Warn(errStr)
 		}
 	}
 	zVolName := handler.status.ZVolName()

--- a/pkg/pillar/zedbox/zedbox.go
+++ b/pkg/pillar/zedbox/zedbox.go
@@ -172,7 +172,7 @@ func runService(serviceName string, sep entrypoint, inline bool) int {
 		// or fatal. Don't hide that as the reboot reason.
 		// If that is not the case, then watchdog will soon detect that this service
 		// is not running.
-		log.Errorf(err.Error())
+		log.Error(err.Error())
 		return 1
 	}
 	return 0
@@ -200,7 +200,7 @@ func runZedbox(ps *pubsub.PubSub, logger *logrus.Logger, log *base.LogObject, ar
 			if err := json.Unmarshal([]byte(subData), &serviceInitStatus); err != nil {
 				err := fmt.Errorf("zedbox: exception while unmarshalling data %s. %s",
 					subData, err.Error())
-				log.Errorf(err.Error())
+				log.Error(err.Error())
 				break
 			}
 			// Kick off the command in a goroutine

--- a/pkg/pillar/zedcloud/lookupproxy.go
+++ b/pkg/pillar/zedcloud/lookupproxy.go
@@ -35,7 +35,7 @@ func LookupProxy(log *base.LogObject, status *types.DeviceNetworkStatus, ifname 
 		u, err := url.Parse(rawUrl)
 		if err != nil {
 			errStr := fmt.Sprintf("LookupProxy: malformed URL %s", rawUrl)
-			log.Errorf(errStr)
+			log.Error(errStr)
 			return nil, errors.New(errStr)
 		}
 
@@ -44,7 +44,7 @@ func LookupProxy(log *base.LogObject, status *types.DeviceNetworkStatus, ifname 
 			pacFile, err := base64.StdEncoding.DecodeString(proxyConfig.Pacfile)
 			if err != nil {
 				errStr := fmt.Sprintf("LookupProxy: Decoding proxy file failed: %s", err)
-				log.Errorf(errStr)
+				log.Error(errStr)
 				return nil, errors.New(errStr)
 			}
 			proxyString, err := zedpac.Find_proxy_sync(
@@ -52,7 +52,7 @@ func LookupProxy(log *base.LogObject, status *types.DeviceNetworkStatus, ifname 
 			if err != nil {
 				errStr := fmt.Sprintf("LookupProxy: PAC file could not find proxy for %s: %s",
 					rawUrl, err)
-				log.Errorf(errStr)
+				log.Error(errStr)
 				return nil, errors.New(errStr)
 			}
 			//if proxyString == "DIRECT" {
@@ -61,7 +61,7 @@ func LookupProxy(log *base.LogObject, status *types.DeviceNetworkStatus, ifname 
 			}
 			proxies := strings.Split(proxyString, ";")
 			if len(proxies) == 0 {
-				log.Errorf("LookupProxy: Number of proxies in PAC file result is Zero")
+				log.Error("LookupProxy: Number of proxies in PAC file result is Zero")
 				return nil, nil
 			}
 
@@ -76,7 +76,7 @@ func LookupProxy(log *base.LogObject, status *types.DeviceNetworkStatus, ifname 
 			if err != nil {
 				errStr := fmt.Sprintf("LookupProxy: PAC file returned invalid proxy %s: %s",
 					proxyString, err)
-				log.Errorf(errStr)
+				log.Error(errStr)
 				return nil, errors.New(errStr)
 			}
 			log.Tracef("LookupProxy: PAC proxy being used is %s", proxy0)
@@ -115,7 +115,7 @@ func LookupProxy(log *base.LogObject, status *types.DeviceNetworkStatus, ifname 
 		proxy, err := proxyFunc(u)
 		if err != nil {
 			errStr := fmt.Sprintf("LookupProxy: proxyFunc error: %s", err)
-			log.Errorf(errStr)
+			log.Error(errStr)
 			return proxy, errors.New(errStr)
 		}
 		return proxy, err

--- a/pkg/pillar/zedcloud/tls.go
+++ b/pkg/pillar/zedcloud/tls.go
@@ -98,7 +98,7 @@ func GetTlsConfig(dns *types.DeviceNetworkStatus, clientCert *tls.Certificate, c
 		sha := strings.TrimSpace(string(line))
 		if len(sha) == 0 {
 			errStr := fmt.Sprintf("Read zero byte from sha file")
-			log.Errorf(errStr)
+			log.Error(errStr)
 			return nil, errors.New(errStr)
 		}
 		v2RootFilename := types.CertificateDirname + "/" + sha
@@ -109,7 +109,7 @@ func GetTlsConfig(dns *types.DeviceNetworkStatus, clientCert *tls.Certificate, c
 		if !caCertPool.AppendCertsFromPEM(caCert) {
 			errStr := fmt.Sprintf("Failed to append certs from %s",
 				v2RootFilename)
-			log.Errorf(errStr)
+			log.Error(errStr)
 			return nil, errors.New(errStr)
 		}
 
@@ -126,7 +126,7 @@ func GetTlsConfig(dns *types.DeviceNetworkStatus, clientCert *tls.Certificate, c
 					}
 					errStr := fmt.Sprintf("Failed to append ProxyCertPEM %s for %s",
 						pemStr, port.IfName)
-					log.Errorf(errStr)
+					log.Error(errStr)
 					return nil, errors.New(errStr)
 				}
 			}
@@ -143,7 +143,7 @@ func GetTlsConfig(dns *types.DeviceNetworkStatus, clientCert *tls.Certificate, c
 		errStr := fmt.Sprintf("Failed to append certs from %s",
 			types.RootCertFileName)
 		if ctx != nil {
-			ctx.log.Errorf(errStr)
+			ctx.log.Error(errStr)
 		}
 		return nil, errors.New(errStr)
 	}
@@ -253,25 +253,25 @@ func UpdateTLSProxyCerts(ctx *ZedCloudContext) bool {
 		line, err := os.ReadFile(types.V2TLSCertShaFilename)
 		if err != nil {
 			errStr := fmt.Sprintf("Failed to read V2TLSCertShaFilename")
-			log.Errorf(errStr)
+			log.Error(errStr)
 			return false
 		}
 		sha := strings.TrimSpace(string(line))
 		if len(sha) == 0 {
 			errStr := fmt.Sprintf("Read zero byte from sha file")
-			log.Errorf(errStr)
+			log.Error(errStr)
 			return false
 		}
 		v2RootFilename := types.CertificateDirname + "/" + sha
 		caCert, err := os.ReadFile(v2RootFilename)
 		if err != nil {
 			errStr := fmt.Sprintf("Failed to read v2RootFilename")
-			log.Errorf(errStr)
+			log.Error(errStr)
 			return false
 		}
 		if !caCertPool.AppendCertsFromPEM(caCert) {
 			errStr := fmt.Sprintf("Failed to append certs from %s", v2RootFilename)
-			log.Errorf(errStr)
+			log.Error(errStr)
 			return false
 		}
 		log.Functionf("UpdateTLSProxyCerts: rebuild root CA\n")
@@ -282,7 +282,7 @@ func UpdateTLSProxyCerts(ctx *ZedCloudContext) bool {
 
 	if caCertPool == nil {
 		errStr := fmt.Sprintf("caCertPool is nil")
-		log.Errorf(errStr)
+		log.Error(errStr)
 		return false
 	}
 
@@ -291,7 +291,7 @@ func UpdateTLSProxyCerts(ctx *ZedCloudContext) bool {
 		for _, pem := range port.ProxyCertPEM {
 			if !caCertPool.AppendCertsFromPEM(pem) {
 				errStr := fmt.Sprintf("Failed to append certs from proxy pem")
-				log.Errorf(errStr)
+				log.Error(errStr)
 				return false
 			}
 		}


### PR DESCRIPTION
Since new version of go vet doesn't like them we need to use log.Error and errors.New etc instead of Errorf and fmt.Error

Split this out of #4709 which has the update to the new version in go.mod