### PR TITLE
Fix: forward disabling the apps logs correctly

### DIFF
--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -61,6 +61,7 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 		MetaDataType:      aiConfig.MetaDataType,
 		Service:           aiConfig.Service,
 		CloudInitVersion:  aiConfig.CloudInitVersion,
+		DisableLogs:       aiConfig.DisableLogs,
 		// This isDNiDnode will be set to true even if the App is not in cluster mode,
 		// This will be set in zedagent parseConfig for the case of single node/device App case.
 		IsDNidNode: aiConfig.IsDesignatedNodeID,


### PR DESCRIPTION
# Description

The correct path to forward the DisableLogs to disable app logs looks like this:
DevConfig -> AppInstanceConfig -> DomainConfig -> DomainStatus -> newlog

The link between AppInstanceConfig and DomainConfig in zedmanager was forgotten, which led to the DisableLogs being always false from DomainConfig onwards. This resulted in inability to disable the logs for the apps.

It's already the second bug that I'm fixing caused by a dev error - forgetting to set a struct field. I researched a bit for options to prevent this from happening and found these two linters:
https://github.com/mbilski/exhaustivestruct
https://github.com/quentin-fox/structinit

The first one refuses to work with vendored dependencies.
And the seconds one works only when explicitly requested on `var` definitions like
```go
type Cat struct {
  Name string
  Color string
  Floofiness int
  Friendly bool
}

//structinit:exhaustive
var cat = Cat{ // fails with "Exhaustive struct literal Cat not initialized with field Friendly"
  Name: "Bad Kitty",
  Color: "Calico",
  Floofiness: 6,
}
```

Both don't suite our purposes :(

Does anybody know any better ways to address this problem?

## PR dependencies

None

## How to test and validate this PR

1. Create an App Instance with Logs Access disabled
2. Deploy it
3. Wait for 5 mins
4. Try to get app logs from the controller's API and confirm no logs are present.

## Changelog notes

Fixed disabling app logs

## PR Backports

Need to backport to the following versions
[ ] 14.5-stable
[ ] 13.4-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR