### PR TITLE
Simplify "Build PR" workflow by removing matrix.os.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,28 +18,19 @@ concurrency:
 
 jobs:
   packages:
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [zededa-ubuntu-2204, zededa-ubuntu-2204-arm64]
-        arch: [arm64, amd64]
-        platform: [generic, nvidia-jp5, nvidia-jp6, evaluation]
+        arch: [ arm64, amd64, riscv64 ]
+        platform: [ generic ]
         include:
-          - os: zededa-ubuntu-2204
-            arch: riscv64
-            platform: generic
-        exclude:
-          - os: zededa-ubuntu-2204-arm64
-            arch: amd64
-          - os: zededa-ubuntu-2204
-            arch: arm64
-          - arch: amd64
-            platform: nvidia-jp5
-          - arch: amd64
-            platform: nvidia-jp6
           - arch: arm64
+            platform: nvidia-jp5
+          - arch: arm64
+            platform: nvidia-jp6
+          - arch: amd64
             platform: evaluation
+    runs-on: ${{ matrix.arch == 'arm64' && 'zededa-ubuntu-2204-arm64' || 'zededa-ubuntu-2204' }}
 
     steps:
       - name: Starting Report
@@ -99,43 +90,32 @@ jobs:
 
   eve:
     needs: packages  # all packages for all platforms must be built first
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [zededa-ubuntu-2204, zededa-ubuntu-2204-arm64]
         arch: [arm64, amd64]
-        hv: [xen, kvm, kubevirt]
-        platform: ["generic"]
+        hv: [xen, kvm]
+        platform: [generic]
         include:
           - arch: riscv64
-            os: zededa-ubuntu-2204
             hv: mini
-            platform: "generic"
+            platform: generic
           - arch: amd64
-            os: zededa-ubuntu-2204
             hv: kvm
-            platform: "rt"
+            platform: rt
           - arch: arm64
-            os: zededa-ubuntu-2204-arm64
             hv: kvm
-            platform: "nvidia-jp5"
+            platform: nvidia-jp5
           - arch: arm64
-            os: zededa-ubuntu-2204-arm64
             hv: kvm
-            platform: "nvidia-jp6"
+            platform: nvidia-jp6
           - arch: amd64
-            os: zededa-ubuntu-2204
             hv: kvm
-            platform: "evaluation"
-        exclude:
-          - arch: arm64
-            os: zededa-ubuntu-2204
+            platform: evaluation
           - arch: amd64
-            os: zededa-ubuntu-2204-arm64
-          - arch: arm64
             hv: kubevirt
-            platform: "generic"
+            platform: generic
+    runs-on: ${{ matrix.arch == 'arm64' && 'zededa-ubuntu-2204-arm64' || 'zededa-ubuntu-2204' }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Eliminate use of `matrix.os` in the `Build PR` workflow to align with the expected build job naming convention. This prevents conflicts with the `PR Gate` workflow, which expects job names in the `arch-hv-platform` format and not influenced by OS. It was originally brought by 4b05c9883428b10ede3a26a3b0c7d3f86eaeeebc

The runner selection is now handled with a conditional expression based on the architecture, removing the need for matrix-level OS logic. This also simplifies the include/exclude logic in both packages and eve jobs.


## PR dependencies

None.

## How to test and validate this PR

Not to be tested externally. Verification is done in Renes repo: https://github.com/rene/eve/actions/runs/16567119570/

## Changelog notes

No user-facing changes.

## PR Backports

- 14.5-stable: to be backported, the commit that brought the problem was already backported there. 
- 13.4-stable: no, as the original commit was not yet backported to the branch.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

