### PR TITLE
Collect-info upload noform

### DIFF
--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -589,7 +589,7 @@ echo "EVE info is collected into '$TARBALL_FILE'"
 if [ -n "$UPLOAD" ];
 then
     echo "Uploading tarball to $UPLOAD"
-    curl --retry-all-errors --retry 10 --retry-delay 3 -s -d @"$TARBALL_FILE" -H "Authorization: $AUTHORIZATION" "$UPLOAD/$INFO_DIR_SUFFIX.tar.gz" && \
+    curl --retry-all-errors --retry 10 --retry-delay 3 -s --data-binary @"$TARBALL_FILE" -H "Authorization: $AUTHORIZATION" "$UPLOAD/$INFO_DIR_SUFFIX.tar.gz" && \
         rm -f "$TARBALL_FILE"
     echo "Uploading tarball to $UPLOAD done"
 fi


### PR DESCRIPTION
# Description
collect-info: do not use form-upload

as the upload is incomplete, because `-d` means `--data-ascii`,
but we upload a tarball which is binary data, so curl
messes it up

Instead use `--data-binary` parameter which uses
`application/octet-stream`
## How to test and validate this PR

`make test`

---

* Create a datastore for upload
* Setup LOC
* Trigger collect-info from LOC
* Check that the uploaded tarball is correct

## Changelog notes

Fix for collect-info upload

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 14.5-stable: yes
- 13.4-stable: feature does not exist there



## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
