### PR TITLE
Linuxkit CLI v1.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ PARSE_PKGS=$(if $(strip $(EVE_HASH)),EVE_HASH=)$(EVE_HASH) DOCKER_ARCH_TAG=$(DOC
 LINUXKIT=$(BUILDTOOLS_BIN)/linuxkit
 # linuxkit version. This **must** be a published semver version so it can be downloaded already compiled from
 # the release page at https://github.com/linuxkit/linuxkit/releases
-LINUXKIT_VERSION=v1.5.3
+LINUXKIT_VERSION=v1.6.0
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit
 LINUXKIT_OPTS=$(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL)
 LINUXKIT_PKG_TARGET=build


### PR DESCRIPTION
Includes some fixes we need, including especially the ability to push packages without leaving dangling images in the manifest, such as sboms.

Also bumps containerd to 2.0.

# Description

Bumps linuxkit for building to v1.6.0

Includes some updates, but main fix for our purposes is ensuring that parallel builds and pushes of packages do not lead to dangling sbom references.

Notably it also bumps containerd to v2. This may or may not impact us. We need to do it eventually, but until CI runs here, it is unclear how much effort that will be.

## How to test and validate this PR

CI, especially eden tests.

Because of the containerd version change, I want extra eyes on it.

## Changelog notes

<!-- Short description to be included in the ChangeLog notes -->

linuxkit v1.6.0, containerd v2.0

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
