### PR TITLE
[13.4-stable] Add USB boot priority to the OVMF firmware (x86_64)

### DIFF
--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -10,7 +10,7 @@ ARG BUILD_PKGS_BASE="git gcc linux-headers libc-dev make linux-pam-dev m4 findut
 # we use the same image in several places
 ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:82df60e43ab9f8c935584b8c7b4d0a4b0271d608
 
-FROM lfedge/eve-uefi:d821658883d6748d8bbf0d6640c62288e3ce8c6f as uefi-build
+FROM lfedge/eve-uefi:8bab7035e4b254ace0bd0dd182de2b1588b94355 as uefi-build
 FROM lfedge/eve-dom0-ztools:09f378d92d6c8ada04fb8e9cf5d45fc8fdf934f9 as zfs
 RUN mkdir /out
 # copy zfs-related files from dom0-ztools using prepared list of files

--- a/pkg/uefi/edk2-patches/edk2-stable202005/0011-OvmfPkg-Add-EveBootOrderLib.patch
+++ b/pkg/uefi/edk2-patches/edk2-stable202005/0011-OvmfPkg-Add-EveBootOrderLib.patch
@@ -1,0 +1,379 @@
+From 7036a6774efb7691b5d7bf424508366bad73775b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
+Date: Mon, 19 May 2025 18:35:54 +0200
+Subject: [PATCH] OvmfPkg: Add EveBootOrderLib
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This commit introduces the EveBootOrderLib. This library aims to allow
+EVE-OS change the boot order of Virtual Machines running OVMF. For now a
+partial implementation is provided, where USB devices are prioritized in
+the boot order list.
+
+Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>
+---
+ OvmfPkg/Include/Library/EveBootOrderLib.h     |  46 +++++
+ .../Library/EveBootOrderLib/EveBootOrderLib.c | 159 ++++++++++++++++++
+ .../EveBootOrderLib/EveBootOrderLib.inf       |  48 ++++++
+ .../PlatformBootManagerLib/BdsPlatform.c      |   1 +
+ .../PlatformBootManagerLib/BdsPlatform.h      |   1 +
+ .../PlatformBootManagerLib.inf                |   1 +
+ OvmfPkg/OvmfPkg.dec                           |   5 +
+ OvmfPkg/OvmfPkgX64.dsc                        |   1 +
+ OvmfPkg/OvmfXen.dsc                           |   1 +
+ 9 files changed, 263 insertions(+)
+ create mode 100644 OvmfPkg/Include/Library/EveBootOrderLib.h
+ create mode 100644 OvmfPkg/Library/EveBootOrderLib/EveBootOrderLib.c
+ create mode 100644 OvmfPkg/Library/EveBootOrderLib/EveBootOrderLib.inf
+
+diff --git a/OvmfPkg/Include/Library/EveBootOrderLib.h b/OvmfPkg/Include/Library/EveBootOrderLib.h
+new file mode 100644
+index 0000000000..78bf4730f5
+--- /dev/null
++++ b/OvmfPkg/Include/Library/EveBootOrderLib.h
+@@ -0,0 +1,46 @@
++/** @file
++  Rewrite the BootOrder NvVar based on EVE-OS "opt/eve.bootorder" fw_cfg file --
++  include file.
++
++  Copyright (C) 2012-2014, Red Hat, Inc.
++  Copyright (C) 2025 Zededa, Inc.
++
++  SPDX-License-Identifier: BSD-2-Clause-Patent
++**/
++
++#ifndef __EVE_BOOT_ORDER_LIB_H__
++#define __EVE_BOOT_ORDER_LIB_H__
++
++#include <Uefi/UefiBaseType.h>
++#include <Base.h>
++
++/**
++
++  Attempt to retrieve the "opt/eve.bootorder" fw_cfg file from QEMU. In
++  case the file is found, set the boot order based on configuration
++  retrieved from QEMU for EVE-OS.
++
++
++  @retval RETURN_SUCCESS            The "opt/eve.bootorder" fw_cfg file has been
++                                    parsed, and the referenced device-subtrees
++                                    have been connected.
++
++  @retval RETURN_UNSUPPORTED        QEMU's fw_cfg is not supported.
++
++  @retval RETURN_NOT_FOUND          Empty or nonexistent "opt/eve.bootorder" fw_cfg
++                                    file.
++
++  @retval RETURN_INVALID_PARAMETER  Parse error in the "opt/eve.bootorder" fw_cfg file.
++
++  @retval RETURN_OUT_OF_RESOURCES   Memory allocation failed.
++
++  @return                           Error statuses propagated from underlying
++                                    functions.
++**/
++RETURN_STATUS
++EFIAPI
++SetBootOrderFromEve (
++  VOID
++  );
++
++#endif
+diff --git a/OvmfPkg/Library/EveBootOrderLib/EveBootOrderLib.c b/OvmfPkg/Library/EveBootOrderLib/EveBootOrderLib.c
+new file mode 100644
+index 0000000000..33b37f86a4
+--- /dev/null
++++ b/OvmfPkg/Library/EveBootOrderLib/EveBootOrderLib.c
+@@ -0,0 +1,159 @@
++/** @file
++  Rewrite the BootOrder NvVar based on EVE-OS "opt/eve.bootorder" fw_cfg file.
++
++  Copyright (C) 2012 - 2014, Red Hat, Inc.
++  Copyright (c) 2013 - 2016, Intel Corporation. All rights reserved.<BR>
++  Copyright (C) 2025 Zededa, Inc.
++
++  SPDX-License-Identifier: BSD-2-Clause-Patent
++**/
++
++#include <Library/QemuFwCfgLib.h>
++#include <Library/DebugLib.h>
++#include <Library/MemoryAllocationLib.h>
++#include <Library/UefiBootManagerLib.h>
++#include <Library/UefiBootServicesTableLib.h>
++#include <Library/UefiRuntimeServicesTableLib.h>
++#include <Library/BaseLib.h>
++#include <Library/PrintLib.h>
++#include <Library/DevicePathLib.h>
++#include <Library/EveBootOrderLib.h>
++#include <Library/BaseMemoryLib.h>
++#include <Guid/GlobalVariable.h>
++#include <Guid/VirtioMmioTransport.h>
++
++/**
++  A simple array of Boot Option ID's.
++**/
++typedef struct {
++  UINT16 *Data;
++  UINTN  Allocated;
++  UINTN  Produced;
++} BOOT_ORDER;
++
++
++/**
++  Check if a DevicePath is an USB Device
++**/
++STATIC
++  BOOLEAN
++IsUSBDevice (
++  IN EFI_DEVICE_PATH_PROTOCOL *DevicePath
++  )
++{
++  EFI_DEVICE_PATH_PROTOCOL *Node;
++
++  for (Node = DevicePath; !IsDevicePathEnd(Node); Node = NextDevicePathNode(Node)) {
++    if (DevicePathType(Node) == MESSAGING_DEVICE_PATH &&
++       ((DevicePathSubType(Node) == MSG_USB_DP ||
++         DevicePathSubType(Node) == MSG_USB_CLASS_DP))) {
++        return TRUE;
++    }
++  }
++
++  return FALSE;
++}
++
++/**
++
++  Attempt to retrieve the "opt/eve.bootorder" fw_cfg file from QEMU. In
++  case the file is found, set the boot order based on configuration
++  retrieved from QEMU for EVE-OS.
++
++
++  @retval RETURN_SUCCESS            The "opt/eve.bootorder" fw_cfg file has been
++                                    parsed, and the referenced device-subtrees
++                                    have been connected.
++
++  @retval RETURN_UNSUPPORTED        QEMU's fw_cfg is not supported.
++
++  @retval RETURN_NOT_FOUND          Empty or nonexistent "opt/eve.bootorder" fw_cfg
++                                    file.
++
++  @retval RETURN_INVALID_PARAMETER  Parse error in the "opt/eve.bootorder" fw_cfg file.
++
++  @retval RETURN_OUT_OF_RESOURCES   Memory allocation failed.
++
++  @return                           Error statuses propagated from underlying
++                                    functions.
++**/
++RETURN_STATUS
++EFIAPI
++SetBootOrderFromEve (
++  VOID
++  )
++{
++  RETURN_STATUS                    Status;
++  BOOT_ORDER                       BootOrder;
++  EFI_BOOT_MANAGER_LOAD_OPTION     *BootOptions;
++  UINTN                            BootOptionCount;
++  UINT16                           BootOptionAux;
++  UINT16                           UsbPos;
++
++  DEBUG ((DEBUG_ERROR, "%a: Force prioritize USB devices for Boot\n", __FUNCTION__));
++
++  // Load boot options
++  BootOptions = EfiBootManagerGetLoadOptions (
++      &BootOptionCount, LoadOptionTypeBoot
++      );
++  if (BootOptions == NULL) {
++    return RETURN_NOT_FOUND;
++  }
++
++  // Create an array for boot order
++  BootOrder.Produced  = BootOptionCount;
++  BootOrder.Allocated = BootOptionCount;
++  BootOrder.Data = AllocatePool (
++      BootOrder.Allocated * sizeof (*BootOrder.Data)
++      );
++  if (BootOrder.Data == NULL) {
++    Status = RETURN_OUT_OF_RESOURCES;
++    goto ErrorFreeBootOptions;
++  }
++  // Store the current boot sequence (indexes)
++  for (UINTN Index = 0; Index < BootOptionCount; Index++) {
++    BootOrder.Data[Index] = BootOptions[Index].OptionNumber;
++  }
++
++  // TODO: This is a partial implementation, for now it will only
++  // prioritize USB devices in the boot list.
++  // Search for USB devices and move them to the top of the list
++  UsbPos = 0;
++  for (UINTN Index = 0; Index < BootOptionCount; Index++) {
++    if (IsUSBDevice(BootOptions[Index].FilePath)) {
++      BootOptionAux          = BootOrder.Data[UsbPos];
++      BootOrder.Data[UsbPos] = BootOrder.Data[Index];
++      BootOrder.Data[Index]  = BootOptionAux;
++      UsbPos++;
++    }
++  }
++
++  //
++  // See Table 10 in the UEFI Spec 2.3.1 with Errata C for the required
++  // attributes.
++  //
++  Status = gRT->SetVariable (
++      L"BootOrder",
++      &gEfiGlobalVariableGuid,
++      EFI_VARIABLE_NON_VOLATILE |
++      EFI_VARIABLE_BOOTSERVICE_ACCESS |
++      EFI_VARIABLE_RUNTIME_ACCESS,
++      BootOrder.Produced * sizeof (*BootOrder.Data),
++      BootOrder.Data
++      );
++  if (EFI_ERROR (Status)) {
++    DEBUG ((DEBUG_ERROR, "%a: setting BootOrder: %r\n", __FUNCTION__,
++          Status));
++    goto ErrorFreeBootOrder;
++  }
++
++ DEBUG ((DEBUG_INFO, "%a: setting BootOrder: success\n", __FUNCTION__));
++
++ErrorFreeBootOrder:
++  FreePool (BootOrder.Data);
++
++ErrorFreeBootOptions:
++  EfiBootManagerFreeLoadOptions (BootOptions, BootOptionCount);
++
++  return Status;
++}
+diff --git a/OvmfPkg/Library/EveBootOrderLib/EveBootOrderLib.inf b/OvmfPkg/Library/EveBootOrderLib/EveBootOrderLib.inf
+new file mode 100644
+index 0000000000..5e11df7242
+--- /dev/null
++++ b/OvmfPkg/Library/EveBootOrderLib/EveBootOrderLib.inf
+@@ -0,0 +1,48 @@
++## @file
++#  Rewrite the BootOrder NvVar based on EVE's "opt/eve.bootorder" fw_cfg file.
++#
++#  Copyright (C) 2025 Zededa, Inc.
++#
++#  SPDX-License-Identifier: BSD-2-Clause-Patent
++#
++##
++
++[Defines]
++  INF_VERSION                    = 0x00010005
++  BASE_NAME                      = EveBootOrderLib
++  FILE_GUID                      = 1E8AB4B5-3497-11F0-9B0F-78AF08E0E8B3
++  MODULE_TYPE                    = DXE_DRIVER
++  VERSION_STRING                 = 1.0
++  LIBRARY_CLASS                  = EveBootOrderLib|DXE_DRIVER
++
++[Sources]
++  EveBootOrderLib.c
++
++[Packages]
++  MdePkg/MdePkg.dec
++  MdeModulePkg/MdeModulePkg.dec
++  OvmfPkg/OvmfPkg.dec
++
++[LibraryClasses]
++  QemuFwCfgLib
++  DebugLib
++  MemoryAllocationLib
++  UefiBootManagerLib
++  UefiBootServicesTableLib
++  UefiRuntimeServicesTableLib
++  BaseLib
++  PrintLib
++  DevicePathLib
++  BaseMemoryLib
++  OrderedCollectionLib
++
++[Guids]
++  gEfiGlobalVariableGuid
++  gVirtioMmioTransportGuid
++
++[Pcd]
++  gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut
++
++[Protocols]
++  gEfiDevicePathProtocolGuid                            ## CONSUMES
++  gEfiPciRootBridgeIoProtocolGuid                       ## CONSUMES
+diff --git a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+index 3c55ec9bd9..68131ef7fc 100644
+--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
++++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+@@ -1534,6 +1534,7 @@ PlatformBootManagerAfterConsole (
+ 
+   RemoveStaleFvFileOptions ();
+   SetBootOrderFromQemu ();
++  SetBootOrderFromEve ();
+ 
+   PlatformBmPrintScRegisterHandler ();
+ }
+diff --git a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.h b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.h
+index 8a581fa1f0..57cc3b9150 100644
+--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.h
++++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.h
+@@ -45,6 +45,7 @@ Abstract:
+ #include <Library/QemuFwCfgLib.h>
+ #include <Library/QemuFwCfgS3Lib.h>
+ #include <Library/QemuBootOrderLib.h>
++#include <Library/EveBootOrderLib.h>
+ 
+ #include <Protocol/Decompress.h>
+ #include <Protocol/PciIo.h>
+diff --git a/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf b/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+index e470b9a6a3..07ebce7758 100644
+--- a/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
++++ b/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+@@ -51,6 +51,7 @@
+   QemuFwCfgS3Lib
+   QemuLoadImageLib
+   QemuBootOrderLib
++  EveBootOrderLib
+   ReportStatusCodeLib
+   UefiLib
+   PlatformBmPrintScLib
+diff --git a/OvmfPkg/OvmfPkg.dec b/OvmfPkg/OvmfPkg.dec
+index 39ce7dd0c0..6c8954da16 100644
+--- a/OvmfPkg/OvmfPkg.dec
++++ b/OvmfPkg/OvmfPkg.dec
+@@ -69,6 +69,11 @@
+   #
+   QemuBootOrderLib|Include/Library/QemuBootOrderLib.h
+ 
++  ##  @libraryclass  Rewrite the BootOrder NvVar based on EVE-OS
++  #                  "opt/eve.bootorder" fw_cfg file.
++  #
++  EveBootOrderLib|Include/Library/EveBootOrderLib.h
++
+   ##  @libraryclass  Load a kernel image and command line passed to QEMU via
+   #                  the command line
+   #
+diff --git a/OvmfPkg/OvmfPkgX64.dsc b/OvmfPkg/OvmfPkgX64.dsc
+index f8cc0c7c7a..c7cccc9caf 100644
+--- a/OvmfPkg/OvmfPkgX64.dsc
++++ b/OvmfPkg/OvmfPkgX64.dsc
+@@ -371,6 +371,7 @@
+   PlatformBootManagerLib|OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+   PlatformBmPrintScLib|OvmfPkg/Library/PlatformBmPrintScLib/PlatformBmPrintScLib.inf
+   QemuBootOrderLib|OvmfPkg/Library/QemuBootOrderLib/QemuBootOrderLib.inf
++  EveBootOrderLib|OvmfPkg/Library/EveBootOrderLib/EveBootOrderLib.inf
+   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
+ !if $(SMM_REQUIRE) == TRUE
+   LockBoxLib|MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxDxeLib.inf
+diff --git a/OvmfPkg/OvmfXen.dsc b/OvmfPkg/OvmfXen.dsc
+index 3af0ee7054..0ec4e12b8b 100644
+--- a/OvmfPkg/OvmfXen.dsc
++++ b/OvmfPkg/OvmfXen.dsc
+@@ -310,6 +310,7 @@
+   PlatformBootManagerLib|OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+   PlatformBmPrintScLib|OvmfPkg/Library/PlatformBmPrintScLib/PlatformBmPrintScLib.inf
+   QemuBootOrderLib|OvmfPkg/Library/QemuBootOrderLib/QemuBootOrderLib.inf
++  EveBootOrderLib|OvmfPkg/Library/EveBootOrderLib/EveBootOrderLib.inf
+   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
+   LockBoxLib|OvmfPkg/Library/LockBoxLib/LockBoxDxeLib.inf
+ !if $(SOURCE_DEBUG_ENABLE) == TRUE
+-- 
+2.47.2
+

--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-uefi:d821658883d6748d8bbf0d6640c62288e3ce8c6f as uefi-build
+FROM lfedge/eve-uefi:8bab7035e4b254ace0bd0dd182de2b1588b94355 as uefi-build
 
 FROM lfedge/eve-alpine:1f7685f95a475c6bbe682f0b976f12180b6c8726 as runx-build
 ENV BUILD_PKGS mkinitfs gcc musl-dev e2fsprogs chrony agetty


### PR DESCRIPTION
# Description

Backport of #4848

Note that the commits of this PR weren't cherry-picked from master because EDK2 version from master is newer than the one present in EVE 13.4-stable, so the code developed for EDK2 was adapted.

## How to test and validate this PR

- Flash an USB Stick with an UEFI bootable image, e.g., an Ubuntu installer or live-image, etc...
- Plug the USB Stick into the Edge Device
- Deploy an Edge App VM with FML virtualization mode (to get UEFI support) passing through the USB Stick (or the whole USB controller) to the Edge App VM
- Open VNC console and check that the VM booted from the USB Stick. Note that the USB Stick must be present at the initialization of the VM to ensure it will be available during boot

## Changelog notes

Add support to UEFI firmware to prioritize boot from USB devices passed-through to Edge App VMs.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template ([<stable-branch>] Original's PR Title)
