### PR TITLE
[11.0-stable] Allow download retrying if the computed and configured checksums differ.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ conf/authorized_keys
 conf/grub.cfg
 conf/device.cert.pem
 conf/device.key.pem
+pkg/installer/vendor

--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -27,6 +27,7 @@
 | timer.port.testbetterinterval | timer in seconds | 600 | test a higher prio port config |
 | network.fallback.any.eth | "enabled" or "disabled" | disabled (enabled forcefully during onboarding if no network config) | if no connectivity try any Ethernet, WiFi, or LTE with DHCP client |
 | network.download.max.cost | 0-255 | 0 | [max port cost for download](DEVICE-CONNECTIVITY.md) to avoid e.g., LTE ports |
+| blob.download.max.retries | 1-10 | 5 | max download retries when image verification fails.|
 | debug.enable.usb | boolean | false | allow USB e.g. keyboards on device |
 | debug.enable.vga | boolean | false | allow VGA console on device |
 | debug.enable.ssh | authorized ssh key | empty string(ssh disabled) | allow ssh to EVE |

--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -485,12 +485,10 @@ func unpublishBlobStatus(ctx *volumemgrContext, blobs ...*types.BlobStatus) {
 		// But the BlobStatus pointer might appear several times in
 		// the list hence we better clear the Has*Ref
 		if blob.HasDownloaderRef {
-			MaybeRemoveDownloaderConfig(ctx, blob.Sha256)
-			blob.HasDownloaderRef = false
+			MaybeRemoveDownloaderConfig(ctx, blob)
 		}
 		if blob.HasVerifierRef {
-			MaybeRemoveVerifyImageConfig(ctx, blob.Sha256)
-			blob.HasVerifierRef = false
+			MaybeRemoveVerifyImageConfig(ctx, blob)
 		}
 		//If blob is loaded, then remove it from CAS
 		if blob.State == types.LOADED {

--- a/pkg/pillar/cmd/volumemgr/handleverifier.go
+++ b/pkg/pillar/cmd/volumemgr/handleverifier.go
@@ -86,7 +86,8 @@ func MaybeAddVerifyImageConfigBlob(ctx *volumemgrContext, blob types.BlobStatus)
 // However, MaybeAddVerifyImageConfig can be called to increment the refcount
 // since the handshake with the verifier will not conclude until the
 // VerifyImageConfig is unpublished
-func MaybeRemoveVerifyImageConfig(ctx *volumemgrContext, imageSha string) {
+func MaybeRemoveVerifyImageConfig(ctx *volumemgrContext, blob *types.BlobStatus) {
+	imageSha := blob.Sha256
 
 	log.Functionf("MaybeRemoveVerifyImageConfig(%s)", imageSha)
 
@@ -111,6 +112,9 @@ func MaybeRemoveVerifyImageConfig(ctx *volumemgrContext, imageSha string) {
 		publishVerifyImageConfig(ctx, m)
 	}
 	log.Functionf("MaybeRemoveVerifyImageConfig done for %s", imageSha)
+
+	// Remove the has verifier reference from blob status
+	blob.HasVerifierRef = false
 }
 
 // deleteVerifyImageConfig checks the refcount and if it is zero it

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -43,7 +43,10 @@ const (
 // Set from Makefile
 var Version = "No version specified"
 
-var volumeFormat = make(map[string]zconfig.Format)
+var (
+	blobDownloadMaxRetries uint32 = 5 // Unless from GlobalConfig
+	volumeFormat                  = make(map[string]zconfig.Format)
+)
 
 type volumemgrContext struct {
 	agentbase.AgentBase
@@ -721,6 +724,10 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 	gcp := agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		ctx.CLIParams().DebugOverride, logger)
 	if gcp != nil {
+		// Set max retries for blob download from global config
+		if gcp.GlobalValueInt(types.BlobDownloadMaxRetries) != 0 {
+			blobDownloadMaxRetries = gcp.GlobalValueInt(types.BlobDownloadMaxRetries)
+		}
 		maybeUpdateConfigItems(ctx, gcp)
 		ctx.globalConfig = gcp
 		ctx.GCInitialized = true

--- a/pkg/pillar/types/blob.go
+++ b/pkg/pillar/types/blob.go
@@ -47,6 +47,7 @@ type BlobStatus struct {
 	Progress uint
 	// ErrorAndTimeWithSource provide common error handling capabilities
 	ErrorAndTimeWithSource
+	RetryCount uint32
 }
 
 // Key returns the pubsub Key.

--- a/pkg/pillar/types/downloadertypes.go
+++ b/pkg/pillar/types/downloadertypes.go
@@ -23,6 +23,7 @@ type DownloaderConfig struct {
 	Size            uint64 // In bytes
 	FinalObjDir     string // final Object Store
 	RefCount        uint
+	LastRetry       time.Time
 }
 
 func (config DownloaderConfig) Key() string {
@@ -119,6 +120,8 @@ type DownloaderStatus struct {
 	RetryCount int
 	// We save the original error when we do a retry
 	OrigError string
+	// Used only when image verification fails after the download
+	LastRetry time.Time
 }
 
 func (status DownloaderStatus) Key() string {

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -218,6 +218,10 @@ const (
 	// ports for image downloads.
 	DownloadMaxPortCost GlobalSettingKey = "network.download.max.cost"
 
+	// BlobDownloadMaxRetries global setting key
+	// how many times EVE will retry to download a blob if its checksum is not verified
+	BlobDownloadMaxRetries GlobalSettingKey = "blob.download.max.retries"
+
 	// Bool Items
 	// UsbAccess global setting key
 	UsbAccess GlobalSettingKey = "debug.enable.usb"
@@ -883,6 +887,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	// LogRemainToSendMBytes - Default is 2 Gbytes, minimum is 10 Mbytes
 	configItemSpecMap.AddIntItem(LogRemainToSendMBytes, 2048, 10, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(DownloadMaxPortCost, 0, 0, 255)
+	configItemSpecMap.AddIntItem(BlobDownloadMaxRetries, 5, 1, 10)
 
 	// Add Bool Items
 	configItemSpecMap.AddBoolItem(UsbAccess, true) // Controller likely default to false

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -176,6 +176,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		ForceFallbackCounter,
 		LogRemainToSendMBytes,
 		DownloadMaxPortCost,
+		BlobDownloadMaxRetries,
 		// Bool Items
 		UsbAccess,
 		VgaAccess,


### PR DESCRIPTION
# Description

Backport of #4455 

## How to test and validate this PR

One approach is to purposely store the wrong checksum of an application image and verify via the logs that EVE retries downloading the image 5 times. Another approach is to corrupt the application image while EVE downloads it and confirm that EVE retries the download and successfully installs the application. 

## Changelog notes

Allow download retrying if the computed and configured checksums differ.

## Checklist

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template ([<stable-branch>] Original's PR Title)