### PR TITLE
pillar: fix ResolveWithSrcIP fuzz test

### DIFF
--- a/pkg/pillar/devicenetwork/dns.go
+++ b/pkg/pillar/devicenetwork/dns.go
@@ -69,11 +69,14 @@ func ResolvConfToIfname(resolvConf string) string {
 	return ""
 }
 
-// ResolveWithSrcIP resolves a domain with a given dns server and source Ip
-func ResolveWithSrcIP(domain string, dnsServerIP net.IP, srcIP net.IP) ([]DNSResponse, error) {
+// ResolveWithSrcIPWithTimeout resolves a domain with a given dns server and source Ip within a time duration
+func ResolveWithSrcIPWithTimeout(domain string, dnsServerIP net.IP, srcIP net.IP, timeout time.Duration) ([]DNSResponse, error) {
 	var response []DNSResponse
 	sourceUDPAddr := net.UDPAddr{IP: srcIP}
-	dialer := net.Dialer{LocalAddr: &sourceUDPAddr}
+	dialer := net.Dialer{
+		LocalAddr: &sourceUDPAddr,
+		Timeout:   timeout,
+	}
 	dnsClient := dns.Client{Dialer: &dialer}
 	msg := dns.Msg{}
 	if !strings.HasSuffix(domain, ".") {
@@ -95,6 +98,11 @@ func ResolveWithSrcIP(domain string, dnsServerIP net.IP, srcIP net.IP) ([]DNSRes
 	}
 
 	return response, nil
+}
+
+// ResolveWithSrcIP resolves a domain with a given dns server and source Ip
+func ResolveWithSrcIP(domain string, dnsServerIP net.IP, srcIP net.IP) ([]DNSResponse, error) {
+	return ResolveWithSrcIPWithTimeout(domain, dnsServerIP, srcIP, 0)
 }
 
 type cachedDNSResponses struct {

--- a/pkg/pillar/devicenetwork/dns_test.go
+++ b/pkg/pillar/devicenetwork/dns_test.go
@@ -294,6 +294,6 @@ func FuzzResolveWithSrcIP(f *testing.F) {
 	) {
 		dnsServerIP := net.ParseIP(dnsServer)
 		srcIP := net.ParseIP(src)
-		devicenetwork.ResolveWithSrcIP(domain, dnsServerIP, srcIP)
+		devicenetwork.ResolveWithSrcIPWithTimeout(domain, dnsServerIP, srcIP, 3*time.Second)
 	})
 }


### PR DESCRIPTION
```
https://github.com/golang/go/commit/5d24203c394e6b64c42a9f69b990d94cb6c8aad4 introduces a timeout of 10 seconds for fuzzing

If you run
go test -run=FuzzResolveWithSrcIP -fuzz=FuzzResolveWithSrcIP -fuzztime=300s then sometimes one can get the following error message: ---
fuzzing process hung or terminated unexpectedly: exit status 2
    Failing input written to testdata/fuzz/FuzzResolveWithSrcIP/0da8dc9ddab68884
    To re-run:
    go test -run=FuzzResolveWithSrcIP/0da8dc9ddab68884
---
Unfortunately running `go test ...` does not reproduce the issue, but when you run the fuzzing in strace one can see the following: ---
50568 write(2</dev/null>, "panic: ", 7) = 7
50568 write(2</dev/null>, "deadlocked!", 11) = 11
50568 write(2</dev/null>, "\n", 1)      = 1
50568 write(2</dev/null>, "\n", 1)      = 1
50568 write(2</dev/null>, "goroutine ", 10) = 10
50568 write(2</dev/null>, "73", 2)      = 2
50568 write(2</dev/null>, " [", 2)      = 2
50568 write(2</dev/null>, "running", 7) = 7
50568 write(2</dev/null>, "]:\n", 3)    = 3
50568 write(2</dev/null>, "internal/fuzz.RunFuzzWorker.func1.1", 35) = 35
50568 write(2</dev/null>, "(", 1)       = 1
50568 write(2</dev/null>, ")\n", 2)     = 2
50568 write(2</dev/null>, "\t", 1)      = 1
50568 write(2</dev/null>, "/usr/lib/go/src/internal/fuzz/worker.go", 39) = 39
50568 write(2</dev/null>, ":", 1)       = 1
50568 write(2</dev/null>, "493", 3)     = 3
50568 write(2</dev/null>, " +", 2)      = 2
50568 write(2</dev/null>, "0x2b", 4)    = 4
50568 write(2</dev/null>, "\n", 1)      = 1
50568 write(2</dev/null>, "created by ", 11) = 11
50568 write(2</dev/null>, "time.goFunc", 11) = 11
50568 write(2</dev/null>, "\n", 1)      = 1
50568 write(2</dev/null>, "\t", 1)      = 1
50568 write(2</dev/null>, "/usr/lib/go/src/time/sleep.go", 29) = 29
50568 write(2</dev/null>, ":", 1)       = 1
50568 write(2</dev/null>, "215", 3)     = 3
50568 write(2</dev/null>, " +", 2)      = 2
50568 write(2</dev/null>, "0x45", 4)    = 4
50568 write(2</dev/null>, "\n", 1)      = 1
---
this is also described here: https://github.com/golang/go/issues/56238#issuecomment-1948138937

So this commit for now introduces a workaround by reducing the dialing timeout to 3 seconds so that the deadlock detection does not panic.
```