### PR TITLE
github/workflows: Fix riscv64 publish action build and improve disk space release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,9 +79,11 @@ jobs:
           docker system df
           docker system df -v
       - name: Clean
+        if: ${{ always() }}
         run: |
           make clean
           docker system prune -f -a
+          docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q)
           rm -rf ~/.linuxkit
 
   # 2) ARM packages, serialized
@@ -169,9 +171,11 @@ jobs:
           docker system df
           docker system df -v
       - name: Clean
+        if: ${{ always() }}
         run: |
           make clean
           docker system prune -f -a
+          docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q)
           rm -rf ~/.linuxkit
 
   # 3) downstream jobs depend on both package jobs
@@ -210,6 +214,13 @@ jobs:
           command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push sbom collected_sources compare_sbom_collected_sources publish_sources"
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+      - name: Clean
+        if: ${{ always() }}
+        run: |
+          make clean
+          docker system prune -f -a
+          docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q)
+          rm -rf ~/.linuxkit
 
   manifest:
     if: github.event.repository.full_name == 'lf-edge/eve'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           SUCCESS=
           for i in 1 2 3; do
-            if make -e V=1 PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
+            if make -e V=1 ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
               SUCCESS=true
               break
             else
@@ -147,7 +147,7 @@ jobs:
           # sadly, our build sometimes times out on network access
           # and running out of disk space: re-trying for 3 times
           for i in 1 2 3; do
-             if make -e V=1 PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
+             if make -e V=1 ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
                 SUCCESS=true
                 break
              else


### PR DESCRIPTION
# Description

This PR fix and improve the publish action:

## Add ZARCH to publish workflow build commands
    
Some build commands in the publish workflow are missing the ZARCH variable, which makes riscv64 build wrongly build for the runner architecture (amd64) instead of riscv64.
    
This PR adds ZARCH to all build commands to ensure it's going to build for the right target architecture.

## Add more aggressive clean up routines

The clean up routines of publish workflow uses docker prune to remove unused volumes, but this is not sufficient to clean up all data created during the build. This commit adds some commands to force the removal of all docker volumes, improving the disk space release.

These changes can help to fix the arm64 builds that are running out of disk space.

## PR dependencies

None.

## How to test and validate this PR

Run CI/CD workflow.

PS: This PR was tested (adapted) on https://github.com/rene/eve/actions/runs/14814491368

## Changelog notes

Fix riscv64 publish action build and improve disk space release

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [x] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions