### PR TITLE
[11.0-stable] set MediaType in BlobStatus from VerifyImageStatus

### DIFF
--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -424,6 +424,7 @@ func lookupOrCreateBlobStatus(ctx *volumemgrContext, blobSha string) *types.Blob
 			State:                  vs.State,
 			Path:                   vs.FileLocation,
 			Size:                   uint64(vs.Size),
+			MediaType:              vs.MediaType,
 			CurrentSize:            vs.Size,
 			TotalSize:              vs.Size,
 			Progress:               100,

--- a/pkg/pillar/types/blob.go
+++ b/pkg/pillar/types/blob.go
@@ -87,7 +87,7 @@ func (status BlobStatus) LogCreate(logBase *base.LogObject) {
 	logObject.CloneAndAddField("state", status.State.String()).
 		AddField("datastoreid-uuids", uuids).
 		AddField("size-int64", status.Size).
-		AddField("blobtype-string", status.MediaType).
+		AddField("mediatype", status.MediaType).
 		AddField("refcount-int64", status.RefCount).
 		AddField("has-verifier-ref-bool", status.HasVerifierRef).
 		AddField("has-downloader-ref-bool", status.HasDownloaderRef).
@@ -108,6 +108,7 @@ func (status BlobStatus) LogModify(logBase *base.LogObject, old interface{}) {
 		oldStatus.Size != status.Size {
 
 		logObject.CloneAndAddField("state", status.State.String()).
+			AddField("mediatype", status.MediaType).
 			AddField("refcount-int64", status.RefCount).
 			AddField("size-int64", status.Size).
 			AddField("has-verifier-ref-bool", status.HasVerifierRef).
@@ -137,6 +138,7 @@ func (status BlobStatus) LogDelete(logBase *base.LogObject) {
 	logObject := base.EnsureLogObject(logBase, base.BlobStatusLogType, status.RelativeURL,
 		nilUUID, status.LogKey())
 	logObject.CloneAndAddField("state", status.State.String()).
+		AddField("mediatype", status.MediaType).
 		AddField("refcount-int64", status.RefCount).
 		AddField("size-int64", status.Size).
 		AddField("has-verifier-ref-bool", status.HasVerifierRef).

--- a/pkg/pillar/types/verifiertypes.go
+++ b/pkg/pillar/types/verifiertypes.go
@@ -41,6 +41,7 @@ func (config VerifyImageConfig) LogCreate(logBase *base.LogObject) {
 		return
 	}
 	logObject.CloneAndAddField("refcount-int64", config.RefCount).
+		AddField("mediatype", config.MediaType).
 		AddField("expired-bool", config.Expired).
 		Noticef("VerifyImage config create")
 }
@@ -58,6 +59,7 @@ func (config VerifyImageConfig) LogModify(logBase *base.LogObject, old interface
 		oldConfig.Expired != config.Expired {
 
 		logObject.CloneAndAddField("refcount-int64", config.RefCount).
+			AddField("mediatype", config.MediaType).
 			AddField("expired-bool", config.Expired).
 			AddField("old-refcount-int64", oldConfig.RefCount).
 			AddField("old-expired-bool", oldConfig.Expired).
@@ -74,6 +76,7 @@ func (config VerifyImageConfig) LogDelete(logBase *base.LogObject) {
 	logObject := base.EnsureLogObject(logBase, base.VerifyImageConfigLogType, config.Name,
 		nilUUID, config.LogKey())
 	logObject.CloneAndAddField("refcount-int64", config.RefCount).
+		AddField("mediatype", config.MediaType).
 		AddField("expired-bool", config.Expired).
 		Noticef("VerifyImage config delete")
 
@@ -116,6 +119,7 @@ func (status VerifyImageStatus) LogCreate(logBase *base.LogObject) {
 		return
 	}
 	logObject.CloneAndAddField("state", status.State.String()).
+		AddField("mediatype", status.MediaType).
 		AddField("refcount-int64", status.RefCount).
 		AddField("expired-bool", status.Expired).
 		AddField("size-int64", status.Size).
@@ -139,6 +143,7 @@ func (status VerifyImageStatus) LogModify(logBase *base.LogObject, old interface
 		oldStatus.FileLocation != status.FileLocation {
 
 		logObject.CloneAndAddField("state", status.State.String()).
+			AddField("mediatype", status.MediaType).
 			AddField("refcount-int64", status.RefCount).
 			AddField("expired-bool", status.Expired).
 			AddField("size-int64", status.Size).
@@ -169,6 +174,7 @@ func (status VerifyImageStatus) LogDelete(logBase *base.LogObject) {
 	logObject := base.EnsureLogObject(logBase, base.VerifyImageStatusLogType, status.Name,
 		nilUUID, status.LogKey())
 	logObject.CloneAndAddField("state", status.State.String()).
+		AddField("mediatype", status.MediaType).
 		AddField("refcount-int64", status.RefCount).
 		AddField("expired-bool", status.Expired).
 		AddField("size-int64", status.Size).


### PR DESCRIPTION
# Description

This PR is a backport of https://github.com/lf-edge/eve/pull/4511.

The MediaType field should not be empty because this can affect correct function of IsManifest() and IsIndex().

This commit additionally logs MediaType in all pubsub structs to facilitate future debugging.

## How to test and validate this PR

We don't know because we cannot reproduce the bug that this PR is trying to fix.

## Changelog notes

None

## Checklist

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template ([<stable-branch>] Original's PR Title)

