### PR TITLE
github/workflows: Switch publish arm64 runners to buildjet

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,13 +25,13 @@ jobs:
           - os: ubuntu-22.04
             arch: amd64
             platform: "generic"
-          - os: arm64-secure
+          - os: buildjet-4vcpu-ubuntu-2204-arm
             arch: arm64
             platform: "generic"
-          - os: arm64-secure
+          - os: buildjet-4vcpu-ubuntu-2204-arm
             arch: arm64
             platform: "nvidia-jp5"
-          - os: arm64-secure
+          - os: buildjet-4vcpu-ubuntu-2204-arm
             arch: arm64
             platform: "nvidia-jp6"
           - os: ubuntu-latest


### PR DESCRIPTION
We are experiencing several issues with arm64-secure runners when building and publishing images to dockerhub. Let's switch to buildjet runners to see if it fixes the recurrent issues.