### PR TITLE
Fix some Edge-Node Clustering Regression issues

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -277,7 +277,6 @@ external_boot_image_import() {
         eve_external_boot_img="${eve_external_boot_img_name}:${eve_external_boot_img_tag}"
         if /var/lib/k3s/bin/k3s crictl --runtime-endpoint=unix:///run/containerd-user/containerd.sock inspecti "$eve_external_boot_img"; then
                 # Already imported
-                logmsg "external-boot-image $eve_external_boot_img already imported"
                 return 0
         fi
 

--- a/pkg/kube/config.yaml
+++ b/pkg/kube/config.yaml
@@ -2,7 +2,9 @@
 # k3s server config file.
 
 write-kubeconfig-mode: "0644"
-log: "/persist/newlog/kube/k3s.log"
+log: "/persist/kubelog/k3s.log"
+# disable agent tunneling, we are on the same network
+egress-selector-mode: "disabled"
 # Use longhorn storage
 disable: local-storage
 etcd-arg:

--- a/pkg/kube/k3s-pod-logs.sh
+++ b/pkg/kube/k3s-pod-logs.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-rm -f /persist/newlog/kube/k3s-pod-logs-*.tar.gz
-OUT_FILE=/persist/newlog/kube/k3s-pod-logs-$(date +'%Y%m%d-%H%M%S' -u).tar.gz
+rm -f /persist/kubelog/k3s-pod-logs-*.tar.gz
+OUT_FILE=/persist/kubelog/k3s-pod-logs-$(date +'%Y%m%d-%H%M%S' -u).tar.gz
 tar cfz "$OUT_FILE" -C /var/log/pods/ .
 echo "Created: $OUT_FILE"

--- a/pkg/kube/longhorn-generate-support-bundle.sh
+++ b/pkg/kube/longhorn-generate-support-bundle.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-LOG_DIR=/persist/newlog/kube
+LOG_DIR=/persist/kubelog
 
 echo "Apply longhorn support bundle yaml at $(date)"
 

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -234,6 +234,9 @@ func (n *nim) run(ctx context.Context) (err error) {
 	if err = n.subOnboardStatus.Activate(); err != nil {
 		return err
 	}
+	if err = n.subEdgeNodeClusterStatus.Activate(); err != nil {
+		return err
+	}
 
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(stillRunTime)


### PR DESCRIPTION
- fix the EdgeNodeClusterStatus subscription failure in nim, thus caused ClusterIPPrefix not installed on interfaces
- remove a noisy cluster-init.sh log message
- fix some kube logging directory issues in eve master