### PR TITLE
kubevirt: Improve pvc upload error handling

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -80,7 +80,7 @@ ARG TARGETARCH
 
 # Actual k3s install and config happens when this container starts during EVE bootup, look at cluster-init.sh
 ### NOTE: the version of virtctl should match the version of kubevirt in cluster_init.sh, else PVC creation might fail due to incompatibility
-ENV VIRTCTL_VERSION v1.1.0
+ENV VIRTCTL_VERSION v1.6.0
 ADD https://github.com/kubevirt/kubevirt/releases/download/${VIRTCTL_VERSION}/virtctl-${VIRTCTL_VERSION}-linux-${TARGETARCH} .
 
 RUN install virtctl-${VIRTCTL_VERSION}-linux-${TARGETARCH} /usr/bin/virtctl


### PR DESCRIPTION
# Description

PVC upload involves volume creation, disk copy and multiple kubernetes components: cdi, longhorn. This commit aims to improve handling of two failure modes.

- Move to virtctl 1.6.0 for --retry support which allows for virtctl to retry for some upload proxy API errors Set retry count to 10 for more flexibility.

	As quoted in virtctl docs:

	When upload server returns a transient error,
	we retry this number of times before giving up (default 5)

- Account for upload pod image download time in timeout calculation. Set to 10 min for slower edge download speeds.

## PR dependencies

None

## How to test and validate this PR

- Configure an HV=kubevirt EVE-OS node
- Deploy one or more VM App Instances each containing 1 or more volumes instances

## Changelog notes

None

## PR Backports

- 14.5-stable: To be backported.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.