### PR TITLE
[14.5-stable] Handle isreplicated flag for the volumes

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -400,7 +400,11 @@ func quantifyChanges(config types.VolumeConfig,
 		needRegeneration = true
 		regenerationReason += str + "\n"
 	}
-	if config.MaxVolSize != status.MaxVolSize {
+
+	// Replicated volumes are special, they are not created on this node
+	// So the config might have size 0 and while generating we calculate the status.MaxVolSize.
+	// they may not match.
+	if config.MaxVolSize != status.MaxVolSize && !config.IsReplicated {
 		str := fmt.Sprintf("MaxVolSize changed from %d to %d for %s",
 			status.MaxVolSize, config.MaxVolSize, config.DisplayName)
 		log.Function(str)

--- a/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
+++ b/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
@@ -128,6 +128,10 @@ func gcVolumes(ctx *volumemgrContext, locations []string) {
 				location, err)
 			continue
 		}
+		// Do not GC a replicated volume.
+		if tempVolumeStatus != nil && tempVolumeStatus.IsReplicated {
+			continue
+		}
 		vs := ctx.LookupVolumeStatus(tempVolumeStatus.Key())
 		if vs == nil {
 			log.Functionf("gcVolumes: Found unused volume %s. Deleting it.",

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -471,8 +471,8 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 
 	log.Functionf("doUpdateVol(%s) name %s", status.Key(), status.DisplayName)
 
-	// Anything to do?
-	if status.State == types.CREATED_VOLUME {
+	// If volume is already created or if is a replicated volume, do nothing.
+	if status.State == types.CREATED_VOLUME || status.IsReplicated {
 		log.Functionf("doUpdateVol(%s) name %s nothing to do",
 			status.Key(), status.DisplayName)
 		return false, true

--- a/pkg/pillar/cmd/zedagent/handlevolume.go
+++ b/pkg/pillar/cmd/zedagent/handlevolume.go
@@ -123,6 +123,8 @@ func parseVolumeConfig(ctx *getconfigContext,
 				for _, vr := range ai.VolumeRefList {
 					if vr.Uuid == volumeConfig.VolumeID.String() && volumeConfig.ContentID != uuid.Nil {
 						volumeConfig.IsNativeContainer = true
+						// Native containers are downloaded to every node, so set isreplciated to false
+						volumeConfig.IsReplicated = false
 						log.Noticef("parseVolumeConfig: setting IsNativeContainer for %s", volumeConfig.VolumeID.String())
 						break
 					}

--- a/pkg/pillar/kubeapi/kubeapi.go
+++ b/pkg/pillar/kubeapi/kubeapi.go
@@ -310,10 +310,11 @@ func waitForNodeReady(client *kubernetes.Clientset, readyCh chan bool, devUUID s
 	}
 }
 
-func waitForPVCReady(ctx context.Context, log *base.LogObject, pvcName string) error {
+// WaitForPVCReady : Loop until PVC is ready for timeout
+func WaitForPVCReady(pvcName string, log *base.LogObject) error {
 	clientset, err := GetClientSet()
 	if err != nil {
-		log.Errorf("waitForPVCReady failed to get clientset err %v", err)
+		log.Errorf("WaitForPVCReady failed to get clientset err %v", err)
 		return err
 	}
 
@@ -333,7 +334,7 @@ func waitForPVCReady(ctx context.Context, log *base.LogObject, pvcName string) e
 				pvcObjName := pvc.ObjectMeta.Name
 				if strings.Contains(pvcObjName, pvcName) {
 					count++
-					log.Noticef("waitForPVCReady(%d): get pvc %s", count, pvcObjName)
+					log.Noticef("WaitForPVCReady(%d): get pvc %s", count, pvcObjName)
 				}
 			}
 			if count == 1 {
@@ -347,7 +348,7 @@ func waitForPVCReady(ctx context.Context, log *base.LogObject, pvcName string) e
 		time.Sleep(5 * time.Second)
 	}
 
-	return fmt.Errorf("waitForPVCReady: time expired count %d, err %v", count, err2)
+	return fmt.Errorf("WaitForPVCReady: time expired count %d, err %v", count, err2)
 }
 
 // CleanupStaleVMI : delete all VMIs. Used by domainmgr on startup.


### PR DESCRIPTION
A volume in an edge cluster has a designated owner either its created through an app or explicitly. We distinguish those using the flag isreplicated.
isreplicated = false  (owner node of the voulme)
isreplicated = true (volume is getting replicated to this node)

1) Do not delete the PVC if is a replicated volume. 2) Do not do volume GC if it is a replicated volume. 3) Ignore volume process in doUpdateVol() if it is replicated volume. 4) CreateVolume() for replicated volumes will just wait for PVC to be created by owner node.

We defined the isreplicated flag in previous commits, but missed the merges of handling it. This commit brings in the code to handle the isreplicated flag from POC branch.


(cherry picked from commit 006cb3b5fad18d33d25bbcb3e5e6417285f1cae6)

Backport of PR#5032