### PR TITLE
Vtpm.health.check

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -6,7 +6,7 @@
 
 # Script version, don't forget to bump up once something is changed
 
-VERSION=34
+VERSION=35
 # Add required packages here, it will be passed to "apk add".
 # Once something added here don't forget to add the same package
 # to the Dockerfile ('ENV PKGS' line) of the debug container,
@@ -458,9 +458,22 @@ find /sys/kernel/security -name "tpm*" | while read -r TPM; do
     fi
 done
 
+echo "- vTPM (SWTPM) logs"
+for dir in /persist/swtpm/tpm-state-*; do
+    if [ -d "$dir" ]; then
+        uuid="${dir##*/tpm-state-}"
+        log_file="$dir/swtpm.log"
+        if [ -f "$log_file" ]; then
+            cp "$log_file" "$DIR/$uuid.swtpm.log"
+        fi
+    fi
+done
+
 if [ -c /dev/tpm0 ]; then
     echo "- TPM persistent handles"
     eve exec vtpm tpm2 getcap handles-persistent > "$DIR/handles-persistent.txt"
+    echo "- TPM PCRs capabilitie"
+    eve exec vtpm tpm2 getcap pcrs > "$DIR/selected-pcrs.txt"
 fi
 
 if [ -n "$COLLECT_LOGS_DAYS" ]; then

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -9,12 +9,12 @@ ENV BUILD_PKGS="gcc g++ autoconf automake libtool make openssl-dev libtasn1-dev 
     json-glib-dev gnutls bash expect gawk socat libseccomp-dev gmp-dev \
     musl-utils autoconf-archive git json-c json-c-dev libcurl curl-dev \
     patch go protobuf-dev"
-ENV PKGS="libseccomp libcurl libstdc++ libprotobuf"
+ENV PKGS="libseccomp libcurl libstdc++ libprotobuf pcre libintl glib libffi json-c json-glib"
 RUN eve-alpine-deploy.sh
 
 # build libtpms, it is needed by swtpm
 WORKDIR /libtpms
-ADD https://github.com/stefanberger/libtpms.git#v0.9.6 /libtpms
+ADD https://github.com/stefanberger/libtpms.git#v0.10.0 /libtpms
 RUN ./autogen.sh --prefix=/usr --with-tpm2
 RUN make -j$(nproc)
 RUN make -j$(nproc) install
@@ -23,9 +23,12 @@ RUN strip --strip-unneeded /out/usr/lib/libtpms.so.*
 
 # build swtpm
 WORKDIR /swtpm
-ADD https://github.com/stefanberger/swtpm.git#v0.9.0 /swtpm
+# This poinst to the latest commit that implements state backup functionality.
+# TODO: revert this when there is a new release in swtpm
+ADD https://github.com/stefanberger/swtpm.git#732bbd6ad3a52b9552b5a1620e03a9f6449a1aab /swtpm
 RUN ./autogen.sh --prefix=/out/usr
 RUN make -j$(nproc)
+RUN src/swtpm/swtpm socket --tpm2 --print-capabilities | grep "tpmstate-dir-backend-opt-backup"
 RUN make -j$(nproc) install
 RUN cp /out/usr/lib/swtpm/* /out/usr/lib/
 RUN strip --strip-unneeded /out/usr/lib/swtpm/*.so*
@@ -45,8 +48,8 @@ WORKDIR /tpm2-tools
 ADD --keep-git-dir=true https://github.com/tpm2-software/tpm2-tools.git#5.5 /tpm2-tools
 COPY patches/ /patches/
 RUN for patch in /patches/*.patch; do \
-        echo "Applying $patch"; \
-        patch -d /tpm2-tools -p1 < "$patch" || exit 1 ; \
+    echo "Applying $patch"; \
+    patch -d /tpm2-tools -p1 < "$patch" || exit 1 ; \
     done
 RUN ./bootstrap && \
     ./configure && \

--- a/pkg/vtpm/swtpm-vtpm/src/main.go
+++ b/pkg/vtpm/swtpm-vtpm/src/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -28,7 +29,7 @@ import (
 
 const (
 	swtpmPath      = "/usr/bin/swtpm"
-	maxInstances   = 10
+	maxInstances   = 32
 	maxPidWaitTime = 5 //seconds
 )
 
@@ -112,6 +113,51 @@ func getSwtpmPid(pidPath string, timeoutSeconds uint) (int, error) {
 	}
 }
 
+func checkSwtpmState(uuid uuid.UUID) error {
+	id := uuid.String()
+	statePath := fmt.Sprintf(swtpmStatePath, id)
+	ctrlSockPath := fmt.Sprintf(swtpmCtrlSockPath, id)
+	pidPath := fmt.Sprintf(swtpmPidPath, id)
+
+	if _, err := os.Stat(statePath); err != nil {
+		return fmt.Errorf("failed to check SWTPM state directory: %w", err)
+	}
+
+	if _, err := os.Stat(ctrlSockPath); err != nil {
+		return fmt.Errorf("failed to check SWTPM control socket: %w", err)
+	}
+
+	if _, err := os.Stat(pidPath); err != nil {
+		return fmt.Errorf("failed to check SWTPM pid file: %w", err)
+	}
+
+	// open the control socket and send a CMD_INIT command to check
+	con, err := net.Dial("unix", ctrlSockPath)
+	if err != nil {
+		return fmt.Errorf("failed to connect to SWTPM control socket: %w", err)
+	}
+	defer con.Close()
+
+	// CMD_INIT = 0x00 00 00 02 + flags
+	cmd := []byte{0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00}
+	if _, err := con.Write(cmd); err != nil {
+		return fmt.Errorf("failed to send CMD_INIT command to SWTPM: %w", err)
+	}
+
+	buf := make([]byte, 4)
+	n, err := con.Read(buf)
+	if err != nil {
+		return fmt.Errorf("failed to read response from SWTPM: %w", err)
+	}
+
+	// expected response is 0x00 00 00 00
+	if n < 4 || buf[0] != 0x00 || buf[1] != 0x00 || buf[2] != 0x00 || buf[3] != 0x00 {
+		return fmt.Errorf("SWTPM is not responding correctly, expected 00 00 00 00, got %x", buf)
+	}
+
+	return nil
+}
+
 func runSwtpm(uuid uuid.UUID) (int, error) {
 	id := uuid.String()
 	statePath := fmt.Sprintf(swtpmStatePath, id)
@@ -119,10 +165,12 @@ func runSwtpm(uuid uuid.UUID) (int, error) {
 	binKeyPath := fmt.Sprintf(stateEncryptionKey, id)
 	pidPath := fmt.Sprintf(swtpmPidPath, id)
 	isEncryptedPath := fmt.Sprintf(swtpmIsEncryptedPath, id)
+	logFile := path.Join(fmt.Sprintf(swtpmStatePath, id), "swtpm.log")
 	swtpmArgs := []string{"socket", "--tpm2",
-		"--tpmstate", "dir=" + statePath,
+		"--tpmstate", "dir=" + statePath + ",backup",
 		"--ctrl", "type=unixio,path=" + ctrlSockPath + ",terminate",
 		"--pid", "file=" + pidPath,
+		"--log", "level=3,truncate,file=" + logFile,
 		"--daemon"}
 
 	// If state directory already exists, this call will do nothing.
@@ -132,9 +180,8 @@ func runSwtpm(uuid uuid.UUID) (int, error) {
 
 	if !isTPMAvailable() {
 		log.Noticef("TPM is not available, starting SWTPM without state encryption!")
-
 		// if SWTPM state for app marked as as encrypted, and TPM is not available
-		// anymore, fail because this will corrupt the SWTPM state.
+		// anymore, fail because this might corrupt the SWTPM state.
 		if utils.FileExists(log, isEncryptedPath) {
 			return 0, fmt.Errorf("state encryption was enabled for SWTPM, but TPM is no longer available")
 		}
@@ -192,7 +239,7 @@ func handleLaunch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// pids and liveInstances is shared, take care of them.
+	// pids and liveInstances are shared, use a lock.
 	m.Lock()
 	defer m.Unlock()
 
@@ -211,7 +258,8 @@ func handleLaunch(w http.ResponseWriter, r *http.Request) {
 	}
 	// If we have a record of SWTPM instance with the requested id,
 	// check if it's still alive. if it is alive, refuse to launch a new
-	// instance with the same id as this might corrupt the state.
+	// instance, even though for dir backend lock is always enabled,
+	// better be safe than sorry and not gamble with state corruption.
 	if _, ok := pids[id]; ok {
 		pidPath := fmt.Sprintf(swtpmPidPath, id)
 		// if pid file does not exist, it means the SWTPM instance gracefully
@@ -224,7 +272,8 @@ func handleLaunch(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			// if the SWTPM instance is still alive, we can move on.
+			// if the SWTPM instance is still alive, we can move on. Maybe we should do a health check
+			// here too? but state should be already loaded in memory :-/
 			if isAlive(pid) {
 				log.Noticef("vTPM SWTPM instance with id %s is already running with pid %d", id, pid)
 				w.WriteHeader(http.StatusOK)
@@ -240,7 +289,44 @@ func handleLaunch(w http.ResponseWriter, r *http.Request) {
 		delete(pids, id)
 	}
 
+	// Run SWTPM for the health check first, if there is no backup state or
+	// both normal state and backup are corrupted, we do a state reset with a warning.
 	pid, err := runSwtpm(id)
+	if err != nil {
+		err := fmt.Sprintf("vTPM failed to start SWTPM instance for health check: %v", err)
+		http.Error(w, err, http.StatusFailedDependency)
+		return
+	}
+
+	// check SWTPM health
+	err = checkSwtpmState(id)
+	// wait for SWTPM instance to get terminated then check for errors
+	for i := 0; i < maxPidWaitTime; i++ {
+		if !isAlive(pid) {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+	if err != nil {
+		log.Warnf("SWTPM instance state with id %s is corrupted, reseting the state...", id)
+		// remove the state directory and start a new SWTPM instance
+		isEncryptedPath := fmt.Sprintf(swtpmIsEncryptedPath, id)
+		if utils.FileExists(log, isEncryptedPath) {
+			os.Remove(isEncryptedPath)
+		}
+		if err := os.RemoveAll(fmt.Sprintf(swtpmStatePath, id)); err != nil {
+			err := fmt.Sprintf("failed to remove SWTPM state directory: %v", err)
+			http.Error(w, err, http.StatusFailedDependency)
+			return
+		}
+	} else {
+		log.Noticef("SWTPM instance state with id %s is healthy", id)
+	}
+
+	// Run SWTPM again, since we run SWTPM with the "terminate" flag, it will
+	// terminate itself when the control socket is closed in checkSwtpmState.
+	// in any case, this should work.
+	pid, err = runSwtpm(id)
 	if err != nil {
 		err := fmt.Sprintf("vTPM failed to start SWTPM instance: %v", err)
 		http.Error(w, err, http.StatusFailedDependency)


### PR DESCRIPTION
# Description

1- SWTPM state is backed up before every write and vTPM first checks the health of the SWTPM before handing it over to the domain manager. Based on the result of the health check, either normal state is used or the backup state is used or if both are corrupted/missing, vTPM will reset the SWTPM state.

2- Add collection of enabled TPM PCRs and SWTPM logs to the collect-info.sh script.


<!-- Clear description what this PR does and why it's needed -->

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## How to test and validate this PR

1- Install a VM (Linux/Windows) on EVE, it will automatically enabled the vTPM.  Check SWTPM state directory, it should contain a state directory for the VM : 
```bash
linuxkit-525400123456:~# ls -al /persist/swtpm/
total 16
drwxr-----    3 vtpm     vtpm          4096 May 16 11:08 .
drwxr-xr-x   23 root     root          4096 May 16 11:28 ..
-rw-------    1 vtpm     vtpm             1 May 16 11:08 7cabc2d6-2833-452b-8bf6-c7c5d01f97e3.encrypted
drwxr-xr-x    2 vtpm     vtpm          4096 May 16 11:08 tpm-state-7cabc2d6-2833-452b-8bf6-c7c5d01f97e3
```

2- Reboot the system and at startup (before application launch), corrupt the SWTPM state, this should kick in the backup upon VM start and VM should start successfully: 

```bash
echo "111" > /persist/swtpm/tpm-state-7cabc2d6-2833-452b-8bf6-c7c5d01f97e3/tpm2-00.permall
```

3- Reboot the system and at startup (before application launch), corrupt the SWTPM state and backup state, this should kick in the reset state process upon VM start and VM should start successfully: 

```bash
echo "111" > /persist/swtpm/tpm-state-7cabc2d6-2833-452b-8bf6-c7c5d01f97e3/tpm2-00.permall
echo "111" > /persist/swtpm/tpm-state-7cabc2d6-2833-452b-8bf6-c7c5d01f97e3/tpm2-00.permall.bak
```

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

## Changelog notes

Added SWTPM state backup before writes and health checks before vTPM handoff, with fallback to backup or state reset on corruption.

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

- [ ] 13.4-stable

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
