### PR TITLE
Set parent interface UP before bringing up VLAN subinterface

### DIFF
--- a/pkg/pillar/dpcreconciler/linuxitems/vlan.go
+++ b/pkg/pillar/dpcreconciler/linuxitems/vlan.go
@@ -165,6 +165,15 @@ func (c *VlanConfigurator) Create(ctx context.Context, item depgraph.Item) error
 		c.Log.Error(err)
 		return err
 	}
+	// Ensure the parent interface is set to UP before bringing up the VLAN subinterface.
+	// Otherwise, netlink.LinkSetUp(vlan) will return a "network is down" error.
+	err = netlink.LinkSetUp(parentLink)
+	if err != nil {
+		err = fmt.Errorf("failed to set parent interface %s UP: %v",
+			vlanCfg.ParentIfName, err)
+		c.Log.Error(err)
+		return err
+	}
 	err = netlink.LinkSetUp(vlan)
 	if err != nil {
 		err = fmt.Errorf("failed to set VLAN sub-interface %s UP: %v",


### PR DESCRIPTION
# Description

<!-- Clear description what this PR does and why it's needed -->

Ensure the parent interface is set to UP before bringing up a VLAN subinterface. Otherwise, `netlink.LinkSetUp(vlan)` returns a `network is down` error.

This issue hasn’t surfaced until now because in the performed VLAN tests:
- the parent ethernet interface was also used for untagged traffic and was therefore coincidentally brought UP beforehand, or
- the device was bootstrapped with a last-resort config, which brings all Ethernet interfaces UP.

However, when bootstrapping a device using a config that includes VLANs but does not use the parent interface directly (i.e. it is in L2-only mode), the VLAN setup fails with the `network is down` error because we forgot to bring the parent UP.

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

Onboard device using a Single-Use installer (with bootstrap config). Network configuration should include at least one physical interface with VLAN sub-interfaces. The physical interface should be used in L2-only mode (no Network object assigned, aka "VLANs-only" usage).
Check that once the bootstrap config is applied, the VLAN subinterfaces are in the UP state (previously they would be DOWN).
For example (notice `state UP`):

```
25074c84-3e1d-4d56-a655-0266615c14da:~# ip addr
//...
8: vlan101: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP qlen 1000
    link/ether 02:fe:22:1a:87:00 brd ff:ff:ff:ff:ff:ff
    inet 172.22.101.10/24 brd 172.22.101.255 scope global noprefixroute vlan101
       valid_lft forever preferred_lft forever
    inet6 fe80::4846:4eb:134e:4274/64 scope link 
       valid_lft forever preferred_lft forever

```

## Changelog notes

<!-- Short description to be included in the ChangeLog notes -->

Ensure parent interface is UP before bringing up VLAN subinterfaces

## PR Backports

- [x] 14.5-stable
- [x] 13.4-stable

Not 12.0-stable, mgmt VLANs are not yet supported in that version. 

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR