### PR TITLE
Handle error IsAlreadyExists

### DIFF
--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -542,12 +542,18 @@ func (ctx kubevirtContext) Start(domainName string) error {
 	for {
 		_, err = virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).Create(repvmi)
 		if err != nil {
+			if errors.IsAlreadyExists(err) {
+				// VMI could have been already started, for example failover from other node.
+				// Its not an error, just proceed.
+				logrus.Warnf("VMI replicaset %v already exists", repvmi)
+				break
+			}
 			if strings.Contains(err.Error(), "dial tcp 127.0.0.1:6443") && i <= 0 {
-				logrus.Infof("Start VMI replicaset failed %v\n", err)
+				logrus.Errorf("Start VMI replicaset failed %v\n", err)
 				return err
 			}
 			time.Sleep(10 * time.Second)
-			logrus.Infof("Start VMI replicaset failed, retry (%d) err %v", i, err)
+			logrus.Errorf("Start VMI replicaset failed, retry (%d) err %v", i, err)
 		} else {
 			break
 		}


### PR DESCRIPTION
# Description

During a failover scenario, kubernetes starts the VMI on the other node, because we just use kubernetes scheduling mechanism. Then we tell eve domainmgr to process the VMI start and publish the DomainStatus. So when domainmgr calls the Start() we need to handle the already exists error and return gracefully. Without this fix after failover domainmgr code goes into forever loop.

This code is present in POC branch, we missed in merges.



## PR dependencies



## How to test and validate this PR

1) Create an edge node cluster of 3 nodes
2) deploy a VM 
3) Trigger failover of the VM by rebooting the node where VM is running.
4) VM will move to other node and then you will see Domainmgr in forever loop and cannot publish DomainStatus.

## Changelog notes

No user facing changes.

## PR Backports


- 14.5-stable


## Checklist

- [x] I've provided a proper description
- [x] I've tested my PR on amd64 device
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
