### PR TITLE
[14.5-stable] Handle error IsAlreadyExists

### DIFF
--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -542,12 +542,18 @@ func (ctx kubevirtContext) Start(domainName string) error {
 	for {
 		_, err = virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).Create(repvmi)
 		if err != nil {
+			if errors.IsAlreadyExists(err) {
+				// VMI could have been already started, for example failover from other node.
+				// Its not an error, just proceed.
+				logrus.Warnf("VMI replicaset %v already exists", repvmi)
+				break
+			}
 			if strings.Contains(err.Error(), "dial tcp 127.0.0.1:6443") && i <= 0 {
-				logrus.Infof("Start VMI replicaset failed %v\n", err)
+				logrus.Errorf("Start VMI replicaset failed %v\n", err)
 				return err
 			}
 			time.Sleep(10 * time.Second)
-			logrus.Infof("Start VMI replicaset failed, retry (%d) err %v", i, err)
+			logrus.Errorf("Start VMI replicaset failed, retry (%d) err %v", i, err)
 		} else {
 			break
 		}


### PR DESCRIPTION
During a failover scenario, kubernetes starts the VMI on the other node, because we just use kubernetes scheduling mechanism. Then we tell eve domainmgr to process the VMI start and publish the DomainStatus. So when domainmgr calls the Start() we need to handle the already exists error and return gracefully. Without this fix after failover domainmgr code goes into forever loop.

This code is present in POC branch, we missed in merges.


(cherry picked from commit 1787b2ee7eeda9e934b4f547942e65d8fa0b8d81)

Backport of PR #5031