### PR TITLE
be sure to include config.img/grub.cfg override in installer

### DIFF
--- a/pkg/eve/installer/grub_installer.cfg
+++ b/pkg/eve/installer/grub_installer.cfg
@@ -63,3 +63,11 @@ if [ "$rootlabel" = "EVEISO" ]; then
       set_global rootfs_root "LABEL=$rootlabel rootimg=/rootfs_installer.img"
    fi
 fi
+
+# include config.img grub, if it exists
+if [ -f "($install_part)/config.img" ]; then
+      loopback loop1 "($install_part)/config.img"
+      if [ -f "(loop1)/grub.cfg" ]; then
+         source "(loop1)/grub.cfg"
+      fi
+fi

--- a/pkg/eve/installer/grub_installer.cfg
+++ b/pkg/eve/installer/grub_installer.cfg
@@ -57,10 +57,10 @@ probe --set rootlabel --label $root
 if [ "$rootlabel" = "EVEISO" ]; then
    if [ "$isnetboot" = "true" ]; then
       set_global initrd "/boot/initrd.img newc:/installer.iso:($install_part)/installer.iso" # add a simple custom initrd that will find the CD based on the label on the next line
-      set_global rootfs_root "/installer.iso rootimg=/rootfs_installer.img"
+      set_global rootfs_root "/installer.iso rootimg=/rootfs_installer.img rootaddmount=/config.img:/config.img"
    else
       set_global initrd "/boot/initrd.img" # add a simple custom initrd that will find the CD based on the label on the next line
-      set_global rootfs_root "LABEL=$rootlabel rootimg=/rootfs_installer.img"
+      set_global rootfs_root "LABEL=$rootlabel rootimg=/rootfs_installer.img rootaddmount=/config.img:/config.img"
    fi
 fi
 

--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -170,11 +170,11 @@ do_installer_raw() {
 # common base for other usages like do_installer_iso and do_installer_net
 create_installer_iso() {
   mkdir -p /installer_root
-  unsquashfs -f -d /installer_root /bits/installer.img 1>&2
+  cp /bits/installer.img /installer_root/
   if [ -e /bits/config.img ]; then
       cp /bits/config.img /installer_root/
   fi
-  tar -C /installer_root -cf - . | VOLUME_LABEL=EVEISO /make-efi installer
+  tar -C /installer_root -cf - . | VOLUME_LABEL=EVEISO IN_IMAGE=installer.img IN_FORMAT=squashfs /make-efi installer
   rm -rf /installer_root
 }
 

--- a/pkg/mkimage-iso-efi/initrd.sh
+++ b/pkg/mkimage-iso-efi/initrd.sh
@@ -8,9 +8,9 @@ mount -t proc none /proc
 mount -t sysfs none /sys
 mount -t devtmpfs none /dev
 
-# debug enabled?
+# debug enabled? Could be via `debug` or `eve_install_debug=<something>` parameter in cmdline
 # shellcheck disable=SC2002
-debug_param=$(cat /proc/cmdline | tr ' ' '\n' | grep '^debug$' | head -n 1)
+debug_param=$(tr ' ' '\n' < /proc/cmdline | grep -E '^debug$|^eve_install_debug(=|$)' | head -n 1)
 if [ -n "$debug_param" ]; then
     set -x
 fi
@@ -27,6 +27,11 @@ root_value=${root_param#root=}
 rootimg_param=$(cat /proc/cmdline | tr ' ' '\n' | grep '^rootimg=' | head -n 1)
 # remove the leading "root="  to get the actual value
 root_img=${rootimg_param#rootimg=}
+
+# Search for the rootaddmount= cmdline property
+# shellcheck disable=SC2002
+rootaddmount_param=$(cat /proc/cmdline | tr ' ' '\n' | grep '^rootaddmount=')
+# remove the leading "rootaddmount="  to get the actual value
 
 # Check if root_value is set
 if [ -z "$root_value" ]; then
@@ -94,6 +99,28 @@ if [ -n "$rootdev" ]; then
             # Mount the image and call switch_root
             mkdir -p /installer_root
             mount "$rootfsimg" /installer_root
+            # check if the rootaddmount parameter is set and add those mounts
+            if [ -n "$rootaddmount_param" ]; then
+                # remove the leading "rootaddmount=" to get the actual value
+                for mountpair in $rootaddmount_param; do
+                    mount=${mountpair#rootaddmount=}
+                    if [ -z "$mount" ]; then
+                        continue
+                    fi
+                    mount_source=$(echo "$mount" | cut -d':' -f1)
+                    mount_target=$(echo "$mount" | cut -d':' -f2)
+                    # make sure the mount target exists, after stripping leading slashes
+                    mount_target="${mount_target#/}"
+                    targetpath="/installer_root/$mount_target"
+                    mount_source="${mount_source#/}"
+                    sourcepath="/newroot/$mount_source"
+                    if [ ! -e "$sourcepath" ]; then
+                        echo "Source path $mount_source does not exist, skipping mount"
+                        continue
+                    fi
+                    mount --bind "${sourcepath}" "${targetpath}"
+                done
+            fi
             exec switch_root /installer_root /sbin/init
         else
             echo "$root_img image not found!"

--- a/pkg/mkimage-iso-efi/make-efi
+++ b/pkg/mkimage-iso-efi/make-efi
@@ -5,6 +5,9 @@
 #
 # The following env variables change the behaviour of this script
 #     DEBUG - makes this script verbose
+#     VOLUME_LABEL - sets the volume label of the ISO image
+#     IN_IMAGE - if set, the file to use as installer rootfs image, from inside the tar stream, rather than the entire stream to make a squashfs
+#     IN_FORMAT - format of the IN_IMAGE, to enable extracting elements from it; can be squashfs or raw
 
 set -e
 [ -n "$DEBUG" ] && set -x
@@ -23,19 +26,58 @@ mkdir -p $ROOTFS
 cd $ROOTFS
 bsdtar xzf -
 
+# BUSYBOXDIR will be used to extract busybox and its components for use in initrd
+BUSYBOXDIR=/var/busybox-$$
+mkdir -p $BUSYBOXDIR
+
 # Create and change to a working directory for the ISO image
 TMPDIR=/var/efiparts-$$
 mkdir -p $TMPDIR
 cd $TMPDIR
 
-# Some files must also be present at the rootfs of the boot device
-cp -r ${ROOTFS}/EFI .
-cp -r ${ROOTFS}/boot .
-mkdir -p ./etc
-cp -r ${ROOTFS}/etc/eve-release ./etc/
+# if IN_IMAGE is set, we will use that as the rootfs image rather than trying to construct it from the tar stream
+# anything else in the tar stream will be placed in the root of the ISO image
+if [ -n "$IN_IMAGE" ]; then
+   # save the contents
+   cp -r "${ROOTFS}/." .
+   # rename the IN_IMAGE to rootfs_installer.img
+   mv "${IN_IMAGE}" rootfs_installer.img
+   # Some files must also be present at the rootfs of the boot device
+   # extract any needed files
+   case "$IN_FORMAT" in
+      squashfs)
+         # extract the rootfs from the squashfs image
+         unsquashfs -d . rootfs_installer.img EFI
+         unsquashfs -d . rootfs_installer.img boot
+         unsquashfs -d ${BUSYBOXDIR} rootfs_installer.img bin lib
+         ;;
+      raw)
+         # extract the rootfs from the raw image
+         mkdir -p /mnt
+         mount -o loop,ro rootfs_installer.img /mnt
+         cp -r /mnt/boot .
+         cp -r /mnt/EFI .
+         cp -r /mnt/bin ${BUSYBOXDIR}/
+         cp -r /mnt/lib ${BUSYBOXDIR}/
+         umount ${ROOTFS}
+         ;;
+      *)
+         echo "Unknown IN_FORMAT: $IN_FORMAT"
+         exit 1
+         ;;
+   esac
+else
+   # Some files must also be present at the rootfs of the boot device
+   cp -r ${ROOTFS}/EFI .
+   cp -r ${ROOTFS}/boot .
+   cp -r ${ROOTFS}/bin ${BUSYBOXDIR}/
+   cp -r ${ROOTFS}/lib ${BUSYBOXDIR}/
+   mkdir -p ./etc
+   cp -r ${ROOTFS}/etc/eve-release ./etc/
 
-# Build a squashfs image for the installer rootfs
-mksquashfs $ROOTFS rootfs_installer.img -noappend -comp xz -no-recovery
+   # IN_IMAGE is not set, so we will create a squashfs rootfs from the tar stream
+   mksquashfs $ROOTFS rootfs_installer.img -noappend -comp xz -no-recovery
+fi
 
 # create a ISO with a EFI boot partition
 # Stuff it into a FAT filesystem, making it as small as possible.  511KiB
@@ -82,8 +124,8 @@ if [ ! -e boot/initrd.img ]; then
    (cd /tmp/initrd
    mkdir -p bin lib sbin etc proc sys newroot
    cp /initrd.sh init
-   cp "${ROOTFS}"/bin/busybox bin/
-   cp "${ROOTFS}"/lib/ld-musl* lib/
+   cp "${BUSYBOXDIR}"/bin/busybox bin/
+   cp "${BUSYBOXDIR}"/lib/ld-musl* lib/
    /bin/busybox --install -s /tmp/initrd/bin
    find . | cpio -H newc -o | gzip > /tmp/initrd.img)
    mv /tmp/initrd.img boot/initrd.img


### PR DESCRIPTION
# Description

When the installer was completely revamped in Sept 2024, beginning primarily with #4248 and several follow-ons, we missed the custom `grub.cfg`. Specifically, you were able to mount a directory with `grub.cfg` in it, and that would get included at install time. E.g. `docker run --rm -v /path/to/custom:/in lfedge/eve installer_iso`. Everything in `/path/to/custom` should be included in `config.img`. A `grub.cfg` in there should be sourced as part of the installer grub.

That works for building it, but it missed sourcing the `config.img/grub.cfg`.

This PR fixes it, so that the installer will source it if it finds `config.img` in which is `grub.cfg`.

## How to test and validate this PR

CI for general regressions.

This specific case of an override `grub.cfg` is being tested manually in 2 steps:

- [x] build an installer iso and check that the grub at various stages includes the "include" code. @deitch 
- [ ] build an installer iso with a custom `grub.cfg` mounted in, create an `installer.iso`, do an install and see that it correctly respects it. @zeljko-zededa

## Changelog notes

<!-- Short description to be included in the ChangeLog notes -->
fix: Installer properly respect custom grub.cfg

## PR Backports

- [ ] 14.5-stable
- [ ] 13.4-stable

