### PR TITLE
.gitignore: Fix pkg/external-boot-image build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,8 @@ conf/device.cert.pem
 conf/device.key.pem
 conf/soft_serial
 pkg/kube/external-boot-image.tar
-pkg/external-boot-image/build.yml
+pkg/external-boot-image/Dockerfile
+pkg/external-boot-image/*.tar
 tools/compare-sbom-sources/vendor
 tools/get-deps/get-deps
 tools/get-deps/vendor


### PR DESCRIPTION
# Description

The build procedure for the package pkg/external-boot-image was changed recently and started to use Dockerfile.in to generate the final Dockerfile. Also, the tarball produced by this package is generated under the same package directory. This broke the pushing of the image because linuxkit will always mark the repository as dirty since it considers the Dockerfile and the tarball as changes in the sources. For instance, in the current state every time pkg/external-boot-image is built we got a dirty hash:

lfedge/eve-external-boot-image:7e86027ed410a803a1c7d0c9f17dc98447f96c7f-dirty-c5eadef

This can be easily fixed by just adding both Dockerfile and the generated tarball to .gitignore.

## How to test and validate this PR

1. Build pkg/external-boot-image (`make pkg/external-boot-image`)
2. Ensure the package has a valid tag (not dirty). For instance:

```
docker.io/lfedge/eve-external-boot-image:7e86027ed410a803a1c7d0c9f17dc98447f96c7f
```

## Changelog notes

None

## PR Backports

No needs since the issue it's only on master.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.