### PR TITLE
Atomicity and consistency in the resume procedure of the downloader.

### DIFF
--- a/pkg/pillar/cmd/downloader/dirs.go
+++ b/pkg/pillar/cmd/downloader/dirs.go
@@ -13,6 +13,7 @@ import (
 )
 
 const progressFileSuffix = ".progress"
+const tmpFileSuffix = ".tmp"
 
 // Create the object download directories we own
 func createDownloadDirs() {


### PR DESCRIPTION
# Description

This PR hardens the downloader’s persistence and finalization without changing the transport/eve-libs logic:

1. Atomic, durable progress file:
    * Persist DownloadedParts to <target>.part.progress.json using write → fsync → rename → fsync(dir).
    * Add a self-check hash (sha256) and store ContentLength as a validator.
    * Auto-recover from a valid leftover *.tmp on reboot.
2. Download into a temp payload
    * Stream bytes into <target>.part (same directory).
    * On success, atomically rename to the final target.
    * Prevents half-written finals from leaking to other agents.

No changes to eve-libs interfaces. Existing WithDoneParts(downloadedParts) resume logic remains; it is now backed by crash-safe, trustworthy state.

## How to test and validate this PR

### Test resumability during a restart

1. Onboard an edge device running EVE-OS on a controller (e.g., Zedcloud)
2. Deploy an edge app on that device with a large image (e.g., more than 5GB).
3. During the download, restart the device mid-transfer.
    * Expect: <target>.part present; <target>.part.progress.json valid; no final file.
    * Restart: download resumes (eve-libs skips done parts), completes, and renames atomically; progress file removed.

### Test resumability during restart when the chunks are corrupted

1. Onboard an edge device running EVE-OS on a controller (e.g., Zedcloud)
2. Deploy an edge app on that device with a large image (e.g., more than 5GB).
3. During the download, corrupt the progress file (edit, truncate), and restart the device mid-transfer.
    * Expect: loader rejects; resume from 0; new progress file created atomically.

### Test resumability in a poor networking environment

1. Onboard an edge device running EVE-OS on a controller (e.g., Zedcloud)
2. Deploy an edge app on that device with a large image (e.g., more than 5GB).
3. During the download, the network goes out for a few minutes, so TCP and the download time out..
    * Expect: <target>.part present; <target>.part.progress.json valid; no final file.
    * Restart: download resumes (eve-libs skips done parts), completes, and renames atomically; progress file removed.

## Changelog notes

EVE supports incremental and resumable downloads from some datastores types (S3, Azure, ...) by checkpointing state to disk. This provides a few improvement in that area:
* Avoid truncated/corrupted final files after crashes or power loss.
* Ensure resumability works reliably across reboots by making progress durable and self-validated.

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

```text
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.
```

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
