### PR TITLE
[11.0-stable] Update github workflows: perform login on docker, self-hosted runners and linuxkit update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: buildjet-4vcpu-ubuntu-2204-arm
+          - os: zededa-ubuntu-2204
             arch: arm64
-          - os: buildjet-4vcpu-ubuntu-2004
+          - os: zededa-ubuntu-2204
             arch: amd64
-          - os: buildjet-4vcpu-ubuntu-2004
+          - os: zededa-ubuntu-2204
             arch: riscv64
     steps:
       - name: Starting Report
@@ -77,7 +77,7 @@ jobs:
 
   eve:
     needs: packages  # all packages for all platforms must be built first
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: zededa-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Login to Docker Hub
+        if: ${{ github.event.repository.full_name }}== 'lf-edge/eve'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_PULL_USER }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
       - name: ensure zstd for cache  # this should be removed once the arm64 VM includes zstd
         if: ${{ matrix.os == 'buildjet-4vcpu-ubuntu-2204-arm' || matrix.os == 'arm64-secure' }}
         run: |
@@ -84,6 +90,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Login to Docker Hub
+        if: ${{ github.event.repository.full_name }}== 'lf-edge/eve'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_PULL_USER }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
       - name: update linuxkit cache for runner arch so we can get desired images
         id: cache_for_docker
         uses: actions/cache/restore@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,11 +19,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: arm64-secure
+          - os: zededa-ubuntu-2204
             arch: arm64
-          - os: ubuntu-24.04
+          - os: zededa-ubuntu-2204
             arch: amd64
-          - os: ubuntu-latest
+          - os: zededa-ubuntu-2204
             arch: riscv64
     steps:
       - name: Starting Report
@@ -66,7 +66,7 @@ jobs:
           # sadly, our build sometimes times out on network access
           # and running out of disk space: re-trying for 3 times
           for i in 1 2 3; do
-             if make -e V=1 LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
+             if make -e V=1 ZARCH=${{ matrix.arch }} LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
                 SUCCESS=true
                 break
              else
@@ -98,7 +98,7 @@ jobs:
   eve:
     if: github.event.repository.full_name == 'lf-edge/eve'
     needs: packages
-    runs-on: ubuntu-latest
+    runs-on: zededa-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:
@@ -126,7 +126,7 @@ jobs:
   verification:
     if: github.event.repository.full_name == 'lf-edge/eve'
     needs: packages
-    runs-on: ubuntu-latest
+    runs-on: zededa-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:
@@ -144,7 +144,7 @@ jobs:
 
   manifest:
     if: github.event.repository.full_name == 'lf-edge/eve'
-    runs-on: ubuntu-latest
+    runs-on: zededa-ubuntu-2204
     needs: packages
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Description

This PR brings several new features and changes from current workflows to 11.0-stable branch:

* Provide Docker login action on the build workflows.
* Switch to Zededa's self hosted runners
* Update linuxkit to version 1.7.0
* Port Makefile changes to support linuxkit 1.7.0

## How to test and validate this PR

Run GH workflows.

## Changelog notes

None.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.