### PR TITLE
.github: Use DockerHub pull-only credentials to avoid rate limits.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,8 @@ jobs:
         if: ${{ github.event.repository.full_name }}== 'lf-edge/eve'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
-          password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_PULL_USER }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
       - name: ensure zstd for cache  # this should be removed once the arm64 VM includes zstd
         if: ${{ matrix.os == 'buildjet-4vcpu-ubuntu-2204-arm' || matrix.os == 'arm64-secure' }}
         run: |
@@ -130,8 +130,8 @@ jobs:
         if: ${{ github.event.repository.full_name }}== 'lf-edge/eve'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
-          password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_PULL_USER }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
       - name: Arch Runner is Matrix
         id: arch_runner_equals_matrix


### PR DESCRIPTION
# Description

This PR updates the DockerHub authentication method in the PR Build workflow. It switches from using LF-Edge owned credentials to using dedicated EVE-owned read-only credentials that have a higher pull rate limit.

This change is necessary because we have been experiencing CI failures with HTTP 429 errors (“too many requests”) from DockerHub, which blocks our ability to reliably pull images during builds.

## PR dependencies

The following secret should exist in our repo:
```
DOCKERHUB_PULL_TOKEN
DOCKERHUB_PULL_USER
```

## How to test and validate this PR

Not to be verified externally, as it's CI/CD change.

For us:

Trigger several CI runs in quick succession (including on different branches and PRs) to ensure DockerHub images are pulled without encountering 429 rate limit errors.

## Changelog notes

No user-facing changes.

## PR Backports

- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

