### PR TITLE
tools/alpine-tools: Fix package branch classification in migration

### DIFF
--- a/tools/alpine-tools/alpine_pkg_add.py
+++ b/tools/alpine-tools/alpine_pkg_add.py
@@ -190,7 +190,7 @@ def main(version: str, packages_to_add: List[str], print_chains: bool = False,
         print("ℹ️  No new packages were added (all already present)")
 
     if print_chains and chains_by_branch_arch is not None:
-        print_dependency_chain(chains_by_branch_arch, available_archs)
+        print_dependency_chain(chains_by_branch_arch, available_archs, apk_indexes)
 
     # Write missing packages report
     write_missing_report(base_path, version, missing_by_branch_arch, available_archs)


### PR DESCRIPTION
# Description

This commit addresses critical issues in Alpine package migration where packages were being incorrectly placed in the wrong branch during dependency resolution.

Key fixes:
- Fix package branch classification: Packages are now placed in their actual branch location in the target Alpine version, not the branch context of the requesting package
- Centralized dependency resolution: Collect all packages first, then resolve once per architecture to avoid duplicates and improve organization by actual package location
- Enhanced dependency chain output: Add branch indicators (:m/:c/:t) to show the actual branch of each package in dependency chains
- Remove empty package files: When a branch has no packages after migration, the corresponding file is removed instead of being left empty
- Track packages in their actual branch in presence mapping

Previously, the migration tool used the requesting package's branch context for dependency classification, causing packages like 'dnsmasq' to be incorrectly placed in 'community' instead of 'main'. This fix ensures packages are classified by their true location in the target Alpine repository.

The dependency chain visualization now clearly shows which branch each package belongs to, improving debugging and migration transparency.

Fixes migration accuracy and improves package classification reliability for Alpine version migrations.

## How to test and validate this PR

try to migrate from 3.16 to 3.16, checkthat `dnsmasq` package appears on `main` and not on `community`

## PR Backports

```text
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
