### PR TITLE
Revert "GHA: use make -j $(nproc) wherever makes sense"

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -84,8 +84,8 @@ jobs:
              EVE=lfedge/eve:${TAG}-${HV}-${{ env.ARCH }}
              docker pull "$EVE"
           else
-             make -j $(getconf _NPROCESSORS_ONLN) pkgs
-             make -j $(getconf _NPROCESSORS_ONLN) HV=${HV} ZARCH=${{ env.ARCH }} eve
+             make pkgs
+             make HV=${HV} ZARCH=${{ env.ARCH }} eve
              EVE=lfedge/eve:$(make version)-${HV}-${{ env.ARCH }}
           fi
           docker run "$EVE" rootfs > assets/rootfs.img

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           key: linuxkit-${{ matrix.arch }}-${{ github.event.pull_request.head.sha }}-${{ matrix.platform }}
       - name: Build packages ${{ matrix.os }} for ${{ matrix.platform }}
         run: |
-          make -j $(getconf _NPROCESSORS_ONLN) V=1 PRUNE=1 PLATFORM=${{ matrix.platform }} ZARCH=${{ matrix.arch }} pkgs
+          make V=1 PRUNE=1 PLATFORM=${{ matrix.platform }} ZARCH=${{ matrix.arch }} pkgs
       - name: Post package report
         run: |
           echo Disk usage
@@ -163,7 +163,7 @@ jobs:
           fail-on-cache-miss: true
       - name: load images we need from linuxkit cache into docker
         run: |
-          make -j $(getconf _NPROCESSORS_ONLN) cache-export-docker-load-all
+          make cache-export-docker-load-all
       - name: clear linuxkit cache so we can load for target arch
         if: ${{ steps.arch_runner_equals_matrix.outputs.matched != 'true' }}
         run: |
@@ -188,7 +188,7 @@ jobs:
 
       - name: Build EVE ${{ matrix.hv }}-${{ matrix.arch }}-${{ matrix.platform }}
         run: |
-          make -j $(getconf _NPROCESSORS_ONLN) V=1 ROOTFS_VERSION="$VERSION" PLATFORM=${{ matrix.platform }} HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} pkgs eve  # note that this already loads it into docker
+          make V=1 ROOTFS_VERSION="$VERSION" PLATFORM=${{ matrix.platform }} HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} pkgs eve  # note that this already loads it into docker
       - name: Post eve build report
         run: |
           echo Disk usage
@@ -199,7 +199,7 @@ jobs:
           docker system df -v
       - name: Export docker container
         run: |
-          make -j $(getconf _NPROCESSORS_ONLN) cache-export ZARCH=${{ matrix.arch }} IMAGE=lfedge/eve:$VERSION-${{ matrix.hv }} OUTFILE=eve-${{ matrix.hv }}-${{ matrix.arch }}-${{ matrix.platform }}.tar IMAGE_NAME=$TAG-${{ matrix.hv }}-${{ matrix.arch }}
+          make cache-export ZARCH=${{ matrix.arch }} IMAGE=lfedge/eve:$VERSION-${{ matrix.hv }} OUTFILE=eve-${{ matrix.hv }}-${{ matrix.arch }}-${{ matrix.platform }}.tar IMAGE_NAME=$TAG-${{ matrix.hv }}-${{ matrix.arch }}
       - name: Upload EVE ${{ matrix.hv }}-${{ matrix.arch }}-${{ matrix.platform }}
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/buildondemand.yml
+++ b/.github/workflows/buildondemand.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Build packages
         uses: ./.github/actions/run-make
         with:
-          command: "-j $(getconf _NPROCESSORS_ONLN) V=1 PRUNE=1 ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push $FORCE_BUILD pkgs"
+          command: "V=1 PRUNE=1 ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push $FORCE_BUILD pkgs"
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
       - name: Post package report
@@ -125,13 +125,13 @@ jobs:
 
       - uses: ./.github/actions/run-make
         with:
-          command: "-j $(getconf _NPROCESSORS_ONLN) V=1 HV=${{ matrix.hv }} PLATFORM=${{ matrix.platform }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push $FORCE_BUILD eve"
+          command: "V=1 HV=${{ matrix.hv }} PLATFORM=${{ matrix.platform }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push $FORCE_BUILD eve"
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
       - uses: ./.github/actions/run-make
         if: matrix.arch != 'riscv64'
         with:
-          command: "-j $(getconf _NPROCESSORS_ONLN) V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push $FORCE_BUILD sbom collected_sources compare_sbom_collected_sources publish_sources"
+          command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push $FORCE_BUILD sbom collected_sources compare_sbom_collected_sources publish_sources"
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
 
@@ -146,6 +146,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/run-make
         with:
-          command: "-j $(getconf _NPROCESSORS_ONLN) V=1 LINUXKIT_PKG_TARGET=manifest pkgs"
+          command: "V=1 LINUXKIT_PKG_TARGET=manifest pkgs"
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,7 @@ jobs:
           # sadly, our build sometimes times out on network access
           # and running out of disk space: re-trying for 3 times
           for i in 1 2 3; do
-             if make -j $(getconf _NPROCESSORS_ONLN) -e V=1 PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
+             if make -e V=1 PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
                 SUCCESS=true
                 break
              else
@@ -137,13 +137,13 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/run-make
         with:
-          command: "-j $(getconf _NPROCESSORS_ONLN) V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push eve"
+          command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push eve"
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
       - uses: ./.github/actions/run-make
         if: matrix.arch != 'riscv64'
         with:
-          command: "-j $(getconf _NPROCESSORS_ONLN) V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push sbom collected_sources compare_sbom_collected_sources publish_sources"
+          command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push sbom collected_sources compare_sbom_collected_sources publish_sources"
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
 
@@ -157,7 +157,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/run-make
         with:
-          command: "-j $(getconf _NPROCESSORS_ONLN) V=1 LINUXKIT_PKG_TARGET=manifest pkgs"
+          command: "V=1 LINUXKIT_PKG_TARGET=manifest pkgs"
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
 


### PR DESCRIPTION
# Description

This PR reverts the commit introducing parallel `make -j $(nproc)` execution in GitHub Actions workflows. The change caused conflicts with docker containers due to race conditions during builder container creation, which led to repeated build failures. Reverting this change restores build stability by ensuring sequential task execution.

## PR dependencies

None.

## How to test and validate this PR

No special validation is required. Successful completion of GitHub Actions workflows will confirm the fix.

## Changelog notes

N/A (internal CI change, not visible to users)

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
