### PR TITLE
Add qmi-firmware-update to enable modem firmware upgrades from EVE

### DIFF
--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -75,6 +75,9 @@ COPY --from=build /out/ /
 # Only for troubleshooting purposes.
 COPY --from=build /usr/bin/mmcli /usr/bin/qmicli /usr/bin/mbimcli /usr/bin/picocom /usr/bin/
 
+# To enable modem firmware upgrades directly from EVE
+COPY --from=build /usr/bin/qmi-firmware-update /usr/bin/
+
 COPY --from=build /usr/libexec/*proxy /usr/libexec/
 COPY --from=build /usr/sbin/ModemManager /usr/bin/
 COPY --from=build /mmagent/mmagent /usr/bin/


### PR DESCRIPTION
# Description

<!-- Clear description what this PR does and why it's needed -->

The [qmi-firmware-update](https://www.freedesktop.org/software/libqmi/man/latest/qmi-firmware-update.1.html) utility allows firmware upgrades for cellular modems over the QMI interface. Including it in the wwan container enables users to upgrade modem firmware directly from EVE, eliminating the need to install another OS or passthrough the modem to a VM with a separate upgrade tool.

Note that the binary was already being built with libqmi, but it wasn’t included in the final wwan container image.

The increase in EVE image size is minimal, as the binary is only 226KB.

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

Enter the wwan container and check that qmi-firmware-update is available
and isn't missing any dependencies:
```
$ eve enter wwan
$ qmi-firmware-update --version
qmi-firmware-update 1.36.0
...
```

## Changelog notes

Add qmi-firmware-update utility to wwan container

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
