### PR TITLE
Fixes VirtualBox EVE VM onboarding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,10 +242,10 @@ QEMU_ACCEL__$(UNAME_S)_riscv64=-machine virt -cpu rv64
 QEMU_ACCEL__$(UNAME_S)_COMMON=-device virtio-rng-pci
 QEMU_ACCEL:=$(QEMU_ACCEL_$(ACCEL:%=Y)_$(UNAME_S)_$(ZARCH)) $(QEMU_ACCEL_$(ACCEL:%=Y)_$(UNAME_S)_COMMON)
 
-QEMU_OPTS_NET1=192.168.1.0/24
-QEMU_OPTS_NET1_FIRST_IP=192.168.1.10
-QEMU_OPTS_NET2=192.168.2.0/24
-QEMU_OPTS_NET2_FIRST_IP=192.168.2.10
+IPS_NET1=192.168.1.0/24
+IPS_NET1_FIRST_IP=192.168.1.10
+IPS_NET2=192.168.2.0/24
+IPS_NET2_FIRST_IP=192.168.2.10
 
 QEMU_MEMORY?=4096
 QEMU_EVE_SERIAL?=31415926
@@ -265,7 +265,7 @@ QEMU_OPTS_TPM=$(QEMU_OPTS_TPM_$(TPM:%=Y)_$(ZARCH))
 ifneq ($(TAP),)
 QEMU_OPTS_eth1=-netdev tap,id=eth1,ifname=$(TAP),script="" -device virtio-net-pci,netdev=eth1,csum=off,guest_csum=off,romfile=""
 else
-QEMU_OPTS_eth1=-netdev user,id=eth1,net=$(QEMU_OPTS_NET2),dhcpstart=$(QEMU_OPTS_NET2_FIRST_IP) -device virtio-net-pci,netdev=eth1,romfile=""
+QEMU_OPTS_eth1=-netdev user,id=eth1,net=$(IPS_NET2),dhcpstart=$(IPS_NET2_FIRST_IP) -device virtio-net-pci,netdev=eth1,romfile=""
 endif
 
 QEMU_OPTS_amd64=-smbios type=1,serial=$(QEMU_EVE_SERIAL)
@@ -279,7 +279,7 @@ QEMU_OPTS_COMMON= -m $(QEMU_MEMORY) -smp 4  $(QEMU_OPTS_BIOS) \
         -serial mon:stdio      \
         -global ICH9-LPC.noreboot=false -watchdog-action reset \
         -rtc base=utc,clock=rt \
-        -netdev user,id=eth0,net=$(QEMU_OPTS_NET1),dhcpstart=$(QEMU_OPTS_NET1_FIRST_IP),hostfwd=tcp::$(SSH_PORT)-:22$(QEMU_TFTP_OPTS) -device virtio-net-pci,netdev=eth0,romfile="" \
+        -netdev user,id=eth0,net=$(IPS_NET1),dhcpstart=$(IPS_NET1_FIRST_IP),hostfwd=tcp::$(SSH_PORT)-:22$(QEMU_TFTP_OPTS) -device virtio-net-pci,netdev=eth0,romfile="" \
 	$(QEMU_OPTS_eth1) \
         -device nec-usb-xhci,id=xhci \
         -qmp unix:$(CURDIR)/qmp.sock,server,wait=off
@@ -631,8 +631,8 @@ run-live-vb:
 	VBoxManage storagectl $(VB_VM_NAME) --name "SATA Controller" --add SATA --controller IntelAhci --bootable on --hostiocache on
 	VBoxManage storageattach $(VB_VM_NAME)  --storagectl "SATA Controller" --port 0 --device 0 --type hdd --medium $(CURRENT_DIR)/live.vdi
 	# Create NAT networks if they don't exist
-	VBoxManage natnetwork add --netname natnet1 --network "$(QEMU_OPTS_NET1)" --enable 2>/dev/null || true
-	VBoxManage natnetwork add --netname natnet2 --network "$(QEMU_OPTS_NET1)" --enable 2>/dev/null || true
+	VBoxManage natnetwork add --netname natnet1 --network "$(IPS_NET1)" --enable 2>/dev/null || true
+	VBoxManage natnetwork add --netname natnet2 --network "$(IPS_NET2)" --enable 2>/dev/null || true
 	VBoxManage modifyvm $(VB_VM_NAME) --nic1 natnetwork --nat-network1 natnet1 --cableconnected1 on --natpf1 "ssh,tcp,,$(SSH_PORT),,22"
 	VBoxManage modifyvm $(VB_VM_NAME) --nic2 natnetwork --nat-network2 natnet2 --cableconnected2 on
 	VBoxManage setextradata $(VB_VM_NAME) "VBoxInternal/Devices/pcbios/0/Config/DmiSystemSerial" "$(QEMU_EVE_SERIAL)"


### PR DESCRIPTION
Ensures VirtualBox EVE VMs can onboard correctly by setting the SMBIOS serial number.

Also includes minor fixes to network configuration for the VMs.

# Description

This PR sets at the SMBIOS of the virtual box vm the serial set in the makefile i order to be able to onboard it in the controller. Some changes were made to the makefile in order to fix the nat network settings.

## PR dependencies
virtualbox installed in the machine

## How to test and validate this PR
change the server address and serial as expected for a proper onboarding
run make live-vdi run-live-vb and it will create a virtualbox vm that should successfuly onboard.
<!-- Please describe how the changes in this PR can be validated or
verified. For example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.
-->

## Changelog notes

<!-- Short description to be included in the ChangeLog notes -->

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
