### PR TITLE
[11.0-stable] Re-execute full validation for AppNetworkConfig once pending NIs are ready

### DIFF
--- a/pkg/pillar/cmd/zedrouter/appnetwork.go
+++ b/pkg/pillar/cmd/zedrouter/appnetwork.go
@@ -259,7 +259,12 @@ func (z *zedrouter) checkAndRecreateAppNetworks(niID uuid.UUID) {
 		}
 		if !appNetStatus.HasError() && !appNetStatus.AwaitNetworkInstance &&
 			appNetConfig.Activate && !appNetStatus.Activated {
-			z.doActivateAppNetwork(*appNetConfig, &appNetStatus)
+			// Re-execute the entire pubsub handler to repeat the full validation process.
+			// The conditions might have changed while the application was waiting for the
+			// network instance to appear or get fixed. For instance, another application
+			// with conflicting port forwarding rules could have been deployed during this
+			// time, which would necessitate preventing the activation of this app's network.
+			z.handleAppNetworkCreate(nil, appNetConfig.Key(), *appNetConfig)
 		}
 		z.log.Functionf("checkAndRecreateAppNetworks(%v) done for %s",
 			niID, appNetConfig.DisplayName)


### PR DESCRIPTION
# Description

<!-- Clear description what this PR does and why it's needed -->

When an application network configuration depends on a network instance (NI) that is either missing or in an error state, zedrouter flags the `AppNetworkStatus` with `AwaitNetworkInstance`. It then waits until the network instance becomes available and is activated without errors before proceeding with the activation of the application network.

However, conditions may change while the application is waiting for the network instance to be available. For instance, another application with conflicting port forwarding rules could have been deployed during this time, which would necessitate preventing the activation of this app's network.

To address this, we adopt the approach used in `zedrouter.retryFailedAppNetworks()`, where the entire pubsub handler is re-executed to repeat the full validation process. The handler is idempotent, ensuring operations like AppNum allocation reuse previously set values.

(cherry picked from commit e32819eca0caf1062f438ba43b551bf51adf6558)
Backport of PR https://github.com/lf-edge/eve/pull/4458

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

1. Configure a network instance (NI) with an invalid field—EVE will reject the deployment and mark it with an error.
2. Deploy an application connected to this invalid NI—EVE will not deploy the app and will wait for the NI to be fixed.
3. Deploy a second application with identical port forwarding rules as the first one, but connected to a different, valid NI—EVE will successfully deploy this app.
4. Fix the configuration of the previously invalid NI—EVE **should still not deploy** the first application due to port forwarding conflicts with the already deployed second app.

## Changelog notes

<!-- Short description to be included in the ChangeLog notes -->

Re-execute full validation for application network config once pending network instances are ready

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template (`[<stable-branch>] Original's PR Title`)
