### PR TITLE
Add webhook yaml for ACE access for user clusters

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -61,6 +61,10 @@ COPY descheduler_rbac.yaml /etc/
 COPY descheduler-job.yaml /etc/
 COPY descheduler-policy-configmap.yaml /etc/
 
+# ACE
+# https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters
+COPY kube-api-authn-webhook.yaml /etc
+
 # Containerd config
 RUN mkdir -p /etc/containerd
 COPY config-k3s.toml /etc/containerd/

--- a/pkg/kube/config.yaml
+++ b/pkg/kube/config.yaml
@@ -15,3 +15,4 @@ disable-network-policy: true
 disable-cloud-controller: true
 kube-apiserver-arg:
   - "event-ttl=72h"
+  - "authentication-token-webhook-config-file=/etc/kube-api-authn-webhook.yaml"

--- a/pkg/kube/kube-api-authn-webhook.yaml
+++ b/pkg/kube/kube-api-authn-webhook.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+# Sets up the webhook to enable ACE for downstream clusters.
+# https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters
+
+apiVersion: v1
+kind: Config
+clusters:
+- name: Default
+  cluster:
+    server: http://127.0.0.1:6440/v1/authenticate
+users:
+- name: Default
+current-context: webhook
+contexts:
+- name: webhook
+  context:
+    user: Default
+    cluster: Default


### PR DESCRIPTION

# Description

<!-- Clear description what this PR does and why it's needed -->

This commit brings in the webhook yaml which provides the authentication to kubectl access to user clusters configured by ZKS. Please refer https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters

NOTE: This is just dormant until ACE is actually enabled from Orchestrator and also iptable rules in eve are set to open port 6440.



<!-- For Backport PRs, please note the following:

- 

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

Testing done:
=============
1) Enabled ACE on Orchestrator for my cluster.
2) Downloaded the kubeconfig
3) Context switch to downstream cluster ie cluster in kubevirt eve. 
4) Run kubectl commands successfully after manually setting iptable rules.


## Changelog notes

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [ x] I've provided a proper description
- [ x] I've added the proper documentation (when applicable)
- [ x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
