### PR TITLE
pillar: Fix short interval time on handlemetrics.go to seconds

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1013,14 +1013,14 @@ func hardwareHealthTimerTask(ctx *zedagentContext, handleChannel chan interface{
 	// Run a timer for extra safety to send hardwarehealth updates
 	// If we failed with the initial we have a short timer, otherwise
 	// the configurable one.
-	const shortTime = 120 // Short time: two minutes
+	const shortTimeSecs = 120 // Short time: two minutes
 	hardwareHealthInterval := ctx.globalConfig.GlobalValueInt(types.HardwareHealthInterval)
-	interval := time.Duration(hardwareHealthInterval) * time.Second
+	interval := time.Duration(hardwareHealthInterval)
 	if retry {
 		log.Noticef("Initial publishHardwareHealth failed; switching to short timer")
-		interval = shortTime
+		interval = shortTimeSecs
 	}
-	max := float64(interval)
+	max := float64(interval * time.Second)
 	min := max * 0.3
 	ticker := flextimer.NewRangeTicker(time.Duration(min), time.Duration(max))
 	// Return handle to caller
@@ -1049,7 +1049,7 @@ func hardwareHealthTimerTask(ctx *zedagentContext, handleChannel chan interface{
 				retry = false
 			} else if !retry && !success {
 				log.Noticef("Hardwarehealth failed; switching to short timer")
-				updateTaskTimer(shortTime, ticker)
+				updateTaskTimer(shortTimeSecs, ticker)
 				retry = true
 			}
 		case <-stillRunning.C:


### PR DESCRIPTION
# Description

hardwareHealthTimer() uses a short timer in case it fails to send the initial hardware health report to the remote controller. However, the short timer was planned to be 2 minutes (120 seconds) but it wasn't setup properly. This lead edge device to flood the controller with requests, making the deployment of an Edge App very slow, besides consume lots of CPU.

## How to test and validate this PR

This particular error happens only when the request to controller done by the function `hardwareHealthTimer()` fails, e.g., when the API in the remote controller is not updated. So, when the error happens, a message like the following should be seen in the logs:

```txt
2025-06-12T15:40:53.071804708Z;pillar.out;{"file":"/pillar/cmd/zedagent/handlemetrics.go:1691","func":"github.com/lf-
edge/eve/pkg/pillar/cmd/zedagent.sendHardwareHealthProtobufByURL","level":"error","msg":"sendHardwareHealthProtobufBy
URL status 10 failed: All attempts to connect to zedcloud.hummingbird.zededa.net/api/v2/edgedevice/id/25a1bbd1-9f28-4
d15-881b-d9cedbb19e2d/hardwarehealth failed: send via eth0: SendOnIntf to https://zedcloud.hummingbird.zededa.net/api
/v2/edgedevice/id/25a1bbd1-9f28-4d15-881b-d9cedbb19e2d/hardwarehealth reqlen 160 statuscode 404 Not Found body:\n0000
0000  7b 22 63 6f 64 65 22 3a  34 30 34 2c 22 6d 65 73  |{\"code\":404,\"mes|\n00000010  73 61 67 65 22 3a 22 4e  6f 
74 20 46 6f 75 6e 64  |sage\":\"Not Found|\n00000020  22 7d                                             |\"}|","pid":
```

The error fixed by this PR was causing a flood of these requests to the controller. So the best way to guarantee the issue was fixed is to run EVE and check the logs like this:

```sh
logread | grep sendHardwareHealthProtobufByURL
```

There should be just a few messages like the above. On a system without the fix, there will be thousands of this error happening all the time.

Additionally, a side effect of this error is that it makes the deployment of applications really slow. So a heavy application that would take, 25 - 30min to be deployed, can take hours.

## Changelog notes

Fix wrong time interval that was leading edge device to flood remote controller with requests.

## PR Backports

- [x] 14.5-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [x] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR