### PR TITLE
Integrate monitor-rs version v0.6.0

### DIFF
--- a/pkg/monitor/Dockerfile
+++ b/pkg/monitor/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG MONITOR_RS_VERSION=v0.5.0
+ARG MONITOR_RS_VERSION=v0.6.0
 ARG RUST_VERSION=lfedge/eve-rust:1.85.1-1
 FROM --platform=$BUILDPLATFORM ${RUST_VERSION} AS toolchain-base
 ARG TARGETARCH


### PR DESCRIPTION
# Description

Following changes were made

Basically two main issues were addressed
 - IPv6 addresses are correctly supported
 - Manual proxy configuration is now working
And improvement
 - TUI now validates correctness of data in IpDialog e.g. that user entered valid ipv4

b8a4e0d Release 0.6.0
d47b2d5 Fix eve types for ProxyEntry
576ca40 Add support for proxy server
733ac99 Add TextInput trait to manupulate InputFieldElement db3873f Add status bar tips support
f10bc37 Fix config.load() logic
293567e Update device tests
e4dbb88 Update eve types to match PR #5067
98f04c2 gha: add test coverage to pr ci/cd

## How to test and validate this PR

1. run eve with TUI
2. make sure IP addresses are displayed correctly in network tab
3. make sure proxy is actually used by eve when set. it can be monitored in diag output

## Changelog notes

[TUI] - IPv6 addresses are correctly supported
[TUI] - Manual proxy configuration is now working

## PR Backports


```text
- 14.5-stable: **To be backported**.
- 13.4-stable: No, as the feature is not available there.
```

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
