### PR TITLE
Fix IP single-stack options

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1409,31 +1409,35 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 			// Need to be careful since zedcloud can feed us bad Dhcp type
 			port.Dhcp = network.Dhcp
 			port.IgnoreDhcpNtpServers = network.IgnoreDhcpNtpServers
-			switch port.Dhcp {
-			case types.DhcpTypeStatic:
-				if sysAdapter.Addr == "" {
-					errStr := fmt.Sprintf("Port %s configured with static IP config "+
-						"but IP address is not defined", port.Logicallabel)
-					log.Errorf("parseSystemAdapterConfig: %s", errStr)
-					port.RecordFailure(errStr)
-				}
-			case types.DhcpTypeClient:
-				// Do nothing
-			case types.DhcpTypeNone:
-				if isMgmt {
-					errStr := fmt.Sprintf("Port %s configured as Management port "+
-						"with an unsupported DHCP type %d. Client and static are "+
-						"the only allowed DHCP modes for management ports.",
-						port.Logicallabel, types.DhcpTypeNone)
+			// Skip port config validation if the associated network config is invalid,
+			// to avoid overriding the inherited network error.
+			if !network.HasError() {
+				switch port.Dhcp {
+				case types.DhcpTypeStatic:
+					if sysAdapter.Addr == "" {
+						errStr := fmt.Sprintf("Port %s configured with static IP config "+
+							"but IP address is not defined", port.Logicallabel)
+						log.Errorf("parseSystemAdapterConfig: %s", errStr)
+						port.RecordFailure(errStr)
+					}
+				case types.DhcpTypeClient:
+					// Do nothing
+				case types.DhcpTypeNone:
+					if isMgmt {
+						errStr := fmt.Sprintf("Port %s configured as Management port "+
+							"with an unsupported DHCP type %d. Client and static are "+
+							"the only allowed DHCP modes for management ports.",
+							port.Logicallabel, types.DhcpTypeNone)
 
+						log.Errorf("parseSystemAdapterConfig: %s", errStr)
+						port.RecordFailure(errStr)
+					}
+				default:
+					errStr := fmt.Sprintf("Port %s configured with unknown DHCP type %v",
+						port.Logicallabel, network.Dhcp)
 					log.Errorf("parseSystemAdapterConfig: %s", errStr)
 					port.RecordFailure(errStr)
 				}
-			default:
-				errStr := fmt.Sprintf("Port %s configured with unknown DHCP type %v",
-					port.Logicallabel, network.Dhcp)
-				log.Errorf("parseSystemAdapterConfig: %s", errStr)
-				port.RecordFailure(errStr)
 			}
 			// XXX use DnsNameToIpList?
 			if network.Proxy != nil {
@@ -1991,9 +1995,25 @@ func publishNetworkXObjectConfig(ctx *getconfigContext,
 }
 
 func parseOneNetworkXObjectConfig(ctx *getconfigContext, netEnt *zconfig.NetworkConfig) *types.NetworkXObjectConfig {
-
 	config := new(types.NetworkXObjectConfig)
-	config.Type = types.NetworkType(netEnt.Type)
+	switch netEnt.Type {
+	case zconfig.NetworkType_NETWORKTYPENOOP:
+		config.Type = types.NetworkTypeNOOP
+	case zconfig.NetworkType_V4:
+		config.Type = types.NetworkTypeIPv4
+	case zconfig.NetworkType_V6:
+		config.Type = types.NetworkTypeIPV6
+	case zconfig.NetworkType_V4Only:
+		config.Type = types.NetworkTypeIpv4Only
+	case zconfig.NetworkType_V6Only:
+		config.Type = types.NetworkTypeIpv6Only
+	default:
+		errStr := fmt.Sprintf("Unknown Network type (%s)", netEnt.Type.String())
+		log.Errorf("parseOneNetworkXObjectConfig (%s): %s", config.Key(), errStr)
+		config.SetErrorNow(errStr)
+		return config
+	}
+
 	id, err := uuid.FromString(netEnt.Id)
 	if err != nil {
 		errStr := fmt.Sprintf("Malformed UUID ignored: %s", err)
@@ -2052,14 +2072,13 @@ func parseOneNetworkXObjectConfig(ctx *getconfigContext, netEnt *zconfig.Network
 	config.WirelessCfg = parseNetworkWirelessConfig(ctx, config.Key(), netEnt)
 
 	ipspec := netEnt.GetIp()
-	switch config.Type {
-	case types.NetworkTypeIPv4, types.NetworkTypeIPV6:
-		if ipspec == nil {
-			errStr := "Missing IP configuration"
-			log.Errorf("parseOneNetworkXObjectConfig (%s): %s", config.Key(), errStr)
-			config.SetErrorNow(errStr)
-			return config
-		}
+	if ipspec == nil && config.Type != types.NetworkTypeNOOP {
+		errStr := "Missing IP configuration"
+		log.Errorf("parseOneNetworkXObjectConfig (%s): %s", config.Key(), errStr)
+		config.SetErrorNow(errStr)
+		return config
+	}
+	if ipspec != nil {
 		err := parseIpspecNetworkXObject(ipspec, config)
 		if err != nil {
 			errStr := fmt.Sprintf("Invalid IP configuration: %s", err)
@@ -2067,25 +2086,6 @@ func parseOneNetworkXObjectConfig(ctx *getconfigContext, netEnt *zconfig.Network
 			config.SetErrorNow(errStr)
 			return config
 		}
-	case types.NetworkTypeNOOP:
-		// XXX is controller still sending static and dynamic entries with NetworkTypeNOOP? Why?
-		if ipspec != nil {
-			log.Warnf("XXX NetworkTypeNOOP for %s with ipspec %v",
-				config.Key(), ipspec)
-			err := parseIpspecNetworkXObject(ipspec, config)
-			if err != nil {
-				errStr := fmt.Sprintf("Invalid IP configuration: %s", err)
-				log.Errorf("parseOneNetworkXObjectConfig (%s): %s", config.Key(), errStr)
-				config.SetErrorNow(errStr)
-				return config
-			}
-		}
-
-	default:
-		errStr := fmt.Sprintf("Unknown Network type (%d)", config.Type)
-		log.Errorf("parseOneNetworkXObjectConfig (%s): %s", config.Key(), errStr)
-		config.SetErrorNow(errStr)
-		return config
 	}
 
 	// Parse and store DNSNameToIPList form Network configuration


### PR DESCRIPTION
The network types:

- `NetworkTypeIpv4Only`
- `NetworkTypeIpv6Only`

were introduced and implemented a long long time ago to enforce single-stack IP configurations
(either IPv4 or IPv6, not dual-stack). However, the parsing logic was never updated 
to recognize them. As a result, zedagent marked such configs as invalid, and the NIM
microservice did not apply them. Moreover, there was a bug related to `dhcpcd` PID filepath
retrieval for the single-stack cases. 