### PR TITLE
dpcreconciler: add rfkill dependency for WiFi adapters

### DIFF
--- a/pkg/pillar/dpcreconciler/linux_test.go
+++ b/pkg/pillar/dpcreconciler/linux_test.go
@@ -723,9 +723,9 @@ func TestWireless(test *testing.T) {
 	t.Expect(itemDescription(wwan)).To(ContainSubstring("RadioSilence:true"))
 	t.Expect(itemDescription(wwan)).To(ContainSubstring(fmt.Sprintf("Timestamp:%v", rsTimestamp)))
 	t.Expect(itemCountWithType(generic.PhysIfTypename)).To(Equal(2))
-	t.Expect(itemCountWithType(generic.AdapterTypename)).To(Equal(2))
+	t.Expect(itemCountWithType(generic.AdapterTypename)).To(Equal(1))
 	t.Expect(itemCountWithType(generic.AdapterAddrsTypename)).To(Equal(2))
-	t.Expect(itemCountWithType(generic.DhcpcdTypename)).To(Equal(1))
+	t.Expect(itemCountWithType(generic.DhcpcdTypename)).To(Equal(0))
 	t.Expect(itemCountWithType(generic.IPv4RouteTypename)).To(Equal(0))
 	t.Expect(itemCountWithType(generic.ArpTypename)).To(Equal(0))
 }

--- a/pkg/pillar/dpcreconciler/linuxitems/adapter.go
+++ b/pkg/pillar/dpcreconciler/linuxitems/adapter.go
@@ -81,9 +81,12 @@ func (a Adapter) String() string {
 	return fmt.Sprintf("Network Adapter: %#+v", a)
 }
 
-// Dependencies returns underlying lower-layer adapter as the dependency
+// Dependencies returns the underlying lower-layer adapter as the dependency
 // (unless this is physical interface at the lowest layer).
+// For WiFi we additionally require that rfkill for wlan is unblocked first
+// (otherwise LinkSetUp and other netlink calls will fail).
 func (a Adapter) Dependencies() (deps []depgraph.Dependency) {
+	// Dependency 1: underlying lower-layer adapter must exist.
 	var depType string
 	var mustSatisfy func(item depgraph.Item) bool
 	expectedParentUsage := genericitems.IOUsageL3Adapter
@@ -108,16 +111,30 @@ func (a Adapter) Dependencies() (deps []depgraph.Dependency) {
 			return bond.Usage == expectedParentUsage
 		}
 	}
-	return []depgraph.Dependency{
-		{
-			RequiredItem: depgraph.ItemRef{
-				ItemType: depType,
-				ItemName: a.IfName,
-			},
-			MustSatisfy: mustSatisfy,
-			Description: "Underlying network interface must exist",
+	deps = append(deps, depgraph.Dependency{
+		RequiredItem: depgraph.ItemRef{
+			ItemType: depType,
+			ItemName: a.IfName,
 		},
+		MustSatisfy: mustSatisfy,
+		Description: "Underlying network interface must exist",
+	})
+	// Dependency 2: WiFi requires rfkill unblock to be performed first.
+	if a.WirelessType == types.WirelessTypeWifi {
+		deps = append(deps, depgraph.Dependency{
+			RequiredItem: depgraph.Reference(Wlan{}),
+			MustSatisfy: func(item depgraph.Item) bool {
+				wlan, isWlan := item.(Wlan)
+				if !isWlan {
+					// unreachable
+					return false
+				}
+				return wlan.EnableRF
+			},
+			Description: "radio transmission must be enabled",
+		})
 	}
+	return deps
 }
 
 // GetMTU returns MTU configured for the Adapter (applied to bridge).


### PR DESCRIPTION
# Description

Extended the `Dependencies()` method for `Adapter` to include an additional requirement for WiFi interfaces:
- the WLAN rfkill (radio block) must be unblocked before configuring the adapter. This is necessary to ensure that netlink operations like `LinkSetUp` succeed.

The existing dependency on the lower-layer network interface remains unchanged.

## How to test and validate this PR

Onboard device with WiFi adapter, then:
1. Set the WiFi as Disabled. Check with rfkill that wlan is soft-blocked:
```
$ rfkill
ID TYPE      DEVICE    SOFT      HARD
 0 wlan      phy0   blocked unblocked
```
2. Then enable the WiFi adapter and configure valid SSID and credentials. Check that rfkill was unblocked and wlan0 received IP address:
```
$ rfkill
ID TYPE      DEVICE      SOFT      HARD
 0 wlan      phy0   unblocked unblocked

$ ifconfig wlan0
wlan0     Link encap:Ethernet  HWaddr 1C:C1:0C:AF:D7:AA  
          inet addr:10.10.10.104  Bcast:10.10.10.255  Mask:255.255.255.0
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:1336 errors:0 dropped:0 overruns:0 frame:0
          TX packets:1146 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:165095 (161.2 KiB)  TX bytes:599989 (585.9 KiB)
```

Repeat steps 1. and 2. couple times, i.e. iterate between WiFi being disabled and enabled. Each time, the wlan0 interface should successfully come up and receive IP address.
Without this fix, we could experience situation where EVE would try to bring up the wlan0 interface before it was rfkill-unblocked, resulting in error (and wlan0 remaining down and without IP).

## Changelog notes

Improved WiFi adapter handling by ensuring EVE waits for WLAN rfkill unblock before bringing up the interface. This prevents failures during interface setup (e.g., wlan0 staying down and missing IP) when toggling WiFi between disabled and enabled states.

## PR Backports

- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.

