### PR TITLE
github/workflows: Add more clean ups on make retrial

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,8 @@ jobs:
               break
             else
               docker rmi -f $(docker image ls -q) || :
-              docker system prune -f || :
+              docker system prune -f -a || :
+              docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
             fi
           done
           if [ -z "$SUCCESS" ]; then echo "::error::failed to build and push packages" && exit 1; fi
@@ -158,7 +159,8 @@ jobs:
                 # disk space. So the following can't hurt before we
                 # retry:
                 docker rmi -f `docker image ls -q` || :
-                docker system prune -f || :
+                docker system prune -f -a || :
+                docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
              fi
           done
           if [ -z "$SUCCESS" ]; then echo "::error::failed to build and push packages" && exit 1; fi


### PR DESCRIPTION
# Description

The publish workflow already implements a logic where if the `make pkgs` command fails during the build job, it calls docker commands to release some disk space and try to build it again. Previously some aggressive clean up routines were added to the workflow, but these only happen after the build job is complete. In this way, if `make pkgs` fails due to disk space, the clean up routines later on will be no effective.

This PR adds the aggressive clean up commands also to the build job.

## How to test and validate this PR

Run CI/CD workflow.

PS: I cannot test this on my own repo because I don't experience issues due to disk space.

## Changelog notes

Improve disk space release for publish action build

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR