### PR TITLE
Fix update_kernel_commits.py and ignore new branches

### DIFF
--- a/tools/update_kernel_commits.py
+++ b/tools/update_kernel_commits.py
@@ -665,22 +665,25 @@ def adjust_branches_by_docker_tags(new_commits, updated_branches, docker_tags):
         # always update to our source of truth
         new_commits[branch] = docker_commit
 
-        # if we have updated branches check that we have any docker tag for them
-        # it means that the branch is just added
-        saved_updated_branches = updated_branches.copy()
-        for branch in updated_branches:
+        # After processing all branches, handle branches not in docker_tags
+        # Make a copy of keys to avoid modification during iteration
+        branches_to_check = list(updated_branches.keys())
+
+        for branch in branches_to_check:
             if branch not in docker_tags:
-                is_error = True
+                current_gh_commit, latest_gh_commit = updated_branches[branch]
+
                 print(
-                    Fore.RED
-                    + "[Error]"
+                    Fore.YELLOW
+                    + "[ WARN ]"
                     + Style.RESET_ALL
-                    + f" :{branch}: the image for commit {new_commits[branch]}"
-                    + "was not pushed to docker.\n\tNo docker tag found for the branch."
-                    " Is this a new branch?"
+                    + f" :{branch}: the image for commit {latest_gh_commit} was not pushed to "
+                    + "docker.\n\tNo docker tag found for the branch. Is this a new branch?"
                 )
-                del saved_updated_branches[branch]
-        updated_branches = saved_updated_branches
+                print(f"Deleting the branch from updated branches. {branch} will not be updated.")
+                del updated_branches[branch]
+                del new_commits[branch]
+
         return is_error
 
 


### PR DESCRIPTION
# Description

**NOTE:** this is just a script for CI, no need to wait for neither build nor eden!!!

Previously the script stopped with error if new branch without docker tag is found This commit prints warning instead and keep updating kernel_commits.mk

<img width="1461" height="464" alt="image" src="https://github.com/user-attachments/assets/807a61dc-8dba-4034-aef6-4f382cc995aa" />



## How to test and validate this PR

1. Create  a new branch in eve-kernel repo that follows format eve-kenrel-<tag>-platfrom from stable tag, do not add any commits 
2. run the script and make sure the branch is reported as "new branch" and "won't be updated" like in attached screenshot


## PR Backports

```text
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.
```
## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
