### PR TITLE
Makefile: Remove duplicated targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -872,10 +872,6 @@ pkg/kube/external-boot-image.tar: pkg/external-boot-image
 	rm -f pkg/external-boot-image/build.yml
 pkg/kube: pkg/kube/external-boot-image.tar eve-kube
 	$(QUIET): $@: Succeeded
-pkg/pillar: pkg/dnsmasq pkg/gpt-tools pkg/dom0-ztools eve-pillar
-	$(QUIET): $@: Succeeded
-pkg/xen-tools: pkg/uefi eve-xen-tools
-	$(QUIET): $@: Succeeded
 pkg/%: eve-% FORCE
 	$(QUIET): $@: Succeeded
 


### PR DESCRIPTION
# Description
    
In the Makefile we have declared some targets with dependencies that are already covered by the get-deps.mk file, generated by get-deps.

This fixes `make test` failures for PR #4848

## PR dependencies

None

## How to test and validate this PR

Run `make test` when pkg/pillar or dependencies were modified and it need rebuild.

## Changelog notes

Build infra, no need of changelogs.

## PR Backports

- [ ] 14.5-stable
- [ ] 13.4-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR