### PR TITLE
Remove non-hash-related error annotations in hash check

### DIFF
--- a/.github/workflows/check-docker-hashes-consistency.yml
+++ b/.github/workflows/check-docker-hashes-consistency.yml
@@ -78,7 +78,6 @@ jobs:
                 echo "::error file=${BASH_REMATCH[2]}::${line}"
                 continue
               fi
-              echo "::error ::${line}"
             done < "$log_file"
             exit 1
           fi


### PR DESCRIPTION
## Description
This PR refines the Docker hash consistency check by removing fallback annotations for generic errors without file context. Previously, all errors, including those unrelated to hash mismatches, were annotated, which created unnecessary noise in GitHub Actions outputs.

## PR dependencies
None.

## How to test and validate this PR
No need for external testing, as it's just a tooling change. 

## Changelog notes
No user-facing changes. Improves signal quality in internal CI annotations.

## PR Backports
Not needed. Only applies to the current CI logic.

## Checklist

- [ ]  I've provided a proper description
- [ ]  I've added the proper documentation (or not necessary)
- [ ]  I've tested my PR on amd64 device(s)
- [ ]  I've tested my PR on arm64 device(s)
- [ ]  I've written the test verification instructions
- [ ]  I've set the proper labels to this PR (or not necessary)