### PR TITLE
Fixes in the S.M.A.R.T. report

### DIFF
--- a/pkg/pillar/types/smarttypes.go
+++ b/pkg/pillar/types/smarttypes.go
@@ -69,7 +69,7 @@ const (
 type DAttrTable struct {
 	ID            int
 	AttributeName string
-	Value         uint64
+	Value         int64
 	Worst         uint8
 	Flags         uint16
 	RawValue      int


### PR DESCRIPTION
# Description

- Changed how we compute the rawValue attribute for SATA devices
- Fixed the value attribute for SATA devices
- Changed the temperature attribute for NVMe devices to be in Celcious instead of Kelvin
- Filled the missing entries for S.M.A.R.T. attribute names for SATA devices
- Added temperature sensor attributes for NVMe devices

## How to test and validate this PR

To test this PR, compare the S.M.A.R.T. data displayed in the Storage tab of an Edge node in Zedcloud UI with the output of the smartctl -a <devname> command executed directly inside the EVE-OS.

## Changelog notes

This PR fixes the part of the S.M.A.R.T. data displayed in the Storage tab of an Edge node that differs from the smartctl report. 
 - Temperature from Kelvin to Celcious
 - Added missing attributes "temperature sensor" from the NVMe report
 - Fixed the "Unknown attribute" name in the SATA report when possible.

## PR Backports

- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please check the boxes above after submitting the PR in interactive mode.
