### PR TITLE
[13.4-stable] Vtpm fix apparmor

### DIFF
--- a/pkg/apparmor/profiles/usr.bin.vtpm
+++ b/pkg/apparmor/profiles/usr.bin.vtpm
@@ -24,6 +24,9 @@ profile vtpm @{exec_path} {
     # allow executing swtpm
     /usr/bin/swtpm                  Px,
 
+    # allow saving boot variables
+    /persist/status                 rw,
+
     # allow vtpm to send term signal to swtpm
     signal (send) peer=swtpm,
 }


### PR DESCRIPTION
# Description

this is needed for `bootVariablesSealSuccess` and
`bootVariablesUnsealFail` to save boot variables

error message was:
```
[Thu Jun 12 14:12:53 2025] audit: type=1400 audit(1749737574.362:10):
apparmor="DENIED" operation="mkdir" profile="vtpm"
name="/persist/status/" pid=3075 comm="vtpm" requested_mask="c"
denied_mask="c" fsuid=101 ouid=101
```


(cherry picked from commit 886ea55e4f23a0f82da3d950708ff9d4ffd5774a)




Backport of #4969


## PR dependencies



## How to test and validate this PR

Deploy an app with TPM, check that it works and there is no apparmor-DENIED message found in dmesg.

## Changelog notes

Fix apparmor profile for vtpm

## PR Backports

<!-- When applicable, list all stable branches that must have this PR
backported. For example:

- [ ] 13.4-stable
- [ ] 12.0-stable
-->

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (when applicable)
- [ ] I've tested my PR on amd64 device(s)
- [ ] I've tested my PR on arm64 device(s)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
<!-- For Backport PRs only:
- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template ([<stable-branch>] Original's PR Title)
-->
