### PR TITLE
newlog: Improve golangci-lint configuration and code comments

### DIFF
--- a/pkg/newlog/cmd/newlogd.go
+++ b/pkg/newlog/cmd/newlogd.go
@@ -232,6 +232,7 @@ func main() {
 		log.Fatal(err)
 	}
 	// Activate calls populate() internally to retrieve persistent data (if any) and call handlers
+	// We thus assume that once Activate returns the handleGlobalConfigCreate has been called.
 	err = subGlobalConfig.Activate()
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/pillar/.golangci.yml
+++ b/pkg/pillar/.golangci.yml
@@ -28,7 +28,7 @@ linters:
     - wsl               # Way to opinionated
     - whitespace        # Too opinionated about whitespace
     - wrapcheck         # XXX should we switch to wrapped errors etc?
-    - goerr113          # XXX should we switch to wrapped errors etc?
+    - err113            # Too opinioned about error handling (also yetus probably doesn't run it correctly)
     - exhaustivestruct  # Too opinionated
     - gofumpt           # Too opinionated about whitespace
     - gomnd             # We use plenty of magic constants


### PR DESCRIPTION
# Description

Addressing the rest of the comments from https://github.com/lf-edge/eve/pull/5242:

1. **Update golangci-lint configuration**: Rename the deprecated `goerr113` linter to `err113` in the pillar configuration. The linter was renamed in newer versions of golangci-lint. Also updated the comment to better explain why this linter is disabled.

2. **Improve code documentation**: Add a clarifying comment in newlogd.go explaining that the `Activate()` call on a subscription internally calls `populate()` to retrieve persistent data and invoke handlers. This helps future developers understand the assumption that `handleGlobalConfigCreate` has been called once `Activate()` returns.

## PR dependencies

None

## How to test and validate this PR

N/A

## Changelog notes

N/A

## PR Backports

No need

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
