### PR TITLE
Collect info upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,6 +471,7 @@ test: $(LINUXKIT) pkg/pillar | $(DIST)
 	cp pkg/pillar/results.xml $(DIST)/
 	make -C eve-tools/bpftrace-compiler test
 	make -C pkg/dnsmasq test
+	make -C pkg/debug test
 	$(QUIET): $@: Succeeded
 
 test-profiling:

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -11,7 +11,7 @@
 FROM lfedge/eve-recovertpm:25f66701fa7ce348631e5d9bf4efc5082a497b8b AS recovertpm
 FROM lfedge/eve-bpftrace:faebad58df4cddaa07d15937021854d8165d7c9a AS bpftrace
 FROM lfedge/eve-alpine:0f2e0da38e30753c68410727a6cc269e57ff74f2 AS build
-ENV BUILD_PKGS="abuild curl tar make linux-headers patch g++ git gcc gpg ncurses-dev autoconf openssl-dev zlib-dev"
+ENV BUILD_PKGS="abuild curl tar make linux-headers patch g++ git gcc go gpg ncurses-dev autoconf openssl-dev zlib-dev"
 # Feel free to add additional packages here, but be aware that
 # EVE's rootfs image can be no larger than 300Mb (and don't
 # forget to check on all supported architectures: e.g. arm64
@@ -123,6 +123,13 @@ RUN mkdir -p /bpftrace/bpftrace-aotrt
 # add recover-tpm to debug container
 WORKDIR /
 COPY --from=recovertpm /usr/bin/recovertpm /out/usr/bin/recovertpm
+
+FROM build AS test
+# run collect-info test
+COPY collect-info-test /collect-info-test
+WORKDIR /collect-info-test
+RUN go test
+
 
 FROM scratch
 ENTRYPOINT []

--- a/pkg/debug/Makefile
+++ b/pkg/debug/Makefile
@@ -1,0 +1,6 @@
+# Copyright (c) 2025  Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+.PHONY: test
+test:
+	docker build --rm --target test .

--- a/pkg/debug/collect-info-test/collect-info_test.go
+++ b/pkg/debug/collect-info-test/collect-info_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func listenHTTP() (*http.Request, error) {
+	var s *http.Server
+	sm := http.NewServeMux()
+	var req *http.Request
+	var bodyCloseErr error
+	var shutdownErr error
+
+	sm.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		req = r
+
+		http.Error(w, "Bye", http.StatusOK)
+
+		bodyCloseErr = r.Body.Close()
+		shutdownErr = s.Shutdown(context.Background())
+
+	})
+
+	s = &http.Server{
+		Addr:    ":8080",
+		Handler: sm,
+	}
+
+	err := s.ListenAndServe()
+	if !errors.Is(err, http.ErrServerClosed) {
+		panic(err)
+	}
+
+	if bodyCloseErr != nil {
+		return nil, bodyCloseErr
+	}
+	if shutdownErr != nil {
+		return nil, shutdownErr
+	}
+
+	return req, nil
+}
+
+// TestCollectInfoUpload creates an http server and calls collect-info.sh to upload the tarball to it
+func TestCollectInfoUpload(t *testing.T) {
+	var cmd *exec.Cmd
+	reqChan := make(chan *http.Request)
+	go func() {
+		req, err := listenHTTP()
+		if err != nil {
+			t.Logf("error from http server: %+v", err)
+		}
+		err = cmd.Process.Kill()
+		if err != nil {
+			t.Logf("could not kill process: %+v", err)
+		}
+		reqChan <- req
+	}()
+
+	for _, dir := range []string{"/proc/self", "/persist/status"} {
+		err := os.MkdirAll(filepath.Join("/out", dir), 0700)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	defer func() {
+		for _, dir := range []string{"/proc/self", "/persist"} {
+			err := os.RemoveAll(filepath.Join("/out", dir))
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}()
+
+	for _, fileContent := range []struct {
+		file    string
+		content string
+	}{
+		{
+			file:    "/out/proc/self/cgroup",
+			content: "/eve/services/debug",
+		},
+		{
+			file:    "/out/persist/status/uuid",
+			content: "123456",
+		},
+	} {
+
+		err := os.WriteFile(fileContent.file, []byte(fileContent.content), 0600)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cmd = exec.Command("/usr/bin/collect-info.sh", "-u", "http://localhost:8080")
+	cmd.Env = []string{"AUTHORIZATION=Bearer Vm0weGQxSXhiRmRXV0d4V1YwZDRWRmxyVm5kVmJGcHlWV3RLVUZWVU1Eaz0="}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Chroot: "/out",
+	}
+	if testing.Verbose() {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+
+	_ = cmd.Run()
+
+	req := <-reqChan
+	t.Logf("req: %+v", req)
+
+	if req.Header["Authorization"][0] != "Bearer Vm0weGQxSXhiRmRXV0d4V1YwZDRWRmxyVm5kVmJGcHlWV3RLVUZWVU1Eaz0=" {
+		t.Fatalf("authorization header wrong or not set - was %+v", req.Header["Authorization"])
+	}
+
+	if !strings.Contains(req.URL.Path, "123456") {
+		t.Fatalf("http file path does not contain uuid; req: %+v", req)
+	}
+}

--- a/pkg/debug/collect-info-test/go.mod
+++ b/pkg/debug/collect-info-test/go.mod
@@ -1,0 +1,3 @@
+module collectinfo-test
+
+go 1.24


### PR DESCRIPTION
# Description

This is part of tearing apart https://github.com/lf-edge/eve/pull/4992

Add a parameter to the collect-info.sh script to upload the generated tarball to an http/https server.

## PR dependencies


## How to test and validate this PR

`make test`

## Changelog notes

collect-info.sh can upload generated tarball to specified server

## PR Backports


- 14.5-stable: no, because new feature
- 13.4-stable: no, because new feature



## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR



And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
