### PR TITLE
.gitignore: Add pkg/eve/Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ conf/device.cert.pem
 conf/device.key.pem
 conf/soft_serial
 pkg/kube/external-boot-image.tar
+pkg/eve/Dockerfile
 pkg/external-boot-image/Dockerfile
 pkg/external-boot-image/*.tar
 tools/compare-sbom-sources/vendor


### PR DESCRIPTION
# Description

The pkg/eve/Dockerfile file is generated from pkg/eve/Dockerfile.in, so it should not be handled by git and not shown as untracked file. This is making linuxkit mark pkg/eve with a dirty tag while building.

To observe this issue, one needs to run `git status .` while eve is building and then the `pkg/eve/Dockerfile` will be listed as an Untracked file.

```sh
$ git status .
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	pkg/eve/Dockerfile
```

At this moment, linuxkit will mark the pkg/eve tag as dirty:

```sh
$ make eve-show-tag
docker.io/lfedge/eve:2b293a3e3127f41364da46d6c89298c1f7bcc933-dirty-5cf01b3
```

Leading to push failures like here (we cannot push dirty tags): https://github.com/lf-edge/eve/actions/runs/17835690873

However, adding `pkg/eve/Dockerfile` to `.gitignore` solves the problem:

```sh
$ make eve-show-tag
....
....
docker.io/lfedge/eve:2b293a3e3127f41364da46d6c89298c1f7bcc933
```

### Notes

PR https://github.com/lf-edge/eve/pull/5238 fixed get-deps go modules that were making the repo dirty as well, so it was fixing only part of the issue.




## How to test and validate this PR

For now this is just affecting CI/CD, a local build will be able to build eve (side effect is still the dirty flag).

## Changelog notes

Not needed.

## PR Backports

Not needed since this issue was added very recently on master.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.