### PR TITLE
[11.0-stable] skip BaseOS from saved config during upgrade test.

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -150,7 +150,15 @@ func parseConfig(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig,
 		parseSystemAdapterConfig(getconfigCtx, config, source, forceSystemAdaptersParse)
 
 		if source != fromBootstrap {
-			activateNewBaseOS := parseBaseOS(getconfigCtx, config)
+			// Determine if we should skip parsing BaseOS from saved-config during upgrade test/in-progress
+			activateNewBaseOS := false
+			skipSavedBaseOS := (source == savedConfig) && getconfigCtx.updateInprogress
+			if skipSavedBaseOS {
+				log.Noticef("parseConfig: Upgrade test in progress; ignoring BaseOS from saved config")
+				// Do not call parseBaseOS; ensure activateNewBaseOS remains false
+			} else {
+				activateNewBaseOS = parseBaseOS(getconfigCtx, config)
+			}
 			parseNetworkInstanceConfig(getconfigCtx, config)
 			parseContentInfoConfig(getconfigCtx, config)
 			parseVolumeConfig(getconfigCtx, config)


### PR DESCRIPTION
# Description

Introduce a safeguard so the device ignores stale BaseOS entries from `lastconfig` after reboot into a new version.

When the controller sends a config with a new BaseOS **and** activate:true, zedagent skips persisting it, so the outdated config is preserved only. After reboot, EVE would reload the old `lastconfig`, recreate outdated BaseOS/ContentTree objects, and queue an unintended downgrade on the next reboot.

This change ensures that even in the skip case we do not fall back to stale config after reboot. Devices can now tolerate a “stalled” lastconfig during upgrade without triggering a downgrade cycle.

## PR dependencies

None.

## How to test and validate this PR

1. Start a device on 11.0.6.
2. Using TF provider **1.0.6**, upgrade it to a the build containing this fix
3. Observe that after reboot into the new image:
3.1 The old/stalled lastconfig is still present: copy it from /persist/checkpoint/lastconfig **during the 10-min test window**. Decode it (ask EVE eng for the tool), and check that it contains wrong baseos: 11.0.6.
4. Get status from the device, see that it contains only two base os images: 11.0.6 and this version.
5. After 10-min test is done, try reboot the device and wait for some time. Be sure it does not start downgrading into 11.0.6.


## Changelog notes

Fixes an issue where devices could incorrectly downgrade after reboot if a new BaseOS was activated and the previous config was still stored on disk. Devices now tolerate a stalled config after upgrade, preventing unintended downgrades.

## PR Backports

14.5-stable: ???
13.4-stable: ??? 

Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
