### PR TITLE
Build On Demand arm64 should use zededa runner

### DIFF
--- a/.github/workflows/buildondemand.yml
+++ b/.github/workflows/buildondemand.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: buildjet-4vcpu-ubuntu-2204-arm
+          - os: zededa-ubuntu-2204
             arch: arm64
           - os: zededa-ubuntu-2204
             arch: amd64


### PR DESCRIPTION
Only updates to buildondemand.yml, to improve speed/reliability.  Did not select 'tested my PR on' boxes as I do not have permissions.  This PR requested by @rene. 

# Description

Due to issue seen in task: https://github.com/lf-edge/eve/actions/runs/15825281019

## PR dependencies

None

## How to test and validate this PR

Run the "build and publish packages on demand" task in eve CI.

## Changelog notes

None

## PR Backports

None

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

