### PR TITLE
.github: Enforce use of pull credentials for build steps in Publish.

### DIFF
--- a/.github/actions/run-make/action.yml
+++ b/.github/actions/run-make/action.yml
@@ -12,6 +12,10 @@ inputs:
   dockerhub-account:
     required: true
     type: string
+  clean:
+    required: false
+    type: boolean
+    default: true
 
 runs:
   using: 'composite'
@@ -27,7 +31,7 @@ runs:
       with:
         username: ${{ inputs.dockerhub-account }}
         password: ${{ inputs.dockerhub-token }}
-    - name: Build and push `make -e ${{ inputs.command }}`
+    - name: Running `make -e ${{ inputs.command }}`
       run: |
         make -e ${{ inputs.command }}
       shell: bash
@@ -41,6 +45,7 @@ runs:
         docker system df -v
       shell: bash
     - name: Pre clean report
+      if: ${{ inputs.clean == 'true' }}
       run: |
         echo Disk usage
         df -h
@@ -50,6 +55,7 @@ runs:
         docker system df -v
       shell: bash
     - name: Clean
+      if: ${{ inputs.clean == 'true' }}
       run: |
         make clean
         docker system prune -f -a

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -6,6 +6,11 @@ on:  # yamllint disable-line rule:truthy
       tag_ref:
         required: true
         type: string
+    secrets:
+      DOCKERHUB_PULL_TOKEN:
+        required: true
+      DOCKERHUB_PULL_USER:
+        required: true
 
 jobs:
   create_release:
@@ -76,6 +81,12 @@ jobs:
       - name: Ensure clean assets directory
         run: |
           rm -rf assets && mkdir -p assets
+      - name: Login to Docker Hub
+        if: ${{ github.event.repository.full_name }} == 'lf-edge/eve'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_PULL_USER }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
       - name: Pull the EVE release from DockerHUB or build it
         run: |
           HV=${{ matrix.hv }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,12 +58,33 @@ jobs:
         run: |
           echo "ARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
           echo "TAG=$(echo "$REF" | sed -e 's#^.*/##' -e 's#master#snapshot#' -e 's#main#snapshot#')" >> "$GITHUB_ENV"
-      - name: Login to Docker Hub
+      - name: Login to Docker Hub (build)
         uses: docker/login-action@v3
+        if: ${{ github.event.repository.full_name }}== 'lf-edge/eve'
+        with:
+          username: ${{ secrets.DOCKERHUB_PULL_USER }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+      - name: Build packages
+        run: |
+          SUCCESS=
+          for i in 1 2 3; do
+            if make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=build pkgs; then
+              SUCCESS=true
+              break
+            else
+              docker rmi -f $(docker image ls -q) || :
+              docker system prune -f -a || :
+              docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
+            fi
+          done
+          if [ -z "$SUCCESS" ]; then echo "::error::failed to build packages" && exit 1; fi
+      - name: Login to Docker Hub (push)
+        uses: docker/login-action@v3
+        if: ${{ github.event.repository.full_name }}== 'lf-edge/eve'
         with:
           username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
           password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
-      - name: Build packages
+      - name: Push packages
         run: |
           SUCCESS=
           for i in 1 2 3; do
@@ -76,7 +97,7 @@ jobs:
               docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
             fi
           done
-          if [ -z "$SUCCESS" ]; then echo "::error::failed to build and push packages" && exit 1; fi
+          if [ -z "$SUCCESS" ]; then echo "::error::failed to push packages" && exit 1; fi
       - name: Post package report
         run: |
           echo Disk usage
@@ -144,12 +165,12 @@ jobs:
           echo "ARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
           echo "TAG=$(echo "$REF" | sed -e 's#^.*/##' -e 's#master#snapshot#' -e 's#main#snapshot#')" >> "$GITHUB_ENV"
 
-      - name: Login to Docker Hub
+      - name: Login to Docker Hub (build)
         if: ${{ github.event.repository.full_name }}== 'lf-edge/eve'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
-          password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_PULL_USER }}
+          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
       - name: Build packages
         run: |
@@ -157,7 +178,7 @@ jobs:
           # sadly, our build sometimes times out on network access
           # and running out of disk space: re-trying for 3 times
           for i in 1 2 3; do
-             if make -e V=1 ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
+             if make -e V=1 ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=build pkgs; then
                 SUCCESS=true
                 break
              else
@@ -170,7 +191,33 @@ jobs:
                 docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
              fi
           done
-          if [ -z "$SUCCESS" ]; then echo "::error::failed to build and push packages" && exit 1; fi
+          if [ -z "$SUCCESS" ]; then echo "::error::failed to build packages" && exit 1; fi
+      - name: Login to Docker Hub (push)
+        if: ${{ github.event.repository.full_name }}== 'lf-edge/eve'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+          password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+      - name: Push packages
+        run: |
+          SUCCESS=
+          # sadly, our build sometimes times out on network access
+          # and running out of disk space: re-trying for 3 times
+          for i in 1 2 3; do
+             if make -e V=1 ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push pkgs; then
+                SUCCESS=true
+                break
+             else
+                # the most likely reason for 'make pkgs' to fail is
+                # the docker cache produced by the build exhausting
+                # disk space. So the following can't hurt before we
+                # retry:
+                docker rmi -f `docker image ls -q` || :
+                docker system prune -f -a || :
+                docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
+             fi
+          done
+          if [ -z "$SUCCESS" ]; then echo "::error::failed to push packages" && exit 1; fi
       - name: Post package report
         run: |
           echo Disk usage
@@ -212,15 +259,25 @@ jobs:
             hv: kubevirt
             platform: "generic"
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/run-make
+      - name: Build EVE
+        uses: ./.github/actions/run-make
+        with:
+          command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=build eve"
+          dockerhub-token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+          dockerhub-account: ${{ secrets.DOCKERHUB_PULL_USER }}
+          clean: false
+      - name: Push EVE
+        uses: ./.github/actions/run-make
         with:
           command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push eve"
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
-      - uses: ./.github/actions/run-make
+      - name: Collect and push SBOM and sources
+        uses: ./.github/actions/run-make
         if: matrix.arch != 'riscv64'
         with:
           command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push sbom collected_sources compare_sbom_collected_sources publish_sources"
@@ -252,5 +309,8 @@ jobs:
     if: ${{ (startsWith(github.ref, 'refs/tags/')) && (github.event.repository.full_name == 'lf-edge/eve') }}
     needs: [manifest, eve]
     uses: lf-edge/eve/.github/workflows/assets.yml@master
+    secrets:
+      DOCKERHUB_PULL_TOKEN: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
+      DOCKERHUB_PULL_USER: ${{ secrets.DOCKERHUB_PULL_USER }}
     with:
       tag_ref: ${{ github.ref_name }}


### PR DESCRIPTION
# Description

Update the Publish workflow to ensure build steps authenticate to Dockerhub with credentials that are not subject to limited pull rates, preventing build failures caused by rate limiting.

- Add separate Dockerhub login steps for build and push phases, using credentials suited for each purpose. Build operations now reliably use credentials intended for higher pull limits, avoiding rate limit issues during image pulls.

- Separate the build and push steps for both packages and EVE images. The workflow now builds artifacts first, then pushes them in a later step, ensuring that images built in the previous step remain available.

- Introduce a configurable 'clean' input to the reusable action. This allows skipping clean-up between build and push steps. By setting clean: 'false' during the build phase, the workflow preserves build artifacts and images, enabling them to be pushed in subsequent steps without re-building or losing them due to intermediate cleanup.

## PR dependencies

None.

## How to test and validate this PR

Not to be tested externally. Nevertheless, it would be nice to test in a 3rd repo.

## Changelog notes

No user-facing changes

## PR Backports

- 14.5-stable: NO, as this workflow always runs from the default branch (`master` in our case).
- 13.4-stable: NO, as this workflow always runs from the default branch (`master` in our case).

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

