### PR TITLE
Bump up linuxkit version to 1.6.2 to avoid race in parallel build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
 HV_DEFAULT=kvm
 # linuxkit version. This **must** be a published semver version so it can be downloaded already compiled from
 # the release page at https://github.com/linuxkit/linuxkit/releases
-LINUXKIT_VERSION=v1.6.1
+LINUXKIT_VERSION=v1.6.2
 BUILD_KIT_VERSION=v0.23.1
 GOVER ?= 1.24.1
 PKGBASE=github.com/lf-edge/eve


### PR DESCRIPTION
# Description

Bump LinuxKit version to v1.6.2 to avoid race condition in parallel builds.

This PR updates the LINUXKIT_VERSION in the Makefile from v1.6.1 to v1.6.2.
LinuxKit v1.6.2 includes a fix for concurrent access to the git index and improvements to the builder update procedure, which are required for reliable parallel builds.

## PR dependencies

None.

## How to test and validate this PR

No need for external manual verification.

## Changelog notes

No user-facing changes.
This is a tooling update to improve reliability of the build process.

## PR Backports

- 14.5-stable: no need
- 13.4-stable: no need

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (N/A; build tooling only)
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them. 

