### PR TITLE
Handle optional ZKS load-balancer Service

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -74,6 +74,13 @@ RUN mkdir -p /etc/containerd
 COPY config-k3s.toml /etc/containerd/
 WORKDIR /
 
+# Kube-VIP
+COPY kubevip-sa.yaml /etc/
+COPY kubevip-ds.yaml /etc/
+COPY kubevip-apply.sh /usr/bin/
+COPY kubevip-delete.sh /usr/bin/
+RUN chmod +x /usr/bin/kubevip-apply.sh /usr/bin/kubevip-delete.sh
+
 ARG TARGETARCH
 
 # Actual k3s install and config happens when this container starts during EVE bootup, look at cluster-init.sh

--- a/pkg/kube/kubevip-apply.sh
+++ b/pkg/kube/kubevip-apply.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+#
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# kubevip-apply.sh
+# This script creates a Kube-VIP ConfigMap with the specified interface and CIDR range
+# and applies the necessary Kubernetes resources.
+# This script is for testing only, not for production use.
+
+# Function to display usage information
+show_usage() {
+    echo "Usage: $0 <interface-name> <ip-prefix>"
+    echo "Example: $0 eth1 192.168.86.200/29"
+    echo ""
+    echo "This script creates a Kube-VIP ConfigMap with the specified interface and CIDR range"
+    echo "and applies the necessary Kubernetes resources."
+    echo "This script is for testing only, not for production use."
+}
+
+# Check if we have two arguments
+if [ $# -ne 2 ]; then
+    echo "Error: Missing required parameters"
+    show_usage
+    exit 1
+fi
+
+# Assign arguments to variables
+INTERFACE=$1
+CIDR=$2
+
+# Validate interface name (simple check)
+if ! echo "$INTERFACE" | grep -qE '^[a-zA-Z0-9_-]+$'; then
+    echo "Error: Invalid interface name format. Allowed characters: letters, numbers, underscores (_), dots (.), and hyphens (-)"
+    show_usage
+    exit 1
+fi
+
+# Validate CIDR format (simple check)
+if ! echo "$CIDR" | grep -qE '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$'; then
+    echo "Error: Invalid CIDR format. Expected format: x.x.x.x/y"
+    show_usage
+    exit 1
+fi
+
+# Create ConfigMap file
+# see https://github.com/kube-vip/kube-vip-cloud-provider for config examples
+cat > /etc/kubevip-cm.yaml << EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevip
+  namespace: kube-system
+data:
+  # Global settings for all LoadBalancer services
+  cidr-default: "${CIDR}" # Default CIDR for LoadBalancer services
+  cidr-global: "${CIDR}" # Default CIDR for LoadBalancer services
+  interface-default: "${INTERFACE}" # All global LoadBalancer IPs will be advertised on ${INTERFACE}
+  interface-global: "${INTERFACE}" # All global LoadBalancer IPs will be advertised on ${INTERFACE}
+EOF
+
+echo "Created Kube-VIP ConfigMap with interface ${INTERFACE} and CIDR ${CIDR}"
+echo "Applying Kube-VIP resources..."
+
+# Apply Kubernetes resources
+if kubectl apply -f /etc/kubevip-sa.yaml && \
+   kubectl apply -f /etc/kubevip-cm.yaml && \
+   kubectl apply -f /etc/kubevip-ds.yaml; then
+    echo "Kube-VIP resources successfully applied"
+else
+    echo "Error applying Kube-VIP resources"
+    exit 1
+fi
+
+echo "Kube-VIP configuration complete"

--- a/pkg/kube/kubevip-delete.sh
+++ b/pkg/kube/kubevip-delete.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# kubevip-delete.sh
+# This script deletes the Kube-VIP ConfigMap and associated resources.
+# This script is for testing only, not for production use.
+
+if kubectl delete -f /etc/kubevip-ds.yaml && \
+   kubectl delete -f /etc/kubevip-cm.yaml && \
+   kubectl delete -f /etc/kubevip-sa.yaml; then
+    echo "Kube-VIP resources successfully removed"
+else
+    echo "Error deleting Kube-VIP resources"
+    exit 1
+fi

--- a/pkg/kube/kubevip-ds.yaml
+++ b/pkg/kube/kubevip-ds.yaml
@@ -1,0 +1,93 @@
+#
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-vip-ds
+    app.kubernetes.io/version: v0.8.9
+  name: kube-vip-ds
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-vip-ds
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-vip-ds
+        app.kubernetes.io/version: v0.8.9
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+      containers:
+        - args:
+            - manager
+          env:
+            - name: vip_arp
+              value: "true"
+            - name: port
+              value: "6443"
+            - name: vip_nodename
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: vip_interface
+              valueFrom:
+                configMapKeyRef:
+                  name: kubevip
+                  key: interface-global
+                  optional: true
+            - name: dns_mode
+              value: first
+            - name: svc_enable
+              value: "true"
+            - name: cp_enable
+              value: "false"
+            - name: svc_leasename
+              value: plndr-svcs-lock
+            - name: vip_leaderelection
+              value: "true"
+            - name: vip_leasename
+              value: plndr-cp-lock
+            - name: vip_leaseduration
+              value: "15"
+            - name: vip_renewdeadline
+              value: "10"
+            - name: vip_retryperiod
+              value: "2"
+            - name: prometheus_server
+              value: 0.0.0.0:2112
+          image: ghcr.io/kube-vip/kube-vip:v0.8.9
+          imagePullPolicy: IfNotPresent
+          name: kube-vip
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_RAW
+                - SYS_TIME
+      hostNetwork: true
+      serviceAccountName: kube-vip-cloud-controller
+      volumes:
+        - hostPath:
+            path: /etc/rancher/k3s/k3s.yaml
+          name: kubeconfig
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+  updateStrategy: {}

--- a/pkg/kube/kubevip-sa.yaml
+++ b/pkg/kube/kubevip-sa.yaml
@@ -1,0 +1,91 @@
+#
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-vip-cloud-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: system:kube-vip-cloud-controller-role
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "update", "list", "put"]
+  - apiGroups: [""]
+    resources: ["configmaps", "endpoints", "events", "services/status", "leases"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["nodes", "services"]
+    verbs: ["list", "get", "watch", "update"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-vip-cloud-controller-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-vip-cloud-controller-role
+subjects:
+  - kind: ServiceAccount
+    name: kube-vip-cloud-controller
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-vip-cloud-provider
+  namespace: kube-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: kube-vip
+      component: kube-vip-cloud-provider
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: kube-vip
+        component: kube-vip-cloud-provider
+    spec:
+      containers:
+        - name: kube-vip-cloud-provider
+          image: ghcr.io/kube-vip/kube-vip-cloud-provider:v0.0.12
+          imagePullPolicy: IfNotPresent
+          command:
+            - /kube-vip-cloud-provider
+            - --leader-elect-resource-name=kube-vip-cloud-controller
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      serviceAccountName: kube-vip-cloud-controller
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 10
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+            - weight: 10
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists


### PR DESCRIPTION
- have the kube-vip service in servcie-account, config-map, daemonset yaml files
- this is to support the optional on-site cluster load-balancer service
- for the moment, we don't have the controller side configures workflow ready, but it has the script to let later integration with scripts
- for now, user can do testing to manually apply/delete the service by passing in the interface and LB prefix params

# Description

Have the configuration yaml files, and scripts to allow kube-vip load-balancer service on ZKS

<!-- Clear description what this PR does and why it's needed -->

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

Work with the patch in PR ##4948, user can run the '/usr/bin/kubevip-apply.sh' inside the 'kube' container of EVE. Given two params: one is the interface to be used for this LB service, the other is the IP prefix to be used for LB allocation. Combined with the cluster services, user can have the application access through the load-balancer IP address and service port.

Testing Run
have tested this launching of LB service, together with the service PR, have tested the LB in various conditions, such as single node, multi-node cluster, combined cluster-interface or dedicated cluster-interface.

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

## Changelog notes

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [ x ] I've provided a proper description
- [ x ] I've added the proper documentation (when applicable)
- [ x ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
