### PR TITLE
pkg/pillar: update edge-containers

### DIFF
--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/jackwakefield/gopac v1.0.2
 	github.com/jaypipes/ghw v0.8.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.5.0
-	github.com/lf-edge/edge-containers v0.0.0-20240207093504-5dfda0619b80
+	github.com/lf-edge/edge-containers v0.0.0-20250318135001-d53466c3f229
 	github.com/lf-edge/eve-api/go v0.0.0-20250722142628-6e701eb3256b
 	github.com/lf-edge/eve-libs v0.0.0-20250708204318-622ead38398a
 	github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d
@@ -226,6 +226,7 @@ require (
 	github.com/go-kit/kit v0.13.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
+	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/golang/glog v1.2.4 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/google/btree v1.0.1 // indirect

--- a/pkg/pillar/vendor/github.com/jaypipes/ghw/Dockerfile
+++ b/pkg/pillar/vendor/github.com/jaypipes/ghw/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-stretch AS builder
+FROM golang:1.13-stretch as builder
 WORKDIR /go/src/github.com/jaypipes/ghw
 
 # Force the go compiler to use modules.

--- a/pkg/pillar/vendor/github.com/lf-edge/edge-containers/pkg/registry/push.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/edge-containers/pkg/registry/push.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"time"
@@ -73,7 +72,7 @@ func (p Pusher) Push(format Format, verbose bool, statusWriter io.Writer, config
 	legacyOpts = append(legacyOpts, WithTimestamp(p.Timestamp))
 
 	if format == FormatLegacy {
-		tmpDir, err = ioutil.TempDir("", "edge-containers")
+		tmpDir, err = os.MkdirTemp("", "edge-containers")
 		if err != nil {
 			return "", fmt.Errorf("could not make temporary directory for tgz files: %v", err)
 		}

--- a/pkg/pillar/vendor/github.com/lf-edge/edge-containers/pkg/resolver/directory.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/edge-containers/pkg/resolver/directory.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -57,7 +56,7 @@ func (d *Directory) Resolve(ctx context.Context, ref string) (name string, desc 
 	// get the root manifest
 	// try to get it from the image reference file
 	indexFile := path.Join(d.dir, "index.json")
-	contents, err := ioutil.ReadFile(indexFile)
+	contents, err := os.ReadFile(indexFile)
 	if err != nil {
 		return "", ocispec.Descriptor{}, reference.ErrInvalid
 	}
@@ -203,7 +202,7 @@ func (d directoryWriter) Commit(ctx context.Context, size int64, expected digest
 		if err != nil {
 			return fmt.Errorf("could not convert index to json: %v", err)
 		}
-		if err := ioutil.WriteFile(d.indexFile, b, 0644); err != nil {
+		if err := os.WriteFile(d.indexFile, b, 0644); err != nil {
 			return fmt.Errorf("error writing index file %s: %v", d.indexFile, err)
 		}
 	}

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -558,6 +558,8 @@ github.com/go-playground/validator/v10
 # github.com/godbus/dbus/v5 v5.1.0
 ## explicit; go 1.12
 github.com/godbus/dbus/v5
+# github.com/gofrs/uuid v4.4.0+incompatible
+## explicit
 # github.com/gogo/protobuf v1.3.2
 ## explicit; go 1.15
 github.com/gogo/protobuf/gogoproto
@@ -776,8 +778,8 @@ github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1
 # github.com/leodido/go-urn v1.2.4
 ## explicit; go 1.16
 github.com/leodido/go-urn
-# github.com/lf-edge/edge-containers v0.0.0-20240207093504-5dfda0619b80
-## explicit; go 1.15
+# github.com/lf-edge/edge-containers v0.0.0-20250318135001-d53466c3f229
+## explicit; go 1.21
 github.com/lf-edge/edge-containers/pkg/registry
 github.com/lf-edge/edge-containers/pkg/resolver
 github.com/lf-edge/edge-containers/pkg/tgz


### PR DESCRIPTION
# Description

this change was created by:
```
go get -u github.com/lf-edge/edge-containers
go mod tidy
go mod vendor
```

it changes from github.com/mitchellh/osext which does not exist anymore

This PR replaces #5177 - it is better as it works without `replace` in go.mod

## How to test and validate this PR

There are no specific steps to validate, common EVE Test Plan should cover the functionality.

## Changelog notes

* Updating of an internal package
* Turning on x86/arm specific compression to find space for above mentioned update

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 14.5-stable: no, as it updates too many packages
- 13.4-stable: no, as it updates too many packages


## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR



And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
