### PR TITLE
github/workflows: Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,11 @@ jobs:
           - os: zededa-ubuntu-2204
             arch: amd64
             platform: "generic"
-            hv: [kvm, kubevirt]
+            hv: kvm
+          - os: zededa-ubuntu-2204
+            arch: amd64
+            platform: "generic"
+            hv: kubevirt
           - os: zededa-ubuntu-2204
             arch: riscv64
             platform: "generic"


### PR DESCRIPTION
# Description

Break a matrix that was declared for a single hv field that was already part of a matrix of jobs. This was leading to the following error:

```sh
if make -e V=1 HV=Array ZARCH=amd64 PLATFORM=generic LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
```

Notice the `HV=Array`

https://github.com/lf-edge/eve/actions/runs/15845265935/job/44665863044#step:7:4

This PR fixes this issue by declaring to different runs instead of use a matrix for `hv` field.

## How to test and validate this PR

Run the publish workflow.

## Changelog notes

None.

## PR Backports

It only affects master.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.