### PR TITLE
upgrade yetus to 0.15.1

### DIFF
--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Yetus
-        uses: apache/yetus-test-patch-action@0.15.0
+        uses: apache/yetus-test-patch-action@0.15.1
         with:
           basedir: ./src
           buildtool: nobuild

--- a/Makefile
+++ b/Makefile
@@ -503,7 +503,7 @@ check-docker-hashes-consistency: $(DOCKERFILE_FROM_CHECKER)
 yetus:
 	@echo Running yetus
 	mkdir -p yetus-output
-	docker run --rm -v $(CURDIR):/src:delegated,z ghcr.io/apache/yetus:0.15.0 \
+	docker run --rm -v $(CURDIR):/src:delegated,z ghcr.io/apache/yetus:0.15.1 \
 		--basedir=/src \
 		--test-parallel=true \
 		--dirty-workspace \

--- a/tools/mini-yetus.sh
+++ b/tools/mini-yetus.sh
@@ -141,7 +141,7 @@ cd "$SRC_DIR" && \
     git commit -m "Changes in the PR" >/dev/null 2>&1
 
 echo "[+] Running yetus on the changes..."
-docker run --rm -v "$SRC_DIR":/src:delegated,z ghcr.io/apache/yetus:0.15.0 \
+docker run --rm -v "$SRC_DIR":/src:delegated,z ghcr.io/apache/yetus:0.15.1 \
     --basedir=/src \
     --test-parallel=true \
     --dirty-workspace \


### PR DESCRIPTION
Since we switched to go 1.24.1 we need to upgrade golangci-lint to at least v1.64.2 and that means upgrading yetus to the latest 0.15.1.