### PR TITLE
get-deps: fix empty platforms

### DIFF
--- a/tools/get-deps/lktargs.go
+++ b/tools/get-deps/lktargs.go
@@ -108,6 +108,7 @@ func lktBuildArgs(ymlPath string) map[string]string {
 	opts = append(opts, pkglib.WithBuildBuilderImage(defaultBuilderImage))
 	opts = append(opts, pkglib.WithBuildBuilderRestart(false))
 	opts = append(opts, pkglib.WithProgress("auto"))
+	opts = append(opts, pkglib.WithBuildForce())
 
 	for _, pkg := range pkgs {
 		plats := []imagespec.Platform{{OS: TARGETOS, Architecture: TARGETARCH}}

--- a/tools/get-deps/lktargs_test.go
+++ b/tools/get-deps/lktargs_test.go
@@ -24,8 +24,8 @@ func Test_lktBuildArgs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buildArgs := lktBuildArgs(tt.ymlPath)
-			for _, buildArg := range buildArgs {
-				_, found := tt.want[buildArg]
+			for buildArg := range tt.want {
+				_, found := buildArgs[buildArg]
 				if !found {
 					t.Errorf("lktBuildArgs() = %v, want %v", buildArgs, tt.want)
 				}


### PR DESCRIPTION
# Description

if the list of platforms is empty, linuxkit silently ignore to build and does not return any build args.

Unfortunately linuxkit does not populate the platforms if the image has been found in local cache.

The solution is to use an old Yoda-trick and use the force. If the force is used, then linuxkit sets the platforms nevertheless.



## How to test and validate this PR

`make test`

## Changelog notes

Changes to internal build tool

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 14.5-stable: no
- 13.4-stable: no



## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR



And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
