### PR TITLE
Reduce the edgeview keepalive interval

### DIFF
--- a/pkg/edgeview/src/edge-view.go
+++ b/pkg/edgeview/src/edge-view.go
@@ -41,17 +41,18 @@ var (
 )
 
 const (
-	agentName       = "edgeview"
-	closeMessage    = "+++Done+++"
-	tarCopyDoneMsg  = "+++TarCopyDone+++"
-	edgeViewVersion = "0.8.6" // set the version now to 0.8.6
-	cpLogFileString = "copy-logfiles"
-	clientIPMsg     = "YourEndPointIPAddr:"
-	serverRateMsg   = "ServerRateLimit:disable"
-	tcpPktRate      = MbpsToBytes * 5 * 1.2 // 125k Bytes * 5 * 1.2, or 5Mbits add 20%
-	tcpPktBurst     = 65536                 // burst allow bytes
-	tarMinVersion   = "0.8.5"               // for tar operation, expect client to have newer version
-	verifyFailed    = "+++Verify failed+++"
+	agentName         = "edgeview"
+	closeMessage      = "+++Done+++"
+	tarCopyDoneMsg    = "+++TarCopyDone+++"
+	edgeViewVersion   = "0.8.6" // set the version now to 0.8.6
+	cpLogFileString   = "copy-logfiles"
+	clientIPMsg       = "YourEndPointIPAddr:"
+	serverRateMsg     = "ServerRateLimit:disable"
+	tcpPktRate        = MbpsToBytes * 5 * 1.2 // 125k Bytes * 5 * 1.2, or 5Mbits add 20%
+	tcpPktBurst       = 65536                 // burst allow bytes
+	tarMinVersion     = "0.8.5"               // for tar operation, expect client to have newer version
+	verifyFailed      = "+++Verify failed+++"
+	keepaliveInterval = 30 * time.Second // interval for sending websocket ping messages
 )
 
 type cmdOpt struct {
@@ -631,7 +632,7 @@ func initpubInfo(logger *logrus.Logger) pubsub.Publication {
 }
 
 func sendKeepalive() {
-	ticker := time.NewTicker(90 * time.Second)
+	ticker := time.NewTicker(keepaliveInterval)
 	for {
 		for range ticker.C {
 			wssWrMutex.Lock()


### PR DESCRIPTION

# Description

- In some cases, the controller side resets the idle session too fast, jobs like collectinfo may wait for minutes and get interrupted by the idle session reset. Reduce this to 30 seconds for keepalive.

Provide a clear and concise description of the changes in this PR and
explain why they are necessary.

## PR dependencies

## How to test and validate this PR

With the introduction of Edgeview-UI, user can test the 'CollectInfo' and monitor the logs from the dispatcher, and it should not be disconnnect/reconnect from the device using this EVE patch.

## Changelog notes

Reduce the edgeview keepalive interval to 30 seconds

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

