### PR TITLE
Handle expired GitHub token automatically in update_kernel_commits.py

### DIFF
--- a/tools/update_kernel_commits.py
+++ b/tools/update_kernel_commits.py
@@ -82,11 +82,21 @@ def fetch_latest_commits_from_github(user, user_token, verbose=False):
                 repo_url = response.links["next"]["url"]
             else:
                 break
+        elif response.status_code == 401:
+            print(Fore.RED + Style.BRIGHT + "Error: Unauthorized (401). Your GitHub token is invalid or"
+                                            " expired.")
+            print("Please enter a new GitHub personal access token.")
+            if os.path.exists(config_file_path):
+                os.remove(config_file_path)
+            new_token = get_github_token_from_user()
+            write_github_token_to_config(new_token)
+            # Update session headers and retry
+            session.headers.update({"Authorization": f"token {new_token}"})
+            continue  # Retry the request with the new token
         else:
             print(Fore.RED + Style.BRIGHT + "Error:", response.status_code, response.text)
             sys.exit(1)
     return new_commits
-
 
 def is_valid_branch_format(branch_name):
     """


### PR DESCRIPTION
Improve the commit fetching script by detecting a 401 Unauthorized response from GitHub and prompting the user to input a new personal access token. Remove the invalid token from the configuration, update session headers with the new token, and retry the request.

# Description

Handle expired GitHub token when fetching latest commits.

This PR updates the `update_kernel_commits.py` script to handle cases when a GitHub personal access token is invalid or expired. Upon receiving a 401 Unauthorised response, the script prompts the user to input a new token, updates the session, and retries the request without requiring manual interruption. This improves the reliability and usability of the tool.

## PR dependencies

None.

## How to test and validate this PR

No explicit validation is required. This is an internal tool improvement and does not affect production workflows. The behavior will automatically trigger if an invalid GitHub token is used.

## Changelog notes

None. This is an internal tool change not visible to users.

## PR Backports

We can live without this fix in the other branches =)

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
