### PR TITLE
.github: Update Eden to 1.0.7

### DIFF
--- a/.github/workflows/eden-trusted.yml
+++ b/.github/workflows/eden-trusted.yml
@@ -190,14 +190,14 @@ jobs:
     name: ${{ needs.context.outputs.eden_parent_job_title }}
     needs: context
     if: needs.context.outputs.skip_run == 'false'
-    uses: lf-edge/eden/.github/workflows/test.yml@1.0.6
+    uses: lf-edge/eden/.github/workflows/test.yml@1.0.7
     secrets: inherit
     with:
       eve_image: "evebuild/pr:${{ needs.context.outputs.pr_id }}"
       eve_log_level: "debug"
       eve_artifact_name: "eve-${{ needs.context.outputs.hv }}-${{ needs.context.outputs.arch }}-${{ needs.context.outputs.platform }}"
       artifact_run_id: ${{ needs.context.outputs.original_run_id }}
-      eden_version: "1.0.6"
+      eden_version: "1.0.7"
 
   finalize:
     if: always() && needs.context.outputs.skip_run == 'false'


### PR DESCRIPTION
# Description

A full change is here: https://github.com/lf-edge/eden/compare/1.0.6...1.0.7
To be short: it prints public IPs of the runners, updates Eden restart approach, and add some fixes into eden-sdn.

## PR dependencies

None.

## How to test and validate this PR

Internal change, not for external manual testing. 

## Changelog notes

No user-facing changes.

## PR Backports

- 14.5-stable: No, as the WF runs always from master
- 13.4-stable: No, as the WF runs always from master


## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

