### PR TITLE
Fix an issue zedkube failed to decrypt the cluster token

### DIFF
--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -398,7 +398,12 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		select {
 		case change := <-subControllerCert.MsgChan():
 			subControllerCert.ProcessChange(change)
-			controllerCertInitialized = true
+			log.Noticef("EdgeNodeCert, len %d", len(subEdgeNodeCert.GetAll()))
+			// Seen issues where the change is triggered with no controller cert is in it
+			// the publication can be empty, so check the length
+			if len(subEdgeNodeCert.GetAll()) > 0 {
+				controllerCertInitialized = true
+			}
 
 		case change := <-subEdgeNodeCert.MsgChan():
 			subEdgeNodeCert.ProcessChange(change)


### PR DESCRIPTION
# Description

- When receives subControllerCert initially, wait for the record to be populated before moving on. This is the same approach used in msrv for the subControllerCert publication

# Description

Provide a clear and concise description of the changes in this PR and
explain why they are necessary.

## PR dependencies

## How to test and validate this PR

This is to fix an corner case where we've seen the zedkube does not have the controller-cert
1. use the kubevirt image for the devices
2. config an edge-node cluster for the devices
3. make sure we don't have the case where one of the devices can not join the cluster to to the token is missing

Since this is a rare corner case and a timing issue, there is no definite way to verify

## Changelog notes

Fix an issue zedkube failed to decrypt the cluster token

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR


And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

