### PR TITLE
fix: protect against bogus negative timestamps in kernel messages (Closes #4526)

### DIFF
--- a/pkg/newlog/cmd/getKernelMsg.go
+++ b/pkg/newlog/cmd/getKernelMsg.go
@@ -21,11 +21,16 @@ func getKernelMsg(loggerChan chan inputEntry) {
 
 	kmsg := parser.Parse()
 	for msg := range kmsg {
+		// Protect against bogus negative timestamps in kernel messages
+		ts := msg.Timestamp
+		if ts.Unix() < 0 {
+			ts = time.Now()
+		}
 		entry := inputEntry{
 			source:    "kernel",
 			severity:  types.SyslogKernelDefaultLogLevel,
 			content:   msg.Message,
-			timestamp: msg.Timestamp.Format(time.RFC3339Nano),
+			timestamp: ts.Format(time.RFC3339Nano),
 		}
 		if msg.Priority >= 0 {
 			entry.severity = types.SyslogKernelLogLevelStr[msg.Priority%8]

--- a/pkg/newlog/cmd/getKernelMsg.go
+++ b/pkg/newlog/cmd/getKernelMsg.go
@@ -23,7 +23,7 @@ func getKernelMsg(loggerChan chan inputEntry) {
 	for msg := range kmsg {
 		// Protect against bogus negative timestamps in kernel messages
 		ts := msg.Timestamp
-		if ts.Unix() < 0 {
+		if ts.Year() < 2000 {
 			ts = time.Now()
 		}
 		entry := inputEntry{


### PR DESCRIPTION
# Description

This PR fixes an issue where kernel log messages can have negative timestamps, resulting in log entries with timestamps showing dates like "1969-12-31 11:59:59" (Unix epoch -1). 

The fix adds validation in `getKernelMsg()` to check if the kernel message timestamp has a negative Unix timestamp. When detected, it falls back to using the current time instead of the invalid timestamp, ensuring accurate and meaningful log entries.

**Fixes:** #4526

## How to test and validate this PR

make run

## Changelog notes

Fixed kernel log entries showing incorrect timestamps (1969 dates) when kernel messages contain negative timestamp values. Kernel logs now use current time as fallback for invalid timestamps.

## PR Backports

- 14.5-stable: To be backported (logging accuracy is important for debugging)
- 13.4-stable: To be backported (logging accuracy is important for debugging)

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

I do not have an amd64 device or a "standard" (non-Apple) arm64 device.

And the last but not least:
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.