### PR TITLE
[14.5-stable] Reduce the edgeview keepalive interval

### DIFF
--- a/pkg/edgeview/src/edge-view.go
+++ b/pkg/edgeview/src/edge-view.go
@@ -41,16 +41,17 @@ var (
 )
 
 const (
-	agentName       = "edgeview"
-	closeMessage    = "+++Done+++"
-	tarCopyDoneMsg  = "+++TarCopyDone+++"
-	edgeViewVersion = "0.8.4" // set the version now to 0.8.4
-	cpLogFileString = "copy-logfiles"
-	clientIPMsg     = "YourEndPointIPAddr:"
-	serverRateMsg   = "ServerRateLimit:disable"
-	tcpPktRate      = MbpsToBytes * 5 * 1.2 // 125k Bytes * 5 * 1.2, or 5Mbits add 20%
-	tcpPktBurst     = 65536                 // burst allow bytes
-	tarMinVersion   = "0.8.4"               // for tar operation, expect client to have newer version
+	agentName         = "edgeview"
+	closeMessage      = "+++Done+++"
+	tarCopyDoneMsg    = "+++TarCopyDone+++"
+	edgeViewVersion   = "0.8.4" // set the version now to 0.8.4
+	cpLogFileString   = "copy-logfiles"
+	clientIPMsg       = "YourEndPointIPAddr:"
+	serverRateMsg     = "ServerRateLimit:disable"
+	tcpPktRate        = MbpsToBytes * 5 * 1.2 // 125k Bytes * 5 * 1.2, or 5Mbits add 20%
+	tcpPktBurst       = 65536                 // burst allow bytes
+	tarMinVersion     = "0.8.4"               // for tar operation, expect client to have newer version
+	keepaliveInterval = 30 * time.Second      // interval for sending websocket ping messages
 )
 
 type cmdOpt struct {
@@ -586,7 +587,7 @@ func initpubInfo(logger *logrus.Logger) pubsub.Publication {
 }
 
 func sendKeepalive() {
-	ticker := time.NewTicker(90 * time.Second)
+	ticker := time.NewTicker(keepaliveInterval)
 	for {
 		for range ticker.C {
 			wssWrMutex.Lock()


### PR DESCRIPTION

# Description

- In some cases, the controller side resets the idle session too fast, jobs like collectinfo may wait for minutes and get interrupted by the idle session reset. Reduce this to 30 seconds for keepalive.
- backported from PR #5159

(cherry picked from commit 861e38067a5f333f667a0568880a43fc52368fc8)

## PR dependencies

## How to test and validate this PR

Make sure the edgeview sessions won't have the regular disconnect/connect behavior

## Changelog notes

Reduce the edgeview keepalive interval

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've added a reference link to the original PR
- [ ] PR's title follows the template

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
