### PR TITLE
Update rust version for pkg/monitor to 1.85.1-1

### DIFF
--- a/pkg/monitor/Dockerfile
+++ b/pkg/monitor/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG MONITOR_RS_VERSION=v0.4.0
-ARG RUST_VERSION=lfedge/eve-rust:1.84.1
+ARG RUST_VERSION=lfedge/eve-rust:1.85.1-1
 FROM --platform=$BUILDPLATFORM ${RUST_VERSION} AS toolchain-base
 ARG TARGETARCH
 


### PR DESCRIPTION
# Description

The rust version in eve-rust:1.84.1 was effectively 1.85.1 but the CI was broken. Move to new tag, nothing special was changed except for CI

## PR Backports

```text
- 14.5-stable: To be backported.
- 13.4-stable: No, as the feature is not available there.
```

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR


- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

