### PR TITLE
kubevirt: cluster config deletion missing node drain/delete

### DIFF
--- a/pkg/pillar/cmd/zedkube/clusterstatus.go
+++ b/pkg/pillar/cmd/zedkube/clusterstatus.go
@@ -71,6 +71,7 @@ func (z *zedkube) applyClusterConfig(config, oldconfig *types.EdgeNodeClusterCon
 	if config == nil {
 		// Before we let NIM to remove the cluster IP, we need to remove the node
 		// from the cluster.
+		drainAndDeleteNode(z)
 		z.stopClusterStatusServer()
 		z.clusterConfig = types.EdgeNodeClusterConfig{}
 		return


### PR DESCRIPTION
# Description

On node deletion, drain needs to occur to rebuild any degraded volumes before this node leaves.

## PR dependencies

None

## How to test and validate this PR

- Configure 3 EVE-OS nodes as a cluster using a controller
- Deploy one or more VM App Instances each containing 1 or more volumes instances
- Replace a node in the cluster
- Confirm that the node removed sees a drain requested.  This can be confirmed via pubsub zedkube/NodeDrainStatus where the RequestedBy value will be 3 (UPDATE)

```
cat /run/zedkube/NodeDrainStatus/global.json | jq .RequestedBy
3
```

## Changelog notes

None

## PR Backports

```text
- 14.5-stable: To be backported.
- 13.4-stable: No, as the feature is not available there.
```

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
