### PR TITLE
pillar: Do not rename package for kubevirt variants

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -521,17 +521,20 @@ Depending on the values of optional variables, the following pillar build varian
   The name of the built pillar container is `lfedge/eve-pillar:<tag>`.
 * `make pkg/pillar DEV=y`: Development version of pillar for the KVM or Xen hypervisor. Debug symbols
   are preserved and seccomp is disabled in the pillar container.
-  The name of the built pillar container is `lfedge/eve-pillar-dev:<tag>`.
+  The name of the built pillar container is `lfedge/eve-pillar:<hash>-dev`.
 * `make pkg/pillar HV=kubevirt`: Production version of pillar for the KubeVirt hypervisor (EVE using
   K3s + KubeVirt to deploy applications as VMs inside Kubernetes Pods). Contains additional
   microservices and Go package dependencies specific to Kubernetes.
-  The name of the built pillar container is `lfedge/eve-pillar-kube:<tag>`.
+  The name of the built pillar container is `lfedge/eve-pillar:<hash>-kube`.
 * `make pkg/pillar HV=kubevirt DEV=y`: Development version of pillar for the KubeVirt hypervisor.
   Debug symbols are preserved and seccomp is disabled in the pillar container.
-  The name of the built pillar container is `lfedge/eve-pillar-kube-dev:<tag>`.
+  The name of the built pillar container is `lfedge/eve-pillar:<hash>-kube-dev`.
 
-Only `lfedge/eve-pillar` is currently published to Dockerhub as part of `lf-edge/eve` Github actions
-for the master branch and EVE releases.
+Note that the final image tag for the dev and kubevirt variants is the
+combination of the image hash + the variant string (dev, kube or kube-dev).
+
+The `lfedge/eve-pillar` regular + kube variant images are published to Dockerhub
+as part of `lf-edge/eve` Github actions for the master branch and EVE releases.
 
 ### Building packages
 

--- a/pkg/pillar/build-dev.yml
+++ b/pkg/pillar/build-dev.yml
@@ -5,7 +5,8 @@
 
 ---
 org: lfedge
-image: eve-pillar-dev
+image: eve-pillar
+tag: "{{.Hash}}-dev"
 config:
   binds:
     - /lib/modules:/lib/modules

--- a/pkg/pillar/build-kubevirt-dev.yml
+++ b/pkg/pillar/build-kubevirt-dev.yml
@@ -5,7 +5,8 @@
 
 ---
 org: lfedge
-image: eve-pillar-kube-dev
+image: eve-pillar
+tag: "{{.Hash}}-kube-dev"
 config:
   binds:
     - /lib/modules:/lib/modules

--- a/pkg/pillar/build-kubevirt.yml
+++ b/pkg/pillar/build-kubevirt.yml
@@ -5,7 +5,8 @@
 
 ---
 org: lfedge
-image: eve-pillar-kube
+image: eve-pillar
+tag: "{{.Hash}}-kube"
 config:
   binds:
     - /lib/modules:/lib/modules


### PR DESCRIPTION
# Description

Instead of use a different package name for kubevirt variants, such as:

- eve-pillar-kube
- eve-pillar-kube-dev

Use the ability of linuxkit to set a custom tag from the build.yml file. Thus, both variants will have the same eve-pillar image name, but with different hashes. For instance:

- eve-pillar:a85a6e51b4eb0cde41e0e43ae2d0f9e58b30ea06-kube
- eve-pillar:a85a6e51b4eb0cde41e0e43ae2d0f9e58b30ea06-kube-dev

PS: None of these packages: eve-pillar-kube, eve-pillar-kube-dev exist on dockerhub, so publishing of these images is failing.

## How to test and validate this PR

Run GitHub publish workflow.

## Changelog notes

None.

## PR Backports

Changes that broke publish workflow are only on master, so no need to backport.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.