### PR TITLE
msrv: Add /metrics endpoint

### DIFF
--- a/docs/ECO-METADATA.md
+++ b/docs/ECO-METADATA.md
@@ -419,3 +419,45 @@ curl -X GET http://169.254.169.254/eve/v1/patch/download/699fbdb2-e455-448f-84f5
 
 %base64-encoded file contents%
 ```
+
+### Prometheus '/metrics' endpoint
+
+The /metrics endpoint provides access to system-level metrics from the EVE host where your EdgeApp is running.
+These metrics are sourced directly from a Node Exporter instance, expected to be available on localhost:9100 within the EVE host.
+
+When a client inside the EdgeApp makes a request to '/metrics', the EdgeApp transparently forwards the request to the Node Exporter
+and returns the response. The metrics are in Prometheus exposition format, making them compatible with Prometheus scraping and monitoring tools.
+
+>About Prometheus:
+[Prometheus](https://prometheus.io/) is an open-source systems monitoring and alerting toolkit. It collects and stores metrics as time series data, allowing users to query, visualize, and create alerts based on those metrics.
+
+#### Key Details
+
+- Target: Forwards all traffic internally to localhost:9100 on the EVE host.
+- Metrics Format: Prometheus-compatible plain text format.
+- Metrics Scope: Host-level metrics (not EdgeApp-specific).
+- Availability: Exposed within the EdgeApp.
+
+#### Rate Limiting
+
+To protect the system from overload, a *rate limiter* per client IP address is enforced:
+
+- Allowed Rate: 1 request per second.
+- Burst Capacity: Up to 10 requests can be handled immediately before rate limiting applies.
+- Idle Timeout: 4 minutes (if no requests are made from an IP for 4 minutes, the rate limit state is reset).
+
+Exceeding the allowed rate may result in the request being temporarily rejected with an appropriate HTTP error code (e.g., `429 Too Many Requests`).
+
+#### Usage Example
+
+```bash
+curl -X GET http://169.254.169.254/metrics
+```
+
+This command retrieves current host system metrics.
+
+#### Notes
+
+- Ensure that the Node Exporter service is running and accessible at localhost:9100 on the EVE host for this endpoint to function correctly.
+
+- This endpoint is intended for observability and monitoring purposes. Avoid frequent polling to respect rate limits and ensure system stability.

--- a/docs/PROMETHEUS_METRICS.md
+++ b/docs/PROMETHEUS_METRICS.md
@@ -11,6 +11,19 @@ From the EVE itself, you can access these metrics at:
 https://localhost:9100/metrics
 ```
 
+From an application instance, you can access these metrics at:
+
+```text
+http://169.254.169.254/metrics
+```
+
+This IP address is reachable from within any container or VM that EVE runs
+through an interface which is connected to a local network instance.
+
+The metrics endpoint behaves like a standard Prometheus target. You can consume
+it from any Prometheus-compatible agent, library, or application. This endpoint
+contains a request limiter of 1 rps with a burst of 10 for each IP address.
+
 ### Integration into EVE
 
 `node_exporter` is defined as a service in `rootfs.yml.in`. The container
@@ -25,6 +38,9 @@ consistent deployments.
 
 To modify how metrics are collected or adjust the exporter’s flags, edit the
 `CMD` in the `Dockerfile` or update bind mounts in build.yml.
+
+Regarding the metadata server usage for exposing metrics to applications, you
+can find the documentation in the [metadata server doc](./ECO-METADATA.md).
 
 #### iptables rules
 

--- a/pkg/pillar/cmd/msrv/middlewares.go
+++ b/pkg/pillar/cmd/msrv/middlewares.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package msrv
+
+import (
+	"context"
+	"fmt"
+	"golang.org/x/time/rate"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+type middlewareKeys int
+
+const (
+	patchEnvelopesContextKey middlewareKeys = iota
+	appUUIDContextKey
+)
+
+// withPatchEnvelopesByIP is a middleware for Patch Envelopes which adds
+// to a context patchEnvelope variable containing available patch envelopes
+// for given IP address (it gets resolved to app instance UUID)
+// in case there is no patch envelopes available it returns StatusNoContent
+func (msrv *Msrv) withPatchEnvelopesByIP() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			remoteIP := net.ParseIP(strings.Split(r.RemoteAddr, ":")[0])
+			anStatus := msrv.lookupAppNetworkStatusByAppIP(remoteIP)
+			if anStatus == nil {
+				w.WriteHeader(http.StatusNoContent)
+				msrv.Log.Errorf("No AppNetworkStatus for %s",
+					remoteIP.String())
+				return
+			}
+
+			appUUID := anStatus.UUIDandVersion.UUID
+
+			accessablePe := msrv.PatchEnvelopes.Get(appUUID.String())
+			if len(accessablePe.Envelopes) == 0 {
+				sendError(w, http.StatusNotFound, fmt.Sprintf("No envelopes for %s", appUUID.String()))
+			}
+
+			ctx := context.WithValue(r.Context(), patchEnvelopesContextKey, accessablePe)
+			ctx = context.WithValue(ctx, appUUIDContextKey, appUUID.String())
+
+			r = r.WithContext(ctx)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+type ipEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+// withRateLimiterPerIP is a middleware that limits incoming HTTP requests per IP address.
+// It enforces a rate limit with the given RPS and burst size, and automatically removes
+// inactive IPs after the specified idle timeout.
+func withRateLimiterPerIP(rps float64, burst int, idleTimeout time.Duration) func(http.Handler) http.Handler {
+	var (
+		mu       sync.Mutex
+		visitors = make(map[string]*ipEntry)
+	)
+
+	// goroutine to cleanup idle IPs
+	go func() {
+		for {
+			time.Sleep(time.Minute)
+			mu.Lock()
+			now := time.Now()
+			for ip, v := range visitors {
+				if now.Sub(v.lastSeen) > idleTimeout {
+					delete(visitors, ip)
+				}
+			}
+			mu.Unlock()
+		}
+	}()
+
+	getLimiter := func(ip string) *rate.Limiter {
+		mu.Lock()
+		defer mu.Unlock()
+
+		v, exists := visitors[ip]
+		if !exists {
+			limiter := rate.NewLimiter(rate.Limit(rps), burst)
+			visitors[ip] = &ipEntry{limiter: limiter, lastSeen: time.Now()}
+			return limiter
+		}
+
+		v.lastSeen = time.Now()
+		return v.limiter
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ip, _, err := net.SplitHostPort(r.RemoteAddr)
+			if err != nil {
+				http.Error(w, "Invalid IP address", http.StatusInternalServerError)
+				return
+			}
+
+			limiter := getLimiter(ip)
+			if !limiter.Allow() {
+				http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}


### PR DESCRIPTION
### Description

This pull request introduces a `/metrics` endpoint in EVE's metadata server service. This endpoint acts as a reverse proxy to the local `node_exporter` service, allowing AppInstances to retrieve host-level metrics in a standard Prometheus format.

- The `/metrics` endpoint proxies incoming HTTP requests directly to `node_exporter`, which is expected to be running on `localhost:9100`. This integration allows applications running inside AppInstances to collect detailed metrics about the host system without requiring special access or privileges.

- AppInstance can access these metrics by connecting to the following address: http://169.254.169.254/metrics
This IP address is reachable from within any container or VM that EVE runs through an interface connected to a local network instance. No public networking, DNS configuration, or special privileges are needed.

- To prevent abuse and ensure system stability, basic rate limiting is implemented. Each IP address is allowed up to one request per second, with a burst capacity of 10 requests. These limits are currently hardcoded.

The metrics endpoint behaves like a standard Prometheus target. One can consume it from any Prometheus-compatible agent, library, or application.

###  PR dependencies

This PR depends on #4774. It must be rebased after the NodeExporter service is merged to master.

### How to test


Deploy any AppInstance and from inside it run:

```
curl http://169.254.169.254/metrics
```

Expected output: Prometheus metrics =)

Confirm that rate limiting works. Rapidly sending multiple requests should eventually return `429 Too Many Requests` responses if the limit is exceeded.

```
for i in {1..20}; do curl -I http://169.254.169.254/metrics; sleep 0.05; done
```

You should see HTTP 429 responses after bursting over the allowed limits.

### Changelog notes

New Feature: Added `/metrics` metadata server endpoint to proxy Prometheus metrics from `node_exporter` with basic rate limiting. Metrics are now accessible to AppInstances at `http://169.254.169.254/metrics`.

### Checklist

- [x]  I've provided a proper description
- [x]  I've added the proper documentation (when applicable)
- [x]  I've tested my PR on amd64 device(s)
- [ ]  I've tested my PR on arm64 device(s)
- [x]  I've written the test verification instructions
- [x]  I've set the proper labels to this PR
