### PR TITLE
[DO NOT MERGE] pubsub persist mismatch fixes

### DIFF
--- a/pkg/pillar/pubsub/pubsub.go
+++ b/pkg/pillar/pubsub/pubsub.go
@@ -80,6 +80,15 @@ func New(driver Driver, logger *logrus.Logger, log *base.LogObject) *PubSub {
 	}
 }
 
+// Clone returns a new `PubSub` handle using the same settings such as `Driver`
+func (p *PubSub) Clone() {
+	return &PubSub{
+		driver: p.driver,
+		logger: p.logger,
+		log:    p.log,
+	}
+}
+
 // methods unique to this implementation
 
 // NewSubscription creates a new Subscription with given options
@@ -98,6 +107,12 @@ func (p *PubSub) NewSubscription(options SubscriptionOptions) (Subscription, err
 			topic)
 	}
 
+	// Check if we already have a matching <p, agentName, topic>
+	// subscription and if not add it.
+	if checkAndAddSubscription(p, options.AgentName, topic) {
+		log.Fatalf("Duplicate subscription from %s: <%s, %s">",
+			options.MyAgentName, options.AgentName, topic)
+	}
 	// Need some buffering to make sure that when we Close the subscription
 	// the goroutines exit
 	changes := make(chan Change, 3)

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -216,6 +216,18 @@ func (s *Subscriber) connectAndRead() (string, string, []byte) {
 			}
 		}
 		if s.sock == nil {
+			// Do we have a persistent mismatch between publisher
+			// and subscriber?
+			if !strings.Contains(s.sockName, "-persistent.sock") {
+				otherSockName := strings.Replace(s.sockName,
+					".sock", "-persistent.sock", 1)
+				s.log.Noticef("XXX try socket %s", otherSockName)
+				if _, err := os.Stat(otherSockName); err == nil {
+					s.log.Fatalf("Subscriber for %s persistent mismatch",
+						s.name)
+				}
+			}
+
 			sock, err := net.Dial("unixpacket", s.sockName)
 			if err != nil {
 				errStr := fmt.Sprintf("connectAndRead(%s): Dial failed %s",

--- a/pkg/pillar/pubsub/subscribe.go
+++ b/pkg/pillar/pubsub/subscribe.go
@@ -57,6 +57,7 @@ func (sub *SubscriptionImpl) Activate() error {
 }
 
 // Close stops the subscription and removes the content
+// XXX does this imply a delete? Or just undo an Activate?
 func (sub *SubscriptionImpl) Close() error {
 	sub.driver.Stop()
 	items := sub.GetAll()


### PR DESCRIPTION
# Description

This has three commits:
1. Use different socket path for persistent publications than non-persistent. That can be merged with master. But commit also has log.Fatal to detect mismatches, which maybe we shouldn't put in master?
2. @uncleDecart 's fixes for mismatches
3. A few others I've found (and Pavel might have found and fixed the same).

This collectively runs and deploys applications etc.

## How to test and validate this PR

If we are going to include the first part of commit 1, then running the usual EVE regression tests is all that is needed.
If we are not including commit 1, then it still makes sense to run those tests.

## Changelog notes

[No impact on end users]

## PR Backports

No backports needed.

## Checklist

- [X] I've provided a proper description
- [X] I've added the proper documentation
- [X] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [X] I've written the test verification instructions
- [X] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
