### PR TITLE
bpftrace-tools: add capable.bt

### DIFF
--- a/eve-tools/bpftrace-compiler/examples/capable.bt
+++ b/eve-tools/bpftrace-compiler/examples/capable.bt
@@ -1,0 +1,95 @@
+#!/usr/bin/env bpftrace
+/*
+ * capable	Trace security capability checks (cap_capable()).
+ *		For Linux, uses bpftrace and eBPF.
+ * 
+ * Example of usage:
+ * 
+ * # ./capable.bt
+ * TIME      UID    PID    COMM             CAP  NAME                 AUDIT
+ * 22:11:23  114    2676   snmpd            12   CAP_NET_ADMIN        1
+ * 22:11:23  0      6990   run              24   CAP_SYS_RESOURCE     1
+ * 22:11:23  0      7003   chmod            3    CAP_FOWNER           1
+ * 22:11:23  0      7003   chmod            4    CAP_FSETID           1
+ * 22:11:23  0      7005   chmod            4    CAP_FSETID           1
+ * [...]
+ * 
+ * This can be useful for general debugging, and also security enforcement:
+ * determining a whitelist of capabilities an application needs.
+ * 
+ * The output above includes various capability checks: snmpd checking
+ * CAP_NET_ADMIN, run checking CAP_SYS_RESOURCES, then some short-lived processes
+ * checking CAP_FOWNER, CAP_FSETID, etc.
+ * 
+ * To see what each of these capabilities does, check the capabilities(7) man
+ * page and the kernel source.
+ * 
+ * This is a bpftrace version of the bcc tool of the same name.
+ * The bcc version provides options to customize the output. 
+ *
+ * Copyright 2018 Netflix, Inc.
+ *
+ * 08-Sep-2018	Brendan Gregg	Created this.
+ */
+
+BEGIN
+{
+	printf("Tracing cap_capable syscalls... Hit Ctrl-C to end.\n");
+	printf("%-9s %-6s %-6s %-16s %-4s %-20s AUDIT\n", "TIME", "UID", "PID",
+	    "COMM", "CAP", "NAME");
+	@cap[(uint64)0] = "CAP_CHOWN";
+	@cap[1] = "CAP_DAC_OVERRIDE";
+	@cap[2] = "CAP_DAC_READ_SEARCH";
+	@cap[3] = "CAP_FOWNER";
+	@cap[4] = "CAP_FSETID";
+	@cap[5] = "CAP_KILL";
+	@cap[6] = "CAP_SETGID";
+	@cap[7] = "CAP_SETUID";
+	@cap[8] = "CAP_SETPCAP";
+	@cap[9] = "CAP_LINUX_IMMUTABLE";
+	@cap[10] = "CAP_NET_BIND_SERVICE";
+	@cap[11] = "CAP_NET_BROADCAST";
+	@cap[12] = "CAP_NET_ADMIN";
+	@cap[13] = "CAP_NET_RAW";
+	@cap[14] = "CAP_IPC_LOCK";
+	@cap[15] = "CAP_IPC_OWNER";
+	@cap[16] = "CAP_SYS_MODULE";
+	@cap[17] = "CAP_SYS_RAWIO";
+	@cap[18] = "CAP_SYS_CHROOT";
+	@cap[19] = "CAP_SYS_PTRACE";
+	@cap[20] = "CAP_SYS_PACCT";
+	@cap[21] = "CAP_SYS_ADMIN";
+	@cap[22] = "CAP_SYS_BOOT";
+	@cap[23] = "CAP_SYS_NICE";
+	@cap[24] = "CAP_SYS_RESOURCE";
+	@cap[25] = "CAP_SYS_TIME";
+	@cap[26] = "CAP_SYS_TTY_CONFIG";
+	@cap[27] = "CAP_MKNOD";
+	@cap[28] = "CAP_LEASE";
+	@cap[29] = "CAP_AUDIT_WRITE";
+	@cap[30] = "CAP_AUDIT_CONTROL";
+	@cap[31] = "CAP_SETFCAP";
+	@cap[32] = "CAP_MAC_OVERRIDE";
+	@cap[33] = "CAP_MAC_ADMIN";
+	@cap[34] = "CAP_SYSLOG";
+	@cap[35] = "CAP_WAKE_ALARM";
+	@cap[36] = "CAP_BLOCK_SUSPEND";
+	@cap[37] = "CAP_AUDIT_READ";
+	@cap[38] = "CAP_PERFMON";
+	@cap[39] = "CAP_BPF";
+	@cap[40] = "CAP_CHECKPOINT_RESTORE";
+}
+
+kprobe:cap_capable
+{
+	$cap = arg2;
+	$audit = arg3;
+	time("%H:%M:%S  ");
+	printf("%-6d %-6d %-16s %-4d %-20s %d\n", uid, pid, comm, $cap,
+	    @cap[$cap], $audit);
+}
+
+END
+{
+	clear(@cap);
+}


### PR DESCRIPTION
# Description

Downloaded from
https://github.com/bpftrace/bpftrace/raw/refs/heads/master/tools/capable.bt this tools checks which linux capabilities are requested in the system


## How to test and validate this PR

`./bpftrace-compiler run-via-ssh 127.1:2222 examples/capable.bt`

look at the output, you should see at least
```
{"type": "printf", "data": "0      6778   bpftrace-aotrt   39   CAP_BPF              0\n"}
```

## Changelog notes

add bpftrace tool to check linux capabilities

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 14.5-stable: no
- 13.4-stable: no



## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
