### PR TITLE
[13.4-stable] Support ICMP cellular connectivity probe with undefined host IP

### DIFF
--- a/pkg/wwan/mmagent/agent.go
+++ b/pkg/wwan/mmagent/agent.go
@@ -1117,6 +1117,15 @@ func (a *MMAgent) probeModemConnectivity(modem *ModemInfo) error {
 			return nil
 		}
 	case types.ConnectivityProbeMethodICMP:
+		if probeConfig.UserDefinedProbe.ProbeHost == "" {
+			// When ICMP probe is selected but probe host is undefined, we use the default
+			// probing endpoint (Google DNS).
+			err = a.runICMPProbe(modemIP, defaultProbeAddr)
+			if err == nil {
+				return nil
+			}
+			break
+		}
 		// User-configured ICMP probe address.
 		remoteIP := net.ParseIP(probeConfig.UserDefinedProbe.ProbeHost)
 		if remoteIP == nil {


### PR DESCRIPTION
# Description

This commit fixes handling of ICMP-based cellular connectivity probes when the probe host is not specified.
Users can configure periodic connectivity probes for cellular networks, using either ICMP or TCP. For ICMP, the probe host can be left empty to use the default target (Google DNS: `8.8.8.8`), as was the implicit behavior in older EVE versions where the probe address was not yet configurable.

However, it turned out that EVE did not handle the case of an undefined ICMP probe IP at all. This went unnoticed because parsing errors (such as `missing endpoint host address for ICMP probe`) were only logged, while the configuration was still applied — and probing happened to work as intended. With recent improvements in zedagent, parsing failures are now reported to the controller, and EVE rejects configurations with such errors.

This commit fixes the parsing logic to correctly accept an undefined ICMP probe endpoint and ensures it is properly handled by mmagent.

Backport of https://github.com/lf-edge/eve/pull/4976
(cherry picked from commit e2e5e955705256b02d334641eefcf0903291e598)

## How to test and validate this PR

Configure a cellular modem with Connectivity probing enabled. Select ICMP as the connectivity probing method but leave probing host IP empty. EVE should not report `missing endpoint host address for ICMP probe` for the configuration. Instead it should apply the cellular configuration, establish connectivity and use `8.8.8.8` as the default endpoint for ICMP probing.

## Changelog notes

Fix ICMP cellular probe parsing to correctly handle unspecified probe host and use default target (`8.8.8.8`).

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
