### PR TITLE
Create linuxkit-builder manually to support parallel build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ HV_DEFAULT=kvm
 # linuxkit version. This **must** be a published semver version so it can be downloaded already compiled from
 # the release page at https://github.com/linuxkit/linuxkit/releases
 LINUXKIT_VERSION=v1.6.1
+BUILD_KIT_VERSION=v0.23.1
 GOVER ?= 1.24.1
 PKGBASE=github.com/lf-edge/eve
 GOMODULE=$(PKGBASE)/pkg/pillar
@@ -129,6 +130,8 @@ CROSS ?=
 ifneq ($(HOSTARCH),$(ZARCH))
 CROSS = 1
 endif
+
+PARALLEL_BUILD_LOCK:=$(shell mktemp -u $(CURDIR)/eve-parallel-build-XXXXXX)
 
 DOCKER_ARCH_TAG=$(ZARCH)
 
@@ -546,7 +549,7 @@ $(UBOOT_IMG): PKG=u-boot
 $(BSP_IMX_PART): PKG=bsp-imx
 $(EFI_PART) $(BOOT_PART) $(INITRD_IMG) $(IPXE_IMG) $(BIOS_IMG) $(UBOOT_IMG) $(BSP_IMX_PART): $(LINUXKIT) | $(INSTALLER)
 	mkdir -p $(dir $@)
-	$(LINUXKIT) pkg build --pull $(LINUXKIT_ORG_TARGET) --platforms linux/$(ZARCH) pkg/$(PKG) # running linuxkit pkg build _without_ force ensures that we either pull it down or build it.
+	$(LINUXKIT) pkg build --pull $(LINUXKIT_ORG_TARGET) --platforms linux/$(ZARCH) --builders linux/$(ZARCH)=default  pkg/$(PKG) # running linuxkit pkg build _without_ force ensures that we either pull it down or build it.
 	cd $(dir $@) && $(LINUXKIT) cache export --platform linux/$(DOCKER_ARCH_TAG) --format filesystem --outfile - $(shell $(LINUXKIT) pkg $(LINUXKIT_ORG_TARGET) show-tag pkg/$(PKG)) | tar xvf - $(notdir $@)
 	$(QUIET): $@: Succeeded
 
@@ -963,9 +966,30 @@ shell: $(GOBUILDER)
 .PHONY: linuxkit
 linuxkit: $(LINUXKIT)
 
+ensure-builder:
+	@if ! docker --context default container inspect linuxkit-builder >/dev/null 2>&1; then \
+	    echo "Container linuxkit-builder does not exist, creating..."; \
+	    docker --context default container run -d --name linuxkit-builder \
+	        --privileged moby/buildkit:$(BUILD_KIT_VERSION) \
+	        --allow-insecure-entitlement network.host \
+	        --debug --addr unix:///run/buildkit/buildkitd.sock; \
+	else \
+	    current_image=$$(docker --context default container inspect linuxkit-builder | jq -r '.[].Config.Image'); \
+	    if [ "$$current_image" != "moby/buildkit:$(BUILD_KIT_VERSION)" ]; then \
+	        echo "Recreating container (expected moby/buildkit:$(BUILD_KIT_VERSION), found $$current_image)"; \
+	        docker --context default container rm -f linuxkit-builder; \
+	        docker --context default container run -d --name linuxkit-builder \
+	            --privileged moby/buildkit:$(BUILD_KIT_VERSION) \
+	            --allow-insecure-entitlement network.host \
+	            --debug --addr unix:///run/buildkit/buildkitd.sock; \
+	    else \
+	        echo "Container linuxkit-builder is up-to-date"; \
+	    fi; \
+	fi
+
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit
 
-$(LINUXKIT): $(BUILDTOOLS_BIN)/linuxkit-$(LINUXKIT_VERSION)
+$(LINUXKIT): $(BUILDTOOLS_BIN)/linuxkit-$(LINUXKIT_VERSION) | ensure-builder
 	$(QUIET) ln -sf  $(notdir $<) $@
 	$(QUIET): $@: Succeeded
 
@@ -1059,8 +1083,8 @@ eve-%: pkg/%/Dockerfile build-tools $(RESCAN_DEPS)
 	$(eval LINUXKIT_FLAGS := $(if $(filter manifest,$(LINUXKIT_PKG_TARGET)),,$(FORCE_BUILD) $(LINUXKIT_DOCKER_LOAD) $(LINUXKIT_BUILD_PLATFORMS)))
 	$(QUIET)$(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) $(LINUXKIT_ORG_TARGET) $(LINUXKIT_OPTS) $(LINUXKIT_FLAGS) --build-yml $(call get_pkg_build_yml,$*) pkg/$*
 	$(QUIET)if [ -n "$(PRUNE)" ]; then \
-		$(LINUXKIT) pkg $(LINUXKIT_ORG_TARGET) builder prune; \
-		docker image prune -f; \
+		flock $(PARALLEL_BUILD_LOCK) $(LINUXKIT) pkg $(LINUXKIT_ORG_TARGET) builder prune; \
+		flock $(PARALLEL_BUILD_LOCK) docker image prune -f; \
 	fi
 	$(QUIET): "$@: Succeeded (intermediate for pkg/%)"
 


### PR DESCRIPTION
# Description

Linuxkit tries to create docker builder container if it doesn't exist. It works fine for -j 1 but fails for parallel build. LK tries to create or update the builder concurrently and fails. To avoid a race we create builder manually

- the builder name is hard-coded and is linuxkit-builder
- override context name for `linuxkit pkg build` so it doesn't try to create a builder by itself
- ensure-builder target checks if the container exists and of required version

**UPDATE:** we also use flock to prevent `docker prune` to run in parallel

## PR dependencies

After this PR is merged we can try https://github.com/lf-edge/eve/pull/4775 again

## How to test and validate this PR

1. remove LK cache `rm -rf ~/.linuxkit/cache/`
2. Create following file
```
## /etc/docker/daemon.json
{
	"insecure-registries":["localhost:5001"]
}
```
3. restart docker daemon
4. create a docker repository `docker run -d -p 5001:5000 --name lcreg1 registry:2`
5. run full build with new registry `make -j $(nproc) REGISTRY="localhost:5001" LINUXKIT_PKG_TARGET=push pkgs eve`


## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
