### PR TITLE
Fix image size for kubevirt 'docker run <img> installer_raw'

### DIFF
--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -9,6 +9,7 @@ OUTPUT_IMG=/tmp/output.img
 DEFAULT_LIVE_IMG_SIZE=592
 DEFAULT_INSTALLER_IMG_SIZE=592
 DEFAULT_NVIDIA_IMG_SIZE=900
+DEFAULT_KUBEVIRT_IMG_SIZE=2048
 
 bail() {
   echo "$@"
@@ -228,6 +229,11 @@ prepare_for_platform() {
     else
         NVIDIA_PLAT=""
         NVIDIA=false
+    fi
+
+    if grep -q "\(.*\)-kubevirt-\(.*\)" /bits/eve_version; then
+        # Kubevirt image size defaults to a much larger (1GB at this time)
+        DEFAULT_INSTALLER_IMG_SIZE=$DEFAULT_KUBEVIRT_IMG_SIZE
     fi
 
     # Parse platform argument


### PR DESCRIPTION
# Description

pkg/mkimage-raw-efi/make-raw ROOTFS_PART_SIZE_MIN is 1024

Currently this fails for hv=kubevirt:
``` bash
docker run lfedge/eve:<tag> installer_raw > /tmp/kube.installer-raw && echo OK || echo ERROR
``` 

## PR dependencies

None

## How to test and validate this PR

1. Build eve kubevirt variant (HV=kubevirt ZARCH=amd64)
2. Export eve image to docker: make HV=kubevirt eve eve-cache-export-docker-load
3. Check the image exported, e.g.: lfedge/eve:0.0.0-docker-run-kv-installer-raw-8fe50d8b-kubevirt-amd64
4. Run eve container to generate installer raw image:
``` bash
docker run --rm lfedge/eve:0.0.0-docker-run-kv-installer-raw-8fe50d8b-kubevirt-amd64 installer_raw > installer.raw && echo OK || echo ERROR
```

It should output OK at the end

## Changelog notes

None

## PR Backports

- 14.5-stable: May need to be backported
- 13.4-stable: No, as the feature is not available there.


## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.