### PR TITLE
Reapply "Makefile: Use Go builder container to build get-deps"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -490,13 +490,14 @@ $(DOCKERFILE_FROM_CHECKER): $(DOCKERFILE_FROM_CHECKER_DIR)/*.go $(DOCKERFILE_FRO
 IGNORE_DOCKERFILE_HASHES_PKGS=alpine installer
 IGNORE_DOCKERFILE_HASHES_EVE_TOOLS=bpftrace-compiler
 
+IGNORE_DOCKERFILE_DOT_GO_DIR=$(shell find .go/ -name Dockerfile -exec echo "-i {}" \;)
 IGNORE_DOCKERFILE_HASHES_PKGS_ARGS=$(foreach pkg,$(IGNORE_DOCKERFILE_HASHES_PKGS),-i pkg/$(pkg)/Dockerfile)
 IGNORE_DOCKERFILE_HASHES_EVE_TOOLS_ARGS=$(foreach tool,$(IGNORE_DOCKERFILE_HASHES_EVE_TOOLS),$(addprefix -i ,$(shell find eve-tools/$(tool) -path '*/vendor' -prune -o -name Dockerfile -print)))
 
 .PHONY: check-docker-hashes-consistency
 check-docker-hashes-consistency: $(DOCKERFILE_FROM_CHECKER)
 	@echo "Checking Dockerfiles for inconsistencies"
-	$(DOCKERFILE_FROM_CHECKER) ./ $(IGNORE_DOCKERFILE_HASHES_PKGS_ARGS) $(IGNORE_DOCKERFILE_HASHES_EVE_TOOLS_ARGS)
+	$(DOCKERFILE_FROM_CHECKER) ./ $(IGNORE_DOCKERFILE_HASHES_PKGS_ARGS) $(IGNORE_DOCKERFILE_HASHES_EVE_TOOLS_ARGS) $(IGNORE_DOCKERFILE_DOT_GO_DIR)
 
 yetus:
 	@echo Running yetus


### PR DESCRIPTION

# Description
This reverts commit 78d62e8afdf0dc77a9ee18f66ec52518fc38b638 (https://github.com/lf-edge/eve/pull/4877), because $(IGNORE_DOCKERFILE_DOT_GO_DIR) is still needed for the dockerfile-from-scanner, otherwise it checks testdata of linuxkit and docker.

Keep running get-deps without docker

<!-- Clear description what this PR does and why it's needed -->

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

`make check-docker-hashes-consistency`


## Changelog notes



## PR Backports


- [ ] 14.5-stable



## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
