### PR TITLE
[14.5-stable] pillar/zedagent: persist lastconfig even when skipping config update.

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -830,7 +830,17 @@ func requestConfigByURL(getconfigCtx *getconfigContext, url string,
 
 	cfgRetval = inhaleDeviceConfig(getconfigCtx, config, fromController)
 	if cfgRetval != configOK {
-		log.Errorf("inhaleDeviceConfig failed: %d", cfgRetval)
+		log.Warnf("inhaleDeviceConfig failed or skipped: %s", cfgRetval.String())
+		// Even if we skip processing the config (e.g. due to BaseOS activation),
+		// we still need to persist the received proto message. Otherwise the
+		// on-disk lastconfig remains stale, and after reboot EVE will reload
+		// the old config, potentially triggering unwanted BaseOS downloads
+		// or downgrades. Saving it here ensures the checkpoint is always up
+		// to date, even when we intentionally skip applying it right away.
+		if cfgRetval.isSkip() {
+			log.Trace("Skipping config processing, but saving received config")
+			saveReceivedProtoMessage(authWrappedRV.RespContents)
+		}
 		return cfgRetval, rv.TracedReqs
 	}
 


### PR DESCRIPTION
# Description

Backport of #5217 

## PR dependencies

None

## How to test and validate this PR

See the original PR.

## Changelog notes

Improve upgrade reliability. This prevents stale checkpoints that could lead to unnecessary downloads or unintended downgrade after a reboot (notably for upgrades initiated via Terraform provider 1.0.6).

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
