### PR TITLE
[14.5-stable] Cleanup replica sets

### DIFF
--- a/pkg/pillar/kubeapi/nokube.go
+++ b/pkg/pillar/kubeapi/nokube.go
@@ -19,9 +19,9 @@ func WaitForKubernetes(string, *pubsub.PubSub, *time.Ticker,
 	panic("WaitForKubernetes is not built")
 }
 
-// CleanupStaleVMI in this file is just stub for non-kubevirt hypervisors.
-func CleanupStaleVMI() (int, error) {
-	panic("CleanupStaleVMI is not built")
+// CleanupStaleVMIRs in this file is just stub for non-kubevirt hypervisors.
+func CleanupStaleVMIRs() (int, error) {
+	panic("CleanupStaleVMIRs is not built")
 }
 
 // GetPVCList in this file is just stub for non-kubevirt hypervisors.
@@ -39,4 +39,9 @@ func RequestNodeDrain(pubsub.Publication, DrainRequester, string) error {
 func GetNodeDrainStatus(pubsub.Subscription, *base.LogObject) *NodeDrainStatus {
 	// No need to query for inprogress operations, just a noop
 	return &NodeDrainStatus{Status: NOTSUPPORTED}
+}
+
+// IsClusterMode  is a stub for non-kubevirt builds
+func IsClusterMode() bool {
+	return false
 }

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -141,6 +141,8 @@ const (
 	OVMFSettingsTemplate = "/usr/lib/xen/boot/OVMF_VARS.fd"
 	// CustomOVMFSettingsDir - directory for custom OVMF settings (for different resolutions)
 	CustomOVMFSettingsDir = "/hostfs/etc/ovmf"
+	// EdgeNodeClusterConfigFile - the file which contains edgenodecluster config
+	EdgeNodeClusterConfigFile = PersistStatusDir + "/zedagent/EdgeNodeClusterConfig/global.json"
 )
 
 var (


### PR DESCRIPTION
This commit fixes a serious bug in cluster configuration. Basically whenever domainmgr restarts there was a legacy code which deletes all VMs running. That was implemented to handle a corner case where apps were deleted when device is powered off. We want to delete any app config in kubernetes as soon as device reboots. Assumption is device will resync config with the controller.

That works fine for single node cases. In a cluster setup, apps would have moved to other nodes when this device went to reboot. Because of this bug as soon as this device reboots its deleting VMs running on other nodes, basically bouncing all VMs.

Added a new API to check if this device is in cluster mode and ignore delete of VMs.

Also, we no longer directly deal with VMs, its all VM replica sets now. So moved CleanupVMs to CleanupVMRs.

Move the const to types/locationconstants.go
Change the logging to Debugf

Signed-off-by: Pramodh Pallapothu <pramodh@zededa.com>
(cherry picked from commit 43d4287b194dc01c2bb4f8d4fba7da0f071af070)

Backport of PR #5060

