### PR TITLE
[13.4-stable] pillar/zedagent: Check BaseOS Content Tree

### DIFF
--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -370,13 +370,15 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext, dest destinationBitset) {
 		swInfo.ShortVersion = bos.BaseOsVersion
 		swInfo.LongVersion = "" // XXX
 		ctInterface, _ := ctx.getconfigCtx.subContentTreeStatus.Get(bos.ContentTreeUUID)
-		if ctInterface != nil {
-			ct, ok := ctInterface.(types.ContentTreeStatus)
-			if ok {
-				// Assume one - pick first ContentTreeStatus
-				swInfo.DownloadProgress = uint32(ct.Progress)
-			}
+		if ctInterface == nil {
+			continue
 		}
+		ct, ok := ctInterface.(types.ContentTreeStatus)
+		if !ok {
+			continue
+		}
+		// Assume one - pick first ContentTreeStatus
+		swInfo.DownloadProgress = uint32(ct.Progress)
 		if !bos.ErrorTime.IsZero() {
 			log.Tracef("reportMetrics sending error time %v error %v for %s",
 				bos.ErrorTime, bos.Error, bos.BaseOsVersion)


### PR DESCRIPTION
# Description

Backport of #4983 

## How to test and validate this PR

1. Update the Edge Device from the remote controller
2. Observe the EVE-OS images reported to the controller (e.g. from the webui)
3. There shouldn't be any invalid image listed by the device. For instance, if device has EVE 13.4.2-lts and it's upgrading to 14.5.0-lts, it should list (after the upgrade) only 13.4.2-lts and 14.5.0-lts. After the upgrade is done, there shouldn't list any image in downloading state. 

## Changelog notes

Fix the reporting of current EVE-OS images to the remote controller.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.