### PR TITLE
fix: newlog: init counter and filter vars

### DIFF
--- a/pkg/newlog/cmd/counter.go
+++ b/pkg/newlog/cmd/counter.go
@@ -20,6 +20,10 @@ var (
 	counterSuppressedLogs = 0
 )
 
+func init() {
+	logsToCount.Store([]string{})
+}
+
 func countLogsInFile(file *os.File) map[string]int {
 	logCounter := make(map[string]int)
 	for _, logSrcLine := range logsToCount.Load().([]string) {

--- a/pkg/newlog/cmd/counter_test.go
+++ b/pkg/newlog/cmd/counter_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+)
+
+func Test_logsToCount_initialization(t *testing.T) {
+	// Test that logsToCount can be safely accessed without panic
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Accessing logsToCount caused panic: %v", r)
+		}
+	}()
+
+	// This should not panic if properly initialized
+	value := logsToCount.Load()
+	if value == nil {
+		t.Error("logsToCount should not be nil after initialization")
+	}
+
+	// Verify it's initialized as an empty slice
+	slice, ok := value.([]string)
+	if !ok {
+		t.Errorf("logsToCount should be initialized as []string, got %T", value)
+	}
+	if len(slice) != 0 {
+		t.Errorf("logsToCount should be initialized as empty slice, got length %d", len(slice))
+	}
+}

--- a/pkg/newlog/cmd/filter.go
+++ b/pkg/newlog/cmd/filter.go
@@ -15,6 +15,10 @@ var (
 	filterSuppressedLogs = 0
 )
 
+func init() {
+	filenameFilter.Store(map[string]struct{}{})
+}
+
 // filterOut checks if the log entry should be filtered out
 // based on the filename or severity + function name
 func filterOut(l *logs.LogEntry) bool {

--- a/pkg/newlog/cmd/filter_test.go
+++ b/pkg/newlog/cmd/filter_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+)
+
+func Test_filenameFilter_initialization(t *testing.T) {
+	// Test that filenameFilter can be safely accessed without panic
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Accessing filenameFilter caused panic: %v", r)
+		}
+	}()
+
+	// This should not panic if properly initialized
+	value := filenameFilter.Load()
+	if value == nil {
+		t.Error("filenameFilter should not be nil after initialization")
+	}
+
+	// Verify it's initialized as an empty map
+	filterMap, ok := value.(map[string]struct{})
+	if !ok {
+		t.Error("filenameFilter should be initialized as map[string]struct{}")
+	}
+
+	if filterMap == nil {
+		t.Error("filenameFilter map should not be nil")
+	}
+
+	if len(filterMap) != 0 {
+		t.Error("filenameFilter should be initialized as empty map")
+	}
+}


### PR DESCRIPTION
# Description

This fixes a go panic, because of uninitialized vars.

## PR dependencies

None

## How to test and validate this PR

Covered by unit tests.

## Changelog notes

Internal bug fix.

## PR Backports

```text
- 14.5-stable: To be backported.
- 13.4-stable: No, as the feature is not available there.
```

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
