### PR TITLE
Fix controllerCertsTask certificate fetch trigger logic

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -187,7 +187,8 @@ func handleEdgeNodeCertDelete(ctxArg interface{}, key string,
 func controllerCertsTask(ctx *zedagentContext, triggerCerts <-chan struct{}) {
 
 	log.Functionln("starting controller certificate fetch task")
-	retry := !getCertsFromController(ctx, "initial")
+	success := getCertsFromController(ctx, "initial")
+	retry := !success
 
 	wdName := agentName + "ccerts"
 
@@ -213,7 +214,6 @@ func controllerCertsTask(ctx *zedagentContext, triggerCerts <-chan struct{}) {
 	ctx.getconfigCtx.certTickerHandle = periodicTicker
 
 	for {
-		success := true
 		select {
 		case <-triggerCerts:
 			start := time.Now()


### PR DESCRIPTION
The way zedagent triggers the controller certificate fetch is controlled by the triggerCerts channel and a periodic timer called periodicTicker. Initially, periodicTicker is set to a short interval of 2 minutes.

At startup, zedagent attempts to fetch the certificates. If the fetch fails, the retry flag is set to true. However, in the subsequent select loop, the success flag is always set to true, regardless of the actual initial fetch result.

If the triggerCerts case is not triggered in the select loop, the stillRunning timer (set to 25 seconds) will fire before the periodicTicker. When this happens, we fall through with both retry and success flags set to true, causing zedagent to incorrectly switch the periodicTicker to a much longer interval of 1 day.

If the device is shut down before this 1-day interval elapses, the controller certificates will not be fetched again. Upon reboot, if there are connectivity issues or a delay in establishing a connection, the same issue recurs, potentially leaving the device without updated controller certificates.

This commit resolves the issue by ensuring that the success flag is correctly set based on the actual result of the certificate fetch operation.

# Description

<!-- Clear description what this PR does and why it's needed -->

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

Need to figure out how to simulate the situation, and write Eden Tests.

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

## Changelog notes

Fix certificate fetch trigger logic to avoid potential issue with controller certificates update.

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
