### PR TITLE
Fix errors in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2018 Zededa, Inc.
+# Copyright (c) 2018-2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Run make (with no arguments) to see help on what targets are available
@@ -101,11 +101,8 @@ ifeq ($(DEV),y)
 	DEV_TAG:=-dev
 endif
 
-ifeq ($(PLATFORM),generic)
-TAGPLAT=
-else
-TAGPLAT=$(PLATFORM)
-endif
+PLATFORM?=generic
+TAGPLAT=$(if $(filter-out generic,$(PLATFORM)),$(PLATFORM))
 
 # ROOTFS_VERSION used to construct the installer directory
 # set this to the current tag only if we are building from a tag
@@ -1065,10 +1062,10 @@ images/out:
 	mkdir -p $@
 
 images/out/rootfs-%.yml.in: images/rootfs.yml.in $(RESCAN_DEPS) | images/out
-	$(QUIET)tools/compose-image-yml.sh -b $< -v "$(ROOTFS_VERSION)-$*-$(ZARCH)" -o $@ -h $(HV) $(patsubst %,images/modifiers/%.yq,$(subst -, ,$*))
+	$(QUIET)tools/compose-image-yml.sh -b $< -v "$(ROOTFS_VERSION)-$*-$(ZARCH)" -o $@ -h $(HV) $(patsubst %,images/modifiers/%.yq,$(firstword $(subst -, ,$*)))
 
 images/out/installer-%.yml.in: images/installer.yml.in $(RESCAN_DEPS) | images/out
-	$(QUIET)tools/compose-image-yml.sh -b $< -v "$(ROOTFS_VERSION)-$*-$(ZARCH)" -o $@ -h $(HV) $(patsubst %,images/modifiers/%.yq,$(subst -, ,$*))
+	$(QUIET)tools/compose-image-yml.sh -b $< -v "$(ROOTFS_VERSION)-$*-$(ZARCH)" -o $@ -h $(HV) $(patsubst %,images/modifiers/%.yq,$(firstword $(subst -, ,$*)))
 
 pkg-deps.mk: $(GET_DEPS)
 	$(QUIET)$(GET_DEPS) $(ROOTFS_GET_DEPS) -m $@

--- a/kernel-version.mk
+++ b/kernel-version.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Zededa, Inc.
+# Copyright (c) 2023-2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
 # This file is included by the main Makefile.
@@ -12,7 +12,6 @@
 #
 
 KERNEL_COMPILER=gcc
-PLATFORM?=generic
 
 PLATFORMS_amd64=generic rt
 PLATFORMS_arm64=generic nvidia nvidia-jp5 nvidia-jp6 imx8mp_pollux imx8mp_epc_r3720 imx8mq_evk


### PR DESCRIPTION
# Description

- Move PLATFORM definition to main Makefile and define it before it is used. Currently TARGPLAT was never set to empty string
- Use $(first-word) to get only the first modifier for platfroms like nvidia-jp5. The second file images/modifiers/jp5.yq is ignored by tools/compose-image-yml.sh but it is not expected to be passed at all

## PR dependencies

## How to test and validate this PR
build all platforms and validate they are built properly

## PR Backports

- [ ] 14.5-stable
- [ ] 13.4-stable
- [ ] 12.0-stable


## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR

