### PR TITLE
bpftrace-compiler: add coverage target

### DIFF
--- a/eve-tools/bpftrace-compiler/.gitignore
+++ b/eve-tools/bpftrace-compiler/.gitignore
@@ -1,2 +1,3 @@
 bpftrace-compiler
 kernel-commits.mk
+coverage.txt

--- a/eve-tools/bpftrace-compiler/Makefile
+++ b/eve-tools/bpftrace-compiler/Makefile
@@ -7,7 +7,10 @@ bpftrace-compiler: *.go
 .PHONY: test bare-test docker-test
 
 bare-test:
-	go test -test.timeout 1h -v -race .
+	go test -coverprofile=coverage.txt -covermode=atomic -test.timeout 1h -v -race .
+
+show-coverage:
+	go tool cover -html=coverage.txt
 
 test: bare-test
 


### PR DESCRIPTION
# Description

- run tests with recording coverage
- `make show-coverage` to open coverage browser



<!-- Clear description what this PR does and why it's needed -->

<!-- For Backport PRs, please note the following:

- Add a note to indicate the origin of the fix, for example:

Backport of #<original-PR-number>

- PR's title should also indicate the stable branch, for instance:

[<stable-branch>] Original's PR title
-->

## PR dependencies

<!-- List all dependencies of this PR (when applicable) -->

## How to test and validate this PR

in `eve-tools/bptrace-compiler` do:
```
make test
make show-coverage
```

## Changelog notes

Not user visible

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
