### PR TITLE
[11.0-stable] Avoid nil dereference in baseosmgr

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -68,7 +68,7 @@ func installDownloadedObjects(ctx *baseOsMgrContext, uuidStr, finalObjDir string
 
 	if status == nil {
 		return changed, proceed, fmt.Errorf("installDownloadedObjects(%s) cannot found contentTree %s",
-			uuidStr, status.ContentID)
+			uuidStr, contentID)
 	}
 
 	if status.State == types.LOADED {


### PR DESCRIPTION
Backport of #4563 

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
