### PR TITLE
Handle apps  during explicit node reboot

### DIFF
--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -146,6 +146,8 @@ const (
 	LocalActiveAppConfigDir = "/persist/vault/active-app-instance-config/"
 	// EdgeNodeClusterConfigFile - the file which contains edgenodecluster config
 	EdgeNodeClusterConfigFile = PersistStatusDir + "/zedagent/EdgeNodeClusterConfig/global.json"
+	// NodeRebootInProgressFile - A temp file to mark this device reboot is in progress
+	NodeRebootInProgressFile = "/run/node-reboot-inprogress"
 )
 
 var (


### PR DESCRIPTION

# Description

This commit fixes serious bug found during testing.

When the user triggers a reboot of a device from Controller, domainmgr tries to do DomainShutdown (app deactivate), waitforDomain gone and then in worst case Deletes domain.

That is all good and expected procedure on a single device configs. In a cluster mode the apps would have failed over to another node and we cannot delete the app. So handle such cases.

Also, at the same time we need to honor another workflow to deactivate an app. So that is the reason we check for reboot in progress flag. If that flag is not present we go ahead and deactivate the app.



## How to test and validate this PR

1) Create a 3 node cluster
2) Create a VM and make sure its running fine
3) Reboot the node running the VM from the controller.
4) Verify sometimes app gets deleted even though it got failed over to other node.

With this fix we can reboot nodes and observe apps are still running and also tested explicit app deactivate and it works.


## Changelog notes

End users will see that apps still running on another node after a node reboot.

## PR Backports


- 14.5-stable


## Checklist

- [x] I've provided a proper description
- [x] I've tested my PR on amd64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
