### PR TITLE
Handle multiple file inconsistencies and error types in Docker check.

### DIFF
--- a/.github/workflows/check-docker-hashes-consistency.yml
+++ b/.github/workflows/check-docker-hashes-consistency.yml
@@ -68,11 +68,28 @@ jobs:
           fi
           echo "::endgroup::"
 
-          # surface specific mismatch line as an inline PR error
-          if grep -qE 'uses .*:.* but .* is built in this repo' "$log_file"; then
-            mismatch_line=$(grep -E 'uses .*:.* but .* is built in this repo' "$log_file")
-            dockerfile_path=$(awk '{print $1}' <<< "$mismatch_line")
-            echo "::error file=${dockerfile_path}::${mismatch_line}"
+          # If the checker failed, surface every error line as a PR annotation
+          if [ "$rc" -ne 0 ]; then
+            while IFS= read -r line; do
+              # Pattern 1:  <file> uses <image:tag> but <hash> is built in this repo
+              if [[ "$line" =~ ^([^[:space:]]+)\ uses\ .*is\ built\ in\ this\ repo$ ]]; then
+                file="${BASH_REMATCH[1]}"
+                echo "::error file=${file}::${line}"
+                continue
+              fi
+
+              # Pattern 2:  tags differ for image ... in files <file1> and <file2>
+              if [[ "$line" =~ ^tags\ differ\ for\ image\ .*\ in\ files\ ([^[:space:]]+)\ and\ ([^[:space:]]+)$ ]]; then
+                file1="${BASH_REMATCH[1]}"
+                file2="${BASH_REMATCH[2]}"
+                echo "::error file=${file1}::${line}"
+                echo "::error file=${file2}::${line}"
+                continue
+              fi
+
+              # Fallback: generic error not tied to a specific file
+              echo "::error ::${line}"
+            done < "$log_file"
             exit 1
           fi
 


### PR DESCRIPTION
## Description

This PR improves the Dockerfile hash consistency check in CI by enhancing the error detection logic and broadening its coverage. Previously, the workflow only reported a single mismatch line, which often hid other important inconsistencies. Additionally, not all types of errors were surfaced correctly, limiting the usefulness of GitHub annotations.

The updated lint job:

* Handles multiple mismatched files in a single run.
* Detects different types of hash mismatches and tag discrepancies.
* Emits detailed GitHub annotations for each affected file or line.
* Falls back to general annotations when an error cannot be tied to a specific file.

## PR dependencies
None.

## How to test and validate this PR
No additional test is needed as it's a GH linter fix.

## Changelog notes
No customer visible changes here.

## PR Backports
Not needed, the original feature was introduced not that long ago and not a part of the latest LTS (14.5)

## Checklist

- [ ]  I've provided a proper description
- [ ]  I've added the proper documentation (or not necessary)
- [ ]  I've tested my PR on amd64 device(s)
- [ ]  I've tested my PR on arm64 device(s)
- [ ]  I've written the test verification instructions
- [ ]  I've set the proper labels to this PR (or not necessary)