### PR TITLE
github/workflows: Switch to arm64 runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [zededa-ubuntu-latest, zededa-ubuntu-2204]
+        os: [zededa-ubuntu-2204, zededa-ubuntu-2204-arm64]
         arch: [arm64, amd64]
         platform: [generic, nvidia-jp5, nvidia-jp6, evaluation]
         include:
@@ -28,7 +28,7 @@ jobs:
             arch: riscv64
             platform: generic
         exclude:
-          - os: zededa-ubuntu-latest
+          - os: zededa-ubuntu-2204-arm64
             arch: amd64
           - os: zededa-ubuntu-2204
             arch: arm64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -128,13 +128,13 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - os: zededa-ubuntu-2204
+          - os: zededa-ubuntu-2204-arm64
             arch: arm64
             platform: "generic"
-          - os: zededa-ubuntu-2204
+          - os: zededa-ubuntu-2204-arm64
             arch: arm64
             platform: "nvidia-jp5"
-          - os: zededa-ubuntu-2204
+          - os: zededa-ubuntu-2204-arm64
             arch: arm64
             platform: "nvidia-jp6"
     steps:


### PR DESCRIPTION
# Description

We have now 4 arm64 self-hosted runners available. Switch some workflows to make use of them and speed up arm64 builds.

## How to test and validate this PR

Run GitHub workflows.

## Changelog notes

None.

## PR Backports

- [ ] 14.5-stable
- [ ] 13.4-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.