### PR TITLE
[13.4-stable] Move LastResort DPC handling fully into DPCManager

### DIFF
--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -27,7 +26,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/lf-edge/eve/pkg/pillar/zedcloud"
-	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -42,12 +40,8 @@ const (
 const (
 	configDevicePortConfigDir = types.IdentityDirname + "/DevicePortConfig"
 	runDevicePortConfigDir    = "/run/global/DevicePortConfig"
-	maxReadSize               = 16384       // Punt on too large files
-	dpcAvailableTimeLimit     = time.Minute // TODO: make configurable?
+	maxReadSize               = 16384 // Punt on too large files
 )
-
-// Really a constant
-var nilUUID uuid.UUID
 
 // NIM - Network Interface Manager.
 // Manage (physical) network interfaces of the device based on configuration from
@@ -78,7 +72,6 @@ type nim struct {
 	subEdgeNodeCert          pubsub.Subscription
 	subDevicePortConfigA     pubsub.Subscription
 	subDevicePortConfigO     pubsub.Subscription
-	subDevicePortConfigS     pubsub.Subscription
 	subZedAgentStatus        pubsub.Subscription
 	subAssignableAdapters    pubsub.Subscription
 	subOnboardStatus         pubsub.Subscription
@@ -104,9 +97,6 @@ type nim struct {
 	globalConfig       types.ConfigItemValueMap
 	gcInitialized      bool // Received initial GlobalConfig
 	assignableAdapters types.AssignableAdapters
-	enabledLastResort  bool
-	forceLastResort    bool
-	lastResort         *types.DevicePortConfig
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
@@ -193,11 +183,18 @@ func (n *nim) init() (err error) {
 func (n *nim) run(ctx context.Context) (err error) {
 	n.Log.Noticef("Starting %s", agentName)
 
+	// Check if we have a /config/DevicePortConfig/*.json which we need to
+	// take into account by copying it to /run/global/DevicePortConfig/
+	n.ingestDevicePortConfig()
+
 	// Start DPC Manager.
 	if err = n.dpcManager.Init(ctx); err != nil {
 		return err
 	}
-	if err = n.dpcManager.Run(ctx); err != nil {
+	installerDPCs := n.listPublishedDPCs(runDevicePortConfigDir)
+	haveBootstrapConf := fileutils.FileExists(n.Log, types.BootstrapConfFileName)
+	expectBootstrapDPCs := len(installerDPCs) > 0 || haveBootstrapConf
+	if err = n.dpcManager.Run(ctx, expectBootstrapDPCs); err != nil {
 		return err
 	}
 
@@ -214,25 +211,6 @@ func (n *nim) run(ctx context.Context) (err error) {
 	}
 	n.Log.Noticef("Processed GlobalConfig")
 
-	// Check if we have a /config/DevicePortConfig/*.json which we need to
-	// take into account by copying it to /run/global/DevicePortConfig/
-	n.ingestDevicePortConfig()
-
-	// Activate some subscriptions.
-	// Not all yet though, first we wait for last-resort and AA to initialize.
-	if err = n.subControllerCert.Activate(); err != nil {
-		return err
-	}
-	if err = n.subEdgeNodeCert.Activate(); err != nil {
-		return err
-	}
-	if err = n.subDevicePortConfigS.Activate(); err != nil {
-		return err
-	}
-	if err = n.subOnboardStatus.Activate(); err != nil {
-		return err
-	}
-
 	// Run a periodic timer so we always update StillRunning
 	stillRunning := time.NewTicker(stillRunTime)
 	n.PubSub.StillRunning(agentName, warningTime, errorTime)
@@ -243,78 +221,27 @@ func (n *nim) run(ctx context.Context) (err error) {
 	min := max * 0.3
 	publishTimer := flextimer.NewRangeTicker(time.Duration(min), time.Duration(max))
 
-	// Watch for interface changes to update last resort DPC.
-	done := make(chan struct{})
-	defer close(done)
-	netEvents := n.networkMonitor.WatchEvents(ctx, agentName)
+	// Periodically resolve the controller hostname to keep its DNS entry cached,
+	// reducing the need for DNS lookups on every controller API request.
+	go n.runResolverCacheForController()
 
-	// Time limit to obtain some network config.
-	// If it runs out and we still do not have any config, lastresort will be enabled
-	// unconditionally.
-	// This is mainly to handle the case when for whatever reason the device
-	// has lost /persist/status/nim/DevicePortConfigList
-	dpcAvailTimer := time.After(dpcAvailableTimeLimit)
-
-	if !n.enabledLastResort {
-		// Even if lastresort DPC is disabled by config, it can be forcefully used
-		// until NIM obtains any proper network config (from controller or bootstrap config
-		// or override/usb json).
-		//  * Before onboarding, we can easily determine if there is going to be any network
-		//    config available. If there is neither bootstrap device config nor any network
-		//    config override inside the /config partition or inside an (already plugged in)
-		//    USB stick, then device has no source of network configuration (currently)
-		//    available. The only exception is if the user is planning to insert USB stick
-		//    with usb.json *later*, but this cannot be predicted.
-		//    In order to not prolong onboarding in situations where the use of lastresort
-		//    is expected (ethernet + DHCP scenarios; often relied upon in lab/testing cases),
-		//    we will forcefully enable lastresort immediately if the above conditions for
-		//    missing network config source are satisfied. If the user later inserts a USB
-		//    stick with usb.json or the device onboards using lastresort and obtains a proper
-		//    config from the controller, the lastresort DPC will be unpublished (unless it is
-		//    enabled explicitly by config - by default it is disabled).
-		//  * After onboarding, it is expected that device always keeps and persists
-		//    at least the latest and the last working DPC, so it should never run out of
-		//    network configurations. But should device loose all of its /persist partition,
-		//    e.g. due to replacing or wiping the single disk where /persist lives, NIM will
-		//    notice that even after one minute of runtime (when dpcAvailTimer fires) there
-		//    is still no network config available and it will forcefully enable lastresort.
-		if !n.isDeviceOnboarded() &&
-			len(n.listPublishedDPCs(runDevicePortConfigDir)) == 0 &&
-			!fileutils.FileExists(n.Log, types.BootstrapConfFileName) {
-			n.forceLastResort = true
-			n.reevaluateLastResortDPC()
-		}
+	// Activate all subscriptions now.
+	inactiveSubs := []pubsub.Subscription{
+		n.subControllerCert,
+		n.subEdgeNodeCert,
+		n.subOnboardStatus,
+		n.subDevicePortConfigO,
+		n.subDevicePortConfigA,
+		n.subZedAgentStatus,
+		n.subAssignableAdapters,
+		n.subWwanStatus,
+		n.subNetworkInstanceConfig,
 	}
 
-	waitForLastResort := n.enabledLastResort
-	lastResortIsReady := func() error {
-		if err = n.subDevicePortConfigO.Activate(); err != nil {
+	for _, sub := range inactiveSubs {
+		if err = sub.Activate(); err != nil {
 			return err
 		}
-		if err = n.subDevicePortConfigA.Activate(); err != nil {
-			return err
-		}
-		if err = n.subZedAgentStatus.Activate(); err != nil {
-			return err
-		}
-		if err = n.subAssignableAdapters.Activate(); err != nil {
-			return err
-		}
-		if err = n.subWwanStatus.Activate(); err != nil {
-			return err
-		}
-		if err = n.subNetworkInstanceConfig.Activate(); err != nil {
-			return err
-		}
-		go n.runResolverCacheForController()
-		return nil
-	}
-	if !waitForLastResort {
-		if err = lastResortIsReady(); err != nil {
-			return err
-		}
-	} else {
-		n.Log.Notice("Waiting for last-resort DPC...")
 	}
 
 	for {
@@ -327,29 +254,12 @@ func (n *nim) run(ctx context.Context) (err error) {
 
 		case change := <-n.subGlobalConfig.MsgChan():
 			n.subGlobalConfig.ProcessChange(change)
-			if waitForLastResort && !n.enabledLastResort {
-				waitForLastResort = false
-				n.Log.Notice("last-resort DPC is not enabled")
-				if err = lastResortIsReady(); err != nil {
-					return err
-				}
-			}
 
 		case change := <-n.subDevicePortConfigA.MsgChan():
 			n.subDevicePortConfigA.ProcessChange(change)
 
 		case change := <-n.subDevicePortConfigO.MsgChan():
 			n.subDevicePortConfigO.ProcessChange(change)
-
-		case change := <-n.subDevicePortConfigS.MsgChan():
-			n.subDevicePortConfigS.ProcessChange(change)
-			if waitForLastResort && n.lastResort != nil {
-				waitForLastResort = false
-				n.Log.Notice("last-resort DPC is ready")
-				if err = lastResortIsReady(); err != nil {
-					return err
-				}
-			}
 
 		case change := <-n.subZedAgentStatus.MsgChan():
 			n.subZedAgentStatus.ProcessChange(change)
@@ -367,12 +277,6 @@ func (n *nim) run(ctx context.Context) (err error) {
 			n.subNetworkInstanceConfig.ProcessChange(change)
 			n.handleNetworkInstanceUpdate()
 
-		case event := <-netEvents:
-			ifChange, isIfChange := event.(netmonitor.IfChange)
-			if isIfChange {
-				n.processInterfaceChange(ifChange)
-			}
-
 		case <-publishTimer.C:
 			start := time.Now()
 			err = n.cipherMetrics.Publish(n.Log, n.pubCipherMetrics, "global")
@@ -385,20 +289,6 @@ func (n *nim) run(ctx context.Context) (err error) {
 			}
 			n.PubSub.CheckMaxTimeTopic(agentName, "publishTimer", start,
 				warningTime, errorTime)
-
-		case <-dpcAvailTimer:
-			obj, err := n.pubDevicePortConfigList.Get("global")
-			if err != nil {
-				n.Log.Errorf("Failed to get published DPCL: %v", err)
-				continue
-			}
-			dpcl := obj.(types.DevicePortConfigList)
-			if len(dpcl.PortConfigList) == 0 {
-				n.Log.Noticef("DPC Manager has no network config to work with "+
-					"even after %v, enabling lastresort unconditionally", dpcAvailableTimeLimit)
-				n.forceLastResort = true
-				n.reevaluateLastResortDPC()
-			}
 
 		case <-ctx.Done():
 			return nil
@@ -553,10 +443,9 @@ func (n *nim) initSubscriptions() (err error) {
 		return err
 	}
 
-	// We get DevicePortConfig from three sources in this priority:
+	// We get DevicePortConfig from two sources in this priority:
 	// 1. zedagent publishing DevicePortConfig
 	// 2. override file in /run/global/DevicePortConfig/*.json
-	// 3. "lastresort" derived from the set of network interfaces
 	n.subDevicePortConfigA, err = n.PubSub.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedagent",
 		MyAgentName:   agentName,
@@ -571,7 +460,6 @@ func (n *nim) initSubscriptions() (err error) {
 	if err != nil {
 		return err
 	}
-
 	n.subDevicePortConfigO, err = n.PubSub.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "",
 		MyAgentName:   agentName,
@@ -579,21 +467,6 @@ func (n *nim) initSubscriptions() (err error) {
 		Activate:      false,
 		CreateHandler: n.handleDPCFileCreate,
 		ModifyHandler: n.handleDPCFileModify,
-		DeleteHandler: n.handleDPCDelete,
-		WarningTime:   warningTime,
-		ErrorTime:     errorTime,
-	})
-	if err != nil {
-		return err
-	}
-
-	n.subDevicePortConfigS, err = n.PubSub.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:     agentName,
-		MyAgentName:   agentName,
-		TopicImpl:     types.DevicePortConfig{},
-		Activate:      false,
-		CreateHandler: n.handleDPCCreate,
-		ModifyHandler: n.handleDPCModify,
 		DeleteHandler: n.handleDPCDelete,
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
@@ -722,14 +595,12 @@ func (n *nim) applyGlobalConfig(gcp *types.ConfigItemValueMap) {
 	n.dpcManager.UpdateGCP(n.globalConfig)
 	timeout := gcp.GlobalValueInt(types.NetworkTestTimeout)
 	n.connTester.TestTimeout = time.Second * time.Duration(timeout)
-	n.reevaluateLastResortDPC()
 	n.gcInitialized = true
 }
 
-// handleDPCCreate handles three different sources in this priority order:
-// 1. zedagent with any key
-// 2. "usb" key from build or USB stick file
-// 3. "lastresort" derived from the set of network interfaces
+// handleDPCCreate handles two different sources in this priority order:
+// 1. DPC from zedagent (received from the controller or LOC)
+// 2. "override"/"usb" key from build or USB stick file
 // We determine the priority from TimePriority in the config.
 func (n *nim) handleDPCCreate(_ interface{}, key string, configArg interface{}) {
 	n.handleDPCImpl(key, configArg, false)
@@ -776,12 +647,6 @@ func (n *nim) handleDPCImpl(key string, configArg interface{}, fromFile bool) {
 			return
 		}
 	}
-	// Lastresort DPC is allowed to be forcefully used only until NIM receives
-	// any (proper) network configuration.
-	if dpc.Key != dpcmanager.LastResortKey {
-		n.forceLastResort = false
-		n.reevaluateLastResortDPC()
-	}
 	n.dpcManager.AddDPC(dpc)
 }
 
@@ -814,9 +679,6 @@ func (n *nim) handleAssignableAdaptersImpl(key string, configArg interface{}) {
 	assignableAdapters := configArg.(types.AssignableAdapters)
 	n.assignableAdapters = assignableAdapters
 	n.dpcManager.UpdateAA(n.assignableAdapters)
-	if n.enabledLastResort {
-		n.publishLastResortDPC("assignable adapters changed")
-	}
 }
 
 func (n *nim) handleAssignableAdaptersDelete(_ interface{}, key string, _ interface{}) {
@@ -877,18 +739,6 @@ func (n *nim) handleNetworkInstanceUpdate() {
 		}
 	}
 	n.dpcManager.UpdateFlowlogState(flowlogEnabled)
-}
-
-func (n *nim) isDeviceOnboarded() bool {
-	obj, err := n.subOnboardStatus.Get("global")
-	if err != nil {
-		return false
-	}
-	status, ok := obj.(types.OnboardingStatus)
-	if !ok {
-		return false
-	}
-	return status.DeviceUUID != nilUUID
 }
 
 func (n *nim) listPublishedDPCs(directory string) (dpcFilePaths []string) {
@@ -992,160 +842,5 @@ func (n *nim) ingestDevicePortConfigFile(oldDirname string, newDirname string, n
 	if err != nil {
 		n.Log.Errorf("Failed to write new DevicePortConfig to %s: %s",
 			filename, err)
-	}
-}
-
-// reevaluateLastResortDPC re-evaluates the current state of Last resort DPC.
-// If the config or the overall situation around DPC availability changed since
-// the last call, an already enabled lastresort could be disabled and vice versa.
-// The function applies a potential change in the intended state of lastresort
-// by (un)publishing lastresort DPC (notification will be delivered to NIM itself
-// and further propagated to DPCManager).
-// Note that the function also updates n.enabledLastResort, signaling the current
-// (intended) state of Last resort DPC.
-func (n *nim) reevaluateLastResortDPC() {
-	fallbackAnyEth := n.globalConfig.GlobalValueTriState(types.NetworkFallbackAnyEth)
-	enabledByConfig := fallbackAnyEth == types.TS_ENABLED
-	enableLastResort := enabledByConfig || n.forceLastResort
-	if n.enabledLastResort != enableLastResort {
-		if enableLastResort {
-			reason := "lastresort enabled by global config"
-			if !enabledByConfig {
-				reason = "lastresort forcefully enabled"
-			}
-			n.publishLastResortDPC(reason)
-		} else {
-			n.removeLastResortDPC()
-		}
-	}
-	n.enabledLastResort = enableLastResort
-}
-
-func (n *nim) publishLastResortDPC(reason string) {
-	n.Log.Functionf("publishLastResortDPC")
-	dpc, err := n.makeLastResortDPC()
-	if err != nil {
-		n.Log.Error(err)
-		return
-	}
-	if n.lastResort != nil && n.lastResort.MostlyEqual(&dpc) {
-		return
-	}
-	n.Log.Noticef("Publishing last-resort DPC, reason: %v", reason)
-	if err := n.pubDevicePortConfig.Publish(dpcmanager.LastResortKey, dpc); err != nil {
-		n.Log.Errorf("Failed to publish last-resort DPC: %v", err)
-		return
-	}
-	n.lastResort = &dpc
-}
-
-func (n *nim) removeLastResortDPC() {
-	n.Log.Noticef("removeLastResortDPC")
-	if err := n.pubDevicePortConfig.Unpublish(dpcmanager.LastResortKey); err != nil {
-		n.Log.Errorf("Failed to un-publish last-resort DPC: %v", err)
-		return
-	}
-	n.lastResort = nil
-}
-
-func (n *nim) makeLastResortDPC() (types.DevicePortConfig, error) {
-	config := types.DevicePortConfig{}
-	config.Key = dpcmanager.LastResortKey
-	config.Version = types.DPCIsMgmt
-	// Set to higher than all zero but lower than the hardware model derived one above
-	config.TimePriority = time.Unix(0, 0)
-	ifNames, err := n.networkMonitor.ListInterfaces()
-	if err != nil {
-		err = fmt.Errorf("makeLastResortDPC: Failed to list interfaces: %v", err)
-		return config, err
-	}
-	for _, ifName := range ifNames {
-		ifIndex, _, err := n.networkMonitor.GetInterfaceIndex(ifName)
-		if err != nil {
-			n.Log.Errorf("makeLastResortDPC: failed to get interface index: %v", err)
-			continue
-		}
-		ifAttrs, err := n.networkMonitor.GetInterfaceAttrs(ifIndex)
-		if err != nil {
-			n.Log.Errorf("makeLastResortDPC: failed to get interface attrs: %v", err)
-			continue
-		}
-		if !n.includeLastResortPort(ifAttrs) {
-			continue
-		}
-		port := types.NetworkPortConfig{
-			IfName:       ifName,
-			Phylabel:     ifName,
-			Logicallabel: ifName,
-			IsMgmt:       true,
-			IsL3Port:     true,
-			DhcpConfig: types.DhcpConfig{
-				Dhcp: types.DhcpTypeClient,
-			},
-		}
-		dns := n.dpcManager.GetDNS()
-		portStatus := dns.LookupPortByIfName(ifName)
-		if portStatus != nil {
-			port.WirelessCfg = portStatus.WirelessCfg
-		}
-		config.Ports = append(config.Ports, port)
-	}
-	return config, nil
-}
-
-func (n *nim) includeLastResortPort(ifAttrs netmonitor.IfAttrs) bool {
-	ifName := ifAttrs.IfName
-	exclude := strings.HasPrefix(ifName, "vif") ||
-		strings.HasPrefix(ifName, "nbu") ||
-		strings.HasPrefix(ifName, "nbo") ||
-		strings.HasPrefix(ifName, "wlan") ||
-		strings.HasPrefix(ifName, "wwan") ||
-		strings.HasPrefix(ifName, "keth")
-	if exclude {
-		return false
-	}
-	if n.isInterfaceAssigned(ifName) {
-		return false
-	}
-	if ifAttrs.IsLoopback || !ifAttrs.WithBroadcast || ifAttrs.Enslaved {
-		return false
-	}
-
-	switch ifAttrs.IfType {
-	case "device":
-		return true
-	case "bridge":
-		// Was this originally an ethernet interface turned into a bridge?
-		_, exists, _ := n.networkMonitor.GetInterfaceIndex("k" + ifName)
-		return exists
-	case "can", "vcan":
-		return false
-	}
-
-	return false
-}
-
-func (n *nim) isInterfaceAssigned(ifName string) bool {
-	ib := n.assignableAdapters.LookupIoBundleIfName(ifName)
-	if ib == nil {
-		return false
-	}
-	n.Log.Tracef("isAssigned(%s): pciback %t, used %s",
-		ifName, ib.IsPCIBack, ib.UsedByUUID.String())
-	if ib.UsedByUUID != nilUUID {
-		return true
-	}
-	return false
-}
-
-func (n *nim) processInterfaceChange(ifChange netmonitor.IfChange) {
-	if !n.enabledLastResort || n.lastResort == nil {
-		return
-	}
-	includePort := n.includeLastResortPort(ifChange.Attrs)
-	port := n.lastResort.LookupPortByIfName(ifChange.Attrs.IfName)
-	if port == nil && includePort {
-		n.publishLastResortDPC(fmt.Sprintf("interface %s should be included",
-			ifChange.Attrs.IfName))
 	}
 }

--- a/pkg/pillar/dpcmanager/dpc.go
+++ b/pkg/pillar/dpcmanager/dpc.go
@@ -377,6 +377,9 @@ func (m *DpcManager) compressDPCL() {
 						dpc.ShaFile, dpc.PubKey())
 				}
 			}
+			if dpc.Key == LastResortKey {
+				m.lastResort = nil
+			}
 			if i <= m.dpcList.CurrentIndex {
 				newCurrentIndex--
 			}

--- a/pkg/pillar/dpcmanager/dpcmanager.go
+++ b/pkg/pillar/dpcmanager/dpcmanager.go
@@ -71,6 +71,12 @@ type DpcManager struct {
 	// XXX Should we make this a global config parameter?
 	DpcMinTimeSinceFailure time.Duration
 
+	// Time limit for some DPC to become available.
+	// Once this elapses and no DPC has been provided, DPCManager will try lastresort.
+	// By default (if not specified), this is 1 minute.
+	// It is useful to override this for unit testing purposes.
+	DpcAvailTimeLimit time.Duration
+
 	// NIM components that the manager interacts with
 	NetworkMonitor netmonitor.NetworkMonitor
 	DpcReconciler  dpcreconciler.DpcReconciler
@@ -96,6 +102,10 @@ type DpcManager struct {
 	flowlogEnabled   bool
 	// Boot-time configuration
 	dpclPresentAtBoot bool
+
+	// Last-Resort DPC
+	expectBootstrapDPCs bool
+	lastResort          *types.DevicePortConfig
 
 	// DPC verification
 	dpcVerify dpcVerify
@@ -218,6 +228,9 @@ func (m *DpcManager) Init(ctx context.Context) error {
 	if m.DpcMinTimeSinceFailure == 0 {
 		m.DpcMinTimeSinceFailure = 5 * time.Minute
 	}
+	if m.DpcAvailTimeLimit == 0 {
+		m.DpcAvailTimeLimit = time.Minute
+	}
 	m.dpcList.CurrentIndex = -1
 	// We start assuming cloud connectivity works
 	m.dpcVerify.cloudConnWorks = true
@@ -235,9 +248,12 @@ func (m *DpcManager) Init(ctx context.Context) error {
 }
 
 // Run DpcManager as a separate task with its own loop and a watchdog file.
-func (m *DpcManager) Run(ctx context.Context) (err error) {
+// The expectBootstrapDPCs flag indicates whether initial DPCs for network bootstrapping
+// are expected to arrive shortly.
+func (m *DpcManager) Run(ctx context.Context, expectBootstrapDPCs bool) (err error) {
 	m.startTime = time.Now()
 	m.networkEvents = m.NetworkMonitor.WatchEvents(ctx, "dpc-reconciler")
+	m.expectBootstrapDPCs = expectBootstrapDPCs
 	go m.run(ctx)
 	return nil
 }
@@ -250,6 +266,25 @@ func (m *DpcManager) run(ctx context.Context) {
 
 	// Run initial reconciliation.
 	m.reconcileStatus = m.DpcReconciler.Reconcile(ctx, m.reconcilerArgs())
+
+	// Time limit for obtaining a valid network configuration.
+	// If this timer expires without any config being received, lastresort will be enabled
+	// unconditionally.
+	// This primarily handles cases where the device has lost
+	// /persist/status/nim/DevicePortConfigList.
+	//
+	// It can also be triggered if a bootstrapping DPC (e.g., override.json or bootstrap-config.pb)
+	// is present but invalid.
+	//
+	// In normal onboarding, with an initially empty DPCL, DPCManager either:
+	//   - Receives a bootstrapping DPC from nim, or
+	//   - If none is available (i.e., expectBootstrapDPCs set by nim is false), it creates
+	//     and tries lastresort DPC after receiving the global config (ConfigItemValueMap)
+	//     (see doUpdateGCP).
+	//
+	// This timer here is really just a fallback mechanism if something went wrong,
+	// to make sure we never end with empty DPCL.
+	dpcAvailTimer := time.After(m.DpcAvailTimeLimit)
 
 	for {
 		select {
@@ -279,6 +314,16 @@ func (m *DpcManager) run(ctx context.Context) {
 		case <-m.reconcileStatus.ResumeReconcile:
 			m.reconcileStatus = m.DpcReconciler.Reconcile(ctx, m.reconcilerArgs())
 			m.resumeVerifyIfAsyncDone(ctx)
+
+		case <-dpcAvailTimer:
+			if len(m.dpcList.PortConfigList) == 0 {
+				// Add lastresort DPC even if it is disabled by config.
+				reason := fmt.Sprintf("DPC Manager has no network config to work with "+
+					"even after %v, enabling lastresort unconditionally",
+					m.DpcAvailTimeLimit)
+				m.Log.Notice(reason)
+				m.addOrUpdateLastResortDPC(ctx, reason)
+			}
 
 		case _, ok := <-m.dpcTestTimer.C:
 			start := time.Now()
@@ -340,6 +385,7 @@ func (m *DpcManager) run(ctx context.Context) {
 		case event := <-m.networkEvents:
 			switch ev := event.(type) {
 			case netmonitor.IfChange:
+				m.updateLastResortOnIntfChange(ctx, ev)
 				ifName := ev.Attrs.IfName
 				if !m.adapters.Initialized {
 					continue
@@ -511,9 +557,6 @@ func (m *DpcManager) doUpdateGCP(ctx context.Context, gcp types.ConfigItemValueM
 	geoRetryInterval := time.Second *
 		time.Duration(m.globalCfg.GlobalValueInt(types.NetworkGeoRetryTime))
 
-	fallbackAnyEth := m.globalCfg.GlobalValueTriState(types.NetworkFallbackAnyEth)
-	m.enableLastResort = fallbackAnyEth == types.TS_ENABLED
-
 	if m.dpcTestInterval != testInterval {
 		if testInterval == 0 {
 			m.Log.Warn("NOT running TestTimer")
@@ -557,6 +600,31 @@ func (m *DpcManager) doUpdateGCP(ctx context.Context, gcp types.ConfigItemValueM
 	m.reinitNetdumper()
 
 	m.reconcileStatus = m.DpcReconciler.Reconcile(ctx, m.reconcilerArgs())
+
+	// Handle NetworkFallbackAnyEth config property.
+	wasLastResortEnabled := m.enableLastResort
+	fallbackAnyEth := m.globalCfg.GlobalValueTriState(types.NetworkFallbackAnyEth)
+	m.enableLastResort = fallbackAnyEth == types.TS_ENABLED
+	if m.enableLastResort && !wasLastResortEnabled {
+		m.addOrUpdateLastResortDPC(ctx, "lastresort enabled by global config")
+	}
+	if !m.enableLastResort && wasLastResortEnabled {
+		m.compressAndPublishDPCL()
+	}
+	if firstGCP && !m.enableLastResort {
+		// Even if the lastresort DPC is disabled by config, it can be forcefully enabled
+		// until DPCManager receives a valid network configuration (from the controller,
+		// bootstrap, override, or USB).
+		//
+		// Specifically, if no DPC is persisted from a previous run (e.g., during the first
+		// device boot or after /persist is lost due to disk replacement or wiping),
+		// and if no bootstrap DPC is expected to arrive shortly, then use the lastresort
+		// DPC as a fallback to attempt establishing the initial connectivity.
+		if len(m.dpcList.PortConfigList) == 0 && !m.expectBootstrapDPCs {
+			m.addOrUpdateLastResortDPC(ctx, "no DPC available for bootstrapping")
+		}
+	}
+
 	// If we have persisted DPCs then go ahead and pick a working one
 	// with the highest priority, do not wait for dpcTestTimer to fire.
 	if firstGCP && m.currentDPC() == nil && len(m.dpcList.PortConfigList) > 0 {
@@ -566,6 +634,10 @@ func (m *DpcManager) doUpdateGCP(ctx context.Context, gcp types.ConfigItemValueM
 
 func (m *DpcManager) doUpdateAA(ctx context.Context, adapters types.AssignableAdapters) {
 	m.adapters = adapters
+	if m.lastResort != nil {
+		m.addOrUpdateLastResortDPC(ctx, "assignable adapters changed")
+	}
+
 	// In case a verification is in progress and is waiting for return from pciback
 	if dpc := m.currentDPC(); dpc != nil {
 		if dpc.State == types.DPCStatePCIWait || dpc.State == types.DPCStateIntfWait {

--- a/pkg/pillar/dpcmanager/lastresort.go
+++ b/pkg/pillar/dpcmanager/lastresort.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package dpcmanager
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/netmonitor"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func (m *DpcManager) makeLastResortDPC() (types.DevicePortConfig, error) {
+	config := types.DevicePortConfig{}
+	config.Key = LastResortKey
+	config.Version = types.DPCIsMgmt
+	// Set to the lowest priority possible.
+	config.TimePriority = time.Unix(0, 0)
+	ifNames, err := m.NetworkMonitor.ListInterfaces()
+	if err != nil {
+		err = fmt.Errorf("makeLastResortDPC: Failed to list interfaces: %v", err)
+		return config, err
+	}
+	for _, ifName := range ifNames {
+		ifIndex, _, err := m.NetworkMonitor.GetInterfaceIndex(ifName)
+		if err != nil {
+			m.Log.Errorf("makeLastResortDPC: failed to get interface index: %v", err)
+			continue
+		}
+		ifAttrs, err := m.NetworkMonitor.GetInterfaceAttrs(ifIndex)
+		if err != nil {
+			m.Log.Errorf("makeLastResortDPC: failed to get interface attrs: %v", err)
+			continue
+		}
+		if !m.includeLastResortPort(ifAttrs) {
+			continue
+		}
+		port := types.NetworkPortConfig{
+			IfName:       ifName,
+			Phylabel:     ifName,
+			Logicallabel: ifName,
+			IsMgmt:       true,
+			IsL3Port:     true,
+			DhcpConfig: types.DhcpConfig{
+				Dhcp: types.DhcpTypeClient,
+				Type: types.NetworkTypeIPv4, // Dual-stack, IPv4 preferred
+			},
+		}
+		config.Ports = append(config.Ports, port)
+	}
+	config.DoSanitize(m.Log, types.DPCSanitizeArgs{
+		SanitizeSharedLabels: true,
+	})
+	return config, nil
+}
+
+func (m *DpcManager) includeLastResortPort(ifAttrs netmonitor.IfAttrs) bool {
+	ifName := ifAttrs.IfName
+	exclude := strings.HasPrefix(ifName, "vif") ||
+		strings.HasPrefix(ifName, "nbu") ||
+		strings.HasPrefix(ifName, "nbo") ||
+		strings.HasPrefix(ifName, "wlan") ||
+		strings.HasPrefix(ifName, "wwan") ||
+		strings.HasPrefix(ifName, "keth")
+	if exclude {
+		return false
+	}
+	if m.isInterfaceAssigned(ifName) {
+		return false
+	}
+	if ifAttrs.IsLoopback || !ifAttrs.WithBroadcast || ifAttrs.Enslaved {
+		return false
+	}
+
+	switch ifAttrs.IfType {
+	case "device":
+		return true
+	case "bridge":
+		// Was this originally an ethernet interface turned into a bridge?
+		_, exists, _ := m.NetworkMonitor.GetInterfaceIndex("k" + ifName)
+		return exists
+	case "can", "vcan":
+		return false
+	}
+
+	return false
+}
+
+func (m *DpcManager) isInterfaceAssigned(ifName string) bool {
+	ib := m.adapters.LookupIoBundleIfName(ifName)
+	if ib == nil {
+		return false
+	}
+	if ib.UsedByUUID != nilUUID {
+		return true
+	}
+	return false
+}
+
+func (m *DpcManager) updateLastResortOnIntfChange(
+	ctx context.Context, ifChange netmonitor.IfChange) {
+	if m.lastResort == nil {
+		return
+	}
+	includePort := m.includeLastResortPort(ifChange.Attrs)
+	port := m.lastResort.LookupPortByIfName(ifChange.Attrs.IfName)
+	if port == nil && includePort {
+		m.addOrUpdateLastResortDPC(ctx, fmt.Sprintf("interface %s should be included",
+			ifChange.Attrs.IfName))
+	}
+}
+
+func (m *DpcManager) addOrUpdateLastResortDPC(ctx context.Context, reason string) {
+	dpc, err := m.makeLastResortDPC()
+	if err != nil {
+		m.Log.Error(err)
+		return
+	}
+	if m.lastResort != nil && m.lastResort.MostlyEqual(&dpc) {
+		return
+	}
+	m.Log.Noticef("Adding/updating last-resort DPC, reason: %v", reason)
+	m.lastResort = &dpc
+	m.doAddDPC(ctx, dpc)
+}

--- a/pkg/pillar/netmonitor/mock.go
+++ b/pkg/pillar/netmonitor/mock.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"sort"
 	"sync"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
@@ -173,6 +174,8 @@ func (m *MockNetworkMonitor) ListInterfaces() (ifNames []string, err error) {
 	for _, mockIf := range m.interfaces {
 		ifNames = append(ifNames, mockIf.Attrs.IfName)
 	}
+	// Sort to make output deterministic and easier to work with in unit tests.
+	sort.Strings(ifNames)
 	return ifNames, nil
 }
 


### PR DESCRIPTION
# Description

Previously, handling of the LastResort DPC was split between `cmd/nim` and `DPCManager`. The `cmd/nim` part was somewhat obscure — it would publish the LastResort DPC via pubsub and then consume that same publication via its own subscription, effectively (un)publishing the config to itself. The subscribed handler would then pass the DPC (or a removal request) to `DPCManager`.

Meanwhile, `DPCManager` is responsible for testing and persisting DPCs, and already has logic to prune the LastResort DPC during DPCL compression when it is no longer needed. Because it manages connectivity testing and fallback logic, it has the full context required to decide when the LastResort DPC should be retained or removed.

Having both `cmd/nim` and `DPCManager` independently decide on the lifecycle of LastResort led to inconsistencies. For example, NIM might re-publish the LastResort DPC even after `DPCManager` had already pruned it, unintentionally reintroducing it into the DPCL. Worse, **_NIM might prematurely unpublish LastResort while it is still needed_** — for instance, if the device bootstrapped with LastResort, established controller connectivity, but the controller-provided config then broke networking, the device could get stuck offline with no fallback.

To avoid such issues and simplify the design, this change moves all LastResort DPC handling into DPCManager. Since the DPC is internally generated and doesn’t come from an external source, pubsub is unnecessary for its management.

Backport of PR https://github.com/lf-edge/eve/pull/5036

## How to test and validate this PR

First of all, perform regular regression testing concerning lastresort DPC:
- check that device with no network config but connected to ethernet network with DHCP will successfully connect to controller and onboard
- check that when `network.fallback.any.eth` is enabled (disabled by default), lastresort will be retained by the device even when there is good network config received from the controller (check content of `/persist/status/nim/DevicePortConfigList/global.json` and look for `"Key": "lastresort"` in `PortConfigList`)
- check that when `network.fallback.any.eth` is disabled (default value), device will use lastresort only temporarily when absolutely necessary. For example, if device was provided with good working network config from the controller, lastresort should not be present in the persisted DPCL ( `/persist/status/nim/DevicePortConfigList/global.json`)

Additionally, focus testing on the main issue that this PR is addressing -- premature unpublish of LastResort:
1. Install EVE on a device connected to a network with DHCP
2. Keep default value for `network.fallback.any.eth`, i.e. disabled
3. Prepare bad network config on the controller side. For example, configure static IP that does not match the subnet address of the physical network where the device is connected to.
4. Turn the device on and wait for it to connect to the controller (using lastresort) and get onboarded
5. Wait few minutes and then check that device is still reporting to the controller, despite controller-provided config not being correct
6. Check on the device side that EVE tried the controller-provided config but returned to lastresort. Check `/persist/status/nim/DevicePortConfigList/global.json` -- `CurrentIndex` should be `1` and `PortConfigList` should contain 2 entries, first with `"Key": "zedagent"`, second with `"Key": "lastresort"`. The first entry will have some error in `LastError` from the connectivity testing.

Without this patch, NIM would unpublish `lastresort` before `DPCManager` would complete testing of the controller-provided config, leaving the device stuck in no-connectivity state permanently. 

## Changelog notes

Move LastResort DPC handling fully into DPCManager

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
