### PR TITLE
Fix 'unauthenticated pull rate limit reached' problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
 HV_DEFAULT=kvm
 # linuxkit version. This **must** be a published semver version so it can be downloaded already compiled from
 # the release page at https://github.com/linuxkit/linuxkit/releases
-LINUXKIT_VERSION=v1.6.2
+LINUXKIT_VERSION=v1.6.5
 BUILD_KIT_VERSION=v0.23.1
 GOVER ?= 1.24.1
 PKGBASE=github.com/lf-edge/eve
@@ -332,7 +332,7 @@ DOCKER_GO = _() { $(SET_X); mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $
 PARSE_PKGS=$(if $(strip $(EVE_HASH)),EVE_HASH=)$(EVE_HASH) DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG) KERNEL_TAG=$(KERNEL_TAG) PLATFORM=$(PLATFORM) ./tools/parse-pkgs.sh
 
 LINUXKIT_OPTS=$(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL)
-LINUXKIT_PKG_TARGET=build
+LINUXKIT_PKG_TARGET=build --builders linux/$(ZARCH)=default
 
 ifdef LIVE_FAST
 # Check the makerootfs.sh and the linuxkit tool invocation, the --input-tar
@@ -969,12 +969,26 @@ shell: $(GOBUILDER)
 .PHONY: linuxkit
 linuxkit: $(LINUXKIT)
 
+# Detect config files
+BUILDKIT_CONFIG_FILE := /etc/buildkit/buildkitd.toml
+DOCKER_CONFIG_FILE := $(HOME)/.docker/config.json
+
+# Conditional options
+BUILDKIT_CONFIG_OPTS := $(if $(wildcard $(BUILDKIT_CONFIG_FILE)),--config /etc/buildkit/buildkitd.toml,)
+BUILDKIT_MOUNT_OPTS := \
+    $(if $(wildcard $(BUILDKIT_CONFIG_FILE)),-v $(BUILDKIT_CONFIG_FILE):/etc/buildkit/buildkitd.toml,) \
+    $(if $(wildcard $(DOCKER_CONFIG_FILE)),-v $(DOCKER_CONFIG_FILE):/root/.docker/config.json:ro,)
+
 ensure-builder:
-	@if ! docker --context default container inspect linuxkit-builder >/dev/null 2>&1; then \
+	$(QUIET)if ! docker --context default container inspect linuxkit-builder >/dev/null 2>&1; then \
 	    echo "Container linuxkit-builder does not exist, creating..."; \
 	    docker --context default container run -d --name linuxkit-builder \
-	        --privileged moby/buildkit:$(BUILD_KIT_VERSION) \
+	        --privileged \
+	        $(BUILDKIT_MOUNT_OPTS) \
+	        --network=host \
+	        moby/buildkit:$(BUILD_KIT_VERSION) \
 	        --allow-insecure-entitlement network.host \
+	        $(BUILDKIT_CONFIG_OPTS) \
 	        --debug --addr unix:///run/buildkit/buildkitd.sock; \
 	else \
 	    current_image=$$(docker --context default container inspect linuxkit-builder | jq -r '.[].Config.Image'); \
@@ -982,8 +996,12 @@ ensure-builder:
 	        echo "Recreating container (expected moby/buildkit:$(BUILD_KIT_VERSION), found $$current_image)"; \
 	        docker --context default container rm -f linuxkit-builder; \
 	        docker --context default container run -d --name linuxkit-builder \
-	            --privileged moby/buildkit:$(BUILD_KIT_VERSION) \
+	            --privileged \
+	            $(BUILDKIT_MOUNT_OPTS) \
+	            --network=host \
+	            moby/buildkit:$(BUILD_KIT_VERSION) \
 	            --allow-insecure-entitlement network.host \
+	            $(BUILDKIT_CONFIG_OPTS) \
 	            --debug --addr unix:///run/buildkit/buildkitd.sock; \
 	    else \
 	        echo "Container linuxkit-builder is up-to-date"; \
@@ -993,7 +1011,7 @@ ensure-builder:
 LINUXKIT_SOURCE=https://github.com/linuxkit/linuxkit
 
 $(LINUXKIT): $(BUILDTOOLS_BIN)/linuxkit-$(LINUXKIT_VERSION) | ensure-builder
-	$(QUIET) ln -sf  $(notdir $<) $@
+	$(QUIET)ln -sf  $(notdir $<) $@
 	$(QUIET): $@: Succeeded
 
 $(BUILDTOOLS_BIN)/linuxkit-$(LINUXKIT_VERSION):


### PR DESCRIPTION
# Description

- action/docker-login stores credential in ~/.docker/config.json. In theory this file should be mounted
into linuxkit-builder container but I did not know about it. Dut to that fact buildkit was running unauthenticated
- upgrade to linuxkit 1.6.5 that has fixes for a race in builder creation and cache access
- mount /etc/buildkit/buildkitd.toml that MAY define a mirror to speedup the build. Even LK 1.6.5 doens't do it yet
otherwise we could remove the whole block for manual creation of buildkit runner

## How to test and validate this PR

run on CI and locally and make sure your docker credentials are respected as well as /etc/buildkit/buildkitd.toml settings


## PR Backports

No corresponding code in the LTS branches.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
