### PR TITLE
[11.0-stable] github/workflows: Do not use assets action from master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -159,6 +159,6 @@ jobs:
   trigger_assets:
     if: ${{ (startsWith(github.ref, 'refs/tags/')) && (github.event.repository.full_name == 'lf-edge/eve') }}
     needs: [manifest, verification, eve]
-    uses: lf-edge/eve/.github/workflows/assets.yml@master
+    uses: lf-edge/eve/.github/workflows/assets.yml@11.0-stable
     with:
       tag_ref: ${{ github.ref }}


### PR DESCRIPTION
# Description

The assets action from master has different builds for newer platform variants, so change publish workflow to use assets from 11.0-stable branch.

## PR dependencies

None.

## How to test and validate this PR

Run GitHub publishing workflow.

## Changelog notes

Infra change. Not required.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [x] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR