### PR TITLE
[Backport to 14.5-stable] Fix an issue of converting from cluster mode into single node

### DIFF
--- a/pkg/pillar/cmd/zedkube/clusterstatus.go
+++ b/pkg/pillar/cmd/zedkube/clusterstatus.go
@@ -52,7 +52,12 @@ func (z *zedkube) applyDNS(dns types.DeviceNetworkStatus) {
 				z.stopClusterStatusServer()
 			}
 		}
-		z.publishKubeConfigStatus()
+		// NIM can publish network status due to cluster config
+		// removal, and we don't want to publish the dummy/empty
+		// cluster status in that case.
+		if z.clusterConfig.ClusterInterface != "" {
+			z.publishKubeConfigStatus()
+		}
 	}
 }
 


### PR DESCRIPTION
- missed carry over the commit in edge-node clustering poc repo
- when publish the EdgeNodeClusterStatus, need to be sure the Cluster is still configured. Publish an empty status would cause issue when convert from clustering back to single-node
- cherry-pick from PR #4812 of main


(cherry picked from commit 6e2251880163549c48438e7881fb1c6bac3c83a8)

# Description

Backporting the main repo PR #4812
Fix an issue of converting from cluster mode into single node

<!-- Clear description what this PR does and why it's needed -->

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

Need to setup the edge-node clustering nodes, then delete the cluster to
observe if the kubernetes node info not contain the 'etcd' property

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

## Changelog notes

Fix an issue of edge-node clustering converting to single-node

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [ x ] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
