### PR TITLE
Decrease log severity for some periodic log messages

### DIFF
--- a/pkg/pillar/activeapp/activeapp.go
+++ b/pkg/pillar/activeapp/activeapp.go
@@ -58,7 +58,7 @@ func LoadActiveAppInstanceUUIDs(log *base.LogObject) ([]string, error) {
 		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".json" {
 			// Remove the .json extension to get the UUID.
 			uuid := strings.TrimSuffix(entry.Name(), ".json")
-			log.Noticef("Found active app instance UUID: %s", uuid)
+			log.Functionf("Found active app instance UUID: %s", uuid)
 			uuids = append(uuids, uuid)
 		}
 	}

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -1705,10 +1705,10 @@ func updateBasedOnProfile(ctx *zedmanagerContext, oldProfile string) {
 func countRunningAppsForUUIDs(ctx *zedmanagerContext, uuidMap map[string]struct{}) (runningCount uint) {
 	sub := ctx.subAppInstanceStatus
 	items := sub.GetAll()
-	log.Noticef("countRunningAppsForUUIDs: %d items", len(items))
+	log.Functionf("countRunningAppsForUUIDs: %d items", len(items))
 	for _, s := range items {
 		status := s.(types.AppInstanceStatus)
-		log.Noticef("countRunningAppsForUUIDs: %s %s", status.UUIDandVersion, status.State)
+		log.Functionf("countRunningAppsForUUIDs: %s %s", status.UUIDandVersion, status.State)
 		// Check if this status belongs to one of the app UUIDs in our map.
 		if _, exists := uuidMap[status.UUIDandVersion.UUID.String()]; !exists {
 			continue


### PR DESCRIPTION
# Description

These logs appear every 5 seconds, and since they do not carry particularly important information, we will decrease their severity to Debug.

## How to test and validate this PR

Run EVE with the default Info log severity and check that these quite useless logs no longer appear in the log file:

```
2025-09-23 03:45:33.025|info|zedmanager|/pillar/activeapp/activeapp.go:61| Found active app instance UUID: 712cf160-a509-4d49-b754-e34c3462afa3
2025-09-23 03:45:33.026|info|zedmanager|/pillar/activeapp/activeapp.go:61| Found active app instance UUID: aee75403-8922-4105-a86d-c15e82824ada
2025-09-23 03:45:33.026|info|zedmanager|/pillar/cmd/zedmanager/zedmanager.go:1708| countRunningAppsForUUIDs: 2 items 
2025-09-23 03:45:33.028|info|zedmanager|/pillar/cmd/zedmanager/zedmanager.go:1711| countRunningAppsForUUIDs: {aee75403-8922-4105-a86d-c15e82824ada 2} RUNNING
2025-09-23 03:45:33.029|info|zedmanager|/pillar/cmd/zedmanager/zedmanager.go:1711| countRunningAppsForUUIDs: {712cf160-a509-4d49-b754-e34c3462afa3 1} RUNNING
2025-09-23 03:45:38.027|info|zedmanager|/pillar/activeapp/activeapp.go:61| Found active app instance UUID: 712cf160-a509-4d49-b754-e34c3462afa3
2025-09-23 03:45:38.027|info|zedmanager|/pillar/activeapp/activeapp.go:61| Found active app instance UUID: aee75403-8922-4105-a86d-c15e82824ada
2025-09-23 03:45:38.031|info|zedmanager|/pillar/cmd/zedmanager/zedmanager.go:1708| countRunningAppsForUUIDs: 2 items 
2025-09-23 03:45:38.032|info|zedmanager|/pillar/cmd/zedmanager/zedmanager.go:1711| countRunningAppsForUUIDs: {aee75403-8922-4105-a86d-c15e82824ada 2} RUNNING
2025-09-23 03:45:38.033|info|zedmanager|/pillar/cmd/zedmanager/zedmanager.go:1711| countRunningAppsForUUIDs: {712cf160-a509-4d49-b754-e34c3462afa3 1} RUNNING
2025-09-23 03:45:43.026|info|zedmanager|/pillar/activeapp/activeapp.go:61| Found active app instance UUID: 712cf160-a509-4d49-b754-e34c3462afa3
2025-09-23 03:45:43.026|info|zedmanager|/pillar/activeapp/activeapp.go:61| Found active app instance UUID: aee75403-8922-4105-a86d-c15e82824ada
``` 

## Changelog notes

No user-facing changes

## PR Backports

No need to backport, these logs were added in 15.0.0

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.