### PR TITLE
Added threshold to SATA devices for SMART metrics

### DIFF
--- a/pkg/pillar/types/smarttypes.go
+++ b/pkg/pillar/types/smarttypes.go
@@ -71,6 +71,7 @@ type DAttrTable struct {
 	AttributeName string
 	Value         int64
 	Worst         uint8
+	Threshold     uint8
 	Flags         uint16
 	RawValue      int
 	Type          string


### PR DESCRIPTION
# Description

- Added the threshold column for the SMART metrics of SATA devices.

## PR dependencies

List all dependencies of this PR (when applicable, otherwise remove this
section).

## How to test and validate this PR

To test and validate this PR, we need to check the threshold column in the storage tab of edge nodes in ZedUI and verify that the `thres column` of the SMART attributes is not zero.

## Changelog notes

Fixed the `thres column` in the SMART info report of physical storage devices in the storage tab of edge nodes.

## PR Backports

- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
