### PR TITLE
[14.5-stable] Kernel update - [arm64-nvidia-jp5, arm64-nvidia-jp6, arm64-generic]

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,6 +1,6 @@
 KERNEL_COMMIT_amd64_v6.1.111_rt = c708a17493f1
 KERNEL_COMMIT_amd64_v6.1.112_generic = 272f44dbfe09
-KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = 6e54f05fbd3b
-KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 22e03b8516f2
-KERNEL_COMMIT_arm64_v6.1.112_generic = 9f160b774dbc
+KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = 77ad49f1f137
+KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 14693149c305
+KERNEL_COMMIT_arm64_v6.1.112_generic = a5fecf8ec851
 KERNEL_COMMIT_riscv64_v6.1.112_generic = 18e1d313b90b


### PR DESCRIPTION
# Description

Backport of https://github.com/lf-edge/eve/pull/4747

## How to test and validate this PR

- Create a switch network instance on a arm64 device
- Deploy an Edge App, check there are no errors

## Changelog notes

Update kernel for arm64 (and platform variants) to enable missing modules for switch network

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s) (not applicable)
- [x] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

