### PR TITLE
[11.0-stable] fix: volumemgr: update VRS every time VS changes

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlevolumeref.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolumeref.go
@@ -93,14 +93,17 @@ func handleVolumeRefModify(ctxArg interface{}, key string,
 	vs := ctx.LookupVolumeStatus(config.VolumeKey())
 	if vs != nil {
 		if needUpdateVol {
-			doUpdateVol(ctx, vs)
+			changed, _ := doUpdateVol(ctx, vs)
+			if changed {
+				publishVolumeStatus(ctx, vs)
+				updateVolumeRefStatus(ctx, vs)
+				if err := createOrUpdateAppDiskMetrics(ctx, vs); err != nil {
+					log.Errorf("handleVolumeRefModify(%s): exception while publishing diskmetric. %s",
+						status.Key(), err.Error())
+				}
+			}
 		}
 		updateVolumeStatusRefCount(ctx, vs)
-		publishVolumeStatus(ctx, vs)
-		if err := createOrUpdateAppDiskMetrics(ctx, vs); err != nil {
-			log.Errorf("handleVolumeRefModify(%s): exception while publishing diskmetric. %s",
-				status.Key(), err.Error())
-		}
 	}
 	log.Functionf("handleVolumeRefModify(%s) Done", key)
 }
@@ -169,6 +172,8 @@ func unpublishVolumeRefStatus(ctx *volumemgrContext, key string) {
 }
 
 func updateVolumeRefStatus(ctx *volumemgrContext, vs *types.VolumeStatus) {
+
+	log.Functionf("updateVolumeRefStatus(%s)", vs.Key())
 	sub := ctx.subVolumeRefConfig
 	items := sub.GetAll()
 	for _, st := range items {
@@ -229,4 +234,5 @@ func updateVolumeRefStatus(ctx *volumemgrContext, vs *types.VolumeStatus) {
 			publishVolumeRefStatus(ctx, status)
 		}
 	}
+	log.Functionf("updateVolumeRefStatus(%s) Done", vs.Key())
 }


### PR DESCRIPTION
# Description

Backport of #4498 

## How to test and validate this PR

1. Created an edge-app with 2 images (1. OS image, 2. data Volume).
2. In the edge-app, configured the storage for each images as close the device storage (Ex: if the device storage is 1GB then 500 MB each).
3. Then, deployed the edge-app instance on the node. Verify the app instance moves to Error state because of the storage issue.

## Changelog notes

Make sure volumes react properly to the changes in volume config.

## Checklist

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template ([<stable-branch>] Original's PR Title)
