### PR TITLE
[11.0-stable] github/workflows: Fix eve image TAG

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -64,7 +64,7 @@ jobs:
           git fetch --force --tags
       - name: Determine architecture prefix and ref
         env:
-          REF: ${{ inputs.tag_ref }}
+          REF: ${{ github.ref }}
         run: |
           # FIXME: I'd rather be a real matrix job with a functional arm64 runner
           # echo "ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')" >> "$GITHUB_ENV"
@@ -81,7 +81,7 @@ jobs:
         run: |
           HV=kvm
           if [ "${{ github.event.repository.full_name }}" = "lf-edge/eve" ]; then
-             EVE=lfedge/eve:${{ inputs.tag_ref }}-${HV}-${{ env.ARCH }}
+             EVE=lfedge/eve:${TAG}-${HV}-${{ env.ARCH }}
              docker pull "$EVE"
           else
              make pkgs


### PR DESCRIPTION
# Description

Fix the TAG to be used with EVE image published on dockerhub. This issue wasn't noticed before because 11.0-stable was using assets from master.

## PR dependencies

None.

## How to test and validate this PR

Run GitHub CI/CD.

## Changelog notes

Infra change. Not required.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR