### PR TITLE
github/workflows: Build eve (arm64) image on arm64 runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+# Copyright (c) 2025, Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
 ---
 name: PR build
 on:  # yamllint disable-line rule:truthy
@@ -97,30 +99,40 @@ jobs:
 
   eve:
     needs: packages  # all packages for all platforms must be built first
-    runs-on: zededa-ubuntu-2204
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [zededa-ubuntu-2204, zededa-ubuntu-2204-arm64]
         arch: [arm64, amd64]
         hv: [xen, kvm, kubevirt]
         platform: ["generic"]
         include:
           - arch: riscv64
+            os: zededa-ubuntu-2204
             hv: mini
             platform: "generic"
           - arch: amd64
+            os: zededa-ubuntu-2204
             hv: kvm
             platform: "rt"
           - arch: arm64
+            os: zededa-ubuntu-2204-arm64
             hv: kvm
             platform: "nvidia-jp5"
           - arch: arm64
+            os: zededa-ubuntu-2204-arm64
             hv: kvm
             platform: "nvidia-jp6"
           - arch: amd64
+            os: zededa-ubuntu-2204
             hv: kvm
             platform: "evaluation"
         exclude:
+          - arch: arm64
+            os: zededa-ubuntu-2204
+          - arch: amd64
+            os: zededa-ubuntu-2204-arm64
           - arch: arm64
             hv: kubevirt
             platform: "generic"


### PR DESCRIPTION
# Description

In the build workflow the linuxkit cache is exported from build stage to build eve image stage. However, when building in a host different from the target architecture, some packages (such as cross-compilers) will be built for both architectures, which can lead to a lot of building time. In order to avoid this situation this commit switches eve image arm64 builds to arm64 runners as well.

## How to test and validate this PR

Run GitHub build workflow.

Tested on my repo: https://github.com/rene/eve/actions/runs/16522709403/job/46728584491

## Changelog notes

None.

## PR Backports

- [ ] 14.5-stable
- [ ] 13.4-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.