### PR TITLE
Avoid endless loop in DPCManager.runVerify when we get RemoteTemporaryFailure

### DIFF
--- a/pkg/pillar/dpcmanager/dpcmanager_test.go
+++ b/pkg/pillar/dpcmanager/dpcmanager_test.go
@@ -1843,3 +1843,59 @@ func TestOldDPC(test *testing.T) {
 	eth0Dhcpcd := dg.Reference(generic.Dhcpcd{AdapterIfName: "eth0"})
 	t.Expect(itemIsCreated(eth0Dhcpcd)).To(BeTrue())
 }
+
+func TestRemoteTemporaryFailure(test *testing.T) {
+	t := initTest(test)
+
+	// Prepare simulated network stack.
+	eth0 := mockEth0()
+	networkMonitor.AddOrUpdateInterface(eth0)
+
+	// Single interface configured for mgmt.
+	aa := makeAA(selectedIntfs{eth0: true})
+	dpcManager.UpdateAA(aa)
+
+	// Apply global config.
+	dpcManager.UpdateGCP(globalConfig())
+
+	// Apply initial "bootstrap" DPC with single ethernet port.
+	timePrio1 := time.Now()
+	dpc := makeDPC("bootstrap", timePrio1, selectedIntfs{eth0: true})
+	dpcManager.AddDPC(dpc)
+	t.Eventually(testingInProgressCb()).Should(BeTrue())
+	t.Eventually(testingInProgressCb()).Should(BeFalse())
+	t.Eventually(dpcIdxCb()).Should(Equal(0))
+	t.Eventually(dnsKeyCb()).Should(Equal("bootstrap"))
+	t.Eventually(dpcStateCb(0)).Should(Equal(types.DPCStateSuccess))
+
+	// Apply "zedagent" DPC with single ethernet port.
+	timePrio2 := time.Now()
+	dpc = makeDPC("zedagent", timePrio2, selectedIntfs{eth0: true})
+
+	// Simulate certificate error, which is reported from ConnectivityTester to DpcManager
+	// as a RemoteTemporaryFailure.
+	connTester.SetConnectivityError("zedagent", "eth0",
+		&conntester.RemoteTemporaryFailure{
+			Endpoint:   "simulated-controller",
+			WrappedErr: errors.New("certificate error"),
+		})
+
+	// Even though we are getting error from the simulated controller,
+	// the connectivity is working and DPC should be marked as working
+	// and replace the "bootstrap" DPC.
+	// Previously, we had a bug that would result in DPCManager being
+	// stuck in a loop inside runVerify, re-running verification
+	// for the same DPC and constantly getting RemoteTemporaryFailure.
+	dpcManager.AddDPC(dpc)
+	t.Eventually(testingInProgressCb()).Should(BeTrue())
+	t.Eventually(testingInProgressCb()).Should(BeFalse())
+	t.Eventually(dpcListLenCb()).Should(Equal(1)) // "bootstrap" compressed out
+	t.Eventually(dpcIdxCb()).Should(Equal(0))
+	t.Eventually(dnsKeyCb()).Should(Equal("zedagent"))
+	t.Eventually(dpcStateCb(0)).Should(Equal(types.DPCStateRemoteWait))
+	dpc = getDPC(0)
+	t.Expect(dpc.HasError()).To(BeFalse())
+	t.Expect(dpc.HasWarning()).To(BeTrue())
+	t.Expect(dpc.LastWarning).To(Equal(
+		"Remote temporary failure (endpoint: simulated-controller): certificate error"))
+}

--- a/pkg/pillar/dpcmanager/verify.go
+++ b/pkg/pillar/dpcmanager/verify.go
@@ -252,7 +252,7 @@ func (m *DpcManager) verifyDPC(ctx context.Context) (status types.DPCState) {
 			switch dpc.State {
 			case types.DPCStateFail, types.DPCStateFailWithIPAndDNS:
 				controllerConnWorks = false
-			case types.DPCStateSuccess:
+			case types.DPCStateSuccess, types.DPCStateRemoteWait:
 				controllerConnWorks = true
 			default:
 				// DpcManager is waiting for something (IP address, DNS server, etc.)
@@ -278,8 +278,9 @@ func (m *DpcManager) verifyDPC(ctx context.Context) (status types.DPCState) {
 	_, rtf := err.(*conntester.RemoteTemporaryFailure)
 	if rtf {
 		m.Log.Errorf("DPC verify: remoteTemporaryFailure: %v", err)
-		// NOTE: We retry until the certificate or ECONNREFUSED is fixed
-		// on the server side.
+		// We treat RemoteTemporaryFailure as a success because the connectivity is working.
+		// Save and publish the server-side error only as a warning.
+		dpc.RecordSuccessWithWarning(err.Error())
 		status = types.DPCStateRemoteWait
 		dpc.State = status
 		return status


### PR DESCRIPTION
# Description

This PR fixes a bug in `DpcManager.runVerify` that would cause an infinite loop when a `RemoteTemporaryFailure` was returned by the `ConnectivityTester`.

The issue was that `DPCManager` didn’t flag the DPC as tested when a `RemoteTemporaryFailure` was received. Such a DPC was then mistakenly evaluated as a new DPC received during testing, and the entire testing procedure was repeated - resulting in an endless cycle.

This commit fixes the issue by flagging the DPC as tested, and actually as successful, reporting the `RemoteTemporaryFailure` only as a warning, since connectivity itself is working.

There is no need to handle testing retries for `RemoteTemporaryFailure` explicitly, as they are already performed periodically every 5 minutes (`timer.port.testinterval`), even when the latest DPC is marked as successful.

## How to test and validate this PR

For reproduction, I changed the controller handler `/api/v2/edgedevice/ping` to return 500.
Another option is to install controller certificate which is not valid anymore (current date is > `certificate.notAfter`).
Without the fix, diag would continuously show testing as ongoing:
```
cat /run/diag.out 
...
WARNING: The configuration below is under test hence might report failures
WARNING: state DPC_REMOTE_WAIT not SUCCESS
...
```
And running `logread -f | grep "DPC verify"` would reveal that DPC verification is in a constant loop (logs keep streaming).

With the fix, testing should end with `DPC_REMOTE_WAIT`:
```
cat /run/diag.out 
...
INFO: Using highest priority DevicePortConfig key zedagent
WARNING: state DPC_REMOTE_WAIT not SUCCESS
...
```
And `logread -f | grep "DPC verify"` should be quiet most of the time (only once per 5 minutes logs should show up for a periodic re-testing).

You can also check that the latest DPC is being used (`CurrentIndex` is zero) and it is flagged with only warning:
```
$ cat /persist/status/nim/DevicePortConfigList/global.json | jq
{
  "CurrentIndex": 0,
  "PortConfigList": [
    {
      "Version": 1,
      "Key": "zedagent",
      "TimePriority": "2025-06-27T07:08:40.141226832Z",
      "State": 7,
      "ShaFile": "",
      "ShaValue": null,
      "LastFailed": "0001-01-01T00:00:00Z",
      "LastSucceeded": "2025-06-27T07:08:41.312005178Z",
      "LastError": "",
      "LastWarning": "Remote temporary failure (endpoint: mydomain.adam:3333): All attempts to connect to mydomain.adam:3333/api/v2/edgedevice/ping failed: send via eth0: SendOnIntf to https://mydomain.adam:3333/api/v2/edgedevice/ping reqlen 0 statuscode 500 Internal Server Error body:\n; send via eth2: link not found for interface eth2",
...
```

## Changelog notes

Avoid endless loop when we get 5XX error from the controller

## PR Backports

This is quite serious bug, so it should go to every active LTS. We decided to backport this even to 11.0-stable.

- 14.5-stable
- 13.4-stable
- 11.0-stable

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
