### PR TITLE
Handle WirelessType NOOP

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -2169,6 +2169,10 @@ func parseNetworkWirelessConfig(ctx *getconfigContext,
 
 	wType := netWireless.GetType()
 	switch wType {
+	case zconfig.WirelessType_TypeNOOP:
+		// This is not a wireless network adapter.
+		// Return an empty wireless configuration.
+		return wconfig, nil
 	case zconfig.WirelessType_Cellular:
 		wconfig.WType = types.WirelessTypeCellular
 		cellNetConfigs := netWireless.GetCellularCfg()


### PR DESCRIPTION
# Description

<!-- Clear description what this PR does and why it's needed -->

When a port is not a wireless network adapter, the controller may either return `nil` for the `WirelessConfig` or provide a `WirelessConfig` with `Type` set to `NOOP`. These two cases are functionally equivalent. However, EVE returns an `unsupported wireless type` error when encountering the `NOOP` type.

Previously, this wasn’t an issue because errors from `parseNetworkWirelessConfig` were simply logged and ignored.
After recent [refactoring of this function](https://github.com/lf-edge/eve/pull/4779), those errors are no longer ignored and will cause EVE to reject the entire network configuration as invalid.

No need to backport to any stable branch, this problem is only in master.

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

Deploy edge-node with ethernet port and check that it onboards without issues and there is no error reported
for the network port (especially not `unsupported wireless type`).

## Changelog notes

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
