### PR TITLE
pillar tests: don't write log into closed pipe

### DIFF
--- a/pkg/pillar/cmd/watcher/watcher_test.go
+++ b/pkg/pillar/cmd/watcher/watcher_test.go
@@ -484,10 +484,6 @@ func TestGoroutineMonitorStops(t *testing.T) {
 	r, w, _ := os.Pipe()
 	logger.SetOutput(w)
 	logger.SetLevel(logrus.TraceLevel)
-	defer func() {
-		logger.SetOutput(backupOut)
-		logger.SetLevel(backupLevel)
-	}()
 
 	// Create context with default parameters
 	ctx := &watcherContext{}
@@ -506,6 +502,8 @@ func TestGoroutineMonitorStops(t *testing.T) {
 
 	// Close the pipe
 	_ = w.Close()
+	logger.SetOutput(backupOut)
+	logger.SetLevel(backupLevel)
 
 	// Read the log output
 	output, _ := io.ReadAll(r)


### PR DESCRIPTION
# Description

because that does not work:
=== FAIL: cmd/watcher TestGoroutineMonitorStops (3.06s)
    watcher_test.go:518: Expected log output to contain 'Stopping goroutines monitor'
Failed to write to log, write |1: file already closed



<!-- Clear description what this PR does and why it's needed -->

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

`make test`

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

## Changelog notes

Internal; only fixing tests

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
