### PR TITLE
[13.4-stable] github/workflows: Switch to arm64 runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: zededa-ubuntu-latest
+          - os: zededa-ubuntu-2204-arm64
             arch: arm64
           - os: zededa-ubuntu-2204
             arch: amd64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: zededa-ubuntu-2204
+          - os: zededa-ubuntu-2204-arm64
             arch: arm64
           - os: zededa-ubuntu-2204
             arch: amd64


### PR DESCRIPTION
# Description

Switch some workflows to make use of the arm64 runners and avoid cross-compilation issues.

## How to test and validate this PR

Run GitHub workflows.

## Changelog notes

None.

## PR Backports

- No backport is needed for this one because `14.5-stable` and `master` are already fixed.
- No cherry-picks were made.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.