### PR TITLE
[13.4-stable] Fix IP single-stack options

### DIFF
--- a/pkg/pillar/dpcreconciler/genericitems/dhcpcd.go
+++ b/pkg/pillar/dpcreconciler/genericitems/dhcpcd.go
@@ -154,7 +154,7 @@ func (c *DhcpcdConfigurator) Create(ctx context.Context, item depgraph.Item) err
 		op, args := c.dhcpcdArgs(config)
 
 		// Start DHCP client.
-		if c.dhcpcdExists(client.AdapterIfName) {
+		if c.dhcpcdExists(client.AdapterIfName, config.Type) {
 			err := fmt.Errorf("dhcpcd for interface %s is already running", ifName)
 			c.Log.Error(err)
 			done(err)
@@ -168,7 +168,7 @@ func (c *DhcpcdConfigurator) Create(ctx context.Context, item depgraph.Item) err
 			return
 		}
 		// Wait for a bit then give up
-		for !c.dhcpcdExists(ifName) {
+		for !c.dhcpcdExists(ifName, config.Type) {
 			if time.Since(startTime) > dhcpcdStartTimeout {
 				err := fmt.Errorf("dhcpcd for interface %s failed to start in time",
 					ifName)
@@ -220,7 +220,7 @@ func (c *DhcpcdConfigurator) Delete(ctx context.Context, item depgraph.Item) err
 					c.Log.Errorf("dhcpcd release failed for interface %s: %v, elapsed time %v",
 						ifName, err, time.Since(startTime))
 				}
-				if !c.dhcpcdExists(ifName) {
+				if !c.dhcpcdExists(ifName, config.Type) {
 					break
 				}
 				if time.Since(startTime) > dhcpcdStopTimeout {
@@ -248,7 +248,7 @@ func (c *DhcpcdConfigurator) Delete(ctx context.Context, item depgraph.Item) err
 				done(err)
 				return
 			}
-			if !c.dhcpcdExists(ifName) {
+			if !c.dhcpcdExists(ifName, config.Type) {
 				c.Log.Noticef("dhcpcd for interface %s is gone after exit, elapsed time %v",
 					ifName, time.Since(startTime))
 				done(nil)
@@ -362,9 +362,19 @@ func (c *DhcpcdConfigurator) dhcpcdCmd(op string, extras []string,
 	return nil
 }
 
-func (c *DhcpcdConfigurator) dhcpcdExists(ifName string) bool {
+func (c *DhcpcdConfigurator) dhcpcdExists(ifName string, netType types.NetworkType) bool {
 	name := "/sbin/dhcpcd"
-	args := []string{"-P", ifName}
+	args := []string{"-P"}
+	// For --ipv4only and --ipv6only, dhcpcd adds PID filename suffix "-4" and "-6", respectively.
+	// "dhcpcd -P" therefore needs to know if these arguments are used to return the correct
+	// PID file name.
+	switch netType {
+	case types.NetworkTypeIpv4Only:
+		args = append(args, "--ipv4only")
+	case types.NetworkTypeIpv6Only:
+		args = append(args, "--ipv6only")
+	}
+	args = append(args, ifName)
 	out, err := base.Exec(c.Log, name, args...).CombinedOutput()
 	if err != nil {
 		err = fmt.Errorf("dhcpcd command %s failed: %w; output: %s",


### PR DESCRIPTION
# Description

<!-- Clear description what this PR does and why it's needed -->

The network types:

- `NetworkTypeIpv4Only`
- `NetworkTypeIpv6Only`

were introduced and implemented a long long time ago to enforce single-stack IP configurations
(either IPv4 or IPv6, not dual-stack). However, the parsing logic was never updated
to recognize them. As a result, zedagent marked such configs as invalid, and the NIM
microservice did not apply them. Moreover, there was a bug related to dhcpcd PID filepath
retrieval for the single-stack cases.

Backport of https://github.com/lf-edge/eve/pull/4736

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

Configure device management port with a Network of type `NetworkTypeIpv4Only` or `NetworkTypeIpv6Only`.
Check that the port obtains only IPv4 or IPv6 address and keeps connectivity with the cloud and does not report any errors for the network config.

## Changelog notes

Add support for single-stack network types `NetworkTypeIpv4Only` and `NetworkTypeIpv6Only`

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template (`[<stable-branch>] Original's PR Title`)
