### PR TITLE
kubevirt: Handle Base k3s mode expansion, add nodes

### DIFF
--- a/pkg/kube/registration-utils.sh
+++ b/pkg/kube/registration-utils.sh
@@ -22,11 +22,7 @@ appliedRegistrationYamlFilePath="${KUBE_MANIFESTS_DIR}/${appliedRegistrationYaml
 # Pillar may download a yaml for registration, copy it in so that k3s handles applying it
 # This should be called in a very infrequently called cluster-config-change path
 Registration_CheckApply() {
-    if [ ! -d "${PERSIST_MANIFESTS_DIR}" ]; then
-        return
-    fi
-
-    if [ ! -e "${registrationYamlFilePath}" ]; then
+    if ! Registration_ConfigExists; then
         return
     fi
 
@@ -48,6 +44,20 @@ Registration_Exists() {
         return 0
     fi
     return 1
+}
+
+# Registration_ConfigExists is used to do some needed cleanup on a node before
+# applying registration manifest and before joining a pre-existing cluster
+Registration_ConfigExists() {
+    if [ ! -d "${PERSIST_MANIFESTS_DIR}" ]; then
+        return 1
+    fi
+
+    if [ ! -e "${registrationYamlFilePath}" ]; then
+        return 1
+    fi
+
+    return 0
 }
 
 # Registration_Applied checks if the cluster contains the pointer


### PR DESCRIPTION
## Description

Modify the order of operations of uninstall, k3s config and registration yaml application to support adding more nodes into a cluster. Existing cluster nodes will have previously removed infrastructure for VMs and replicated storage, newly joining nodes must also remove these items before connecting to the cluster.

New ordering of operations:
- Uninstall of components.
- Wait until new cluster config is fully available
- Generate k3s config
- Stage registration into k3s which will apply it when k3s is started next.

## PR dependencies

None

## How to test and validate this PR

- onboard three nodes running eve HV=kubevirt
- apply controller config to create cluster and send registration manifest to node 1
- verify system converted to base-k3s-mode by verifying kubevirt and longhorn-system namespaces are deleted
- apply controller config to add nodes 2 and 3 to the cluster
- verify kubevirt and longhorn-system namespaces are still deleted

## Changelog notes

Support adding cluster nodes to clustered eve nodes.

## PR Backports

None

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
