### PR TITLE
Update Eden to 1.0.6 that fixes Dockerhub 429 error

### DIFF
--- a/.github/workflows/eden-trusted.yml
+++ b/.github/workflows/eden-trusted.yml
@@ -190,14 +190,14 @@ jobs:
     name: ${{ needs.context.outputs.eden_parent_job_title }}
     needs: context
     if: needs.context.outputs.skip_run == 'false'
-    uses: lf-edge/eden/.github/workflows/test.yml@1.0.5
+    uses: lf-edge/eden/.github/workflows/test.yml@1.0.6
     secrets: inherit
     with:
       eve_image: "evebuild/pr:${{ needs.context.outputs.pr_id }}"
       eve_log_level: "debug"
       eve_artifact_name: "eve-${{ needs.context.outputs.hv }}-${{ needs.context.outputs.arch }}-${{ needs.context.outputs.platform }}"
       artifact_run_id: ${{ needs.context.outputs.original_run_id }}
-      eden_version: "1.0.5"
+      eden_version: "1.0.6"
 
   finalize:
     if: always() && needs.context.outputs.skip_run == 'false'


### PR DESCRIPTION
# Description

Eden 1.0.6 has following important update and can now login to dockerhub to avoid "428 - unauthenticated limit reached" error

- 8500275b985 Authenticate EDEN and EDEN tests to Dockerhub

## How to test and validate this PR

- Validate on CI or locally, there must be no 429 errors form Dockerhub

## Changelog notes

```text
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.
```

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
