### PR TITLE
pillar/Makefile: only run lkt when build-args need

### DIFF
--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -10,6 +10,7 @@ ZARCH         ?= $(HOSTARCH)
 DISTDIR       := dist/$(ZARCH)
 BUILD_VERSION ?=
 
+DOCKER_LIKE_LKT:= ../../build-tools/bin/linuxkit pkg build --network --platforms linux/$(ZARCH) --dry-run --force ./ | tail -n1 | perl -pe 's/ buildx / /g'
 DOCKER_TAG:=lfedge/eve-pillar:local-$(ZARCH)
 
 APPS = zedbox
@@ -66,18 +67,18 @@ $(APPS1): $(DISTDIR)
 shell:
 	make -C ../.. shell
 
-build-docker build-docker-test: DOCKER_LIKE_LKT = $(shell ../../build-tools/bin/linuxkit pkg build --network --platforms linux/$(ZARCH) --dry-run --force ./ | tail -n1 | perl -pe 's/ buildx / /g')
-
 build-docker:
-	$(DOCKER_LIKE_LKT) -t $(DOCKER_TAG)
+	$(shell $(DOCKER_LIKE_LKT)) -t $(DOCKER_TAG)
 
 enter-docker-dev: build-docker-test
 	docker run --platform linux/$(ZARCH) -it --rm --entrypoint /bin/sh $(DOCKER_TAG)
 
-build-docker-test:
+build-docker-test-dependencies:
 	make -C ../../ pillar-cache-export-docker-load
-	$(DOCKER_LIKE_LKT) --build-arg TEST_TOOLS=y --load --target build
-	docker image tag $(shell $(DOCKER_LIKE_LKT) --build-arg TEST_TOOLS=y --load -q --target build) $(DOCKER_TAG)
+build-docker-test-build: build-docker-test-dependencies
+	$(shell $(DOCKER_LIKE_LKT)) --build-arg TEST_TOOLS=y --load --target build
+build-docker-test: build-docker-test-build
+	docker image tag $(shell $(shell $(DOCKER_LIKE_LKT)) --build-arg TEST_TOOLS=y --load -q --target build) $(DOCKER_TAG)
 
 test: build-docker-test
 	rm -f results.json

--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -10,7 +10,6 @@ ZARCH         ?= $(HOSTARCH)
 DISTDIR       := dist/$(ZARCH)
 BUILD_VERSION ?=
 
-DOCKER_LIKE_LKT:=$(shell ../../build-tools/bin/linuxkit pkg build --network --platforms linux/$(ZARCH) --dry-run --force ./ | tail -n1 | perl -pe 's/ buildx / /g')
 DOCKER_TAG:=lfedge/eve-pillar:local-$(ZARCH)
 
 APPS = zedbox
@@ -66,6 +65,8 @@ $(APPS1): $(DISTDIR)
 
 shell:
 	make -C ../.. shell
+
+build-docker build-docker-test: DOCKER_LIKE_LKT = $(shell ../../build-tools/bin/linuxkit pkg build --network --platforms linux/$(ZARCH) --dry-run --force ./ | tail -n1 | perl -pe 's/ buildx / /g')
 
 build-docker:
 	$(DOCKER_LIKE_LKT) -t $(DOCKER_TAG)


### PR DESCRIPTION
# Description

   
  this change runs lkt only for the targets `build-docker` and
`build-docker-test`, it does not run anymore for all the other
targets as the global variable `DOCKER_LIKE_LKT` now holds the
command and not the output of the command

otherwise it leads to:
```
35 [build  7/14] RUN --mount=type=cache,target=/root/.cache/go-build echo "Running go vet" && make HV="$HV" vet &&     echo "Running go fmt" && ERR="$(find . -name \*.go | grep -v /vendor/ | xargs gofmt -d -e -l -s)" &&        if [ -n "$ERR" ] ; then printf 'go fmt Failed - ERR: %s' "$ERR" ; exit 1 ; fi &&        make ZARCH=amd64 HV="$HV" DEV="n" RSTATS=n RSTATS_ENDPOINT= RSTATS_TAG= DISTDIR=/final/opt/zededa/bin BUILD_VERSION=v0.0.0-20250911170914-280122ca6335 build
35 1.824 Running go vet
35 1.828 /bin/sh: ../../build-tools/bin/linuxkit: not found
35 1.830 go vet  ./...
```
as inside of the pillar docker image there is no linuxkit
    
this was introduced with https://github.com/lf-edge/eve/pull/5190

## How to test and validate this PR

`make pkg/pillar` and there is no:
```
/bin/sh: ../../build-tools/bin/linuxkit: not found
```

## Changelog notes

internal beauty fix

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 14.5-stable: no, as there is no https://github.com/lf-edge/eve/pull/5190 in that version
- 13.4-stable: same as above

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
