### PR TITLE
vector: add apparmor profile

### DIFF
--- a/pkg/apparmor/profiles/usr.bin.ptpm
+++ b/pkg/apparmor/profiles/usr.bin.ptpm
@@ -3,8 +3,7 @@
 
 #include <tunables/global>
 
-@{exec_path} = /usr/bin/ptpm
-profile ptpm @{exec_path} {
+profile ptpm /usr/bin/ptpm {
     #include <abstractions/base>
 
     # allow necessary access for operations

--- a/pkg/apparmor/profiles/usr.bin.swtpm
+++ b/pkg/apparmor/profiles/usr.bin.swtpm
@@ -3,8 +3,7 @@
 
 #include <tunables/global>
 
-@{exec_path} = /usr/bin/swtpm
-profile swtpm @{exec_path} {
+profile swtpm /usr/bin/swtpm {
     #include <abstractions/base>
 
     # allow necessary access for operations

--- a/pkg/apparmor/profiles/usr.bin.tpm2
+++ b/pkg/apparmor/profiles/usr.bin.tpm2
@@ -3,8 +3,7 @@
 
 #include <tunables/global>
 
-@{exec_path} = /usr/bin/tpm2
-profile tpm2 @{exec_path} {
+profile tpm2 /usr/bin/tpm2 {
     #include <abstractions/base>
 
     # allow necessary access for operations

--- a/pkg/apparmor/profiles/usr.bin.vector
+++ b/pkg/apparmor/profiles/usr.bin.vector
@@ -1,0 +1,22 @@
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+#include <tunables/global>
+
+profile vector /usr/bin/vector {
+    #include <abstractions/base>
+
+    # allow access to vector's config and buffers
+    owner /persist/vector/** rwk,
+
+    # allow to access the sockets to communicate with newlogd
+    owner /run/devKeep_source.sock w,
+    owner /run/devUpload_source.sock w,
+
+    # allow to inspect it's own state / environment
+    owner /proc/*/cgroup r,
+    owner /proc/*/mountinfo r,
+    owner /proc/*/mounts r,
+    owner /sys/fs/cgroup/cpu/cpu.cfs_period_us r,
+    owner /sys/fs/cgroup/cpu/cpu.cfs_quota_us r,
+}

--- a/pkg/apparmor/profiles/usr.bin.vtpm
+++ b/pkg/apparmor/profiles/usr.bin.vtpm
@@ -3,8 +3,7 @@
 
 #include <tunables/global>
 
-@{exec_path} = /usr/bin/vtpm
-profile vtpm @{exec_path} {
+profile vtpm /usr/bin/vtpm {
     #include <abstractions/base>
 
     # allow necessary access for operations

--- a/pkg/apparmor/profiles/usr.sbin.guacd
+++ b/pkg/apparmor/profiles/usr.sbin.guacd
@@ -3,8 +3,7 @@
 
 #include <tunables/global>
 
-@{exec_path} = /usr/sbin/guacd
-profile guacd @{exec_path} {
+profile guacd /usr/sbin/guacd {
     #include <abstractions/base>
 
     # allow network access


### PR DESCRIPTION
# Description

Added apparmor profile for vector binary.

Also replace exec_path variable in profiles, with the actual path. `apparmor_parser` parsed it fine, but it confused the python-based aa-* tools. And it wasn't really used.

## PR dependencies

None

## How to test and validate this PR

Run `dmesg | grep DENIED | grep vector` - nothing should come up. If something comes up - that's a failure.

## Changelog notes

Not important. Follow up of integrating vector.

## PR Backports

N/A, vector is not yet part of any LTS release.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
