### PR TITLE
[12.0-stable] Actually use dnsmasq

### DIFF
--- a/pkg/dnsmasq/Dockerfile
+++ b/pkg/dnsmasq/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM lfedge/eve-alpine:9fb9b9cbf7d90066a70e4704d04a6fe248ff52bb as build
-ENV BUILD_PKGS gcc make patch libc-dev linux-headers tar xz
+ENV BUILD_PKGS gcc make patch libc-dev linux-headers tar xz coreutils
 RUN eve-alpine-deploy.sh
 
 ENV DNSMASQ_VERSION 2.91

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -116,7 +116,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build if [ "${TEST_TOOLS}" = "y" ]
 fi
 
 FROM lfedge/eve-fscrypt:68d40d7e70585669adef91279ba39dd134d3a15f as fscrypt
-FROM lfedge/eve-dnsmasq:3af908d86a95a627c729e09b1b125bf8de7fadcb as dnsmasq
+FROM lfedge/eve-dnsmasq:7e660e19281d9859a6ccacc5cc14156675c990cf as dnsmasq
 FROM lfedge/eve-gpt-tools:51ecda7bc185c655c1d0423228dc83e29d4c674d as gpttools
 
 # collector collects everything together and then does any processing like stripping binaries.


### PR DESCRIPTION
# Description

Actually use dnsmasq, the previous PR (https://github.com/lf-edge/eve/pull/4788) only bumped it up. Also fix show version number in dnsmasq.

original PR: https://github.com/lf-edge/eve/pull/4874

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

run EVE and call `/opt/zededa/bin/dnsmasq --version` in pillar container - version should be 2.91


## Changelog notes

Use dnsmasq 2.91 in pillar container




## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
