### PR TITLE
vault: Check policyID exist before indexing

### DIFF
--- a/pkg/pillar/vault/handler_ext4.go
+++ b/pkg/pillar/vault/handler_ext4.go
@@ -224,6 +224,10 @@ func (h *Ext4Handler) removeProtectorIfAny(vaultPath string) error {
 			return err
 		}
 		policyID, err := h.getPolicyIDByProtectorID(protectorID[0][1])
+		if err == nil && len(policyID) == 0 {
+			// No policy found, nothing to be done.
+			return nil
+		}
 		if err == nil {
 			h.log.Functionf("Removing policyID %s for vaultPath %s", policyID[0][1], vaultPath)
 			args := h.getRemovePolicyParams(policyID[0][1])


### PR DESCRIPTION

# Description
Check if the policyID exists before indexing it to avoid a panic when no policy is found for the given protector ID. 

Closes https://github.com/lf-edge/eve/issues/4907.

## How to test and validate this PR


## Changelog notes
 
Fix panic in ext4 fscrypt handler when checking for protector policy.

## PR Backports

- [ ] 14.5-stable
- [ ] 13.4-stable

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
