### PR TITLE
Makefile: Fix eve target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1211,7 +1211,7 @@ pkg-deps.mk: $(GET_DEPS)
 
 $(ROOTFS_FULL_NAME)-kvm-adam-$(ZARCH).$(ROOTFS_FORMAT): fullname-rootfs $(SSH_KEY)
 fullname-rootfs: $(ROOTFS_FULL_NAME)-$(HV)-$(ZARCH).$(ROOTFS_FORMAT) current
-$(ROOTFS_FULL_NAME)-%-$(ZARCH).$(ROOTFS_FORMAT): $(ROOTFS_IMG)
+$(ROOTFS_FULL_NAME)-%-$(ZARCH).$(ROOTFS_FORMAT): $(ROOTFS_IMG_BASE).img
 	@rm -f $@ && ln -s $(notdir $<) $@
 	$(QUIET): $@: Succeeded
 


### PR DESCRIPTION
# Description

Commit 7b9076f9b824fe94de0b7bae644a01d6b340881a renamed the variable ROOTFS_IMG to ROOTFS_IMG_BASE, which broke the target eve because of dependencies that ended to a intermediary symbolic that is created during the build. The creation of this symlink was failing because of the usage of the old variable ROOTFS_IMG. This commit fixes this issue and make eve works flawlessly.

## How to test and validate this PR

1. Run `make eve` it should work without errors.

## Changelog notes

No user-facing changes (Makefile).

## PR Backports

Not needed since it's only on master.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.