### PR TITLE
Integrate node_exporter

### DIFF
--- a/docs/PROMETHEUS_METRICS.md
+++ b/docs/PROMETHEUS_METRICS.md
@@ -26,6 +26,14 @@ consistent deployments.
 To modify how metrics are collected or adjust the exporter’s flags, edit the
 `CMD` in the `Dockerfile` or update bind mounts in build.yml.
 
+#### iptables rules
+
+To enhance security, EVE configures iptables rules to restrict access to the
+node exporter metrics endpoint. Only connections from localhost (127.0.0.1
+and ::1) are allowed to access TCP port 9100, while all remote access attempts
+to this port are explicitly rejected. This ensures that metrics are not exposed
+to the external network. It's done via DPCReconciler.
+
 ### Exposed Metrics Categories
 
 #### System Uptime

--- a/docs/PROMETHEUS_METRICS.md
+++ b/docs/PROMETHEUS_METRICS.md
@@ -1,0 +1,136 @@
+# Prometheus-Compatible Metrics in EVE
+
+This document describes how EVE exposes system metrics in the Prometheus exposition format.
+
+## Node Exporter Metrics
+
+EVE exposes a broad set of metrics under the `node_exporter` style.
+From the EVE itself, you can access these metrics at:
+
+```text
+https://localhost:9100/metrics
+```
+
+### Integration into EVE
+
+`node_exporter` is defined as a service in `rootfs.yml.in`. The container
+runs with host network and PID namespaces to access system-wide process and
+networking information. Key system directories are mounted read-only under
+`/hostfs` to allow safe metric collection without modifying the host.
+
+The `Dockerfile` for the service is located in `pkg/node-exporter`, and its
+runtime config is defined in `build.yml`. The image version is pinned via
+`NODE_EXPORTER_TAG` in the build system (`tools/parse-pkgs.sh`), ensuring
+consistent deployments.
+
+To modify how metrics are collected or adjust the exporter’s flags, edit the
+`CMD` in the `Dockerfile` or update bind mounts in build.yml.
+
+### Exposed Metrics Categories
+
+#### System Uptime
+
+- **node_boot_time_seconds** - Host boot timestamp.
+- **node_time_seconds** - Current system time (epoch seconds).
+
+#### CPU and Scheduler
+
+- **node_cpu_seconds_total** - CPU time per mode.
+- **node_cpu_guest_seconds_total** - CPU time for guest workloads.
+- **node_context_switches_total** - Context switches count.
+- **node_intr_total** - Total hardware interrupts.
+
+#### Load
+
+- **node_load1**, **node_load5**, **node_load15** - 1-, 5-, 15-minute load averages.
+
+#### Memory
+
+- **node_memory_MemTotal_bytes** - Total RAM.
+- **node_memory_MemFree_bytes** - Unused RAM.
+- **node_memory_MemAvailable_bytes** - Estimation of RAM available without swapping.
+- **node_memory_Cached_bytes** - Page cache size.
+- **node_memory_Buffers_bytes** - Buffer cache size.
+- **node_memory_Slab_bytes** - Kernel slab allocations.
+- **node_memory_KReclaimable_bytes** - Reclaimable slab memory.
+- **node_memory_KernelStack_bytes** - Memory used by kernel stacks.
+- **node_memory_Active_bytes**, **node_memory_Inactive_bytes** - Active/inactive pages.
+- **node_memory_**\* - Other detailed fields (Dirty, Writeback, HugePages, etc.).
+
+#### Disk I/O
+
+- **node_disk_io_time_seconds_total** - Total I/O time.
+- **node_disk_read_bytes_total**, **node_disk_written_bytes_total** - Total throughput.
+- **node_disk_reads_completed_total**, **node_disk_writes_completed_total** - Number of I/O operations.
+- **node_disk_read_time_seconds_total**, **node_disk_write_time_seconds_total** - Time spent on I/O.
+- **node_disk_io_time_weighted_seconds_total** - Weighted I/O time.
+- **node_disk_discards_**\*, **node_disk_flush_requests_**\* - TRIM and flush stats.
+- **node_disk_info** - Disk metadata (model, vendor, etc.).
+
+#### Filesystem
+
+- **node_filesystem_size_bytes**, **node_filesystem_free_bytes**, **node_filesystem_avail_bytes** - Disk space metrics.
+- **node_filesystem_files**, **node_filesystem_files_free** - Inode metrics.
+- **node_filesystem_readonly** - Filesystem read-only flag.
+
+#### Network Interfaces
+
+- **node_network_receive_bytes_total**, **node_network_transmit_bytes_total** - Bytes received/sent.
+- **node_network_receive_packets_total**, **node_network_transmit_packets_total** - Packet counters.
+- **node_network_receive_multicast_total** - Multicast traffic.
+- **node_network_speed_bytes** - Link speed.
+- **node_network_carrier** - Link state (1 = up, 0 = down).
+- **node_network_carrier_*_changes_total** - Link state transitions.
+- **node_network_**\* - MTU, queue length, flags, protocol type, etc.
+- **node_network_info** - Per-interface constant.
+
+#### Processes and Threads
+
+- **node_procs_running**, **node_procs_blocked** - Runnable and blocked processes.
+- **node_processes_**\* - PIDs, thread counts, state breakdowns.
+
+#### Cgroups
+
+- **node_cgroups_cgroups** - Count of cgroups.
+- **node_cgroups_enabled** - Cgroups enabled flag.
+
+#### Entropy
+
+- **node_entropy_available_bits** - Available entropy.
+- **node_entropy_pool_size_bits** - Total entropy pool size.
+
+#### Pressure Stall Information
+
+- **node_pressure_*_waiting_seconds_total** - Time waiting for CPU, memory, I/O.
+- **node_pressure_*_stalled_seconds_total** - Stalled time due to contention.
+
+#### Time and Clock
+
+- **node_timex_**\* - Clock timing, frequency, sync status.
+- **node_time_clocksource_**\* - Clock source info.
+
+#### Hardware and System Info
+
+- **node_dmi_info** - BIOS and hardware identifiers.
+- **node_uname_info** - Kernel version and architecture.
+
+#### Network Protocol Counters
+
+- **node_netstat_Icmp\*, Ip\*, Tcp\*, Udp**\* - Protocol stats.
+- **node_netstat_Ip_Forwarding** - IP forwarding state.
+
+#### ZFS (if applicable)
+
+- **node_zfs_arc_**\* - ARC cache stats.
+- **node_zfs_abd_*, node_zfs_dbuf_**\* - Buffer metrics.
+
+#### Error Metrics
+
+- **node_network_receive_errs_total** - Cumulative receive error count per interface.
+- **node_network_transmit_errs_total** - Cumulative transmit error count per interface.
+- **node_netstat_TcpExt_InErrs_total** - Bad inbound TCP packets.
+- **node_netstat_TcpExt_RetransSegs_total** - TCP retransmits.
+- **node_filesystem_device_error** - Errors returned by `statfs()` on each mounted filesystem.
+
+It is not a full list of all metrics, to see all available metrics, please check
+the `/metrics` endpoint.

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -52,6 +52,9 @@ nav:
   - 'Configuration properties': 'docs/CONFIG-PROPERTIES.md'
   - CI-CD: 'docs/CI-CD.md'
   - FAQ: 'docs/FAQ.md'
+  - 'Metrics and Monitoring':
+      - 'Prometheus': 'docs/PROMETHEUS_METRICS.md'
+      - 'Memory Monitoring': 'pkg/memory-monitor/README.md'
   - 'Building EVE':
       - 'How to build EVE': 'docs/BUILD.md'
       - 'EVE image reproducibility': 'docs/EVE-IMAGE-REPRODUCIBILITY.md'

--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -90,6 +90,10 @@ services:
     image: XENTOOLS_TAG
     cgroupsPath: /eve/services/xen-tools
     oomScoreAdj: -999
+  - name: node-exporter
+    image: NODE_EXPORTER_TAG
+    cgroupsPath: /eve/services/node-exporter
+    oomScoreAdj: -999
 files:
   - path: /etc/eve-release
     source: eve_version

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -132,4 +132,6 @@ WORKDIR /
 COPY --from=build /out/ /
 COPY --from=build /bpftrace/bpftrace-aotrt /
 
+RUN rm -rf /usr/share/vim/vim82/doc/
+
 CMD ["/sbin/tini", "/usr/bin/debug-services.sh"]

--- a/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
+++ b/pkg/dom0-ztools/rootfs/etc/init.d/010-eve-cgroup
@@ -9,7 +9,7 @@ hv=`cat /run/eve-hv-type`
 default_cgroup_cpus_limit=1
 
 default_cgroup_memory_limit=838860800 #800M
-EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd memlogd memory-monitor debug monitor"
+EVESERVICES="sshd eve-edgeview wwan wlan lisp guacd pillar vtpm watchdog xen-tools newlogd memlogd memory-monitor debug monitor node-exporter"
 
 #Increase memory limits temporarily for kubevirt type only.
 case $hv in

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -35,11 +35,15 @@ FROM ${PLATFORM} AS build
 
 ADD ${NVIDIA_FW_URL} /${NVIDIA_FW_TEGRA}
 RUN mkdir -p /nvidia-firmware && \
-    cd /nvidia-firmware ;\
-    ar x ../"${NVIDIA_FW_TEGRA}" ;\
-    zstd -d < data.tar.zst > data.tar ;\
-    tar -xvf data.tar -C ./ ;\
-    rm data.tar.zst data.tar
+    if [ "${TARGETARCH}" = "arm64" ]; then \
+        cd /nvidia-firmware ;\
+        ar x ../"${NVIDIA_FW_TEGRA}" ;\
+        zstd -d < data.tar.zst > data.tar ;\
+        tar -xvf data.tar -C ./ ;\
+        rm data.tar.zst data.tar ;\
+    else \
+        mkdir -p /nvidia-firmware/lib/firmware/ ;\
+    fi
 
 # RTL8822ce firmware
 ENV RTL8822_FW_VERSION ca9f4e199efbf8c377e8a1769ba5b05b23f92c82
@@ -65,9 +69,11 @@ RUN ln -s brcmfmac4356-pcie.gpd-win-pocket.txt /lib/firmware/brcm/brcmfmac4356-p
 ENV RPI_FIRMWARE_VERSION 2c8f665254899a52260788dd902083bb57a99738
 ENV RPI_FIRMWARE_URL https://github.com/RPi-Distro/firmware-nonfree/archive
 ADD ${RPI_FIRMWARE_URL}/${RPI_FIRMWARE_VERSION}.tar.gz /rpifirmware.tar.gz
-RUN mkdir /rpi-firmware &&\
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+    mkdir /rpi-firmware &&\
     tar -xz --strip-components=1 -C /rpi-firmware -f /rpifirmware.tar.gz &&\
-    cp -a /rpi-firmware/debian/config/brcm80211/brcm/brcmfmac43436* /lib/firmware/brcm
+    cp -a /rpi-firmware/debian/config/brcm80211/brcm/brcmfmac43436* /lib/firmware/brcm ;\
+    fi
 
 ENV RPI_BT_FIRMWARE_VERSION e7fd166981ab4bb9a36c2d1500205a078a35714d
 ENV RPI_BT_FIRMWARE_URL https://github.com/RPi-Distro/bluez-firmware/raw
@@ -171,6 +177,31 @@ COPY --from=build /rtw88/*.bin /lib/firmware/rtw88/
 # Intel ICE firmware.
 COPY --from=build /lib/firmware/intel/ice /lib/firmware/intel/ice
 COPY --from=build /lib/firmware/hailo /lib/firmware/hailo
+
+ARG TARGETARCH
+
+# Remove unnecessary firmware based on TARGETARCH and print freed space
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+    initial_size=$(du -sm /lib/firmware | cut -f1); \
+    rm -rf /lib/firmware/nvidia \
+           /lib/firmware/ti-connectivity \
+           /lib/broadcom \
+           /lib/firmware/*t234* \
+           /lib/firmware/*t194* \
+           /lib/firmware/nvpva* ; \
+    final_size=$(du -sm /lib/firmware | cut -f1); \
+    freed_space=$((initial_size - final_size)); \
+    echo "Freed space: ${freed_space} MB"; \
+    fi
+
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+    initial_size=$(du -s /lib/firmware | cut -f1); \
+    rm -rf /lib/firmware/ice; \
+    final_size=$(du -s /lib/firmware | cut -f1); \
+    freed_space=$((initial_size - final_size)); \
+    echo "Freed space: ${freed_space} KB"; \
+    fi
+
 
 FROM scratch
 ENTRYPOINT []

--- a/pkg/node-exporter/Dockerfile
+++ b/pkg/node-exporter/Dockerfile
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM prom/node-exporter:v1.9.1
+
+CMD ["--path.procfs=/hostfs/proc", "--path.sysfs=/hostfs/sys", "--path.rootfs=/hostfs", "--collector.cgroups", "--collector.processes"]

--- a/pkg/node-exporter/build.yml
+++ b/pkg/node-exporter/build.yml
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+org: lfedge
+image: eve-node-exporter
+config:
+  binds:
+    - /:/hostfs:ro,rslave
+    - /proc:/hostfs/proc
+    - /sys:/hostfs/sys
+    - /persist:/persist
+  net: host
+  pid: host

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -179,6 +179,8 @@ SHELL ["/bin/sh", "-c"]
 
 COPY --from=collector /out /
 
+RUN rm -rf /usr/bin/qemu-storage-daemon
+
 # FIXME: replace with tini+monit ASAP
 WORKDIR /
 CMD ["/init.sh"]

--- a/pkg/pillar/dpcreconciler/linux_test.go
+++ b/pkg/pillar/dpcreconciler/linux_test.go
@@ -173,9 +173,12 @@ func TestReconcileWithEmptyArgs(test *testing.T) {
 	t.Expect(itemCountWithType(linux.IPRuleTypename)).To(Equal(1))
 	t.Expect(itemCountWithType(iptables.ChainV4Typename)).To(Equal(14))
 	t.Expect(itemCountWithType(iptables.ChainV6Typename)).To(Equal(14))
-	t.Expect(itemCountWithType(iptables.RuleV4Typename)).To(Equal(22))
-	t.Expect(itemCountWithType(iptables.RuleV6Typename)).To(Equal(21))
+	t.Expect(itemCountWithType(iptables.RuleV4Typename)).To(Equal(24))
+	t.Expect(itemCountWithType(iptables.RuleV6Typename)).To(Equal(23))
 	t.Expect(itemIsCreatedWithDescrSnippet("--dport 22 -j REJECT")).To(BeTrue())
+
+	// Check that the node_exporter port is blocked for non-local traffic
+	t.Expect(itemIsCreatedWithDescrSnippet("--dport 9100 -j REJECT")).To(BeTrue())
 
 	// Enable SSH access
 	gcp := types.DefaultConfigItemValueMap()

--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -96,8 +96,11 @@ WORKDIR /xen
 
 # disable golang as it does not play well together with musl (stderr is defined as FILE* const and fails to compile)
 RUN ./configure --prefix=/usr --disable-xen --disable-golang --disable-qemu-traditional --disable-docs --enable-9pfs \
- --with-system-ovmf=/usr/lib/xen/boot/ovmf.bin --disable-stubdom \
- --enable-vhost-vsock --enable-vhost-scsi
+ --with-system-ovmf=/usr/lib/xen/boot/ovmf.bin --disable-stubdom --disable-openbios \
+ --enable-vhost-vsock --enable-vhost-scsi \
+ --disable-microblaze --disable-mips --disable-ppc \
+ --disable-sparc --disable-tricore --disable-alpha --disable-hppa \
+ --disable-storage-daemon
 RUN make -j "$(getconf _NPROCESSORS_ONLN)" && make dist
 RUN dist/install.sh /out
 
@@ -122,6 +125,10 @@ COPY qemu-ifup xen-start /etc/xen/scripts/
 
 # We need to keep a slim profile, which means removing things we don't need
 RUN rm -rf /usr/lib/libxen*.a /usr/lib/libxl*.a /usr/lib/debug /usr/lib/python*
+
+RUN rm -rf /usr/share/man \
+    /usr/share/qemu-xen/qemu/openbios-* \
+    /usr/lib/xen/bin/qemu-storage-daemon
 
 # Adjust /var/run, /var/lib and /var/lock to be shared
 RUN mv /var /var.template && ln -s /run /var && ln -s /run /var.template/run

--- a/tools/parse-pkgs.sh
+++ b/tools/parse-pkgs.sh
@@ -93,6 +93,7 @@ ACRN_KERNEL_TAG=${ACRN_KERNEL_TAG}
 KERNEL_TAG=${KERNEL_TAG}
 FW_TAG=${FW_TAG}
 XENTOOLS_TAG=${XENTOOLS_TAG}
+NODE_EXPORTER_TAG=${NODE_EXPORTER_TAG}
 DOM0ZTOOLS_TAG=${DOM0ZTOOLS_TAG}
 RNGD_TAG=${RNGD_TAG}
 XEN_TAG=${XEN_TAG}
@@ -140,6 +141,7 @@ EOF
 
 ACRN_KERNEL_TAG=$(linuxkit_tag pkg/acrn-kernel)
 FW_TAG=$(linuxkit_tag pkg/fw)
+NODE_EXPORTER_TAG=$(linuxkit_tag pkg/node-exporter)
 XENTOOLS_TAG=$(linuxkit_tag pkg/xen-tools)
 XEN_TAG=$(linuxkit_tag pkg/xen)
 ACRN_TAG=$(linuxkit_tag pkg/acrn)


### PR DESCRIPTION
# Description

This pull request introduces a new Prometheus metrics collection service and reduces the size of several system images by removing unnecessary components.

* Metrics Collection with `node_exporter`
A new system service based on `node_exporter` has been added to enable collection of hardware and OS-level metrics. The service runs in a container built from the official image, with required configuration for host metric access. It is integrated into the root filesystem, cgroup settings, and packaging workflow to ensure it starts automatically and adheres to resource limits.

* Image Optimization
Multiple Dockerfiles have been cleaned up to reduce image size. This includes removing unused tools like qemu-storage-daemon, non-essential documentation, man pages, and firmware specific to unsupported architectures. Architecture-specific exclusions further streamline the xen-tools image. These adjustments maintain necessary functionality while improving efficiency, especially on constrained systems.

## PR dependencies

This PR is a dependency for #4772 

## How to test and validate this PR

1. Verify the process is running:

```
eve status | grep exporter
```
You should see the node_exporter service listed among running processes.

```
node-exporter     2102    RUNNING
```

2. Check that the service is listening on the expected port:

```
netstat -ntpl | grep exporter
```

Expected output (example):

```
tcp        0      0 :::9100                 :::*                    LISTEN      2078/node_exporter
```

3. Verify that Prometheus metrics are exposed:

First, go to the debug container.

```
eve enter debug
```

then run 

```
curl localhost:9100/metrics
```

This should return a large set of Prometheus-formatted metrics.

5. Confirm correct cgroup resource limits:

```
cat /sys/fs/cgroup/memory/eve/services/node-exporter/memory.limit_in_bytes
```

The output should be:

```
681574400
```

This confirms that the memory limit is applied correctly via cgroups.



## Changelog notes

New Feature: Added node_exporter as a system service to enable Prometheus-compatible metrics collection.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [x] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

