### PR TITLE
github/workflows: Switch yetus actions to EVE custom yetus

### DIFF
--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Yetus
-        uses: apache/yetus-test-patch-action@0.15.1
+        uses: rene/yetus-test-patch-action@eve
         with:
           basedir: ./src
           buildtool: nobuild


### PR DESCRIPTION
# Description

This PR switches the yetus GitHub action from `apache/yetus-test-patch-action@0.15.1` to `rene/yetus-test-patch-action@eve`, the new action uses a yetus container prepared to check EVE's source code, having the libzfs installed on it.

In order to confirm it works, I did a fake PR changing zfs related code and pushed to two EVE repos: mine, which uses the new action, and to @europaul's repo, which uses the current one. Below are the results:

1. https://github.com/rene/eve/actions/runs/15412089583/job/43366209734?pr=62 (@rene's repo, working)
2. https://github.com/europaul/eve/actions/runs/15412164830?pr=1 (@europaul 's repo, failed)

Let's test this PR and use it as a temporary solution until we integrate the custom yetus container to EVE and the proper repositories (under LF-Edge).

## PR dependencies

None.

## How to test and validate this PR

Run GH yetus action.

## Changelog notes

Not required (infra change).

## PR Backports

Not needed for now. Let's first test this change.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR