### PR TITLE
.github: Partially roll back tag normalization in assets workflow.

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -31,14 +31,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RAW_TAG="${{ inputs.tag_ref }}"
-          TAG="${RAW_TAG#refs/tags/}"
           response=$(curl -s -X POST \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Content-Type: application/json" \
             -d '{
-              "tag_name": "${TAG}",
-              "name": "${TAG}",
+              "tag_name": "${{ inputs.tag_ref }}",
+              "name": "${{ inputs.tag_ref }}",
               "draft": false,
               "prerelease": true
             }' https://api.github.com/repos/${{ github.repository }}/releases)


### PR DESCRIPTION
# Description
Restore use of ${{ inputs.tag_ref }} directly in the release creation step, removing the Bash variable and tag normalization logic. This is necessary because Bash variables are not expanded inside single-quoted strings, which caused the literal ${TAG} to be sent to the GitHub API instead of the intended tag name.

Other unrelated changes from the previous commit are retained.

## PR dependencies

None.

## How to test and validate this PR

No need for external manual verification.

## Changelog notes
None (internal CI tooling change only).

## PR Backports

14.5-stable: No, not required.
13.4-stable: No, not required.

## Checklist
- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR