### PR TITLE
Update Hailo TPU FW to 4.21.0

### DIFF
--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -91,7 +91,7 @@ ADD ${RPI_BT_FIRMWARE_URL}/${RPI_BT_FIRMWARE_VERSION}/broadcom/BCM43430B0.hcd .
 ADD ${RPI_BT_FIRMWARE_URL}/${RPI_BT_FIRMWARE_VERSION}/broadcom/BCM4345C5.hcd .
 
 # Hailo 8 GPU firmware
-ENV HAILO_FW_VERSION=4.16.0
+ENV HAILO_FW_VERSION=4.21.0
 ADD https://hailo-hailort.s3.eu-west-2.amazonaws.com/Hailo8/${HAILO_FW_VERSION}/FW/hailo8_fw.${HAILO_FW_VERSION}.bin /lib/firmware/hailo/hailo8_fw.bin
 
 # generate initrd for Intel's and AMD's microcode


### PR DESCRIPTION
# Description
Update Hailo TPU FW to 4.21.0
It is required to support the latest Hailo TPU HW

## PR dependencies

it depends on kernel PR https://github.com/lf-edge/eve-kernel/pull/187

## How to test and validate this PR

it should just build. we cannot validate it because we do not have HW

## Changelog notes

Update Hailo TPU FW and kernel drivers to 4.21.0

## PR Backports

```text
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.
```


## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.


