### PR TITLE
Support ICMP cellular connectivity probe with undefined host IP

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -582,14 +582,27 @@ func parseConnectivityProbe(probe *zconfig.ConnectivityProbe) (
 	case zconfig.ConnectivityProbeMethod_CONNECTIVITY_PROBE_METHOD_ICMP:
 		parsedProbe.Method = types.ConnectivityProbeMethodICMP
 		parsedProbe.ProbeHost = probe.GetProbeEndpoint().GetHost()
-		if parsedProbe.ProbeHost == "" {
-			return parsedProbe, errors.New("missing endpoint host address for ICMP probe")
+		// Undefined host for ICMP probing is allowed - EVE will probe Google DNS
+		// (8.8.8.8) in that case.
+		// However, if host address is defined, it should be a valid IP address.
+		if parsedProbe.ProbeHost != "" {
+			probeIP := net.ParseIP(parsedProbe.ProbeHost)
+			if probeIP == nil {
+				return parsedProbe, fmt.Errorf("invalid IP address for ICMP probe: %s",
+					parsedProbe.ProbeHost)
+			}
 		}
 	case zconfig.ConnectivityProbeMethod_CONNECTIVITY_PROBE_METHOD_TCP:
 		parsedProbe.Method = types.ConnectivityProbeMethodTCP
+		// Host address should be a valid (and non-empty) IP address.
 		parsedProbe.ProbeHost = probe.GetProbeEndpoint().GetHost()
 		if parsedProbe.ProbeHost == "" {
 			return parsedProbe, errors.New("missing endpoint host address for TCP probe")
+		}
+		probeIP := net.ParseIP(parsedProbe.ProbeHost)
+		if probeIP == nil {
+			return parsedProbe, fmt.Errorf("invalid IP address for TCP probe: %s",
+				parsedProbe.ProbeHost)
 		}
 		probePort := probe.GetProbeEndpoint().GetPort()
 		if probePort == 0 {
@@ -2256,7 +2269,7 @@ func parseNetworkWirelessConfig(ctx *getconfigContext,
 		if err != nil {
 			return wconfig, err
 		}
-		if customProbe.Method == types.ConnectivityProbeMethodNone || err != nil {
+		if customProbe.Method == types.ConnectivityProbeMethodNone {
 			// For backward compatibility.
 			if probeCfg.GetProbeAddress() != "" {
 				customProbe = types.ConnectivityProbe{

--- a/pkg/wwan/mmagent/agent.go
+++ b/pkg/wwan/mmagent/agent.go
@@ -1358,6 +1358,15 @@ func (a *MMAgent) probeModemConnectivity(modem *ModemInfo) error {
 			return nil
 		}
 	case types.ConnectivityProbeMethodICMP:
+		if probeConfig.UserDefinedProbe.ProbeHost == "" {
+			// When ICMP probe is selected but probe host is undefined, we use the default
+			// probing endpoint (Google DNS).
+			err = a.runICMPProbe(modemIP, defaultProbeAddr)
+			if err == nil {
+				return nil
+			}
+			break
+		}
 		// User-configured ICMP probe address.
 		remoteIP := net.ParseIP(probeConfig.UserDefinedProbe.ProbeHost)
 		if remoteIP == nil {


### PR DESCRIPTION
# Description

This commit fixes handling of ICMP-based cellular connectivity probes when the probe host is not specified.
Users can configure periodic connectivity probes for cellular networks, using either ICMP or TCP. For ICMP, the probe host can be left empty to use the default target (Google DNS: 8.8.8.8), as was the implicit behavior in older EVE versions where the probe address was not yet configurable.

However, it turned out that EVE did not handle the case of an undefined ICMP probe IP at all. This went unnoticed because parsing errors (such as "missing endpoint host address for ICMP probe") were only logged, while the configuration was still applied — and probing happened to work as intended. With recent improvements in zedagent (in PR https://github.com/lf-edge/eve/pull/4779), parsing failures are now reported to the controller, and EVE rejects configurations with such errors.

This commit fixes the parsing logic to correctly accept an undefined ICMP probe endpoint and ensures it is properly handled by mmagent.

## How to test and validate this PR

Configure a cellular modem with Connectivity probing enabled. Select ICMP as the connectivity probing method but leave probing host IP empty. EVE should not report "missing endpoint host address for ICMP probe" for the configuration. Instead it should apply the cellular configuration, establish connectivity and use `8.8.8.8` as the default endpoint for ICMP probing.

## Changelog notes

Fix ICMP cellular probe parsing to correctly handle unspecified probe host and use default target (`8.8.8.8`).

## PR Backports

- 14.5-stable: To be backported.
- 13.4-stable: To be backported.
- 12.0-stable: No, https://github.com/lf-edge/eve/pull/4779 was not backported there and therefore this issue is not reproducible.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.