### PR TITLE
Bump up linuxkit version to 1.6.1 to avoid race in parallel build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
 HV_DEFAULT=kvm
 # linuxkit version. This **must** be a published semver version so it can be downloaded already compiled from
 # the release page at https://github.com/linuxkit/linuxkit/releases
-LINUXKIT_VERSION=v1.6.0
+LINUXKIT_VERSION=v1.6.1
 GOVER ?= 1.24.1
 PKGBASE=github.com/lf-edge/eve
 GOMODULE=$(PKGBASE)/pkg/pillar


### PR DESCRIPTION
# Description

Linuxkit tries to create docker builder container if it doesn't exist. It works fine for -j 1 but fails for parallel build. LK tries to create or update the builder concurrently and fails. 

new version 1.6.1 has a fix for this problem 

## PR dependencies

After this PR is merged we can try https://github.com/lf-edge/eve/pull/4775 again

## How to test and validate this PR

1. remove LK cache `rm -rf ~/.linuxkit/cache/`
2. Create following file
```
## /etc/docker/daemon.json
{
	"insecure-registries":["localhost:5001"]
}
```
3. restart docker daemon
4. create a docker repository `docker run -d -p 5001:5000 --name lcreg1 registry:2`
5. run full build with new registry `make -j $(nproc) REGISTRY="localhost:5001" LINUXKIT_PKG_TARGET=push pkgs eve`


## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
