### PR TITLE
Introduce Air-gap mode

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -41,6 +41,7 @@
 | timer.appcontainer.stats.interval | integer in seconds | 300 | collect application container stats |
 | timer.vault.ready.cutoff | integer in seconds | 300 | reboot after inaccessible vault |
 | maintenance.mode | "enabled" or "disabled" | "none" | don't run applications etc |
+| airgap.mode | "enabled" or "disabled" | "none" | Enable when the device is expected to operate without connectivity to the main controller and is instead managed locally via the LOC (Local Operator Console) |
 | force.fallback.counter | integer | 0 | forces fallback to other image if counter is changed |
 | newlog.allow.fastupload | boolean | false | allow faster upload gzip logfiles to controller |
 | memory.apps.ignore.check | boolean | false | Ignore memory usage check for Apps |

--- a/docs/DEVICE-CONNECTIVITY.md
+++ b/docs/DEVICE-CONNECTIVITY.md
@@ -558,6 +558,39 @@ There are two levels of errors:
 - A particular management port could not be used to reach the controller. In that case
   the `ErrorInfo` for the particular `DevicePort` is set to indicate the error and timestamp.
 
+## Air-Gap Mode
+
+Air-Gap mode allows a device to operate without connectivity to the main controller,
+supporting scenarios where local-only management is required. In this mode,
+the *Local Operator Console* (*LOC*) is used to manage the device locally.
+
+When Air-Gap mode is enabled, [the connectivity tester](#testing-device-connectivity)
+reports the device as connected if either the main controller *or the LOC is reachable*.
+This ensures that when network configuration changes are made, EVE does not incorrectly
+mark the configuration as non-working or revert it, as long as LOC connectivity is maintained.
+
+Error and warning logs about lost controller connectivity are either suppressed or downgraded
+to trace-level to avoid log clutter, since loss of controller connectivity is expected
+in this mode. However, the device still attempts to contact the controller, so it can resume
+normal operation if connectivity is restored.
+
+Air-Gap mode is controlled through the configuration property `airgap.mode`. Setting this
+property to `enable` enables Air-Gap mode, while setting it to `disable` disables it.
+By default, Air-Gap mode is disabled.
+
+Air-Gap mode activation is indicated in the console output by the diagnostic microservice.
+If Air-Gap mode is enabled and Local Operator Console (LOC) is configured, it will report:
+
+```text
+INFO : Air-gap mode enabled, using LOC: <loc-url>
+```
+
+But if LOC is not configured while Air-Gap mode is enabled, the user will be warned:
+
+```text
+WARNING: Air-gap mode enabled without LOC configuration
+```
+
 ## Troubleshooting
 
 There are multiple sources of information that provide a picture of the current or a past

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -796,6 +796,15 @@ func printOutput(ctx *diagContext, caller string) {
 		level, ctx.zedagentStatus.DeviceState.String(),
 		attestStatus, vaultStatus, pcrStatus)
 
+	if ctx.zedagentStatus.AirgapMode {
+		if ctx.zedagentStatus.LOCUrl != "" {
+			ctx.ph.Print("INFO : Air-gap mode enabled, using LOC: %s\n",
+				ctx.zedagentStatus.LOCUrl)
+		} else {
+			ctx.ph.Print("WARNING: Air-gap mode enabled without LOC configuration\n")
+		}
+	}
+
 	// Determine what we print for app summary
 	summary := ctx.appInstanceSummary
 	if ctx.appInstanceSummary.TotalError > 0 {

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -751,6 +751,7 @@ func (n *nim) handleZedAgentStatusModify(_ interface{}, key string, statusArg, _
 func (n *nim) handleZedAgentStatusImpl(_ string, statusArg interface{}) {
 	zedagentStatus := statusArg.(types.ZedAgentStatus)
 	n.dpcManager.UpdateRadioSilence(zedagentStatus.RadioSilence)
+	n.dpcManager.UpdateLOCUrl(zedagentStatus.LOCUrl)
 }
 
 func (n *nim) handleOnboardStatusCreate(_ interface{}, key string, statusArg interface{}) {

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -2847,6 +2847,8 @@ func parseConfigItems(ctx *getconfigContext, config *zconfig.EdgeDevConfig,
 			ctx.zedagentCtx.gcpMaintenanceMode = newMaintenanceMode
 			mergeMaintenanceMode(ctx.zedagentCtx, "parseConfigItems")
 		}
+		airgapModeVal := newGlobalConfig.GlobalValueTriState(types.AirGapMode)
+		ctx.zedagentCtx.airgapMode = airgapModeVal == types.TS_ENABLED
 
 		pub := ctx.zedagentCtx.pubGlobalConfig
 		err := pub.Publish("global", *gcPtr)

--- a/pkg/pillar/conntester/conntester.go
+++ b/pkg/pillar/conntester/conntester.go
@@ -16,8 +16,24 @@ type ConnectivityTester interface {
 	// TestConnectivity returns nil error if connectivity test has passed.
 	// Additionally, it returns test result for each tested device network interface
 	// and network traces of executed probes if withNetTrace was enabled.
-	TestConnectivity(dns types.DeviceNetworkStatus,
+	TestConnectivity(dns types.DeviceNetworkStatus, airGapMode AirGapMode,
 		withNetTrace bool) (types.IntfStatusMap, []netdump.TracedNetRequest, error)
+}
+
+// AirGapMode defines the configuration for operating the device in an air-gapped
+// network environment, where connectivity to the main controller is not available.
+type AirGapMode struct {
+	// Enabled indicates whether air-gap mode is active. When true, and a LOC
+	// (Local Operator Console) URL is configured, the connectivity tester will
+	// report device as "connected" if either the main controller or the LOC
+	// is reachable. In other words, device is still considered connected
+	// even if the main controller is unreachable, as long as the LOC can be accessed.
+	Enabled bool
+
+	// LocURL specifies the URL of the Local Operator Console used to manage the device
+	// when it is running in air-gap mode. This URL is used by the connectivity tester
+	// to validate local accessibility.
+	LocURL string
 }
 
 // RemoteTemporaryFailure can be returned by TestConnectivity to indicate that test failed

--- a/pkg/pillar/conntester/mock.go
+++ b/pkg/pillar/conntester/mock.go
@@ -47,8 +47,9 @@ func (t *MockConnectivityTester) SetConnectivityError(dpcKey, ifName string, err
 }
 
 // TestConnectivity simulates connectivity test.
-func (t *MockConnectivityTester) TestConnectivity(dns types.DeviceNetworkStatus,
-	withNetTrace bool) (intfStatusMap types.IntfStatusMap, tracedReqs []netdump.TracedNetRequest, err error) {
+func (t *MockConnectivityTester) TestConnectivity(
+	dns types.DeviceNetworkStatus, airGapMode AirGapMode, withNetTrace bool) (
+	intfStatusMap types.IntfStatusMap, tracedReqs []netdump.TracedNetRequest, err error) {
 	t.Lock()
 	defer t.Unlock()
 

--- a/pkg/pillar/controllerconn/deferred.go
+++ b/pkg/pillar/controllerconn/deferred.go
@@ -151,7 +151,7 @@ func (q *DeferredQueue) processQueueTask(ps *pubsub.PubSub,
 		case <-q.Ticker.C:
 			start := time.Now()
 			if !q.handleDeferred() {
-				q.log.Noticef("processQueueTask: some deferred items remain to be sent")
+				q.log.Functionf("processQueueTask: some deferred items remain to be sent")
 			}
 			if ps != nil {
 				ps.CheckMaxTimeTopic(agentName, ctxName, start, warningTime, errorTime)
@@ -287,7 +287,7 @@ func (q *DeferredQueue) handleDeferred() bool {
 
 	if len(notSentReqs) > 0 {
 		// Log the content of the rest in the queue
-		q.log.Noticef("handleDeferred() the rest to be sent: %d",
+		q.log.Functionf("handleDeferred() the rest to be sent: %d",
 			len(notSentReqs))
 		if q.sentHandler != nil {
 			for _, item := range notSentReqs {

--- a/pkg/pillar/dpcmanager/verify.go
+++ b/pkg/pillar/dpcmanager/verify.go
@@ -234,7 +234,7 @@ func (m *DpcManager) verifyDPC(ctx context.Context) (status types.DPCState) {
 	m.updateDNS()
 	withNetTrace := m.traceNextConnTest()
 	intfStatusMap, tracedProbes, err := m.ConnTester.TestConnectivity(
-		m.deviceNetStatus, withNetTrace)
+		m.deviceNetStatus, m.getAirGapModeConf(), withNetTrace)
 	// Use TestResults to update the DevicePortConfigList and DeviceNetworkStatus
 	// Note that the TestResults will at least have an updated timestamp
 	// for one of the ports.
@@ -408,7 +408,7 @@ func (m *DpcManager) testConnectivityToController(ctx context.Context) error {
 
 	withNetTrace := m.traceNextConnTest()
 	intfStatusMap, tracedProbes, err := m.ConnTester.TestConnectivity(
-		m.deviceNetStatus, withNetTrace)
+		m.deviceNetStatus, m.getAirGapModeConf(), withNetTrace)
 	dpc.UpdatePortStatusFromIntfStatusMap(intfStatusMap)
 	if err == nil {
 		dpc.State = types.DPCStateSuccess
@@ -619,6 +619,13 @@ func (m *DpcManager) waitForWwanUpdate() bool {
 	statusIsUpToDate := dpc.Key == m.wwanStatus.DPCKey &&
 		dpc.TimePriority.Equal(m.wwanStatus.DPCTimestamp)
 	return !statusIsUpToDate
+}
+
+func (m *DpcManager) getAirGapModeConf() conntester.AirGapMode {
+	return conntester.AirGapMode{
+		Enabled: m.airGapMode,
+		LocURL:  m.locURL,
+	}
 }
 
 // If error returned from connectivity test was wrapped into PortsNotReady,

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -298,6 +298,9 @@ const (
 
 	// MaintenanceMode global setting key
 	MaintenanceMode GlobalSettingKey = "maintenance.mode"
+	// AirGapMode should be enabled when device is operated in an air-gapped network environment,
+	// where connectivity to the main controller is not available.
+	AirGapMode GlobalSettingKey = "airgap.mode"
 
 	// String Items
 	// SSHAuthorizedKeys global setting key
@@ -1055,6 +1058,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	// Add TriState Items
 	configItemSpecMap.AddTriStateItem(NetworkFallbackAnyEth, TS_DISABLED)
 	configItemSpecMap.AddTriStateItem(MaintenanceMode, TS_NONE)
+	configItemSpecMap.AddTriStateItem(AirGapMode, TS_NONE)
 
 	// Add String Items
 	configItemSpecMap.AddStringItem(SSHAuthorizedKeys, "", blankValidator)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -208,6 +208,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		// TriState Items
 		NetworkFallbackAnyEth,
 		MaintenanceMode,
+		AirGapMode,
 		// String Items
 		SSHAuthorizedKeys,
 		DefaultLogLevel,

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -551,6 +551,8 @@ type ZedAgentStatus struct {
 	VaultStatus           info.DataSecAtRestStatus
 	PCRStatus             info.PCRStatus
 	VaultErr              string
+	AirgapMode            bool
+	LOCUrl                string
 }
 
 // DeviceState represents overall state


### PR DESCRIPTION
# Description

Air-gap mode was added to support scenarios where a device operates without physical connectivity to the main controller. In such cases, a Local Operator Console (LOC) is used to manage the device locally.

When air-gap mode is enabled and a LOC URL is configured, the connectivity tester will report the device as "connected" if either the main controller **_or the LOC is reachable_**. This ensures that when a user makes a network configuration change, EVE does not flag the configuration as non-working -- and does not revert to the previous configuration -- as long as LOC connectivity is maintained.

Additionally, when in air-gap mode, if the device fails to access the main controller, error and warning logs related to the lost connection are completely suppressed or at least downgraded to the trace level. This prevents log clutter, as lack of controller connectivity is expected in this mode. However, EVE will continue attempting to communicate with the main controller in case connectivity is restored (at least temporarily).

_We may want to consider adjusting the frequency of EVE’s attempts to contact the main controller when Air-gap mode is enabled, as repeated timeouts can introduce significant delays -- especially when multiple management ports are configured. These delays also extend the effective interval between `/config` and `/metrics` requests sent to the LOC, since they are executed only after the requests to the main controller have completed (or timed out).
As of now, no changes have been made in this area. In terms of the `/info` messages, we use separate deferred queues for the controller and LOC, which handle air-gap scenarios reasonably well._

## How to test and validate this PR

Deploy the edge node together with the Local Operator Console (LOC). [Configure the edge node to use the LOC instance](https://github.com/lf-edge/eve-api/blob/c725ece2f4358802654ab0cb5b597e31fb667f82/proto/config/devconfig.proto#L27-L39).

By default, Air-gap mode is disabled, and the device behaves as before -- including standard connectivity testing behavior.

1. Baseline behavior:
    Change the network configuration to an invalid setup that prevents controller connectivity.
    The device should detect the failure, report an error, and revert to the previous working configuration.

2. Enable Air-gap mode:
    Set the configuration property `airgap.mode` to `enabled`.

3. Validate LOC fallback behavior (before putting device into an actual physical air-gapped environment):
    Change the network configuration so that controller connectivity is broken but LOC remains accessible.
    The device should accept the new configuration and not revert to the previous one.
    On the LOC side, verify that no connectivity error is reported.

4. Simulate full air-gapped environment:
    Physically disconnect the device from the controller (but keep LOC connectivity).
    Ensure that the device continues reporting info and metrics to the LOC, without any connectivity errors.
    Change the device’s network configuration again, this time using LOC (but preserve LOC accessibility with the new config).
    The new configuration should be accepted without fallback.

5. Check logging behavior in Air-gap mode:
    Verify that error logs related to controller disconnection are suppressed or downgraded to trace level, preventing log clutter.

6. Reconnect to the main controller:
    Restore physical connectivity between the device and the controller.
    Even with Air-gap mode still enabled, the device should prefer the main controller.
    Any configuration changes made via the controller should now take effect.

## Changelog notes

Added Air-gap mode to support offline operation via Local Operator Console, with improved connectivity handling and log suppression when the main controller is unreachable.

## PR Backports

We will have an internal discussion to decide if this should be backported to the currently active LTS versions or not.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.