### PR TITLE
[11.0-stable] stat st_blocks block size read from DEV_BSIZE

### DIFF
--- a/pkg/pillar/diskmetrics/usage.go
+++ b/pkg/pillar/diskmetrics/usage.go
@@ -3,6 +3,9 @@
 
 package diskmetrics
 
+// #include <sys/param.h>
+import "C"
+
 import (
 	"fmt"
 	"io"
@@ -27,7 +30,11 @@ func StatAllocatedBytes(path string) (uint64, error) {
 	if err != nil {
 		return uint64(0), err
 	}
-	return uint64(stat.Blocks * int64(stat.Blksize)), nil
+	// From POSIX standard for st_blocks block size:
+	// Traditionally, some implementations defined
+	// the multiplier for st_blocks in <sys/param.h>
+	// as the symbol DEV_BSIZE.
+	return uint64(stat.Blocks * C.DEV_BSIZE), nil
 }
 
 // SizeFromDir performs a du -s equivalent operation.

--- a/pkg/pillar/diskmetrics/usage_test.go
+++ b/pkg/pillar/diskmetrics/usage_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package diskmetrics
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+func TestStatAllocatedBytes(t *testing.T) {
+	// Generate a tmpfile path
+	tmpdir, err := os.MkdirTemp("", "teststatallocatedbytes")
+	if err != nil {
+		t.Fatalf("os.MkdirTemp failed: %v", err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	// Create a file for io
+	// Allocate the last half of the file
+	file, err := os.Create(tmpdir + "/testfile.dat")
+	if err != nil {
+		t.Fatalf("os.Create failed creating testfile.dat : %v", err)
+	}
+	defer file.Close()
+	_, err = file.Seek(1024*512, io.SeekStart)
+	if err != nil {
+		t.Fatalf("file.Seek failed: %v", err)
+	}
+	halfMB := make([]byte, 1024*512)
+	_, err = file.Write(halfMB)
+	if err != nil {
+		t.Fatalf("file.Write failed: %v", err)
+	}
+	err = file.Close()
+	if err != nil {
+		t.Fatalf("file.Close failed: %v", err)
+	}
+	allocatedBytes, err := StatAllocatedBytes(tmpdir + "/testfile.dat")
+	if err != nil {
+		t.Fatalf("StatAllocatedBytes failed: %v", err)
+	}
+	// check if the allocated bytes are 50% of 1MB
+	if allocatedBytes != 1024*512 {
+		t.Fatalf("Test file should be half allocated")
+	}
+
+	//
+	// Now fully allocate it (allocate the first half of the file)
+	//
+	file, err = os.OpenFile(tmpdir+"/testfile.dat", os.O_RDWR, 0644)
+	_, err = file.Seek(0, io.SeekStart)
+	if err != nil {
+		t.Fatalf("file.Seek failed: %v", err)
+	}
+	halfMB = make([]byte, 1024*512)
+	_, err = file.Write(halfMB)
+	if err != nil {
+		t.Fatalf("file.Write failed: %v", err)
+	}
+	err = file.Close()
+	if err != nil {
+		t.Fatalf("file.Close failed: %v", err)
+	}
+	allocatedBytes, err = StatAllocatedBytes(tmpdir + "/testfile.dat")
+	if err != nil {
+		t.Fatalf("StatAllocatedBytes failed: %v", err)
+	}
+	// check if the allocated bytes are 100% of 1MB
+	if allocatedBytes != 1024*1024 {
+		t.Fatalf("Test File should be fully allocated")
+	}
+}


### PR DESCRIPTION
# Description

From POSIX standard:
Traditionally, some implementations defined
the multiplier for st_blocks in <sys/param.h>
as the symbol DEV_BSIZE.

Don't use stat.Blksize which can return 4k
and overinflate sizes.

Added pillar gotest TestStatAllocatedBytes

Signed-off-by: Andrew Durbin [andrewd@zededa.com](mailto:andrewd@zededa.com)
(cherry picked from commit https://github.com/lf-edge/eve/commit/56a26d9b996a11ac64097218cf4db529f4f4321e)

Backport of https://github.com/lf-edge/eve/pull/4596

<!-- Clear description what this PR does and why it's needed -->

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

Test coverage implemented in pillar:
```
cd pkg/pillar
make test
```

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

## Changelog notes

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
