### PR TITLE
[gha] disable publishing for feature/* branches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,6 @@ on:  # yamllint disable-line rule:truthy
       - "master"
       - "[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+-stable"
-      - "feature/*"
     paths-ignore:
       - '**/*.md'
       - '.github/**'


### PR DESCRIPTION
# Description

These artifacts are not used in production so in order to save space on Dockerhub let's disable publishing for feature branches

## How to test and validate this PR

publish should not be triggered for push and PR actions on feature branches

## PR Backports

None

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

