### PR TITLE
Avoid Repeatedly Clearing Bearers for Disabled Modems

### DIFF
--- a/pkg/wwan/mmagent/agent.go
+++ b/pkg/wwan/mmagent/agent.go
@@ -822,12 +822,10 @@ func (a *MMAgent) reconcileModem(
 			connErrChanged = true
 			a.logReconcileOp(modem, "close connection", opReason, connErr)
 		}
-		if connErr == nil {
+		if connErr == nil && modem.Status.Module.OpMode != types.WwanOpModeRadioOff {
 			// Not a necessary step hence we do not touch connErr if it fails.
 			err := a.mmClient.DeleteBearers(modem.Path)
 			a.logReconcileOp(modem, "delete bearers", opReason, err)
-		}
-		if connErr == nil && modem.Status.Module.OpMode != types.WwanOpModeRadioOff {
 			// Note that we disable radio function of all unmanaged modems.
 			connErr = a.mmClient.DisableRadio(modem.Path)
 			connErrChanged = true


### PR DESCRIPTION
# Description

<!-- Clear description what this PR does and why it's needed -->

Disabled modems (i.e., those without an attached network configuration) have their radios turned off and all bearers disconnected and cleared.
However, due to a bug introduced in [recent changes](https://github.com/lf-edge/eve/pull/4779) (only in master, not in stable branches), the bearer clearing is now triggered on every call to `reconcileModem`, which runs both periodically and in response to modem state changes.

This repeated clearing is unnecessary. It should occur only once, alongside turning off the radio.

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

Run EVE on a device with a modem but leave the modem Disabled, i.e. do not assign network config.
Then check EVE logs and verify that `delete bearers for unmanaged modem...` does not appear repeatedly in the logs.

## Changelog notes

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
