### PR TITLE
Return unknown error if k3s is not reachable

### DIFF
--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -691,6 +691,9 @@ func (ctx kubevirtContext) Info(domainName string) (int, types.SwState, error) {
 		res, err = getVMIStatus(vmis, nodeName)
 	}
 	if err != nil {
+		if isK3sUnreachable(err) {
+			return 0, types.UNKNOWN, nil
+		}
 		return 0, types.BROKEN, logError("domain %s failed to get info: %v", domainName, err)
 	}
 
@@ -776,6 +779,12 @@ func getVMIStatus(vmis *vmiMetaData, nodeName string) (string, error) {
 	// List VMIs with a label selector that matches the replicaset name
 	vmiList, err := virtClient.VirtualMachineInstance(kubeapi.EVEKubeNameSpace).List(context.Background(), &metav1.ListOptions{})
 	if err != nil {
+
+		if isK3sUnreachable(err) {
+			// This means we are unable to talk to kubernetes.
+			// May be API server crashed or network cable got pulled ??
+			return "Unknown", err
+		}
 		retStatus, err2 := checkAndReturnStatus(vmis, true)
 		logError("getVMIStatus: domain %s failed to get VMI info %s, return %s", repVmiName, err, retStatus)
 		return retStatus, err2
@@ -1760,4 +1769,14 @@ func checkAndReturnStatus(vmis *vmiMetaData, gotUnknown bool) (string, error) {
 		vmis.startUnknownTime = time.Time{}
 	}
 	return "", nil
+}
+
+// check if the error is due to k3s unreachable or any other timeouts.
+func isK3sUnreachable(err error) bool {
+
+	// k3s API server timeout or any other timeouts or if etcd service or any other service is not available.
+	if errors.IsServerTimeout(err) || errors.IsTimeout(err) || errors.IsServiceUnavailable(err) {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION

# Description

If we cannot reach kubernetes to get the status of VM, handle that error and return "unknown" status for domainmgr. This could happen if k3s is down or network cable was pulled on the device to remove the device from the cluster.



## How to test and validate this PR

1) Create a 3 node cluster
2) Deploy an app and make sure its up and running
3) Pull the cluster interface network cable of the device where app is running.
4) With this fix app will quickly failover to another node since error is handling correctly and replica set is not deleted.

Without this fix failover is very random.

## Changelog notes

User should see relatively quick failovers after network connection is lost.

## PR Backports


- 14.5-stable


## Checklist

- [x] I've provided a proper description
- [x] I've tested my PR on amd64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
