### PR TITLE
pubsub: ensure subscription persistence consistency & remove double activation

### DIFF
--- a/pkg/pillar/cmd/collectinfo/collectinfo.go
+++ b/pkg/pillar/cmd/collectinfo/collectinfo.go
@@ -258,7 +258,7 @@ func (ci *collectInfo) subscribe(ps *pubsub.PubSub) {
 		AgentName:   "zedagent",
 		MyAgentName: agentName,
 		TopicImpl:   types.LOCConfig{},
-		Activate:    true,
+		Activate:    false,
 	})
 	if err != nil {
 		log.Fatalf("could not subscribe to LOCConfig: %+v", err)
@@ -269,13 +269,13 @@ func (ci *collectInfo) subscribe(ps *pubsub.PubSub) {
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
 		CreateHandler: ci.handleCollectInfoCmd,
-		ModifyHandler: func(ctx interface{}, key string, status, oldStatus interface{}) {
+		ModifyHandler: func(ctx any, key string, status, oldStatus any) {
 			ci.handleCollectInfoCmd(ctx, key, status)
 		},
 		AgentName:   "zedagent",
 		MyAgentName: agentName,
 		TopicImpl:   types.CollectInfoCmd{},
-		Activate:    true,
+		Activate:    false,
 	})
 	if err != nil {
 		log.Fatalf("could not subscribe to CollectInfoCmd: %+v", err)

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -363,7 +363,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		log.Fatal(err)
 	}
 	ctx.subAppInstanceStatus = subAppInstanceStatus
-	subAppInstanceStatus.Activate()
 
 	// Look for DownloaderStatus from downloader
 	subDownloaderStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{

--- a/pkg/pillar/cmd/diag/handlenodedrain.go
+++ b/pkg/pillar/cmd/diag/handlenodedrain.go
@@ -26,7 +26,6 @@ func initDrainSub(ps *pubsub.PubSub, ctx *diagContext) {
 		log.Fatal(err)
 	}
 	ctx.subNodeDrainStatus = subNodeDrainStatus
-	ctx.subNodeDrainStatus.Activate()
 }
 
 func handleNodeDrainStatusCreate(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -441,7 +441,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		log.Fatal(err)
 	}
 	domainCtx.subZFSPoolStatus = subZFSPoolStatus
-	subZFSPoolStatus.Activate()
 
 	// Look for edge node info
 	subEdgeNodeInfo, err := ps.NewSubscription(pubsub.SubscriptionOptions{

--- a/pkg/pillar/cmd/msrv/msrv.go
+++ b/pkg/pillar/cmd/msrv/msrv.go
@@ -545,7 +545,6 @@ func (msrv *Msrv) Activate() error {
 		msrv.subPatchEnvelopeInfo,
 		msrv.subVolumeStatus,
 		msrv.subContentTreeStatus,
-		msrv.subAppInstanceStatus,
 	}
 
 	for _, sub := range inactiveSubs {

--- a/pkg/pillar/cmd/msrv/msrv.go
+++ b/pkg/pillar/cmd/msrv/msrv.go
@@ -250,12 +250,16 @@ func (msrv *Msrv) initPublications() (err error) {
 	return nil
 }
 
+// initSubscriptions sets up all msrv subscriptions.
+// Note: Persistent and non-persistent subscriptions must be consistent.
+// Use the `persistent` flag to specify persistence. When deployed, it defaults to false.
+// This flag is required for the PubSub memdriver, which only works with persistent subscriptions.
 func (msrv *Msrv) initSubscriptions(persist bool) (err error) {
 	msrv.subGlobalConfig, err = msrv.PubSub.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedagent",
 		MyAgentName:   agentName,
 		TopicImpl:     types.ConfigItemValueMap{},
-		Persistent:    persist,
+		Persistent:    true,
 		Activate:      false,
 		CreateHandler: msrv.handleGlobalConfigCreate,
 		ModifyHandler: msrv.handleGlobalConfigModify,
@@ -272,7 +276,7 @@ func (msrv *Msrv) initSubscriptions(persist bool) (err error) {
 		MyAgentName: agentName,
 		TopicImpl:   types.EdgeNodeInfo{},
 		Activate:    false,
-		Persistent:  persist,
+		Persistent:  true,
 	})
 	if err != nil {
 		return err
@@ -299,7 +303,7 @@ func (msrv *Msrv) initSubscriptions(persist bool) (err error) {
 		Activate:    false,
 		WarningTime: warningTime,
 		ErrorTime:   errorTime,
-		Persistent:  persist,
+		Persistent:  true,
 	})
 	if err != nil {
 		return err
@@ -313,7 +317,7 @@ func (msrv *Msrv) initSubscriptions(persist bool) (err error) {
 		Activate:    false,
 		WarningTime: warningTime,
 		ErrorTime:   errorTime,
-		Persistent:  persist,
+		Persistent:  true,
 	})
 	if err != nil {
 		return err
@@ -447,6 +451,7 @@ func (msrv *Msrv) initSubscriptions(persist bool) (err error) {
 		Activate:    false,
 		WarningTime: warningTime,
 		ErrorTime:   errorTime,
+		Persistent:  persist,
 	})
 	if err != nil {
 		return err
@@ -463,7 +468,7 @@ func (msrv *Msrv) initSubscriptions(persist bool) (err error) {
 		DeleteHandler: msrv.handlePatchEnvelopeDelete,
 		WarningTime:   warningTime,
 		ErrorTime:     errorTime,
-		Persistent:    persist,
+		Persistent:    true,
 	})
 	if err != nil {
 		return err
@@ -511,6 +516,7 @@ func (msrv *Msrv) initSubscriptions(persist bool) (err error) {
 		Activate:    false,
 		WarningTime: warningTime,
 		ErrorTime:   errorTime,
+		Persistent:  persist,
 	})
 	if err != nil {
 		return err

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -466,7 +466,7 @@ func (n *nim) initSubscriptions() (err error) {
 		AgentName:     "monitor",
 		MyAgentName:   agentName,
 		TopicImpl:     types.DevicePortConfig{},
-		Persistent:    false,
+		Persistent:    true,
 		Activate:      false,
 		CreateHandler: n.handleDPCCreate,
 		ModifyHandler: n.handleDPCModify,

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -1708,11 +1708,13 @@ func initPostOnboardSubs(zedagentCtx *zedagentContext) {
 		log.Fatal(err)
 	}
 
+	zedagentCtx.DevicePortConfigList = &types.DevicePortConfigList{}
 	zedagentCtx.subDevicePortConfigList, err = ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "nim",
 		MyAgentName:   agentName,
 		TopicImpl:     types.DevicePortConfigList{},
 		Activate:      true,
+		Persistent:    true,
 		Ctx:           zedagentCtx,
 		CreateHandler: handleDPCLCreate,
 		ModifyHandler: handleDPCLModify,
@@ -1723,7 +1725,6 @@ func initPostOnboardSubs(zedagentCtx *zedagentContext) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	zedagentCtx.DevicePortConfigList = &types.DevicePortConfigList{}
 
 	zedagentCtx.subBlobStatus, err = ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "volumemgr",


### PR DESCRIPTION
# Description

Subscriptions must match the persistence of their corresponding publications. Previously, this consistency was not enforced in the msrv service, potentially causing issues—especially when using the PubSub memdriver, which requires all subscriptions to be persistent.

This patch fixes the inconsistency and adds a clarifying comment to help maintain correct persistence settings in future changes.

## How to test and validate this PR

The issue is not seen on socketdriver since AF_UNIX socket pathname is the same for persistent and non-persistent publications

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.