### PR TITLE
Kernel update - Add HWE kernel

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,6 +1,6 @@
 KERNEL_COMMIT_amd64_v6.1.111_rt = c708a17493f1
-KERNEL_COMMIT_amd64_v6.1.112_generic = fbba2324d2be
-KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = 77ad49f1f137
-KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 14693149c305
-KERNEL_COMMIT_arm64_v6.1.112_generic = a5fecf8ec851
+KERNEL_COMMIT_amd64_v6.1.112_generic = a3533c933cb0
+KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = 0c6f395e2eda
+KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 726082c6a5f9
+KERNEL_COMMIT_arm64_v6.1.112_generic = a4135477cbf7
 KERNEL_COMMIT_riscv64_v6.1.112_generic = 18e1d313b90b


### PR DESCRIPTION
# Description

This PR updates kernel versions to the point where kernel config flavors exist. It enables builds for evaluation platform

Only important commits are mentioned bellow, the full list in the commit message

This commit changes:
eve-kernel-amd64-v6.1.112-generic
    a3533c933cb0: Update Linuxkit version to v1.7.0
    b083f6c36865: Add HWE defconfig
    c02109756748: Fix incorrect check for CONFIG_BPF_KPROBE_OVERRIDE
    4ce2ddacb72f: Update .dockerignore to minimize docker context
    1b257aac9525: Split workflows for PRs and Merge
    2c3cdad114a4: GHA: create separate concurancy groups
    38f52f302162: Change pull_request to pull_request_target to allow secrets
    32a83f87dba8: Login to Dockerhub for pulling images
    c08cb88e6824: Allow building all kernel flavors in parallel
    766859b4fda8: Add HWE builds to CI

eve-kernel-arm64-v5.10.192-nvidia-jp5
    0c6f395e2eda: Login to Dockerhub for pulling images

eve-kernel-arm64-v5.15.136-nvidia-jp6
    726082c6a5f9: Login to Dockerhub for pulling images

eve-kernel-arm64-v6.1.112-generic
    a4135477cbf7: Login to Dockerhub for pulling images

## How to test and validate this PR

run build for evaluation platform
```
make PLATFORM=evaluation pkgs eve
```

## Changelog notes

Eve bulds for evaluation platform are now available

## PR Backports

```text
- 14.5-stable: No
- 13.4-stable: No
```

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.


