### PR TITLE
[11.0-stable] Add UDP source IP into golang dialer https connection for Edgeview

### DIFF
--- a/pkg/edgeview/src/websocket.go
+++ b/pkg/edgeview/src/websocket.go
@@ -1,10 +1,11 @@
-// Copyright (c) 2021 Zededa, Inc.
+// Copyright (c) 2021-2005 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -89,6 +90,13 @@ func setupWebC(hostname, token string, u url.URL, isServer bool) bool {
 		useProxy++
 		// walk through default route intfs if exist, and try also without specifying the source
 		// if we know the index it worked previously before disconnect, try that first
+		// For the source IP, we on EVE device, relies on the policy routing to route the
+		// IP packets to the correct outbound interface. For a normal Linux host, this may
+		// not be available, or it needs to be implemented on the host which runs Edgeview.
+		// The below for loop, only gets the interfaces pointed to by default IP route,
+		// and using the Interface IP address as the source IP for the TLS connection, it walks
+		// through all the interfaces on this list, plus one more without using the source IP,
+		// in the case the controller IP route is statically configured in the routing table.
 		for idx := len(intfSrcs) - 1; idx >= -1; idx-- {
 			if websIndex != invalidIndex && websIndex < len(intfSrcs) {
 				idx = websIndex
@@ -135,11 +143,13 @@ func setupWebC(hostname, token string, u url.URL, isServer bool) bool {
 				}
 				return true
 			}
-			retry++
 			if !isServer && retry > 1 {
 				return false
 			}
 		}
+		// do exponential backoff after walking through all the interfaces
+		// to speed up the connection retrial
+		retry++
 	}
 }
 
@@ -174,7 +184,21 @@ func tlsDial(isServer bool, pIP string, pport int, src []net.IP, idx int) (*webs
 		dialer.Proxy = http.ProxyURL(proxyURL)
 	}
 	if idx >= 0 && len(src) > 0 && idx < len(src) {
-		dialer.NetDialContext = (&net.Dialer{LocalAddr: &net.TCPAddr{IP: src[idx]}}).DialContext
+		srcSelected := src[idx]
+		localAddr := &net.TCPAddr{IP: srcSelected}
+		netDialer := &net.Dialer{
+			LocalAddr: localAddr,
+			Resolver: &net.Resolver{
+				PreferGo: true,
+				Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+					d := net.Dialer{
+						LocalAddr: &net.UDPAddr{IP: srcSelected},
+					}
+					return d.DialContext(ctx, network, address)
+				},
+			},
+		}
+		dialer.NetDialContext = netDialer.DialContext
 	}
 
 	return dialer, nil


### PR DESCRIPTION
(cherry picked from commit daf734e04995a7ed130cf50ffba9c91a88fd3d1d)

# Description

- have seen on certain EVE devices, even walk through various ports, the UDP source IP address used stuck on one particular IP address, and it then failed on DNS query and failed Edgeview connection.
- change retry connection backoff after walking through all the intfs to speed up the initial connection time

Backport of #4551 

---
- Add a note to indicate the origin of the fix, for example: https://github.com/lf-edge/eve/pull/4551/

- PR's title should also indicate the stable branch, for instance:


## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR


## Changelog notes

Add UDP source IP into golang dialer https connection for Edgeview

## PR Backports

this is the backport

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
