### PR TITLE
kubevirt: detect and attempt to fix inconsistent nodeDeploymentMap

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -1007,7 +1007,7 @@ if [ ! -f /var/lib/all_components_initialized ]; then
         if ! longhorn_install "$HOSTNAME"; then
                 continue
         fi
-        if ! longhorn_is_ready; then
+        if ! Longhorn_is_ready; then
                 # It can take a moment for the new pods to get to ContainerCreating
                 # Just back off until they are caught by the earlier are_all_pods_ready
                 sleep 30
@@ -1093,7 +1093,7 @@ else
                         fi
                 fi
 
-                if longhorn_is_ready; then
+                if Longhorn_is_ready; then
                         check_overwrite_nsmounter
                 fi
                 if [ ! -e /var/lib/longhorn_configured ]; then


### PR DESCRIPTION
## Description 
 
Detection and recovery mechanisms for a condition seen in longhorn which blocks successful volume creation.

- RolloutDiskToPVC: differentiate the error when upload fails and attempt to diagnose where the provisioning process failed.
- Expand Longhorn_is_ready() to detect install issues. In some cases the engineimage can fail to deploy to one or more nodes.  Have each node responsible for its own recovery, detect if you are missing from the nodes.longhorn.io list and if so create an object.  

Next check the nodeDeploymentMap and if missing             

1. delete the engine-image pod running locally
2. delete the longhorn-manager pod running on the ownerID reported by engineimage status.
            
Testing shows this will populate the map on next pod start.

## PR dependencies

None

## How to test and validate this PR

- Configure an HV=kubevirt EVE-OS node
- Deploy one or more VM App Instances each containing 1 or more volumes instances.

## Changelog notes

None

## PR Backports

TBD

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
