### PR TITLE
Update Eden to version 1.0.5.

### DIFF
--- a/.github/workflows/eden-trusted.yml
+++ b/.github/workflows/eden-trusted.yml
@@ -190,14 +190,14 @@ jobs:
     name: ${{ needs.context.outputs.eden_parent_job_title }}
     needs: context
     if: needs.context.outputs.skip_run == 'false'
-    uses: lf-edge/eden/.github/workflows/test.yml@1.0.4
+    uses: lf-edge/eden/.github/workflows/test.yml@1.0.5
     secrets: inherit
     with:
       eve_image: "evebuild/pr:${{ needs.context.outputs.pr_id }}"
       eve_log_level: "debug"
       eve_artifact_name: "eve-${{ needs.context.outputs.hv }}-${{ needs.context.outputs.arch }}-${{ needs.context.outputs.platform }}"
       artifact_run_id: ${{ needs.context.outputs.original_run_id }}
-      eden_version: "1.0.4"
+      eden_version: "1.0.5"
 
   finalize:
     if: always() && needs.context.outputs.skip_run == 'false'


### PR DESCRIPTION
# Description

Bump the Eden version to 1.0.5 in the eden-trusted.yml workflow to include recent improvements. This version adds support for DockerHub login during test jobs, which enhances access to required container resources in CI.

## PR dependencies

None.

## How to test and validate this PR

Not to be externally tested. 

## Changelog notes

No user-facing changes.

## PR Backports

- 14.5-stable: to be backported
- 13.4-stable: to be backported

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

