### PR TITLE
remove memory limitation to containers running pillar tests

### DIFF
--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -88,7 +88,7 @@ test: build-docker-test
 	rm -f results.xml
 	touch results.json
 	touch results.xml
-	docker run --memory=800m --platform linux/$(ZARCH) -w /pillar \
+	docker run --platform linux/$(ZARCH) -w /pillar \
 		--mount type=bind,source=./results.json,target=/pillar/results.json \
 		--mount type=bind,source=./results.xml,target=/pillar/results.xml \
 		--entrypoint /final/opt/gotestsum $(DOCKER_TAG) \
@@ -96,12 +96,12 @@ test: build-docker-test
 		--junitfile /pillar/results.xml \
 		--raw-command -- go test -tags kubevirt -coverprofile=coverage.txt -covermode=atomic -race -json \
 		./...
-	docker run --memory=800m --platform linux/$(ZARCH) -w /pillar \
+	docker run --platform linux/$(ZARCH) -w /pillar \
 		--entrypoint /bin/sh $(DOCKER_TAG) \
 		/pillar/build-scripts/fuzz_test.sh
 
 test-profiling-create: build-docker-test
-	docker run --memory=800m --platform linux/$(ZARCH) -w /pillar \
+	docker run --platform linux/$(ZARCH) -w /pillar \
                 --mount type=bind,source=./,target=/pillar/ \
                 --entrypoint /bin/sh $(DOCKER_TAG) \
                 /pillar/build-scripts/memprof_test.sh


### PR DESCRIPTION
# Description

In my local setup ( linux PC, with 16 CPU cores) the tests fail. It has to do with the combination of limiting the memory usage of the container that runs the tests and not limiting the CPU, the golang runtime spans multiple threads to run the tests in parallel which causes an oomKill on both the tests as well as the fuzzy testing. Moreover, the tests with 800m limitation are using swap space, so if this is not activated at a PC running the tests it will fail.
By investigation I found that I could run the tests with 1300m of memory and the fuzzy tests with 1600m but this will may not be the case to another user that may have a CPU with more cores. 

Either we can limit the tests to use specific cores as well as specific RAM or we do not limit the RAM usage of the containers.  I proposed, at this PR to not limit the RAM usage since it will be hard to find the proper CPU cores limit to suit everyone use case. 

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## How to test and validate this PR

Execute ```make test``` inside pillar to run the tests, it should not fail.

## Changelog notes

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
