### PR TITLE
Fix spelling in runme.sh

### DIFF
--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -267,7 +267,7 @@ prepare_for_hv() {
     case "$hv" in
     kvm|xen|acrn)
         ;;
-    kubervir)
+    kubevirt)
         # Override image sizes with the max of the two values
         if [ "$DEFAULT_KUBEVIRT_IMG_SIZE" -gt "$DEFAULT_INSTALLER_IMG_SIZE" ]; then
             DEFAULT_INSTALLER_IMG_SIZE="$DEFAULT_KUBEVIRT_IMG_SIZE"


### PR DESCRIPTION
# Description

kubevir -> kubevirt

## PR dependencies

None

## How to test and validate this PR

```
docker run "lfedge/eve:<kubevirt eve>" installer_raw > assets/installer.raw
```

## Changelog notes

None

## PR Backports

- 14.5-stable: No?
- 13.4-stable: No?

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
