### PR TITLE
Fix compare_sbom_collected_sources for evaluation platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -846,9 +846,9 @@ $(COMPARESOURCES):
 	@echo Done building packages
 	$(QUIET): $@: Succeeded
 
-compare_sbom_collected_sources: $(COLLECTED_SOURCES) $(SBOM) | $(COMPARESOURCES)
+compare_sbom_collected_sources: $(SBOM) $(COLLECTED_SOURCES) $(COMPARESOURCES)
 	$(QUIET): $@: Begin
-	$(COMPARESOURCES) $(COLLECTED_SOURCES):./collected_sources_manifest.csv $(SBOM)
+	$(COMPARESOURCES) $(COLLECTED_SOURCES):./collected_sources_manifest.csv $<
 	@echo Done comparing the sbom and collected sources manifest file
 	$(QUIET): $@: Succeeded
 


### PR DESCRIPTION
# Description

- reorder dependencies for compare_sbom_collected_sources so we can use `$<` to point to the first file from `$(SBOM)` which is -generic

## How to test and validate this PR

- CI must pass

## PR Backports

```text
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
