### PR TITLE
Fix issues of Previous Edgeview Authentication Patch

### DIFF
--- a/pkg/edgeview/src/basics.go
+++ b/pkg/edgeview/src/basics.go
@@ -317,7 +317,8 @@ func getBasics() {
 
 	ips := []string{}
 	for _, i := range allUPIntfIPv4() {
-		if strings.HasPrefix(i.intfName, "bn") {
+		// exclude the interfaces that are not used for device management
+		if strings.HasPrefix(i.intfName, "bn") || strings.HasPrefix(i.intfName, "flannel") || i.intfName == "cni0" {
 			continue
 		}
 		ips = append(ips, i.ipAddr)

--- a/pkg/edgeview/src/crypto.go
+++ b/pkg/edgeview/src/crypto.go
@@ -245,7 +245,7 @@ func verifyEnvelopeData(data []byte, checkClientAuth bool) (bool, bool, []byte, 
 			}
 			log.Errorf("Signature is empty")
 			_ = addEnvelopeAndWriteWss([]byte("Edgeview requires client authentication signing by "+errTypeStr+verifyFailed), true, false)
-			return false, false, nil, keyComment
+			return true, false, nil, keyComment
 		}
 
 		var isValid bool
@@ -588,7 +588,11 @@ func signClientCertAuthenData(msg []byte, ecPrivateKey string) []byte {
 func loadPrivateKey(pemData string) (interface{}, error) {
 	block, _ := pem.Decode([]byte(pemData))
 	if block == nil || !strings.Contains(block.Type, "PRIVATE KEY") { // it can be "EC PRIVATE KEY" or "OPENSSH PRIVATE KEY"
-		return nil, errors.New("failed to decode PEM block containing private key certificate, type: " + block.Type)
+		blockType := "unknown"
+		if block != nil {
+			blockType = block.Type
+		}
+		return nil, errors.New("failed to decode PEM block containing private key certificate, type: " + blockType)
 	}
 
 	var privateKey interface{}

--- a/pkg/edgeview/src/edge-view.go
+++ b/pkg/edgeview/src/edge-view.go
@@ -44,7 +44,7 @@ const (
 	agentName       = "edgeview"
 	closeMessage    = "+++Done+++"
 	tarCopyDoneMsg  = "+++TarCopyDone+++"
-	edgeViewVersion = "0.8.4" // set the version now to 0.8.4
+	edgeViewVersion = "0.8.6" // set the version now to 0.8.6
 	cpLogFileString = "copy-logfiles"
 	clientIPMsg     = "YourEndPointIPAddr:"
 	serverRateMsg   = "ServerRateLimit:disable"


### PR DESCRIPTION
- fix an crash due to log message does not check and dereference to the block struct
- mistakenly up'ed an incorrect version for tarMinVersion while it should be edgeViewVersion
- this patch is partly moved from the PR #4934

# Description

Fix a possible crash in last PR #4762, the log message using dereference without check if Edgeview authentication is used

<!-- Clear description what this PR does and why it's needed -->

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

If we enable the edgeview authentication, using key pairs, and make sure even if the user does not supply the path to the correct private key, it won't generate the message causing the edgeview container to crash.

Also the last PR since changed the version incorrectly, cause the log/copy-logfiles operation to deny it due the version being mismatch.

Tested the above with local setup.

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

## Changelog notes

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [ x ] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [ x ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
