### PR TITLE
.github: Update Eden workflow to version 1.0.10.

### DIFF
--- a/.github/workflows/eden-trusted.yml
+++ b/.github/workflows/eden-trusted.yml
@@ -179,14 +179,14 @@ jobs:
     name: ${{ needs.context.outputs.eden_parent_job_title }}
     needs: context
     if: needs.context.outputs.skip_run == 'false'
-    uses: lf-edge/eden/.github/workflows/test.yml@1.0.9
+    uses: lf-edge/eden/.github/workflows/test.yml@1.0.10
     secrets: inherit
     with:
       eve_image: "evebuild/pr:${{ needs.context.outputs.pr_id }}"
       eve_log_level: "debug"
       eve_artifact_name: "eve-${{ needs.context.outputs.hv }}-${{ needs.context.outputs.arch }}-${{ needs.context.outputs.platform }}"
       artifact_run_id: ${{ needs.context.outputs.original_run_id }}
-      eden_version: "1.0.9"
+      eden_version: "1.0.10"
 
   finalize:
     name: Finalize Eden Runner status


### PR DESCRIPTION
# Description

Update workflow to use Eden v1.0.10 with fixes for uploading debug archives. This version includes improvements to correctly upload the debug archive created by collect-info.sh after a test failure.

## PR dependencies

None

## How to test and validate this PR

Internal CI/CD change, not to be tested externally. 

## Changelog notes

No user-facing changes.

## PR Backports

- 14.5-stable: no, as the workflow always runs from master
- 13.4-stable: no, as the workflow always runs from master

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
