### PR TITLE
[14.5-stable] Fix missing reboot on rollback without purge

### DIFF
--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -1300,6 +1300,14 @@ func handleModify(ctxArg interface{}, key string,
 		restartReason = "Restart to create immediate snapshot"
 	}
 
+	// Check if we need to roll back to a snapshot, and if so, mark the application
+	// as in purge state. We can apply snapshot only when the application is halted.
+	if status.SnapStatus.HasRollbackRequest {
+		status.PurgeInprogress = types.DownloadAndVerify
+		status.PurgeStartedAt = time.Now()
+		restartReason = "Restart to rollback snapshot"
+	}
+
 	if config.RestartCmd.Counter != oldConfig.RestartCmd.Counter ||
 		config.LocalRestartCmd.Counter != oldConfig.LocalRestartCmd.Counter {
 


### PR DESCRIPTION
# Description

Backport of #4847

## PR dependencies

## How to test and validate this PR

1. Run a VM application
2. Trigger an on-demand snapshot from the controller UI
3. Wait for the application to be restarted
4. Trigger a rollback from the controller UI
5. Confirm that the VM is restarted after the rollback is triggered

## Changelog notes

Bug Fix: Ensure rollback works properly even without volume updates or purge

## PR Backports

Backport of #4847

## Checklist

- [x] I've provided a proper description
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template ([\<stable-branch\>] Original's PR Title)
