### PR TITLE
GitHub actions: Serialize ARM builds to avoid race conditions in para…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,5 @@
+# Copyright (c) 2025, Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
 ---
 name: Publish
 on:  # yamllint disable-line rule:truthy
@@ -15,7 +17,8 @@ on:  # yamllint disable-line rule:truthy
       - "[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
 
 jobs:
-  packages:
+  # 1) non-ARM packages, fully parallel
+  packages-non-arm:
     if: github.event.repository.full_name == 'lf-edge/eve'
     runs-on: ${{ matrix.os }}
     strategy:
@@ -25,6 +28,71 @@ jobs:
           - os: ubuntu-22.04
             arch: amd64
             platform: "generic"
+          - os: ubuntu-latest
+            arch: riscv64
+            platform: "generic"
+    steps:
+      - name: Starting Report
+        run: |
+          echo Git Ref: ${{ github.ref }}
+          echo GitHub Event: ${{ github.event_name }}
+          echo Disk usage
+          df -h
+          echo Memory
+          free -m
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Force fetch annotated tags (workaround)
+        run: |
+          git fetch --force --tags
+      - name: Determine architecture prefix and ref
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          echo "ARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
+          echo "TAG=$(echo "$REF" | sed -e 's#^.*/##' -e 's#master#snapshot#' -e 's#main#snapshot#')" >> "$GITHUB_ENV"
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+          password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+      - name: Build packages
+        run: |
+          SUCCESS=
+          for i in 1 2 3; do
+            if make -e V=1 PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
+              SUCCESS=true
+              break
+            else
+              docker rmi -f $(docker image ls -q) || :
+              docker system prune -f || :
+            fi
+          done
+          if [ -z "$SUCCESS" ]; then echo "::error::failed to build and push packages" && exit 1; fi
+      - name: Post package report
+        run: |
+          echo Disk usage
+          df -h
+          echo Memory
+          free -m
+          docker system df
+          docker system df -v
+      - name: Clean
+        run: |
+          make clean
+          docker system prune -f -a
+          rm -rf ~/.linuxkit
+
+  # 2) ARM packages, serialized
+  packages-arm:
+    if: github.event.repository.full_name == 'lf-edge/eve'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
           - os: buildjet-4vcpu-ubuntu-2204-arm
             arch: arm64
             platform: "generic"
@@ -34,9 +102,6 @@ jobs:
           - os: buildjet-4vcpu-ubuntu-2204-arm
             arch: arm64
             platform: "nvidia-jp6"
-          - os: ubuntu-latest
-            arch: riscv64
-            platform: "generic"
     steps:
       - name: Starting Report
         run: |
@@ -109,11 +174,10 @@ jobs:
           docker system prune -f -a
           rm -rf ~/.linuxkit
 
-  # eve composition can run as a separate job, even on a separate runner, because the packages job
-  # published everything. Which means all images are already on the OCI registry.
+  # 3) downstream jobs depend on both package jobs
   eve:
     if: github.event.repository.full_name == 'lf-edge/eve'
-    needs: packages
+    needs: [packages-non-arm, packages-arm]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -149,8 +213,8 @@ jobs:
 
   manifest:
     if: github.event.repository.full_name == 'lf-edge/eve'
+    needs: [packages-non-arm, packages-arm]
     runs-on: ubuntu-latest
-    needs: packages
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# Description

This pull request restructures the GitHub Actions packaging workflow to serialize ARM builds and reduce the chance of race conditions during parallel execution. The existing setup allowed multiple ARM variants (e.g., arm64/generic, arm64/nvidia-jp5, arm64/nvidia-jp6) to build and push packages at the same time. When the same package was built concurrently on separate runners, it could result in multiple conflicting uploads to the registry.

The new structure splits the workflow into two distinct jobs:

* packages-non-arm: handles non-ARM platforms in full parallel
* packages-arm: handles ARM builds but runs them sequentially

This change helps avoid issues such as duplicate SBOMs or inconsistent image manifests caused by uncoordinated pushes

## PR dependencies

None directly, but for full effect this change should be coordinated with registry cleanup if broken manifests already exist from previous builds (and it exists: https://hub.docker.com/layers/lfedge/eve-node-exporter/a29e8b7bf14374433379922e130b4f362d6244ea/images/sha256-1bd4524c78bdabc07dcc8b6df9616e0b45434451cdc3a17e816e5276744abf92)

## How to test and validate this PR

NOT FOR THE VEIFICATION STEP TESTING, it's only to confirm it works very after the merge

1. Trigger the `publish.yml` workflow from a tag push or manually.

Observe that:

- Non-ARM jobs run concurrently.
- Optionally, inspect the final multi-arch manifests via Docker Hub or docker manifest inspect.

## Changelog notes

Infra Change: not to be mentioned in release notes.

## Backport

? TODO

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR


