### PR TITLE
pillar/zedagent: persist lastconfig even when skipping config update.

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -845,7 +845,17 @@ func requestConfigByURL(getconfigCtx *getconfigContext, url string,
 
 	cfgRetval = inhaleDeviceConfig(getconfigCtx, config, fromController)
 	if cfgRetval != configOK {
-		log.Errorf("inhaleDeviceConfig failed: %d", cfgRetval)
+		log.Warnf("inhaleDeviceConfig failed or skipped: %s", cfgRetval.String())
+		// Even if we skip processing the config (e.g. due to BaseOS activation),
+		// we still need to persist the received proto message. Otherwise the
+		// on-disk lastconfig remains stale, and after reboot EVE will reload
+		// the old config, potentially triggering unwanted BaseOS downloads
+		// or downgrades. Saving it here ensures the checkpoint is always up
+		// to date, even when we intentionally skip applying it right away.
+		if cfgRetval.isSkip() {
+			log.Trace("Skipping config processing, but saving received config")
+			saveReceivedProtoMessage(authWrappedRV.RespContents)
+		}
 		return cfgRetval, rv.TracedReqs
 	}
 


### PR DESCRIPTION
# Description

zedagent: persist lastconfig even when inhaleDeviceConfig returns skip (e.g., during BaseOS activation).

Previously, if `inhaleDeviceConfig` returned `skip`, `zedagent` exited early and did not write the received device config to `/persist/checkpoint/lastconfig`. After a reboot (including mid test-window), EVE could reload a stale checkpoint, recreate outdated BaseOS/ContentTree objects, trigger unnecessary downloads, and in some cases downgrade on the next boot.

This change writes the received proto to the on-disk checkpoint also in the skip path, ensuring lastconfig always reflects the latest controller config.

It eliminates a class of upgrade instabilities caused by stale `lastconfig` after a reboot during activation. Specifically addresses configs produced by TF provider 1.0.6, which previously exposed this behaviour.

## PR dependencies

None.

## How to test and validate this PR

Verify that when upgrading from a build containing this fix using TF 1.0.6, the device persists `lastconfig` during BaseOS activation (skip path), so the checkpoint is current.


### Steps

1. Install/boot the fixed build on the device and confirm it is running.
2. Using TF 1.0.6, start an upgrade to any other EVE version (target version arbitrary; TF 1.0.6 is key).
3. Wait until the device reboots into the new version (10-minute test window starts).
4. During the 10-minute testing window, copy /persist/checkpoint/lastconfig from the device.
5. Decode lastconfig.

#### Expected (with this fix)

Decoded config’s BaseOS list includes the target (new) version and does not include the pre-update version. In other words, `lastconfig` reflects the latest controller config used for the just-activated image.

#### For reference (pre-fix behavior)

`lastconfig` would contain only the pre-update version (stale), which could lead to resurrected objects or a downgrade on the next reboot.

6. After the 10-minute test id done, reboot the device with an API call
7. Wait, it boots again.
8. Wait for some time. Observe that it does not downgrade to the version with the fix.

## Changelog notes

Improve upgrade reliability. This prevents stale checkpoints that could lead to unnecessary downloads or unintended downgrade after a reboot (notably for upgrades initiated via Terraform provider 1.0.6).

## PR Backports:

- [x] 14.5-stable: To be backported.
- [x] 13.4-stable: To be backported.
- [x] 11.0-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.