### PR TITLE
Follow up PR for PR#5111

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ ROOTFS_TAR_EVAL_LTS=$(ROOTFS_TAR_BASE)-evaluation-lts.tar
 
 # for evaluation platform we generate 3 rootfs tarballs:
 ROOTFS_TARS= $(if $(findstring evaluation,$(PLATFORM)), \
-	$(ROOTFS_TAR_EVAL_HWE) $(ROOTFS_TAR_EVAL_LTS) $(ROOTFS_TAR_BASE)-evaluation-generic.tar, \
+	$(ROOTFS_TAR_BASE)-evaluation-generic.tar $(ROOTFS_TAR_EVAL_HWE) $(ROOTFS_TAR_EVAL_LTS), \
 	$(ROOTFS_TAR_BASE)-$(PLATFORM).tar)
 
 CONFIG_IMG=$(INSTALLER)/config.img


### PR DESCRIPTION
# Description

PR https://github.com/lf-edge/eve/pull/5111 fixes incorrect source for compare_sbom_collected_sources but the order of TAR files in  `$(ROOTFS_TARS)` also matters because we use `$<` to refer to the first prerequisite. -hwe-* file was taken for 'evaluation' platform

## PR dependencies

Must be backported together with #5111 if it is ever required

## How to test and validate this PR

tools/collect-sources.sh must be called with eve/dist/amd64/0.0.0-master-e9041b52-evaluation/rootfs-evaluation-**generic**.tar not rootfs-evaluation-**hwe**.tar asa parameter

## PR Backports

```text
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
