### PR TITLE
linuxkit: update to version 1.8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
 HV_DEFAULT=kvm
 # linuxkit version. This **must** be a published semver version so it can be downloaded already compiled from
 # the release page at https://github.com/linuxkit/linuxkit/releases
-LINUXKIT_VERSION=v1.7.0
+LINUXKIT_VERSION=v1.8.1
 GOVER ?= 1.24.1
 PKGBASE=github.com/lf-edge/eve
 GOMODULE=$(PKGBASE)/pkg/pillar


### PR DESCRIPTION
# Description

This version has necessary fixes for concurrent cache and index access and it allows us to re-enable parallel build for EVE
Full release notes https://github.com/linuxkit/linuxkit/releases/tag/v1.8.1

# How to test

just run a build, it should not fail.

## PR Backports

```text
- 14.5-stable: Probably. Need to check whether parallel build related fixes were merged
- 13.4-stable:  Probably. Need to check whether parallel build related fixes were merged
```

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
