### PR TITLE
Support for ZKS service and ingress networking

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -7,11 +7,6 @@ ENV PKGS alpine-baselayout musl-utils iproute2 iptables curl openrc \
          cni-plugins nfs-utils
 RUN eve-alpine-deploy.sh
 
-# Remove unused CNI plugins
-RUN for plugin in bandwidth ipvlan macvlan ptp static vlan firewall sbr tuning vrf; do \
-        rm /out/usr/libexec/cni/${plugin}; \
-    done
-
 COPY eve-bridge /plugins/eve-bridge
 WORKDIR /plugins/eve-bridge
 RUN GO111MODULE=on CGO_ENABLED=0 go build -v -ldflags "-s -w" -mod=vendor -o /out/usr/bin/eve-bridge .

--- a/pkg/kube/debuguser-role-binding.yaml
+++ b/pkg/kube/debuguser-role-binding.yaml
@@ -80,6 +80,18 @@ rules:
   - apiGroups: ["", "apps", "extensions", "k8s.cni.cncf.io", "apiextensions.k8s.io"]
     resources: ['*']
     verbs: ["get", "list"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "ingresses/status", "ingressclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["get", "list"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["endpoints", "services", "nodes"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -79,6 +79,7 @@ type nim struct {
 	subWwanStatus            pubsub.Subscription
 	subNetworkInstanceConfig pubsub.Subscription
 	subEdgeNodeClusterStatus pubsub.Subscription
+	subKubeUserServices      pubsub.Subscription
 
 	// Publications
 	pubDummyDevicePortConfig pubsub.Publication // For logging
@@ -241,6 +242,7 @@ func (n *nim) run(ctx context.Context) (err error) {
 		n.subAssignableAdapters,
 		n.subWwanStatus,
 		n.subNetworkInstanceConfig,
+		n.subKubeUserServices,
 	}
 	for _, sub := range inactiveSubs {
 		if err = sub.Activate(); err != nil {
@@ -286,6 +288,9 @@ func (n *nim) run(ctx context.Context) (err error) {
 		case change := <-n.subNetworkInstanceConfig.MsgChan():
 			n.subNetworkInstanceConfig.ProcessChange(change)
 			n.handleNetworkInstanceUpdate()
+
+		case change := <-n.subKubeUserServices.MsgChan():
+			n.subKubeUserServices.ProcessChange(change)
 
 		case <-publishTimer.C:
 			start := time.Now()
@@ -591,6 +596,23 @@ func (n *nim) initSubscriptions() (err error) {
 	if err != nil {
 		return err
 	}
+
+	// Subscribe to KubeUserServices to get the Kubernetes services and ingresses
+	// for firewall configuration.
+	n.subKubeUserServices, err = n.PubSub.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "zedkube",
+		MyAgentName:   agentName,
+		TopicImpl:     types.KubeUserServices{},
+		Activate:      false,
+		CreateHandler: n.handleKubeUserServicesCreate,
+		ModifyHandler: n.handleKubeUserServicesModify,
+		DeleteHandler: n.handleKubeUserServicesDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -807,6 +829,23 @@ func (n *nim) handleEdgeNodeClusterStatusModify(_ interface{}, _ string,
 func (n *nim) handleEdgeNodeClusterStatusDelete(_ interface{}, _ string, _ interface{}) {
 	// Apply empty cluster status, which effectively removes the cluster IP.
 	n.dpcManager.UpdateClusterStatus(types.EdgeNodeClusterStatus{})
+}
+
+func (n *nim) handleKubeUserServicesCreate(_ interface{}, _ string,
+	statusArg interface{}) {
+	services := statusArg.(types.KubeUserServices)
+	n.dpcManager.UpdateKubeUserServices(services)
+}
+
+func (n *nim) handleKubeUserServicesModify(_ interface{}, _ string,
+	statusArg, _ interface{}) {
+	services := statusArg.(types.KubeUserServices)
+	n.dpcManager.UpdateKubeUserServices(services)
+}
+
+func (n *nim) handleKubeUserServicesDelete(_ interface{}, _ string, _ interface{}) {
+	// Apply empty services, which effectively removes all services and ingresses.
+	n.dpcManager.UpdateKubeUserServices(types.KubeUserServices{})
 }
 
 func (n *nim) listPublishedDPCs(directory string) (dpcFilePaths []string) {

--- a/pkg/pillar/cmd/zedkube/kubeservice.go
+++ b/pkg/pillar/cmd/zedkube/kubeservice.go
@@ -1,0 +1,347 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build kubevirt
+
+package zedkube
+
+import (
+	"context"
+	"net"
+	"sort"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	kubeServiceCIDR *net.IPNet
+)
+
+// Define the excluded namespaces map at package level
+var excludedKubeNamespaces = map[string]struct{}{
+	"kube-system":     {},
+	"kubevirt":        {},
+	"longhorn-system": {},
+	"cdi":             {},
+	"eve-kube-app":    {},
+}
+
+func (z *zedkube) initKubePrefixes() error {
+	var err error
+	_, kubeServiceCIDR, err = net.ParseCIDR(types.KubeServicePrefix)
+	return err
+}
+
+func (z *zedkube) collectKubeSvcs() {
+	log.Functionf("collectKubeStats: Started collecting kube stats")
+
+	clientset, err := getKubeClientSet()
+	if err != nil {
+		log.Errorf("collectKubeSvcs: can't get clientset %v", err)
+		return
+	}
+
+	// Get services
+	serviceInfoList, err := z.GetAllKubeServices(clientset)
+	if err != nil {
+		log.Errorf("collectKubeSvcs: can't get services %v", err)
+		return
+	}
+
+	// Get ingresses, passing the service list to avoid redundant API calls
+	ingressInfoList, err := z.GetAllKubeIngresses(clientset, serviceInfoList)
+	if err != nil {
+		log.Errorf("collectKubeSvcs: can't get ingresses %v", err)
+		// Continue anyway, we might have some services
+	}
+
+	// Create new KubeUserServices struct with collected data
+	newKubeUserServices := types.KubeUserServices{
+		UserService: serviceInfoList,
+		UserIngress: ingressInfoList,
+	}
+
+	// Get previous published data to compare
+	currentInfoPtr, err := z.pubKubeUserServices.Get("global")
+	var currentInfo types.KubeUserServices
+	if err == nil && currentInfoPtr != nil {
+		currentInfo = currentInfoPtr.(types.KubeUserServices)
+	}
+
+	// Only publish if there are changes
+	if !currentInfo.Equal(newKubeUserServices) {
+		log.Tracef("collectKubeSvcs: detected changes in services/ingresses, publishing updates")
+		z.pubKubeUserServices.Publish("global", newKubeUserServices)
+	} else {
+		log.Tracef("collectKubeSvcs: no changes detected in services/ingresses, skipping publish")
+	}
+
+	log.Functionf("collectKubeSvcs: found %d services, %d ingress", len(newKubeUserServices.UserService), len(newKubeUserServices.UserIngress))
+}
+
+// GetAllKubeServices returns a slice of KubeServiceInfo containing all Kubernetes services across namespaces,
+// excluding kube-system, kubevirt, longhorn-system, cdi namespaces,
+// and the 'kubernetes' service in the default namespace.
+func (z *zedkube) GetAllKubeServices(clientset *kubernetes.Clientset) ([]types.KubeServiceInfo, error) {
+	// List all services across all namespaces
+	services, err := clientset.CoreV1().Services("").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("GetAllKubeServices: can't get services: %v", err)
+		return nil, err
+	}
+
+	var serviceInfoList []types.KubeServiceInfo
+
+	for _, svc := range services.Items {
+		// Skip services in excluded namespaces
+		if _, excluded := excludedKubeNamespaces[svc.Namespace]; excluded {
+			continue
+		}
+
+		// Skip the 'kubernetes' service in the 'default' namespace
+		if svc.Namespace == "default" && svc.Name == "kubernetes" {
+			continue
+		}
+
+		// Skip the 'zks-cluster-agent' service in the 'cattle-system' namespace
+		if svc.Namespace == "cattle-system" && svc.Name == "zks-cluster-agent" {
+			continue
+		}
+
+		// Include all service types, including ClusterIP services
+		// ClusterIP services might be referenced by ingresses, so we need to include them
+		// to determine the service type for ingresses
+
+		// Extract port information for each service
+		for _, port := range svc.Spec.Ports {
+			// Initialize service info
+			serviceInfo := types.KubeServiceInfo{
+				Name:      svc.Name,
+				Namespace: svc.Namespace,
+				Protocol:  port.Protocol,
+				Port:      port.Port,
+				NodePort:  port.NodePort, // Store the NodePort separately
+				Type:      svc.Spec.Type,
+			}
+
+			// Special handling for cattle-system services with port 443
+			// Convert to NodePort with port 6443 to allow kubeconfig access via api-server
+			if svc.Namespace == "cattle-system" && port.Port == 443 {
+				serviceInfo.Type = corev1.ServiceTypeNodePort
+				serviceInfo.Port = 6443
+				serviceInfo.ACEenabled = true // Enabled ACE for kubectl access locally
+			}
+
+			var loadbalancerIP string
+			// For LoadBalancer services, look for an external IP
+			if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
+				// First, check if LoadBalancerIP is explicitly specified in the Spec
+				// This is the IP the user has requested from the provider (e.g. 192.168.86.200)
+				if svc.Spec.LoadBalancerIP != "" {
+					loadbalancerIP = svc.Spec.LoadBalancerIP
+				}
+
+				// If no Spec.LoadBalancerIP, check external IPs
+				if loadbalancerIP == "" && len(svc.Spec.ExternalIPs) > 0 {
+					loadbalancerIP = svc.Spec.ExternalIPs[0]
+				}
+
+				// If still no IP, check annotations for kube-vip loadbalancer IPs
+				if loadbalancerIP == "" {
+					if ip, ok := svc.Annotations["kube-vip.io/loadbalancerIPs"]; ok && ip != "" {
+						loadbalancerIP = ip
+					}
+				}
+
+				// If we have a LoadBalancerIP, check if it's within the K8s service CIDR range
+				if loadbalancerIP != "" {
+					ipAddr := net.ParseIP(loadbalancerIP)
+					if ipAddr != nil && kubeServiceCIDR.Contains(ipAddr) {
+						log.Functionf("GetAllKubeServices: skipping service %s/%s with LoadBalancerIP %s as it's in the K8s service CIDR range",
+							svc.Namespace, svc.Name, loadbalancerIP)
+						continue // Skip this service port
+					}
+				} else {
+					continue // Skip LoadBalancer services without an IP
+				}
+				serviceInfo.LoadBalancerIP = loadbalancerIP
+
+				// Note: Deliberately not using LoadBalancer.Ingress IPs as fallback
+				// as these are typically internal IPs assigned by the LoadBalancer controller
+				// rather than the external IPs that we want to target with specific rules
+			}
+
+			serviceInfoList = append(serviceInfoList, serviceInfo)
+		}
+	}
+
+	log.Functionf("GetAllKubeServices: found %d service ports", len(serviceInfoList))
+	return serviceInfoList, nil
+}
+
+// GetAllKubeIngresses returns a list of all Kubernetes ingresses across namespaces,
+// excluding the same namespaces that we exclude for services.
+// It takes the serviceInfoList to avoid making redundant API calls for service information.
+func (z *zedkube) GetAllKubeIngresses(clientset *kubernetes.Clientset, serviceInfoList []types.KubeServiceInfo) ([]types.KubeIngressInfo, error) {
+	// List all ingresses across all namespaces
+	ingresses, err := clientset.NetworkingV1().Ingresses("").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("GetAllKubeIngresses: can't get ingresses: %v", err)
+		return nil, err
+	}
+
+	var ingressInfoList []types.KubeIngressInfo
+
+	for _, ing := range ingresses.Items {
+		// Skip ingresses in excluded namespaces
+		if _, excluded := excludedKubeNamespaces[ing.Namespace]; excluded {
+			continue
+		}
+
+		// Get the IP addresses of the ingress (if any)
+		var ingressIPs []string
+		for _, lbIngress := range ing.Status.LoadBalancer.Ingress {
+			if lbIngress.IP != "" {
+				// Check if the IP is on one of our interfaces and log accordingly
+				isDeviceIP := z.isDeviceInterfaceIP(lbIngress.IP)
+				if isDeviceIP {
+					log.Functionf("Ingress %s/%s includes IP %s that matches a device interface",
+						ing.Namespace, ing.Name, lbIngress.IP)
+					// Only add the IP if it belongs to one of our interfaces
+					ingressIPs = append(ingressIPs, lbIngress.IP)
+				}
+			} else if lbIngress.Hostname != "" {
+				ingressIPs = append(ingressIPs, lbIngress.Hostname) // Use hostname if IP is not available
+			}
+		}
+
+		// Sort the IPs to ensure consistent order
+		if len(ingressIPs) > 1 {
+			sort.Strings(ingressIPs)
+			log.Functionf("Sorted %d ingress IPs for %s/%s", len(ingressIPs), ing.Namespace, ing.Name)
+		}
+
+		// Process each rule in the ingress
+		for _, rule := range ing.Spec.Rules {
+			hostname := rule.Host
+			if rule.HTTP == nil {
+				continue
+			}
+
+			// Process each path in the rule
+			for _, path := range rule.HTTP.Paths {
+				if path.Backend.Service == nil {
+					continue
+				}
+
+				// Default to HTTP, check for TLS configuration
+				protocol := "http"
+				for _, tls := range ing.Spec.TLS {
+					for _, host := range tls.Hosts {
+						if host == hostname || host == "" {
+							protocol = "https"
+							break
+						}
+					}
+					if protocol == "https" {
+						break
+					}
+				}
+
+				// Create ingress info object
+				pathType := ""
+				if path.PathType != nil {
+					pathType = string(*path.PathType)
+				}
+
+				// Get the service type by looking up the service in already fetched serviceInfoList
+				var serviceType corev1.ServiceType = corev1.ServiceTypeClusterIP // default if not found
+				serviceName := path.Backend.Service.Name
+				serviceNamespace := ing.Namespace
+
+				// Look for the service in our already fetched serviceInfoList
+				serviceFound := false
+				for _, svcInfo := range serviceInfoList {
+					if svcInfo.Name == serviceName && svcInfo.Namespace == serviceNamespace {
+						serviceType = svcInfo.Type
+						serviceFound = true
+
+						// Add more detailed logging for LoadBalancer and NodePort services
+						if serviceType == corev1.ServiceTypeLoadBalancer {
+							log.Functionf("GetAllKubeIngresses: found LoadBalancer service %s/%s (LB IP: %s)",
+								serviceNamespace, serviceName, svcInfo.LoadBalancerIP)
+						} else if serviceType == corev1.ServiceTypeNodePort {
+							log.Functionf("GetAllKubeIngresses: found NodePort service %s/%s (NodePort: %d)",
+								serviceNamespace, serviceName, svcInfo.NodePort)
+						} else {
+							log.Functionf("GetAllKubeIngresses: found service %s/%s with type %s in serviceInfoList",
+								serviceNamespace, serviceName, serviceType)
+						}
+						break
+					}
+				}
+
+				// If not found in our list (which should include all services now),
+				// try to get it directly - this might happen in rare cases like race conditions
+				if !serviceFound {
+					log.Warningf("GetAllKubeIngresses: service %s/%s not found in serviceInfoList, fetching directly",
+						serviceNamespace, serviceName)
+
+					svc, err := clientset.CoreV1().Services(serviceNamespace).Get(
+						context.Background(), serviceName, metav1.GetOptions{})
+					if err != nil {
+						log.Warningf("GetAllKubeIngresses: couldn't get service %s/%s: %v",
+							serviceNamespace, serviceName, err)
+					} else {
+						serviceType = svc.Spec.Type
+						log.Functionf("GetAllKubeIngresses: direct fetch of service %s/%s found type %s",
+							serviceNamespace, serviceName, serviceType)
+					}
+				}
+
+				ingressInfo := types.KubeIngressInfo{
+					Name:        ing.Name,
+					Namespace:   ing.Namespace,
+					Hostname:    hostname,
+					Path:        path.Path,
+					PathType:    pathType,
+					Protocol:    protocol,
+					Service:     serviceName,
+					ServicePort: path.Backend.Service.Port.Number,
+					ServiceType: serviceType,
+					IngressIP:   ingressIPs,
+				}
+				ingressInfoList = append(ingressInfoList, ingressInfo)
+			}
+		}
+	}
+
+	log.Functionf("GetAllKubeIngresses: found %d ingress paths", len(ingressInfoList))
+	return ingressInfoList, nil
+}
+
+// isDeviceInterfaceIP checks if the given IP is assigned to any of the device's network interfaces
+func (z *zedkube) isDeviceInterfaceIP(ipStr string) bool {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		// Not a valid IP
+		return false
+	}
+
+	// Check each port in deviceNetworkStatus
+	for _, port := range z.deviceNetworkStatus.Ports {
+		// Check each address in the port's AddrInfoList
+		for _, addrInfo := range port.AddrInfoList {
+			if addrInfo.Addr.Equal(ip) {
+				log.Functionf("Found matching interface IP %s on port %s", ipStr, port.IfName)
+				return true
+			}
+		}
+	}
+
+	// IP is not on any of our interfaces
+	return false
+}

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -68,6 +68,7 @@ type zedkube struct {
 	pubENClusterAppStatus    pubsub.Publication
 	pubKubeClusterInfo       pubsub.Publication
 	pubLeaderElectInfo       pubsub.Publication
+	pubKubeUserServices      pubsub.Publication
 
 	subNodeDrainRequestZA  pubsub.Subscription
 	subNodeDrainRequestBoM pubsub.Subscription
@@ -297,6 +298,16 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	zedkubeCtx.pubKubeClusterInfo = pubKubeClusterInfo
 
+	pubKubeUserServices, err := ps.NewPublication(
+		pubsub.PublicationOptions{
+			AgentName: agentName,
+			TopicType: types.KubeUserServices{},
+		})
+	if err != nil {
+		log.Fatal(err)
+	}
+	zedkubeCtx.pubKubeUserServices = pubKubeUserServices
+
 	pubLeaderElectInfo, err := ps.NewPublication(
 		pubsub.PublicationOptions{
 			AgentName: agentName,
@@ -515,6 +526,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		log.Errorf("zedkube: WaitForKubenetes %v", err)
 	}
 
+	err = zedkubeCtx.initKubePrefixes()
+	if err != nil { // should never happen
+		log.Fatalf("zedkube: initKubePrefixes %v", err)
+	}
 	appLogTimer := time.NewTimer(logcollectInterval * time.Second)
 
 	log.Notice("zedkube online")
@@ -531,6 +546,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			zedkubeCtx.collectAppLogs()
 			zedkubeCtx.checkAppsStatus()
 			zedkubeCtx.collectKubeStats()
+			zedkubeCtx.collectKubeSvcs()
 			appLogTimer = time.NewTimer(logcollectInterval * time.Second)
 
 		case change := <-subGlobalConfig.MsgChan():

--- a/pkg/pillar/dpcreconciler/dpcreconciler.go
+++ b/pkg/pillar/dpcreconciler/dpcreconciler.go
@@ -34,6 +34,8 @@ type Args struct {
 	FlowlogEnabled bool
 	// Cluster network status used when edge node is part of a kubernetes cluster.
 	ClusterStatus types.EdgeNodeClusterStatus
+	// Kubernetes service and ingress information for firewall configuration.
+	KubeUserServices types.KubeUserServices
 }
 
 // ReconcileStatus : state data related to config reconciliation.

--- a/pkg/pillar/dpcreconciler/linux.go
+++ b/pkg/pillar/dpcreconciler/linux.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"golang.org/x/sys/unix"
+	corev1 "k8s.io/api/core/v1"
 
 	dg "github.com/lf-edge/eve-libs/depgraph"
 	"github.com/lf-edge/eve-libs/reconciler"
@@ -419,6 +420,10 @@ func (r *LinuxDpcReconciler) Reconcile(ctx context.Context, args Args) Reconcile
 			// Reconcile all items.
 			r.addPendingReconcile(GraphName, "Cluster status change", false)
 		}
+		if !r.lastArgs.KubeUserServices.Equal(args.KubeUserServices) {
+			// Services and ingresses affect ACLs
+			r.addPendingReconcile(ACLsSG, "Kube services/ingresses change", false)
+		}
 	}
 	if r.pendingReconcile.isPending {
 		reconcileSG = r.pendingReconcile.forSubGraph
@@ -466,7 +471,7 @@ func (r *LinuxDpcReconciler) Reconcile(ctx context.Context, args Args) Reconcile
 			intSG = r.getIntendedWirelessCfg(args.DPC, args.AA, args.RS)
 		case ACLsSG:
 			intSG = r.getIntendedACLs(args.DPC, args.ClusterStatus, args.GCP,
-				args.FlowlogEnabled)
+				args.FlowlogEnabled, args.KubeUserServices)
 		default:
 			// Only these top-level subgraphs are used for selective-reconcile for now.
 			r.Log.Fatalf("Unexpected SG select for reconcile: %s", reconcileSG)
@@ -630,6 +635,13 @@ func (r *LinuxDpcReconciler) saveArgs(args Args) {
 	for i := range args.AA.IoBundleList {
 		r.lastArgs.AA.IoBundleList[i] = args.AA.IoBundleList[i]
 	}
+
+	// Deep copy KubeUserServices
+	r.lastArgs.KubeUserServices.UserService = make([]types.KubeServiceInfo, len(args.KubeUserServices.UserService))
+	copy(r.lastArgs.KubeUserServices.UserService, args.KubeUserServices.UserService)
+
+	r.lastArgs.KubeUserServices.UserIngress = make([]types.KubeIngressInfo, len(args.KubeUserServices.UserIngress))
+	copy(r.lastArgs.KubeUserServices.UserIngress, args.KubeUserServices.UserIngress)
 }
 
 func (r *LinuxDpcReconciler) dpcChanged(newDPC types.DevicePortConfig) bool {
@@ -867,7 +879,7 @@ func (r *LinuxDpcReconciler) updateIntendedState(args Args) {
 	r.intendedState.PutSubGraph(r.getIntendedL3Cfg(args.DPC, args.ClusterStatus))
 	r.intendedState.PutSubGraph(r.getIntendedWirelessCfg(args.DPC, args.AA, args.RS))
 	r.intendedState.PutSubGraph(r.getIntendedACLs(args.DPC, args.ClusterStatus, args.GCP,
-		args.FlowlogEnabled))
+		args.FlowlogEnabled, args.KubeUserServices))
 }
 
 func (r *LinuxDpcReconciler) getIntendedGlobalCfg(dpc types.DevicePortConfig,
@@ -1568,7 +1580,7 @@ func (r *LinuxDpcReconciler) getIntendedWwanConfig(dpc types.DevicePortConfig,
 
 func (r *LinuxDpcReconciler) getIntendedACLs(dpc types.DevicePortConfig,
 	clusterStatus types.EdgeNodeClusterStatus, gcp types.ConfigItemValueMap,
-	withFlowlog bool) dg.Graph {
+	withFlowlog bool, kubeUserServices types.KubeUserServices) dg.Graph {
 	graphArgs := dg.InitArgs{
 		Name:        ACLsSG,
 		Description: "Device-wide ACLs",
@@ -1651,16 +1663,33 @@ func (r *LinuxDpcReconciler) getIntendedACLs(dpc types.DevicePortConfig,
 		}
 	}
 
-	r.getIntendedFilterRules(gcp, dpc, clusterStatus, intendedIPv4ACLs, intendedIPv6ACLs)
-	if withFlowlog {
-		r.getIntendedMarkingRules(dpc, intendedIPv4ACLs, intendedIPv6ACLs)
+	r.getIntendedFilterRules(gcp, dpc, clusterStatus, kubeUserServices, intendedIPv4ACLs, intendedIPv6ACLs)
+	if withFlowlog || r.HVTypeKube {
+		r.getIntendedMarkingRules(dpc, intendedIPv4ACLs, intendedIPv6ACLs, kubeUserServices)
 	}
 	return intendedACLs
 }
 
+// KubeACEEnabled checks if any Kubernetes user service has ACE (Authorized Cluster Endpoint) enabled
+func (r *LinuxDpcReconciler) KubeACEEnabled(services types.KubeUserServices) bool {
+	for _, service := range services.UserService {
+		if service.ACEenabled {
+			return true
+		}
+	}
+	return false
+}
+
+// GetIntendedFilterRules is an exported version of getIntendedFilterRules for testing
+func (r *LinuxDpcReconciler) GetIntendedFilterRules(gcp types.ConfigItemValueMap,
+	dpc types.DevicePortConfig, clusterStatus types.EdgeNodeClusterStatus,
+	services types.KubeUserServices, intendedIPv4ACLs, intendedIPv6ACLs dg.Graph) {
+	r.getIntendedFilterRules(gcp, dpc, clusterStatus, services, intendedIPv4ACLs, intendedIPv6ACLs)
+}
+
 func (r *LinuxDpcReconciler) getIntendedFilterRules(gcp types.ConfigItemValueMap,
-	dpc types.DevicePortConfig, clusterStatus types.EdgeNodeClusterStatus, intendedIPv4ACLs,
-	intendedIPv6ACLs dg.Graph) {
+	dpc types.DevicePortConfig, clusterStatus types.EdgeNodeClusterStatus,
+	services types.KubeUserServices, intendedIPv4ACLs, intendedIPv6ACLs dg.Graph) {
 	// Prepare filter/INPUT rules.
 	var inputV4Rules, inputV6Rules []iptables.Rule
 
@@ -1876,6 +1905,22 @@ func (r *LinuxDpcReconciler) getIntendedFilterRules(gcp types.ConfigItemValueMap
 		}
 	}
 
+	// When the kubernetes has Authorized Cluster Endpoint (ACE) enabled, accept the api-server port 6443
+	if r.HVTypeKube && r.KubeACEEnabled(services) {
+		k3sAPIServerRule := iptables.Rule{
+			RuleLabel:   "Allow K3s API Servier requests",
+			MatchOpts:   []string{"-p", "tcp", "--dport", "6443"},
+			Target:      "ACCEPT",
+			Description: "Allow K3s API Server requests to enter the device",
+		}
+		forIPv6 := clusterStatus.ClusterIPPrefix != nil && clusterStatus.ClusterIPPrefix.IP.To4() == nil
+		if forIPv6 {
+			inputV6Rules = append(inputV6Rules, k3sAPIServerRule)
+		} else {
+			inputV4Rules = append(inputV4Rules, k3sAPIServerRule)
+		}
+	}
+
 	// Allow all traffic that belongs to an already established connection.
 	allowEstablishedConn := iptables.Rule{
 		RuleLabel:   "Allow established connection",
@@ -2001,7 +2046,7 @@ func (r *LinuxDpcReconciler) getIntendedFilterRules(gcp types.ConfigItemValueMap
 
 // Marking rules are only used if at least one Network instance has flow logging enabled.
 func (r *LinuxDpcReconciler) getIntendedMarkingRules(dpc types.DevicePortConfig,
-	intendedIPv4ACLs, intendedIPv6ACLs dg.Graph) {
+	intendedIPv4ACLs, intendedIPv6ACLs dg.Graph, kubeUserServices types.KubeUserServices) {
 	// Mark ingress control-flow traffic.
 	// For connections originating from outside we use App ID = 0.
 	markSSHAndGuacamole := iptables.Rule{
@@ -2049,6 +2094,12 @@ func (r *LinuxDpcReconciler) getIntendedMarkingRules(dpc types.DevicePortConfig,
 
 	if r.HVTypeKube {
 		protoMarkV4Rules = append(protoMarkV4Rules, defaultKubernetesIptablesRules()...)
+		// Add Marking rules for Kubernetes user services.
+		// The reason kubernetes service ports need to add to marking rules and not adding
+		// to the Input rules in getIntendedFilterRules() is that the Kubernetes kube-proxy
+		// will install the service ports and using DNAT rules to forwarding to the service
+		// destination. We only need to enable the mangle table marking rules to allow it.
+		protoMarkV4Rules = append(protoMarkV4Rules, r.AddKubeServiceRules(kubeUserServices)...)
 	}
 
 	// Do not overwrite mark that was already added be rules from zedrouter
@@ -2231,10 +2282,10 @@ func defaultKubernetesIptablesRules() []iptables.Rule {
 		Description: "Mark traffic from Kubernetes pods to Kubernetes services",
 	}
 
-	// Allow all traffic forwarded between Kubernetes pods.
+	// Allow all traffic from the Kubernetes network to pods or external endpoints.
 	markKubePod := iptables.Rule{
 		RuleLabel:   "Kubernetes pod mark",
-		MatchOpts:   []string{"-s", kubePodCIDR.String(), "-d", kubePodCIDR.String()},
+		MatchOpts:   []string{"-s", kubePodCIDR.String()},
 		Target:      "CONNMARK",
 		TargetOpts:  []string{"--set-mark", controlProtoMark("kube_pod")},
 		Description: "Mark all traffic directly forwarded between Kubernetes pods",
@@ -2332,4 +2383,259 @@ func defaultKubernetesIptablesRules() []iptables.Rule {
 		markNFS,
 		markClusterStatus,
 	}
+}
+
+// AddKubeServiceRules creates iptables rules for Kubernetes services and ingresses
+func (r *LinuxDpcReconciler) AddKubeServiceRules(kubeUserServices types.KubeUserServices) []iptables.Rule {
+	var rules []iptables.Rule
+
+	// 1. Create TCP rules for nodePort services and LoadBalancer services
+	// First, collect TCP LoadBalancer services with IPs for IP-specific rules
+
+	// tcpLoadBalancerIPRules is used to track TCP LoadBalancer services with specific IPs
+	// as the first key of the map, and the second keys are the ports associated with that IP.
+	tcpLoadBalancerIPRules := make(map[string]map[string]struct{}) // map[ip]map[port]struct{}
+
+	// Track NodePort TCP ports and LoadBalancer TCP ports without IPs
+	tcpPortsMap := make(map[string]bool)
+
+	for _, svc := range kubeUserServices.UserService {
+		if svc.Protocol == "TCP" {
+			if svc.ACEenabled { // this is handled in the interface filter section
+				continue
+			}
+			// Handle NodePort services
+			if svc.Type == "NodePort" && svc.NodePort > 0 {
+				tcpPortsMap[strconv.Itoa(int(svc.NodePort))] = true
+			} else if svc.Type == "LoadBalancer" && svc.Port > 0 {
+				portStr := strconv.Itoa(int(svc.Port))
+				// For LoadBalancer with IP, create IP-specific rules
+				if svc.LoadBalancerIP == "" {
+					// For LoadBalancer without IP, add to generic port list
+					tcpPortsMap[portStr] = true
+					continue
+				}
+
+				// For LoadBalancer with IP, ensure the inner map exists
+				if _, exists := tcpLoadBalancerIPRules[svc.LoadBalancerIP]; !exists {
+					tcpLoadBalancerIPRules[svc.LoadBalancerIP] = make(map[string]struct{})
+				}
+
+				// Add port to this IP's map
+				tcpLoadBalancerIPRules[svc.LoadBalancerIP][portStr] = struct{}{}
+			}
+		}
+	}
+
+	// Create IP-specific rules for TCP LoadBalancer services
+	ruleIndex := 0
+	for ip, ports := range tcpLoadBalancerIPRules {
+		var tcpPorts []string
+		for port := range ports {
+			tcpPorts = append(tcpPorts, port)
+		}
+
+		// If there are ports for this IP
+		if len(tcpPorts) > 0 {
+			markTCPSvcPortIP := iptables.Rule{
+				RuleLabel:   fmt.Sprintf("KubeSvcPortTCP_IP_%d", ruleIndex),
+				MatchOpts:   []string{"-p", "tcp", "-d", ip, "--match", "multiport", "--dports", strings.Join(tcpPorts, ",")},
+				Target:      "CONNMARK",
+				TargetOpts:  []string{"--set-mark", controlProtoMark("in_tcp_svc_port")},
+				Description: fmt.Sprintf("Mark Kubernetes TCP service port traffic for LoadBalancer IP %s", ip),
+			}
+			rules = append(rules, markTCPSvcPortIP)
+			ruleIndex++
+		}
+	}
+
+	// Create generic rule for TCP NodePorts and LoadBalancer services without IPs
+	if len(tcpPortsMap) > 0 {
+		var tcpPorts []string
+		for port := range tcpPortsMap {
+			tcpPorts = append(tcpPorts, port)
+		}
+
+		markTCPSvcPort := iptables.Rule{
+			RuleLabel:   "KubeSvcPortTCP",
+			MatchOpts:   []string{"-p", "tcp", "--match", "multiport", "--dports", strings.Join(tcpPorts, ",")},
+			Target:      "CONNMARK",
+			TargetOpts:  []string{"--set-mark", controlProtoMark("in_tcp_svc_port")},
+			Description: "Mark Kubernetes TCP service port traffic",
+		}
+		rules = append(rules, markTCPSvcPort)
+	}
+
+	// 2. Create UDP rules for nodePort services and LoadBalancer services
+	// First, collect UDP LoadBalancer services with IPs for IP-specific rules
+
+	// udpLoadBalancerIPRules is used to track UDP LoadBalancer services with specific IPs
+	// as the first key of the map, and the second keys are the ports associated with that IP.
+	udpLoadBalancerIPRules := make(map[string]map[string]struct{}) // map[ip]map[port]struct{}
+
+	// Track NodePort UDP ports and LoadBalancer UDP ports without IPs
+	udpPortsMap := make(map[string]bool)
+
+	for _, svc := range kubeUserServices.UserService {
+		if svc.Protocol == "UDP" {
+			// Handle NodePort services
+			if svc.Type == "NodePort" && svc.NodePort > 0 {
+				udpPortsMap[strconv.Itoa(int(svc.NodePort))] = true
+			} else if svc.Type == "LoadBalancer" && svc.Port > 0 {
+				// For LoadBalancer with IP, create IP-specific rules
+				if svc.LoadBalancerIP != "" {
+					portStr := strconv.Itoa(int(svc.Port))
+
+					// Initialize map for this IP if it doesn't exist
+					if _, exists := udpLoadBalancerIPRules[svc.LoadBalancerIP]; !exists {
+						udpLoadBalancerIPRules[svc.LoadBalancerIP] = make(map[string]struct{})
+					}
+
+					// Add port to this IP's map
+					udpLoadBalancerIPRules[svc.LoadBalancerIP][portStr] = struct{}{}
+				} else {
+					// For LoadBalancer without IP, add to generic port list
+					udpPortsMap[strconv.Itoa(int(svc.Port))] = true
+				}
+			}
+		}
+	}
+
+	// Create IP-specific rules for UDP LoadBalancer services
+	ruleIndex = 0
+	for ip, ports := range udpLoadBalancerIPRules {
+		var udpPorts []string
+		for port := range ports {
+			udpPorts = append(udpPorts, port)
+		}
+
+		// If there are ports for this IP
+		if len(udpPorts) > 0 {
+			markUDPSvcPortIP := iptables.Rule{
+				RuleLabel:   fmt.Sprintf("KubeSvcPortUDP_IP_%d", ruleIndex),
+				MatchOpts:   []string{"-p", "udp", "-d", ip, "--match", "multiport", "--dports", strings.Join(udpPorts, ",")},
+				Target:      "CONNMARK",
+				TargetOpts:  []string{"--set-mark", controlProtoMark("in_udp_svc_port")},
+				Description: fmt.Sprintf("Mark Kubernetes UDP service port traffic for LoadBalancer IP %s", ip),
+			}
+			rules = append(rules, markUDPSvcPortIP)
+			ruleIndex++
+		}
+	}
+
+	// Create generic rule for UDP NodePorts and LoadBalancer services without IPs
+	if len(udpPortsMap) > 0 {
+		var udpPorts []string
+		for port := range udpPortsMap {
+			udpPorts = append(udpPorts, port)
+		}
+
+		markUDPSvcPort := iptables.Rule{
+			RuleLabel:   "KubeSvcPortUDP",
+			MatchOpts:   []string{"-p", "udp", "--match", "multiport", "--dports", strings.Join(udpPorts, ",")},
+			Target:      "CONNMARK",
+			TargetOpts:  []string{"--set-mark", controlProtoMark("in_udp_svc_port")},
+			Description: "Mark Kubernetes UDP service port traffic",
+		}
+		rules = append(rules, markUDPSvcPort)
+	}
+
+	// 3. Create rules for HTTP and HTTPS ingresses
+	// Track which protocols are used and collect unique ingress IPs
+	httpIngressIPs := make(map[string]bool)
+	httpsIngressIPs := make(map[string]bool)
+	var hasHTTPNoIP bool
+	var hasHTTPSNoIP bool
+
+	// Collect information about ingresses, unique IPs and protocols
+	// Two cases, with IP and protocol or the protocol only for non-loadBalancer services
+	for _, ing := range kubeUserServices.UserIngress {
+		// Only process ingress IPs for LoadBalancer services
+		// For NodePort types, the addresses will be cluster-prefixes which we use 10.244.244.0
+		// private addresses, and user may not have access to them.
+		if ing.ServiceType == corev1.ServiceTypeLoadBalancer {
+			// Process IPs for LoadBalancer
+			for _, ip := range ing.IngressIP {
+				if ip == "" {
+					continue
+				}
+				if ing.Protocol == "http" {
+					httpIngressIPs[ip] = true
+				} else { // https
+					httpsIngressIPs[ip] = true
+				}
+			}
+		} else if ing.Protocol == "http" {
+			// For NodePort HTTP, we don't track IPs, just mark the port
+			hasHTTPNoIP = true
+		} else if ing.Protocol == "https" {
+			// For NodePort HTTPS, we don't track IPs, just mark the port
+			hasHTTPSNoIP = true
+		}
+	}
+
+	// Add HTTP ingress rules
+	if len(httpIngressIPs) > 0 {
+		// Create one rule per unique ingress IP for HTTP
+		ruleIndex := 0
+		for ingressIP := range httpIngressIPs {
+			markHTTPIngressIP := iptables.Rule{
+				RuleLabel:   fmt.Sprintf("KubeIngressHTTP_IP_%d", ruleIndex),
+				MatchOpts:   []string{"-p", "tcp", "-d", ingressIP, "--dport", "80"},
+				Target:      "CONNMARK",
+				TargetOpts:  []string{"--set-mark", controlProtoMark("in_http_ingress")},
+				Description: fmt.Sprintf("Mark Kubernetes HTTP ingress traffic for IP %s", ingressIP),
+			}
+			rules = append(rules, markHTTPIngressIP)
+			ruleIndex++
+		}
+	}
+
+	// Add generic HTTP ingress rule if no IngressIP (only one rule for port 80 without IPs)
+	if hasHTTPNoIP {
+		markHTTPIngress := iptables.Rule{
+			RuleLabel:   "KubeIngressHTTP",
+			MatchOpts:   []string{"-p", "tcp", "--dport", "80"},
+			Target:      "CONNMARK",
+			TargetOpts:  []string{"--set-mark", controlProtoMark("in_http_ingress")},
+			Description: "Mark Kubernetes HTTP ingress traffic",
+		}
+		rules = append(rules, markHTTPIngress)
+	}
+
+	// Add HTTPS ingress rules
+	if len(httpsIngressIPs) > 0 {
+		// Create one rule per unique ingress IP for HTTPS
+		ruleIndex := 0
+		for ingressIP := range httpsIngressIPs {
+			markHTTPSIngressIP := iptables.Rule{
+				RuleLabel:   fmt.Sprintf("KubeIngressHTTPS_IP_%d", ruleIndex),
+				MatchOpts:   []string{"-p", "tcp", "-d", ingressIP, "--dport", "443"},
+				Target:      "CONNMARK",
+				TargetOpts:  []string{"--set-mark", controlProtoMark("in_https_ingress")},
+				Description: fmt.Sprintf("Mark Kubernetes HTTPS ingress traffic for IP %s", ingressIP),
+			}
+			rules = append(rules, markHTTPSIngressIP)
+			ruleIndex++
+		}
+	}
+
+	// Add generic HTTPS ingress rule if needed (only one rule for port 443 without IPs)
+	if hasHTTPSNoIP {
+		markHTTPSIngress := iptables.Rule{
+			RuleLabel:   "KubeIngressHTTPS",
+			MatchOpts:   []string{"-p", "tcp", "--dport", "443"},
+			Target:      "CONNMARK",
+			TargetOpts:  []string{"--set-mark", controlProtoMark("in_https_ingress")},
+			Description: "Mark Kubernetes HTTPS ingress traffic",
+		}
+		rules = append(rules, markHTTPSIngress)
+	}
+
+	return rules
+}
+
+// GetLastArgs returns the last arguments used by the reconciler
+func (r *LinuxDpcReconciler) GetLastArgs() Args {
+	return r.lastArgs
 }

--- a/pkg/pillar/iptables/connmark.go
+++ b/pkg/pillar/iptables/connmark.go
@@ -81,6 +81,16 @@ var ControlProtocolMarkingIDMap = map[string]uint32{
 	"in_nfs": 22,
 	// for cluster advertise status
 	"in_cluster_status": 23,
+	// for TCP service ports (NodePort and LoadBalancer)
+	"in_tcp_svc_port": 24,
+	// for UDP service ports (NodePort and LoadBalancer)
+	"in_udp_svc_port": 25,
+	// for HTTP ingress (port 80)
+	"in_http_ingress": 26,
+	// for HTTPS ingress (port 443)
+	"in_https_ingress": 27,
+	// for DNS traffic in Kubernetes environments
+	"kube_dns": 28,
 }
 
 // GetConnmark : create connection mark corresponding to the given attributes.

--- a/pkg/pillar/types/zedkubetypes.go
+++ b/pkg/pillar/types/zedkubetypes.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/lf-edge/eve-api/go/info"
+	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // KubeNodeStatus - Enum for the status of a Kubernetes node
@@ -419,4 +421,78 @@ func (ksi KubeStorageInfo) ZKubeStorageInfo() *info.KubeStorageInfo {
 		iKsi.Volumes = append(iKsi.Volumes, vol.ZKubeVolumeInfo())
 	}
 	return iKsi
+}
+
+// KubeServiceInfo represents information about a Kubernetes Service
+type KubeServiceInfo struct {
+	Name           string             // Name of the service
+	Namespace      string             // Namespace of the service
+	Protocol       corev1.Protocol    // Protocol used by the service (TCP, UDP, etc.)
+	Port           int32              // Port number for the service
+	NodePort       int32              // NodePort number for NodePort services
+	Type           corev1.ServiceType // Type of the service (ClusterIP, NodePort, LoadBalancer, etc.)
+	LoadBalancerIP string             // IP address assigned to LoadBalancer service
+	ACEenabled     bool               // Authorized Cluster Endpoint access is enabled
+}
+
+// Define the K8s service CIDR that we want to exclude from external IP handling
+const (
+	KubeServicePrefix = "10.43.0.0/16" // Standard K3s service CIDR
+)
+
+// KubeIngressInfo represents information about a Kubernetes Ingress
+type KubeIngressInfo struct {
+	Name        string             // Name of the Ingress resource
+	Namespace   string             // Namespace of the Ingress resource
+	Hostname    string             // e.g. "example.com"
+	Path        string             // e.g. "/api/v1"
+	PathType    string             // "Prefix" or "Exact"
+	Protocol    string             // "http" or "https"
+	Service     string             // Target service name
+	ServicePort int32              // Target service port
+	ServiceType corev1.ServiceType // Type of the target service (LoadBalancer, NodePort, etc.)
+	IngressIP   []string           // LoadBalancer IPs if available
+}
+
+// KubeUserServices - Collected User services from kubernetes
+type KubeUserServices struct {
+	UserService []KubeServiceInfo
+	UserIngress []KubeIngressInfo
+}
+
+// Equal checks if two KubeUserServices instances are equal
+func (s KubeUserServices) Equal(s2 KubeUserServices) bool {
+	// Use generics.EqualSetsFn to compare service arrays
+	servicesEqual := generics.EqualSetsFn(s.UserService, s2.UserService,
+		func(svc1, svc2 KubeServiceInfo) bool {
+			return svc1.Namespace == svc2.Namespace &&
+				svc1.Name == svc2.Name &&
+				svc1.Protocol == svc2.Protocol &&
+				svc1.Port == svc2.Port &&
+				svc1.NodePort == svc2.NodePort &&
+				svc1.LoadBalancerIP == svc2.LoadBalancerIP &&
+				svc1.Type == svc2.Type &&
+				svc1.ACEenabled == svc2.ACEenabled
+		})
+
+	if !servicesEqual {
+		return false
+	}
+
+	// Use generics.EqualSetsFn to compare ingress arrays
+	return generics.EqualSetsFn(s.UserIngress, s2.UserIngress,
+		func(ing1, ing2 KubeIngressInfo) bool {
+			if ing1.Namespace != ing2.Namespace ||
+				ing1.Name != ing2.Name ||
+				ing1.Hostname != ing2.Hostname ||
+				ing1.Path != ing2.Path ||
+				ing1.PathType != ing2.PathType ||
+				ing1.ServiceType != ing2.ServiceType ||
+				ing1.Protocol != ing2.Protocol {
+				return false
+			}
+
+			// Compare the ingress IPs
+			return generics.EqualSets(ing1.IngressIP, ing2.IngressIP)
+		})
 }


### PR DESCRIPTION
- Allow zedkube to periodically checking on cluster service, ingress
- exclude certain namespaces, and services, allow dynamically learning on cluster services ports, and ingress
- publish to the KubeUserServices for kubernetes services
- nim subscribe to the KubeUserServices from zedkube and triggers update if the items changes
- handle the service ports, and ingress ports with NodePort or Loadbalancer types
- allow cni0/cluster-prefix outbound traffic to be marked properly
- handle Authorized Cluster Endpoint for local kubectl access
- documented the zks networking in zedkube.md

# Description

Allow for ZKS networking to enable kubernetes services, ingress and load-balancer operations

<!-- Clear description what this PR does and why it's needed -->

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

With this PR patch, compile EVE with HV type 'kubevirt', one can deploy services, ingress resources and allow the users to access the pod through the NodePort or LoadBalancer types.

Testing Done.

Have tested on single node k3s and multiple node cluster setup, with combined cluster-prefix interface and separate cluster-prefix interfaces. and configured with different service types, ingress types, and load-balancers.

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

## Changelog notes

Support the EVE device allowing kubernetes services, ingresses

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [ x ] I've provided a proper description
- [ x ] I've added the proper documentation (when applicable)
- [ x ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
