### PR TITLE
Revert "Makefile: Use Go builder container to build get-deps"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -490,14 +490,13 @@ $(DOCKERFILE_FROM_CHECKER): $(DOCKERFILE_FROM_CHECKER_DIR)/*.go $(DOCKERFILE_FRO
 IGNORE_DOCKERFILE_HASHES_PKGS=alpine installer
 IGNORE_DOCKERFILE_HASHES_EVE_TOOLS=bpftrace-compiler
 
-IGNORE_DOCKERFILE_DOT_GO_DIR=$(shell find .go/ -name Dockerfile -exec echo "-i {}" \;)
 IGNORE_DOCKERFILE_HASHES_PKGS_ARGS=$(foreach pkg,$(IGNORE_DOCKERFILE_HASHES_PKGS),-i pkg/$(pkg)/Dockerfile)
 IGNORE_DOCKERFILE_HASHES_EVE_TOOLS_ARGS=$(foreach tool,$(IGNORE_DOCKERFILE_HASHES_EVE_TOOLS),$(addprefix -i ,$(shell find eve-tools/$(tool) -path '*/vendor' -prune -o -name Dockerfile -print)))
 
 .PHONY: check-docker-hashes-consistency
 check-docker-hashes-consistency: $(DOCKERFILE_FROM_CHECKER)
 	@echo "Checking Dockerfiles for inconsistencies"
-	$(DOCKERFILE_FROM_CHECKER) ./ $(IGNORE_DOCKERFILE_HASHES_PKGS_ARGS) $(IGNORE_DOCKERFILE_HASHES_EVE_TOOLS_ARGS) $(IGNORE_DOCKERFILE_DOT_GO_DIR)
+	$(DOCKERFILE_FROM_CHECKER) ./ $(IGNORE_DOCKERFILE_HASHES_PKGS_ARGS) $(IGNORE_DOCKERFILE_HASHES_EVE_TOOLS_ARGS)
 
 yetus:
 	@echo Running yetus
@@ -760,8 +759,8 @@ ifeq ($(ROOTFS_FORMAT),squash)
 endif
 	$(QUIET): $@: Succeeded
 
-$(GET_DEPS): $(GOBUILDER)
-	$(QUIET)$(DOCKER_GO) "make" $(GET_DEPS_DIR)
+$(GET_DEPS):
+	$(MAKE) -C $(GET_DEPS_DIR) GOOS=$(LOCAL_GOOS)
 
 sbom_info:
 	@echo "$(SBOM)"


### PR DESCRIPTION
# Description

The new runners have all Go installed in the host, so no need to use our container (it will speed up get-deps execution).

This reverts commit e1c327a20245d0f4e7f1a43b5aaba22ed0b4d7b7.

## PR dependencies

None.

## How to test and validate this PR

Run `make` and check that `get-deps` is built and executed, i.e., `pkg-deps.mk` file is created.

## Changelog notes

Use go installed on host to build get-deps again.

## PR Backports

- [ ] 14.5-stable
- [ ] 13.4-stable
- [ ] 11.0-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR