### PR TITLE
bpftrace-compiler: decrease needed go version

### DIFF
--- a/eve-tools/bpftrace-compiler/go.mod
+++ b/eve-tools/bpftrace-compiler/go.mod
@@ -1,6 +1,6 @@
 module bpftrace-compiler
 
-go 1.24.1
+go 1.23.7
 
 require (
 	github.com/creack/pty v1.1.24


### PR DESCRIPTION
make bpftrace-compiler more accessible to computers with older go versions and only require 1.23.7