### PR TITLE
node-exporter: Add image metadata labels to Dockerfile.

### DIFF
--- a/pkg/node-exporter/Dockerfile
+++ b/pkg/node-exporter/Dockerfile
@@ -3,4 +3,9 @@
 
 FROM prom/node-exporter:v1.9.1
 
+LABEL org.opencontainers.image.title="EVE Node Exporter"
+LABEL org.opencontainers.image.description="Prometheus Node Exporter with EVE specific flags"
+LABEL org.opencontainers.image.authors="Zededa, Inc."
+LABEL org.opencontainers.image.license="Apache-2.0"
+
 CMD ["--path.procfs=/hostfs/proc", "--path.sysfs=/hostfs/sys", "--path.rootfs=/hostfs", "--collector.cgroups", "--collector.processes"]


### PR DESCRIPTION
# Description

This pull request updates the Dockerfile for EVE’s Node Exporter package by adding Open Container Initiative (OCI) metadata labels. These labels include details such as the image title, description, license, and authorship, aligning the image with best practices for container metadata.

While the added labels improve image clarity and compliance, the primary purpose of this change is to trigger a rebuild and republishing of the node-exporter package. This is necessary to fix a broken manifest currently in the master branch, which prevents ARM builds from completing successfully.

## PR dependencies

None.

## testing and verification

This PR does not require testing by the verification team. Internal testing is sufficient.

After the PR is merged:

1. Confirm that the CI publish workflow completes successfully, especially for ARM arch.
2. Validate that building the master branch locally results in consumption of the newly published package, indicating the broken manifest has been replaced. Basically, the build should work.

No manual feature testing or QA validation is needed.

## Changelog notes

No user-visible changes. 

## PR Backports

None.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

