### PR TITLE
Fast VM failover for unreachable node.

### DIFF
--- a/pkg/kube/config.yaml
+++ b/pkg/kube/config.yaml
@@ -19,8 +19,8 @@ kube-controller-arg:
   - "node-monitor-period=5s"
   - "node-monitor-grace-period=40s"
 kube-controller-manager-arg:
-  - "node-monitor-period=5s"
-  - "node-monitor-grace-period=40s"
+  - "node-monitor-period=2s"
+  - "node-monitor-grace-period=10s"
 kube-apiserver-arg:
   - "event-ttl=72h"
   - "authentication-token-webhook-config-file=/etc/kube-api-authn-webhook.yaml"

--- a/pkg/kube/kubevirt-utils.sh
+++ b/pkg/kube/kubevirt-utils.sh
@@ -12,10 +12,10 @@ Kubevirt_install() {
     # so we download kubevirt-operator.yaml and patch it
     logmsg "Installing patched Kubevirt"
     kubectl apply -f /etc/kubevirt-operator.yaml
-    logmsg "Updating replica to 1 for virt-operator and virt-controller"
-    kubectl patch deployment virt-operator -n kubevirt --patch '{"spec":{"replicas": 1 }}'
+    logmsg "Updating replica to 3 for virt-operator and virt-controller"
+    kubectl patch deployment virt-operator -n kubevirt --patch '{"spec":{"replicas": 3 }}'
     kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
-    kubectl patch KubeVirt kubevirt -n kubevirt --patch '{"spec": {"infra": {"replicas": 1}}}' --type='merge'
+    kubectl patch KubeVirt kubevirt -n kubevirt --patch '{"spec": {"infra": {"replicas": 3}}}' --type='merge'
     #Add kubevirt feature gates
     kubectl apply -f /etc/kubevirt-features.yaml
 }

--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -6,7 +6,8 @@ package base
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/satori/go.uuid"
+
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -174,6 +175,8 @@ const (
 	CachedResolvedIPsLogType LogObjectType = "cached_resolved_ips"
 	// AppMACGeneratorLogType : type for AppMACGenerator log entries
 	AppMACGeneratorLogType LogObjectType = "app_mac_generator"
+	// KubeAppFailover
+	KubeAppFailover LogObjectType = "kube_app_failover"
 )
 
 // RelationObjectType :

--- a/pkg/pillar/cmd/zedkube/applogs.go
+++ b/pkg/pillar/cmd/zedkube/applogs.go
@@ -22,11 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// If DeletionTimestamp is not null, the pod is terminating.
-func isPodTerminating(pod corev1.Pod) bool {
-	return pod.ObjectMeta.DeletionTimestamp != nil
-}
-
 // collect App logs from pods which covers both containers and virt-launcher pods
 func (z *zedkube) collectAppLogs() {
 	sub := z.subAppInstanceConfig
@@ -146,27 +141,36 @@ func (z *zedkube) checkAppsStatus() {
 
 	var oldStatus *types.ENClusterAppStatus
 	for _, item := range items {
-		var foundPod bool
 		aiconfig := item.(types.AppInstanceConfig)
-
 		encAppStatus := types.ENClusterAppStatus{
 			AppUUID:    aiconfig.UUIDandVersion.UUID,
 			IsDNidNode: aiconfig.IsDesignatedNodeID,
 		}
 		contName := base.GetAppKubeName(aiconfig.DisplayName, aiconfig.UUIDandVersion.UUID)
 
+		//
+		// We're looking for two pods:
+		// 1. An existing copy of a VMs virt-launcher pod which is terminating
+		//  We use this as a starting anchor to find and detach persistent volumes
+		//  So that the app can complete failover
+		// 2. A new copy of a VMs virt-launcher pod which is starting on a new node
+		//	We use this to fill in the ENClusterAppStatus above and tell the controller
+		//	Where the app is moved to.
+		//
+		// Both Pods will be of the pattern <appname>-<uuid prefix>-<pod uuid suffix>
 		for _, pod := range pods.Items {
 			contVMIName := "virt-launcher-" + contName
-			log.Functionf("checkAppsStatus: pod %s, cont %s", pod.Name, contName)
+			log.Noticef("checkAppsStatus: pod %s, looking for cont %s", pod.Name, contName)
 			foundVMIPod := strings.HasPrefix(pod.Name, contVMIName)
 			if strings.HasPrefix(pod.Name, contName) || foundVMIPod {
+				// Case 1
 				if isPodTerminating(pod) {
 					// This is the old copy on the failed node, ignore it.
 					// Next in the list should be a new copy in 'Scheduling'
-					log.Noticef("Pod:%s is terminating onNode:%s deletionTime:%v",
-						pod.Name, pod.Spec.NodeName, pod.ObjectMeta.DeletionTimestamp)
 					continue
 				}
+
+				// Case 2
 				if pod.Spec.NodeName == z.nodeName {
 					encAppStatus.ScheduledOnThisNode = true
 				}
@@ -176,9 +180,9 @@ func (z *zedkube) checkAppsStatus() {
 				if foundVMIPod {
 					encAppStatus.AppIsVMI = true
 					encAppStatus.AppKubeName, _ = base.GetVMINameFromVirtLauncher(pod.Name)
+					log.Functionf("aiDisplayName:%s aiUUID:%s Pod:%s is attempting to start onNode:%s",
+						aiconfig.DisplayName, aiconfig.UUIDandVersion.UUID, pod.Name, pod.Spec.NodeName)
 				}
-				foundPod = true
-				break
 			}
 		}
 
@@ -189,62 +193,19 @@ func (z *zedkube) checkAppsStatus() {
 				break
 			}
 		}
+
 		log.Functionf("checkAppsStatus: devname %s, pod (%d) status %+v, old %+v", z.nodeName, len(pods.Items), encAppStatus, oldStatus)
 
-		// If this is first time after zedkube started (oldstatus is nil) and I am DNid and the app is not shceduled
+		// If this is first time after zedkube started (oldstatus is nil) and I am DNid and the app is not scheduled
 		// on this node. This condition is seen for two reasons
 		// 1) We just got appinstanceconfig and domainmgr did not get chance to start it yet, timing issue, zedkube checked first
 		// 2) We are checking after app failover to other node, either this node network failed and came back or this just got rebooted
-
-		if oldStatus == nil && !encAppStatus.ScheduledOnThisNode && encAppStatus.IsDNidNode && !foundPod {
-			log.Noticef("checkAppsStatus: app not yet scheduled on this node %v", encAppStatus)
-			continue
-		}
-
-		// Publish if there is a status change
-		if oldStatus == nil || oldStatus.ScheduledOnThisNode != encAppStatus.ScheduledOnThisNode || oldStatus.StatusRunning != encAppStatus.StatusRunning {
-			log.Functionf("checkAppsStatus: status differ, publish")
+		if oldStatus == nil || !oldStatus.Equal(encAppStatus) {
+			log.Functionf("checkAppsStatus: aiDisplayName:%s aiUUID:%s status differ, publish", aiconfig.DisplayName, aiconfig.UUIDandVersion.UUID)
 			// If app scheduled on this node, could happen for 3 reasons.
 			// 1) I am designated node.
 			// 2) I am not designated node but failover happened.
 			// 3) I am designated node but this is failback after failover.
-			// Get the list of volumes referenced by this app and delete the volume attachments from previous node.
-			// We need to do that because longhorn volumes are RWO and only one node can attach to those volumes.
-			// This will ensure at any given time only one node can write to those volumes, avoids corruptions.
-			// Basically if app is scheduled on this node, no other node should have volumeattachments.
-			// This is our fencing mechanism.
-			if encAppStatus.ScheduledOnThisNode {
-				for _, vol := range aiconfig.VolumeRefConfigList {
-					pvcName := fmt.Sprintf("%s-pvc-%d", vol.VolumeID.String(), vol.GenerationCounter)
-					// Get the PV name for this PVC
-					pv, err := kubeapi.GetPVFromPVC(pvcName, log)
-					if err != nil {
-						log.Errorf("Error getting PV from PVC %v", err)
-						continue
-					}
-
-					va, remoteNodeName, err := kubeapi.GetVolumeAttachmentFromPV(pv, log)
-					if err != nil {
-						log.Errorf("Error getting volumeattachment PV %s err %v", pv, err)
-						continue
-					}
-					// If no volumeattachment found, continue
-					if va == "" {
-						continue
-					}
-
-					// Delete the attachment if not on this node.
-					if remoteNodeName != z.nodeName {
-						log.Noticef("Deleting volumeattachment %s on remote node %s", va, remoteNodeName)
-						err = kubeapi.DeleteVolumeAttachment(va, log)
-						if err != nil {
-							log.Errorf("Error deleting volumeattachment %s from PV %v", va, err)
-							continue
-						}
-					}
-
-				}
-			}
 			z.pubENClusterAppStatus.Publish(aiconfig.Key(), encAppStatus)
 		}
 	}

--- a/pkg/pillar/cmd/zedkube/failover.go
+++ b/pkg/pillar/cmd/zedkube/failover.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build kubevirt
+
+package zedkube
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (z *zedkube) shouldDetachApp(oldStatus *types.ENClusterAppStatus, newStatus *types.ENClusterAppStatus) bool {
+	return (oldStatus == nil) && newStatus.ScheduledOnThisNode
+}
+
+// Interface to determining a node allowed to make cluster-wide operations
+func (z *zedkube) isDecisionNode() (isNode bool) {
+	if z.isKubeStatsLeader.Load() {
+		isNode = true
+	}
+	return isNode
+}
+
+func (z *zedkube) checkAppsFailover(wdFunc func()) {
+	sub := z.subAppInstanceConfig
+	items := sub.GetAll()
+	if len(items) == 0 {
+		return
+	}
+
+	clientset, err := getKubeClientSet()
+	if err != nil {
+		log.Errorf("checkAppsFailover: can't get clientset %v", err)
+		return
+	}
+
+	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("checkAppsFailover: can't get pods %v", err)
+		return
+	}
+
+	for _, item := range items {
+		wdFunc()
+
+		aiconfig := item.(types.AppInstanceConfig)
+		encAppStatus := types.ENClusterAppStatus{
+			AppUUID:    aiconfig.UUIDandVersion.UUID,
+			IsDNidNode: aiconfig.IsDesignatedNodeID,
+		}
+		contName := base.GetAppKubeName(aiconfig.DisplayName, aiconfig.UUIDandVersion.UUID)
+
+		//
+		// We're looking for two pods:
+		// 1. An existing copy of a VMs virt-launcher pod which is terminating
+		//  We use this as a starting anchor to find and detach persistent volumes
+		//  So that the app can complete failover
+		// 2. A new copy of a VMs virt-launcher pod which is starting on a new node
+		//	We use this to fill in the ENClusterAppStatus above and tell the controller
+		//	Where the app is moved to.
+		//
+		// Both Pods will be of the pattern <appname>-<uuid prefix>-<pod uuid suffix>
+		terminatingVirtLauncherPod := ""
+		terminatingNodeName := ""
+		appDomainNameLbl := ""
+		foundNewSchedulingPod := false
+		var durationTerminating time.Duration
+
+		for _, pod := range pods.Items {
+			contVMIName := "virt-launcher-" + contName
+			log.Noticef("checkAppsStatus: pod %s, looking for cont %s", pod.Name, contName)
+			foundVMIPod := strings.HasPrefix(pod.Name, contVMIName)
+			if strings.HasPrefix(pod.Name, contName) || foundVMIPod {
+				// Case 1
+				if isPodTerminating(pod) {
+					// This is the old copy on the failed node, ignore it.
+					// Next in the list should be a new copy in 'Scheduling'
+					log.Noticef("aiDisplayName:%s aiUUID:%s Pod:%s is terminating onNode:%s deletionTime:%v",
+						aiconfig.DisplayName, aiconfig.UUIDandVersion.UUID, pod.Name, pod.Spec.NodeName, pod.ObjectMeta.DeletionTimestamp)
+					terminatingVirtLauncherPod = pod.Name
+					terminatingNodeName = pod.Spec.NodeName
+					val, lblExists := pod.ObjectMeta.Labels[kubeapi.EVEAppDomainNameLbl]
+					if lblExists {
+						appDomainNameLbl = val
+					}
+					durationTerminating = getPodTerminatingTime(pod)
+					continue
+				}
+
+				// Case 2
+				if pod.Spec.NodeName == z.nodeName {
+					encAppStatus.ScheduledOnThisNode = true
+				}
+				if pod.Status.Phase == corev1.PodRunning {
+					encAppStatus.StatusRunning = true
+				}
+				if foundVMIPod {
+					encAppStatus.AppIsVMI = true
+					encAppStatus.AppKubeName, _ = base.GetVMINameFromVirtLauncher(pod.Name)
+					log.Functionf("aiDisplayName:%s aiUUID:%s Pod:%s is attempting to start onNode:%s",
+						aiconfig.DisplayName, aiconfig.UUIDandVersion.UUID, pod.Name, pod.Spec.NodeName)
+				}
+				foundNewSchedulingPod = true
+			}
+		}
+
+		//
+		// If the app is running, nothing to do.
+		//
+		if (terminatingVirtLauncherPod == "") && encAppStatus.StatusRunning {
+			// No need to failover
+			log.Functionf("aiDisplayName:%s aiUUID:%s no terminating virtLauncher and reporting status running",
+				aiconfig.DisplayName, aiconfig.UUIDandVersion.UUID)
+			continue
+		}
+
+		//
+		// App is not running, but kubernetes has not scheduled a new copy yet.
+		//
+		// Sometimes when a node becomes unreachable, the kubevirt control-plane seems to
+		// Get stuck and not schedule a new VMI or virt-launcher pod.  This tested step seems
+		// to push kubevirt into scheduling a new replica.
+		//
+		if !foundNewSchedulingPod && ((durationTerminating > (time.Minute * 2)) && z.isDecisionNode()) {
+			log.Noticef("aiDisplayName:%s aiUUID:%s only a terminating pod for 2+min, moving to reset vmirs",
+				aiconfig.DisplayName, aiconfig.UUIDandVersion.UUID)
+			vmiRsName, err := kubeapi.GetVmiRsName(log, appDomainNameLbl)
+			if err != nil {
+				log.Errorf("aiDisplayName:%s aiUUID:%s vmirsname get err:%v",
+					aiconfig.DisplayName, aiconfig.UUIDandVersion.UUID, err)
+			} else {
+				err := kubeapi.DetachUtilVmirsReplicaReset(log, vmiRsName)
+				if err != nil {
+					log.Errorf("aiDisplayName:%s aiUUID:%s replica reset for vmirs:%s err:%v",
+						aiconfig.DisplayName, aiconfig.UUIDandVersion.UUID, vmiRsName, err)
+				}
+			}
+			continue
+		}
+
+		log.Noticef("aiDisplayName:%s aiUUID:%s newStatus:%v",
+			aiconfig.DisplayName, aiconfig.UUIDandVersion.UUID, encAppStatus)
+
+		if encAppStatus.ScheduledOnThisNode {
+			kubeapi.DetachOldWorkload(log, terminatingNodeName, appDomainNameLbl, wdFunc)
+			log.Noticef("checkAppsFailover: complete for appDomainName: %s", appDomainNameLbl)
+			continue
+		}
+	}
+}

--- a/pkg/pillar/cmd/zedkube/podutils.go
+++ b/pkg/pillar/cmd/zedkube/podutils.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build kubevirt
+
+package zedkube
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func getPodTerminatingTime(pod corev1.Pod) time.Duration {
+	if pod.ObjectMeta.DeletionTimestamp == nil {
+		return 0
+	}
+	return time.Since(pod.ObjectMeta.DeletionTimestamp.Time)
+}
+
+// If DeletionTimestamp is not null, the pod is terminating.
+func isPodTerminating(pod corev1.Pod) bool {
+	return pod.ObjectMeta.DeletionTimestamp != nil
+}

--- a/pkg/pillar/kubeapi/nokube.go
+++ b/pkg/pillar/kubeapi/nokube.go
@@ -45,3 +45,8 @@ func GetNodeDrainStatus(pubsub.Subscription, *base.LogObject) *NodeDrainStatus {
 func IsClusterMode() bool {
 	return false
 }
+
+// DetachOldWorkload is a stub for non HV=kubevirt builds
+func DetachOldWorkload(log *base.LogObject, virtLauncherPodName string) error {
+	return nil
+}

--- a/pkg/pillar/types/clustertypes.go
+++ b/pkg/pillar/types/clustertypes.go
@@ -53,9 +53,13 @@ type ENClusterAppStatus struct {
 	IsDNidNode          bool      // DesignatedNodeID is set on the App for this node
 	ScheduledOnThisNode bool      // App is running on this device
 	StatusRunning       bool      // Status of the app in "Running" state
-	IsVolumeDetached    bool      // Are volumes detached after failover ?
 	AppIsVMI            bool      // Is this a VMI app, vs a Pod app
 	AppKubeName         string    // Kube name of the app, either VMI or Pod
+}
+
+// Equal returns true if all ENClusterAppStatus fields are equal
+func (enc ENClusterAppStatus) Equal(newEnc ENClusterAppStatus) bool {
+	return newEnc == enc
 }
 
 // Key - returns the key for the config of EdgeNodeClusterConfig


### PR DESCRIPTION
# Description 

For failed nodes, a delete of the volumeattachment is not enough.

1. Detect when a kubernetes node has become NotReady/NodeUnreachable: Checking node status taints.
2. Handle terminating control-plane pods on unreachable node: Force Deletion cleans them up so that kubevirt and longhorn API can quickly available again on remaining nodes.
3. Before cleanup, collect a chain of information from stuck terminating workload. vmi, virt-launcher pod, PVC, volume, and replica names.
4. Force delete old copies on unreachable node.
5. Kubernetes will reschedule new work on a remaining ready node.

failover-events.sh: a new script added to aid in debugging failover
	pass it the VM app instance name (vmirs name prefix)
	Output to the console will be all kubernetes events associated
	with the vmirs, pod, vmi, pvc, volume, replica sorted by time.

zedkube:
- Extension of waitForVMI time 5min->15min to allow longer failovers to complete.
- checkAppsStatus should update StillRunning to help avoid a watchdog while failing over multiple apps.
- Implement scheduledOnMe() to guard against vmirs deletion on failover. Use stats leaseholder flag as a decision flag for one node to bounce vmirs replica scaling when kubevirt control plane is not scheduling new failover vmi copy.

## PR dependencies

- https://github.com/lf-edge/eve/pull/5169
- https://github.com/lf-edge/eve/pull/5188

## How to test and validate this PR

- Configure 3 EVE-OS nodes as a cluster using a controller
- Deploy one or more VM App Instances each containing 1 or more volumes instances
- Create a network outage for only one node.  This can be completed by physically disconnecting a node or temporarily disabling the network on one node with a script run over ssh (for a simple process when unmanaged networking equipment is used).

```
nohup sh /persist/network_disable.sh
```

where the network disable script does the following:

```
ifconfig eth0 down
sleep 900
ifconfig eth0 up
```

- The VM app instance will schedule on a new node, the detach code will run once the node is marked as unreachable and all volumes attached to the vm will be set to attach to the new node.

## Changelog notes

Enable Fast VM failover between clustered EVE-OS nodes.

## PR Backports

None

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
