### PR TITLE
log: remove XXX debug markers and improve message clarity (Closes #4521)

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -103,7 +103,7 @@ func installDownloadedObject(ctx *baseOsMgrContext, contentID uuid.UUID, finalOb
 	}
 	refID = ctsPtr.ReferenceID()
 	if refID == "" {
-		log.Fatalf("XXX no image ID for LOADED %s",
+		log.Fatalf("Content tree status is LOADED but missing required image ID for content %s",
 			contentID)
 	}
 	log.Functionf("For %s reference ID for LOADED: %s",

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -805,7 +805,7 @@ func updateStatusByBlob(ctx *volumemgrContext, sha ...string) {
 		}
 	}
 	if !found {
-		log.Warnf("XXX updateStatusByBlob(%s) NOT FOUND", sha)
+		log.Warnf("updateStatusByBlob(%s) NOT FOUND", sha)
 	}
 }
 
@@ -896,7 +896,7 @@ func updateContentTreeStatus(ctx *volumemgrContext, contentSha256 string, conten
 		}
 	}
 	if !found {
-		log.Warnf("XXX updateContentTreeStatus(%s) NOT FOUND", contentID)
+		log.Warnf("updateContentTreeStatus(%s) NOT FOUND", contentID)
 	}
 }
 
@@ -926,7 +926,7 @@ func updateVolumeStatus(ctx *volumemgrContext, volumeID uuid.UUID) bool {
 		}
 	}
 	if !found {
-		log.Warnf("XXX updateVolumeStatus(%s) NOT FOUND", volumeID)
+		log.Warnf("updateVolumeStatus(%s) NOT FOUND", volumeID)
 	}
 	return found
 }
@@ -956,6 +956,6 @@ func updateVolumeStatusFromContentID(ctx *volumemgrContext, contentID uuid.UUID)
 		}
 	}
 	if !found {
-		log.Warnf("XXX updateVolumeStatusFromContentID(%s) NOT FOUND", contentID)
+		log.Warnf("updateVolumeStatusFromContentID(%s) NOT FOUND", contentID)
 	}
 }

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1598,7 +1598,7 @@ func SendProtobuf(url string, buf *bytes.Buffer, size int64,
 		switch rv.HTTPResp.StatusCode {
 		// XXX Some controller gives a generic 400 which should be fixed
 		case http.StatusBadRequest:
-			log.Warnf("XXX SendProtoBuf: %s silently ignore code %d %s",
+			log.Warnf("SendProtoBuf: Ignoring bad request for %s - code %d %s (controller issue should be fixed)",
 				url, rv.HTTPResp.StatusCode, http.StatusText(rv.HTTPResp.StatusCode))
 			return nil
 

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -1267,7 +1267,7 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 	sysAdapter *zconfig.SystemAdapter, version types.DevicePortConfigVersion,
 ) (ports []*types.NetworkPortConfig, err error) {
 
-	log.Functionf("XXX parseOneSystemAdapterConfig name %s lowerLayerName %s",
+	log.Functionf("parseOneSystemAdapterConfig name %s lowerLayerName %s",
 		sysAdapter.Name, sysAdapter.LowerLayerName)
 
 	// We check if any phyio has FreeUplink set. If so we operate
@@ -1358,7 +1358,7 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 		if phyioFreeUplink || sysAdapter.FreeUplink {
 			portCost = 0
 		} else if oldController {
-			log.Warnf("XXX oldController and !FreeUplink; assume %s cost=1",
+			log.Warnf("oldController and !FreeUplink; assume %s cost=1",
 				sysAdapter.Name)
 			portCost = 1
 		}
@@ -1366,7 +1366,7 @@ func parseOneSystemAdapterConfig(getconfigCtx *getconfigContext,
 
 	var isMgmt bool
 	if version < types.DPCIsMgmt {
-		log.Warnf("XXX old version; assuming %s isMgmt and cost=0",
+		log.Warnf("old version; assuming %s isMgmt and cost=0",
 			sysAdapter.Name)
 		// This should go away when cloud sends proper values
 		isMgmt = true
@@ -2586,9 +2586,9 @@ func parseAppNetAdapterConfig(appInstance *types.AppInstanceConfig,
 		adapterCfg.IfIdx = 0
 	}
 
-	// XXX remove? Debug?
+	// Debug logging for multiple network adapters
 	if len(appInstance.AppNetAdapterList) > 1 {
-		log.Functionf("XXX post sort %+v", appInstance.AppNetAdapterList)
+		log.Functionf("App network adapters after sorting: %+v", appInstance.AppNetAdapterList)
 	}
 }
 
@@ -3264,7 +3264,7 @@ func scheduleBackup(backup *zconfig.DeviceOpsCmd) {
 		return
 	}
 	log.Functionf("scheduleBackup: Applying updated config %v", backup)
-	log.Errorf("XXX handle Backup Config: %v", backup)
+	log.Errorf("handle Backup Config: %v", backup)
 }
 
 // user driven reboot/shutdown/poweroff command originating from controller or

--- a/pkg/pillar/types/dpc.go
+++ b/pkg/pillar/types/dpc.go
@@ -370,12 +370,12 @@ func (config *DevicePortConfig) DoSanitize(log *base.LogObject, args DPCSanitize
 			port := &config.Ports[i]
 			if port.Phylabel == "" {
 				port.Phylabel = port.IfName
-				log.Functionf("XXX DoSanitize: Forcing Phylabel for %s ifname %s\n",
+				log.Functionf("DoSanitize: Setting missing Phylabel to match ifname for %s ifname %s",
 					config.Key, port.IfName)
 			}
 			if port.Logicallabel == "" {
 				port.Logicallabel = port.IfName
-				log.Functionf("XXX DoSanitize: Forcing Logicallabel for %s ifname %s\n",
+				log.Functionf("DoSanitize: Setting missing Logicallabel to match ifname for %s ifname %s",
 					config.Key, port.IfName)
 			}
 		}


### PR DESCRIPTION
# Description

This PR resolves Issue #4521 by removing "XXX" debug markers from log messages across multiple pillar components and improving message clarity for better debugging experience. The changes maintain existing log levels while making messages more professional and informative for production use.

Five source files have been updated to remove placeholder "XXX" prefixes and enhance log message descriptions:

* **pkg/pillar/cmd/baseosmgr/handledownload.go**
   * Enhanced error message for missing image ID in content tree status
   * Changed from generic "XXX no image ID" to descriptive explanation

* **pkg/pillar/cmd/volumemgr/updatestatus.go**
   * Cleaned up "NOT FOUND" warning messages in four functions
   * Removed "XXX" prefixes from updateStatusByBlob, updateContentTreeStatus, updateVolumeStatus, and updateVolumeStatusFromContentID

* **pkg/pillar/cmd/zedagent/handlemetrics.go**
   * Improved HTTP bad request handling message
   * Added context about controller issue that should be fixed

* **pkg/pillar/cmd/zedagent/parseconfig.go**
   * Updated old controller and version handling warning messages
   * Replaced debug comment with descriptive text for network adapter sorting
   * Clarified backup config handling message

* **pkg/pillar/types/dpc.go**
   * Enhanced Phylabel/Logicallabel sanitization messages
   * Made it clear when missing labels are being set to match interface names

## PR dependencies

Related to PR #4522
Continues XXX cleanup from commits 8a29188, d31ef12, 6272db1, 0dcf46f, 4f0e689, 71509e3

## How to test and validate this PR

`make test pkg/pillar`

## Changelog notes

This continues the XXX cleanup effort from related commits and is part of the broader codebase cleanup initiative.

## PR Backports

## Checklist

- [X] I've provided a proper description
- [X] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [X] I've written the test verification instructions
- [X] I've set the proper labels to this PR
