### PR TITLE
eve: Fix kubevirt platform name

### DIFF
--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -267,7 +267,7 @@ prepare_for_hv() {
     case "$hv" in
     kvm|xen|acrn)
         ;;
-    kubervir)
+    kubevirt)
         # Override image sizes with the max of the two values
         if [ "$DEFAULT_KUBEVIRT_IMG_SIZE" -gt "$DEFAULT_INSTALLER_IMG_SIZE" ]; then
             DEFAULT_INSTALLER_IMG_SIZE="$DEFAULT_KUBEVIRT_IMG_SIZE"


### PR DESCRIPTION
# Description

Fix a typo in the kubevirt platform name in the runme.sh script.

## How to test and validate this PR

1. Build kubevirt eve image and export it to docker
2. Run eve container to generate installer_raw image

The following commands can be used:

```sh
make HV=kubevirt eve eve-cache-export-docker-load
```

The image name+hash will be output at the end of the building process:

```
072b1a2861fa: Loading layer [==================================================>]  9.778MB/9.778MB
895420b979d8: Loading layer [==================================================>]  1.033GB/1.033GB
b12aa5c8292b: Loading layer [==================================================>]  3.902kB/3.902kB
2d100264d351: Loading layer [==================================================>]     108B/108B
5f70bf18a086: Loading layer [==================================================>]      32B/32B
Loaded image: lfedge/eve:0.0.0-fix-kubevirt-asset-109274a3-kubevirt-amd64
Tagging docker.io/lfedge/eve:0.0.0-fix-kubevirt-asset-109274a3-kubevirt-amd64 as docker.io/lfedge/eve:0.0.0-fix-kubevirt-asset-109274a3-kubevirt
Build complete, not pushing, all done.
Missing image docker.io/lfedge/eve:9e8ac87442a3436576bf58665b16c679927ead05 in cache
```

Run the eve container to generate the installer image (using the output image name):

```
docker run --rm docker.io/lfedge/eve:0.0.0-fix-kubevirt-asset-109274a3-kubevirt-amd64 installer_raw > hv.r
```

Everything should work flawlessly.

## Changelog notes

Fix kubevirt platform name when running eve container to generate installer images.

## PR Backports

No since it's only available on master.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.