### PR TITLE
Enable Node Convert to base k3s.

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -29,6 +29,7 @@ COPY --from=build /out/ /
 COPY cluster-init.sh /usr/bin/
 COPY cluster-utils.sh /usr/bin/
 COPY cgconfig.conf /etc
+COPY utils.sh /usr/bin/
 
 # upgrades
 COPY cluster-update.sh /usr/bin/
@@ -48,6 +49,7 @@ COPY multus-daemonset.yaml /etc
 COPY kubevirt-operator.yaml /etc
 COPY kubevirt-features.yaml /etc
 COPY external-boot-image.tar /etc/
+COPY kubevirt-utils.sh /usr/bin/
 
 # Longhorn config
 COPY longhorn-utils.sh /usr/bin/
@@ -55,6 +57,7 @@ COPY lh-cfg-v1.6.3.yaml /etc/
 COPY iscsid.conf /etc/iscsi/
 COPY longhorn-generate-support-bundle.sh /usr/bin/
 COPY nsmounter /usr/bin/
+COPY longhorn_uninstall_settings.yaml /etc/
 
 # descheduler
 COPY descheduler-utils.sh /usr/bin/

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -3,8 +3,6 @@
 # Copyright (c) 2023-2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-KUBEVIRT_VERSION=v1.1.0
-CDI_VERSION=v1.57.1
 NODE_IP=""
 RESTART_COUNT=0
 K3S_LOG_DIR="/persist/kubelog"
@@ -22,6 +20,7 @@ MAX_WAIT_TIME=$((10 * 60)) # 10 minutes in seconds, exponential backoff for k3s 
 current_wait_time=$INITIAL_WAIT_TIME
 CLUSTER_WAIT_FILE="/run/kube/cluster-change-wait-ongoing"
 All_PODS_READY=true
+install_kubevirt=1
 
 # shellcheck source=pkg/kube/descheduler-utils.sh
 . /usr/bin/descheduler-utils.sh
@@ -34,6 +33,10 @@ All_PODS_READY=true
 . /usr/bin/cluster-update.sh
 # shellcheck source=pkg/kube/registration-utils.sh
 . /usr/bin/registration-utils.sh
+# shellcheck source=pkg/kube/utils.sh
+. /usr/bin/utils.sh
+# shellcheck source=pkg/kube/kubevirt-utils.sh
+. /usr/bin/kubevirt-utils.sh
 
 # get cluster IP address from the cluster status file
 get_cluster_node_ip() {
@@ -261,6 +264,10 @@ check_start_k3s() {
 }
 
 external_boot_image_import() {
+        if [ "$install_kubevirt" = "0" ]; then
+                return 0
+        fi
+
         # NOTE: https://kubevirt.io/user-guide/virtual_machines/boot_from_external_source/
         # Install external-boot-image image to our eve user containerd registry.
         # This image contains just kernel and initrd to bootstrap a container image as a VM.
@@ -328,6 +335,14 @@ apply_node_uuid_label () {
                 logmsg "Not all pods are ready, Continue to wait while applying node labels"
         fi
         kubectl label node "$HOSTNAME" node-uuid="$DEVUUID"
+}
+
+node_uuid_label_set() {
+        val=$(kubectl get "node/${HOSTNAME}" -o jsonpath='{.metadata.labels.node-uuid}')
+        if [ "$val" != "$DEVUUID" ]; then
+                return 1
+        fi
+        return 0
 }
 
 # reapply the node labels
@@ -523,6 +538,7 @@ check_cluster_config_change() {
           return 0
         fi
         Registration_Cleanup
+        rm /var/lib/left_edge_node_cluster_mode
         touch /var/lib/convert-to-single-node
         reboot
       fi
@@ -575,6 +591,15 @@ check_cluster_config_change() {
       fi
     fi
     logmsg "Check cluster config change done"
+
+    ## Convert system
+    Registration_CheckApply
+    if Registration_Exists; then
+        if [ ! -f /var/lib/left_edge_node_cluster_mode ]; then
+                uninstall_components &
+                touch /var/lib/left_edge_node_cluster_mode
+        fi
+    fi
 }
 
 monitor_cluster_config_change() {
@@ -582,6 +607,45 @@ monitor_cluster_config_change() {
         check_cluster_config_change
         sleep 15
     done
+}
+
+# started when we detect registration addition
+# start cleaning up some components
+# these are cluster-wide operations, only one nodes initiates it
+# Marked via the Registration_Exists fence
+uninstall_components() {
+        logmsg "Post-registration cleanup steps: wait api available"
+        while ! kubectl cluster-info; do
+                sleep 5
+        done
+        logmsg "Post-registration cleanup steps: kubectl cluster-info ready, wait nodes ready"
+        while true; do
+                # shellcheck disable=SC2281,SC2154,SC2046,SC2016
+                $not_ready_nodes=$(kubectl get nodes -o go-template='{{range .items}}{{ $ready := false }}{{range .status.conditions}}{{if and (eq .type "Ready") (eq .status "True")}}{{ $ready = true }}{{end}}{{end}}{{if not $ready}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}')
+                if [ "$not_ready_nodes" = "" ]; then
+                        break
+                fi
+                sleep 5
+        done
+        logmsg "Post-registration cleanup steps: nodes ready"
+
+        logmsg "Cleanup Descheduler"
+        Descheduler_uninstall
+
+        logmsg "Cleanup longhorn"
+        Longhorn_uninstall
+        rm /var/lib/longhorn_initialized
+
+        logmsg "Cleanup cdi"
+        Cdi_uninstall
+
+        logmsg "Cleanup kubevirt"
+        Kubevirt_uninstall
+        rm /var/lib/kubevirt_initialized
+
+        logmsg "Cleanup multus"
+        Multus_uninstall
+        rm /var/lib/multus_initialized
 }
 
 # provision the config.yaml and bootstrap-config.yaml for cluster node, passing $1 as k3s needs initializing
@@ -745,6 +809,11 @@ fi
 # use part of the /run/eve-release to get the OS-IMAGE string
 get_eve_os_release
 
+if ! is_amd64; then
+        # no cdi support yet
+        install_kubevirt=0
+fi
+
 #Forever loop every 15 secs
 while true;
 do
@@ -774,7 +843,9 @@ if [ ! -f /var/lib/all_components_initialized ]; then
         fi
 
         # label the node with device uuid
-        apply_node_uuid_label
+        if ! node_uuid_label_set; then
+                apply_node_uuid_label
+        fi
 
         if ! are_all_pods_ready; then
                 All_PODS_READY=false
@@ -810,27 +881,17 @@ if [ ! -f /var/lib/all_components_initialized ]; then
                 continue
         fi
 
-        if [ ! -f /var/lib/kubevirt_initialized ]; then
-                wait_for_item "kubevirt"
-                # This patched version will be removed once the following PR https://github.com/kubevirt/kubevirt/pull/9668 is merged
-                logmsg "Installing patched Kubevirt"
-                kubectl apply -f /etc/kubevirt-operator.yaml
-                logmsg "Updating replica to 1 for virt-operator and virt-controller"
-                kubectl patch deployment virt-operator -n kubevirt --patch '{"spec":{"replicas": 1 }}'
-                kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
-                kubectl patch KubeVirt kubevirt -n kubevirt --patch '{"spec": {"infra": {"replicas": 1}}}' --type='merge'
+        if [ "$install_kubevirt" = "1" ]; then
+                if [ ! -f /var/lib/kubevirt_initialized ]; then
+                        wait_for_item "kubevirt"
+                        Kubevirt_install
 
-                wait_for_item "cdi"
-                #CDI (containerzed data importer) is need to convert qcow2/raw formats to Persistent Volumes and Data volumes
-                #Since CDI goes with kubevirt we install with that.
-                logmsg "Installing CDI version $CDI_VERSION"
-                kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
-                kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
-                #Add kubevirt feature gates
-                kubectl apply -f /etc/kubevirt-features.yaml
+                        wait_for_item "cdi"
+                        Cdi_install
 
-                touch /var/lib/kubevirt_initialized
-                continue
+                        touch /var/lib/kubevirt_initialized
+                        continue
+                fi
         fi
 
         #
@@ -853,12 +914,13 @@ if [ ! -f /var/lib/all_components_initialized ]; then
         # Descheduler
         #
         wait_for_item "descheduler"
+        logmsg "Applying Descheduler ${DESCHEDULER_VERSION}"
         if ! descheduler_install; then
                 continue
         fi
 
 
-        if [ -f /var/lib/kubevirt_initialized ] && [ -f /var/lib/longhorn_initialized ]; then
+        if [ -f /var/lib/longhorn_initialized ]; then
                 logmsg "All components initialized"
                 touch /var/lib/node-labels-initialized
                 touch /var/lib/all_components_initialized
@@ -942,9 +1004,11 @@ fi
         check_kubeconfig_yaml_files
         check_and_remove_excessive_k3s_logs
         check_and_run_vnc
-        Update_CheckClusterComponents
-        Update_RunDeschedulerOnBoot
-        Registration_CheckApply
+        if ! Registration_Applied; then
+                # Upgrades declared via EVE baseOS updates
+                Update_CheckClusterComponents
+                Update_RunDeschedulerOnBoot
+        fi
         wait_for_item "wait"
         sleep 15
 done

--- a/pkg/kube/cluster-utils.sh
+++ b/pkg/kube/cluster-utils.sh
@@ -291,3 +291,9 @@ wait_for_default_route() {
         done < /proc/net/route
         return 1
 }
+
+Multus_uninstall() {
+        logmsg "multus uninstall"
+        kubectl delete -f /etc/multus-daemonset-new.yaml
+        rm /var/lib/multus_initialized
+}

--- a/pkg/kube/descheduler-utils.sh
+++ b/pkg/kube/descheduler-utils.sh
@@ -7,7 +7,6 @@ DESCHEDULER_VERSION="v0.29.0"
 
 descheduler_install()
 {
-    logmsg "Applying Descheduler ${DESCHEDULER_VERSION}"
     if ! kubectl apply -f /etc/descheduler_rbac.yaml; then
             logmsg "descheduler rbac not yet applied"
             return 1
@@ -17,4 +16,17 @@ descheduler_install()
             return 1
     fi
     return 0
+}
+
+Descheduler_uninstall() {
+        logmsg "Removing Descheduler ${DESCHEDULER_VERSION}"
+        if ! kubectl delete -f /etc/descheduler-policy-configmap.yaml; then
+                logmsg "descheduler config not deleted"
+                return 1
+        fi
+        if ! kubectl delete -f /etc/descheduler_rbac.yaml; then
+                logmsg "descheduler not deleted"
+                return 1
+        fi
+        return 0
 }

--- a/pkg/kube/kubevirt-utils.sh
+++ b/pkg/kube/kubevirt-utils.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+#
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+KUBEVIRT_VERSION=v1.1.0
+CDI_VERSION=v1.57.1
+
+Kubevirt_install() {
+    # This patched version will be removed once the following PR https://github.com/kubevirt/kubevirt/pull/9668 is merged
+    logmsg "Installing patched Kubevirt"
+    kubectl apply -f /etc/kubevirt-operator.yaml
+    logmsg "Updating replica to 1 for virt-operator and virt-controller"
+    kubectl patch deployment virt-operator -n kubevirt --patch '{"spec":{"replicas": 1 }}'
+    kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
+    kubectl patch KubeVirt kubevirt -n kubevirt --patch '{"spec": {"infra": {"replicas": 1}}}' --type='merge'
+    #Add kubevirt feature gates
+    kubectl apply -f /etc/kubevirt-features.yaml
+}
+
+Kubevirt_uninstall() {
+    logmsg "Removing patched Kubevirt"
+    kubectl delete -f /etc/kubevirt-features.yaml
+    kubectl delete -f /etc/kubevirt-operator.yaml
+
+    # Kubevirt applies a large amount of labels to nodes detailing available cpu flags, remove them
+    for n in $(kubectl get node -o NAME); do
+        logmsg "removing kubevirt.io labels from node: $n"
+        labelsToRemove=$(kubectl get "$n" -o json | jq -r '.metadata.labels | to_entries[] | select(.key | contains("kubevirt.io")) | .key' | awk '{printf "%s- ", $0}')
+        # shellcheck disable=SC2086
+        kubectl label $n $labelsToRemove
+    done
+    rm /var/lib/kubevirt_initialized
+}
+
+Cdi_install() {
+    #CDI (containerzed data importer) is need to convert qcow2/raw formats to Persistent Volumes and Data volumes
+    logmsg "Installing CDI version $CDI_VERSION"
+    kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
+    kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
+}
+
+Cdi_uninstall() {
+    #CDI (containerzed data importer) is need to convert qcow2/raw formats to Persistent Volumes and Data volumes
+    logmsg "Removing CDI version $CDI_VERSION"
+    kubectl delete -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
+    kubectl delete -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
+}

--- a/pkg/kube/longhorn-generate-support-bundle.sh
+++ b/pkg/kube/longhorn-generate-support-bundle.sh
@@ -5,6 +5,14 @@
 
 LOG_DIR=/persist/kubelog
 
+# This script is called from collect-info, help it avoid a timeout
+# by checking for longhorn installed state and return before applying
+# the support bundle manifest.
+if ! kubectl get namespace/longhorn-system; then
+    echo "Longhorn not installed, skipping SupportBundle"
+    exit 1
+fi
+
 echo "Apply longhorn support bundle yaml at $(date)"
 
 cat <<EOF | kubectl apply -f -

--- a/pkg/kube/longhorn_uninstall_settings.yaml
+++ b/pkg/kube/longhorn_uninstall_settings.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: longhorn.io/v1beta2
+kind: Setting
+metadata:
+  name: deleting-confirmation-flag
+  namespace: longhorn-system
+value: "true"

--- a/pkg/kube/utils.sh
+++ b/pkg/kube/utils.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+is_amd64() {
+    mach_type=$(uname -m)
+    if [ "$mach_type" = "x86_64" ]; then
+        return 0
+    fi
+    if [ "$mach_type" = "amd64" ]; then
+        return 0
+    fi
+    return 1
+}

--- a/pkg/pillar/cmd/zedkube/clusterstatus.go
+++ b/pkg/pillar/cmd/zedkube/clusterstatus.go
@@ -115,7 +115,10 @@ func (z *zedkube) publishKubeConfigStatus() {
 			// Don't store the decrypted manifest in EdgeNodeClusterStatus as its a pubsub published
 			// structure and could lead to some log.Fatal due to this buffer size.
 			regExists, err := kubeapi.RegistrationExists(kubeapi.PillarPersistManifestPath)
-			if z.clusterConfig.BootstrapNode && (len(decGzipManifest) != 0) && (!regExists || err != nil) {
+			if regExists && (err == nil) {
+				log.Warn("Registration exists, overwriting")
+			}
+			if z.clusterConfig.BootstrapNode && (len(decGzipManifest) != 0) {
 				go func() {
 					err := kubeapi.RegistrationAdd(kubeapi.PillarPersistManifestPath, decGzipManifest)
 					if err != nil {

--- a/pkg/pillar/kubeapi/registration.go
+++ b/pkg/pillar/kubeapi/registration.go
@@ -8,12 +8,18 @@ package kubeapi
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	utils "github.com/lf-edge/eve/pkg/pillar/utils/file"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 )
 
 //
@@ -45,6 +51,10 @@ func RegistrationAdd(rootPath string, gzipYamlBody []byte) error {
 	if _, err := os.Stat(rootPath); err != nil {
 		os.MkdirAll(rootPath, 0700)
 	}
+	exists, err := RegistrationExists(rootPath)
+	if exists {
+		os.Remove(filepath.Join(rootPath, registrationFileName))
+	}
 	//return WriteAndRename(registrationFileName, rootPath, yamlBody)
 	return utils.WriteRename(filepath.Join(rootPath, registrationFileName), yamlBody)
 }
@@ -56,4 +66,30 @@ func RegistrationExists(rootPath string) (bool, error) {
 		return true, nil
 	}
 	return false, err
+}
+
+// registrationAppliedToCluster returns nil if the AddOn has been applied
+// to the cluster
+func registrationAppliedToCluster() error {
+	config, err := GetKubeConfig()
+	if err != nil {
+		return fmt.Errorf("Failed to create dynamic client: %v", err)
+	}
+
+	dyn, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("Failed to create dynamic client: %v", err)
+	}
+
+	addonGVR := schema.GroupVersionResource{
+		Group:    "k3s.cattle.io",
+		Version:  "v1",
+		Resource: "addons",
+	}
+
+	addon, err := dyn.Resource(addonGVR).Get(context.TODO(), "persist-registration", metav1.GetOptions{})
+	if (err != nil) || (addon == nil) {
+		return fmt.Errorf("Failed to get AddOn/persist-registration: %v", err)
+	}
+	return nil
 }


### PR DESCRIPTION
# Description

The goal of this PR is to enable a base-k3s mode of HV=kubevirt EVE-OS.  The existing mode of HV=kubevirt is that after first-boot the k3s node will contain installed a series of components to enable running virtual machines and redundant storage.  With this PR, the controller sends config declaring that EVE should change to a base-k3s mode/state.  This PR implements the detection and conversion-to this new mode.

- Move component install steps to clean functions
- Uninstall components if registration completes. This marks conversion from edge node storage cluster which provides VMs on replicated storage to a simpler kubernetes cluster awaiting further config.  The original configuration is restored later with the existing convert-to-single-node path when EdgeNodeClusterConfig us unpublished.
- Enable all_components_initialized on arm64 by skipping install of kubevirt/cdi components.  CDI is amd64 only at least in this version.
- Skip calling longhorn API when it's not expected to be available.  This is used in pillar's node drain path as well as replicated volume instance metrics.  Search for the longhorn-system namespace to determine if the longhorn http api is expected to be available.  The kubernetes API server should always be available in HV=kubevirt.
For reference the node drain path is documented in: https://github.com/lf-edge/eve/blob/master/pkg/pillar/docs/zedkube.md#kubernetes-node-draining

<!-- Clear description what this PR does and why it's needed -->

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

https://github.com/lf-edge/eve/pull/4870

## How to test and validate this PR

<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

- Configure an EVE controller to create a cluster of EVE-OS nodes, and generate a registration manifest.
- eve enter kube
- Verify the correct registration deployments are running on the cluster.
- Verify the longhorn-system, kubevirt, cdi, multus namespaces are cleaned up.

## Changelog notes

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
