### PR TITLE
Revert amd64 kubevirt generic publish

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -49,9 +49,6 @@ jobs:
           - arch: arm64
             platform: "nvidia-jp6"
             hv: "kvm"
-          - arch: amd64
-            platform: "generic"
-            hv: "kubevirt"
     steps:
       - name: checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/buildondemand.yml
+++ b/.github/workflows/buildondemand.yml
@@ -110,9 +110,6 @@ jobs:
           - arch: arm64
             hv: kvm
             platform: "imx8mp_epc_r3720"
-          - arch: amd64
-            hv: kubevirt
-            platform: "generic"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,10 +30,6 @@ jobs:
             platform: "generic"
             hv: kvm
           - os: zededa-ubuntu-2204
-            arch: amd64
-            platform: "generic"
-            hv: kubevirt
-          - os: zededa-ubuntu-2204
             arch: riscv64
             platform: "generic"
             hv: mini
@@ -208,9 +204,6 @@ jobs:
           - arch: arm64
             hv: kvm
             platform: "nvidia-jp6"
-          - arch: amd64
-            hv: kubevirt
-            platform: "generic"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# Description

Issues seen in linuxkit cache export are blocking
all other build/publish jobs.

> make cache-export IMAGE=lfedge/eve-external-boot-image:325e7463e093db2c1abc0da0260b193e73bcef5d OUTFILE=pkg/kube/external-boot-image.tar
> make[1]: Entering directory '/opt/actions-runner/_work/eve/eve'
> Container linuxkit-builder is up-to-date
> /opt/actions-runner/_work/eve/eve/build-tools/bin/linuxkit -v 2 cache export --format docker --platform linux/amd64 --outfile pkg/kube/external-boot-image.tar  lfedge/eve-external-boot-image:325e7463e093db2c1abc0da0260b193e73bcef5d
> time="2025-06-25T22:42:49Z" level=fatal msg="error getting reader for image lfedge/eve-external-boot-image:325e7463e093db2c1abc0da0260b193e73bcef5d: could not find image or index for docker.io/lfedge/eve-external-boot-image:325e7463e093db2c1abc0da0260b193e73bcef5d"
> make[1]: *** [Makefile:906: cache-export] Error 1
> make[1]: Leaving directory '/opt/actions-runner/_work/eve/eve'
> make: *** [Makefile:870: pkg/kube/external-boot-image.tar] Error 2
> Error: Process completed with exit code 2.

## PR dependencies

None

## How to test and validate this PR

Covered by PR build and publish CI jobs.

## Changelog notes

None

## PR Backports

- 14.5-stable:  No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
