### PR TITLE
Makefile: Remove buildkit options for manifest command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,14 +330,15 @@ DOCKER_GO = _() { $(SET_X); mkdir -p $(CURDIR)/.go/src/$${3:-dummy} ; mkdir -p $
 
 PARSE_PKGS=$(if $(strip $(EVE_HASH)),EVE_HASH=)$(EVE_HASH) DOCKER_ARCH_TAG=$(DOCKER_ARCH_TAG) KERNEL_TAG=$(KERNEL_TAG) PLATFORM=$(PLATFORM) ./tools/parse-pkgs.sh
 
+LINUXKIT_PKG_TARGET=build
+
 # buildkitd.toml configuration file can control a configuration of the buildkit daemon
 # it is used for example to setup a Docker registry mirror for CI to speedup the builds
 # this option can be overridden by setting BUILDKIT_CONFIG_FILE variable on make command line
 BUILDKIT_CONFIG_FILE ?= /etc/buildkit/buildkitd.toml
-BUILDKIT_CONFIG_OPTS := $(if $(wildcard $(BUILDKIT_CONFIG_FILE)),--builder-config $(BUILDKIT_CONFIG_FILE),)
+BUILDKIT_CONFIG_OPTS := $(if $(filter manifest,$(LINUXKIT_PKG_TARGET)),,$(if $(wildcard $(BUILDKIT_CONFIG_FILE)),--builder-config $(BUILDKIT_CONFIG_FILE),))
 
 LINUXKIT_OPTS=$(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_REL)),--release) $(EVE_REL) $(BUILDKIT_CONFIG_OPTS)
-LINUXKIT_PKG_TARGET=build
 
 ifdef LIVE_FAST
 # Check the makerootfs.sh and the linuxkit tool invocation, the --input-tar


### PR DESCRIPTION
# Description

When available, buildkit configuration is passed to linuxkit using the `--builder-config` parameter. However, this parameter doesn't exist for manifest command, so let's make sure to not use it when LINUXKIT_PKG_TARGET is equal to manifest.

## How to test and validate this PR

Two possible ways:

* Run Git Hub publish workflow. Make sure it passes 100%.
* Run `make LINUXKIT_PKG_TARGET=manifest pkgs` with a valid `/etc/buildkit/buildkitd.toml` file present in the system.

## Changelog notes

None.

## PR Backports

No backports since this bug is only on master.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.