### PR TITLE
Fix broken regex in Docker hash check annotations

### DIFF
--- a/.github/workflows/check-docker-hashes-consistency.yml
+++ b/.github/workflows/check-docker-hashes-consistency.yml
@@ -70,20 +70,19 @@ jobs:
 
           # If the checker failed, surface every error line as a PR annotation
           if [ "$rc" -ne 0 ]; then
+            # Pattern 1: <file> uses <image:tag> but <hash> is built in this repo
+            pat_uses='^[[:space:]]*([^[:space:]]+)[[:space:]]+uses[[:space:]].*is[[:space:]]+built[[:space:]]+in[[:space:]]+this[[:space:]]+repo[[:space:]]*$'
+            # Pattern 2: tags differ for image ... in files <file1> and <file2>
+            pat_tags='^[[:space:]]*tags[[:space:]]+differ[[:space:]]+for[[:space:]]+image[[:space:]]+.+[[:space:]]+in[[:space:]]+files[[:space:]]+([^[:space:]]+)[[:space:]]+and[[:space:]]+([^[:space:]]+)[[:space:]]*$'
             while IFS= read -r line; do
-              # Pattern 1:  <file> uses <image:tag> but <hash> is built in this repo
-              if [[ "$line" =~ ^([^[:space:]]+)\ uses\ .*is\ built\ in\ this\ repo$ ]]; then
-                file="${BASH_REMATCH[1]}"
-                echo "::error file=${file}::${line}"
+              if [[ $line =~ $pat_uses ]]; then
+                echo "::error file=${BASH_REMATCH[1]}::${line}"
                 continue
               fi
 
-              # Pattern 2:  tags differ for image ... in files <file1> and <file2>
-              if [[ "$line" =~ ^tags\ differ\ for\ image\ .*\ in\ files\ ([^[:space:]]+)\ and\ ([^[:space:]]+)$ ]]; then
-                file1="${BASH_REMATCH[1]}"
-                file2="${BASH_REMATCH[2]}"
-                echo "::error file=${file1}::${line}"
-                echo "::error file=${file2}::${line}"
+              if [[ $line =~ $pat_tags ]]; then
+                echo "::error file=${BASH_REMATCH[1]}::${line}"
+                echo "::error file=${BASH_REMATCH[2]}::${line}"
                 continue
               fi
 


### PR DESCRIPTION
## Description

This PR corrects the regular expressions used in the Docker hash consistency GitHub workflow. The previous patterns failed to match expected error lines, which prevented GitHub from surfacing per-file annotations.

## PR dependencies

None.

## How to test and validate this PR
No additional testing is required. The fix applies to CI lint logic only.
But I DID THE TEST of the regexp this time!!!

## Changelog notes
No user-facing changes. Internal CI improvement only.

## PR Backports
Not needed. The issue exists only in recent non-LTS branches.

## Checklist

- [x]  I've provided a proper description
- [x]  I've added the proper documentation (or not necessary)
- [x]  I've tested my PR on amd64 device(s)
- [ ]  I've tested my PR on arm64 device(s)
- [x]  I've written the test verification instructions
- [x]  I've set the proper labels to this PR (or not necessary)