### PR TITLE
diag: make Internet probe endpoints configurable

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -85,6 +85,8 @@
 | wwan.modem.recovery.watchdog | boolean | false | Enable watchdog for cellular modems. If a modem firmware crashes and fails to recover, the device will automatically reboot.|
 | wwan.modem.recovery.reload.drivers | boolean | false | If a modem firmware crashes and fails to recover, EVE will attempt to reload the MBIM/QMI/MHI drivers as a recovery step. This occurs before the watchdog mechanism is triggered (if enabled). |
 | wwan.modem.recovery.restart.modemmanager | boolean | false | If a modem firmware crash occurs and ModemManager fails to properly recognize or manage the restarted modem, EVE will attempt to restart ModemManager as a recovery step. This occurs before the watchdog mechanism is triggered (if enabled) and can be combined with driver reload recovery mechanism. |
+| diag.probe.remote.http.endpoint | string | `"http://www.google.com"` | Remote endpoint (URL, IP instead of hostname is accepted) queried over HTTP to assess the state of network connectivity whenever the controller is not reachable. Used only for diagnostics (no functional impact). Set to an empty string to disable. |
+| diag.probe.remote.https.endpoint | string | `"https://www.google.com"` | Remote endpoint (URL, IP instead of hostname is NOT accepted) queried over HTTPS to assess the state of network connectivity whenever the controller is not reachable. Used only for diagnostics (no functional impact). Set to an empty string to disable. |
 
 ## Log levels
 

--- a/docs/DEVICE-CONNECTIVITY.md
+++ b/docs/DEVICE-CONNECTIVITY.md
@@ -678,9 +678,14 @@ what is the status of connectivity between the device and the controller and whe
 has already onboarded. Diag also prints the list of physical network adapters visible to EVE
 (i.e. not assigned to applications) with their assigned IP addresses, associated DNS servers
 and proxy config (if any). Finally, it also outputs results of some connectivity checks that
-it performs, including `/ping` request to the controller and `GET google.com` request, both
-performed via each management interface.
-It does not send this information to the Controller or to the log, however. One must access
+it performs, including `/ping` request to the controller and `GET` requests to configurable
+remote endpoints over HTTP/HTTPS when the controller is unreachable to assess the state of
+network connectivity. Previously, these requests were hardcoded to `www.google.com`,
+but they can now be configured via the global configuration properties
+`diag.probe.remote.http.endpoint` and `diag.probe.remote.https.endpoint`. These probes are
+used only for diagnostics and can be disabled by setting the properties to an empty string.
+
+Diag does not send this information to the Controller or to the log, however. One must access
 the device console to have this information printed on the stdout. With ssh access, you can
 view this output in `/run/diag.out`. Should this diag output interfere with other work
 performed via the console, disable the printing of diagnostics with `eve verbose off`.
@@ -851,6 +856,13 @@ Currently, traced HTTP requests are:
  by `netdump.topic.preonboard.interval` and `netdump.topic.postonboard.interval`, respectively).
  The pre-onboard interval is intentionally lower (by default) to get more frequent diagnostics
  for initial connectivity troubleshooting.
+ When network tracing is enabled and controller connectivity is not working, NIM additionally
+ performs connectivity tests towards configurable remote endpoints over HTTP and HTTPS and
+ includes network traces from them in the netdump for troubleshooting purposes. The URLs
+ of remote endpoints used are configurable via `diag.probe.remote.http.endpoint` and
+ `diag.probe.remote.https.endpoint` and can be disabled by setting them to empty strings
+ (default is `www.google.com` for both).
+
 - `/config` and `/info` requests done by zedagent to obtain device configuration and publish info
  messages, respectively. Packet capture is not enabled in this case. Netdump is produced at the interval
  as given by `netdump.topic.postonboard.interval` (`/config` and `/info` requests are not run before
@@ -862,6 +874,7 @@ Currently, traced HTTP requests are:
  remotely manageable).
  Netdumps are published separately into topics `zedagent-config-<ok|fail>`
  and `zedagent-info-<ok|fail>`.
+
 - *every* download request performed by [downloader](../pkg/pillar/cmd/downloader) using the HTTP
  protocol is traced and netdump is published into the topic `downloader-ok` or `downloader-fail`,
  depending on the outcome of the download process. By default, this does not include any packet

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"syscall"
@@ -91,6 +92,7 @@ type diagContext struct {
 	columnPtr              *int
 	triggerPrintChan       chan<- string
 	ph                     *PrintHandle
+	remoteProbes           []*url.URL
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
@@ -1012,28 +1014,12 @@ func printOutput(ctx *diagContext, caller string) {
 		}
 		// ping and getUuid calls
 		if !tryPing(ctx, ifname, "") {
-			ctx.ph.Print("ERROR: %s: ping failed to %s; trying google\n",
-				ifname, ctx.serverNameAndPort)
-			origServerName := ctx.serverName
-			origServerNameAndPort := ctx.serverNameAndPort
-			ctx.serverName = "www.google.com"
-			ctx.serverNameAndPort = ctx.serverName
-			if tryPing(ctx, ifname, "http://www.google.com") {
-				ctx.ph.Print("WARNING: %s: Can reach http://google.com but not https://%s\n",
-					ifname, origServerNameAndPort)
-			} else {
-				ctx.ph.Print("ERROR: %s: Can't reach http://google.com; likely lack of Internet connectivity\n",
-					ifname)
+			if len(ctx.remoteProbes) != 0 {
+				ctx.ph.Print("ERROR: %s: ping failed to %s; trying %v\n",
+					ifname, ctx.serverNameAndPort,
+					utils.JoinStrings(ctx.remoteProbes, ", "))
+				tryNetworkConnectivity(ctx, ifname)
 			}
-			if tryPing(ctx, ifname, "https://www.google.com") {
-				ctx.ph.Print("WARNING: %s: Can reach https://google.com but not https://%s\n",
-					ifname, origServerNameAndPort)
-			} else {
-				ctx.ph.Print("ERROR: %s: Can't reach https://google.com; likely lack of Internet connectivity\n",
-					ifname)
-			}
-			ctx.serverName = origServerName
-			ctx.serverNameAndPort = origServerNameAndPort
 			continue
 		}
 		if !tryPostUUID(ctx, ifname) {
@@ -1158,6 +1144,21 @@ func printProxy(ctx *diagContext, port types.NetworkPortStatus,
 		if len(port.ProxyCertPEM) > 0 {
 			ctx.ph.Print("INFO: %d proxy certificate(s)",
 				len(port.ProxyCertPEM))
+		}
+	}
+}
+
+func tryNetworkConnectivity(ctx *diagContext, ifname string) {
+	for _, probeURL := range ctx.remoteProbes {
+		if probeURL == nil {
+			continue
+		}
+		if tryPing(ctx, ifname, probeURL.String()) {
+			ctx.ph.Print("WARNING: %s: Can reach %v but not https://%s\n",
+				ifname, probeURL, ctx.serverNameAndPort)
+		} else {
+			ctx.ph.Print("ERROR: %s: Can't reach %v; "+
+				"likely lack of network connectivity\n", ifname, probeURL)
 		}
 	}
 }
@@ -1530,9 +1531,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 	log.Functionf("handleGlobalConfigImpl for %s", key)
 	gcp := agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		ctx.CLIParams().DebugOverride, logger)
-	if gcp != nil {
-		ctx.globalConfig = gcp
-	}
+	ctx.remoteProbes = types.GetDiagRemoteEndpointURLs(log, gcp)
 	ctx.GCInitialized = true
 	log.Functionf("handleGlobalConfigImpl done for %s", key)
 }

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -660,6 +660,7 @@ func (n *nim) applyGlobalConfig(gcp *types.ConfigItemValueMap) {
 	n.dpcManager.UpdateGCP(n.globalConfig)
 	timeout := gcp.GlobalValueInt(types.NetworkTestTimeout)
 	n.connTester.TestTimeout = time.Second * time.Duration(timeout)
+	n.connTester.DiagRemoteEndpoints = types.GetDiagRemoteEndpointURLs(n.Log, gcp)
 	n.gcInitialized = true
 }
 

--- a/pkg/pillar/conntester/controller.go
+++ b/pkg/pillar/conntester/controller.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"strings"
 	"syscall"
@@ -37,6 +38,12 @@ type ControllerConnectivityTester struct {
 	TestTimeout    time.Duration // can be changed in run-time
 	Metrics        *controllerconn.AgentMetrics
 	NetworkMonitor netmonitor.NetworkMonitor
+
+	// Configurable remote endpoints used to query and collect nettrace when
+	// the controller is not accessible, to provide information about
+	// network connectivity for troubleshooting purposes.
+	// This list is injected and potentially updated at runtime by NIM.
+	DiagRemoteEndpoints []*url.URL
 
 	iteration          int
 	prevTLSConfig      *tls.Config
@@ -135,9 +142,10 @@ func (t *ControllerConnectivityTester) TestConnectivity(
 	if !airGapMode.Enabled && withNetTrace && controllerTestRV.testErr != nil {
 		if _, isRTF := controllerTestRV.testErr.(*RemoteTemporaryFailure); !isRTF {
 			// When network tracing is enabled and controller connectivity is not working,
-			// we additionally perform google.com connectivity tests and include network
-			// traces from them in the netdump for troubleshooting purposes.
-			tracedReqs = append(tracedReqs, t.tryGoogleWithTracing(dns)...)
+			// we additionally perform connectivity tests towards configurable remote
+			// endpoints and include network traces from them in the netdump for
+			// troubleshooting purposes.
+			tracedReqs = append(tracedReqs, t.tryRemoteEndpointsWithTracing(dns)...)
 		}
 	}
 
@@ -312,7 +320,7 @@ func (t *ControllerConnectivityTester) getPortsNotReady(
 	return ports
 }
 
-// Enable all net traces, including packet capture - ping and google.com requests
+// Enable all net traces, including packet capture - ping and diag requests
 // are quite small.
 func (t *ControllerConnectivityTester) netTraceOpts(
 	dns types.DeviceNetworkStatus) []nettrace.TraceOpt {
@@ -336,10 +344,10 @@ func (t *ControllerConnectivityTester) netTraceOpts(
 }
 
 // If net tracing is enabled and the controller connectivity test fails, we try to access
-// google.com over HTTP and HTTPS and include collected traces in the output.
-// This can help to determine if the issue is with the Internet access or with
+// configured remote HTTP and HTTPS endpoints and include collected traces in the output.
+// This can help to determine if the issue is with the network connectivity or with
 // something specific to the controller.
-func (t *ControllerConnectivityTester) tryGoogleWithTracing(
+func (t *ControllerConnectivityTester) tryRemoteEndpointsWithTracing(
 	dns types.DeviceNetworkStatus) (tracedReqs []netdump.TracedNetRequest) {
 	client := controllerconn.NewClient(t.Log, controllerconn.ClientOptions{
 		AgentName:           t.AgentName,
@@ -357,15 +365,11 @@ func (t *ControllerConnectivityTester) tryGoogleWithTracing(
 	})
 	ctx, cancel := client.GetContextForAllIntfFunctions()
 	defer cancel()
-	tests := []struct {
-		url  string
-		name string
-	}{
-		{url: "http://www.google.com", name: "google.com-over-http"},
-		{url: "https://www.google.com", name: "google.com-over-https"},
-	}
-	for _, test := range tests {
-		rv, _ := client.SendOnAllIntf(ctx, test.url, nil,
+	for _, url := range t.DiagRemoteEndpoints {
+		if url == nil {
+			continue
+		}
+		rv, _ := client.SendOnAllIntf(ctx, url.String(), nil,
 			controllerconn.RequestOptions{
 				WithNetTracing: true,
 				BailOnHTTPErr:  true,
@@ -373,7 +377,8 @@ func (t *ControllerConnectivityTester) tryGoogleWithTracing(
 			})
 		for i := range rv.TracedReqs {
 			reqName := rv.TracedReqs[i].RequestName
-			rv.TracedReqs[i].RequestName = test.name + "-" + reqName
+			rv.TracedReqs[i].RequestName = strings.Join(
+				[]string{url.Scheme, url.Hostname(), reqName}, "-")
 		}
 		tracedReqs = append(tracedReqs, rv.TracedReqs...)
 	}

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -243,6 +243,8 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		MsrvPrometheusMetricsRequestPerSecond,
 		MsrvPrometheusMetricsBurst,
 		MsrvPrometheusMetricsIdleTimeoutSeconds,
+		DiagProbeRemoteHTTPEndpoint,
+		DiagProbeRemoteHTTPSEndpoint,
 	}
 	if len(specMap.GlobalSettings) != len(gsKeys) {
 		t.Errorf("GlobalSettings has more (%d) than expected keys (%d)",


### PR DESCRIPTION
# Description

Previously, diagnostic network connectivity checks were hardcoded to use `www.google.com` over HTTP/HTTPS. In some deployments this can be blocked by firewalls or trigger unwanted security alerts.

This change introduces two new global config options:
  - `diag.probe.remote.http.endpoint`
  - `diag.probe.remote.https.endpoint`

These define the remote endpoints (URL, bare IP is also accepted for HTTP) that EVE will query over HTTP/HTTPS when the controller is unreachable. They are used only for diagnostics (no functional impact) and can be disabled by setting them to an empty string.

## How to test and validate this PR

1. Onboard an edge-node and configure `diag.probe.remote.http.endpoint` and `diag.probe.remote.https.endpoint` to point to remote (e.g. from Internet) web servers other than `www.google.com`.  

2. Block connectivity between the edge-node and the controller (e.g., block the controller IP on the firewall).  

3. Check the console output (or `/run/diag.out`) to confirm that the configured endpoints are being queried instead of `www.google.com`. Example output: 
```
...
ERROR: eth0: ping failed to mydomain.adam:3333; trying http://www.shmu.sk, https://go.dev
INFO: eth0: http://www.shmu.sk StatusOK
WARNING: eth0: Can reach http://www.shmu.sk but not https://mydomain.adam:3333
INFO: eth0: https://go.dev StatusOK
WARNING: eth0: Can reach https://go.dev but not https://mydomain.adam:3333
```

4. Verify that collected nettraces correspond to the configured endpoints and not to `www.google.com`.  
On the device, unpack a `/persist/netdump/nim-fail-*` tarball created during controller connectivity failure:  
```
/persist/netdump$ tar -xvf nim-fail-2025-09-26T11-36-50.tgz
nim-fail-2025-09-26T11-36-50
nim-fail-2025-09-26T11-36-50/eve
nim-fail-2025-09-26T11-36-50/linux
nim-fail-2025-09-26T11-36-50/requests
...
nim-fail-2025-09-26T11-36-50/requests/ping-controller-eth0-0
nim-fail-2025-09-26T11-36-50/requests/ping-controller-eth0-0/nettrace.json
nim-fail-2025-09-26T11-36-50/requests/ping-controller-eth0-0/eth0.pcap
nim-fail-2025-09-26T11-36-50/requests/http-www.shmu.sk-eth0-0
nim-fail-2025-09-26T11-36-50/requests/http-www.shmu.sk-eth0-0/nettrace.json
nim-fail-2025-09-26T11-36-50/requests/http-www.shmu.sk-eth0-0/eth0.pcap
nim-fail-2025-09-26T11-36-50/requests/https-go.dev-eth0-0
nim-fail-2025-09-26T11-36-50/requests/https-go.dev-eth0-0/nettrace.json
nim-fail-2025-09-26T11-36-50/requests/https-go.dev-eth0-0/eth0.pcap
```
Check the directory names where each `nettrace.json` is stored. Optionally, inspect the JSON files themselves to confirm the target endpoints.

5. Re-enable connectivity between the edge-node and the controller.  

6. Set both configuration properties to empty strings.  

6. Block connectivity between the edge-node and the controller again.  

7. Repeat the same checks (`diag.out` + nettrace output) and confirm that there are no connectivity tests beyond the controller `/ping` request.  

8. (Optional) Capture packets on the management ports to confirm that `www.google.com` (or any previously configured remote endpoints) are no longer queried.  
With both properties empty, there should be **no HTTP (port 80) traffic** originating from EVE.  

## Changelog notes

Remote endpoints used to assess connectivity when the controller is unreachable are now configurable via properties `diag.probe.remote.http.endpoint` and `diag.probe.remote.https.endpoint`. These probes are used only for diagnostics and can be disabled by setting the properties to an empty string.

## PR Backports

It was requested that this be made available in both currently active LTS versions.

```text
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.
```

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
