### PR TITLE
Get-deps for *-cache-export-docker-load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -807,7 +807,7 @@ ifeq ($(ROOTFS_FORMAT),squash)
 endif
 	$(QUIET): $@: Succeeded
 
-$(GET_DEPS):
+$(GET_DEPS): tools/get-deps/*.go
 	$(MAKE) -C $(GET_DEPS_DIR) GOOS=$(LOCAL_GOOS)
 
 sbom_info:

--- a/Makefile
+++ b/Makefile
@@ -960,7 +960,7 @@ cache-export-docker-load: $(LINUXKIT)
 	$(MAKE) cache-export OUTFILE=${TARFILE} && cat ${TARFILE} | docker load
 	rm -rf ${TARFILE}
 
-%-cache-export-docker-load: $(LINUXKIT)
+%-cache-export-docker-load: $(LINUXKIT) pkg/%
 	$(eval IMAGE_TAG := $(shell $(LINUXKIT) pkg $(LINUXKIT_ORG_TARGET) show-tag --canonical pkg/$*))
 	$(eval CACHE_CONTENT := $(shell $(LINUXKIT) cache ls 2>&1))
 	$(if $(filter $(IMAGE_TAG),$(CACHE_CONTENT)),$(MAKE) cache-export-docker-load IMAGE=$(IMAGE_TAG),@echo "Missing image $(IMAGE_TAG) in cache")

--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -81,10 +81,7 @@ build-docker-git:
 	git archive HEAD | docker build $(DOCKER_ARGS) -t $(DOCKER_TAG) -
 
 build-docker-test:
-	$(MAKE) -C ../../ pkg/alpine pkg/dom0-ztools pkg/recovertpm
-	make -C ../.. alpine-cache-export-docker-load
-	make -C ../.. dom0-ztools-cache-export-docker-load
-	make -C ../.. recovertpm-cache-export-docker-load
+	make -C ../../ pillar-cache-export-docker-load
 	docker build $(DOCKER_ARGS) --build-arg TEST_TOOLS=y -t $(DOCKER_TAG) . --target build
 
 test: build-docker-test

--- a/tools/get-deps/go.mod
+++ b/tools/get-deps/go.mod
@@ -3,18 +3,17 @@ module get-deps
 go 1.21
 
 require (
-	github.com/containerd/containerd v1.7.27
+	github.com/containerd/platforms v0.2.1
 	github.com/linuxkit/linuxkit/src/cmd/linuxkit v0.0.0-20240611152911-4f89f4f67e39
 	github.com/moby/buildkit v0.14.1
 	github.com/opencontainers/image-spec v1.1.0
 )
 
 require (
-	github.com/Microsoft/hcsshim v0.11.7 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/containerd/containerd v1.7.27 // indirect
 	github.com/containerd/errdefs v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
-	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.15.1 // indirect
 	github.com/containerd/typeurl/v2 v2.1.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect

--- a/tools/get-deps/go.sum
+++ b/tools/get-deps/go.sum
@@ -1,5 +1,3 @@
-github.com/Microsoft/hcsshim v0.11.7 h1:vl/nj3Bar/CvJSYo7gIQPyRWc9f3c6IeSNavBTSZNZQ=
-github.com/Microsoft/hcsshim v0.11.7/go.mod h1:MV8xMfmECjl5HdO7U/3/hFVnkmSBjAjmA09d4bExKcU=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/containerd/containerd v1.7.27 h1:yFyEyojddO3MIGVER2xJLWoCIn+Up4GaHFquP7hsFII=

--- a/tools/get-deps/main.go
+++ b/tools/get-deps/main.go
@@ -345,6 +345,9 @@ func main() {
 			if d != pkgName {
 				// Write a single dependency of the package
 				writeToFile(outfile, p.printDep(pkgName, d))
+				exportPkgName := fmt.Sprintf("%s-cache-export-docker-load", pkgName[4:])
+				exportD := fmt.Sprintf("%s-cache-export-docker-load", d[4:])
+				writeToFile(outfile, p.printDep(exportPkgName, exportD))
 			}
 		}
 	}

--- a/tools/get-deps/main.go
+++ b/tools/get-deps/main.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/platforms"
 	"github.com/linuxkit/linuxkit/src/cmd/linuxkit/moby"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"


### PR DESCRIPTION
# Description

add docker export cache dependencies
    
f.e. if you now do `make fscrypt-cache-export-docker-load`
it will first run the following dependencies:
```
fscrypt-cache-export-docker-load: pkg/fscrypt
fscrypt-cache-export-docker-load: alpine-cache-export-docker-load
```
    
This will allow to specify the dependencies automatically in https://github.com/lf-edge/eve/blob/master/pkg/pillar/Makefile#L83

## How to test and validate this PR

`rm pkg-deps.mk ; rm tools/get-deps/get-deps ; make help; cat pkg-deps.mk`

or 

`./tools/get-deps/get-deps -i foo.png && xdg-open foo.png`

## Changelog notes

not user-visible

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 14.5-stable: no
- 13.4-stable: no



## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
