### PR TITLE
Refactor zboot partition API for evaluation platform

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Zededa, Inc.
+// Copyright (c) 2017-2025 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // base os event handlers
@@ -831,7 +831,7 @@ func baseOsSetPartitionInfoInStatus(ctx *baseOsMgrContext, status *types.BaseOsS
 // scratch
 func updateAndPublishZbootStatusAll(ctx *baseOsMgrContext) {
 	log.Functionf("updateAndPublishZbootStatusAll")
-	partitionNames := []string{"IMGA", "IMGB"}
+	partitionNames := zboot.GetValidPartitionLabels()
 	for _, partName := range partitionNames {
 		status := getZbootStatus(ctx, partName)
 		if status == nil {
@@ -848,7 +848,7 @@ func updateAndPublishZbootStatusAll(ctx *baseOsMgrContext) {
 func createZbootStatus(ctx *baseOsMgrContext, partName string) *types.ZbootStatus {
 	var err error
 	partName = strings.TrimSpace(partName)
-	if !isValidBaseOsPartitionLabel(partName) {
+	if !zboot.IsValidPartitionLabel(partName) {
 		return nil
 	}
 	testComplete := false
@@ -869,7 +869,7 @@ func createZbootStatus(ctx *baseOsMgrContext, partName string) *types.ZbootStatu
 // Updates current and partitionstate by default. If updateVersions
 // is set the version strings are also updated.
 func updateAndPublishZbootStatus(ctx *baseOsMgrContext, partName string, updateVersions bool) {
-	if !isValidBaseOsPartitionLabel(partName) {
+	if !zboot.IsValidPartitionLabel(partName) {
 		log.Errorf("Invalid partname %s", partName)
 		return
 	}
@@ -901,7 +901,7 @@ func publishZbootStatus(ctx *baseOsMgrContext, status types.ZbootStatus) {
 
 func getZbootStatus(ctx *baseOsMgrContext, partName string) *types.ZbootStatus {
 	partName = strings.TrimSpace(partName)
-	if !isValidBaseOsPartitionLabel(partName) {
+	if !zboot.IsValidPartitionLabel(partName) {
 		return nil
 	}
 	pub := ctx.pubZbootStatus
@@ -912,17 +912,6 @@ func getZbootStatus(ctx *baseOsMgrContext, partName string) *types.ZbootStatus {
 	}
 	status := st.(types.ZbootStatus)
 	return &status
-}
-
-func isValidBaseOsPartitionLabel(name string) bool {
-	partitionNames := []string{"IMGA", "IMGB"}
-	name = strings.TrimSpace(name)
-	for _, partName := range partitionNames {
-		if name == partName {
-			return true
-		}
-	}
-	return false
 }
 
 // only thing to do is to look at the other partition and update

--- a/pkg/pillar/cmd/nodeagent/handlezboot.go
+++ b/pkg/pillar/cmd/nodeagent/handlezboot.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Zededa, Inc.
+// Copyright (c) 2017-2025 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // zboot config, status and util APIs
@@ -8,9 +8,10 @@ package nodeagent
 import (
 	"syscall"
 
+	"strings"
+
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/zboot"
-	"strings"
 )
 
 func lookupZbootStatus(ctx *nodeagentContext, key string) *types.ZbootStatus {
@@ -67,7 +68,7 @@ func getZbootConfigAll(ctx *nodeagentContext) []types.ZbootConfig {
 }
 
 func publishZbootConfig(ctx *nodeagentContext, config types.ZbootConfig) {
-	if !isValidZbootPartitionLabel(config.PartitionLabel) {
+	if !zboot.IsValidPartitionLabel(config.PartitionLabel) {
 		return
 	}
 	pub := ctx.pubZbootConfig
@@ -78,7 +79,7 @@ func publishZbootConfig(ctx *nodeagentContext, config types.ZbootConfig) {
 
 func publishZbootConfigAll(ctx *nodeagentContext) {
 	log.Tracef("publishZbootConfigAll")
-	partitionNames := []string{"IMGA", "IMGB"}
+	partitionNames := zboot.GetValidPartitionLabels()
 	for _, partName := range partitionNames {
 		config := types.ZbootConfig{}
 		partName = strings.TrimSpace(partName)
@@ -108,15 +109,4 @@ func isZbootOtherPartitionStateUpdating(ctx *nodeagentContext) bool {
 		return false
 	}
 	return zboot.IsOtherPartitionStateUpdating()
-}
-
-func isValidZbootPartitionLabel(name string) bool {
-	partitionNames := []string{"IMGA", "IMGB"}
-	name = strings.TrimSpace(name)
-	for _, partName := range partitionNames {
-		if name == partName {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/pillar/cmd/zedagent/handlebaseos.go
+++ b/pkg/pillar/cmd/zedagent/handlebaseos.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Zededa, Inc.
+// Copyright (c) 2017-2025 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // basic zboot partition status APIs
@@ -6,8 +6,10 @@
 package zedagent
 
 import (
-	"github.com/lf-edge/eve/pkg/pillar/types"
 	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/zboot"
 )
 
 // base os status event handlers
@@ -53,7 +55,7 @@ func handleZbootStatusImpl(ctxArg interface{}, key string,
 	statusArg interface{}) {
 
 	ctx := ctxArg.(*zedagentContext)
-	if !isZbootValidPartitionLabel(key) {
+	if !zboot.IsValidPartitionLabel(key) {
 		log.Errorf("handleZbootStatusImpl: invalid key %s", key)
 		return
 	}
@@ -64,7 +66,7 @@ func handleZbootStatusImpl(ctxArg interface{}, key string,
 
 func handleZbootStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
-	if !isZbootValidPartitionLabel(key) {
+	if !zboot.IsValidPartitionLabel(key) {
 		log.Errorf("handleZbootStatusDelete: invalid key %s", key)
 		return
 	}
@@ -73,15 +75,6 @@ func handleZbootStatusDelete(ctxArg interface{}, key string,
 }
 
 // utility routines to access baseos partition status
-func isZbootValidPartitionLabel(name string) bool {
-	partitionNames := []string{"IMGA", "IMGB"}
-	for _, partName := range partitionNames {
-		if name == partName {
-			return true
-		}
-	}
-	return false
-}
 
 func getZbootPartitionStatusAll(ctx *zedagentContext) map[string]interface{} {
 	sub := ctx.subZbootStatus
@@ -91,7 +84,7 @@ func getZbootPartitionStatusAll(ctx *zedagentContext) map[string]interface{} {
 
 func getZbootPartitionStatus(ctx *zedagentContext, partName string) *types.ZbootStatus {
 	partName = strings.TrimSpace(partName)
-	if !isZbootValidPartitionLabel(partName) {
+	if !zboot.IsValidPartitionLabel(partName) {
 		log.Errorf("getZbootPartitionStatus(%s) invalid partition", partName)
 		return nil
 	}


### PR DESCRIPTION
# Description

Remove redundant functions that duplicated zboot functionality across baseosmgr, nodeagent, and zedagent components. Consolidate partition management logic into the zboot package to eliminate code duplication.

Prepare validPartitionLabels for extension to support additional partition types required by the evaluation platform. The streamlined zboot API will enable the evaluation platform to seamlessly switch between partitions during HW evaluation.

This refactoring improves maintainability by centralizing partition management logic and provides a cleaner interface for partition switching operations.

## How to test and validate this PR

Nothing speciall to validate, this is just a refactoring

## Changelog notes

None

## PR Backports


```text
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

