### PR TITLE
[13.4-stable] Added threshold to SATA devices for SMART metrics

### DIFF
--- a/pkg/pillar/types/smarttypes.go
+++ b/pkg/pillar/types/smarttypes.go
@@ -71,6 +71,7 @@ type DAttrTable struct {
 	AttributeName string
 	Value         int64
 	Worst         uint8
+	Threshold     uint8
 	Flags         uint16
 	RawValue      int
 	Type          string


### PR DESCRIPTION
Backport of [#5158](https://github.com/lf-edge/eve/pull/5158/files)

## PR dependencies

List all dependencies of this PR (when applicable, otherwise remove this
section).

## How to test and validate this PR

To test and validate this PR:
1. Deploy an edge device with the 13.4-stable EVE version
2. Onboard in Zedcloud 
3. Check the threshold column in the storage tab of edge nodes in ZedUI and verify that the thres column of the SMART attributes is not zero.

## Changelog notes

Text in this section will be used to generate the changelog entry for
release notes. The consumers of this are end users, not developers.
So, provide a clear and short description of what is changed in the PR from
the end user perspective. If it changes only tooling or some internal
implementation, put a note like "No user-facing changes" or "None".

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
