### PR TITLE
[14.5-stable] Move LastResort DPC handling fully into DPCManager

### DIFF
--- a/pkg/pillar/dpcmanager/dpc.go
+++ b/pkg/pillar/dpcmanager/dpc.go
@@ -402,6 +402,9 @@ func (m *DpcManager) compressDPCL() {
 						dpc.ShaFile, dpc.PubKey())
 				}
 			}
+			if dpc.Key == LastResortKey {
+				m.lastResort = nil
+			}
 			if i <= m.dpcList.CurrentIndex {
 				newCurrentIndex--
 			}

--- a/pkg/pillar/dpcmanager/lastresort.go
+++ b/pkg/pillar/dpcmanager/lastresort.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package dpcmanager
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/netmonitor"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func (m *DpcManager) makeLastResortDPC() (types.DevicePortConfig, error) {
+	config := types.DevicePortConfig{}
+	config.Key = LastResortKey
+	config.Version = types.DPCIsMgmt
+	// Set to the lowest priority possible.
+	config.TimePriority = time.Unix(0, 0)
+	ifNames, err := m.NetworkMonitor.ListInterfaces()
+	if err != nil {
+		err = fmt.Errorf("makeLastResortDPC: Failed to list interfaces: %v", err)
+		return config, err
+	}
+	for _, ifName := range ifNames {
+		ifIndex, _, err := m.NetworkMonitor.GetInterfaceIndex(ifName)
+		if err != nil {
+			m.Log.Errorf("makeLastResortDPC: failed to get interface index: %v", err)
+			continue
+		}
+		ifAttrs, err := m.NetworkMonitor.GetInterfaceAttrs(ifIndex)
+		if err != nil {
+			m.Log.Errorf("makeLastResortDPC: failed to get interface attrs: %v", err)
+			continue
+		}
+		if !m.includeLastResortPort(ifAttrs) {
+			continue
+		}
+		port := types.NetworkPortConfig{
+			IfName:       ifName,
+			Phylabel:     ifName,
+			Logicallabel: ifName,
+			IsMgmt:       true,
+			IsL3Port:     true,
+			DhcpConfig: types.DhcpConfig{
+				Dhcp: types.DhcpTypeClient,
+				Type: types.NetworkTypeIPv4, // Dual-stack, IPv4 preferred
+			},
+		}
+		config.Ports = append(config.Ports, port)
+	}
+	config.DoSanitize(m.Log, types.DPCSanitizeArgs{
+		SanitizeSharedLabels: true,
+	})
+	return config, nil
+}
+
+func (m *DpcManager) includeLastResortPort(ifAttrs netmonitor.IfAttrs) bool {
+	ifName := ifAttrs.IfName
+	exclude := strings.HasPrefix(ifName, "vif") ||
+		strings.HasPrefix(ifName, "nbu") ||
+		strings.HasPrefix(ifName, "nbo") ||
+		strings.HasPrefix(ifName, "wlan") ||
+		strings.HasPrefix(ifName, "wwan") ||
+		strings.HasPrefix(ifName, "keth")
+	if exclude {
+		return false
+	}
+	if m.isInterfaceAssigned(ifName) {
+		return false
+	}
+	if ifAttrs.IsLoopback || !ifAttrs.WithBroadcast || ifAttrs.Enslaved {
+		return false
+	}
+
+	switch ifAttrs.IfType {
+	case "device":
+		return true
+	case "bridge":
+		// Was this originally an ethernet interface turned into a bridge?
+		_, exists, _ := m.NetworkMonitor.GetInterfaceIndex("k" + ifName)
+		return exists
+	case "can", "vcan":
+		return false
+	}
+
+	return false
+}
+
+func (m *DpcManager) isInterfaceAssigned(ifName string) bool {
+	ib := m.adapters.LookupIoBundleIfName(ifName)
+	if ib == nil {
+		return false
+	}
+	if ib.UsedByUUID != nilUUID {
+		return true
+	}
+	return false
+}
+
+func (m *DpcManager) updateLastResortOnIntfChange(
+	ctx context.Context, ifChange netmonitor.IfChange) {
+	if m.lastResort == nil {
+		return
+	}
+	includePort := m.includeLastResortPort(ifChange.Attrs)
+	port := m.lastResort.LookupPortByIfName(ifChange.Attrs.IfName)
+	if port == nil && includePort {
+		m.addOrUpdateLastResortDPC(ctx, fmt.Sprintf("interface %s should be included",
+			ifChange.Attrs.IfName))
+	}
+}
+
+func (m *DpcManager) addOrUpdateLastResortDPC(ctx context.Context, reason string) {
+	dpc, err := m.makeLastResortDPC()
+	if err != nil {
+		m.Log.Error(err)
+		return
+	}
+	if m.lastResort != nil && m.lastResort.MostlyEqual(&dpc) {
+		return
+	}
+	m.Log.Noticef("Adding/updating last-resort DPC, reason: %v", reason)
+	m.lastResort = &dpc
+	m.doAddDPC(ctx, dpc)
+}

--- a/pkg/pillar/netmonitor/mock.go
+++ b/pkg/pillar/netmonitor/mock.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"slices"
 	"sync"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
@@ -173,6 +174,8 @@ func (m *MockNetworkMonitor) ListInterfaces() (ifNames []string, err error) {
 	for _, mockIf := range m.interfaces {
 		ifNames = append(ifNames, mockIf.Attrs.IfName)
 	}
+	// Sort to make output deterministic and easier to work with in unit tests.
+	slices.Sort(ifNames)
 	return ifNames, nil
 }
 


### PR DESCRIPTION
# Description

Previously, handling of the LastResort DPC was split between `cmd/nim` and `DPCManager`. The `cmd/nim` part was somewhat obscure — it would publish the LastResort DPC via pubsub and then consume that same publication via its own subscription, effectively (un)publishing the config to itself. The subscribed handler would then pass the DPC (or a removal request) to `DPCManager`.

Meanwhile, `DPCManager` is responsible for testing and persisting DPCs, and already has logic to prune the LastResort DPC during DPCL compression when it is no longer needed. Because it manages connectivity testing and fallback logic, it has the full context required to decide when the LastResort DPC should be retained or removed.

Having both `cmd/nim` and `DPCManager` independently decide on the lifecycle of LastResort led to inconsistencies. For example, NIM might re-publish the LastResort DPC even after `DPCManager` had already pruned it, unintentionally reintroducing it into the DPCL. Worse, **_NIM might prematurely unpublish LastResort while it is still needed_** — for instance, if the device bootstrapped with LastResort, established controller connectivity, but the controller-provided config then broke networking, the device could get stuck offline with no fallback.

To avoid such issues and simplify the design, this change moves all LastResort DPC handling into DPCManager. Since the DPC is internally generated and doesn’t come from an external source, pubsub is unnecessary for its management.

Backport of PR https://github.com/lf-edge/eve/pull/5036

## How to test and validate this PR

First of all, perform regular regression testing concerning lastresort DPC:
- check that device with no network config but connected to ethernet network with DHCP will successfully connect to controller and onboard
- check that when `network.fallback.any.eth` is enabled (disabled by default), lastresort will be retained by the device even when there is good network config received from the controller (check content of `/persist/status/nim/DevicePortConfigList/global.json` and look for `"Key": "lastresort"` in `PortConfigList`)
- check that when `network.fallback.any.eth` is disabled (default value), device will use lastresort only temporarily when absolutely necessary. For example, if device was provided with good working network config from the controller, lastresort should not be present in the persisted DPCL ( `/persist/status/nim/DevicePortConfigList/global.json`)

Additionally, focus testing on the main issue that this PR is addressing -- premature unpublish of LastResort:
1. Install EVE on a device connected to a network with DHCP
2. Keep default value for `network.fallback.any.eth`, i.e. disabled
3. Prepare bad network config on the controller side. For example, configure static IP that does not match the subnet address of the physical network where the device is connected to.
4. Turn the device on and wait for it to connect to the controller (using lastresort) and get onboarded
5. Wait few minutes and then check that device is still reporting to the controller, despite controller-provided config not being correct
6. Check on the device side that EVE tried the controller-provided config but returned to lastresort. Check `/persist/status/nim/DevicePortConfigList/global.json` -- `CurrentIndex` should be `1` and `PortConfigList` should contain 2 entries, first with `"Key": "zedagent"`, second with `"Key": "lastresort"`. The first entry will have some error in `LastError` from the connectivity testing.

Without this patch, NIM would unpublish `lastresort` before `DPCManager` would complete testing of the controller-provided config, leaving the device stuck in no-connectivity state permanently. 

## Changelog notes

Move LastResort DPC handling fully into DPCManager

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
