### PR TITLE
docs: clarify Metadata Server access-limitations (Close #3956)

### DIFF
--- a/docs/CLOUD-INIT.md
+++ b/docs/CLOUD-INIT.md
@@ -4,9 +4,9 @@ EVE supports [cloud-init](https://cloudinit.readthedocs.io/en/latest/) for confi
 
 ## Support in VMs
 
-For VMs, EVE supports cloud-init configuration using the NoCloud datasource. With NoCloud, EVE manually provides both meta-data and user-data received from the controller to the VM. This is done by placing these files on a virtual CD-ROM in the form of an ISO image. Further EVE relies on the cloud-init system present in the ECO's VM image. Upon booting the VM instance, if a cloud-init installation is present, the system checks for these data files, and if found, processes the configurations or scripts defined in them.
+For VMs, EVE supports cloud-init configuration using the NoCloud datasource. With NoCloud, EVE manually provides both metadata and user-data received from the controller to the VM. This is done by placing these files on a virtual CD-ROM in the form of an ISO image. Further EVE relies on the cloud-init system present in the ECO's VM image. Upon booting the VM instance, if a cloud-init installation is present, the system checks for these data files, and if found, processes the configurations or scripts defined in them.
 
-For more information on the meta-data consult [ECO-METADATA.md](ECO-METADATA.md).
+For more information on the metadata service consult [ECO-METADATA.md](ECO-METADATA.md).
 
 ## Support in Containers
 
@@ -41,6 +41,6 @@ As opposed to the VM implementation, cloud-init in ECO containers does not rely 
 
 ## Versioning
 
-Both VM and container implementations support versioning of the user-data. This means that the cloud-init configuration is only reapplied if the version of the user-data has changed. The version is specified in the meta-data file in the `instance-id` field.
+Both VM and container implementations support versioning of the user-data. This means that the cloud-init configuration is only reapplied if the version of the user-data has changed. The version is specified in the metadata file in the `instance-id` field.
 
 If the controller implementation does not support versioning, the user-data will be reapplied each time the version of the `AppInstanceConfig` changes.

--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -9,7 +9,7 @@
 | timer.metric.interval  | integer in seconds | 60 | how frequently device reports metrics |
 | timer.metric.diskscan.interval  | integer in seconds | 300 | how frequently device should scan the disk for metrics |
 | timer.location.cloud.interval | integer in seconds | 1 hour | how frequently device reports geographic location information to controller |
-| timer.location.app.interval | integer in seconds | 20 | how frequently device reports geographic location information to applications (to local profile server and to other apps via meta-data server) |
+| timer.location.app.interval | integer in seconds | 20 | how frequently device reports geographic location information to applications (to local profile server and to other apps via metadata server) |
 | timer.ntpsources.interval | integer in seconds | 10 minutes | how frequently device forcibly reports information about NTP sources to which EVE has established a connection for the NTP synchronization. Requests are also sent to the controller if the list of NTP peers or NTP peer fields, such as mode, state, have changed. |
 | timer.send.timeout | timer in seconds | 120 | time for each http/send |
 | timer.dial.timeout | timer in seconds | 10 | maximum time allowed to establish connection |
@@ -55,7 +55,7 @@
 | netdump.enable | boolean | true | enable publishing of network diagnostics (as tgz archives to /persist/netdump) |
 | netdump.topic.preonboard.interval | integer in seconds | 1 hour | how frequently (in seconds) can be netdumps of the same topic published while device is not yet onboarded |
 | netdump.topic.postonboard.interval | integer in seconds | 1 day | how frequently (in seconds) can be netdumps of the same topic published after device has been onboarded |
-| netdump.topic.maxcount | integer | 10 | maximum number of netdumps that can be published for each topic. The oldest netdump is unpublished should a new netdump exceed the limit.
+| netdump.topic.maxcount | integer | 10 | maximum number of netdumps that can be published for each topic. The oldest netdump is unpublished should a new netdump exceed the limit. |
 | netdump.downloader.with.pcap | boolean | false | include packet captures inside netdumps for download requests. However, even if enabled, TCP segments carrying non-empty payload (i.e. content which is being downloaded) are excluded and the overall PCAP size is limited to 64MB. |
 | netdump.downloader.http.with.fieldvalue | boolean | false | include HTTP header field values in captured network traces for download requests (beware: may contain secrets, such as datastore credentials). |
 | network.switch.enable.arpsnoop | boolean | true | enable ARP Snooping on switch Network Instances |
@@ -68,7 +68,7 @@
 | goroutine.leak.detection.cooldown.minutes | integer (minutes) | 5 | Cooldown period in minutes after the leak detection is triggered. During this period, no stack traces are collected; only warning messages are logged. |
 | kubevirt.drain.timeout | integer | 24 | hours to allow kubernetes to drain a node |
 | memory-monitor.enabled | boolean | false | Enable external memory monitoring and memory pressure events handling |
-| debug.tui.loglevel | string | info | Set log level for EVE Text UI (TUI) monitor. Possible values are "OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE" and are case insensitive
+| debug.tui.loglevel | string | info | Set log level for EVE Text UI (TUI) monitor. Possible values are "OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE" and are case insensitive |
 | log.dedup.window.size | integer | 0 | The size of the log deduplicator's sliding window (in number of messages). See logging [docs](LOGGING.md#log-filtering-counting-and-deduplication) for details. If the window size is set to 0 (default), no deduplication is performed. |
 | log.count.filenames | string | "" | Comma-separated list of log's filenames to be counted and logged once instead of logging them every time. Example `/my-pkg/main.go:123,/other-pkg/code.go:42`. Empty string `""` doesn't filter anything out, however a single comma `","` will filter out all entries that don't have a filename field set (e.g. logs not coming from components written in Golang). See logging [docs](LOGGING.md#log-filtering-counting-and-deduplication) for details. |
 | log.filter.filenames | string | "" | Comma-separated list of log's filenames to be filtered out. Example `/my-pkg/main.go:123,/other-pkg/code.go:42`. Empty string `""` doesn't filter anything out, however a single comma `","` will filter out all entries that don't have a filename field set (e.g. logs not coming from components written in Golang). See logging [docs](LOGGING.md#log-filtering-counting-and-deduplication) for details. |
@@ -97,24 +97,24 @@ Additionally all log levels can be set to "none" to disable logging for the corr
 Furthermore, the "remote" log levels control which subset of the generated logs are sent to the controller.
 A corresponding "remote" log level can be set for each of the three components: EVE microservices, syslog, and kernel.
 
-| Name | Type | Default | Description |
-| ---- | ---- | ------- | ----------- |
-| debug.default.loglevel | string | debug | default level of logs produced by EVE microservices. Can be overwritten by agent.*agentname*.debug.loglevel. Uses logrus log levels as described here ["https://pkg.go.dev/github.com/sirupsen/logrus"]: panic, fatal, error, warning, info, debug and trace.
+| Name                          | Type | Default | Description |
+|-------------------------------| ---- | ------- | ----------- |
+| debug.default.loglevel        | string | debug | default level of logs produced by EVE microservices. Can be overwritten by agent.*agentname*.debug.loglevel. Uses logrus log levels as described here ["https://pkg.go.dev/github.com/sirupsen/logrus"]: panic, fatal, error, warning, info, debug and trace. |
 | debug.default.remote.loglevel | string | warning | default level of logs sent by EVE microservices to the controller. Can be overwritten by agent.*agentname*.debug.remote.loglevel. Uses logrus log levels as described here ["https://pkg.go.dev/github.com/sirupsen/logrus"]: panic, fatal, error, warning, info, debug and trace. |
-| debug.syslog.loglevel | string | info | level of the produced syslog messages. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
-| debug.syslog.remote.loglevel | string | info | level of the syslog messages sent to the controller. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
-| debug.kernel.loglevel | string | info | level of the produced kernel log messages. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
-| debug.kernel.remote.loglevel | string | info | level of the kernel log messages sent to the controller. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
-debug.tui.loglevel | string | info | Set log level for EVE Text UI (TUI) monitor. Possible values are "OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE" and are case insensitive
+| debug.syslog.loglevel         | string | info | level of the produced syslog messages. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
+| debug.syslog.remote.loglevel  | string | info | level of the syslog messages sent to the controller. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
+| debug.kernel.loglevel         | string | info | level of the produced kernel log messages. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
+| debug.kernel.remote.loglevel  | string | info | level of the kernel log messages sent to the controller. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
+| debug.tui.loglevel            | string | info | Set log level for EVE Text UI (TUI) monitor. Possible values are "OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE" and are case insensitive |
 
 In addition, there can be per-agent settings to overwrite the default log level set for EVE microservices.
 These use the same log levels as the default log level settings (logrus).
 The per-agent settings begin with "agent.*agentname*.*setting*":
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| agent.*agentname*.debug.loglevel | string | if set overrides debug.default.loglevel for this particular agent | (Legacy setting debug.*agentname*.loglevel still supported)
-| agent.*agentname*.debug.remote.loglevel | string | if set overrides debug.default.remote.loglevel for this particular agent | (Legacy setting debug.*agentname*.remote.loglevel)
+| Name | Type | Default | Description                                                    |
+| ---- | ---- |---------|----------------------------------------------------------------|
+| agent.*agentname*.debug.loglevel | string | if set overrides debug.default.loglevel for this particular agent        | (Legacy setting debug.*agentname*.loglevel still supported)    |
+| agent.*agentname*.debug.remote.loglevel | string | if set overrides debug.default.remote.loglevel for this particular agent | (Legacy setting debug.*agentname*.remote.loglevel)             |
 
 Right now the following agents support per-agent log level settings:
 

--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -6,8 +6,8 @@
 | app.fml.resolution | string | notset | Set system-wide value of forced resolution for applications running in FML mode, it can be one of [predefined](/pkg/pillar/types/global.go) FmlResolution* values. |
 | timer.config.interval | integer in seconds | 60 | how frequently device gets config |
 | timer.cert.interval | integer in seconds | 1 day (24*3600) | how frequently device checks for new controller certificates |
-| timer.metric.interval  | integer in seconds | 60 | how frequently device reports metrics |
-| timer.metric.diskscan.interval  | integer in seconds | 300 | how frequently device should scan the disk for metrics |
+| timer.metric.interval | integer in seconds | 60 | how frequently device reports metrics |
+| timer.metric.diskscan.interval | integer in seconds | 300 | how frequently device should scan the disk for metrics |
 | timer.location.cloud.interval | integer in seconds | 1 hour | how frequently device reports geographic location information to controller |
 | timer.location.app.interval | integer in seconds | 20 | how frequently device reports geographic location information to applications (to local profile server and to other apps via metadata server) |
 | timer.ntpsources.interval | integer in seconds | 10 minutes | how frequently device forcibly reports information about NTP sources to which EVE has established a connection for the NTP synchronization. Requests are also sent to the controller if the list of NTP peers or NTP peer fields, such as mode, state, have changed. |
@@ -43,7 +43,7 @@
 | maintenance.mode | "enabled" or "disabled" | "none" | don't run applications etc |
 | force.fallback.counter | integer | 0 | forces fallback to other image if counter is changed |
 | newlog.allow.fastupload | boolean | false | allow faster upload gzip logfiles to controller |
-| memory.apps.ignore.check | boolean | false | Ignore memory usage check for Apps|
+| memory.apps.ignore.check | boolean | false | Ignore memory usage check for Apps |
 | memory.vmm.limit.MiB | integer | 0 | Manually override how much overhead is allocated for each running VMM |
 | gogc.memory.limit.bytes | integer | 0 | Golang runtime soft memory limit, see details in API doc ["https://pkg.go.dev/runtime/debug#SetMemoryLimit"] |
 | gogc.percent | integer | 100 | Golang runtime garbage collector target percentage, see details in API doc ["https://pkg.go.dev/runtime/debug#SetGCPercent"] |
@@ -97,24 +97,24 @@ Additionally all log levels can be set to "none" to disable logging for the corr
 Furthermore, the "remote" log levels control which subset of the generated logs are sent to the controller.
 A corresponding "remote" log level can be set for each of the three components: EVE microservices, syslog, and kernel.
 
-| Name                          | Type | Default | Description |
-|-------------------------------| ---- | ------- | ----------- |
-| debug.default.loglevel        | string | debug | default level of logs produced by EVE microservices. Can be overwritten by agent.*agentname*.debug.loglevel. Uses logrus log levels as described here ["https://pkg.go.dev/github.com/sirupsen/logrus"]: panic, fatal, error, warning, info, debug and trace. |
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| debug.default.loglevel | string | debug | default level of logs produced by EVE microservices. Can be overwritten by agent.*agentname*.debug.loglevel. Uses logrus log levels as described here ["https://pkg.go.dev/github.com/sirupsen/logrus"]: panic, fatal, error, warning, info, debug and trace. |
 | debug.default.remote.loglevel | string | warning | default level of logs sent by EVE microservices to the controller. Can be overwritten by agent.*agentname*.debug.remote.loglevel. Uses logrus log levels as described here ["https://pkg.go.dev/github.com/sirupsen/logrus"]: panic, fatal, error, warning, info, debug and trace. |
-| debug.syslog.loglevel         | string | info | level of the produced syslog messages. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
-| debug.syslog.remote.loglevel  | string | info | level of the syslog messages sent to the controller. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
-| debug.kernel.loglevel         | string | info | level of the produced kernel log messages. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
-| debug.kernel.remote.loglevel  | string | info | level of the kernel log messages sent to the controller. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
-| debug.tui.loglevel            | string | info | Set log level for EVE Text UI (TUI) monitor. Possible values are "OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE" and are case insensitive |
+| debug.syslog.loglevel | string | info | level of the produced syslog messages. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
+| debug.syslog.remote.loglevel | string | info | level of the syslog messages sent to the controller. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
+| debug.kernel.loglevel | string | info | level of the produced kernel log messages. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
+| debug.kernel.remote.loglevel | string | info | level of the kernel log messages sent to the controller. System default loglevel string representation should be used as described here ["https://man7.org/linux/man-pages/man3/syslog.3.html"]: emerg, alert, crit, err, warning, notice, info, debug. |
+| debug.tui.loglevel | string | info | Set log level for EVE Text UI (TUI) monitor. Possible values are "OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE" and are case insensitive |
 
 In addition, there can be per-agent settings to overwrite the default log level set for EVE microservices.
 These use the same log levels as the default log level settings (logrus).
 The per-agent settings begin with "agent.*agentname*.*setting*":
 
-| Name | Type | Default | Description                                                    |
-| ---- | ---- |---------|----------------------------------------------------------------|
-| agent.*agentname*.debug.loglevel | string | if set overrides debug.default.loglevel for this particular agent        | (Legacy setting debug.*agentname*.loglevel still supported)    |
-| agent.*agentname*.debug.remote.loglevel | string | if set overrides debug.default.remote.loglevel for this particular agent | (Legacy setting debug.*agentname*.remote.loglevel)             |
+| Name | Type | Default | Description |
+| ---- | ---- |---------|------------ |
+| agent.*agentname*.debug.loglevel | string | if set overrides debug.default.loglevel for this particular agent | (Legacy setting debug.*agentname*.loglevel still supported) |
+| agent.*agentname*.debug.remote.loglevel | string | if set overrides debug.default.remote.loglevel for this particular agent | (Legacy setting debug.*agentname*.remote.loglevel) |
 
 Right now the following agents support per-agent log level settings:
 

--- a/docs/ECO-METADATA.md
+++ b/docs/ECO-METADATA.md
@@ -10,7 +10,7 @@ The initial metadata service provides merely that, but over time we expect to ad
 
 ## Access Limitation
 
-The metadata server endpoints (e.g. <http://169.254.169.254/eve/v1/network.json> and <http://169.254.169.254/eve/v1/external_ipv4> are only accessible over a **local network instance** (the built-in host-NAT network). These endpoints are **not** available if the app or VM is running on a "switch network" or an "app-direct" network.
+The metadata server endpoints (e.g. <http://169.254.169.254/eve/v1/network.json> and <http://169.254.169.254/eve/v1/external_ipv4>) are only accessible over a **local network instance** (the built-in host-NAT network). These endpoints are **not** available if the app or VM is running on a "switch network" or an "app-direct" network.
 
 *See "Networking Modes" in the main EVE architecture guide for more details on local vs. switch/app-direct network.*
 
@@ -18,7 +18,7 @@ The metadata server endpoints (e.g. <http://169.254.169.254/eve/v1/network.json>
 
 There is no existing industry standard schema specifying a notion of an external IP; existing schemas contain public and private IP addresses but the external IP is a different thing necessitated by the internal NAT which EVE deploys for the local network instances.
 
-Thus this particular part of the metadata uses a EVE-unique schema, which we do not expect for other meta-data information.
+Thus this particular part of the metadata uses an EVE-unique schema, which we do not expect for other meta-data information.
 
 The API endpoint is <http://169.254.169.254/eve/v1/network.json>
 

--- a/docs/ECO-METADATA.md
+++ b/docs/ECO-METADATA.md
@@ -1,18 +1,24 @@
-# EVE meta-data server for app instances
+# EVE metadata server for app instances
 
-EVE provides an old method to serve cloud-init meta-data in the form of a read-only CDROM disk which is created on the fly when an app instance is booted if the API specifies userData/cipherData in the [AppInstanceConfig message](https://github.com/lf-edge/eve-api/tree/main/proto/config/appconfig.proto).
+EVE provides an old method to serve cloud-init metadata in the form of a read-only CDROM disk which is created on the fly when an app instance is booted if the API specifies userData/cipherData in the [AppInstanceConfig message](https://github.com/lf-edge/eve-api/tree/main/proto/config/appconfig.proto).
 
-However, there is also a need to provide access to meta-data which might change while the app instance is running.
+However, there is also a need to provide access to metadata which might change while the app instance is running.
 
 The first data which is needed by applications is determining the external IP address of the edge node, so that when there is a portmap ACL in place the application instance can determine which IP plus port its peers should use to connect to it.
 
-The initial meta-data service provides merely that, but over time we expect to add the rest of the cloud-init content.
+The initial metadata service provides merely that, but over time we expect to add the rest of the cloud-init content.
+
+## Access Limitation
+
+The metadata server endpoints (e.g. <http://169.254.169.254/eve/v1/network.json> and <http://169.254.169.254/eve/v1/external_ipv4> are only accessible over a **local network instance** (the built-in host-NAT network). These endpoints are **not** available if the app or VM is running on a "switch network" or an "app-direct" network.
+
+*See "Networking Modes" in the main EVE architecture guide for more details on local vs. switch/app-direct network.*
 
 ## Schema
 
 There is no existing industry standard schema specifying a notion of an external IP; existing schemas contain public and private IP addresses but the external IP is a different thing necessitated by the internal NAT which EVE deploys for the local network instances.
 
-Thus this particular part of the meta-data uses a EVE-unique schema, which we do not expect for other meta-data information.
+Thus this particular part of the metadata uses a EVE-unique schema, which we do not expect for other meta-data information.
 
 The API endpoint is <http://169.254.169.254/eve/v1/network.json>
 
@@ -29,7 +35,7 @@ The returned json contains
 - enterprise-id: a string with the id of the enterprise the device is associated with
 - enterprise-name: a string with the name of the enterprise the device is associated with
 
-Note that there is no need to specify the application instance identity since the meta-data server in EVE determines that from the virtual network adapter the application instance is using to communicate with EVE.
+Note that there is no need to specify the application instance identity since the metadata server in EVE determines that from the virtual network adapter the application instance is using to communicate with EVE.
 
 ## Example usage
 
@@ -54,7 +60,7 @@ curl <http://169.254.169.254/eve/v1/external_ipv4>
 
 ## Location API endpoint
 
-Meta-data service allows applications to obtain geographic coordinates of the device,
+Metadata service allows applications to obtain geographic coordinates of the device,
 determined using Global Navigation Satellite Systems. This is available only if device
 has a supported LTE modem with an integrated GNSS receiver (e.g. Sierra Wireless EM7565).
 Standalone GPS receivers are currently not supported.
@@ -122,7 +128,7 @@ coordinates presented to applications are never older than 20 seconds.
 
 ## Cellular connectivity metadata
 
-Using meta-data server, applications are able to request information about the current state
+Using metadata server, applications are able to request information about the current state
 of the cellular connectivity of the device. This covers all wireless wide area networks (WWANs)
 configured for the device, with information about the installed cellular equipment (modem(s)
 and SIM card(s)), identity information (IMEI, IMSI, ICCID), available network providers (PLMNs),

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -78,7 +78,7 @@ EVE provides 2 types of network instances:
   - traffic between apps and external endpoints is routed and NATed
   - from outside, applications can be accessed only through port forwarding rules
   - provides basic services like: DHCP (with its own IPAM), DNS, access-control,
-    HTTP metadata server (e.g. for cloud-init)
+    HTTP metadata server (e.g. for cloud-init) (For more information on the meta-data service consult [ECO-METADATA.md](ECO-METADATA.md))
   - one or more network ports can be attached to network instance to provide
     external connectivity
 - **Switch**:

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -78,7 +78,7 @@ EVE provides 2 types of network instances:
   - traffic between apps and external endpoints is routed and NATed
   - from outside, applications can be accessed only through port forwarding rules
   - provides basic services like: DHCP (with its own IPAM), DNS, access-control,
-    HTTP metadata server (e.g. for cloud-init) (For more information on the meta-data service consult [ECO-METADATA.md](ECO-METADATA.md))
+    HTTP metadata server (e.g. for cloud-init) (For more information on the metadata service consult [ECO-METADATA.md](ECO-METADATA.md))
   - one or more network ports can be attached to network instance to provide
     external connectivity
 - **Switch**:

--- a/docs/PATCH-ENVELOPES.md
+++ b/docs/PATCH-ENVELOPES.md
@@ -19,7 +19,7 @@ you don’t want to recreate VM image) or when downtime is not an option for you
 In EVE every App Instance connected to local network instances is exposed to Metadata server at
 `169.254.169.254`. It has bunch of useful endpoints, amongst them are patch envelope endpoints. So within
 App Instance one can access Patch Envelopes available to specific App Instance by getting description.json.
-This would return list of Patch Envelopes available to this App Instance.
+This would return list of Patch Envelopes available to this App Instance. (For more information on the metadata service consult [ECO-METADATA.md](ECO-METADATA.md).)
 
 ```bash
 curl -X GET -v http://169.254.169.254/eve/v1/patch/description.json
@@ -66,7 +66,7 @@ Flow diagram of the process is below
 
 ![process-flow](./images/eve-pe-process-flow.png)
 
-Full OpenAPI (Swagger) specification for patch envelope endpoint can be found [here](./api/patch-envelopes.yml).
+Full OpenAPI (Swagger) [specification for patch envelope endpoint can be found here](./api/patch-envelopes.yml).
 You can generate client from this specification and use it to develop your application.
 
 ## What types of Binary Artifacts are there?
@@ -94,8 +94,8 @@ Metadata server stores VolRef – volume references, which are changed to Binary
 once volumes are downloaded. Note that this process is async and it might take time.
 All communication in this process is done via PubSub. When AppInstance downloads inline
 object it’s served from Metadata server (zedrouter microservice). In case of external
-patch envelopes – Metadata serves file from volume. For more information on how it works
-in code refer [here](https://github.com/lf-edge/eve/blob/0a8b21ec5de3bf6a2613c2c6f2e2af7e353b1e98/pkg/pillar/cmd/zedrouter/patchenvelopes.go#L18C1-L47C88)
+patch envelopes – Metadata serves file from volume. For more information [on how envelopes works
+in code refer here](https://github.com/lf-edge/eve/blob/0a8b21ec5de3bf6a2613c2c6f2e2af7e353b1e98/pkg/pillar/cmd/zedrouter/patchenvelopes.go#L18C1-L47C88)
 
 ## Encryption/Description of patch envelopes data
 

--- a/docs/api/patch-envelopes.yml
+++ b/docs/api/patch-envelopes.yml
@@ -12,7 +12,9 @@ info:
 
 servers:
   - url: http://169.254.169.254/eve/v1
-    description: EVE Metadata endpoint
+    description: |
+      EVE Metadata server endpoint
+      **Access:** only via the *local network instance*. Not reachable over switch or app-direct networks.
 
 tags:
   - name: PatchEnvelopes

--- a/pkg/pillar/cmd/msrv/msrv.go
+++ b/pkg/pillar/cmd/msrv/msrv.go
@@ -6,6 +6,8 @@
 // parameters and download patch envelopes.
 // You can think of metadata server as a translator from pubsub to REST API for
 // Application Instances
+//
+// Limitation: only via local-access and not accessible over switch or app-direct networks.
 
 package msrv
 

--- a/pkg/pillar/cmd/msrv/patchenvelopes.go
+++ b/pkg/pillar/cmd/msrv/patchenvelopes.go
@@ -32,6 +32,8 @@ const PatchEnvelopeURLPath = "/eve/v1/patch/"
 // for more info check docs/PATCH-ENVELOPES.md
 // Must be created by calling NewPatchEnvelopes()
 //
+// Limitation: only via local-access and not accessible over switch or app-direct networks.
+//
 // Internally, PatchEnvelopes structure stores envelopes which
 // come from EdgeDevConfig parsed by zedagent. This envelopes contains
 // both inline binary artifacts which are ready to be downloaded by app instances


### PR DESCRIPTION
# Description

This PR resolves Issue #3956 by making it clearer that the EVE metadata server (`169.254.169.254/eve/v1/...`) is reachable **only** via **local-access** and **not** accessible over switch or app-direct networks. Six documentation files have been updated to standardize “metadata” terminology (making it easier to search for) with respect to Metadata Server, insert “See also” links, and explicitly call out access limitations:

- **docs/ECO-METADATA.md**  
  - Inserted a new “## Access Limitation” section under “EVE metadata server for app instances”
  - Standardized all occurrences of “meta-data” or “meta data” to **“metadata.”**

- **docs/CONFIG-PROPERTIES.md**  
  - Replaced every “meta-data” (or “meta data”) with **“metadata.”**  
  - Updated the `timer.location.app.interval` description

- **docs/CLOUD-INIT.md**  
  - Standardized “meta-data” to **“metadata.”**  

- **docs/NETWORKING.md**  
  - Fixed minor delinting issues
  - Standardized “meta-data” to **“metadata.”** 

- **docs/PATCH-ENVELOPES.md**  
  - Updated the reference to ECO-METADATA
  -   - Standardized “meta-data” to **“metadata.”** 

- **docs/api/patch-envelopes.yml**  
  - Updated the 'servers' block description to reflect local-access

**NOTE:** there is still inconsistent uses of "meta data", "meta-data", and "metadata" throughout the documentation. This only corrects the files affected by adding the documentation for Metadata Server. There also exists references as "Metadata HTTP Server" and "MSRV" elsewhere.

## PR dependencies

None

## How to test and validate this PR

Delint with 'markdownlint' and 'yamllint' on affected files

## Changelog notes

Clearer documentation that Metadata Server has local-access restriction.

## PR Backports

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)