### PR TITLE
[11.0-stable]  Cleanup BaseOsConfig if controller removes it

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -273,7 +273,7 @@ func parseBaseOS(getconfigCtx *getconfigContext,
 			log.Functionf("parseBaseOS: deleting %s\n", idStr)
 			unpublishBaseOsConfig(getconfigCtx, idStr)
 		}
-		baseOSPrevConfigHash = nil
+		baseOSPrevConfigHash = []byte{}
 		return
 	}
 	h := sha256.New()
@@ -2747,6 +2747,12 @@ func scheduleDeviceOperation(getconfigCtx *getconfigContext, opsCmd *zconfig.Dev
 
 	if opsCmd == nil {
 		removeDeviceOpsCmdConfig(op)
+		switch op {
+		case types.DeviceOperationReboot:
+			rebootPrevConfigHash = []byte{}
+		case types.DeviceOperationShutdown:
+			shutdownPrevConfigHash = []byte{}
+		}
 		return false
 	}
 
@@ -2835,6 +2841,7 @@ var backupPrevConfigHash []byte
 func scheduleBackup(backup *zconfig.DeviceOpsCmd) {
 	// XXX:FIXME  handle backup semantics
 	if backup == nil {
+		backupPrevConfigHash = []byte{}
 		return
 	}
 	configHash := computeConfigSha(backup)


### PR DESCRIPTION
# Description
This PR is a part 2 of a 3 series backport of PRs in order to address the improval of the stability of eve os update: 
 (1st PR is #5221) 
 
(cherry picked from commits  7544d0df67198c26b9f0d8078aacf89cddf92d72, 97fd68ae6dcc8d2b2919642bd3ef023a08417b13) 

Backport of #3637

## How to test and validate this PR
Delete all the BaseOs configs from the controller and then it should be deleted in EVE
 
## Changelog notes

None

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
