### PR TITLE
Update task timer use duration

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -516,16 +516,15 @@ func updateConfigTimer(configInterval uint32, tickerHandle interface{}) {
 
 // updateTaskTimer updates the given tickerHandle to use a new interval based on configInterval.
 // It adjusts the ticker's range and triggers an immediate tick to ensure the new interval takes effect promptly.
-func updateTaskTimer(configInterval uint32, tickerHandle interface{}) {
+func updateTaskTimer(configInterval time.Duration, tickerHandle interface{}) {
 
 	if tickerHandle == nil {
 		// Happens if the tickerHandle has not been initialized yet.
 		log.Warnf("updateConfigTimer: no tickerHandle yet")
 		return
 	}
-	interval := time.Duration(configInterval) * time.Second
-	log.Functionf("updateTaskTimer() change to %v", interval)
-	max := float64(interval)
+	log.Functionf("updateTaskTimer() change to %v", configInterval)
+	max := float64(configInterval)
 	min := max * 0.3
 	// Update the ticker to use the new interval range.
 	flextimer.UpdateRangeTicker(tickerHandle,

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -2854,8 +2854,8 @@ func parseConfigItems(ctx *getconfigContext, config *zconfig.EdgeDevConfig,
 		// Set GlobalStatus Values from GlobalConfig.
 		oldConfigInterval := oldGlobalConfig.GlobalValueInt(types.ConfigInterval)
 		newConfigInterval := newGlobalConfig.GlobalValueInt(types.ConfigInterval)
-		oldCertInterval := oldGlobalConfig.GlobalValueInt(types.CertInterval)
-		newCertInterval := newGlobalConfig.GlobalValueInt(types.CertInterval)
+		oldCertInterval := oldGlobalConfig.GlobalValueDuration(types.CertInterval)
+		newCertInterval := newGlobalConfig.GlobalValueDuration(types.CertInterval)
 
 		oldMetricInterval := oldGlobalConfig.GlobalValueInt(types.MetricInterval)
 		newMetricInterval := newGlobalConfig.GlobalValueInt(types.MetricInterval)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -23,6 +23,8 @@ func TestDefaultValue(t *testing.T) {
 			assert.Equal(t, item.TriStateDefault, defaultValue.TriStateValue)
 		} else if item.ItemType == ConfigItemTypeString {
 			assert.Equal(t, item.StringDefault, defaultValue.StrValue)
+		} else if item.ItemType == ConfigItemTypeDuration {
+			assert.Equal(t, item.DurationDefault, defaultValue.DurationValue)
 		}
 	}
 


### PR DESCRIPTION
# Description

this is a follow-up of  https://github.com/lf-edge/eve/pull/4967#discussion_r2142691676
pillar/updateTaskTimer: switch to less-error prone
    
    time.Duration


## How to test and validate this PR

same as https://github.com/lf-edge/eve/pull/4967


## Changelog notes

No user-visible changes. 

## PR Backports

- 14.5-stable: no
- 13.4-stable: no


## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

