### PR TITLE
yetus: Exclude go-libzfs from checks

### DIFF
--- a/.yetus/excludes.txt
+++ b/.yetus/excludes.txt
@@ -2,6 +2,7 @@
 ^pkg/mkimage-raw-efi/initramfs-init
 ^pkg/mkimage-raw-efi/nlplug-findfs.c
 ^pkg/pillar/rootfs/fscrypt.conf
+^pkg/pillar/vendor/github.com/andrewd-zededa/go-libzfs
 ^pkg/fw/
 ^pkg/debug/abuild/
 ^pkg/pillar/zedpac/


### PR DESCRIPTION
Yetus container doesn't have libzfs headers, so we must exclude go-libzfs from checks to avoid GH Yetus action to fail.