### PR TITLE
github/workflows: Ignore errors during Clean job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,10 +82,10 @@ jobs:
       - name: Clean
         if: ${{ always() }}
         run: |
-          make clean
-          docker system prune -f -a
-          docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q)
-          rm -rf ~/.linuxkit
+          make clean || :
+          docker system prune -f -a || :
+          docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
+          rm -rf ~/.linuxkit || :
 
   # 2) ARM packages, serialized
   packages-arm:
@@ -175,10 +175,10 @@ jobs:
       - name: Clean
         if: ${{ always() }}
         run: |
-          make clean
-          docker system prune -f -a
-          docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q)
-          rm -rf ~/.linuxkit
+          make clean || :
+          docker system prune -f -a || :
+          docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
+          rm -rf ~/.linuxkit || :
 
   # 3) downstream jobs depend on both package jobs
   eve:
@@ -219,10 +219,10 @@ jobs:
       - name: Clean
         if: ${{ always() }}
         run: |
-          make clean
-          docker system prune -f -a
-          docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q)
-          rm -rf ~/.linuxkit
+          make clean || :
+          docker system prune -f -a || :
+          docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
+          rm -rf ~/.linuxkit || :
 
   manifest:
     if: github.event.repository.full_name == 'lf-edge/eve'


### PR DESCRIPTION
# Description

Sometimes the publish workflow can run almost everything right and fail during the Clean phase, which is not relevant anymore, since the packages were already published, so let's ignore errors on the Clean job.

I think these are the last changes to bring publish workflow back to live, we've got a full pass after the latest changes: https://github.com/lf-edge/eve/actions/runs/14937710388 but now we are experiencing a fail during the Clean phase for 15.0 build. 

## How to test and validate this PR

Run publish workflow.

## Changelog notes

github/workflows: Ignore errors during Clean job.

## PR Backports

- [ ] 14.5-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR