### PR TITLE
[backport for 11.0-stable] Fix an issue in Edgeview not getting App i…

### DIFF
--- a/pkg/edgeview/vendor/github.com/lf-edge/eve/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/edgeview/vendor/github.com/lf-edge/eve/pkg/pillar/base/logobjecttypes.go
@@ -170,6 +170,8 @@ const (
 	EncryptedVaultKeyFromControllerLogType LogObjectType = "encrypted_vault_key_from_controller"
 	// CachedResolvedIPsLogType:
 	CachedResolvedIPsLogType LogObjectType = "cached_resolved_ips"
+	// AppMACGeneratorLogType : type for AppMACGenerator log entries
+	AppMACGeneratorLogType LogObjectType = "app_mac_generator"
 )
 
 // RelationObjectType :

--- a/pkg/edgeview/vendor/github.com/lf-edge/eve/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/edgeview/vendor/github.com/lf-edge/eve/pkg/pillar/types/zedroutertypes.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/objtonum"
 	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
 )
 
 // AppNetworkConfig : network configuration for a given application.
@@ -106,6 +108,8 @@ type AppNetworkStatus struct {
 	GetStatsIPAddr       net.IP
 	AppNetAdapterList    []AppNetAdapterStatus
 	AwaitNetworkInstance bool // If any Missing flag is set in the networks
+	// ID of the MAC generator variant that was used to generate MAC addresses for this app.
+	MACGenerator int
 	// Any errors from provisioning the network
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
@@ -341,10 +345,9 @@ type AppNetAdapterStatus struct {
 	AppNetAdapterConfig
 	VifInfo
 	BridgeMac         net.HardwareAddr
-	BridgeIPAddr      net.IP   // The address for DNS/DHCP service in zedrouter
-	AllocatedIPv4Addr net.IP   // Assigned to domU
-	AllocatedIPv6List []net.IP // IPv6 addresses assigned to domU
-	IPv4Assigned      bool     // Set to true once DHCP has assigned it to domU
+	BridgeIPAddr      net.IP        // The address for DNS/DHCP service in zedrouter
+	AssignedAddresses AssignedAddrs // IPv4 and IPv6 addresses assigned to domU
+	IPv4Assigned      bool          // Set to true once DHCP has assigned it to domU
 	IPAddrMisMatch    bool
 	HostName          string
 }
@@ -363,15 +366,6 @@ type NetworkInstanceInfo struct {
 	// Set of vifs on this bridge
 	Vifs []VifNameMac
 
-	// Vif metric map. This should have a union of currently existing
-	// vifs and previously deleted vifs.
-	// XXX When a vif is removed from bridge (app instance delete case),
-	// device might start reporting smaller statistic values. To avoid this
-	// from happening, we keep a list of all vifs that were ever connected
-	// to this bridge and their statistics.
-	// We add statistics from all vifs while reporting to cloud.
-	VifMetricMap map[string]NetworkMetric
-
 	// Maintain a map of all access vlan ids to their counts, used by apps
 	// connected to this network instance.
 	VlanMap map[uint32]uint32
@@ -381,8 +375,48 @@ type NetworkInstanceInfo struct {
 
 // AssignedAddrs : IP addresses assigned to application network adapter.
 type AssignedAddrs struct {
-	IPv4Addr  net.IP
-	IPv6Addrs []net.IP
+	IPv4Addrs []AssignedAddr
+	IPv6Addrs []AssignedAddr
+}
+
+// GetInternallyLeasedIPv4Addr returns IPv4 address leased by EVE using
+// an internally run DHCP server.
+func (aa AssignedAddrs) GetInternallyLeasedIPv4Addr() net.IP {
+	for _, addr := range aa.IPv4Addrs {
+		if addr.AssignedBy == AddressSourceInternalDHCP {
+			return addr.Address
+		}
+	}
+	return nil
+}
+
+// AddressSource determines the source of an IP address assigned to an app VIF.
+// Values are power of two and therefore can be used with a bit mask.
+type AddressSource uint8
+
+const (
+	// AddressSourceUndefined : IP address source is not defined
+	AddressSourceUndefined AddressSource = 0
+	// AddressSourceEVEInternal : IP address is used only internally by EVE
+	// (i.e. inside dom0).
+	AddressSourceEVEInternal AddressSource = 1 << iota
+	// AddressSourceInternalDHCP : IP address is leased to an app by an internal DHCP server
+	// run by EVE.
+	AddressSourceInternalDHCP
+	// AddressSourceExternalDHCP : IP address is leased to an app by an external DHCP server.
+	AddressSourceExternalDHCP
+	// AddressSourceSLAAC : Stateless Address Autoconfiguration (SLAAC) was used by the client
+	// to generate a unique IPv6 address.
+	AddressSourceSLAAC
+	// AddressSourceStatic : IP address is assigned to an app statically
+	// (using e.g. cloud-init).
+	AddressSourceStatic
+)
+
+// AssignedAddr : IP address assigned to an application interface (on the guest side).
+type AssignedAddr struct {
+	Address    net.IP
+	AssignedBy AddressSource
 }
 
 // VifNameMac : name and MAC address assigned to app VIF.
@@ -450,6 +484,7 @@ type NetworkInstanceMetrics struct {
 	UUIDandVersion UUIDandVersion
 	DisplayName    string
 	Type           NetworkInstanceType
+	BridgeName     string
 	NetworkMetrics NetworkMetrics
 	ProbeMetrics   ProbeMetrics
 	VlanMetrics    VlanMetrics
@@ -658,9 +693,28 @@ type NetworkInstanceConfig struct {
 	DhcpRange       IPRange
 	DnsNameToIPList []DNSNameToIP // Used for DNS and ACL ipset
 
+	// Route configuration
+	PropagateConnRoutes bool
+	StaticRoutes        []IPRoute
+
 	// Any errors from the parser
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
+}
+
+// IPRoute : single IP route entry.
+type IPRoute struct {
+	DstNetwork *net.IPNet
+	Gateway    net.IP
+}
+
+// IsDefaultRoute returns true if this is a default route, i.e. matches all destinations.
+func (r IPRoute) IsDefaultRoute() bool {
+	if r.DstNetwork == nil {
+		return true
+	}
+	ones, _ := r.DstNetwork.Mask.Size()
+	return r.DstNetwork.IP.IsUnspecified() && ones == 0
 }
 
 // Key :
@@ -787,7 +841,10 @@ type NetworkInstanceStatus struct {
 	Activate uint64
 
 	ChangeInProgress ChangeInProgressType
-	NIConflict       bool // True if config conflicts with another NI
+
+	// True if NI IP subnet overlaps with the subnet of one the device ports
+	// or another NI.
+	IPConflict bool
 
 	// Activated is true if the network instance has been created in the network stack.
 	Activated bool
@@ -843,70 +900,16 @@ func (status NetworkInstanceStatus) LogKey() string {
 	return string(base.NetworkInstanceStatusLogType) + "-" + status.Key()
 }
 
-// UpdateNetworkMetrics : update collected network metrics.
-// Tx/Rx of bridge is equal to the total of Tx/Rx on all member
-// virtual interfaces excluding the bridge itself.
-// Drops/Errors/AclDrops of bridge is equal to total of Drops/Errors/AclDrops
-// on all member virtual interface including the bridge.
-func (status *NetworkInstanceStatus) UpdateNetworkMetrics(log *base.LogObject,
-	nms *NetworkMetrics) (brNetMetric *NetworkMetric) {
-
-	brNetMetric = &NetworkMetric{IfName: status.BridgeName}
-	status.VifMetricMap = make(map[string]NetworkMetric) // clear previous metrics
-	for _, vif := range status.Vifs {
-		metric, found := nms.LookupNetworkMetrics(vif.Name)
-		if !found {
-			log.Tracef("No metrics found for interface %s",
-				vif.Name)
-			continue
-		}
-		status.VifMetricMap[vif.Name] = metric
-	}
-	for _, metric := range status.VifMetricMap {
-		brNetMetric.TxBytes += metric.TxBytes
-		brNetMetric.RxBytes += metric.RxBytes
-		brNetMetric.TxPkts += metric.TxPkts
-		brNetMetric.RxPkts += metric.RxPkts
-		brNetMetric.TxErrors += metric.TxErrors
-		brNetMetric.RxErrors += metric.RxErrors
-		brNetMetric.TxDrops += metric.TxDrops
-		brNetMetric.RxDrops += metric.RxDrops
-		brNetMetric.TxAclDrops += metric.TxAclDrops
-		brNetMetric.RxAclDrops += metric.RxAclDrops
-		brNetMetric.TxAclRateLimitDrops += metric.TxAclRateLimitDrops
-		brNetMetric.RxAclRateLimitDrops += metric.RxAclRateLimitDrops
-	}
-	return brNetMetric
-}
-
-// UpdateBridgeMetrics records metrics of the bridge interface itself.
-func (status *NetworkInstanceStatus) UpdateBridgeMetrics(log *base.LogObject,
-	nms *NetworkMetrics, netMetric *NetworkMetric) {
-	// Get bridge metrics
-	bridgeMetric, found := nms.LookupNetworkMetrics(status.BridgeName)
-	if !found {
-		log.Tracef("No metrics found for Bridge %s",
-			status.BridgeName)
-	} else {
-		netMetric.TxErrors += bridgeMetric.TxErrors
-		netMetric.RxErrors += bridgeMetric.RxErrors
-		netMetric.TxDrops += bridgeMetric.TxDrops
-		netMetric.RxDrops += bridgeMetric.RxDrops
-		netMetric.TxAclDrops += bridgeMetric.TxAclDrops
-		netMetric.RxAclDrops += bridgeMetric.RxAclDrops
-		netMetric.TxAclRateLimitDrops += bridgeMetric.TxAclRateLimitDrops
-		netMetric.RxAclRateLimitDrops += bridgeMetric.RxAclRateLimitDrops
-	}
-}
-
 // IsIpAssigned returns true if the given IP address is assigned to any app VIF.
 func (status *NetworkInstanceStatus) IsIpAssigned(ip net.IP) bool {
 	for _, assignments := range status.IPAssignments {
-		if ip.Equal(assignments.IPv4Addr) {
-			return true
+		for _, assignedIP := range assignments.IPv4Addrs {
+			if ip.Equal(assignedIP.Address) {
+				return true
+			}
 		}
-		for _, nip := range assignments.IPv6Addrs {
-			if ip.Equal(nip) {
+		for _, assignedIP := range assignments.IPv6Addrs {
+			if ip.Equal(assignedIP.Address) {
 				return true
 			}
 		}
@@ -1065,3 +1068,66 @@ type AppBlobsAvailable struct {
 type AppInfo struct {
 	AppBlobs []AppBlobsAvailable
 }
+
+// AppMACGenerator persistently stores ID of the MAC generator that was used to generate
+// MAC addresses for interfaces of a given app.
+type AppMACGenerator struct {
+	*UuidToNum
+}
+
+// New is used by objtonum.ObjNumPublisher.
+func (g *AppMACGenerator) New(objKey objtonum.ObjKey) objtonum.ObjNumContainer {
+	uuidToNum, ok := g.UuidToNum.New(objKey).(*UuidToNum)
+	if !ok {
+		logrus.Fatalf("Wrong type returned by UuidToNum.New()")
+	}
+	return &AppMACGenerator{
+		UuidToNum: uuidToNum,
+	}
+}
+
+// LogCreate logs newly added AppMACGenerator entry.
+func (g AppMACGenerator) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.AppMACGeneratorLogType, "",
+		g.UUID, g.LogKey())
+	logObject.Noticef("AppMACGenerator item create")
+}
+
+// LogModify logs modified AppMACGenerator entry.
+func (g AppMACGenerator) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.AppMACGeneratorLogType, "",
+		g.UUID, g.LogKey())
+	oldEntry, ok := old.(AppMACGenerator)
+	if !ok {
+		logObject.Clone().Fatalf("LogModify: old object is not of AppMACGenerator type")
+	}
+	logObject.CloneAndAddField("diff", cmp.Diff(oldEntry, g)).
+		Noticef("AppMACGenerator item modify")
+}
+
+// LogDelete logs deleted AppMACGenerator entry.
+func (g AppMACGenerator) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.AppMACGeneratorLogType, "",
+		g.UUID, g.LogKey())
+	logObject.Noticef("AppMACGenerator item delete")
+	base.DeleteLogObject(logBase, g.LogKey())
+}
+
+// LogKey identifies AppMACGenerator entry for logging purposes.
+func (g AppMACGenerator) LogKey() string {
+	return string(base.AppMACGeneratorLogType) + "-" + g.Key()
+}
+
+// IDs assigned to different variants of MAC generators.
+const (
+	// MACGeneratorUnspecified : MAC generator is not specified.
+	MACGeneratorUnspecified = 0
+	// MACGeneratorNodeScoped generates MAC addresses which are guaranteed to be unique
+	// only within the scope of the given single device.
+	// The exception are MAC addresses generated for switch network instances,
+	// which are always generated with global scope.
+	MACGeneratorNodeScoped = 1
+	// MACGeneratorGloballyScoped generates MAC addresses which are with high probability
+	// unique globally, i.e. across entire fleet of devices.
+	MACGeneratorGloballyScoped = 2
+)


### PR DESCRIPTION
…nterface IP address

- this is backport the PR #4352 to 11.0-stable
- didn't do the cherry-pick, since it would cause massive vendor file conflicts.
- due to the change of multiple port in zedrouter, the AppNetAdapterList.AllocatedIPv4Addr was changed to AssignedAddresses, do the same change

# Description

port the PR #4352 to 11.0-stable

<!-- Clear description what this PR does and why it's needed -->

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

Need to configure an app on the edge-node, enable edgeview, and use the
tcp command such as tcp/{app-ipaddr}:22 to verify if this is ok.

### Testing Done
tested this patch on 11.0-stable, with edgeview, and application.
was able to edgeview using tcp/{app-ip-address}:22 to ssh into the app.

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

## Changelog notes
[backport to 11.0-stable] Fix an issue in Edgeview not getting App interface IP address

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [ x ] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [ x ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ x ] I've added a reference link to the original PR
- [ x ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
