### PR TITLE
github/workflows: Increase timeout for arm64 publish builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,6 +91,7 @@ jobs:
   packages-arm:
     if: github.event.repository.full_name == 'lf-edge/eve'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 1440 # It takes more time when building arm64 on an amd64 runner
     strategy:
       fail-fast: false
       max-parallel: 1


### PR DESCRIPTION
# Description

Build arm64 packages on amd64 runners, specially the cross-compilers, can take more than the default 360 minutes (6h) maximum execution time. We can increase this timeout on self-hosted runners, so this PR sets the timeout for the arm64 build packages job to 1440 minutes (24h).

## How to test and validate this PR

Run GH publish workflow.

## Changelog notes

None.

## PR Backports

Not required since we are hitting the timeout limit only for new TAGs, e.g., 15.x.x.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.