### PR TITLE
Fix cross-compilation of kubevirt for arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -862,7 +862,7 @@ pkg/kernel:
 	$(QUIET): $@: No-op pkg/kernel
 
 pkg/external-boot-image/build.yml: pkg/external-boot-image/build.yml.in
-	$(QUIET)tools/compose-external-boot-image-yml.sh $< $@ $(shell echo ${KERNEL_TAG} | cut -d':' -f2) $(shell $(LINUXKIT) pkg show-tag pkg/xen-tools | cut -d':' -f2)
+	$(QUIET)tools/compose-external-boot-image-yml.sh $< $@ $(shell echo $(KERNEL_TAG) | cut -d':' -f2) $(shell $(LINUXKIT) pkg show-tag pkg/xen-tools | cut -d':' -f2)
 eve-external-boot-image: pkg/external-boot-image/build.yml
 pkg/kube/external-boot-image.tar: pkg/external-boot-image
 	$(MAKE) cache-export IMAGE=$(shell $(LINUXKIT) pkg show-tag pkg/external-boot-image) OUTFILE=pkg/kube/external-boot-image.tar

--- a/Makefile
+++ b/Makefile
@@ -861,7 +861,8 @@ pkgs: build-tools $(PKGS)
 pkg/kernel:
 	$(QUIET): $@: No-op pkg/kernel
 
-pkg/external-boot-image/build.yml: pkg/external-boot-image/build.yml.in
+# Need to force build.yml target in order to always get the current KERNEL_TAG
+pkg/external-boot-image/build.yml: pkg/external-boot-image/build.yml.in pkg/xen-tools FORCE
 	$(QUIET)tools/compose-external-boot-image-yml.sh $< $@ $(shell echo $(KERNEL_TAG) | cut -d':' -f2) $(shell $(LINUXKIT) pkg show-tag pkg/xen-tools | cut -d':' -f2)
 eve-external-boot-image: pkg/external-boot-image/build.yml
 pkg/kube/external-boot-image.tar: pkg/external-boot-image

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -66,13 +66,16 @@ RUN mkdir -p /etc/containerd
 COPY config-k3s.toml /etc/containerd/
 WORKDIR /
 
+ARG TARGETARCH
+
 # Actual k3s install and config happens when this container starts during EVE bootup, look at cluster-init.sh
 ### NOTE: the version of virtctl should match the version of kubevirt in cluster_init.sh, else PVC creation might fail due to incompatibility
 ENV VIRTCTL_VERSION v1.1.0
-ADD https://github.com/kubevirt/kubevirt/releases/download/${VIRTCTL_VERSION}/virtctl-${VIRTCTL_VERSION}-linux-amd64 .
-RUN install virtctl-${VIRTCTL_VERSION}-linux-amd64 /usr/bin/virtctl
+ADD https://github.com/kubevirt/kubevirt/releases/download/${VIRTCTL_VERSION}/virtctl-${VIRTCTL_VERSION}-linux-${TARGETARCH} .
+
+RUN install virtctl-${VIRTCTL_VERSION}-linux-${TARGETARCH} /usr/bin/virtctl
 # We installed under /usr/bin. Remove the downloaded version
-RUN rm -f ./virtctl-${VIRTCTL_VERSION}-linux-amd64
+RUN rm -f ./virtctl-${VIRTCTL_VERSION}-linux-${TARGETARCH}
 
 ENTRYPOINT []
 CMD ["/usr/bin/cluster-init.sh"]

--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -40,7 +40,7 @@ ifneq ($(TAGS),)
 	TAGS:=-tags "$(TAGS)"
 endif
 
-LDFLAGS=
+LDFLAGS=-extldflags=-fuse-ld=bfd
 ifneq ($(DEV),y)
 	LDFLAGS+=-s -w
 endif

--- a/tools/compose-external-boot-image-yml.sh
+++ b/tools/compose-external-boot-image-yml.sh
@@ -3,7 +3,16 @@
 set -e
 
 yq() {
-  docker run -i --rm -v "${PWD}/":/workdir intoiter/yq:3.1.0 -y -i "$@"
+  docker run -i --rm -v "${PWD}/":/workdir -w /workdir mikefarah/yq:4.40.5 "$@"
+}
+
+# because sponge doesn't exist everywhere, and this one uses a tmpfile
+spongefile() {
+    local tmp=""
+    tmp=$(mktemp)
+    cat > "$tmp"
+    cat "$tmp" > "$1"
+    rm "$tmp"
 }
 
 patch_xentools() {
@@ -22,9 +31,9 @@ main() {
     cp "${base_templ_path}" "${out_templ_path}"
 
     # Replace kernel_tag
-    patch_kernel "${kernel_tag}" "${out_templ_path}"
+    patch_kernel "${kernel_tag}" "${out_templ_path}" | spongefile "${out_templ_path}"
     # Replace xentools_tag
-    patch_xentools "${xentools_tag}" "${out_templ_path}"
+    patch_xentools "${xentools_tag}" "${out_templ_path}" | spongefile "${out_templ_path}"
 }
 
 main "$@"


### PR DESCRIPTION
# Description

This is an initial effort to bring up kubevirt variant for arm64 platforms. Cross-compilation of pillar fails for kubevirt variant:

```sh
make ZARCH=arm64 HV=kubevirt pkg/pillar
```

Error:

```text
#38 40.66 Running go fmt
#38 41.01 mkdir -p /final/opt/zededa/bin
#38 41.02 Building /final/opt/zededa/bin/zedbox
#38 41.02 GO111MODULE=on GOOS=linux GOARCH=arm64 go build -mod=vendor -tags "kubevirt"  -ldflags "-s -w" -o /final/opt/zededa/bin/zedbox ./zedbox
#38 45.83 # github.com/lf-edge/eve/pkg/pillar/zedbox
#38 45.83 /usr/lib/go/pkg/tool/linux_amd64/link: running aarch64-alpine-linux-musl-gcc failed: exit status 1
#38 45.83 /usr/bin/aarch64-alpine-linux-musl-gcc -s -Wl,-z,now -Wl,-z,nocopyreloc -fuse-ld=gold -Wl,--build-id=0x93ce9eb8766e16b1ba8f8a2db351419a68caa4ae -o $WORK/b001/exe/a.out -rdynamic /tmp/go-link-1433675572/go.o /tmp/go-link-1433675572/000000.o /tmp/go-link-1433675572/000001.o /tmp/go-link-1433675572/000002.o /tmp/go-link-1433675572/000003.o /tmp/go-link-1433675572/000004.o /tmp/go-link-1433675572/000005.o /tmp/go-link-1433675572/000006.o /tmp/go-link-1433675572/000007.o /tmp/go-link-1433675572/000008.o /tmp/go-link-1433675572/000009.o /tmp/go-link-1433675572/000010.o /tmp/go-link-1433675572/000011.o /tmp/go-link-1433675572/000012.o /tmp/go-link-1433675572/000013.o /tmp/go-link-1433675572/000014.o /tmp/go-link-1433675572/000015.o /tmp/go-link-1433675572/000016.o /tmp/go-link-1433675572/000017.o /tmp/go-link-1433675572/000018.o /tmp/go-link-1433675572/000019.o /tmp/go-link-1433675572/000020.o /tmp/go-link-1433675572/000021.o /tmp/go-link-1433675572/000022.o /tmp/go-link-1433675572/000023.o /tmp/go-link-1433675572/000024.o /tmp/go-link-1433675572/000025.o /tmp/go-link-1433675572/000026.o /tmp/go-link-1433675572/000027.o /tmp/go-link-1433675572/000028.o /tmp/go-link-1433675572/000029.o /tmp/go-link-1433675572/000030.o /tmp/go-link-1433675572/000031.o /tmp/go-link-1433675572/000032.o /tmp/go-link-1433675572/000033.o /tmp/go-link-1433675572/000034.o /tmp/go-link-1433675572/000035.o /tmp/go-link-1433675572/000036.o -O2 -g -lresolv -O2 -g -O2 -g -lzfs -lzpool -lnvpair -lzfs_core -O2 -g -lpthread -O2 -g -O2 -g -ldl
#38 45.83 collect2: fatal error: cannot find 'ld'
#38 45.83 compilation terminated.
#38 45.83 
#38 45.84 make: *** [Makefile:61: /final/opt/zededa/bin/zedbox] Error 1
#38 ERROR: process "/bin/sh -c echo \"Running go vet\" && make HV=\"$HV\" vet &&     echo \"Running go fmt\" && ERR=\"$(find . -name \\*.go | grep -v /vendor/ | xargs gofmt -d -e -l -s)\" &&        if [ -n \"$ERR\" ] ; then printf 'go fmt Failed - ERR: %s' \"$ERR\" ; exit 1 ; fi &&        make ZARCH=${TARGETARCH} HV=\"$HV\" DEV=\"$DEV\" RSTATS=$RSTATS RSTATS_ENDPOINT=$RSTATS_ENDPOINT RSTATS_TAG=$RSTATS_TAG DISTDIR=/final/opt/zededa/bin BUILD_VERSION=${GOPKGVERSION} build" did not complete successfully: exit code: 2
Error: error building "lfedge/eve-pillar-kube:97baaa5de2f5862a8b62787c39cdf27840fba637": error building for arch arm64: failed to solve: process "/bin/sh -c echo \"Running go vet\" && make HV=\"$HV\" vet &&     echo \"Running go fmt\" && ERR=\"$(find . -name \\*.go | grep -v /vendor/ | xargs gofmt -d -e -l -s)\" &&        if [ -n \"$ERR\" ] ; then printf 'go fmt Failed - ERR: %s' \"$ERR\" ; exit 1 ; fi &&        make ZARCH=${TARGETARCH} HV=\"$HV\" DEV=\"$DEV\" RSTATS=$RSTATS RSTATS_ENDPOINT=$RSTATS_ENDPOINT RSTATS_TAG=$RSTATS_TAG DISTDIR=/final/opt/zededa/bin BUILD_VERSION=${GOPKGVERSION} build" did not complete successfully: exit code: 2
------
 > [build 4/8] RUN --mount=type=cache,target=/root/.cache/go-build echo "Running go vet" && make HV="kubevirt" vet &&     echo "Running go fmt" && ERR="$(find . -name \*.go | grep -v /vendor/ | xargs gofmt -d -e -l -s)" &&        if [ -n "$ERR" ] ; then printf 'go fmt Failed - ERR: %s' "$ERR" ; exit 1 ; fi &&        make ZARCH=arm64 HV="kubevirt" DEV="n" RSTATS=n RSTATS_ENDPOINT= RSTATS_TAG= DISTDIR=/final/opt/zededa/bin BUILD_VERSION=v0.0.0-20250409182221-5d5f555a4aeb
 build:
41.01 mkdir -p /final/opt/zededa/bin
41.02 Building /final/opt/zededa/bin/zedbox
41.02 GO111MODULE=on GOOS=linux GOARCH=arm64 go build -mod=vendor -tags "kubevirt"  -ldflags "-s -w" -o /final/opt/zededa/bin/zedbox ./zedbox
45.83 # github.com/lf-edge/eve/pkg/pillar/zedbox
45.83 /usr/lib/go/pkg/tool/linux_amd64/link: running aarch64-alpine-linux-musl-gcc failed: exit status 1
45.83 /usr/bin/aarch64-alpine-linux-musl-gcc -s -Wl,-z,now -Wl,-z,nocopyreloc -fuse-ld=gold -Wl,--build-id=0x93ce9eb8766e16b1ba8f8a2db351419a68caa4ae -o $WORK/b001/exe/a.out -rdynamic /tmp/go-link-1433675572/go.o /tmp/go-link-1433675572/000000.o /tmp/go-link-1433675572/000001.o /tmp/go-link-1433675572/000002.o /tmp/go-link-1433675572/000003.o /tmp/go-link-1433675572/000004.o /tmp/go-link-1433675572/000005.o /tmp/go-link-1433675572/000006.o /tmp/go-link-1433675572/000007.o /tmp/go-link-1433675572/000008.o /tmp/go-link-1433675572/000009.o /tmp/go-link-1433675572/000010.o /tmp/go-link-1433675572/000011.o /tmp/go-link-1433675572/000012.o /tmp/go-link-1433675572/000013.o /tmp/go-link-1433675572/000014.o /tmp/go-link-1433675572/000015.o /tmp/go-link-1433675572/000016.o /tmp/go-link-1433675572/000017.o /tmp/go-link-1433675572/000018.o /tmp/go-link-1433675572/000019.o /tmp/go-link-1433675572/000020.o /tmp/go-link-1433675572/000021.o /tmp/go-link-1433675572/000022.o /tmp/go-link-1433675572/000023.o /tmp/go-link-1433675572/000024.o /tmp/go-link-1433675572/000025.o /tmp/go-link-1433675572/000026.o /tmp/go-link-1433675572/000027.o /tmp/go-link-1433675572/000028.o /tmp/go-link-1433675572/000029.o /tmp/go-link-1433675572/000030.o /tmp/go-link-1433675572/000031.o /tmp/go-link-1433675572/000032.o /tmp/go-link-1433675572/000033.o /tmp/go-link-1433675572/000034.o /tmp/go-link-1433675572/000035.o /tmp/go-link-1433675572/000036.o -O2 -g -lresolv -O2 -g -O2 -g -lzfs -lzpool -lnvpair -lzfs_core -O2 -g -lpthread -O2 -g -O2 -g -ldl
45.83 collect2: fatal error: cannot find 'ld'
45.83 compilation terminated.
45.83 
45.84 make: *** [Makefile:61: /final/opt/zededa/bin/zedbox] Error 1
------
```

Building from an arm64 host it works.

Note that kubevirt variant still hard codes x86_64 stuff at other points, such as:

https://github.com/lf-edge/eve/blob/master/pkg/kube/install-etcdctl.sh#L7
https://github.com/lf-edge/eve/blob/master/pkg/kube/update-component/multus.go#L18
https://github.com/lf-edge/eve/blob/master/pkg/kube/multus-daemonset.yaml#L178

So it keeps not being supported on arm64, that's why this is an initial effort.

## How to test and validate this PR

Build pkg/pillar for arm64 + kubevirt from an amd64 host:

`make ZARCH=arm64 HV=kubevirt pkg/pillar`

## Changelog notes

Fix cross-compilation of eve kubevirt variant for arm64

## PR Backports

Kubevirt is still not supported on arm64, so there is no need to backport this fix at this moment.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [x] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR