### PR TITLE
Ignore build artifacts to allow linuxkit push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ tags
 tmp/
 mkdocs.yml
 yetus-output/
+*.squash
 assets/
 pkg/kernel/build.yml
 pkg/new-kernel/build.yml


### PR DESCRIPTION
# Description

linuxkit refuses to push if the repo is dirty. we must ignore any build artifact  so we must ignore a symlink to rootfs


## PR Backports

we may need to backport it if we backported new modifiers parsing to stable

```text
- 14.5-stable: NO
- 13.4-stable: NO
```


## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR


- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.


