### PR TITLE
pillar: report device name to controller/LOC

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -43,6 +43,14 @@ const (
 	maxVlanID = 4094
 )
 
+func (dif *deviceInfoFields) parseConfig(config *zconfig.EdgeDevConfig) {
+	dif.deviceName = config.DeviceName
+	dif.enterpriseName = config.EnterpriseName
+	dif.enterpriseID = config.EnterpriseId
+	dif.projectName = config.ProductName
+	dif.projectID = config.ProjectId
+}
+
 func parseConfig(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig,
 	source configSource) configProcessingRetval {
 
@@ -50,6 +58,8 @@ func parseConfig(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig,
 	// from the primary controller is being applied. Or vice versa.
 	getconfigCtx.sideController.Lock()
 	defer getconfigCtx.sideController.Unlock()
+
+	getconfigCtx.deviceInfoFields.parseConfig(config)
 
 	// Make sure we do not accidentally revert to an older configuration.
 	// This depends on the controller attaching config timestamp.

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -226,6 +226,11 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext, dest destinationBitset) {
 	log.Functionf("PublishDeviceInfoToZedCloud uuid %s", deviceUUID)
 
 	ReportDeviceInfo := new(info.ZInfoDevice)
+	ReportDeviceInfo.DeviceName = ctx.getconfigCtx.deviceInfoFields.enterpriseName
+	ReportDeviceInfo.EnterpriseName = ctx.getconfigCtx.deviceInfoFields.enterpriseName
+	ReportDeviceInfo.EnterpriseId = ctx.getconfigCtx.deviceInfoFields.enterpriseID
+	ReportDeviceInfo.ProjectName = ctx.getconfigCtx.deviceInfoFields.projectName
+	ReportDeviceInfo.ProjectId = ctx.getconfigCtx.deviceInfoFields.projectID
 
 	// Get the remote access status
 	ReportDeviceInfo.RemoteAccessDisabled = utils.RemoteAccessDisabled()


### PR DESCRIPTION
# Description

    pillar: report device name to controller/LOC
    
    a DeviceInfoMsg is used for that



## PR dependencies

https://github.com/lf-edge/eve-api/pull/109


## How to test and validate this PR

Check if device name, enterprise and project are set in the DeviceInfoMsg.

## Changelog notes

report device name to controller/LOC

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 14.5-stable: no
- 13.4-stable: no

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
