### PR TITLE
pkg/mkrootfs-squash: improve compression

### DIFF
--- a/pkg/mkrootfs-squash/make-rootfs
+++ b/pkg/mkrootfs-squash/make-rootfs
@@ -35,7 +35,7 @@ IMGFILE=/rootfs.img
   ROOTFS_PART_SIZE_KB=$(( ( ($ROOTFS_PART_SIZE + 1024) / 1024 * 1024) / 1024 ))
   ROOTFS_PART_SECTORS=$(( $ROOTFS_PART_SIZE_KB * 2 ))
 
-  mksquashfs /tmp/rootfs/ $IMGFILE -noappend -comp xz -no-recovery
+  mksquashfs /tmp/rootfs/ $IMGFILE -noappend -comp xz -Xbcj x86,arm -no-recovery
 )
 
 $EXPORT_CMD


### PR DESCRIPTION
# Description

    pkg/mkrootfs-squash: improve compression
    
    save around 3MB by using compression filters for
    x86 and arm

## How to test and validate this PR

There are no specific steps to validate, common EVE Test Plan should cover the functionality.

## Changelog notes

Improve image compression

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 14.5-stable: no, not needed
- 13.4-stable: no, not needed

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
