### PR TITLE
Fix targets and scripts that were not taking REGISTRY into account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -390,6 +390,7 @@ endif
 # Check for a custom registry (used for development purposes)
 ifdef REGISTRY
 LINUXKIT_ORG_TARGET=--org $(REGISTRY)/lfedge
+export LINUXKIT_ORG_TARGET
 else
 LINUXKIT_ORG_TARGET=
 endif
@@ -553,8 +554,8 @@ $(UBOOT_IMG): PKG=u-boot
 $(BSP_IMX_PART): PKG=bsp-imx
 $(EFI_PART) $(BOOT_PART) $(INITRD_IMG) $(IPXE_IMG) $(BIOS_IMG) $(UBOOT_IMG) $(BSP_IMX_PART): $(LINUXKIT) | $(INSTALLER)
 	mkdir -p $(dir $@)
-	$(LINUXKIT) pkg build --pull --platforms linux/$(ZARCH) pkg/$(PKG) # running linuxkit pkg build _without_ force ensures that we either pull it down or build it.
-	cd $(dir $@) && $(LINUXKIT) cache export --platform linux/$(DOCKER_ARCH_TAG) --format filesystem --outfile - $(shell $(LINUXKIT) pkg show-tag pkg/$(PKG)) | tar xvf - $(notdir $@)
+	$(LINUXKIT) pkg build --pull $(LINUXKIT_ORG_TARGET) --platforms linux/$(ZARCH) pkg/$(PKG) # running linuxkit pkg build _without_ force ensures that we either pull it down or build it.
+	cd $(dir $@) && $(LINUXKIT) cache export --platform linux/$(DOCKER_ARCH_TAG) --format filesystem --outfile - $(shell $(LINUXKIT) pkg $(LINUXKIT_ORG_TARGET) show-tag pkg/$(PKG)) | tar xvf - $(notdir $@)
 	$(QUIET): $@: Succeeded
 
 # run swtpm if TPM flag defined
@@ -864,10 +865,10 @@ pkg/kernel:
 
 # Need to force build.yml target in order to always get the current KERNEL_TAG
 pkg/external-boot-image/build.yml: pkg/external-boot-image/build.yml.in pkg/xen-tools FORCE
-	$(QUIET)tools/compose-external-boot-image-yml.sh $< $@ $(shell echo $(KERNEL_TAG) | cut -d':' -f2) $(shell $(LINUXKIT) pkg show-tag pkg/xen-tools | cut -d':' -f2)
+	$(QUIET)tools/compose-external-boot-image-yml.sh $< $@ $(shell echo $(KERNEL_TAG) | cut -d':' -f2) $(shell $(LINUXKIT) pkg $(LINUXKIT_ORG_TARGET) show-tag pkg/xen-tools | cut -d':' -f2)
 eve-external-boot-image: pkg/external-boot-image/build.yml
 pkg/kube/external-boot-image.tar: pkg/external-boot-image
-	$(MAKE) cache-export IMAGE=$(shell $(LINUXKIT) pkg show-tag pkg/external-boot-image) OUTFILE=pkg/kube/external-boot-image.tar
+	$(MAKE) cache-export IMAGE=$(shell $(LINUXKIT) pkg $(LINUXKIT_ORG_TARGET) show-tag pkg/external-boot-image) OUTFILE=pkg/kube/external-boot-image.tar
 	rm -f pkg/external-boot-image/build.yml
 pkg/kube: pkg/kube/external-boot-image.tar eve-kube
 	$(QUIET): $@: Succeeded
@@ -916,7 +917,7 @@ cache-export-docker-load: $(LINUXKIT)
 	rm -rf ${TARFILE}
 
 %-cache-export-docker-load: $(LINUXKIT)
-	$(eval IMAGE_TAG := $(shell $(LINUXKIT) pkg show-tag --canonical pkg/$*))
+	$(eval IMAGE_TAG := $(shell $(LINUXKIT) pkg $(LINUXKIT_ORG_TARGET) show-tag --canonical pkg/$*))
 	$(eval CACHE_CONTENT := $(shell $(LINUXKIT) cache ls 2>&1))
 	$(if $(filter $(IMAGE_TAG),$(CACHE_CONTENT)),$(MAKE) cache-export-docker-load IMAGE=$(IMAGE_TAG),@echo "Missing image $(IMAGE_TAG) in cache")
 
@@ -1059,7 +1060,7 @@ eve-%: pkg/%/Dockerfile build-tools $(RESCAN_DEPS)
 	$(eval LINUXKIT_FLAGS := $(if $(filter manifest,$(LINUXKIT_PKG_TARGET)),,$(FORCE_BUILD) $(LINUXKIT_DOCKER_LOAD) $(LINUXKIT_BUILD_PLATFORMS)))
 	$(QUIET)$(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) $(LINUXKIT_ORG_TARGET) $(LINUXKIT_OPTS) $(LINUXKIT_FLAGS) --build-yml $(call get_pkg_build_yml,$*) pkg/$*
 	$(QUIET)if [ -n "$(PRUNE)" ]; then \
-		$(LINUXKIT) pkg builder prune; \
+		$(LINUXKIT) pkg $(LINUXKIT_ORG_TARGET) builder prune; \
 		docker image prune -f; \
 	fi
 	$(QUIET): "$@: Succeeded (intermediate for pkg/%)"
@@ -1086,7 +1087,7 @@ $(ROOTFS_FULL_NAME)-%-$(ZARCH).$(ROOTFS_FORMAT): $(ROOTFS_IMG)
 	$(QUIET): $@: Succeeded
 
 %-show-tag:
-	@$(LINUXKIT) pkg show-tag --canonical pkg/$*
+	@$(LINUXKIT) pkg $(LINUXKIT_ORG_TARGET) show-tag --canonical pkg/$*
 
 %Gopkg.lock: %Gopkg.toml | $(GOBUILDER)
 	@$(DOCKER_GO) "dep ensure -update $(GODEP_NAME)" $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -750,9 +750,9 @@ ifdef LIVE_UPDATE
 # Don't regenerate the whole image if tar was changed, but
 # do generate if does not exist. qcow2 target will handle
 # the rest
-$(ROOTFS_IMG): | $(ROOTFS_TAR) $(INSTALLER)
+$(ROOTFS_IMG): pkg/mkrootfs-$(ROOTFS_FORMAT) | $(ROOTFS_TAR) $(INSTALLER)
 else
-$(ROOTFS_IMG): $(ROOTFS_TAR) | $(INSTALLER)
+$(ROOTFS_IMG): pkg/mkrootfs-$(ROOTFS_FORMAT) $(ROOTFS_TAR) | $(INSTALLER)
 endif
 	$(QUIET): $@: Begin
 	./tools/makerootfs.sh imagefromtar -t $(ROOTFS_TAR) -i $@ -f $(ROOTFS_FORMAT) -a $(ZARCH)

--- a/tools/makeconfig.sh
+++ b/tools/makeconfig.sh
@@ -5,7 +5,8 @@
 #
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
 PATH="$EVE/build-tools/bin:$PATH"
-MKCONFIG_TAG="$(linuxkit pkg show-tag "$EVE/pkg/mkconf")"
+# shellcheck disable=SC2086
+MKCONFIG_TAG="$(linuxkit pkg ${LINUXKIT_ORG_TARGET} show-tag "$EVE/pkg/mkconf")"
 IMAGE="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 ROOTFS_VERSION="$2"
 

--- a/tools/makeflash.sh
+++ b/tools/makeflash.sh
@@ -5,7 +5,8 @@
 #
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
 PATH="$EVE/build-tools/bin:$PATH"
-MKFLASH_TAG="$(linuxkit pkg show-tag "$EVE/pkg/$1")"
+# shellcheck disable=SC2086
+MKFLASH_TAG="$(linuxkit pkg ${LINUXKIT_ORG_TARGET} show-tag "$EVE/pkg/$1")"
 shift 1
 
 # Recreate image file

--- a/tools/makeiso.sh
+++ b/tools/makeiso.sh
@@ -5,7 +5,8 @@
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
 PATH="$EVE/build-tools/bin:$PATH"
 INSTALLER_TAR="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
-MKIMAGE_TAG="$(linuxkit pkg show-tag "$EVE/pkg/mkimage-iso-efi")"
+# shellcheck disable=SC2086
+MKIMAGE_TAG="$(linuxkit pkg ${LINUXKIT_ORG_TARGET} show-tag "$EVE/pkg/mkimage-iso-efi")"
 ISO="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
 
 if [ ! -f "$INSTALLER_TAR" ] || [ $# -lt 2 ]; then

--- a/tools/makerootfs.sh
+++ b/tools/makerootfs.sh
@@ -161,7 +161,8 @@ done
 
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
 PATH="$EVE/build-tools/bin:$PATH"
-MKROOTFS_TAG="$(linuxkit pkg show-tag "$EVE/pkg/mkrootfs-${format}")"
+# shellcheck disable=SC2086
+MKROOTFS_TAG="$(linuxkit pkg ${LINUXKIT_ORG_TARGET} show-tag "$EVE/pkg/mkrootfs-${format}")"
 IMAGE="$(cd "$(dirname "$imgfile")" && pwd)/$(basename "$imgfile")"
 
 [ -n "$execdir" ] && cd "$execdir"

--- a/tools/makeusbconf.sh
+++ b/tools/makeusbconf.sh
@@ -7,7 +7,8 @@ USAGE="Usage: $0 [-d] [-i] [-s <size in Kb>] [-f <file> ] <output.img>"
 
 EVE="$(cd "$(dirname "$0")" && pwd)/../"
 PATH="$EVE/build-tools/bin:$PATH"
-MKFLASH_TAG="$(linuxkit pkg show-tag "$EVE/pkg/mkimage-raw-efi")"
+# shellcheck disable=SC2086
+MKFLASH_TAG="$(linuxkit pkg ${LINUXKIT_ORG_TARGET} show-tag "$EVE/pkg/mkimage-raw-efi")"
 
 cleanup() {
     rm "$TMPDIR"/* 2>/dev/null

--- a/tools/parse-pkgs.sh
+++ b/tools/parse-pkgs.sh
@@ -56,7 +56,8 @@ _linuxkit_tag() {
       build_yml_cmd=(--build-yml "build-${PLATFORM}.yml")
     fi
 
-    linuxkit pkg show-tag "${build_yml_cmd[@]}" ${EVE_HASH:+--hash $EVE_HASH} "${EVE}/${pkg}"
+    # shellcheck disable=SC2086
+    linuxkit pkg ${LINUXKIT_ORG_TARGET} show-tag "${build_yml_cmd[@]}" ${EVE_HASH:+--hash $EVE_HASH} "${EVE}/${pkg}"
 }
 
 immutable_tag() {


### PR DESCRIPTION
# Description

When using a custom registry through the variable REGISTRY it's expected that EVE's build system will be able to produce a full build that can be pushed to the custom registry. However, several places were not taking this variable into account. This PR fixes this issue and makes it possible to build and publish EVE images to a custom registry specified by REGISTRY.

## Fix 1:  Fix make targets to take LINUXKIT_ORG_TARGET into account

LINUXKIT_ORG_TARGET was not taking into account on some make targets and by the tools/makerootfs.sh and tools/parse-pkgs.sh scripts. Even when using linuxkit show-tag, it's important to take LINUXKIT_ORG_TARGET into account. Otherwise, make eve will fail when using a custom REGISTRY value.

## Fix 2:  Makefile: Add build dependencies for rootfs image

When using a custom registry (through REGISTRY variable) not all images must be already pushed, so make sure we have the right dependencies listed for rootfs image so they can be built if not present in the registry.

## How to test and validate this PR

Build EVE from scratch (with push) to a custom registry. For example:

```sh
make REGISTRY=<my-custom-registry> LINUXKIT_PKG_TARGET=push pkgs
make REGISTRY=<my-custom-registry> LINUXKIT_PKG_TARGET=push eve
```

PS: This PR was tested (adapted) successfully on a personal EVE repo: https://github.com/rene/eve/actions/runs/14824819585

## Changelog notes

Build system: Fix targets and scripts that were not taking REGISTRY into account

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [x] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
