### PR TITLE
implement DhcpOptionsIgnore for IP, DNS, and Gateway

### DIFF
--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -30,6 +30,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
@@ -962,23 +963,27 @@ func printOutput(ctx *diagContext, caller string) {
 			}
 			continue
 		}
-		ctx.ph.Print("INFO: %s: DNS servers: ", ifname)
-		for _, ds := range port.DNSServers {
-			ctx.ph.Print("%s, ", ds.String())
+		if len(port.DNSServers) != 0 {
+			ctx.ph.Print("INFO: %s: DNS servers: %s\n", ifname,
+				utils.JoinStrings(port.DNSServers, ", "))
+		} else {
+			ctx.ph.Print("WARNING: %s: No DNS servers configured\n", ifname)
 		}
-		ctx.ph.Print("\n")
-		// If static print static config
-		if port.Dhcp == types.DhcpTypeStatic {
+		if port.ConfiguredSubnet != nil {
 			ctx.ph.Print("INFO: %s: Static IP subnet: %s\n",
 				ifname, port.ConfiguredSubnet.String())
-			for _, r := range port.DefaultRouters {
-				ctx.ph.Print("INFO: %s: Static IP router: %s\n",
-					ifname, r.String())
-			}
-			ctx.ph.Print("INFO: %s: Static Domain Name: %s\n",
+		}
+		if len(port.DefaultRouters) != 0 {
+			ctx.ph.Print("INFO: %s: IP routers: %s\n", ifname,
+				utils.JoinStrings(port.DefaultRouters, ", "))
+		}
+		if port.DomainName != "" {
+			ctx.ph.Print("INFO: %s: Domain Name: %s\n",
 				ifname, port.DomainName)
-			ctx.ph.Print("INFO: %s: Static NTP server: %+v\n",
-				ifname, port.ConfiguredNtpServers)
+		}
+		if len(port.NtpServers) != 0 {
+			ctx.ph.Print("INFO: %s: NTP servers: %s\n", ifname,
+				utils.JoinStrings(port.NtpServers, ", "))
 		}
 		printProxy(ctx, port, ifname)
 		if port.HasError() {

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1240,16 +1240,12 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 			networkInfo.DevName = *proto.String(name)
 			niStatus := appIfnameToNetworkInstance(ctx, aiStatus, ifname)
 			if niStatus != nil {
-				networkInfo.NtpServers = append(networkInfo.NtpServers, niStatus.NTPServers...)
+				networkInfo.NtpServers = utils.ToStrings(niStatus.NtpServers)
 				networkInfo.DefaultRouters = []string{niStatus.Gateway.String()}
 				networkInfo.Dns = &info.ZInfoDNS{
 					DNSservers: []string{},
 				}
-				networkInfo.Dns.DNSservers = []string{}
-				for _, dnsServer := range niStatus.DnsServers {
-					networkInfo.Dns.DNSservers = append(networkInfo.Dns.DNSservers,
-						dnsServer.String())
-				}
+				networkInfo.Dns.DNSservers = utils.ToStrings(niStatus.DnsServers)
 			}
 			ReportAppInfo.Network = append(ReportAppInfo.Network,
 				networkInfo)
@@ -1855,14 +1851,10 @@ func protoEncodeProbeMetrics(probeMetrics types.ProbeMetrics) *metrics.ZProbeNIM
 		UplinkCnt:      probeMetrics.PortCount,
 	}
 	for _, intfStats := range probeMetrics.IntfProbeStats {
-		var nextHops []string
-		for _, nh := range intfStats.NexthopIPs {
-			nextHops = append(nextHops, nh.String())
-		}
 		protoMetrics.IntfMetric = append(protoMetrics.IntfMetric,
 			&metrics.ZProbeNIMetrics_ZProbeIntfMetric{
 				IntfName:           intfStats.IntfName,
-				GatewayNexhtop:     strings.Join(nextHops, ", "),
+				GatewayNexhtop:     utils.JoinStrings(intfStats.NexthopIPs, ", "),
 				GatewayUP:          intfStats.NexthopUP,
 				RemoteHostUP:       intfStats.RemoteUP,
 				NexthopUpCount:     intfStats.NexthopUPCnt,

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/sriov"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
+	"github.com/lf-edge/eve/pkg/pillar/utils/netutils"
 )
 
 func initGetConfigCtx(g *GomegaWithT) *getconfigContext {
@@ -1680,7 +1682,8 @@ func TestParseIpspecNetworkXObject_ValidConfig(t *testing.T) {
 	g.Expect(config.DhcpRange.Start.String()).To(Equal("192.168.1.100"))
 	g.Expect(config.DhcpRange.End.String()).To(Equal("192.168.1.120"))
 	g.Expect(config.IgnoreDhcpNtpServers).To(BeTrue())
-	g.Expect(config.NTPServers).To(ConsistOf("192.168.1.10", "192.168.1.11"))
+	expNTPs := netutils.NewHostnameOrIPs("192.168.1.10", "192.168.1.11")
+	g.Expect(generics.EqualSetsFn(config.NTPServers, expNTPs, netutils.EqualHostnameOrIPs)).To(BeTrue())
 }
 
 func TestParseIpspecNetworkXObject_ValidConfig_IPv6(t *testing.T) {
@@ -1722,7 +1725,8 @@ func TestParseIpspecNetworkXObject_ValidConfig_IPv6(t *testing.T) {
 	Expect(config.DhcpRange.End.String()).To(Equal("fd00::1ff"))
 
 	Expect(config.IgnoreDhcpNtpServers).To(BeTrue())
-	Expect(config.NTPServers).To(ConsistOf("fd00::123", "fd00::124"))
+	expNTPs := netutils.NewHostnameOrIPs("fd00::123", "fd00::124")
+	Expect(generics.EqualSetsFn(config.NTPServers, expNTPs, netutils.EqualHostnameOrIPs)).To(BeTrue())
 }
 
 func TestParseIpspecNetworkXObject_InvalidSubnet(t *testing.T) {
@@ -1804,7 +1808,8 @@ func TestParseIpspec_Valid(t *testing.T) {
 	g.Expect(err).To(BeNil())
 	g.Expect(config.DomainName).To(Equal("test.local"))
 	g.Expect(config.Gateway.String()).To(Equal("192.168.0.1"))
-	g.Expect(config.NtpServers).To(ConsistOf("192.168.0.5"))
+	expNTPs := netutils.NewHostnameOrIPs("192.168.0.5")
+	Expect(generics.EqualSetsFn(config.NtpServers, expNTPs, netutils.EqualHostnameOrIPs)).To(BeTrue())
 	g.Expect(config.DnsServers[0].String()).To(Equal("192.168.0.2"))
 	g.Expect(config.DhcpRange.Start).ToNot(BeNil())
 	g.Expect(config.DhcpRange.End).ToNot(BeNil())

--- a/pkg/pillar/dpcreconciler/linux_test.go
+++ b/pkg/pillar/dpcreconciler/linux_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/iptables"
 	"github.com/lf-edge/eve/pkg/pillar/netmonitor"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils/netutils"
 )
 
 var (
@@ -277,7 +278,7 @@ func TestSingleEthInterface(test *testing.T) {
 	eth0.IPAddrs = append(eth0.IPAddrs, eth0IP)
 	eth0.DHCP = netmonitor.DHCPInfo{
 		IPv4Subnet:     ipSubnet("192.168.10.0/24"),
-		IPv4NtpServers: []net.IP{net.ParseIP("132.163.96.5")},
+		IPv4NtpServers: netutils.NewHostnameOrIPs("132.163.96.5"),
 	}
 	eth0.DNS = []netmonitor.DNSInfo{
 		{
@@ -479,7 +480,7 @@ func TestMultipleEthsSameSubnet(test *testing.T) {
 	// Simulate IP addresses being allocated by DHCP server.
 	// Both interfaces will be in the same subnet.
 	subnet := ipSubnet("192.168.10.0/24")
-	ntpServers := []net.IP{net.ParseIP("132.163.96.5")}
+	ntpServers := netutils.NewHostnameOrIPs("132.163.96.5")
 	eth0IP := ipAddress("192.168.10.5/24")
 	eth0.IPAddrs = append(eth0.IPAddrs, eth0IP)
 	eth0.DHCP = netmonitor.DHCPInfo{
@@ -1436,7 +1437,7 @@ func TestSingleEthInterfaceWithIPv6(test *testing.T) {
 	eth0.IPAddrs = append(eth0.IPAddrs, eth0IP)
 	eth0.DHCP = netmonitor.DHCPInfo{
 		IPv4Subnet:     ipSubnet("2000:1111::/64"),
-		IPv4NtpServers: []net.IP{net.ParseIP("2001:db8:3c4d:15::1")},
+		IPv4NtpServers: netutils.NewHostnameOrIPs("2001:db8:3c4d:15::1"),
 	}
 	eth0.DNS = []netmonitor.DNSInfo{
 		{

--- a/pkg/pillar/netmonitor/netmonitor.go
+++ b/pkg/pillar/netmonitor/netmonitor.go
@@ -6,6 +6,8 @@ package netmonitor
 import (
 	"context"
 	"net"
+
+	"github.com/lf-edge/eve/pkg/pillar/utils/netutils"
 )
 
 // NetworkMonitor should allow to:
@@ -188,8 +190,6 @@ type DNSInfo struct {
 type DHCPInfo struct {
 	IPv4Subnet     *net.IPNet
 	IPv6Subnets    []*net.IPNet
-	IPv4NtpServers []net.IP
-	IPv6NtpServers []net.IP
-	// NTP servers configured with hostname instead of IP address.
-	HostnameNtpServers []string
+	IPv4NtpServers []netutils.HostnameOrIP
+	IPv6NtpServers []netutils.HostnameOrIP
 }

--- a/pkg/pillar/nireconciler/linux_acl.go
+++ b/pkg/pillar/nireconciler/linux_acl.go
@@ -648,6 +648,7 @@ func (r *LinuxNIReconciler) getIntendedAppConnACLs(vif vifInfo,
 			ips = generics.FilterList(ips, func(ipNet *net.IPNet) bool {
 				return ipNet.IP.IsGlobalUnicast()
 			})
+			ips = r.filterIgnoredDhcpIPs(port, ips...)
 			portIPs[port.IfName] = ips
 		}
 	}

--- a/pkg/pillar/nireconciler/linux_currentstate.go
+++ b/pkg/pillar/nireconciler/linux_currentstate.go
@@ -90,6 +90,7 @@ func (r *LinuxNIReconciler) updateCurrentGlobalState(onlyPortsChanged bool) (cha
 					LogAndErrPrefix, portIfName, err)
 				// Continue as if this port interface didn't have any IP addresses...
 			}
+			ips = r.filterIgnoredDhcpIPs(port, ips...)
 			currentPorts.PutItem(generic.Port{
 				IfName:       portIfName,
 				LogicalLabel: port.LogicalLabel,
@@ -385,6 +386,7 @@ func (r *LinuxNIReconciler) getBridgeAddrs(niID uuid.UUID) (ipsWithSubnet,
 			if err != nil {
 				return
 			}
+			ips = r.filterIgnoredDhcpIPs(ni.bridge.Ports[0], ips...)
 			// Take global unicast IPs.
 			for _, ip := range ips {
 				if ip.IP.IsGlobalUnicast() {

--- a/pkg/pillar/nireconciler/linux_test.go
+++ b/pkg/pillar/nireconciler/linux_test.go
@@ -285,7 +285,7 @@ var (
 		IPAddrs: []*net.IPNet{ipAddressWithPrefix("192.168.10.5/24")},
 		DHCP: netmonitor.DHCPInfo{
 			IPv4Subnet:     ipSubnet("192.168.10.0/24"),
-			IPv4NtpServers: []net.IP{ipAddress("132.163.96.5")},
+			IPv4NtpServers: netutils.NewHostnameOrIPs("132.163.96.5"),
 		},
 		DNS: []netmonitor.DNSInfo{
 			{
@@ -307,6 +307,20 @@ var (
 				Dst:       nil,
 				Gw:        ipAddress("192.168.10.1"),
 				Table:     unix.RT_TABLE_MAIN,
+				Family:    netlink.FAMILY_V4,
+				Protocol:  unix.RTPROT_DHCP,
+			},
+		},
+		{
+			IfIndex: 2,
+			Dst:     ipAddressWithPrefix("0.0.0.0/0"),
+			Gw:      ipAddress("192.168.10.1"),
+			Table:   types.DPCBaseRTIndex + 2,
+			Data: netlink.Route{
+				LinkIndex: 2,
+				Dst:       nil,
+				Gw:        ipAddress("192.168.10.1"),
+				Table:     types.DPCBaseRTIndex + 2,
 				Family:    netlink.FAMILY_V4,
 				Protocol:  unix.RTPROT_DHCP,
 			},
@@ -364,6 +378,20 @@ var (
 				Protocol:  unix.RTPROT_DHCP,
 			},
 		},
+		{
+			IfIndex: 4,
+			Dst:     ipAddressWithPrefix("0.0.0.0/0"),
+			Gw:      ipAddress("172.20.0.1"),
+			Table:   types.DPCBaseRTIndex + 4,
+			Data: netlink.Route{
+				LinkIndex: 4,
+				Dst:       nil,
+				Gw:        ipAddress("172.20.0.1"),
+				Table:     types.DPCBaseRTIndex + 4,
+				Family:    netlink.FAMILY_V4,
+				Protocol:  unix.RTPROT_DHCP,
+			},
+		},
 	}
 
 	// Device network port "eth2" (IPv6 connectivity)
@@ -410,6 +438,20 @@ var (
 				Dst:       ipAddressWithPrefix("::/0"),
 				Gw:        ipAddress("2001::1"),
 				Table:     unix.RT_TABLE_MAIN,
+				Family:    netlink.FAMILY_V4,
+				Protocol:  unix.RTPROT_DHCP,
+			},
+		},
+		{
+			IfIndex: 6,
+			Dst:     ipAddressWithPrefix("::/0"),
+			Gw:      ipAddress("2001::1"),
+			Table:   types.DPCBaseRTIndex + 6,
+			Data: netlink.Route{
+				LinkIndex: 6,
+				Dst:       ipAddressWithPrefix("::/0"),
+				Gw:        ipAddress("2001::1"),
+				Table:     types.DPCBaseRTIndex + 6,
 				Family:    netlink.FAMILY_V4,
 				Protocol:  unix.RTPROT_DHCP,
 			},
@@ -463,6 +505,20 @@ var (
 				Dst:       nil,
 				Gw:        ipAddress("172.30.30.1"),
 				Table:     unix.RT_TABLE_MAIN,
+				Family:    netlink.FAMILY_V4,
+				Protocol:  unix.RTPROT_DHCP,
+			},
+		},
+		{
+			IfIndex: 8,
+			Dst:     ipAddressWithPrefix("0.0.0.0/0"),
+			Gw:      ipAddress("172.30.30.1"),
+			Table:   types.DPCBaseRTIndex + 8,
+			Data: netlink.Route{
+				LinkIndex: 8,
+				Dst:       nil,
+				Gw:        ipAddress("172.30.30.1"),
+				Table:     types.DPCBaseRTIndex + 8,
 				Family:    netlink.FAMILY_V4,
 				Protocol:  unix.RTPROT_DHCP,
 			},
@@ -3126,7 +3182,7 @@ func TestSwitchNIWithMultiplePorts(test *testing.T) {
 		IPAddrs: []*net.IPNet{ipAddressWithPrefix("192.168.10.5/24")},
 		DHCP: netmonitor.DHCPInfo{
 			IPv4Subnet:     ipSubnet("192.168.10.0/24"),
-			IPv4NtpServers: []net.IP{ipAddress("132.163.96.5")},
+			IPv4NtpServers: netutils.NewHostnameOrIPs("132.163.96.5"),
 		},
 		DNS: []netmonitor.DNSInfo{
 			{

--- a/pkg/pillar/nireconciler/nireconciler.go
+++ b/pkg/pillar/nireconciler/nireconciler.go
@@ -136,14 +136,16 @@ func (b NIBridge) GetPort(logicalLabel string) *Port {
 // Port is a physical network device used by a network instance to provide external
 // connectivity for applications.
 type Port struct {
-	LogicalLabel string
-	SharedLabels []string
-	IfName       string
-	IsMgmt       bool
-	MTU          uint16
-	DhcpType     types.DhcpType
-	DNSServers   []net.IP
-	NTPServers   []net.IP
+	LogicalLabel  string
+	SharedLabels  []string
+	IfName        string
+	IsMgmt        bool
+	MTU           uint16
+	DhcpType      types.DhcpType
+	DNSServers    []net.IP
+	NTPServers    []net.IP
+	StaticIP      *net.IPNet
+	IgnoreDhcpIPs bool
 }
 
 // Equal compares two ports for equality.

--- a/pkg/pillar/types/zedroutertypes.go
+++ b/pkg/pillar/types/zedroutertypes.go
@@ -722,7 +722,7 @@ type NetworkInstanceConfig struct {
 	Subnet          *net.IPNet
 	Gateway         net.IP
 	DomainName      string
-	NtpServers      []string
+	NtpServers      []netutils.HostnameOrIP
 	DnsServers      []net.IP // If not set we use Gateway as DNS server
 	DhcpRange       IPRange
 	DnsNameToIPList []DNSNameToIP // Used for DNS and ACL ipset
@@ -1002,7 +1002,7 @@ type NetworkInstanceStatus struct {
 	// List of NTP servers published to applications connected to this network instance.
 	// This includes the NTP server from the NI config (if any) and all NTP servers
 	// associated with ports used by the network instance for external connectivity.
-	NTPServers []string
+	NTPServers []netutils.HostnameOrIP
 	// The intended state of the routing table.
 	// Includes user-configured static routes and potentially also automatically
 	// generated default route.

--- a/pkg/pillar/utils/common.go
+++ b/pkg/pillar/utils/common.go
@@ -4,8 +4,29 @@
 package utils
 
 import (
+	"strings"
+
 	uuid "github.com/satori/go.uuid"
 )
 
 // Really a constant
 var nilUUID = uuid.UUID{}
+
+// Stringer is a type constraint for anything that implements String() string.
+type Stringer interface {
+	String() string
+}
+
+// ToStrings converts a slice of Stringer values to a slice of strings.
+func ToStrings[T Stringer](items []T) []string {
+	strs := make([]string, len(items))
+	for i, item := range items {
+		strs[i] = item.String()
+	}
+	return strs
+}
+
+// JoinStrings joins a slice of Stringer values using the given separator.
+func JoinStrings[T Stringer](items []T, sep string) string {
+	return strings.Join(ToStrings(items), sep)
+}

--- a/pkg/pillar/utils/netutils/hostnameorip.go
+++ b/pkg/pillar/utils/netutils/hostnameorip.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package netutils
+
+import (
+	"encoding/json"
+	"net"
+)
+
+// HostnameOrIP holds either a literal IP address or a hostname.
+// It stores both the original string and the parsed IP (if valid).
+type HostnameOrIP struct {
+	raw string // original string
+	ip  net.IP // parsed IP if raw is a literal IP, nil if hostname
+}
+
+// NewHostnameOrIP creates a HostnameOrIP from a string.
+func NewHostnameOrIP(s string) HostnameOrIP {
+	return HostnameOrIP{
+		raw: s,
+		ip:  net.ParseIP(s),
+	}
+}
+
+// NewHostnameOrIPs creates a slice of HostnameOrIP from one or more string values.
+func NewHostnameOrIPs(values ...string) []HostnameOrIP {
+	result := make([]HostnameOrIP, len(values))
+	for i, s := range values {
+		result[i] = NewHostnameOrIP(s)
+	}
+	return result
+}
+
+// EqualHostnameOrIPs compares two HostnameOrIP values for equality.
+func EqualHostnameOrIPs(a, b HostnameOrIP) bool {
+	return a.Equal(b)
+}
+
+// String returns the original string (IP or hostname).
+func (h HostnameOrIP) String() string {
+	return h.raw
+}
+
+// IsIP returns true if this is a literal IP.
+func (h HostnameOrIP) IsIP() bool {
+	return h.ip != nil
+}
+
+// GetIP returns the literal IP.
+func (h HostnameOrIP) GetIP() net.IP {
+	return h.ip
+}
+
+// Equal compares two HostnameOrIP values for equality.
+func (h HostnameOrIP) Equal(h2 HostnameOrIP) bool {
+	if h.IsIP() != h2.IsIP() {
+		return false
+	}
+	if h.IsIP() {
+		return h.ip.Equal(h2.ip)
+	}
+	return h.raw == h2.raw
+}
+
+// MarshalJSON serializes HostnameOrIP as a string.
+func (h HostnameOrIP) MarshalJSON() ([]byte, error) {
+	return json.Marshal(h.raw)
+}
+
+// UnmarshalJSON parses from string and sets IP if valid.
+func (h *HostnameOrIP) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	h.raw = s
+	h.ip = net.ParseIP(s)
+	return nil
+}

--- a/pkg/pillar/utils/netutils/ip.go
+++ b/pkg/pillar/utils/netutils/ip.go
@@ -57,6 +57,18 @@ func AddToIP(ip net.IP, addition int) net.IP {
 	return net.IP{}
 }
 
+// NewIPNet combines a given IP and subnet into net.IPNet.
+// Returns nil if either the IP or subnet is nil.
+func NewIPNet(ip net.IP, subnet *net.IPNet) *net.IPNet {
+	if ip == nil || subnet == nil {
+		return nil
+	}
+	return &net.IPNet{
+		IP:   ip,
+		Mask: subnet.Mask,
+	}
+}
+
 // GetIPAddrCountOnSubnet return the number or available IP addresses inside a subnet.
 func GetIPAddrCountOnSubnet(subnet *net.IPNet) int {
 	if subnet == nil {


### PR DESCRIPTION
# Description

- Extended support for `DhcpOptionsIgnore` to cover IP addresses, DNS servers/domains, and gateway addresses, in addition to the already supported NTP servers.
- By default, DHCP-provided options are merged with static configuration.
- If a given `*_exclusively` flag is enabled, static values replace DHCP-provided ones. If no static values are present, the resulting config is then empty (e.g. no DNS servers, no IP).
- Domain name and gateway are special cases: only one per-port value is supported. Here, static config always takes priority over DHCP. Regardless of the flag value, non-zero static values always overwrites DHCP config. If static is nil, then the DHCP value is used unless the corresponding `*_exclusively` flag is set, in which case the field is cleared.

Implementation notes:
- Simplified handling of NTP servers: `DeviceNetworkStatus` now exposes a single combined list of NTP servers, so consumers do not need to distinguish DHCP vs static.
- Introduced `HostnameOrIP` type for representing NTP servers, supporting both IPs and hostnames and (un)marshalling as strings.
- When ignoring DHCP-provided IP addresses, the lease is still acquired and `dhcpcd` configures the address on the interface. However, EVE suppresses propagation of this IP and its routes into per-port and per-NI routing tables, ensuring only the static configuration is applied.

## How to test and validate this PR

Once supported by the controller, it will be possible to configure network port with DHCP, but at the same time statically configure port IP addresses, gateways and DNS servers, and for each decide if it should be merged with DHCP-provided configuration or replace DHCP configuration. Then it is a matter of checking the reported network configuration or entering the device and checking output from `ip addr`, `cat /etc/resolv.conf` and `ip route`. (as well as testing connectivity)

But in the foreseeable future, it will be possible to use this feature only through the [new LPS endpoint](https://github.com/lf-edge/eve-api/blob/main/PROFILE.md#network) `/api/v/network`, which is still under development.

(I tested this using eden+adam, which allows me to create and submit any `EdgeDevConfig` edited using a text/JSON editor)

## Changelog notes

Added support to selectively merge or replace DHCP-provided configuration (IP address, DNS servers/domains, gateways, NTP servers) with statically entered values. Previously, this was supported only for NTP servers.

## PR Backports

New feature, not to be backported.

- 14.5-stable: No
- 13.4-stable: No

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.