### PR TITLE
Makefile: Fix pkg/kube build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -867,7 +867,10 @@ pkg/external-boot-image/build.yml: pkg/external-boot-image/build.yml.in pkg/xen-
 	$(QUIET)tools/compose-external-boot-image-yml.sh $< $@ $(shell echo $(KERNEL_TAG) | cut -d':' -f2) $(shell $(LINUXKIT) pkg $(LINUXKIT_ORG_TARGET) show-tag pkg/xen-tools | cut -d':' -f2)
 eve-external-boot-image: pkg/external-boot-image/build.yml
 pkg/kube/external-boot-image.tar: pkg/external-boot-image
-	$(MAKE) cache-export IMAGE=$(shell $(LINUXKIT) pkg $(LINUXKIT_ORG_TARGET) show-tag pkg/external-boot-image) OUTFILE=pkg/kube/external-boot-image.tar
+	$(eval BOOT_IMAGE_TAG := $(shell $(LINUXKIT) pkg $(LINUXKIT_ORG_TARGET) show-tag --canonical pkg/external-boot-image))
+	$(eval CACHE_CONTENT := $(shell $(LINUXKIT) cache ls 2>&1))
+	$(if $(filter $(BOOT_IMAGE_TAG),$(CACHE_CONTENT)),,$(LINUXKIT) cache pull $(BOOT_IMAGE_TAG))
+	$(MAKE) cache-export IMAGE=$(BOOT_IMAGE_TAG) OUTFILE=pkg/kube/external-boot-image.tar
 	rm -f pkg/external-boot-image/build.yml
 pkg/kube: pkg/kube/external-boot-image.tar eve-kube
 	$(QUIET): $@: Succeeded


### PR DESCRIPTION
# Description

Now that we have pkg/external-boot-image on dockerhub, it cannot be present on linuxkit's cache, so we try first to import to the cache before run "make cache-export".

## How to test and validate this PR

Run `make pkg/kube`. It should work.

## Changelog notes

Fix build of pkg/kube after publication of pkg/external-boot-image on dockerhub.

## PR Backports

- [x] 14.5-stable
- [x] 13.4-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.