### PR TITLE
.github: Remove strict error handling to allow rerun without Eden Runner

### DIFF
--- a/.github/workflows/rerun-ci.yml
+++ b/.github/workflows/rerun-ci.yml
@@ -71,8 +71,6 @@ jobs:
           REPO: ${{ github.repository }}
           MODE: ${{ steps.mode.outputs.mode }}
         run: |
-          set -euo pipefail
-
           # Get all runs for the branch (could be for old commits, so we'll filter below)
           RUNS=$(gh run list --repo "$REPO" --branch "$BRANCH" --json databaseId,status,conclusion,headSha,workflowName,displayTitle,event)
 


### PR DESCRIPTION
# Description

Previously, rerun-ci used `set -euo pipefail`, which caused the job to exit early if any command failed. This made the rerun logic fragile in cases where no Eden Runner status existed for the commit, or if GitHub CLI commands returned partial data.

Removing this strict mode allows the workflow to proceed gracefully even when some optional components like Eden Runner are missing.

## PR dependencies

None.

## How to test and validate this PR

CI/CD change, not to be externally verified.

## Changelog notes

No user-facing changes.

- 14.5-stable: no, as the WF always runs from master.
- 13.4-stable: no, as the WF always runs from master.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
