### PR TITLE
[14.5-Stable] Return isLowerUp directly from the link attributes lower up

### DIFF
--- a/pkg/pillar/netmonitor/linux.go
+++ b/pkg/pillar/netmonitor/linux.go
@@ -151,18 +151,6 @@ func (m *LinuxNetworkMonitor) getInterfaceAttrs(ifIndex int) (attrs IfAttrs, err
 }
 
 func (m *LinuxNetworkMonitor) ifAttrsFromLink(link netlink.Link) IfAttrs {
-	var lowerUP bool
-	switch link.Attrs().OperState {
-	case netlink.OperUnknown:
-		// It is common for cellular modems that the operating state is not reported,
-		// whereas lower-layer IFF_* flags are available and can be used to determine
-		// link status.
-		lowerUP = link.Attrs().RawFlags&unix.IFF_LOWER_UP != 0
-	case netlink.OperUp:
-		lowerUP = true
-	default:
-		lowerUP = false
-	}
 	return IfAttrs{
 		IfIndex:       link.Attrs().Index,
 		IfName:        link.Attrs().Name,
@@ -170,7 +158,7 @@ func (m *LinuxNetworkMonitor) ifAttrsFromLink(link netlink.Link) IfAttrs {
 		IsLoopback:    (link.Attrs().Flags & net.FlagLoopback) != 0,
 		WithBroadcast: (link.Attrs().Flags & net.FlagBroadcast) != 0,
 		AdminUp:       (link.Attrs().Flags & net.FlagUp) != 0,
-		LowerUp:       lowerUP,
+		LowerUp:       link.Attrs().RawFlags&unix.IFF_LOWER_UP != 0,
 		Enslaved:      link.Attrs().MasterIndex != 0,
 		MasterIfIndex: link.Attrs().MasterIndex,
 		MTU:           uint16(link.Attrs().MTU),


### PR DESCRIPTION
The boolean lowerUp should reflect the interface lower up status, so we should not check the management status but the link attribute lower up .


(cherry picked from commit a96ecec88abfaa7180dacdf0450f6dadd973873d)

# Description
The boolean lowerUp should reflect the interface lower up status, so we should not check the management status but the link attribute lower up .


(cherry picked from commit a96ecec88abfaa7180dacdf0450f6dadd973873d)

Backport of #5139

## How to test and validate this PR

Run eve on a device with multiple network interfaces, when you unplug the eth cable from the device, the metadata interface endpoint should state the network device as down.

## Changelog notes

The status of network interfaces in the metadata endpoint now accurately reflects whether the network cable is connected or not. If a cable is unplugged or there’s no connection, the interface will now show as “down” in the metadata, making it easier to diagnose connectivity issues on your device.

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
