### PR TITLE
kubevirt: Debug Improvements

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -6,7 +6,7 @@
 
 # Script version, don't forget to bump up once something is changed
 
-VERSION=40
+VERSION=41
 # Add required packages here, it will be passed to "apk add".
 # Once something added here don't forget to add the same package
 # to the Dockerfile ('ENV PKGS' line) of the debug container,
@@ -416,6 +416,13 @@ collect_kube_info()
            echo "============"
            eve exec kube kubectl top pod -A --sum
            echo "============"
+           echo "kubectl get volumeattachment"
+           echo "============"
+           eve exec kube kubectl get volumeattachment
+           echo "============"
+           echo "/usr/bin/all-kube-events.sh"
+           echo "============"
+           eve exec kube /usr/bin/all-kube-events.sh
         } > "$DIR/kube-info"
     fi
 }

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -38,6 +38,7 @@ COPY config.yaml /etc/rancher/k3s
 COPY debuguser-role-binding.yaml /etc/
 COPY k3s-pod-logs.sh /usr/bin/
 COPY registration-utils.sh /usr/bin/
+COPY all-kube-events.sh /usr/bin/
 
 # kubevirt yaml files are patched files and will be removed later, look at cluster-init.sh
 COPY multus-daemonset.yaml /etc
@@ -53,6 +54,7 @@ COPY iscsid.conf /etc/iscsi/
 COPY longhorn-generate-support-bundle.sh /usr/bin/
 COPY nsmounter /usr/bin/
 COPY longhorn_uninstall_settings.yaml /etc/
+COPY failover-events.sh /usr/bin/
 
 # descheduler
 COPY descheduler-utils.sh /usr/bin/

--- a/pkg/kube/all-kube-events.sh
+++ b/pkg/kube/all-kube-events.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+LOG_DIR=/persist/kubelog
+
+kubectl get events --all-namespaces -o custom-columns="TIME:.metadata.creationTimestamp,NAMESPACE:.metadata.namespace,TYPE:.type,REASON:.reason,OBJECT:.involvedObject.name,MESSAGE:.message" --sort-by='.metadata.creationTimestamp' > ${LOG_DIR}/all-kube-events-sorted.log

--- a/pkg/kube/failover-events.sh
+++ b/pkg/kube/failover-events.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Usage: ./failover-events.sh <vmi-replicaset-prefix>
+
+PREFIX="$1"
+NAMESPACE="eve-kube-app"
+
+if [ -z "$PREFIX" ]; then
+  echo "Usage: $0 <vmi-replicaset-prefix>"
+  exit 1
+fi
+
+VMIRS_NAMES=$(kubectl get vmirs -n "$NAMESPACE" --no-headers | awk '{print $1}' | grep "^$PREFIX")
+for vmirs in $VMIRS_NAMES; do
+  appDomainNameSelector=$(kubectl -n "$NAMESPACE" get "vmirs/${vmirs}" -o json | jq -r .status.labelSelector)
+
+  # Find all VMI names matching the prefix
+  VMI_NAMES=$(kubectl get vmi -n "$NAMESPACE" -l "$appDomainNameSelector" --no-headers | awk '{print $1}')
+
+  # Find all virt-launcher pods associated with those VMIs
+  POD_NAMES=""
+  PVC_NAMES=""
+  LH_VOL_NAMES=""
+  LH_VOL_REPS=""
+
+  pods=$(kubectl get pods -n "$NAMESPACE" -l "$appDomainNameSelector" --no-headers | awk '{print $1}')
+  POD_NAMES="$POD_NAMES $pods"
+
+  # All PVCs for this pod
+  pvcs=$(kubectl get pod -n "$NAMESPACE" -l "$appDomainNameSelector" -o json | jq -r '.items[].spec.volumes[] | select(.persistentVolumeClaim) | .persistentVolumeClaim.claimName')
+  PVC_NAMES="$PVC_NAMES $pvcs"
+  for pvc in $pvcs; do
+    volname=$(kubectl -n "$NAMESPACE" get "pvc/${pvc}" -o json | jq -r .spec.volumeName)
+    LH_VOL_NAMES="$LH_VOL_NAMES $volname"
+
+    reps=$(kubectl -n longhorn-system get replicas -l "longhornvolume=$volname" --no-headers | awk '{print $1}')
+    LH_VOL_REPS="$LH_VOL_REPS $reps"
+  done
+
+  # Collect all relevant object names
+  OBJECTS="$vmirs $VMI_NAMES $POD_NAMES $PVC_NAMES"
+  LHOBJECTS="$LH_VOL_NAMES $LH_VOL_REPS"
+
+  # Get events for each object and print them with creationTimestamp
+  for obj in $OBJECTS; do
+    kubectl get events -n "$NAMESPACE" --field-selector involvedObject.name="$obj" -o json \
+      | jq -r '.items[] | [.metadata.creationTimestamp, .involvedObject.kind, .involvedObject.name, .reason, .message] | @tsv'
+  done | sort
+  for obj in $LHOBJECTS; do
+    kubectl get events -n longhorn-system --field-selector involvedObject.name="$obj" -o json \
+      | jq -r '.items[] | [.metadata.creationTimestamp, .involvedObject.kind, .involvedObject.name, .reason, .message] | @tsv'
+  done | sort
+done

--- a/pkg/kube/longhorn-generate-support-bundle.sh
+++ b/pkg/kube/longhorn-generate-support-bundle.sh
@@ -13,6 +13,16 @@ if ! kubectl get namespace/longhorn-system; then
     exit 1
 fi
 
+echo "============"
+echo "kubectl -n longhorn-system get replicaset,deployment,daemonset,service,pod,volume,replica,engine,engineimage,nodes.longhorn.io,volumeattachments.longhorn.io -o wide"
+echo "============"
+kubectl -n longhorn-system get replicaset,deployment,daemonset,service,pod,volume,replica,engine,engineimage,nodes.longhorn.io,volumeattachments.longhorn.io -o wide
+echo "============"
+echo "kubectl -n longhorn-system get volume fields:  .metadata.name spec.nodeID status.currentNodeID status.ownerID status.pendingNodeId"
+echo "============"
+kubectl -n longhorn-system get volume -o json | jq '.items[] | "name:\(.metadata.name) spec.nodeID:\(.spec.nodeID) status.currentNodeID:\(.status.currentNodeID) status.ownerID:\(.status.ownerID) status.pendingNodeId:\(.status.pendingNodeID)"'
+echo "============"
+
 echo "Apply longhorn support bundle yaml at $(date)"
 
 cat <<EOF | kubectl apply -f -


### PR DESCRIPTION
# Description

These changes aim to improve the debug experience
for VM app instance failover between EVE-OS nodes.

- add kubernetes events sorted by utc time as /persist/kubelog/all-kube-events-sorted.log
- longhorn-info text file in collect-info tar will include longhorn object states,volume nodeIds
- failover-events.sh used for manual live debug. Pass the VM app instance name and the script will dump k3s object events for objects linked to the VMI. eg. vmirs, vmi, virt-launcher pod, pvcs, lh volumes.

## PR dependencies

None

## How to test and validate this PR

- Configure an HV=kubevirt EVE-OS node
- Deploy one or more VM App Instances each containing 1 or more volumes instances
- Generate a collect-info tar from the debug container

## Changelog notes

None

## PR Backports

- 14.5-stable: To be backported.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
