### PR TITLE
fix: newlog: read global config before processing logs

### DIFF
--- a/pkg/newlog/cmd/newlogd.go
+++ b/pkg/newlog/cmd/newlogd.go
@@ -174,29 +174,6 @@ func main() {
 		}
 	}
 
-	if vectorEnabled.Load() {
-		go listenOnSocketAndWriteToChan(uploadSockVectorSink, uploadLogChan)
-		go listenOnSocketAndWriteToChan(keepSockVectorSink, keepLogChan)
-	}
-
-	// handle the write log messages to /persist/newlog/collect/ logfiles
-	go writelogFile(movefileChan, appLogChan, uploadLogChan, keepLogChan)
-
-	// put the logs through vector before writing to logfiles
-	go sendLogsToVector(loggerChan, appLogChan, uploadLogChan, keepLogChan)
-
-	// handle the kernel messages
-	go getKernelMsg(loggerChan)
-
-	// handle collect other container log messages from memlogd
-	go getMemlogMsg(loggerChan, panicFileChan)
-
-	// handle linux Syslog /dev/log messages
-	go getSyslogMsg(loggerChan)
-
-	stillRunning := time.NewTicker(stillRunningInerval)
-	ps.StillRunning(agentName, warningTime, errorTime)
-
 	// Publish newlog metrics
 	metricsPub, err := ps.NewPublication(
 		pubsub.PublicationOptions{
@@ -245,7 +222,7 @@ func main() {
 		AgentName:     "zedagent",
 		TopicImpl:     types.ConfigItemValueMap{},
 		Persistent:    true,
-		Activate:      false,
+		Activate:      false, // needs to be activated separately, since getting the config depends on the subscription already existing
 		CreateHandler: handleGlobalConfigCreate,
 		ModifyHandler: handleGlobalConfigModify,
 		WarningTime:   warningTime,
@@ -286,6 +263,29 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	if vectorEnabled.Load() {
+		go listenOnSocketAndWriteToChan(uploadSockVectorSink, uploadLogChan)
+		go listenOnSocketAndWriteToChan(keepSockVectorSink, keepLogChan)
+	}
+
+	// handle the write log messages to /persist/newlog/collect/ logfiles
+	go writelogFile(movefileChan, appLogChan, uploadLogChan, keepLogChan)
+
+	// put the logs through vector before writing to logfiles
+	go sendLogsToVector(loggerChan, appLogChan, uploadLogChan, keepLogChan)
+
+	// handle the kernel messages
+	go getKernelMsg(loggerChan)
+
+	// handle collect other container log messages from memlogd
+	go getMemlogMsg(loggerChan, panicFileChan)
+
+	// handle linux Syslog /dev/log messages
+	go getSyslogMsg(loggerChan)
+
+	stillRunning := time.NewTicker(stillRunningInerval)
+	ps.StillRunning(agentName, warningTime, errorTime)
 
 	// newlog Metrics publish timer. Publish log metrics every 5 minutes.
 	interval := time.Duration(metricsPublishInterval)


### PR DESCRIPTION
# Description

We first need to read the global config to know what log levels to apply. Otherwise we might process some logs before we set the right log levels. This is especially important for "remote" log levels, determining which log entries get sent to the controller and which have to stay on the device.

## PR dependencies

None

## How to test and validate this PR

Eden test will follow...

## Changelog notes

Fixes bug in newlogd, when settings were applied to late to some log entries.

## PR Backports

```text
- 14.5-stable: To be backported, since remote log levels were introduced here.
- 13.4-stable: Probably not necessary, since there are no relevant settings here.
```

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

