### PR TITLE
kubevirt: fix node name used in ndm verification

### DIFF
--- a/pkg/kube/cluster-update.sh
+++ b/pkg/kube/cluster-update.sh
@@ -2,6 +2,10 @@
 #
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
+
+# shellcheck source=/dev/null
+. /usr/bin/cluster-utils.sh
+
 K3S_VERSION=v1.33.3+k3s1
 
 #
@@ -173,6 +177,7 @@ Update_RunDeschedulerOnBoot() {
     fi
     # node ready and allowing scheduling
     node=$(jq -r '.DeviceName' < $EdgeNodeInfoPath | tr -d '\n' | tr '[:upper:]' '[:lower:]')
+    node=$(convert_to_k8s_compatible "$node")
     node_count_ready=$(kubectl get "node/${node}" | grep -v SchedulingDisabled | grep -cw Ready )
     if [ "$node_count_ready" -ne 1 ]; then
         return

--- a/pkg/kube/longhorn-utils.sh
+++ b/pkg/kube/longhorn-utils.sh
@@ -3,6 +3,9 @@
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# shellcheck source=/dev/null
+. /usr/bin/cluster-utils.sh
+
 LONGHORN_VERSION=v1.9.1
 
 # Used to gate logging only once in Longhorn_is_ready
@@ -105,7 +108,7 @@ Longhorn_is_ready() {
     fi
 
     node=$(jq -r '.DeviceName' < /persist/status/zedagent/EdgeNodeInfo/global.json | tr -d '\n')
-    node=$(echo "$node" | tr '[:upper:]' '[:lower:]')
+    node=$(convert_to_k8s_compatible "$node")
 
     # longhorn node exists
     if ! kubectl -n longhorn-system get nodes.longhorn.io "$node"; then


### PR DESCRIPTION
# Description

node name in pubsub can have '_' but k8s hostnames will be converted to '-'.

## PR dependencies

None

## How to test and validate this PR

- onboard 3 HV=kubevirt eve nodes which have a name containing a '_' character
- configure the controller to send EdgeNodeClusterConfig including all nodes.
- verify all three nodes join the cluster.

## Changelog notes

None

## PR Backports

- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
