### PR TITLE
msrv: Add configurable rate limiting for Prometheus metrics endpoint.

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -72,6 +72,9 @@
 | log.dedup.window.size | integer | 0 | The size of the log deduplicator's sliding window (in number of messages). See logging [docs](LOGGING.md#log-filtering-counting-and-deduplication) for details. If the window size is set to 0 (default), no deduplication is performed. |
 | log.count.filenames | string | "" | Comma-separated list of log's filenames to be counted and logged once instead of logging them every time. Example `/my-pkg/main.go:123,/other-pkg/code.go:42`. Empty string `""` doesn't filter anything out, however a single comma `","` will filter out all entries that don't have a filename field set (e.g. logs not coming from components written in Golang). See logging [docs](LOGGING.md#log-filtering-counting-and-deduplication) for details. |
 | log.filter.filenames | string | "" | Comma-separated list of log's filenames to be filtered out. Example `/my-pkg/main.go:123,/other-pkg/code.go:42`. Empty string `""` doesn't filter anything out, however a single comma `","` will filter out all entries that don't have a filename field set (e.g. logs not coming from components written in Golang). See logging [docs](LOGGING.md#log-filtering-counting-and-deduplication) for details. |
+| msrv.prometheus.metrics.rps | integer | 1 | The maximum number of requests per second (RPS) for the Prometheus metrics endpoint. |
+| msrv.prometheus.metrics.burst | integer | 10 | The maximum burst size for the Prometheus metrics endpoint. |
+| msrv.prometheus.metrics.idletimeout.seconds | integer | 240 | The idle timeout in seconds for the Prometheus metrics endpoint. If the connection is idle for this duration, the limit is reset. |
 
 ## Log levels
 

--- a/docs/PROMETHEUS_METRICS.md
+++ b/docs/PROMETHEUS_METRICS.md
@@ -42,6 +42,22 @@ To modify how metrics are collected or adjust the exporter’s flags, edit the
 Regarding the metadata server usage for exposing metrics to applications, you
 can find the documentation in the [metadata server doc](./ECO-METADATA.md).
 
+#### Limits Configuration
+
+The metrics are exposed with a limit of 1 request per second (rps) and a burst of 10
+for each IP address. This is done to prevent overloading the system with too many
+requests.
+
+The limits can be configured with the following global configuration options:
+
+```text
+msrv.prometheus.metrics.rps # Rate limit for requests per second
+msrv.prometheus.metrics.burst # Burst limit for requests
+msrv.prometheus.metrics.idletimeout.seconds # Timeout for requests
+```
+
+You can find description of these options in the [EVE configuration doc](./CONFIG-PROPERTIES.md).
+
 #### iptables rules
 
 To enhance security, EVE configures iptables rules to restrict access to the

--- a/pkg/pillar/cmd/msrv/pubsub.go
+++ b/pkg/pillar/cmd/msrv/pubsub.go
@@ -479,6 +479,10 @@ func (srv *Msrv) handleGlobalConfigImpl(ctxArg interface{}, key string,
 			}
 			srv.metricInterval = metricInterval
 		}
+		// Set up rate limiting for prometheus metrics
+		srv.pmc.RPS = int(gcp.GlobalValueInt(types.MsrvPrometheusMetricsRequestPerSecond))
+		srv.pmc.Burst = int(gcp.GlobalValueInt(types.MsrvPrometheusMetricsBurst))
+		srv.pmc.IdleTimeout = time.Duration(gcp.GlobalValueInt(types.MsrvPrometheusMetricsIdleTimeoutSeconds)) * time.Second
 	}
 	srv.Log.Functionf("handleGlobalConfigImpl done for %s", key)
 }

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -374,6 +374,13 @@ const (
 
 	// TUIMonitorLogLevel: log level for TUI monitor
 	TUIMonitorLogLevel GlobalSettingKey = "debug.tui.loglevel"
+
+	// MsrvPrometheusMetricsRequestPerSecond: limit the number of requests per second
+	MsrvPrometheusMetricsRequestPerSecond GlobalSettingKey = "msrv.prometheus.metrics.rps"
+	// MsrvPrometheusMetricsBurst: limit the burst of requests
+	MsrvPrometheusMetricsBurst GlobalSettingKey = "msrv.prometheus.metrics.burst"
+	// MsrvPrometheusMetricsIdleTimeoutSeconds: idle timeout for the connection
+	MsrvPrometheusMetricsIdleTimeoutSeconds GlobalSettingKey = "msrv.prometheus.metrics.idletimeout.seconds"
 )
 
 // AgentSettingKey - keys for per-agent settings
@@ -1054,6 +1061,11 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(NetDumpTopicMaxCount, 10, 1, 0xFFFFFFFF)
 	configItemSpecMap.AddBoolItem(NetDumpDownloaderPCAP, false)
 	configItemSpecMap.AddBoolItem(NetDumpDownloaderHTTPWithFieldValue, false)
+
+	// Add Metadata Server Prometheus metrics limits settings
+	configItemSpecMap.AddIntItem(MsrvPrometheusMetricsRequestPerSecond, 1, 1, 0xFFFFFFFF)
+	configItemSpecMap.AddIntItem(MsrvPrometheusMetricsBurst, 10, 1, 0xFFFFFFFF)
+	configItemSpecMap.AddIntItem(MsrvPrometheusMetricsIdleTimeoutSeconds, 4*60, 1, 0xFFFFFFFF)
 
 	return configItemSpecMap
 }

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -231,6 +231,9 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		GoroutineLeakDetectionKeepStatsHours,
 		GoroutineLeakDetectionCooldownMinutes,
 		TUIMonitorLogLevel,
+		MsrvPrometheusMetricsRequestPerSecond,
+		MsrvPrometheusMetricsBurst,
+		MsrvPrometheusMetricsIdleTimeoutSeconds,
 	}
 	if len(specMap.GlobalSettings) != len(gsKeys) {
 		t.Errorf("GlobalSettings has more (%d) than expected keys (%d)",


### PR DESCRIPTION
## Description

This pull request introduces new configuration options for controlling request rates on the Prometheus metrics endpoint provided by EVE's metadata server. It adds three parameters:

- `msrv.prometheus.metrics.rps`: Controls the maximum requests per second allowed.
- `msrv.prometheus.metrics.burst`: Sets the maximum burst size of requests allowed.
- `msrv.prometheus.metrics.idletimeout.seconds`: Specifies the idle timeout in seconds, after which inactive connections reset their limits.

Previously, rate limiting was hardcoded. With these new settings, users can dynamically adjust the request limits according to their specific needs and operational requirements.

The middleware handling rate limiting has been refactored to dynamically read these settings from the global configuration, ensuring runtime flexibility and better manageability.

Documentation has been updated to include clear descriptions and usage examples for the new parameters, aiding users in configuration and maintenance.

## PR dependencies

None.

## How to test

Run with the default configuration (burst = 10) and verify that only the first 10 requests per second receive HTTP 200 responses:

```
for i in {1..20}; do curl -I http://169.254.169.254/metrics; sleep 0.05; done
```

Change the `msrv.prometheus.metrics.burst` configuration to 30 and apply the configuration update.

```
zcli edge-node update "${NODE_NAME}" --config="msrv.prometheus.metrics.burst:30"
```

Wait until the configuration is applied, then run the same command again:

```
for i in {1..20}; do curl -I http://169.254.169.254/metrics; sleep 0.05; done
```

Verify that now all 20 requests return HTTP 200, demonstrating the updated burst limit.

## Changelog notes

Enhancement: Added configuration parameters (msrv.prometheus.metrics.rps, msrv.prometheus.metrics.burst, and msrv.prometheus.metrics.idletimeout.seconds) to dynamically control request rate limits and connection idle timeouts on the Prometheus metrics endpoint.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
