### PR TITLE
volumemgr: recreate CT on significant changes

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -38,11 +38,31 @@ func handleContentTreeModify(ctxArg interface{}, key string,
 
 	log.Functionf("handleContentTreeModify(%s)", key)
 	config := configArg.(types.ContentTreeConfig)
+	oldConfig := oldConfigArg.(types.ContentTreeConfig)
 	ctx := ctxArg.(*volumemgrContext)
 	status := ctx.LookupContentTreeStatus(config.Key())
 	if status == nil {
 		log.Fatalf("Missing ContentTreeStatus for %s", config.Key())
 	}
+
+	// if the change is significant, i.e. the content has changed, then
+	// delete the whole content tree (incl blobs) and create a new one
+	// otherwise, just update the status and proceed normally
+	if config.RelativeURL != oldConfig.RelativeURL ||
+		config.Format != oldConfig.Format ||
+		config.ContentSha256 != oldConfig.ContentSha256 {
+
+		// make sure the delete is immediate
+		oldDeferContextDelete := ctx.deferContentDelete
+		ctx.deferContentDelete = 0
+		deleteContentTree(ctx, status)
+		status = createContentTreeStatus(ctx, config)
+		// restore the original value
+		ctx.deferContentDelete = oldDeferContextDelete
+	} else {
+		status.UpdateFromContentTreeConfig(config)
+	}
+
 	updateContentTree(ctx, status)
 	log.Functionf("handleContentTree(%s) Done", key)
 }


### PR DESCRIPTION
# Description

When the content tree config parameters are changed (but the UUID stays the same) we need to differentiate between significant and insignificant changes. The significant changes include the change to the content itself, like change of the URL or the checksum. When such changes are detected, we need to remove the old content tree including the old blobs and create a new one with the new content. Otherwise the changes will not take effect.

## PR dependencies

none

## How to test and validate this PR

1. Create an app based e.g. on a container image alpine:3.16 and deploy it. Wait for it to be deployed
2. Change only the tag of the container image e.g. to alpine:3.17. Make sure the UUID of the content tree stays the same
3. Trigger the app purge and update
4. Make sure the old container image was removed from the device and the new image version was deployed correctly, e.g. by going inside the container and checking the version or checking the hash of the container image

## Changelog notes

Fixed the bug of changes to content tree (like URL) not having effect on the deployed app image.

## PR Backports

- [ ] 13.4-stable
- [ ] 12.0-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR