### PR TITLE
kubevirt: fix BaseOs Update defer check, ensure drain is requested

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -35,8 +35,33 @@ func baseOsHandleStatusUpdateUUID(ctx *baseOsMgrContext, id string) {
 	// We want to wait to drain until we're sure we actually have a usable image locally.
 	// eve baseos image is downloaded locally, verified, available, and most importantly has been activated
 	// before the node downtime/reboot is initiated, see if we need to defer the operation
-	if ((status.State == types.LOADED) || (status.State == types.INSTALLED)) && config.Activate && !status.Activated {
-		log.Tracef("baseOsHandleStatusUpdateUUID() image just activated id:%s config:%v status:%v state:%s", id, config, status, status.State)
+	statusCt := lookupContentTreeStatus(ctx, status.ContentTreeUUID)
+	if statusCt == nil {
+		log.Errorf("baseOsHandleStatusUpdateUUID(%s) ct:%s not found",
+			id, status.ContentTreeUUID)
+		return
+	}
+
+	log.Functionf("baseOsHandleStatusUpdateUUID() image id:%s"+
+		" status.BaseOsVersion:%s config.BaseOsVersion:%s status.State:%v"+
+		" config.Activate:%t status.Activated:%t status.ContentTreeUUID%s"+
+		" prog:%d state:%v", id,
+		status.BaseOsVersion, config.BaseOsVersion, status.State,
+		config.Activate, status.Activated, status.ContentTreeUUID,
+		statusCt.Progress, statusCt.State)
+
+	baseOsContentTreeAvailable := statusCt.State == types.LOADED
+	baseOsAvailableLocally := ((status.State == types.LOADING) ||
+		(status.State == types.LOADED) ||
+		(status.State == types.INSTALLED)) && baseOsContentTreeAvailable
+	baseOsMgrSwitchingToImage := config.Activate && !status.Activated
+
+	if baseOsAvailableLocally && baseOsMgrSwitchingToImage {
+		log.Functionf("baseOsHandleStatusUpdateUUID() image just activated "+
+			"id:%s status.BaseOsVersion:%s config.BaseOsVersion:%s config:%v "+
+			"status:%v state:%s",
+			id, status.BaseOsVersion, config.BaseOsVersion, config,
+			status, status.State)
 		deferUpdate := shouldDeferForNodeDrain(ctx, id, config, status)
 		if deferUpdate {
 			return


### PR DESCRIPTION
# Description

The previous combination of states is no longer seen here which leads to BaseOs update skipping checking for a needed defer while the drain process blocks to allow a volume rebuild operation to complete.

As part of this fix the condition was cleaned up
for readability.  In kubevirt, BaseOs updates
which are locally available and being switched to
may be deferred while a drain process completes.

## PR dependencies

None

## How to test and validate this PR

- Configure 3 EVE-OS nodes as a cluster using a controller
- Deploy one or more VM App Instances each containing 1 or more volumes instances
- Begin a BaseOs update on the nodes
- Confirm that each node sees a drain requested.  This can be confirmed via pubsub zedkube/NodeDrainStatus where the RequestedBy value will be 3 (UPDATE)

```
cat /run/zedkube/NodeDrainStatus/global.json | jq .RequestedBy
3
```

## Changelog notes

None

## PR Backports

- 14.5-stable: To be backported
- 13.4-stable: No

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
