### PR TITLE
Makefile: Fix eve release string for push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,16 +371,16 @@ ifeq ($(LINUXKIT_PKG_TARGET),push)
   # only builds from master branch are allowed to be called snapshots
   # everything else gets tagged with a branch name itself UNLESS
   # we're building off of a annotated tag
-  EVE_REL_$(REPO_BRANCH)_$(REPO_TAG):=$(REPO_TAG)
+  EVE_REL_$(REPO_BRANCH)_$(REPO_TAG):=$(if $(TAGPLAT),$(REPO_TAG)-$(TAGPLAT),$(REPO_TAG))
   EVE_REL_$(REPO_BRANCH)_snapshot:=$(REPO_BRANCH)
-  EVE_REL_master_snapshot:=snapshot
+  EVE_REL_master_snapshot:=$(if $(TAGPLAT),$(TAGPLAT)-snapshot,snapshot)
   EVE_REL:=$(EVE_REL_$(REPO_BRANCH)_$(REPO_TAG))
 
   # the only time we rebuild everything from scratch is when we're building 'latest' release
   # in order to achieve that we have to force EVE_HASH to be the release version
   ifeq ($(shell [ "`git tag | grep -E '[0-9]*\.[0-9]*\.[0-9]*' | sort -t. -n -k1,1 -k2,2 -k3,3 | tail -1`" = $(REPO_TAG) ] && echo latest),latest)
     EVE_HASH:=$(REPO_TAG)
-    EVE_REL:=latest
+    EVE_REL:=$(if $(TAGPLAT),$(TAGPLAT)-latest,latest)
   endif
 endif
 


### PR DESCRIPTION
# Description

The EVE_REL variable contains the release string to be used when pushing eve images. For a tagged release, e.g., 14.5.0, it translates to something like 14.5.0-kvm. However, it must also consider the platform variant, for instance:

For nvidia-jp6: 14.5.0-nvidia-jp6-kvm

Otherwise the final pushed image will overwrite any generic image already pushed to the registry.

## PR dependencies

None.

## How to test and validate this PR

Run Git Hub CI/CD.

## Changelog notes

This is basically infra change. Not required.

## PR Backports

- [x] 14.5-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
