### PR TITLE
[14.5-stable] Tune parameters for quicker failovers

### DIFF
--- a/pkg/kube/config.yaml
+++ b/pkg/kube/config.yaml
@@ -13,5 +13,13 @@ etcd-expose-metrics: true
 container-runtime-endpoint: "/run/containerd-user/containerd.sock"
 disable-network-policy: true
 disable-cloud-controller: true
+kubelet-arg:
+  - "node-status-update-frequency=2s"
+kube-controller-arg:
+  - "node-monitor-period=5s"
+  - "node-monitor-grace-period=40s"
+kube-controller-manager-arg:
+  - "node-monitor-period=5s"
+  - "node-monitor-grace-period=40s"
 kube-apiserver-arg:
   - "event-ttl=72h"

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -30,7 +30,7 @@ const (
 	errorTime            = 3 * time.Minute
 	warningTime          = 40 * time.Second
 	stillRunningInterval = 25 * time.Second
-	logcollectInterval   = 30
+	logcollectInterval   = 10
 	// run VNC file
 	vmiVNCFileName = "/run/zedkube/vmiVNC.run"
 

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -47,7 +47,7 @@ const (
 	eveLabelKey            = "App-Domain-Name"
 	waitForPodCheckCounter = 5  // Check 5 times
 	waitForPodCheckTime    = 15 // Check every 15 seconds, don't wait for too long to cause watchdog
-	tolerateSec            = 30 // Pod/VMI reschedule delay after node unreachable seconds
+	tolerateSec            = 15 // Pod/VMI reschedule delay after node unreachable seconds
 	unknownToHaltMinutes   = 5  // If VMI is unknown for 5 minutes, return halt state
 )
 


### PR DESCRIPTION


Kubernetes node ready (node monitor) timeout is set to 90 secs by default. Reduce it to 40 secs for our env, to get quicker failover of apps.

In kubevirt we reschedule the pod within 15 secs if remote node is unreachable. In zedkube we look reduce the loop to 10 sec wait instead of 30 secs to detect the failover quickly and reschedule the apps.


(cherry picked from commit ab77d22e0c490cb0aadbdd035ac776264e7a493e)

Backport of PR #5062




