### PR TITLE
[WIP] GitHub Actions: switch to Zededa-provided runners 🥳🎉

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -21,7 +21,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   create_release:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: zededa-ubuntu-2204
     outputs:
       release_id: ${{ steps.create_release.outputs.release_id }}
       upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -46,7 +46,7 @@ jobs:
           echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
           echo "upload_url=$upload_url" >> "$GITHUB_OUTPUT"
   build:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: zededa-ubuntu-2204
     needs: create_release
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,17 +20,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [buildjet-4vcpu-ubuntu-2204-arm, buildjet-4vcpu-ubuntu-2204]
+        os: [buildjet-4vcpu-ubuntu-2204-arm, zededa-ubuntu-2204]
         arch: [arm64, amd64]
         platform: [generic, nvidia-jp5, nvidia-jp6]
         include:
-          - os: buildjet-4vcpu-ubuntu-2204
+          - os: zededa-ubuntu-2204
             arch: riscv64
             platform: generic
         exclude:
           - os: buildjet-4vcpu-ubuntu-2204-arm
             arch: amd64
-          - os: buildjet-4vcpu-ubuntu-2204
+          - os: zededa-ubuntu-2204
             arch: arm64
           - arch: amd64
             platform: nvidia-jp5
@@ -94,7 +94,7 @@ jobs:
 
   eve:
     needs: packages  # all packages for all platforms must be built first
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: zededa-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/buildondemand.yml
+++ b/.github/workflows/buildondemand.yml
@@ -28,9 +28,9 @@ jobs:
         include:
           - os: buildjet-4vcpu-ubuntu-2204-arm
             arch: arm64
-          - os: buildjet-4vcpu-ubuntu-2204
+          - os: zededa-ubuntu-2204
             arch: amd64
-          - os: buildjet-4vcpu-ubuntu-2204
+          - os: zededa-ubuntu-2204
             arch: riscv64
     steps:
       - name: Starting Report
@@ -84,7 +84,7 @@ jobs:
     needs: packages  # all packages for all platforms must be built first
     # Only run for the default branch
     if: github.ref_name == github.event.repository.default_branch
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: zededa-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: zededa-ubuntu-22.04
             arch: amd64
             platform: "generic"
-          - os: ubuntu-latest
+          - os: zededa-ubuntu-2204
             arch: riscv64
             platform: "generic"
     steps:
@@ -184,7 +184,7 @@ jobs:
   eve:
     if: github.event.repository.full_name == 'lf-edge/eve'
     needs: [packages-non-arm, packages-arm]
-    runs-on: ubuntu-latest
+    runs-on: zededa-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:
@@ -227,7 +227,7 @@ jobs:
   manifest:
     if: github.event.repository.full_name == 'lf-edge/eve'
     needs: [packages-non-arm, packages-arm]
-    runs-on: ubuntu-latest
+    runs-on: zededa-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: zededa-ubuntu-22.04
+          - os: zededa-ubuntu-2204
             arch: amd64
             platform: "generic"
           - os: zededa-ubuntu-2204


### PR DESCRIPTION
# Description

We're excited to announce that Zededa Inc. is generously providing our project with self-hosted GitHub runners! This amazing contribution will help speed up development and make our CI/CD pipeline smoother. Huge thanks to Zededa for supporting our community!

That will accelerate our CI/CD pipeline giving us better visibility and more control over hardware pool

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
