### PR TITLE
[14.5-stable] Fix the issue of missing calling resp.Body.Close

### DIFF
--- a/pkg/edgeview/src/multiinst.go
+++ b/pkg/edgeview/src/multiinst.go
@@ -102,10 +102,15 @@ func reportInstStats() {
 		return
 	}
 
-	_, err = http.Post("http://"+multiInstStatsEPString+"/evStats", "application/json", bytes.NewBuffer(jmsg))
+	resp, err := http.Post("http://"+multiInstStatsEPString+"/evStats", "application/json", bytes.NewBuffer(jmsg))
 	if err != nil {
 		log.Errorf("InstStats: stats client http post error: %v", err)
 		return
+	}
+	defer resp.Body.Close()
+	// Drain body to allow connection reuse; ignore content but check error to satisfy linters
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		log.Tracef("InstStats: drain response body error: %v", err)
 	}
 	log.Tracef("InstStats: inst %d, posted ok", edgeviewInstID)
 }

--- a/pkg/edgeview/src/system.go
+++ b/pkg/edgeview/src/system.go
@@ -1007,10 +1007,16 @@ func runPprof() {
 }
 
 func stopPprof() {
-	_, err := http.Post("http://localhost:6543/stop", "", nil)
-	if err != nil && !errors.Is(err, io.EOF) {
-		fmt.Printf("could not stop pprof: %+v\n", err)
+	// Use a short timeout; server may be shutting down.
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Post("http://localhost:6543/stop", "", nil)
+	if err != nil {
+		if !errors.Is(err, io.EOF) {
+			fmt.Printf("could not stop pprof: %+v\n", err)
+		}
+		return
 	}
+	resp.Body.Close()
 }
 
 func getTarFile(opt string, timeRange *logSearchRange) {


### PR DESCRIPTION
# Description

- fix in reportInstStats() and in stopPprof(), the code missed the resp.Body.Close() calls
- backport part of the PR #5203

(cherry picked from commit d1b24f1183fb9f3b05f7dd8fcea9331817d744b7)

## PR dependencies

## How to test and validate this PR

This PR (part of it) fixes a potential memory leak. Testing may not be possible to verify.

## Changelog notes

Fix the issue of missing calling resp.Body.Close

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
