### PR TITLE
pkg/bpftrace: disable tests when cross-compiling

### DIFF
--- a/pkg/bpftrace/Dockerfile
+++ b/pkg/bpftrace/Dockerfile
@@ -22,11 +22,17 @@ RUN make install
 # skip file exist test - probably broken because of container
 
 # unfortunately /proc/cpuinfo on docker on M1 mac is not telling much, so let's use the bogomips
-RUN if perl -ne 'exit 1 if (m/^bogomips\s*:\s*(\d+)/i && $1 < 500);' /proc/cpuinfo ; then \
-        ./tests/bpftrace_test --gtest_filter=-"portability_analyser.*:utils.file_exists_and_ownedby_root" 2>/dev/null; \
+ARG TARGETARCH
+ARG BUILDARCH
+RUN if [ "$TARGETARCH" = "$BUILDARCH" ]; then \
+        if perl -ne 'exit 1 if (m/^bogomips\s*:\s*(\d+)/i && $1 < 500);' /proc/cpuinfo ; then \
+            ./tests/bpftrace_test --gtest_filter=-"portability_analyser.*:utils.file_exists_and_ownedby_root" 2>/dev/null; \
+        else \
+            echo "You are a Mac user? Let's disable some tests we don't know why they fail!" \
+            ./tests/bpftrace_test --gtest_filter=-"portability_analyser.*:utils.file_exists_and_ownedby_root:childproc.ptrace_child*" 2>/dev/null; \
+        fi \
     else \
-        echo "You are a Mac user? Let's disable some tests we don't know why they fail!" \
-        ./tests/bpftrace_test --gtest_filter=-"portability_analyser.*:utils.file_exists_and_ownedby_root:childproc.ptrace_child*" 2>/dev/null; \
+        echo "Running bpftrace tests is disabled, because TARGETARCH=${TARGETARCH} and BUILDARCH=${BUILDARCH}"; \
     fi
 
 FROM scratch AS bin

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -9,7 +9,7 @@
 # to be a perfect place to put any other kind of debug info
 # into the package: see abuild/etc/abuild.conf.
 FROM lfedge/eve-recovertpm:25f66701fa7ce348631e5d9bf4efc5082a497b8b AS recovertpm
-FROM lfedge/eve-bpftrace:31a885bb79cc1cde850340a80dd38427213f3518 AS bpftrace
+FROM lfedge/eve-bpftrace:faebad58df4cddaa07d15937021854d8165d7c9a AS bpftrace
 FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
 ENV BUILD_PKGS="abuild curl tar make linux-headers patch g++ git gcc gpg ncurses-dev autoconf openssl-dev zlib-dev"
 # Feel free to add additional packages here, but be aware that


### PR DESCRIPTION

# Description

1. running the tests with qemu-bin emulation is slow
2. the tests might actually not work because of the different architecture

## PR dependencies


## How to test and validate this PR

on an amd64 machine:
```
docker build --target=build . -t f --platform linux/arm64
```
should print:
```
#20 0.278 Running bpftrace tests is disabled, because TARGETARCH=arm64 and BUILDARCH=amd64
```

but it does not happen when running:
```
docker build --target=build . -t f --platform linux/amd64
```

## Changelog notes

Probably not interesting for the changelog, but if then perhaps: Disable bpftrace tests when cross-compiling

## PR Backports



## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
