### PR TITLE
dockerize the build of vector package

### DIFF
--- a/pkg/monitor/Dockerfile
+++ b/pkg/monitor/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG MONITOR_RS_VERSION=v0.6.0
-ARG RUST_VERSION=lfedge/eve-rust:1.85.1-1
+ARG RUST_VERSION=lfedge/eve-rust:1.85.1-2
 FROM --platform=$BUILDPLATFORM ${RUST_VERSION} AS toolchain-base
 ARG TARGETARCH
 

--- a/pkg/vector/Dockerfile
+++ b/pkg/vector/Dockerfile
@@ -1,12 +1,78 @@
 # Copyright (c) 2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM paulzededa/eve-vector:no-lua
+ARG RUST_VERSION=lfedge/eve-rust:1.85.1-2
+ARG VECTOR_FEATURES='--no-default-features --features \
+sources-socket,\
+sources-internal_metrics,\
+transforms-aws_ec2_metadata,\
+transforms-dedupe,\
+transforms-filter,\
+transforms-window,\
+transforms-log_to_metric,\
+transforms-metric_to_log,\
+transforms-reduce,\
+transforms-remap,\
+transforms-route,\
+transforms-exclusive-route,\
+transforms-sample,\
+transforms-throttle,\
+sinks-socket,\
+sources-prometheus-scrape,\
+sinks-prometheus'
 
-RUN apk add --no-cache inotify-tools=4.23.9.0-r0
+# hadolint ignore=DL3006
+FROM --platform=$BUILDPLATFORM ${RUST_VERSION} AS toolchain-base
+ARG TARGETARCH
+
+FROM toolchain-base AS target-amd64
+ENV CARGO_BUILD_TARGET="x86_64-unknown-linux-musl"
+
+FROM toolchain-base AS target-arm64
+ENV CARGO_BUILD_TARGET="aarch64-unknown-linux-musl"
+
+FROM toolchain-base AS target-riscv64
+ENV CARGO_BUILD_TARGET="riscv64gc-unknown-linux-gnu"
+
+# hadolint ignore=DL3006
+FROM target-$TARGETARCH AS toolchain
+RUN echo "Cargo target: $CARGO_BUILD_TARGET"
+
+# building the final image
+FROM toolchain AS builder
+ARG VECTOR_FEATURES
+ADD https://github.com/vectordotdev/vector.git#v0.47.0 /app
+# we have our own options, so remove the default cargo config
+# if this doesn't help then remove everything leaving only
+# the files from .dockerignore except rust-toolchain.toml
+RUN rm -rf /app/.cargo /app/rust-toolchain.toml
+
+WORKDIR /app
+
+ENV RUSTFLAGS="\
+    -C opt-level=z \
+    -C lto=fat \
+    -C embed-bitcode=yes \
+    -C codegen-units=1"
+RUN cargo build --release $VECTOR_FEATURES
+
+# strip unneeded symbols
+RUN strip "/app/target/$CARGO_BUILD_TARGET/release/vector"
+
+RUN cargo sbom > sbom.spdx.json
+RUN cp "/app/target/$CARGO_BUILD_TARGET/release/vector" /app/target/
+
+FROM lfedge/eve-alpine:745ae9066273c73b0fd879c4ba4ff626a8392d04 AS runtime
+ENV PKGS="inotify-tools"
+RUN eve-alpine-deploy.sh
+
+# Assemble the final image
+FROM scratch
+COPY --from=runtime /out/ /
+COPY --from=builder /app/target/vector /usr/bin/vector
+COPY --from=builder /app/sbom.spdx.json /sbom.spdx.json
 
 COPY etc/vector.yaml /etc/vector/vector.yaml
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
# Description

This PR addresses some suggestions from the original PR that introduced vector https://github.com/lf-edge/eve/pull/5008#issuecomment-3028328973.

Remove the dependency on the minimal version of vector built externally. Now we have the full vector package built in the EVE build system, using lf-edge's eve-rust image as a base toolchain.

## PR dependencies

None.

## How to test and validate this PR

Only includes changes to the EVE build. No testing necessary.

## Changelog notes

N/A

## PR Backports

Nope.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR