### PR TITLE
Handle the Patch-Envelope Encrypted Artifacts

### DIFF
--- a/docs/PATCH-ENVELOPES.md
+++ b/docs/PATCH-ENVELOPES.md
@@ -96,3 +96,237 @@ All communication in this process is done via PubSub. When AppInstance downloads
 object it’s served from Metadata server (zedrouter microservice). In case of external
 patch envelopes – Metadata serves file from volume. For more information on how it works
 in code refer [here](https://github.com/lf-edge/eve/blob/0a8b21ec5de3bf6a2613c2c6f2e2af7e353b1e98/pkg/pillar/cmd/zedrouter/patchenvelopes.go#L18C1-L47C88)
+
+## Encryption/Description of patch envelopes data
+
+### Overview
+
+The cipher-based patch envelope enhancement introduces encryption options for specific parts of the patch envelope. Instead of encrypting the entire envelope or binary artifact blob, the new scheme allows encryption of the `artifactMetaData` field and/or one of the two `binaryBlob` items: `inline` or `volumeRef`. These encrypted items are represented as `encrypted_inline` or `encrypted_volumeref` types in the binary artifact structure.
+
+### How It Works
+
+#### **Parsing the Cipher Block**
+
+When the EVE device receives a patch envelope configuration, and the `binaryBlob` type is either `encrypted_inline` or `encrypted_volumeref`, the `zedagent` performs the following steps:
+
+* It parses the cipher block based on the type (`inline` or `volumeref`).
+* The `zedagent` does not decrypt the blob content. Instead, it uses the first 16 bytes of the `cipherData` as the key.
+* The `cipherData` is encoded using `gob` and saved in the cache directory for later retrieval.
+
+#### **Creating a New Structure**
+
+A new structure, `BinaryCipherBlob`, is introduced in the `pillar` module to handle encrypted binary blobs:
+
+```go
+type BinaryCipherBlob struct {
+  // EncType is type of encryption
+  EncType BlobEncrytedType `json:"encType"`
+  // ArtifactMetadata is generic info i.e. user info, desc etc.
+  ArtifactMetaData string `json:"artifactMetaData"`
+  // Encrypted ArtifactMetadata for blob
+  EncArtifactMeta CipherBlockStatus `json:"encArtifactMeta"`
+  // EncURL is URL to download encrypted binary blob in CipherBlockStatus format
+  // which contains either ONEOF inline or volume encrypted data
+  EncURL string `json:"encURL"`
+  // EncFileName is file name of the encrypted binary blob
+  EncFileName string `json:"encFileName"`
+  // Inline - used for post decrypt inline binary blob
+  Inline *BinaryBlobCompleted `json:"inline"`
+  // Volume - used for post decrypt volume binary blob
+  Volume *BinaryBlobVolumeRef `json:"volume"`
+}
+```
+
+* The EncType field indicates whether the encryption type is BlobEncryptedTypeInline or BlobEncryptedTypeVolume.
+* The ArtifactMetaData and EncArtifactMeta fields are similar to the existing BinaryBlobCompleted and BinaryBlobVolumeRef structures.
+* The EncURL field points to the cached directory containing the saved cipherData.
+* The EncFileName field specifies the key or filename for the saved cipherData.
+
+#### **Publishing the Patch Envelope**
+
+When the zedagent publishes the PatchEnvelopeInfo, the Inline and Volume fields are set to nil. The EncURL contains the cached URL for the encrypted inline data.
+
+#### **Decryption on the MSRV Side**
+
+* When the Metadata Server (MSRV) receives the PatchEnvelopeInfo, it iterates through all binary blobs to check for EncArtifactMeta fields that require decryption. If decryption is required, the decrypted data is populated into the ArtifactMetaData field.
+* For BinaryCipherBlob data, the MSRV fetches the saved cipherData from the cache directory. Based on the type (inline or volumeref), it decrypts the data and populates the Inline or Volume structure.
+
+#### **Serving the Data**
+
+* For inline blobs, the MSRV dynamically formats the url string when a metadata client queries the description.json. This is handled by the zedagent parser for unencrypted cases.
+* When a client requests to download an inline file, the MSRV dynamically decrypts the data from the cache directory, retrieves the content, and forwards it to the client in the download response.
+
+#### **Serving Zip File Download**
+
+When a client requests a zip file containing the patch envelope, the GetZipArchive() utility function:
+
+* Decrypts the CipherBlobs.
+* Appends the decrypted data to the zip entries.
+* Includes the decrypted data in the final zip file for download.
+
+### Example of patch envelope from zedagent 'PatchEnvelopeInfoList' and client description.json
+
+Below is an example of a patch envelope containing one unencrypted BinaryBlob, one unencrypted VolumeRef, and three encrypted CipherBlobs with inline blobs. This example demonstrates how encrypted and unencrypted blobs coexist within a patch envelope.
+
+```json
+b6806473-ab5f-4807-828d-725dcddc45ec:/persist/status/zedagent/PatchEnvelopeInfoList# jq < global.json
+{
+  "Envelopes": [
+    {
+      "Name": "retry-runtime-VM-70c87459-d1e8-411a-b81f-4ec2255db882",
+      "Version": "1",
+      "AllowedApps": [
+        "bc29c80d-e237-429c-a143-f65e7613f635"
+      ],
+      "PatchID": "8986a760-5a6f-4b74-950a-0ca8c3e46838",
+      "Errors": null,
+      "State": 5,
+      "BinaryBlobs": [
+        {
+          "artifactMetaData": "",
+          "encArtifactMeta": {},
+          "fileMetaData": "",
+          "fileName": "NestedAppInstanceConfigManifest.json",
+          "fileSha": "d8fc32cb3de33a0ec79e6cc627f80faac62dd5d7c4c627281fd3d2f88524118a",
+          "size": 156,
+          "url": "/persist/patchEnvelopesCache/NestedAppInstanceConfigManifest.json"
+        }
+      ],
+      "VolumeRefs": [
+        {
+          "artifactMetaData": "",
+          "encArtifactMeta": {},
+          "fileMetaData": "",
+          "fileName": "envdump-compose-tar4e6c75c9-9601-492b-9454-c824b603ca9c",
+          "imageId": "0349dbb1-2e82-4eb6-a736-a4d1a0bd7db0",
+          "imageName": "envdump-compose-tar"
+        },
+        {
+          "artifactMetaData": "",
+          "encArtifactMeta": {},
+          "fileMetaData": "",
+          "fileName": "hello-eve-compose-tar5766797a-7180-4e06-94f1-47c816964637",
+          "imageId": "deb85d21-d7ff-4806-abb5-3c4a3c44696e",
+          "imageName": "hello-eve-compose-tar"
+        }
+      ],
+      "CipherBlobs": [
+        {
+          "artifactMetaData": "",
+          "encArtifactMeta": {},
+          "encFileName": "encInline-7bb22e113642633a2249260d4d4d0823",
+          "encType": 1,
+          "encURL": "/persist/patchEnvelopesCache/encInline-7bb22e113642633a2249260d4d4d0823",
+          "inline": null,
+          "volume": null
+        },
+        {
+          "artifactMetaData": "",
+          "encArtifactMeta": {},
+          "encFileName": "encInline-7bea2d113642243a1c56340d63521523",
+          "encType": 1,
+          "encURL": "/persist/patchEnvelopesCache/encInline-7bea2d113642243a1c56340d63521523",
+          "inline": null,
+          "volume": null
+        },
+        {
+          "artifactMetaData": "",
+          "encArtifactMeta": {},
+          "encFileName": "encInline-7bd62e113642622e0c4a7e0d4d705135",
+          "encType": 1,
+          "encURL": "/persist/patchEnvelopesCache/encInline-7bd62e113642622e0c4a7e0d4d705135",
+          "inline": null,
+          "volume": null
+        }
+      ]
+    }
+  ]
+}
+```
+
+```sh
+curl http://169.254.169.254/eve/v1/patch/description.json
+```
+
+```json
+[
+  {
+    "PatchID": "8986a760-5a6f-4b74-950a-0ca8c3e46838",
+    "Version": "1",
+    "BinaryBlobs": [
+      {
+        "artifactMetaData": "",
+        "encArtifactMeta": {},
+        "fileMetaData": "",
+        "fileName": "NestedAppInstanceConfigManifest.json",
+        "fileSha": "d8fc32cb3de33a0ec79e6cc627f80faac62dd5d7c4c627281fd3d2f88524118a",
+        "size": 156,
+        "url": "http://169.254.169.254/eve/v1/patch/download/8986a760-5a6f-4b74-950a-0ca8c3e46838/NestedAppInstanceConfigManifest.json"
+      },
+      {
+        "artifactMetaData": "",
+        "encArtifactMeta": {},
+        "fileMetaData": "",
+        "fileName": "envdump-compose-tar4e6c75c9-9601-492b-9454-c824b603ca9c",
+        "fileSha": "d2371d63df77fcc5cc6f7753e5f07e1b742bb3a0088e1be68f4c55f9f06024f9",
+        "size": 672,
+        "url": "http://169.254.169.254/eve/v1/patch/download/8986a760-5a6f-4b74-950a-0ca8c3e46838/envdump-compose-tar4e6c75c9-9601-492b-9454-c824b603ca9c"
+      },
+      {
+        "artifactMetaData": "",
+        "encArtifactMeta": {},
+        "fileMetaData": "",
+        "fileName": "hello-eve-compose-tar5766797a-7180-4e06-94f1-47c816964637",
+        "fileSha": "38a47238a57c3ecf0e012eca61fc5f539347e00d63bec1fd5d904a6e830e97a8",
+        "size": 416,
+        "url": "http://169.254.169.254/eve/v1/patch/download/8986a760-5a6f-4b74-950a-0ca8c3e46838/hello-eve-compose-tar5766797a-7180-4e06-94f1-47c816964637"
+      },
+      {
+        "artifactMetaData": "",
+        "encArtifactMeta": {},
+        "fileMetaData": "",
+        "fileName": "4e6c75c9-9601-492b-9454-c824b603ca9c",
+        "fileSha": "299dac7b02cda04ca904fba028549919be17869d67b0cc68f033e784bda3d69b",
+        "size": 156,
+        "url": "http://169.254.169.254/eve/v1/patch/download/8986a760-5a6f-4b74-950a-0ca8c3e46838/4e6c75c9-9601-492b-9454-c824b603ca9c"
+      },
+      {
+        "artifactMetaData": "",
+        "encArtifactMeta": {},
+        "fileMetaData": "",
+        "fileName": "0f115208-6780-453f-9827-39d8d9fa200f",
+        "fileSha": "043811693f3ca1ba1f22c60ba2e7ab2d4daadb1c388828f37e86a7b566ecb5c6",
+        "size": 324,
+        "url": "http://169.254.169.254/eve/v1/patch/download/8986a760-5a6f-4b74-950a-0ca8c3e46838/0f115208-6780-453f-9827-39d8d9fa200f"
+      },
+      {
+        "artifactMetaData": "",
+        "encArtifactMeta": {},
+        "fileMetaData": "",
+        "fileName": "5766797a-7180-4e06-94f1-47c816964637",
+        "fileSha": "215960d4a3a6f3edcf12cfdad0cdb9c72d30121700049b05da159afb127714f2",
+        "size": 248,
+        "url": "http://169.254.169.254/eve/v1/patch/download/8986a760-5a6f-4b74-950a-0ca8c3e46838/5766797a-7180-4e06-94f1-47c816964637"
+      }
+    ],
+    "VolumeRefs": [
+      {
+        "artifactMetaData": "",
+        "encArtifactMeta": {},
+        "fileMetaData": "",
+        "fileName": "envdump-compose-tar4e6c75c9-9601-492b-9454-c824b603ca9c",
+        "imageId": "0349dbb1-2e82-4eb6-a736-a4d1a0bd7db0",
+        "imageName": "envdump-compose-tar"
+      },
+      {
+        "artifactMetaData": "",
+        "encArtifactMeta": {},
+        "fileMetaData": "",
+        "fileName": "hello-eve-compose-tar5766797a-7180-4e06-94f1-47c816964637",
+        "imageId": "deb85d21-d7ff-4806-abb5-3c4a3c44696e",
+        "imageName": "hello-eve-compose-tar"
+      }
+    ]
+  }
+]
+```

--- a/pkg/pillar/cipher/cipher.go
+++ b/pkg/pillar/cipher/cipher.go
@@ -34,13 +34,42 @@ func getEncryptionBlock(
 // GetCipherCredentials : decrypt encryption block
 func GetCipherCredentials(ctx *DecryptCipherContext,
 	status types.CipherBlockStatus) (types.CipherBlockStatus, types.EncryptionBlock, error) {
+	var decBlock types.EncryptionBlock
+	cipherBlock, clearBytes, err := GetCipherMarshalledData(ctx, status)
+	if err != nil {
+		return handleCipherBlockCredError(ctx, &cipherBlock,
+			decBlock, err, types.DecryptFailed)
+	}
+
+	var zconfigDecBlock zcommon.EncryptionBlock
+	err = UnmarshalCipherData(ctx, clearBytes, &zconfigDecBlock)
+	if err != nil {
+		ctx.Log.Errorf("%s, encryption block unmarshall failed, %v\n",
+			cipherBlock.Key(), err)
+		return handleCipherBlockCredError(ctx, &cipherBlock,
+			decBlock, err, types.UnmarshalFailed)
+	}
+	ctx.Log.Functionf("%s, cipherblock decryption successful", cipherBlock.Key())
+	decBlock = getEncryptionBlock(&zconfigDecBlock)
+	ctx.AgentMetrics.RecordSuccess(ctx.Log)
+	return cipherBlock, decBlock, err
+}
+
+// GetCipherMarshalledData : decrypt encryption block, without assuming the proto
+// encoding data is zcommon.EncryptionBlock, since the data before encryption may have
+// its own data structure, it is up to the caller to unmarshal the data using
+// 'UnmarshalCipherData' function. Future use cases may not need to add a new
+// item in the EncryptionBLock.
+func GetCipherMarshalledData(ctx *DecryptCipherContext,
+	status types.CipherBlockStatus) (types.CipherBlockStatus, []byte, error) {
 	cipherBlock := new(types.CipherBlockStatus)
 	*cipherBlock = status
 	var decBlock types.EncryptionBlock
 	if !cipherBlock.IsCipher {
 		// Should not be called if IsCipher is not set
-		return handleCipherBlockCredError(ctx, cipherBlock,
+		cblock, _, err := handleCipherBlockCredError(ctx, cipherBlock,
 			decBlock, nil, types.Invalid)
+		return cblock, nil, err
 	}
 	ctx.Log.Functionf("%s, cipherblock decryption, using cipher-context: %s\n",
 		cipherBlock.Key(), cipherBlock.CipherContextID)
@@ -49,29 +78,31 @@ func GetCipherCredentials(ctx *DecryptCipherContext,
 			cipherBlock.Key(), cipherBlock.Error)
 		ctx.Log.Errorln(errStr)
 		err := errors.New(errStr)
-		return handleCipherBlockCredError(ctx, cipherBlock,
+		cblock, _, err := handleCipherBlockCredError(ctx, cipherBlock,
 			decBlock, err, types.NotReady)
+		return cblock, nil, err
 	}
 	clearBytes, err := DecryptCipherBlock(ctx, *cipherBlock)
 	if err != nil {
 		ctx.Log.Errorf("%s, cipherblock decryption failed, %v\n",
 			cipherBlock.Key(), err)
-		return handleCipherBlockCredError(ctx, cipherBlock,
-			decBlock, err, types.DecryptFailed)
+		cblock, _, err := handleCipherBlockCredError(ctx, cipherBlock,
+			decBlock, nil, types.Invalid)
+		return cblock, nil, err
 	}
 
-	var zconfigDecBlock zcommon.EncryptionBlock
-	err = proto.Unmarshal(clearBytes, &zconfigDecBlock)
+	return *cipherBlock, clearBytes, err
+}
+
+// UnmarshalCipherData generalizes the unmarshalling of cipher data into different Go data structures.
+func UnmarshalCipherData(ctx *DecryptCipherContext, clearBytes []byte, out proto.Message) error {
+	err := proto.Unmarshal(clearBytes, out)
 	if err != nil {
-		ctx.Log.Errorf("%s, encryption block unmarshall failed, %v\n",
-			cipherBlock.Key(), err)
-		return handleCipherBlockCredError(ctx, cipherBlock,
-			decBlock, err, types.UnmarshalFailed)
+		ctx.Log.Errorf("encryption block unmarshall failed, %v\n", err)
+		return fmt.Errorf("failed to unmarshal cipher block: %w", err)
 	}
-	ctx.Log.Functionf("%s, cipherblock decryption successful", cipherBlock.Key())
-	decBlock = getEncryptionBlock(&zconfigDecBlock)
-	ctx.AgentMetrics.RecordSuccess(ctx.Log)
-	return *cipherBlock, decBlock, err
+	ctx.Log.Functionf("cipherblock decryption successful")
+	return nil
 }
 
 // GetCipherData : decrypt plain text

--- a/pkg/pillar/cmd/msrv/msrv_test.go
+++ b/pkg/pillar/cmd/msrv/msrv_test.go
@@ -205,6 +205,26 @@ func TestRequestPatchEnvelopes(t *testing.T) {
 						URL:      "a.txt",
 					},
 				},
+				CipherBlobs: []types.BinaryCipherBlob{
+					{
+						EncType: types.BlobEncrytedTypeInline,
+						Inline: &types.BinaryBlobCompleted{
+							FileName: "abcd2",
+							FileSha:  "abcd2",
+							URL:      "a2.txt",
+						},
+					},
+					{
+						EncType: types.BlobEncrytedTypeVolume,
+						Volume: &types.BinaryBlobVolumeRef{
+							FileName:         "abcd3a",
+							ImageName:        "abcd3b",
+							FileMetadata:     "abcd3c",
+							ArtifactMetadata: "abcd3d",
+							ImageID:          "abcd3e",
+						},
+					},
+				},
 			},
 		},
 	})
@@ -259,6 +279,23 @@ func TestRequestPatchEnvelopes(t *testing.T) {
 							ArtifactMetadata: "",
 							URL:              "http://169.254.169.254/eve/v1/patch/download/6ba7b810-9dad-11d1-80b4-111111111111/abcd",
 							Size:             0,
+						},
+						{
+							FileName:         "abcd2",
+							FileSha:          "abcd2",
+							FileMetadata:     "",
+							ArtifactMetadata: "",
+							URL:              "http://169.254.169.254/eve/v1/patch/download/6ba7b810-9dad-11d1-80b4-111111111111/abcd2",
+							Size:             0,
+						},
+					},
+					VolumeRefs: []types.BinaryBlobVolumeRef{
+						{
+							FileName:         "abcd3a",
+							ImageName:        "abcd3b",
+							FileMetadata:     "abcd3c",
+							ArtifactMetadata: "abcd3d",
+							ImageID:          "abcd3e",
 						},
 					},
 				},

--- a/pkg/pillar/cmd/msrv/patchenvelopes_test.go
+++ b/pkg/pillar/cmd/msrv/patchenvelopes_test.go
@@ -27,7 +27,12 @@ func TestPatchEnvelopes(t *testing.T) {
 	logger := logrus.StandardLogger()
 	log := base.NewSourceLogObject(logger, "petypes", 1234)
 	ps := pubsub.New(&pubsub.EmptyDriver{}, logger, log)
-	peStore := msrv.NewPatchEnvelopes(log, ps)
+	srv := &msrv.Msrv{
+		Log:    log,
+		PubSub: ps,
+		Logger: logger,
+	}
+	peStore := msrv.NewPatchEnvelopes(srv)
 
 	patch1UUID := "6ba7b810-9dad-11d1-80b4-000000000000"
 	app1UUID := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"

--- a/pkg/pillar/cmd/msrv/pubsub.go
+++ b/pkg/pillar/cmd/msrv/pubsub.go
@@ -341,11 +341,6 @@ func (srv *Msrv) handlePatchEnvelopeModify(ctxArg interface{}, key string,
 	statusArg interface{}, oldStatusArg interface{}) {
 	peInfo := statusArg.(types.PatchEnvelopeInfoList)
 
-	if len(peInfo.Envelopes) == 0 {
-		srv.Log.Functionf("handlePatchEnvelopeModify: (UUID: %s). Empty envelopes", key)
-		return
-	}
-
 	srv.Log.Functionf("handlePatchEnvelopeModify: (UUID: %s) %v", key, peInfo.Envelopes)
 
 	srv.handlePatchEnvelopeImpl(peInfo)

--- a/pkg/pillar/types/cipherinfotypes.go
+++ b/pkg/pillar/types/cipherinfotypes.go
@@ -146,4 +146,6 @@ type EncryptionBlock struct {
 	CellularNetPassword string
 	ProtectedUserData   string
 	ClusterToken        string
+	User                zcommon.EncryptionBlockUser
+	EncryptedData       string
 }

--- a/pkg/pillar/utils/patchenvelopesutils.go
+++ b/pkg/pillar/utils/patchenvelopesutils.go
@@ -46,5 +46,24 @@ func GetZipArchive(root string, pe types.PatchEnvelopeInfo) (string, error) {
 
 	}
 
+	// The CipherBlobs, temporarily, store the decrypted content of the blob file in
+	// the Inline.URL string. Directly use that for zipEntry write.
+	for _, b := range pe.CipherBlobs {
+		// We only want to archive cipher blobs which are ready
+		if b.EncType != types.BlobEncrytedTypeInline || b.Inline == nil {
+			continue
+		}
+
+		zipEntry, err := zipWriter.Create(b.Inline.FileName)
+		if err != nil {
+			return "", err
+		}
+
+		_, err = zipEntry.Write([]byte(b.Inline.URL))
+		if err != nil {
+			return "", err
+		}
+	}
+
 	return zipFilename, nil
 }


### PR DESCRIPTION
- the application is for the nested-app secure configuration
- modified the cipher GetCipherCredentials() function, it does not need to assume the encrypted data is in 'EncryptionBlock' struct, this is easier to have an entire struct to be encrypted
- handle on the zedagent side of setup of publication for encrypted data inside the 'PatchEnvelopeInfo' with slice of 'BinaryCipherBlob'
- handle the cipher data in MSRV, decrypt the data to populate inline or volumeref blobs
- handle the meta-data service for description query, the inline decrypted file downloading and zipfile downloading
- add some test cases using sample cipher blobs