### PR TITLE
installer: Fix broken netboot

### DIFF
--- a/pkg/eve/installer/grub_installer.cfg
+++ b/pkg/eve/installer/grub_installer.cfg
@@ -57,7 +57,7 @@ probe --set rootlabel --label $root
 if [ "$rootlabel" = "EVEISO" ]; then
    if [ "$isnetboot" = "true" ]; then
       set_global initrd "/boot/initrd.img newc:/installer.iso:($install_part)/installer.iso" # add a simple custom initrd that will find the CD based on the label on the next line
-      set_global rootfs_root "/installer.iso"
+      set_global rootfs_root "/installer.iso rootimg=/rootfs_installer.img"
    else
       set_global initrd "/boot/initrd.img" # add a simple custom initrd that will find the CD based on the label on the next line
       set_global rootfs_root "LABEL=$rootlabel rootimg=/rootfs_installer.img"


### PR DESCRIPTION
# Description

The installer rootfs is now a squashfs image inside the ISO image, the kernel parameter with the image must also be present for netboot.

## PR dependencies

None.

## How to test and validate this PR

Build netboot installer, run it and ensure it's working.

- `make installer-net`
- `make run-installer-net`
- `make run-target`

## Changelog notes

Fix netboot for installer

## PR Backports

- [ ] 14.5-stable
- [ ] 13.4-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR