### PR TITLE
Retry publishing ECC memory report if failure to send to controller

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -233,12 +233,12 @@ func controllerCertsTask(ctx *zedagentContext, triggerCerts <-chan struct{}) {
 		if retry && success {
 			log.Noticef("getCertsFromController succeeded; switching to long timer %d seconds",
 				ctx.globalConfig.GlobalValueInt(types.CertInterval))
-			updateCertTimer(ctx.globalConfig.GlobalValueInt(types.CertInterval),
+			updateTaskTimer(ctx.globalConfig.GlobalValueInt(types.CertInterval),
 				ctx.getconfigCtx.certTickerHandle)
 			retry = false
 		} else if !retry && !success {
 			log.Noticef("getCertsFromController failed; switching to short timer")
-			updateCertTimer(shortTime,
+			updateTaskTimer(shortTime,
 				ctx.getconfigCtx.certTickerHandle)
 			retry = true
 		}

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -513,22 +513,23 @@ func updateConfigTimer(configInterval uint32, tickerHandle interface{}) {
 	flextimer.TickNow(tickerHandle)
 }
 
-// Called when globalConfig changes
-// Assumes the caller has verified that the interval has changed
-func updateCertTimer(configInterval uint32, tickerHandle interface{}) {
+// updateTaskTimer updates the given tickerHandle to use a new interval based on configInterval.
+// It adjusts the ticker's range and triggers an immediate tick to ensure the new interval takes effect promptly.
+func updateTaskTimer(configInterval uint32, tickerHandle interface{}) {
 
 	if tickerHandle == nil {
-		// Happens if we have a GlobalConfig setting in /persist/
-		log.Warnf("updateConfigTimer: no certTickerHandle yet")
+		// Happens if the tickerHandle has not been initialized yet.
+		log.Warnf("updateConfigTimer: no tickerHandle yet")
 		return
 	}
 	interval := time.Duration(configInterval) * time.Second
-	log.Functionf("updateCertTimer() change to %v", interval)
+	log.Functionf("updateTaskTimer() change to %v", interval)
 	max := float64(interval)
 	min := max * 0.3
+	// Update the ticker to use the new interval range.
 	flextimer.UpdateRangeTicker(tickerHandle,
 		time.Duration(min), time.Duration(max))
-	// Force an immediate timeout since timer could have decreased
+	// Force an immediate tick in case the interval was decreased.
 	flextimer.TickNow(tickerHandle)
 }
 

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -2809,7 +2809,7 @@ func parseConfigItems(ctx *getconfigContext, config *zconfig.EdgeDevConfig,
 		if newCertInterval != oldCertInterval {
 			log.Functionf("parseConfigItems: %s change from %d to %d",
 				"CertInterval", oldCertInterval, newCertInterval)
-			updateCertTimer(newCertInterval, ctx.certTickerHandle)
+			updateTaskTimer(newCertInterval, ctx.certTickerHandle)
 		}
 		if newMetricInterval != oldMetricInterval {
 			log.Functionf("parseConfigItems: %s change from %d to %d",


### PR DESCRIPTION
# Description

On EVE startup, the ECC‐memory‐report publisher may fire before ZedCloud networking is available, causing the initial report to be dropped. This change blocks the ECC publisher until networking is fully up, ensuring the first memory report is always delivered.

## PR dependencies

## How to test and validate this PR

Run EVE on a device with an ECC-capable memory controller.
Then, check EVE logs and verify that EVE sends the ECC memory report successfully the first time.

## Changelog notes

## PR Backports

- [ ] 14.5-stable

## Checklist

 

- [x] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [x]  I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
