### PR TITLE
Kernel update - [amd64-generic]

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,5 +1,5 @@
 KERNEL_COMMIT_amd64_v6.1.111_rt = c708a17493f1
-KERNEL_COMMIT_amd64_v6.1.112_generic = 63f4d774fbc8
+KERNEL_COMMIT_amd64_v6.1.112_generic = fbba2324d2be
 KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = 77ad49f1f137
 KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 14693149c305
 KERNEL_COMMIT_arm64_v6.1.112_generic = a5fecf8ec851


### PR DESCRIPTION
# Description

This commit changes:
eve-kernel-amd64-v6.1.112-generic
    fbba2324d2be: Bump up Hailo TPU driver to the latest 4.21

## PR dependencies

- https://github.com/lf-edge/eve/pull/4995

## How to test and validate this PR

- see dependent PR

## Changelog notes

Bump up Hailo TPU driver to the latest 4.21

## PR Backports

```text
- 14.5-stable: To be backported.
- 13.4-stable: To be backported
```

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
