### PR TITLE
[13.4-stable] wwan: update Lenovo FCC unlock binary to support SE30 with 5G modem

### DIFF
--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
-# Copyright (c) 2023 Zededa, Inc.
+# Copyright (c) 2023-2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 FROM lfedge/eve-alpine:82df60e43ab9f8c935584b8c7b4d0a4b0271d608 as build
@@ -13,7 +13,7 @@ ENV LIBMBIM_VERSION=1.30.0
 ENV LIBQMI_VERSION=1.34.0
 ENV LIBQRTR_VERSION=1.2.2
 ENV PICOCOM_COMMIT=1acf1ddabaf3576b4023c4f6f09c5a3e4b086fb8
-ENV LENOVO_WWAN_UNLOCK_COMMIT=dc9a7eccf72b83e6db528da930cc7f19d6cdd523
+ENV LENOVO_WWAN_UNLOCK_COMMIT=1c0753d709f0efa57575c5a7491bc5456417b073
 
 ADD --keep-git-dir=true https://gitlab.freedesktop.org/mobile-broadband/libqrtr-glib.git#${LIBQRTR_VERSION} /libqrtr
 WORKDIR /libqrtr
@@ -53,6 +53,7 @@ RUN make -j "$(getconf _NPROCESSORS_ONLN)" && strip picocom && cp picocom /usr/b
 ADD --keep-git-dir=true https://github.com/lenovo/lenovo-wwan-unlock.git#${LENOVO_WWAN_UNLOCK_COMMIT} /lenovo-wwan-unlock
 WORKDIR /lenovo-wwan-unlock
 RUN cp libmbimtools.so /out/usr/lib/ && chmod 444 /out/usr/lib/libmbimtools.so
+RUN cp libdpr.so.2.0.1 /out/usr/lib/ && chmod 444 /out/usr/lib/libdpr.so.2.0.1
 RUN mkdir -p /out/opt/lenovo/ && \
     cp DPR_Fcc_unlock_service /out/opt/lenovo/ && chmod 544 /out/opt/lenovo/DPR_Fcc_unlock_service
 COPY --chown=root:root --chmod=500 fcc-unlock /out/usr/lib/ModemManager/fcc-unlock.d

--- a/pkg/wwan/fcc-unlock/105b:e0ab
+++ b/pkg/wwan/fcc-unlock/105b:e0ab
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Foxconn SDX55 5G FCC Unlock Script
+
+ARCH="$(uname -m)"
+VENDOR="$(cat /sys/class/dmi/id/sys_vendor)"
+PRODUCT="$(cat /sys/class/dmi/id/product_family)"
+
+# Fallback to the open-source FCC unlock script when vendor-specific unlock tool
+# is not available or fails.
+# shellcheck disable=SC2015
+[ "$ARCH" = "x86_64" ] && [ "$VENDOR" = "LENOVO" ] && [ "$PRODUCT" = "ThinkEdge SE30" ] &&
+  /opt/lenovo/DPR_Fcc_unlock_service || /etc/ModemManager/fcc-unlock.d/105b "$@"
+exit $?

--- a/pkg/wwan/mm-init.sh
+++ b/pkg/wwan/mm-init.sh
@@ -14,7 +14,7 @@ enable_fcc_unlock() {
     if [ -f "$SCRIPT" ]; then
       SCRIPT_NAME="$(basename "$SCRIPT")"
       case "$SCRIPT_NAME" in
-        "1eac:1002" | "2c7c:030a" | "2c7c:0311")
+        "1eac:1002" | "2c7c:030a" | "2c7c:0311" | "105b:e0ab")
           # For these modems we have our own custom scripts.
           continue
           ;;


### PR DESCRIPTION
This commit updates Lenovo FCC unlock repository to a newer version to support Lenovo ThinkEdge SE30 with Foxconn SDX55 5G modem

Signed-off-by: Pavel Abramov <uncle.decart@gmail.com>
(cherry picked from commit 4fd54db366486d201321c7a3433df67ea142d586)

Backporting this to 13.4-stable (only) because it is required to support Foxconn SDX55 on EVE 13.4 LTS.

### How to test and verify the PR

Test EVE on Lenovo ThinkEdge SE30 with Foxconn SDX55 5G modem. Configure cellular connection and check that connection comes up as opposed to modem being stuck in radio-off state.
To confirm, ssh to the device, enter wwan container and check modem status:
```
eve enter wwan
mmcli -m 0
...
           |                state: connected
           |          power state: on
...
```
If FCC-locked (i.e. the patch failed), the power state would be low and state would be disabled