### PR TITLE
[13.4-stable] Enforce always-on power mode for specific problematic PCI modems

### DIFF
--- a/pkg/udev/etc/udev/rules.d/02-modem.rules
+++ b/pkg/udev/etc/udev/rules.d/02-modem.rules
@@ -1,0 +1,10 @@
+# Certain modem firmware versions are known to become unstable, or even
+# crash, when the PCI driver engages in runtime power management and
+# alters the device's power state. To prevent this, we disable power
+# management for affected devices and force them to remain continuously
+# powered-on.
+
+# Foxconn Qualcomm Snapdragon X55 5G
+SUBSYSTEM=="pci", ATTR{vendor}=="0x105b", ATTR{device}=="0xe0ab", ATTR{power/control}="on"
+# Quectel EM160R_GL
+SUBSYSTEM=="pci", ATTR{vendor}=="0x1eac", ATTR{device}=="0x1002", ATTR{power/control}="on"


### PR DESCRIPTION
# Description

<!-- Clear description what this PR does and why it's needed -->

Certain modem firmware versions are known to become unstable, or even crash, when the PCI driver engages in runtime power management and alters the device's power state. To prevent this, we disable power management for affected devices and force them to remain continuously powered-on while connected.

(cherry picked from commit 89284aa935cd46978096d411fcd28d81f78c77e3)
Backport of the PR https://github.com/lf-edge/eve/pull/4825

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

Test EVE with a Foxconn Qualcomm Snapdragon X55 5G modem or with
a Quectel EM160R-GL modem connected via PCIe. Verify that the modem
operates stably and that power management is disabled.
The value for power control should be on:

```
cat /sys/bus/pci/devices/<modem-pci-address>/power/control
on
```

And runtime state is always active:

```
cat /sys/bus/pci/devices/<modem-pci-address>/power/runtime_status
active
```

## Changelog notes

Disable power management for Foxconn Qualcomm Snapdragon X55 5G and Quectel EM160R-GL modems to prevent firmware crashes.

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template (`[<stable-branch>] Original's PR Title`)
