### PR TITLE
pillar/getconfigCtx: don't give unnecessary access if not needed

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -1307,7 +1307,7 @@ func updateHasLocalServer(ctx *getconfigContext) {
 			log.Noticef("HasLocalServer(%s) for %s change to %t",
 				aic.Key(), aic.DisplayName, hasLocalServer)
 			// Verify that it fits and if not publish with error
-			checkAndPublishAppInstanceConfig(ctx, aic)
+			checkAndPublishAppInstanceConfig(ctx.pubAppInstanceConfig, aic)
 		}
 	}
 }

--- a/pkg/pillar/cmd/zedagent/handlevolume.go
+++ b/pkg/pillar/cmd/zedagent/handlevolume.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	zconfig "github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	uuid "github.com/satori/go.uuid"
 )
@@ -63,14 +64,14 @@ func parseVolumeConfig(ctx *getconfigContext,
 		if !foundVolume || !sameGenCounter {
 			// volume not found, delete
 			log.Functionf("parseVolumeConfig: deleting %s\n", volume.Key())
-			unpublishVolumeConfig(ctx, volume.Key())
+			unpublishVolumeConfig(ctx.pubVolumeConfig, volume.Key())
 			if !foundVolume {
 				delLocalVolumeConfig(ctx, uuid)
 			}
 		} else {
 			// check links from apps
 			volume.HasNoAppReferences = checkVolumeHasNoAppReferences(ctx, cfgVolume, config)
-			publishVolumeConfig(ctx, volume)
+			publishVolumeConfig(ctx.pubVolumeConfig, volume)
 		}
 	}
 
@@ -131,7 +132,7 @@ func parseVolumeConfig(ctx *getconfigContext,
 				}
 			}
 		}
-		publishVolumeConfig(ctx, *volumeConfig)
+		publishVolumeConfig(ctx.pubVolumeConfig, *volumeConfig)
 	}
 
 	//signal publisher restarted to apply deferred changes inside volumemgr
@@ -162,21 +163,19 @@ func checkVolumeHasNoAppReferences(ctx *getconfigContext, cfgVolume *zconfig.Vol
 	return true
 }
 
-func publishVolumeConfig(ctx *getconfigContext,
+func publishVolumeConfig(pub pubsub.Publication,
 	config types.VolumeConfig) {
 
 	key := config.Key()
 	log.Tracef("publishVolumeConfig(%s)\n", key)
-	pub := ctx.pubVolumeConfig
 	pub.Publish(key, config)
 	log.Tracef("publishVolumeConfig(%s) done\n", key)
 }
 
-func unpublishVolumeConfig(ctx *getconfigContext,
+func unpublishVolumeConfig(pub pubsub.Publication,
 	key string) {
 
 	log.Tracef("unpublishVolumeConfig(%s)\n", key)
-	pub := ctx.pubVolumeConfig
 	config, _ := pub.Get(key)
 	if config == nil {
 		log.Errorf("unpublishVolumeConfig(%s) not found\n", key)

--- a/pkg/pillar/cmd/zedagent/localinfo.go
+++ b/pkg/pillar/cmd/zedagent/localinfo.go
@@ -295,7 +295,7 @@ func triggerLocalCommand(ctx *getconfigContext, cmd types.AppCommand,
 		appCounters.RestartCmd.Counter++
 		appCounters.RestartCmd.ApplyTime = timestamp
 		app.LocalRestartCmd = appCounters.RestartCmd
-		checkAndPublishAppInstanceConfig(ctx, *app)
+		checkAndPublishAppInstanceConfig(ctx.pubAppInstanceConfig, *app)
 
 	case types.AppCommandPurge:
 		// To trigger application purge we take the previously published
@@ -328,16 +328,16 @@ func triggerLocalCommand(ctx *getconfigContext, cmd types.AppCommand,
 				continue
 			}
 			volume := volObj.(types.VolumeConfig)
-			unpublishVolumeConfig(ctx, volKey)
+			unpublishVolumeConfig(ctx.pubVolumeConfig, volKey)
 			// Publish volume with an increased local generation counter.
 			localGenCounter++
 			ctx.sideController.localCommands.VolumeGenCounters[uuid] = localGenCounter
 			vr.LocalGenerationCounter = localGenCounter
 			volume.LocalGenerationCounter = localGenCounter
-			publishVolumeConfig(ctx, volume)
+			publishVolumeConfig(ctx.pubVolumeConfig, volume)
 			changedVolumes = true
 		}
-		checkAndPublishAppInstanceConfig(ctx, *app)
+		checkAndPublishAppInstanceConfig(ctx.pubAppInstanceConfig, *app)
 	}
 	return changedVolumes
 }

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -21,6 +21,7 @@ import (
 	zconfig "github.com/lf-edge/eve-api/go/config"
 	zevecommon "github.com/lf-edge/eve-api/go/evecommon"
 	"github.com/lf-edge/eve/pkg/pillar/objtonum"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/sriov"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
@@ -815,7 +816,7 @@ func parseAppInstanceConfig(getconfigCtx *getconfigContext,
 		}
 
 		// Verify that it fits and if not publish with error
-		checkAndPublishAppInstanceConfig(getconfigCtx, appInstance)
+		checkAndPublishAppInstanceConfig(getconfigCtx.pubAppInstanceConfig, appInstance)
 	}
 }
 
@@ -2889,12 +2890,11 @@ func mergeMaintenanceMode(ctx *zedagentContext, caller string) {
 		ctx.apiMaintenanceMode, ctx.localMaintenanceMode)
 }
 
-func checkAndPublishAppInstanceConfig(getconfigCtx *getconfigContext,
+func checkAndPublishAppInstanceConfig(pub pubsub.Publication,
 	config types.AppInstanceConfig) {
 
 	key := config.Key()
 	log.Tracef("checkAndPublishAppInstanceConfig UUID %s", key)
-	pub := getconfigCtx.pubAppInstanceConfig
 	if err := pub.CheckMaxSize(key, config); err != nil {
 		log.Error(err)
 		var clearNumBytes int


### PR DESCRIPTION
# Description

Instead of passing around the whole `getconfigCtx`, only pass around it's member `pubVolumeConfig`. Apparently some methods do not need all of this.

This makes it easier for the code reader to understand what variables actually have impact on functions. Because variables that cannot be accessed, are for sure not used.

This PR comes from https://github.com/lf-edge/eve/pull/4992 .

## PR dependencies

## How to test and validate this PR

No new feature or bugfix added. So testing that everything still works is enough.

## Changelog notes

Refactoring

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 14.5-stable: No
- 13.4-stable: No

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
