### PR TITLE
Return isLowerUp directly from the link attributes lower up

### DIFF
--- a/pkg/pillar/netmonitor/linux.go
+++ b/pkg/pillar/netmonitor/linux.go
@@ -151,18 +151,6 @@ func (m *LinuxNetworkMonitor) getInterfaceAttrs(ifIndex int) (attrs IfAttrs, err
 }
 
 func (m *LinuxNetworkMonitor) ifAttrsFromLink(link netlink.Link) IfAttrs {
-	var lowerUP bool
-	switch link.Attrs().OperState {
-	case netlink.OperUnknown:
-		// It is common for cellular modems that the operating state is not reported,
-		// whereas lower-layer IFF_* flags are available and can be used to determine
-		// link status.
-		lowerUP = link.Attrs().RawFlags&unix.IFF_LOWER_UP != 0
-	case netlink.OperUp:
-		lowerUP = true
-	default:
-		lowerUP = false
-	}
 	return IfAttrs{
 		IfIndex:       link.Attrs().Index,
 		IfName:        link.Attrs().Name,
@@ -170,7 +158,7 @@ func (m *LinuxNetworkMonitor) ifAttrsFromLink(link netlink.Link) IfAttrs {
 		IsLoopback:    (link.Attrs().Flags & net.FlagLoopback) != 0,
 		WithBroadcast: (link.Attrs().Flags & net.FlagBroadcast) != 0,
 		AdminUp:       (link.Attrs().Flags & net.FlagUp) != 0,
-		LowerUp:       lowerUP,
+		LowerUp:       link.Attrs().RawFlags&unix.IFF_LOWER_UP != 0,
 		Enslaved:      link.Attrs().MasterIndex != 0,
 		MasterIfIndex: link.Attrs().MasterIndex,
 		MTU:           uint16(link.Attrs().MTU),


### PR DESCRIPTION
The boolean lowerUp should reflect the interface lower up status, so we should not check the management status but the link attribute lower up .

# Description

The boolean lowerUp should reflect the interface lower up status, so we should not check the management status but the link attribute lower up . The lower up state represents the operational state of the interface. For more information visit https://www.kernel.org/doc/Documentation/networking/operstates.txt

## How to test and validate this PR

Run eve on a device with multiple network interfaces, when you unplug the eth cable from the device, the metadata interface endpoint should state the network device as down.
## Changelog notes
The LowerUp field in metadata endpoint now represents the operational state of the interface. In order to be true the interface should be up and also a carrier should be detected by the driver.
## PR Backports
- 14.5-stable: To be backported
- 13.4-stable: To be backported

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
