### PR TITLE
Remove EVE_REL from tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,13 +377,7 @@ ifeq ($(LINUXKIT_PKG_TARGET),push)
   EVE_REL_$(REPO_BRANCH)_snapshot:=$(REPO_BRANCH)
   EVE_REL_master_snapshot:=$(if $(TAGPLAT),$(TAGPLAT)-snapshot,snapshot)
   EVE_REL:=$(EVE_REL_$(REPO_BRANCH)_$(REPO_TAG))
-
-  # the only time we rebuild everything from scratch is when we're building 'latest' release
-  # in order to achieve that we have to force EVE_HASH to be the release version
-  ifeq ($(shell [ "`git tag | grep -E '[0-9]*\.[0-9]*\.[0-9]*' | sort -t. -n -k1,1 -k2,2 -k3,3 | tail -1`" = $(REPO_TAG) ] && echo latest),latest)
-    EVE_HASH:=$(REPO_TAG)
-    EVE_REL:=$(if $(TAGPLAT),$(TAGPLAT)-latest,latest)
-  endif
+  EVE_REL:=$(EVE_REL)$(if $(TAGPLAT),-$(TAGPLAT),)
 endif
 
 # Check for a custom registry (used for development purposes)


### PR DESCRIPTION
# Description

We had a strange logic, where if the HEAD commit has a tag on it, *and* it is the highest semver tag available, then instead of building and pushing packages with the usual tree hash and also adding the tag, we actually override the usual and force the tag. This is strange and bad in two ways.

First, it means that even if nothing changes, it forced a rebuild of every single package. Which is silly. We want to use the existing ones, and just add the tag. Second, it means that we did it only for the most recent semver. So if we already have 15.2.0 and 14.5.0, then 15.3.0 would trigger this behaviour, but 14.5.1 would not? That makes no sense.

This eliminates it. From this point forward, every tag that is on HEAD gets --release to add the tag.

This has a significant impact on the build process for when we cut a release. Tagging (cutting a release) should be massively quicker, especially on emulated builds.

## PR dependencies

None

## How to test and validate this PR

CI should handle it in most cases. Unfortunately, it affects releases, so the only 100% way to test it will be when we cut a release. 

## Changelog notes

No user-facing changes

## PR Backports

I believe this should be backported to both of these, but would like input.

- 14.5-stable
- 13.4-stable

