### PR TITLE
Fix Bearer ConnectionError type

### DIFF
--- a/pkg/wwan/mmagent/mmdbus/client.go
+++ b/pkg/wwan/mmagent/mmdbus/client.go
@@ -783,17 +783,18 @@ func (c *Client) getBearerStatus(bearerObj dbus.BusObject) (bearer types.WwanBea
 			bearer.ConnectedAt = uint64(time.Now().Unix()) - uint64(value)
 		}
 	}
-	connectionError := struct {
-		DBusErrName string
-		ErrMessage  string
-	}{}
+
+	var connectionError []interface{}
 	_ = getDBusProperty(c, bearerObj, BearerPropertyConnectionError, &connectionError)
-	if connectionError.DBusErrName != "" {
-		if connectionError.ErrMessage != "" {
-			bearer.ConnectionError = connectionError.DBusErrName + ": " +
-				connectionError.ErrMessage
-		} else {
-			bearer.ConnectionError = connectionError.DBusErrName
+	if len(connectionError) == 2 {
+		dbusErrName, ok1 := connectionError[0].(string)
+		errMessage, ok2 := connectionError[1].(string)
+		if ok1 && ok2 && dbusErrName != "" {
+			if errMessage != "" {
+				bearer.ConnectionError = dbusErrName + ": " + errMessage
+			} else {
+				bearer.ConnectionError = dbusErrName
+			}
 		}
 	}
 	var bearerProperties map[string]dbus.Variant


### PR DESCRIPTION
# Description

<!-- Clear description what this PR does and why it's needed -->

Bearer's `ConnectionError` is represented in ModemManager DBus API as a list of two fields: DBus Error Name and Error message. The method for retrieving this propery expects generic list `[]interface{}`, which will have length 2 and contain 2 strings.

See:
https://www.freedesktop.org/software/ModemManager/doc/latest/ModemManager/gdbus-org.freedesktop.ModemManager1.Bearer.html#gdbus-property-org-freedesktop-ModemManager1-Bearer.ConnectionError

This commit fixes the previous code which assumed that `struct` with the two strings is returned.

Already included in the backport PRs:
 - for 13.4: https://github.com/lf-edge/eve/pull/4852
 - for 14.5: https://github.com/lf-edge/eve/pull/4857

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

If modem is failing to connect, ssh to device, enter pillar container and check the content of
```
cat /run/wwan/WwanStatus/global.json | jq
```
Under `Bearers` you should see the bearer which is failing to connect and this fix ensures that the bearer's attribute `ConnectionError` is properly reported (not empty).  

## Changelog notes

Fix retrieving of the cellular bearer's `ConnectionError` attribute 

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
