### PR TITLE
Remove the hardcoded architecture configs and scripts for kubevirt

### DIFF
--- a/pkg/kube/install-etcdctl.sh
+++ b/pkg/kube/install-etcdctl.sh
@@ -4,6 +4,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ETCDCTL_VERSION=v3.5.5
-/usr/bin/wget https://github.com/etcd-io/etcd/releases/download/${ETCDCTL_VERSION}/etcd-${ETCDCTL_VERSION}-linux-amd64.tar.gz
-tar -zxv --strip-components=1 -C /usr/local/bin  < ./etcd-${ETCDCTL_VERSION}-linux-amd64.tar.gz
-rm ./etcd-${ETCDCTL_VERSION}-linux-amd64.tar.gz
+# Detect architecture
+ARCH=$(uname -m)
+if [ "$ARCH" = "x86_64" ]; then
+    ARCH="amd64"
+elif [ "$ARCH" = "aarch64" ]; then
+    ARCH="arm64"
+else
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+fi
+
+# Download the appropriate etcd binary
+/usr/bin/wget https://github.com/etcd-io/etcd/releases/download/${ETCDCTL_VERSION}/etcd-${ETCDCTL_VERSION}-linux-${ARCH}.tar.gz
+
+# Extract and install
+tar -zxv --strip-components=1 -C /usr/local/bin < ./etcd-${ETCDCTL_VERSION}-linux-${ARCH}.tar.gz
+rm ./etcd-${ETCDCTL_VERSION}-linux-${ARCH}.tar.gz

--- a/pkg/kube/multus-daemonset.yaml
+++ b/pkg/kube/multus-daemonset.yaml
@@ -154,7 +154,7 @@ data:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: kube-multus-ds-amd64
+  name: kube-multus-ds
   namespace: kube-system
   labels:
     tier: node
@@ -174,8 +174,6 @@ spec:
         name: multus
     spec:
       hostNetwork: true
-      nodeSelector:
-        kubernetes.io/arch: amd64
       tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/pkg/kube/update-component/multus.go
+++ b/pkg/kube/update-component/multus.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	multusNamespace     = "kube-system"
-	compMultusDaemonset = "kube-multus-ds-amd64"
+	compMultusDaemonset = "kube-multus-ds"
 )
 
 type multusComponent struct {


### PR DESCRIPTION
- remove the multus config specific setting for amd64, the image is for both architecture
- change the etcdctl tarball download w/ architecture settings

# Description

This patch removes some hard-coded amd64 items in multus and etcdctl download script
together with PR #4776, the 'make ZARCH=arm64 HV=kubevirt pkgs' compiles now.

<!-- Clear description what this PR does and why it's needed -->

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

this patch need to have the PR #4776 to compile for arm64

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

I have tested this patch with build on the amd64 kubevirt image, and tested on devices with edge-node clustering. In specific, it exercises the 'Multus' of the kubernetes cluster with multiple interfaces.
I don't have an Arm device to test this patch with.

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

## Changelog notes

Fixes the hard-coded amd64 configs in kubevirt modules 

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

No backporting of this patch is needed.

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
