### PR TITLE
[11.0-stable] GitHub Actions: bump runners ubuntu version to latest available

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -6,7 +6,7 @@
 # to "emulated" arm64 side on the amd64 runner.
 #
 # The trick we play is that we keep it as a matrix job still, but we make
-# it use the same GitHub provided x86 ubuntu-20.04 runners. The runner that
+# it use the same GitHub provided x86 ubuntu-24.04 runners. The runner that
 # gets to unpack arm64 artifacts does so with the help of binfmt-support and
 # qemu-user-static
 
@@ -46,7 +46,7 @@ jobs:
           echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
           echo "upload_url=$upload_url" >> "$GITHUB_OUTPUT"
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: create_release
     strategy:
       fail-fast: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - os: arm64-secure
             arch: arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             arch: amd64
           - os: ubuntu-latest
             arch: riscv64

--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -16,7 +16,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   yetus:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Accoring to [1] Ubuntu 20.04 runners in GitHub will be fully unsuppoerted by 2025-04-01. This commit bumps GitHub-provided runners to latest available Ubuntu 24.04 and BuildJet-provided runners are updated to latest available Ubuntu 22.04

I am not changing runners to latest because fixed version guarantees stability of packages across workflow runs

[1] - https://github.com/actions/runner-images/issues/11101

Modified backport, origin commit 51a61f8595e0844895dfaf909ebc468f5098caa5

Backport #4618

## How to test and validate this PR

respective workflows are running

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
