### PR TITLE
[11.0-stable] Fix tag handling in release workflow by stripping refs/tags/

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -31,12 +31,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          RAW_TAG="${{ inputs.tag_ref }}"
+          TAG="${RAW_TAG#refs/tags/}"
           response=$(curl -s -X POST \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Content-Type: application/json" \
             -d '{
-              "tag_name": "${{ inputs.tag_ref }}",
-              "name": "${{ inputs.tag_ref }}",
+              "tag_name": "${TAG}",
+              "name": "${TAG}",
               "draft": false,
               "prerelease": true
             }' https://api.github.com/repos/${{ github.repository }}/releases)
@@ -92,7 +94,7 @@ jobs:
           docker run "$EVE" installer_net | tar -C assets -xvf -
       - name: Create direct iPXE config
         run: |
-          URL="${{ github.event.repository.html_url }}/releases/download/${{ inputs.tag_ref }}/${{ env.ARCH }}."
+          URL="${{ github.event.repository.html_url }}/releases/download/${TAG}/${{ env.ARCH }}."
           sed -i. -e '/# set url https:/s#^.*$#set url '"$URL"'#' assets/ipxe.efi.cfg
           for comp in initrd rootfs installer; do
               sed -i. -e "s#initrd=${comp}#initrd=${{ env.ARCH }}.${comp}#g" assets/ipxe.efi.cfg
@@ -110,7 +112,7 @@ jobs:
       - name: Pull eve-sources and publish collected_sources.tar.gz to assets
         run: |
           HV=kvm
-          EVE_SOURCES=lfedge/eve-sources:${{ inputs.tag_ref }}-${HV}-${{ env.ARCH }}
+          EVE_SOURCES=lfedge/eve-sources:${TAG}-${HV}-${{ env.ARCH }}
           docker pull "$EVE_SOURCES"
           docker create --name eve_sources "$EVE_SOURCES" bash
           docker export --output assets/collected_sources.tar.gz eve_sources


### PR DESCRIPTION
# Description 
Fix tag handling in release workflow by stripping `refs/tags/` prefix

Update the assets workflow to consistently strip the refs/tags/ prefix from tag references. Previously, some steps used the full tag ref provided by GitHub, which caused issues when creating releases, building Docker image references, and generating download URLs.

## PR dependencies

None.

## How to test and validate this PR

Internal change, no need for external manual verification.

## Changelog notes

Not a user-visible chnage.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

