### PR TITLE
Makefile: add kernel-tag target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1096,6 +1096,9 @@ docker-old-images:
 docker-image-clean:
 	docker rmi -f $(shell ./tools/oldimages.sh)
 
+kernel-tag:
+	@echo $(KERNEL_TAG)
+
 .PRECIOUS: rootfs-% $(ROOTFS)-%.img $(ROOTFS_COMPLETE)
 .PHONY: all clean test run pkgs help build-tools live rootfs config installer live current FORCE $(DIST) HOSTARCH image-set cache-export
 FORCE:
@@ -1137,6 +1140,7 @@ help:
 	@echo "                                    MYETUS_DBRANCH, in addition if MYETUS_VERBOSE is set to"
 	@echo "                                    Y, the output will be echoed to the console"
 	@echo "   check-docker-hashes-consistency  check for Dockerfile image inconsistencies"
+	@echo "   kernel-tag                       show current KERNEL_TAG"
 	@echo
 	@echo "Seldom used maintenance and development targets:"
 	@echo "   bump-eve-api    bump eve-api in all subprojects"


### PR DESCRIPTION
# Description

Introduces a new target called kernel-tag that can be used to show the full kernel image specified by KERNEL_TAG variable. In this way, developers can easily get which kernel image will be built with the rootfs by just running make kernel-tag.

## How to test and validate this PR

Run:

`make kernel-tag`

It should output the kernel docker image tag, for instance:

`docker.io/lfedge/eve-kernel:eve-kernel-amd64-v6.1.112-generic-272f44dbfe09-gcc`

## Changelog notes

Add kernel-tag target to Makefile to check KERNEL_TAG value

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [x] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR