### PR TITLE
Set all components initialized only after backup

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -1027,9 +1027,6 @@ if [ ! -f /var/lib/all_components_initialized ]; then
 
 
         if [ -f /var/lib/longhorn_initialized ]; then
-                logmsg "All components initialized"
-                touch /var/lib/node-labels-initialized
-                touch /var/lib/all_components_initialized
                 sleep 5
                 logmsg "stop the k3s server and wait for copy /var/lib"
                 terminate_k3s
@@ -1037,6 +1034,9 @@ if [ ! -f /var/lib/all_components_initialized ]; then
                 sleep 5
                 save_var_lib
                 logmsg "saved the copy of /var/lib, done"
+                logmsg "All components initialized"
+                touch /var/lib/node-labels-initialized
+                touch /var/lib/all_components_initialized
         fi
 else
         if ! check_start_k3s; then


### PR DESCRIPTION
# Description

We set /var/lib/all_components_initialized when all components are initialized. That will be use to check and configure clusters (both ZKS and edge node cluster). But we also take backup of single node config to /var/lib so that we can factory reset and switch back to single node mode if user deletes cluster.

There is a timing issue here, we are prematutely setting the flag all_components_initialized before the backup is saved, so in some race conditions we run into an issue where backup was not saved before switching to cluster mode. This commit fixes that.




## How to test and validate this PR

It's hard to reproduce this issue. But it could happen with following steps.

1) On board eve device with kubevrt eve installed.
2) It takes about 10 mins to download and install all components
3) Meanwhile create a cluster with this eve device in the controller
4) Cluster gets created before single node backup finished.
5) Delete the cluster from controller
6) Device reboots to single node but the backup is messy with some cluster components since backup happened in middle of cluster create.
7) Device does not convert properly to single node mode.

This fix handles that issue.

## Changelog notes

User facing issue seen is that device cannot gracefully convert to single node mode after cluster is deleted.
It requires reinstall.

## PR Backports
14.5: no, the feature is not officially part of that version
13.4: no, the feature is not officially part of that version


## Checklist

- [x] I've provided a proper description
- [x] I've tested my PR on amd64 device
- [x] I've written the test verification instructions

