### PR TITLE
pillar: move runInDebugContainer to containerd pkg

### DIFF
--- a/pkg/pillar/agentlog/http-debug.go
+++ b/pkg/pillar/agentlog/http-debug.go
@@ -4,7 +4,6 @@
 package agentlog
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -15,15 +14,11 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
-	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
-	ctrdd "github.com/containerd/containerd"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/containerd"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 var (
@@ -119,147 +114,14 @@ func dumpMemoryInfo(log *base.LogObject, fileName string) {
 	}
 }
 
-type mutexWriter struct {
-	w     io.Writer
-	mutex *sync.Mutex
-}
-
-func (m mutexWriter) Write(p []byte) (n int, err error) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	// seems containerd sometimes wants to write something into it,
-	// but it is already too late
-	if m.w == nil {
-		return 0, syscall.ENOENT
-	}
-	n, err = m.w.Write(p)
-
-	return n, err
-}
-
 type bpftraceHandler struct {
 	log *base.LogObject
 }
 
 func (b bpftraceHandler) runInDebugContainer(clientCtx context.Context, w io.Writer, args []string, timeout time.Duration) error {
-	ctrd, err := containerd.NewContainerdClient(false)
-	if err != nil {
-		return fmt.Errorf("could not initialize containerd client: %+v\n", err)
-	}
-
-	ctx, done := ctrd.CtrNewSystemServicesCtx()
-	defer done()
-
-	container, err := ctrd.CtrLoadContainer(ctx, "debug")
-	if err != nil {
-		return fmt.Errorf("loading container failed: %+v", err)
-	}
-
-	task, err := container.Task(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("getting debug container task failed: %+v", err)
-	}
-
-	pspec := specs.Process{
-		Args: args,
-		Cwd:  "/",
-		Scheduler: &specs.Scheduler{
-			Deadline: uint64(time.Now().Add(timeout).Unix()),
-		},
-	}
 	taskID := fmt.Sprintf("bpftrace-%d", rand.Int()) // TODO: avoid collision
-	stderrBuf := bytes.Buffer{}
 
-	writingDone := make(chan struct{})
-	defer close(writingDone)
-	mutexWriter := mutexWriter{
-		w:     w,
-		mutex: &sync.Mutex{},
-	}
-	stdcio := ctrd.CtrWriterCreator(mutexWriter, &stderrBuf)
-
-	process, err := task.Exec(ctx, taskID, &pspec, stdcio)
-	if err != nil {
-		return fmt.Errorf("executing in task failed: %+v", err)
-	}
-	waiter, err := process.Wait(ctx)
-	if err != nil {
-		return fmt.Errorf("process wait failed: %+v", err)
-	}
-	err = process.Start(ctx)
-	if err != nil {
-		return fmt.Errorf("process start failed: %+v", err)
-	}
-
-	exitStatus := struct {
-		exitCode        uint32
-		killedByTimeout bool
-	}{
-		exitCode:        0,
-		killedByTimeout: false,
-	}
-
-	timeoutTimer := time.NewTimer(timeout)
-	select {
-	case <-clientCtx.Done():
-		exitStatus.killedByTimeout = true
-		err := b.killProcess(ctx, process)
-		if err != nil {
-			b.log.Warnf("writer closed - killing process %+v failed: %v", args, err)
-		}
-	case <-timeoutTimer.C:
-		exitStatus.killedByTimeout = true
-		err := b.killProcess(ctx, process)
-		if err != nil {
-			b.log.Warnf("timeout - killing process %+v failed: %v", args, err)
-		}
-	case containerExitStatus := <-waiter:
-		exitStatus.exitCode = containerExitStatus.ExitCode()
-	}
-	timeoutTimer.Stop()
-
-	if !exitStatus.killedByTimeout {
-		st, err := process.Status(ctx)
-		if err != nil {
-			return fmt.Errorf("process status failed: %+v", err)
-		}
-		b.log.Noticef("process status is: %+v", st)
-
-		status, err := process.Delete(ctx)
-		if err != nil {
-			return fmt.Errorf("process delete (%+v) failed: %+v", status, err)
-		}
-	}
-
-	stderrBytes, err := io.ReadAll(&stderrBuf)
-	if len(stderrBytes) > 0 {
-		return fmt.Errorf("Stderr output was: %s", string(stderrBytes))
-	}
-
-	mutexWriter.w = nil
-
-	return nil
-}
-
-func (b bpftraceHandler) killProcess(ctx context.Context, process ctrdd.Process) error {
-	err := process.Kill(ctx, syscall.SIGTERM)
-	if err != nil {
-		return fmt.Errorf("timeout reached, killing of process failed: %w", err)
-	}
-	time.Sleep(time.Second)
-	st, err := process.Status(ctx)
-	if err != nil {
-		return fmt.Errorf("timeout reached, retrieving status of process failed: %w", err)
-	}
-	if st.Status == ctrdd.Stopped {
-		return nil
-	}
-	err = process.Kill(ctx, syscall.SIGKILL)
-	if err != nil {
-		return fmt.Errorf("timeout reached, killing of process (SIGKILL) failed: %w", err)
-	}
-
-	return nil
+	return containerd.RunInDebugContainer(clientCtx, taskID, w, args, timeout)
 }
 
 func (b bpftraceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/pkg/pillar/containerd/run.go
+++ b/pkg/pillar/containerd/run.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"sync"
 	"syscall"
 	"time"
@@ -112,12 +111,6 @@ func RunInDebugContainer(clientCtx context.Context, taskID string, w io.Writer, 
 	timeoutTimer.Stop()
 
 	if !exitStatus.killedByTimeout {
-		st, err := process.Status(ctx)
-		if err != nil {
-			return fmt.Errorf("process status failed: %+v", err)
-		}
-		fmt.Fprintf(os.Stderr, "process status is: %+v", st)
-
 		status, err := process.Delete(ctx)
 		if err != nil {
 			return fmt.Errorf("process delete (%+v) failed: %+v", status, err)

--- a/pkg/pillar/containerd/run.go
+++ b/pkg/pillar/containerd/run.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package containerd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+
+	ctrdd "github.com/containerd/containerd"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+type mutexWriter struct {
+	w     io.Writer
+	mutex *sync.Mutex
+}
+
+func (m mutexWriter) Write(p []byte) (n int, err error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	// seems containerd sometimes wants to write something into it,
+	// but it is already too late
+	if m.w == nil {
+		return 0, syscall.ENOENT
+	}
+	n, err = m.w.Write(p)
+
+	return n, err
+}
+
+// RunInDebugContainer runs a program in the debug container
+func RunInDebugContainer(clientCtx context.Context, taskID string, w io.Writer, args []string, timeout time.Duration) error {
+	ctrd, err := NewContainerdClient(false)
+	if err != nil {
+		return fmt.Errorf("could not initialize containerd client: %+v\n", err)
+	}
+
+	ctx, done := ctrd.CtrNewSystemServicesCtx()
+	defer done()
+
+	container, err := ctrd.CtrLoadContainer(ctx, "debug")
+	if err != nil {
+		return fmt.Errorf("loading container failed: %+v", err)
+	}
+
+	task, err := container.Task(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("getting debug container task failed: %+v", err)
+	}
+
+	pspec := specs.Process{
+		Args: args,
+		Cwd:  "/",
+		Scheduler: &specs.Scheduler{
+			Deadline: uint64(time.Now().Add(timeout).Unix()),
+		},
+	}
+	stderrBuf := bytes.Buffer{}
+
+	writingDone := make(chan struct{})
+	defer close(writingDone)
+	mutexWriter := mutexWriter{
+		w:     w,
+		mutex: &sync.Mutex{},
+	}
+	stdcio := ctrd.CtrWriterCreator(mutexWriter, &stderrBuf)
+
+	process, err := task.Exec(ctx, taskID, &pspec, stdcio)
+	if err != nil {
+		return fmt.Errorf("executing in task failed: %+v", err)
+	}
+	waiter, err := process.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("process wait failed: %+v", err)
+	}
+	err = process.Start(ctx)
+	if err != nil {
+		return fmt.Errorf("process start failed: %+v", err)
+	}
+
+	exitStatus := struct {
+		exitCode        uint32
+		killedByTimeout bool
+	}{
+		exitCode:        0,
+		killedByTimeout: false,
+	}
+
+	timeoutTimer := time.NewTimer(timeout)
+	select {
+	case <-clientCtx.Done():
+		exitStatus.killedByTimeout = true
+		err := killProcess(ctx, process)
+		if err != nil {
+			return fmt.Errorf("writer closed - killing process %+v failed: %w", args, err)
+		}
+	case <-timeoutTimer.C:
+		exitStatus.killedByTimeout = true
+		err := killProcess(ctx, process)
+		if err != nil {
+			return fmt.Errorf("timeout - killing process %+v failed: %w", args, err)
+		}
+	case containerExitStatus := <-waiter:
+		exitStatus.exitCode = containerExitStatus.ExitCode()
+	}
+	timeoutTimer.Stop()
+
+	if !exitStatus.killedByTimeout {
+		st, err := process.Status(ctx)
+		if err != nil {
+			return fmt.Errorf("process status failed: %+v", err)
+		}
+		fmt.Fprintf(os.Stderr, "process status is: %+v", st)
+
+		status, err := process.Delete(ctx)
+		if err != nil {
+			return fmt.Errorf("process delete (%+v) failed: %+v", status, err)
+		}
+	}
+
+	stderrBytes, err := io.ReadAll(&stderrBuf)
+	if len(stderrBytes) > 0 {
+		return fmt.Errorf("Stderr output was: %s", string(stderrBytes))
+	}
+
+	mutexWriter.w = nil
+
+	return nil
+}
+
+func killProcess(ctx context.Context, process ctrdd.Process) error {
+	err := process.Kill(ctx, syscall.SIGTERM)
+	if err != nil {
+		return fmt.Errorf("timeout reached, killing of process failed: %w", err)
+	}
+	time.Sleep(time.Second)
+	st, err := process.Status(ctx)
+	if err != nil {
+		return fmt.Errorf("timeout reached, retrieving status of process failed: %w", err)
+	}
+	if st.Status == ctrdd.Stopped {
+		return nil
+	}
+	err = process.Kill(ctx, syscall.SIGKILL)
+	if err != nil {
+		return fmt.Errorf("timeout reached, killing of process (SIGKILL) failed: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Description

This is part of tearing apart https://github.com/lf-edge/eve/pull/4992

so that it cannot only be used by bpftrace, but also by the collectinfo to run collect-info.sh from LOC

## PR dependencies

## How to test and validate this PR

Run a bpftrace script with `run-via-http` verb on `bpftrace-compiler`.

## Changelog notes

Refactoring

## PR Backports

- 14.5-stable: no
- 13.4-stable: no



## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
