### PR TITLE
spec.sh: fix modem assigngrp

### DIFF
--- a/pkg/debug/spec.sh
+++ b/pkg/debug/spec.sh
@@ -324,7 +324,6 @@ print_usb_devices() {
         then
             cost=10
             assigngrp="modem${busAndPort}"
-            assigngrp=$(get_assignmentgroup "${ifname}" "${pciaddr}")
             ztype="IO_TYPE_WWAN"
             labelprefix="WWAN"
         fi

--- a/pkg/installer/spec.sh
+++ b/pkg/installer/spec.sh
@@ -328,7 +328,6 @@ print_usb_devices() {
         then
             cost=10
             assigngrp="modem${busAndPort}"
-            assigngrp=$(get_assignmentgroup "${ifname}" "${pciaddr}")
             ztype="IO_TYPE_WWAN"
             labelprefix="WWAN"
         fi


### PR DESCRIPTION




# Description

do not overwrite assigngrp with wrong value

## How to test and validate this PR

Run `spec.sh` on device with modem (connected via usb) and check that the assigngrp of this device starts with `modem`



## Changelog notes

Fix creating model manifest for modems.

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 14.5-stable: Yes
- 13.4-stable: Yes

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
