### PR TITLE
Fix the replicated volume status

### DIFF
--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -471,8 +471,17 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 
 	log.Functionf("doUpdateVol(%s) name %s", status.Key(), status.DisplayName)
 
-	// If volume is already created or if is a replicated volume, do nothing.
-	if status.State == types.CREATED_VOLUME || status.IsReplicated {
+	// Anything to do?
+	// If volume is a replicated volume, we expect it to be created on owner node, so set the status
+	// as such and publish
+	if status.IsReplicated {
+		status.State = types.CREATED_VOLUME
+		status.SubState = types.VolumeSubStateCreated
+		return true, true
+	}
+
+	// If volume is already created, do nothing
+	if status.State == types.CREATED_VOLUME {
 		log.Functionf("doUpdateVol(%s) name %s nothing to do",
 			status.Key(), status.DisplayName)
 		return false, true


### PR DESCRIPTION

# Description

A replicated volume will always have a designated node where the volume is created. So if we are processing doUpdateVol() and the volume is replicated, just set the volume created state and return to publish the volumestatus.

During failover zedmanager looks for volumestatus to be created before activating the app.


## PR dependencies


## How to test and validate this PR

1) Create a 3 node cluster
2) Deploy a VM, the volume will be replicated to 3 nodes.
3) Trigger a failover either by reboot/network cable pull etc.
4) VM will failover to some other node
5) Observe in the controller that the VM app comes online after failover.

Without this fix, app will stay in booting state forever. Because volume status will always be init.

## Changelog notes

None.

## PR Backports

Backport not required since this is a new feature for November LTS release.

## Checklist

- [x] I've provided a proper description
- [x] I've tested my PR on amd64 device
- [x] I've written the test verification instructions

