### PR TITLE
Bump golang

### DIFF
--- a/pkg/acrn-kernel/Dockerfile
+++ b/pkg/acrn-kernel/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS kernel-build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS kernel-build
 
 ENV BUILD_PKGS \
     argp-standalone automake bash bc binutils-dev bison build-base \

--- a/pkg/acrn/Dockerfile
+++ b/pkg/acrn/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS kernel-build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS kernel-build
 
 ENV BUILD_PKGS \
     gcc make libc-dev dev86 xz-dev perl bash python3-dev gettext iasl         \

--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -12,6 +12,7 @@ ARG ALPINE_VERSION=3.16
 # this is only needed once, when this package
 # is rebased on the new version of Alpine and
 # you have to have FROM alpine:x.y.z above:
+# Trigger update for go package
 RUN apk update && apk upgrade -a
 
 # Copy Dockerfile so we can include it in the hash
@@ -57,13 +58,13 @@ COPY eve-alpine-deploy.sh go-compile.sh /bin/
 RUN apk update && apk upgrade -a
 
 # define arch-specific envs
-FROM scratch as final-amd64
+FROM scratch AS final-amd64
 ENV EVE_BUILD_ARCH=x86_64
 ENV EVE_TARGET_ARCH=x86_64
-FROM scratch as final-arm64
+FROM scratch AS final-arm64
 ENV EVE_BUILD_ARCH=aarch64
 ENV EVE_TARGET_ARCH=aarch64
-FROM scratch as final-riscv64
+FROM scratch AS final-riscv64
 ENV EVE_BUILD_ARCH=riscv64
 ENV EVE_TARGET_ARCH=riscv64
 

--- a/pkg/apparmor/Dockerfile
+++ b/pkg/apparmor/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV BUILD_PKGS linux-headers musl-dev musl-utils musl-libintl git gcc g++ \
                autoconf automake libtool make flex bison bash sed gettext
 ENV PKGS alpine-baselayout

--- a/pkg/apparmor/Dockerfile
+++ b/pkg/apparmor/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
 ENV BUILD_PKGS linux-headers musl-dev musl-utils musl-libintl git gcc g++ \
                autoconf automake libtool make flex bison bash sed gettext
 ENV PKGS alpine-baselayout

--- a/pkg/bpftrace/Dockerfile
+++ b/pkg/bpftrace/Dockerfile
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 
 ENV BUILD_PKGS make gcc g++ git perl linux-headers musl-dev cmake zlib-dev bcc-dev libbpf-dev cereal flex bison llvm13-libs llvm13-dev llvm13-static clang-dev clang-static pahole gtest-dev bash
 

--- a/pkg/bsp-imx/Dockerfile
+++ b/pkg/bsp-imx/Dockerfile
@@ -10,12 +10,12 @@ ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2
 FROM lfedge/eve-optee-os:ac2e9c3c4b9cb9f1bd7280af7e646b2b69f389ab AS optee-os
 
 # hadolint ignore=DL3006
-FROM ${EVE_ALPINE_IMAGE} as build-native
+FROM ${EVE_ALPINE_IMAGE} AS build-native
 ARG BUILD_PKGS_BASE
 RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
 
 # hadolint ignore=DL3006,DL3029
-FROM --platform=${BUILDPLATFORM} ${EVE_ALPINE_IMAGE} as build-cross
+FROM --platform=${BUILDPLATFORM} ${EVE_ALPINE_IMAGE} AS build-cross
 ARG BUILD_PKGS_BASE
 RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
 

--- a/pkg/bsp-imx/Dockerfile
+++ b/pkg/bsp-imx/Dockerfile
@@ -4,10 +4,10 @@
 ARG BUILD_PKGS_BASE="bash binutils-dev build-base bc bison flex openssl-dev util-linux-dev swig gnutls-dev perl python3 python3-dev py3-setuptools py3-pycryptodome py3-elftools"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f
 
 # OPTEE-OS images
-FROM lfedge/eve-optee-os:ac2e9c3c4b9cb9f1bd7280af7e646b2b69f389ab AS optee-os
+FROM lfedge/eve-optee-os:316059d08952d15c15fd0ee6c50111045aa0bf41 AS optee-os
 
 # hadolint ignore=DL3006
 FROM ${EVE_ALPINE_IMAGE} AS build-native
@@ -20,7 +20,7 @@ ARG BUILD_PKGS_BASE
 RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
 
 # hadolint ignore=DL3029
-FROM --platform=${BUILDPLATFORM} lfedge/eve-cross-compilers:6c849909e9a62da563148c70897f74e6d2689dd0 AS cross-compilers
+FROM --platform=${BUILDPLATFORM} lfedge/eve-cross-compilers:871591942d8fe4b28b129b10cc63bd8052db81b9 AS cross-compilers
 
 # will use several packages from target arch and copy them to sysroot
 # hadolint ignore=DL3006

--- a/pkg/cross-compilers/Dockerfile
+++ b/pkg/cross-compilers/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build-base
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build-base
 ENV BUILD_PKGS abuild curl tar make linux-headers patch g++ git gcc ncurses-dev autoconf file sudo
 RUN eve-alpine-deploy.sh
 
@@ -47,7 +47,7 @@ FROM build-base AS build-armhf
 # we do not support cross-compilers for riscv64 host
 # as gcc-gnat is not available on riscv64
 # we cannot build cross-compilers without additional patches
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build-riscv64
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build-riscv64
 
 # hadolint ignore=DL3006
 FROM build-${TARGETARCH} AS build

--- a/pkg/cross-compilers/Dockerfile
+++ b/pkg/cross-compilers/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build-base
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build-base
 ENV BUILD_PKGS abuild curl tar make linux-headers patch g++ git gcc ncurses-dev autoconf file sudo
 RUN eve-alpine-deploy.sh
 
@@ -41,16 +41,16 @@ RUN [ "x86_64" = "${EVE_BUILD_ARCH}" ] || sh -x ./scripts/bootstrap.sh "x86_64"
 RUN rm -rf /home/builder/packages/main/"${EVE_BUILD_ARCH}"/gcc-pass2*
 RUN cp -r /home/builder/packages/main/"${EVE_BUILD_ARCH}" /packages/
 
-FROM build-base as build-amd64
-FROM build-base as build-arm64
-FROM build-base as build-armhf
+FROM build-base AS build-amd64
+FROM build-base AS build-arm64
+FROM build-base AS build-armhf
 # we do not support cross-compilers for riscv64 host
 # as gcc-gnat is not available on riscv64
 # we cannot build cross-compilers without additional patches
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build-riscv64
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build-riscv64
 
 # hadolint ignore=DL3006
-FROM build-${TARGETARCH} as build
+FROM build-${TARGETARCH} AS build
 RUN mkdir -p /packages
 
 FROM scratch

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -8,9 +8,9 @@
 # has a fast path for stack unwinding. This also happens
 # to be a perfect place to put any other kind of debug info
 # into the package: see abuild/etc/abuild.conf.
-FROM lfedge/eve-recovertpm:233d896d8713bc4ba1a22ce8e2bd13e487a52459 AS recovertpm
-FROM lfedge/eve-bpftrace:faebad58df4cddaa07d15937021854d8165d7c9a AS bpftrace
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-recovertpm:6bfac2a42181926d6e9144f30c0a6ee634a75156 AS recovertpm
+FROM lfedge/eve-bpftrace:abb65c7e35c1236f406ca8c56b39feeb560c13b3 AS bpftrace
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV BUILD_PKGS="abuild curl tar make linux-headers patch g++ git gcc go gpg ncurses-dev autoconf openssl-dev zlib-dev"
 # Feel free to add additional packages here, but be aware that
 # EVE's rootfs image can be no larger than 300Mb (and don't

--- a/pkg/debug/Makefile
+++ b/pkg/debug/Makefile
@@ -3,4 +3,5 @@
 
 .PHONY: test
 test:
+	make -C ../../ debug-cache-export-docker-load
 	docker build --rm --target test .

--- a/pkg/dnsmasq/Dockerfile
+++ b/pkg/dnsmasq/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
 ENV BUILD_PKGS gcc make patch libc-dev linux-headers tar xz coreutils
 RUN eve-alpine-deploy.sh
 

--- a/pkg/dnsmasq/Dockerfile
+++ b/pkg/dnsmasq/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV BUILD_PKGS gcc make patch libc-dev linux-headers tar xz coreutils
 RUN eve-alpine-deploy.sh
 

--- a/pkg/dom0-ztools/Dockerfile
+++ b/pkg/dom0-ztools/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as zfs
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS zfs
 ENV BUILD_PKGS git patch ca-certificates util-linux build-base gettext-dev libtirpc-dev automake autoconf \
     libtool linux-headers attr-dev e2fsprogs-dev glib-dev openssl-dev util-linux-dev coreutils
 ENV PKGS ca-certificates util-linux libintl libuuid libtirpc libblkid libcrypto1.1 zlib

--- a/pkg/dom0-ztools/Dockerfile
+++ b/pkg/dom0-ztools/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS zfs
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS zfs
 ENV BUILD_PKGS git patch ca-certificates util-linux build-base gettext-dev libtirpc-dev automake autoconf \
     libtool linux-headers attr-dev e2fsprogs-dev glib-dev openssl-dev util-linux-dev coreutils
 ENV PKGS ca-certificates util-linux libintl libuuid libtirpc libblkid libcrypto1.1 zlib

--- a/pkg/edgeview/Dockerfile
+++ b/pkg/edgeview/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
 ENV BUILD_PKGS git go
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables
 RUN eve-alpine-deploy.sh

--- a/pkg/edgeview/Dockerfile
+++ b/pkg/edgeview/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV BUILD_PKGS git go
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables
 RUN eve-alpine-deploy.sh

--- a/pkg/external-boot-image/Dockerfile
+++ b/pkg/external-boot-image/Dockerfile
@@ -3,8 +3,8 @@
 ARG KERNEL=latest
 ARG XENTOOLS=latest
 
-FROM lfedge/eve-xen-tools:$XENTOOLS as initrd-build
-FROM lfedge/eve-kernel:$KERNEL as kernel-build
+FROM lfedge/eve-xen-tools:$XENTOOLS AS initrd-build
+FROM lfedge/eve-kernel:$KERNEL AS kernel-build
 
 FROM scratch
 COPY --from=initrd-build --chmod=666 /usr/lib/xen/boot/runx-initrd /

--- a/pkg/fscrypt/Dockerfile
+++ b/pkg/fscrypt/Dockerfile
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build-base
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build-base
 
 FROM build-base AS build-amd64
 FROM build-base AS build-arm64

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 ARG PLATFORM=generic
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build-base
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build-base
 
 ARG TARGETARCH
 
@@ -96,10 +96,10 @@ ADD https://hailo-hailort.s3.eu-west-2.amazonaws.com/Hailo8/${HAILO_FW_VERSION}/
 
 # generate initrd for Intel's and AMD's microcode
 # it makes sense only for x86_64 platform
-FROM --platform=${TARGETPLATFORM} lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as ucode-build-common
+FROM --platform=${TARGETPLATFORM} lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS ucode-build-common
 RUN mkdir -p /boot /tmp/ucode/intel /tmp/ucode/amd /usr/share/licenses/ucode
 
-FROM ucode-build-common as ucode-build-amd64
+FROM ucode-build-common AS ucode-build-amd64
 ENV BUILD_PKGS=iucode-tool
 RUN eve-alpine-deploy.sh
 
@@ -133,11 +133,11 @@ RUN cp /tmp/ucode/amd/linux-firmware/LICENSE.amd-ucode /usr/share/licenses/ucode
 # merge intel and amd microcode
 RUN cat /tmp/ucode/intel/intel-ucode.img /tmp/ucode/amd/amd-ucode.img >/boot/ucode.img
 
-FROM ucode-build-common as ucode-build-arm64
-FROM ucode-build-common as ucode-build-riscv64
-FROM ucode-build-${TARGETARCH} as ucode-build
+FROM ucode-build-common AS ucode-build-arm64
+FROM ucode-build-common AS ucode-build-riscv64
+FROM ucode-build-${TARGETARCH} AS ucode-build
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as compactor-common
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS compactor-common
 ENTRYPOINT []
 WORKDIR /
 COPY --from=build /lib/firmware/regulatory* /lib/firmware/
@@ -209,7 +209,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
     fi
 
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as compactor-full
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS compactor-full
 # get all possible FW
 COPY --from=build /lib/firmware/ /lib/firmware/
 
@@ -218,7 +218,7 @@ FROM compactor-common AS compactor-nvidia-jp5
 FROM compactor-common AS compactor-nvidia-jp6
 FROM compactor-full AS compactor-evaluation
 
-FROM compactor-${PLATFORM} as compactor
+FROM compactor-${PLATFORM} AS compactor
 
 FROM scratch
 ENTRYPOINT []

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 ARG PLATFORM=generic
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build-base
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build-base
 
 ARG TARGETARCH
 
@@ -96,7 +96,7 @@ ADD https://hailo-hailort.s3.eu-west-2.amazonaws.com/Hailo8/${HAILO_FW_VERSION}/
 
 # generate initrd for Intel's and AMD's microcode
 # it makes sense only for x86_64 platform
-FROM --platform=${TARGETPLATFORM} lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS ucode-build-common
+FROM --platform=${TARGETPLATFORM} lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS ucode-build-common
 RUN mkdir -p /boot /tmp/ucode/intel /tmp/ucode/amd /usr/share/licenses/ucode
 
 FROM ucode-build-common AS ucode-build-amd64
@@ -137,7 +137,7 @@ FROM ucode-build-common AS ucode-build-arm64
 FROM ucode-build-common AS ucode-build-riscv64
 FROM ucode-build-${TARGETARCH} AS ucode-build
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS compactor-common
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS compactor-common
 ENTRYPOINT []
 WORKDIR /
 COPY --from=build /lib/firmware/regulatory* /lib/firmware/
@@ -209,7 +209,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
     fi
 
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS compactor-full
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS compactor-full
 # get all possible FW
 COPY --from=build /lib/firmware/ /lib/firmware/
 

--- a/pkg/gpt-tools/Dockerfile
+++ b/pkg/gpt-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
 ENV BUILD_PKGS gcc make file patch libc-dev util-linux-dev linux-headers openssl-dev g++ tar
 RUN eve-alpine-deploy.sh
 

--- a/pkg/gpt-tools/Dockerfile
+++ b/pkg/gpt-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV BUILD_PKGS gcc make file patch libc-dev util-linux-dev linux-headers openssl-dev g++ tar
 RUN eve-alpine-deploy.sh
 

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -63,7 +63,7 @@ RUN ln -s python3 /usr/bin/python && \
 
 ADD ${GRUB_REPO}/snapshot/grub-${GRUB_COMMIT}.tar.gz /grub.tar.gz
 ENV GNULIB_REVISION=d271f868a8df9bbec29049d01e056481b7a1a263
-ADD --keep-git-dir https://github.com/coreutils/gnulib#${GNULIB_REVISION} /gnulib
+ADD --keep-git-dir https://github.com/coreutils/gnulib.git#${GNULIB_REVISION} /gnulib
 
 # the below does a weird init of a git repo, because we are not cloning the
 # repo, yet we need to be in a repo to apply patches with `git am`.

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as grub-build-base
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS grub-build-base
 ENV BUILD_PKGS automake \
                make \
                bison \

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS grub-build-base
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS grub-build-base
 ENV BUILD_PKGS automake \
                make \
                bison \

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -63,7 +63,7 @@ RUN ln -s python3 /usr/bin/python && \
 
 ADD ${GRUB_REPO}/snapshot/grub-${GRUB_COMMIT}.tar.gz /grub.tar.gz
 ENV GNULIB_REVISION=d271f868a8df9bbec29049d01e056481b7a1a263
-ADD --keep-git-dir git://git.sv.gnu.org/gnulib#${GNULIB_REVISION} /gnulib
+ADD --keep-git-dir https://github.com/coreutils/gnulib#${GNULIB_REVISION} /gnulib
 
 # the below does a weird init of a git repo, because we are not cloning the
 # repo, yet we need to be in a repo to apply patches with `git am`.

--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV BUILD_PKGS cairo-dev jpeg-dev libpng-dev gcc make libc-dev openssl-dev libvncserver-dev file patch
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs p11-kit cairo jpeg libpng libvncserver
 RUN eve-alpine-deploy.sh

--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
 ENV BUILD_PKGS cairo-dev jpeg-dev libpng-dev gcc make libc-dev openssl-dev libvncserver-dev file patch
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs p11-kit cairo jpeg libpng libvncserver
 RUN eve-alpine-deploy.sh

--- a/pkg/ipxe/Dockerfile
+++ b/pkg/ipxe/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 
 ENV BUILD_PKGS="patch make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev"
 RUN eve-alpine-deploy.sh

--- a/pkg/kdump/Dockerfile
+++ b/pkg/kdump/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 
 ENV BUILD_PKGS patch curl make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev elfutils-dev libbz2
 ENV PKGS xz-libs elfutils-dev libbz2

--- a/pkg/kexec/Dockerfile
+++ b/pkg/kexec/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 
 ENV BUILD_PKGS patch curl make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev elfutils-dev libbz2
 ENV PKGS xz-libs util-linux elfutils-dev libbz2

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV BUILD_PKGS go
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables curl openrc \
          open-iscsi libvirt libvirt-client util-linux grep findutils jq \

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
 ENV BUILD_PKGS go
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables curl openrc \
          open-iscsi libvirt libvirt-client util-linux grep findutils jq \

--- a/pkg/kvm-tools/Dockerfile
+++ b/pkg/kvm-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
 # Building qemu in strip-down mirovm only mode:
 # qemu 5.1 dependencies: python3 glib-dev pixman-dev
 # qemu 5.2+ dependencies: py3-setuptools bash perl

--- a/pkg/kvm-tools/Dockerfile
+++ b/pkg/kvm-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 # Building qemu in strip-down mirovm only mode:
 # qemu 5.1 dependencies: python3 glib-dev pixman-dev
 # qemu 5.2+ dependencies: py3-setuptools bash perl

--- a/pkg/measure-config/Dockerfile
+++ b/pkg/measure-config/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
 ENV BUILD_PKGS git go
 ENV PKGS alpine-baselayout musl-utils
 RUN eve-alpine-deploy.sh

--- a/pkg/measure-config/Dockerfile
+++ b/pkg/measure-config/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV BUILD_PKGS git go
 ENV PKGS alpine-baselayout musl-utils
 RUN eve-alpine-deploy.sh

--- a/pkg/memory-monitor/Dockerfile
+++ b/pkg/memory-monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS memory-monitor-build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS memory-monitor-build
 
 ENV BUILD_PKGS gcc musl-dev make linux-headers cmake build-base
 ENV PKGS alpine-baselayout curl strace

--- a/pkg/memory-monitor/Dockerfile
+++ b/pkg/memory-monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as memory-monitor-build
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS memory-monitor-build
 
 ENV BUILD_PKGS gcc musl-dev make linux-headers cmake build-base
 ENV PKGS alpine-baselayout curl strace

--- a/pkg/mkconf/Dockerfile
+++ b/pkg/mkconf/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 
 ENV PKGS mtools dosfstools
 RUN eve-alpine-deploy.sh

--- a/pkg/mkimage-iso-efi/Dockerfile
+++ b/pkg/mkimage-iso-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 
 ENV PKGS="dosfstools libarchive-tools binutils mtools xorriso mkinitfs squashfs-tools"
 RUN eve-alpine-deploy.sh

--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -5,7 +5,7 @@
 #   /EFI/BOOT/grub.cfg - Chainloads main bootloader
 #   /UsbInvocationScript.txt - Enables USB boot on Dell 3000 series
 #
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 ENV BUILD_PKGS="grep patch git make gcc linux-headers musl-dev autoconf automake pkgconfig kmod-dev util-linux-dev cryptsetup-dev lddtree libgcc mkinitfs"
 ENV PKGS="mtools dosfstools libarchive-tools sgdisk e2fsprogs util-linux squashfs-tools coreutils tar dmidecode \

--- a/pkg/mkrootfs-ext4/Dockerfile
+++ b/pkg/mkrootfs-ext4/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools sfdisk sgdisk xfsprogs \
          e2fsprogs util-linux coreutils multipath-tools squashfs-tools

--- a/pkg/mkrootfs-squash/Dockerfile
+++ b/pkg/mkrootfs-squash/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools sfdisk sgdisk \
     xfsprogs e2fsprogs util-linux coreutils multipath-tools squashfs-tools

--- a/pkg/monitor/Dockerfile
+++ b/pkg/monitor/Dockerfile
@@ -49,7 +49,7 @@ RUN cargo sbom > sbom.spdx.json
 RUN cp /app/target/$CARGO_BUILD_TARGET/release/monitor /app/target/
 
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS runtime
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS runtime
 ENV PKGS="kbd pciutils usbutils"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
 ENV BUILD_PKGS git go
 ENV PKGS coreutils
 RUN eve-alpine-deploy.sh

--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV BUILD_PKGS git go
 ENV PKGS coreutils
 RUN eve-alpine-deploy.sh

--- a/pkg/nvidia/Dockerfile
+++ b/pkg/nvidia/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG PLATFORM=generic
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build-base
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build-base
 ENV BUILD_PKGS="autoconf automake build-base coreutils gettext git glib-dev go libtool libmd-dev ncurses-dev tar xz-dev yq zstd-dev"
 
 RUN eve-alpine-deploy.sh

--- a/pkg/nvidia/Dockerfile
+++ b/pkg/nvidia/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG PLATFORM=generic
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build-base
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build-base
 ENV BUILD_PKGS="autoconf automake build-base coreutils gettext git glib-dev go libtool libmd-dev ncurses-dev tar xz-dev yq zstd-dev"
 
 RUN eve-alpine-deploy.sh
@@ -34,11 +34,11 @@ FROM build-base AS riscv64-generic
 FROM build-base AS riscv64-nvidia-jp5
 FROM build-base AS riscv64-nvidia-jp6
 
-FROM build-base as arm64-nvidia-jp5
+FROM build-base AS arm64-nvidia-jp5
 ENV JETSON_LINUX=${JETSON_JP5}
 ENV JETPACK_VER=jp5
 
-FROM build-base as arm64-nvidia-jp6
+FROM build-base AS arm64-nvidia-jp6
 ENV JETSON_LINUX=${JETSON_JP6}
 ENV JETPACK_VER=jp6
 

--- a/pkg/optee-os/Dockerfile
+++ b/pkg/optee-os/Dockerfile
@@ -7,12 +7,12 @@ ARG BUILD_PKGS_BASE="autoconf automake bash binutils binutils-dev build-base bc 
 ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2
 
 # hadolint ignore=DL3006
-FROM ${EVE_ALPINE_IMAGE} as build-native
+FROM ${EVE_ALPINE_IMAGE} AS build-native
 ARG BUILD_PKGS_BASE
 RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
 
 # hadolint ignore=DL3006,DL3029
-FROM --platform=${BUILDPLATFORM} ${EVE_ALPINE_IMAGE} as build-cross
+FROM --platform=${BUILDPLATFORM} ${EVE_ALPINE_IMAGE} AS build-cross
 ARG BUILD_PKGS_BASE
 RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
 

--- a/pkg/optee-os/Dockerfile
+++ b/pkg/optee-os/Dockerfile
@@ -4,7 +4,7 @@
 ARG BUILD_PKGS_BASE="autoconf automake bash binutils binutils-dev build-base bc bison curl dtc expat flex openssl-dev util-linux-dev swig gnutls-dev perl python3 python3-dev py3-setuptools py3-pycryptodome py3-elftools py3-cryptography"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f
 
 # hadolint ignore=DL3006
 FROM ${EVE_ALPINE_IMAGE} AS build-native
@@ -17,7 +17,7 @@ ARG BUILD_PKGS_BASE
 RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
 
 # hadolint ignore=DL3029
-FROM --platform=${BUILDPLATFORM} lfedge/eve-cross-compilers:6c849909e9a62da563148c70897f74e6d2689dd0 AS cross-compilers
+FROM --platform=${BUILDPLATFORM} lfedge/eve-cross-compilers:871591942d8fe4b28b129b10cc63bd8052db81b9 AS cross-compilers
 
 # will use several packages from target arch and copy them to sysroot
 # hadolint ignore=DL3006

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -10,8 +10,8 @@ ARG BUILD_PKGS_BASE="git gcc linux-headers libc-dev make linux-pam-dev m4 findut
 # we use the same image in several places
 ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2
 
-FROM lfedge/eve-uefi:575f1b1b2f033dc5f61c03a66e8b60a896c5bb56 as uefi-build
-FROM lfedge/eve-dom0-ztools:53b39e8af34f7510170801e7c89ac44668ee7134 as zfs
+FROM lfedge/eve-uefi:575f1b1b2f033dc5f61c03a66e8b60a896c5bb56 AS uefi-build
+FROM lfedge/eve-dom0-ztools:53b39e8af34f7510170801e7c89ac44668ee7134 AS zfs
 RUN mkdir /out
 # copy zfs-related files from dom0-ztools using prepared list of files
 RUN while read -r x; do \
@@ -23,12 +23,12 @@ RUN while read -r x; do \
     done < /etc/zfs-files
 
 # hadolint ignore=DL3006
-FROM ${EVE_ALPINE_IMAGE} as build-native
+FROM ${EVE_ALPINE_IMAGE} AS build-native
 ARG BUILD_PKGS_BASE
 RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
 
 # hadolint ignore=DL3006,DL3029
-FROM --platform=${BUILDPLATFORM} ${EVE_ALPINE_IMAGE} as build-cross
+FROM --platform=${BUILDPLATFORM} ${EVE_ALPINE_IMAGE} AS build-cross
 ARG BUILD_PKGS_BASE
 RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
 
@@ -137,14 +137,14 @@ RUN --mount=type=cache,target=/root/.cache/go-build if [ "${TEST_TOOLS}" = "y" ]
     GOBIN=/final/opt/ GOFLAGS="" go install gotest.tools/gotestsum@v1.7.0; \
 fi
 
-FROM lfedge/eve-fscrypt:d4cdcc1a6d34cb03ba17f05f6a493d156281e01e as fscrypt
-FROM lfedge/eve-dnsmasq:b8ca1cb29bf98184b90eeb91e0705696c0b80abd as dnsmasq
-FROM lfedge/eve-gpt-tools:825f5ad1b706cffeb1dccd75f0759d755d87289e as gpttools
+FROM lfedge/eve-fscrypt:d4cdcc1a6d34cb03ba17f05f6a493d156281e01e AS fscrypt
+FROM lfedge/eve-dnsmasq:b8ca1cb29bf98184b90eeb91e0705696c0b80abd AS dnsmasq
+FROM lfedge/eve-gpt-tools:825f5ad1b706cffeb1dccd75f0759d755d87289e AS gpttools
 
 # collector collects everything together and then does any processing like stripping binaries.
 # We use this interim "collector" so that we can do processing.
 # hadolint ignore=DL3006
-FROM ${EVE_ALPINE_IMAGE} as collector
+FROM ${EVE_ALPINE_IMAGE} AS collector
 ENV BUILD_PKGS patch
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs pciutils yajl xz bash iptables ip6tables iproute2 \
     coreutils dmidecode libbz2 libuuid ipset curl radvd ethtool util-linux e2fsprogs libcrypto1.1 xorriso \

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -8,10 +8,10 @@ ARG BUILD_PKGS_BASE="git gcc linux-headers libc-dev make linux-pam-dev m4 findut
                      libintl libuuid libtirpc libblkid libcrypto1.1 zlib tar"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f
 
-FROM lfedge/eve-uefi:575f1b1b2f033dc5f61c03a66e8b60a896c5bb56 AS uefi-build
-FROM lfedge/eve-dom0-ztools:53b39e8af34f7510170801e7c89ac44668ee7134 AS zfs
+FROM lfedge/eve-uefi:d31bc38759b0e3548284132dd1524a360621296d AS uefi-build
+FROM lfedge/eve-dom0-ztools:10f26732c697a32706ed749c5d4314c0468a95c9 AS zfs
 RUN mkdir /out
 # copy zfs-related files from dom0-ztools using prepared list of files
 RUN while read -r x; do \
@@ -33,7 +33,7 @@ ARG BUILD_PKGS_BASE
 RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
 
 # hadolint ignore=DL3029
-FROM --platform=${BUILDPLATFORM} lfedge/eve-cross-compilers:6c849909e9a62da563148c70897f74e6d2689dd0 AS cross-compilers
+FROM --platform=${BUILDPLATFORM} lfedge/eve-cross-compilers:871591942d8fe4b28b129b10cc63bd8052db81b9 AS cross-compilers
 
 # will use several packages from target arch and copy them to sysroot
 # hadolint ignore=DL3006
@@ -137,9 +137,9 @@ RUN --mount=type=cache,target=/root/.cache/go-build if [ "${TEST_TOOLS}" = "y" ]
     GOBIN=/final/opt/ GOFLAGS="" go install gotest.tools/gotestsum@v1.7.0; \
 fi
 
-FROM lfedge/eve-fscrypt:d4cdcc1a6d34cb03ba17f05f6a493d156281e01e AS fscrypt
-FROM lfedge/eve-dnsmasq:b8ca1cb29bf98184b90eeb91e0705696c0b80abd AS dnsmasq
-FROM lfedge/eve-gpt-tools:825f5ad1b706cffeb1dccd75f0759d755d87289e AS gpttools
+FROM lfedge/eve-fscrypt:6e3d54a6a18dedcf425271e0c35e140510afba3d AS fscrypt
+FROM lfedge/eve-dnsmasq:ce9e18006f571de5e7d043e2111a02cffcc69f78 AS dnsmasq
+FROM lfedge/eve-gpt-tools:e42241d0feb04edf4efb11ca7d007f0a2908221d AS gpttools
 
 # collector collects everything together and then does any processing like stripping binaries.
 # We use this interim "collector" so that we can do processing.

--- a/pkg/pillar/vendor/github.com/jaypipes/ghw/Dockerfile
+++ b/pkg/pillar/vendor/github.com/jaypipes/ghw/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-stretch as builder
+FROM golang:1.13-stretch AS builder
 WORKDIR /go/src/github.com/jaypipes/ghw
 
 # Force the go compiler to use modules.

--- a/pkg/recovertpm/Dockerfile
+++ b/pkg/recovertpm/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV BUILD_PKGS go
 RUN eve-alpine-deploy.sh
 

--- a/pkg/recovertpm/Dockerfile
+++ b/pkg/recovertpm/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
 ENV BUILD_PKGS go
 RUN eve-alpine-deploy.sh
 

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV BUILD_PKGS go gcc musl-dev linux-headers
 RUN eve-alpine-deploy.sh
 

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
 ENV BUILD_PKGS go gcc musl-dev linux-headers
 RUN eve-alpine-deploy.sh
 

--- a/pkg/sources/Dockerfile
+++ b/pkg/sources/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS tools
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS tools
 
 COPY collected_sources.tar.gz /var/collected_sources.tar.gz
 RUN mkdir -p /var/sources && tar -C /var/sources -xzf /var/collected_sources.tar.gz

--- a/pkg/sources/Dockerfile
+++ b/pkg/sources/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as tools
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS tools
 
 COPY collected_sources.tar.gz /var/collected_sources.tar.gz
 RUN mkdir -p /var/sources && tar -C /var/sources -xzf /var/collected_sources.tar.gz

--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV PKGS="alpine-baselayout musl-utils bash glib squashfs-tools util-linux e2fsprogs e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 as build
+FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
 ENV PKGS="alpine-baselayout musl-utils bash glib squashfs-tools util-linux e2fsprogs e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/u-boot/Dockerfile
+++ b/pkg/u-boot/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build-base
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build-base
 ENV BUILD_PKGS bash binutils-dev build-base bc bison flex openssl-dev python3 swig dtc
 ENV BUILD_PKGS_amd64 python3-dev py-pip
 RUN eve-alpine-deploy.sh

--- a/pkg/udev/Dockerfile
+++ b/pkg/udev/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV PKGS udev
 RUN eve-alpine-deploy.sh
 

--- a/pkg/uefi/Dockerfile
+++ b/pkg/uefi/Dockerfile
@@ -10,7 +10,7 @@
 #   git clone https://git.linaro.org/uefi/uefi-tools.git
 #   ./uefi-tools/edk2-build.sh -b DEBUG -b RELEASE all
 #
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV BUILD_PKGS make gcc g++ python3 libuuid nasm util-linux-dev bash git util-linux patch
 ENV BUILD_PKGS_amd64 iasl
 ENV BUILD_PKGS_arm64 iasl

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -3,8 +3,8 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-dom0-ztools:53b39e8af34f7510170801e7c89ac44668ee7134 AS dom0
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-dom0-ztools:10f26732c697a32706ed749c5d4314c0468a95c9 AS dom0
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV BUILD_PKGS="gcc g++ autoconf automake libtool make openssl-dev libtasn1-dev \
     json-glib-dev gnutls bash expect gawk socat libseccomp-dev gmp-dev \
     musl-utils autoconf-archive git json-c json-c-dev libcurl curl-dev \

--- a/pkg/watchdog/Dockerfile
+++ b/pkg/watchdog/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS watchdog-build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS watchdog-build
 ENV BUILD_PKGS build-base file libtirpc-dev linux-headers tar util-linux
 ENV PKGS alpine-baselayout musl-utils libsmartcols
 RUN eve-alpine-deploy.sh

--- a/pkg/wlan/Dockerfile
+++ b/pkg/wlan/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV PKGS alpine-baselayout musl-utils wireless-tools wpa_supplicant
 RUN eve-alpine-deploy.sh
 

--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023-2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV BUILD_PKGS meson ninja git libc-dev glib-dev make gcc udev dbus-dev libgudev-dev go
 ENV PKGS alpine-baselayout dbus glib kmod-dev libgudev
 RUN eve-alpine-deploy.sh

--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-uefi:575f1b1b2f033dc5f61c03a66e8b60a896c5bb56 as uefi-build
+FROM lfedge/eve-uefi:575f1b1b2f033dc5f61c03a66e8b60a896c5bb56 AS uefi-build
 FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS runx-build
 ENV BUILD_PKGS mkinitfs gcc musl-dev e2fsprogs chrony agetty
 RUN eve-alpine-deploy.sh

--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -3,8 +3,8 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-uefi:575f1b1b2f033dc5f61c03a66e8b60a896c5bb56 AS uefi-build
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS runx-build
+FROM lfedge/eve-uefi:d31bc38759b0e3548284132dd1524a360621296d AS uefi-build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS runx-build
 ENV BUILD_PKGS mkinitfs gcc musl-dev e2fsprogs chrony agetty
 RUN eve-alpine-deploy.sh
 
@@ -20,7 +20,7 @@ RUN gcc -s -o /chroot2 /tmp/chroot2.c -Wall -Werror
 RUN gcc -s -o /hacf /tmp/hacf.c -Wall -Werror
 RUN mkinitfs -n -F base -i /init-initrd -o /runx-initrd
 
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS build
 ENV BUILD_PKGS \
     gcc make libc-dev dev86 xz-dev perl bash python3-dev \
     gettext iasl util-linux-dev ncurses-dev glib-dev \

--- a/pkg/xen/Dockerfile
+++ b/pkg/xen/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS kernel-build
+FROM lfedge/eve-alpine:e799def68af51dba83ec5a41f34bd0109704574f AS kernel-build
 
 ENV BUILD_PKGS argp-standalone automake bash bc binutils-dev bison build-base \
                diffutils flex git gmp-dev gnupg installkernel kmod \


### PR DESCRIPTION
# Description

was https://github.com/lf-edge/eve/pull/5025 - but reopen is not allowed

    this bumps some packages, including golang to 1.24.4
    to prevent:
    GO-2025-3563
    GO-2025-3749
    GO-2025-3750
    GO-2025-3751

OSV checker is complaining, e.g.: https://github.com/lf-edge/eve/actions/runs/15906835554/job/44863871543?pr=4992

## How to test and validate this PR

run OSV checker

and 

```
strings /containers/services/pillar/rootfs/opt/zededa/bin/zedbox | grep "1.24.4"
```

## Changelog notes

    this bumps some packages, including golang to 1.24.4
    to prevent:
    GO-2025-3563
    GO-2025-3749
    GO-2025-3750
    GO-2025-3751

## PR Backports

No, because it seems the vulns are not severe.

Here is the list of current LTS branches (it should be always up to date):

- 14.5-stable: No
- 13.4-stable: No

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
