### PR TITLE
[11.0-stable] App-shared port without DNS server is not necessarily an issue

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -149,6 +149,10 @@ func encodeTestResults(tr types.TestResults) *info.ErrorInfo {
 		errInfo.Description = tr.LastError
 	} else {
 		timestamp = tr.LastSucceeded
+		if tr.HasWarning() {
+			errInfo.Description = tr.LastWarning
+			errInfo.Severity = info.Severity_SEVERITY_WARNING
+		}
 	}
 	if !timestamp.IsZero() {
 		protoTime, err := ptypes.TimestampProto(timestamp)

--- a/pkg/pillar/types/dns.go
+++ b/pkg/pillar/types/dns.go
@@ -108,6 +108,7 @@ func (status DeviceNetworkStatus) LogCreate(logBase *base.LogObject) {
 		// XXX different logobject for a particular port?
 		logObject.CloneAndAddField("ifname", p.IfName).
 			AddField("last-error", p.LastError).
+			AddField("last-warning", p.LastWarning).
 			AddField("last-succeeded", p.LastSucceeded).
 			AddField("last-failed", p.LastFailed).
 			Noticef("DeviceNetworkStatus port create")
@@ -155,16 +156,20 @@ func (status DeviceNetworkStatus) LogModify(logBase *base.LogObject, old interfa
 		if p.HasError() != op.HasError() ||
 			p.LastFailed != op.LastFailed ||
 			p.LastSucceeded != op.LastSucceeded ||
-			p.LastError != op.LastError {
+			p.LastError != op.LastError ||
+			p.LastWarning != op.LastWarning {
 			logData := logObject.CloneAndAddField("ifname", p.IfName).
 				AddField("last-error", p.LastError).
+				AddField("last-warning", p.LastWarning).
 				AddField("last-succeeded", p.LastSucceeded).
 				AddField("last-failed", p.LastFailed).
 				AddField("old-last-error", op.LastError).
+				AddField("old-last-warning", op.LastWarning).
 				AddField("old-last-succeeded", op.LastSucceeded).
 				AddField("old-last-failed", op.LastFailed)
 			if p.HasError() == op.HasError() &&
-				p.LastError == op.LastError {
+				p.LastError == op.LastError &&
+				p.LastWarning == op.LastWarning {
 				// if we have success or the same error again, reduce log level
 				logData.Function("DeviceNetworkStatus port modify")
 			} else {
@@ -186,6 +191,7 @@ func (status DeviceNetworkStatus) LogDelete(logBase *base.LogObject) {
 		// XXX different logobject for a particular port?
 		logObject.CloneAndAddField("ifname", p.IfName).
 			AddField("last-error", p.LastError).
+			AddField("last-warning", p.LastWarning).
 			AddField("last-succeeded", p.LastSucceeded).
 			AddField("last-failed", p.LastFailed).
 			Noticef("DeviceNetworkStatus port delete")

--- a/pkg/pillar/types/dpc.go
+++ b/pkg/pillar/types/dpc.go
@@ -119,12 +119,14 @@ func (config DevicePortConfig) LogCreate(logBase *base.LogObject) {
 		AddField("last-failed", config.LastFailed).
 		AddField("last-succeeded", config.LastSucceeded).
 		AddField("last-error", config.LastError).
+		AddField("last-warning", config.LastWarning).
 		AddField("state", config.State.String()).
 		Noticef("DevicePortConfig create")
 	for _, p := range config.Ports {
 		// XXX different logobject for a particular port?
 		logObject.CloneAndAddField("ifname", p.IfName).
 			AddField("last-error", p.LastError).
+			AddField("last-warning", p.LastWarning).
 			AddField("last-succeeded", p.LastSucceeded).
 			AddField("last-failed", p.LastFailed).
 			Noticef("DevicePortConfig port create")
@@ -144,21 +146,25 @@ func (config DevicePortConfig) LogModify(logBase *base.LogObject, old interface{
 		oldConfig.LastFailed != config.LastFailed ||
 		oldConfig.LastSucceeded != config.LastSucceeded ||
 		oldConfig.LastError != config.LastError ||
+		oldConfig.LastWarning != config.LastWarning ||
 		oldConfig.State != config.State {
 
 		logData := logObject.CloneAndAddField("ports-int64", len(config.Ports)).
 			AddField("last-failed", config.LastFailed).
 			AddField("last-succeeded", config.LastSucceeded).
 			AddField("last-error", config.LastError).
+			AddField("last-warning", config.LastWarning).
 			AddField("state", config.State.String()).
 			AddField("old-ports-int64", len(oldConfig.Ports)).
 			AddField("old-last-failed", oldConfig.LastFailed).
 			AddField("old-last-succeeded", oldConfig.LastSucceeded).
 			AddField("old-last-error", oldConfig.LastError).
+			AddField("old-last-warning", oldConfig.LastWarning).
 			AddField("old-state", oldConfig.State.String())
 		if len(oldConfig.Ports) == len(config.Ports) &&
 			config.LastFailed == oldConfig.LastFailed &&
 			config.LastError == oldConfig.LastError &&
+			config.LastWarning == oldConfig.LastWarning &&
 			oldConfig.State == config.State &&
 			config.LastSucceeded.After(oldConfig.LastFailed) &&
 			oldConfig.LastSucceeded.After(oldConfig.LastFailed) {
@@ -178,16 +184,20 @@ func (config DevicePortConfig) LogModify(logBase *base.LogObject, old interface{
 		if p.HasError() != op.HasError() ||
 			p.LastFailed != op.LastFailed ||
 			p.LastSucceeded != op.LastSucceeded ||
-			p.LastError != op.LastError {
+			p.LastError != op.LastError ||
+			p.LastWarning != op.LastWarning {
 			logData := logObject.CloneAndAddField("ifname", p.IfName).
 				AddField("last-error", p.LastError).
+				AddField("last-warning", p.LastWarning).
 				AddField("last-succeeded", p.LastSucceeded).
 				AddField("last-failed", p.LastFailed).
 				AddField("old-last-error", op.LastError).
+				AddField("old-last-warning", op.LastWarning).
 				AddField("old-last-succeeded", op.LastSucceeded).
 				AddField("old-last-failed", op.LastFailed)
 			if p.HasError() == op.HasError() &&
-				p.LastError == op.LastError {
+				p.LastError == op.LastError &&
+				p.LastWarning == op.LastWarning {
 				// if we have success or the same error again, reduce log level
 				logData.Function("DevicePortConfig port modify")
 			} else {
@@ -205,12 +215,14 @@ func (config DevicePortConfig) LogDelete(logBase *base.LogObject) {
 		AddField("last-failed", config.LastFailed).
 		AddField("last-succeeded", config.LastSucceeded).
 		AddField("last-error", config.LastError).
+		AddField("last-warning", config.LastWarning).
 		AddField("state", config.State.String()).
 		Noticef("DevicePortConfig delete")
 	for _, p := range config.Ports {
 		// XXX different logobject for a particular port?
 		logObject.CloneAndAddField("ifname", p.IfName).
 			AddField("last-error", p.LastError).
+			AddField("last-warning", p.LastWarning).
 			AddField("last-succeeded", p.LastSucceeded).
 			AddField("last-failed", p.LastFailed).
 			Noticef("DevicePortConfig port delete")

--- a/pkg/pillar/zedcloud/send.go
+++ b/pkg/pillar/zedcloud/send.go
@@ -396,6 +396,19 @@ func VerifyAllIntf(ctx *ZedCloudContext, url string, requiredSuccessCount uint,
 					continue
 				}
 			}
+			var noDNSErr *types.DNSNotAvailError
+			if errors.As(err, &noDNSErr) {
+				// The interface link is up and an IP address is assigned, but no DNS
+				// server is configured. This is not necessarily a failure for an app-shared
+				// interface. Some applications might not require DNS for external hostnames
+				// and may only use internal DNS servers to resolve the names of other apps
+				// running on the same device. However, we should still issue a warning about
+				// this potential issue.
+				if !portStatus.IsMgmt {
+					verifyRV.IntfStatusMap.RecordSuccessWithWarning(intf, err.Error())
+					continue
+				}
+			}
 			log.Errorf("Zedcloud un-reachable via interface %s: %s",
 				intf, err)
 			if sendErr, ok := err.(*SendError); ok && len(sendErr.Attempts) > 0 {


### PR DESCRIPTION
# Description

<!-- Clear description what this PR does and why it's needed -->

Not having DNS servers configured (while link is OK and IP address is assigned), is not necessarily a failure for an app-shared interface. Some applications might not require DNS for external hostnames and may only use internal DNS servers to resolve the names of other apps running on the same device. However, we should still issue a warning about this potential issue.

(cherry picked from commit e7bb2302a8214cf5e6097bb212ca9f5636e6c29d)
Backport of https://github.com/lf-edge/eve/pull/4315

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

Configure app-shared interface without any DNS servers (e.g. use static IP config and leave the DNS servers field empty).
Then verify that the error `no DNS server available` is published to controller for the interface with `SEVERITY_WARNING`.

## Changelog notes

<!-- Short description to be included in the ChangeLog notes -->
Decreased severity of missing DNS configuration on app-shared interfaces to `WARNING`.

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template (`[<stable-branch>] Original's PR Title`)
