### PR TITLE
fw: Fix build for arm64

### DIFF
--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -3,6 +3,8 @@ ARG PLATFORM=generic
 
 FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build-base
 
+ARG TARGETARCH
+
 ENV BUILD_PKGS tar make binutils zstd rdfind coreutils
 RUN eve-alpine-deploy.sh
 


### PR DESCRIPTION
# Description

On Dockerfile, the ARG instruction has effect from the line is declared. An ARG TARGETARCH was missing in pkg/fw/Dockerfile so the NVIDIA firmware was not getting integrated into arm64 builds.

Fixes: https://github.com/lf-edge/eve/commit/1e5264bbc2290539ad989843e3bb3f79a8e87b9d

PS: This issue makes EVE crash on Aetina AIE-KN32, AIE-KN42 and all NVIDIA JP5/JP6 compatible devices (thanks @zedi-pramodh for reporting this crash to us).

## PR dependencies

None.

## How to test and validate this PR

1. Build EVE for nvidia-jp5 or nvidia-jp6 variants
2. Boot EVE on any nvidia-jp5/nvidia-jp6 compatible device (Jetson Xavier, Orin AGX, NX, Nano, etc)

## Changelog notes

Fix firmware build for EVE NVIDIA variants

## PR Backports

No need to backport because the bug it's only on master.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [x] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
