### PR TITLE
Fix "PR Gate" WF to identify build runs correctly.

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -53,12 +53,10 @@ jobs:
         id: from_review
         if: github.event_name == 'pull_request_review'
         env:
-          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pr_sha="${{ github.event.pull_request.head.sha }}"
-          original_run_id=$(gh api /repos/${GH_REPO}/actions/runs \
-                   -q ".workflow_runs[] | select(.head_sha==\"$pr_sha\" and .name==\"${{ env.BUILD_WF_NAME }}\") | .id" | head -n1)
+          original_run_id=$(gh run --repo ${{ github.repository }} list -c "$pr_sha" --json name,databaseId | jq ".[] | select(.name == \"${{ env.BUILD_WF_NAME }}\") | .databaseId " | head -n1)
           echo "pr_id=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           echo "pr_sha=$pr_sha" >> "$GITHUB_OUTPUT"
           echo "original_run_id=$original_run_id" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Description

Fixes the issue where Eden tests were not triggered after PR approval on pull requests with multiple commits. To do so: use `gh run list -c <sha>` to fetch the workflow run ID instead of `gh api`.

## PR dependencies

None.

## How to test and validate this PR

Not to be verified manually. 

## Changelog notes

No user-facing changes.

## PR Backports

- 14.5-stable: to be backported
- 13.4-stable: to be backported

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
