### PR TITLE
Kernel update - [amd64-generic]

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,5 +1,5 @@
 KERNEL_COMMIT_amd64_v6.1.111_rt = c708a17493f1
-KERNEL_COMMIT_amd64_v6.1.112_generic = 9c0e9c9de5ae
+KERNEL_COMMIT_amd64_v6.1.112_generic = 272f44dbfe09
 KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = 6e54f05fbd3b
 KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 22e03b8516f2
 KERNEL_COMMIT_arm64_v6.1.112_generic = 9f160b774dbc


### PR DESCRIPTION
This commit changes:
eve-kernel-amd64-v6.1.112-generic
    272f44dbfe09: Added drivers for supporting ECC error correction and detection