### PR TITLE
[13.4-stable] diag: make remote probe endpoints configurable

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -66,6 +66,8 @@
 | wwan.query.visible.providers | bool | false | enable to periodically (once per hour) query the set of visible cellular service providers and publish them under WirelessStatus (for every modem) |
 | network.local.legacy.mac.address | bool | false | enables legacy MAC address generation for local network instances for those EVE nodes where changing MAC addresses in applications will lead to incorrect network configuration |
 | memory-monitor.enabled | boolean | false | Enable external memory monitoring and memory pressure events handling |
+| diag.probe.remote.http.endpoint | string | `"http://www.google.com"` | Remote endpoint (URL, IP instead of hostname is accepted) queried over HTTP to assess the state of network connectivity whenever the controller is not reachable. Used only for diagnostics (no functional impact). Set to an empty string to disable. |
+| diag.probe.remote.https.endpoint | string | `"https://www.google.com"` | Remote endpoint (URL, IP instead of hostname is NOT accepted) queried over HTTPS to assess the state of network connectivity whenever the controller is not reachable. Used only for diagnostics (no functional impact). Set to an empty string to disable. |
 
 In addition, there can be per-agent settings.
 The Per-agent settings begin with "agent.*agentname*.*setting*"

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"syscall"
@@ -90,6 +91,7 @@ type diagContext struct {
 	columnPtr              *int
 	triggerPrintChan       chan<- string
 	ph                     *PrintHandle
+	remoteProbes           []*url.URL
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
@@ -992,28 +994,11 @@ func printOutput(ctx *diagContext, caller string) {
 		}
 		// ping and getUuid calls
 		if !tryPing(ctx, ifname, "") {
-			ctx.ph.Print("ERROR: %s: ping failed to %s; trying google\n",
-				ifname, ctx.serverNameAndPort)
-			origServerName := ctx.serverName
-			origServerNameAndPort := ctx.serverNameAndPort
-			ctx.serverName = "www.google.com"
-			ctx.serverNameAndPort = ctx.serverName
-			if tryPing(ctx, ifname, "http://www.google.com") {
-				ctx.ph.Print("WARNING: %s: Can reach http://google.com but not https://%s\n",
-					ifname, origServerNameAndPort)
-			} else {
-				ctx.ph.Print("ERROR: %s: Can't reach http://google.com; likely lack of Internet connectivity\n",
-					ifname)
+			if len(ctx.remoteProbes) != 0 {
+				ctx.ph.Print("ERROR: %s: ping failed to %s; trying %v\n",
+					ifname, ctx.serverNameAndPort, ctx.remoteProbes)
+				tryNetworkConnectivity(ctx, ifname)
 			}
-			if tryPing(ctx, ifname, "https://www.google.com") {
-				ctx.ph.Print("WARNING: %s: Can reach https://google.com but not https://%s\n",
-					ifname, origServerNameAndPort)
-			} else {
-				ctx.ph.Print("ERROR: %s: Can't reach https://google.com; likely lack of Internet connectivity\n",
-					ifname)
-			}
-			ctx.serverName = origServerName
-			ctx.serverNameAndPort = origServerNameAndPort
 			continue
 		}
 		if !tryPostUUID(ctx, ifname) {
@@ -1136,6 +1121,21 @@ func printProxy(ctx *diagContext, port types.NetworkPortStatus,
 		if len(port.ProxyCertPEM) > 0 {
 			ctx.ph.Print("INFO: %d proxy certificate(s)",
 				len(port.ProxyCertPEM))
+		}
+	}
+}
+
+func tryNetworkConnectivity(ctx *diagContext, ifname string) {
+	for _, probeURL := range ctx.remoteProbes {
+		if probeURL == nil {
+			continue
+		}
+		if tryPing(ctx, ifname, probeURL.String()) {
+			ctx.ph.Print("WARNING: %s: Can reach %v but not https://%s\n",
+				ifname, probeURL, ctx.serverNameAndPort)
+		} else {
+			ctx.ph.Print("ERROR: %s: Can't reach %v; "+
+				"likely lack of network connectivity\n", ifname, probeURL)
 		}
 	}
 }
@@ -1500,6 +1500,7 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 	if gcp != nil {
 		ctx.globalConfig = gcp
 	}
+	ctx.remoteProbes = types.GetDiagRemoteEndpointURLs(log, gcp)
 	ctx.GCInitialized = true
 	log.Functionf("handleGlobalConfigImpl done for %s", key)
 }

--- a/pkg/pillar/cmd/nim/nim.go
+++ b/pkg/pillar/cmd/nim/nim.go
@@ -595,6 +595,7 @@ func (n *nim) applyGlobalConfig(gcp *types.ConfigItemValueMap) {
 	n.dpcManager.UpdateGCP(n.globalConfig)
 	timeout := gcp.GlobalValueInt(types.NetworkTestTimeout)
 	n.connTester.TestTimeout = time.Second * time.Duration(timeout)
+	n.connTester.DiagRemoteEndpoints = types.GetDiagRemoteEndpointURLs(n.Log, gcp)
 	n.gcInitialized = true
 }
 

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -5,10 +5,13 @@ package types
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/sirupsen/logrus" // OK for logrus.Fatal
 )
 
@@ -324,6 +327,13 @@ const (
 
 	// MemoryMonitorEnabled : Enable memory monitor
 	MemoryMonitorEnabled GlobalSettingKey = "memory-monitor.enabled"
+
+	// DiagProbeRemoteHTTPEndpoint : remote endpoint queried over **HTTP** to assess
+	// the state of network connectivity whenever the controller is not reachable.
+	DiagProbeRemoteHTTPEndpoint GlobalSettingKey = "diag.probe.remote.http.endpoint"
+	// DiagProbeRemoteHTTPSEndpoint : remote endpoint queried over **HTTPS** to assess
+	// the state of network connectivity whenever the controller is not reachable.
+	DiagProbeRemoteHTTPSEndpoint GlobalSettingKey = "diag.probe.remote.https.endpoint"
 )
 
 // AgentSettingKey - keys for per-agent settings
@@ -981,6 +991,9 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddBoolItem(NetDumpDownloaderPCAP, false)
 	configItemSpecMap.AddBoolItem(NetDumpDownloaderHTTPWithFieldValue, false)
 
+	// Add diag probing settings
+	configItemSpecMap.AddStringItem(DiagProbeRemoteHTTPEndpoint, "www.google.com", makeURLValidator("http", true))
+	configItemSpecMap.AddStringItem(DiagProbeRemoteHTTPSEndpoint, "www.google.com", makeURLValidator("https", false))
 	return configItemSpecMap
 }
 
@@ -998,6 +1011,74 @@ func validateSyslogKernelLevel(level string) error {
 		return fmt.Errorf("validateSyslogKernelLevel: unknown loglevel '%v'", level)
 	}
 	return nil
+}
+
+// makeURLValidator returns a validator that checks if an address is either empty,
+// a hostname with no scheme, or a valid URL using the specified allowed scheme.
+// If allowIP is false, bare or scheme-prefixed IP addresses are rejected.
+func makeURLValidator(allowedScheme string, allowIP bool) func(addr string) error {
+	return func(addr string) error {
+		if addr == "" {
+			// Accept empty value.
+			return nil
+		}
+		u, err := parseURL(addr, allowedScheme)
+		if err != nil {
+			return err
+		}
+		if !allowIP && net.ParseIP(u.Hostname()) != nil {
+			return fmt.Errorf("IP addresses are not allowed: %q", u.Hostname())
+		}
+		if strings.ToLower(u.Scheme) != strings.ToLower(allowedScheme) {
+			return fmt.Errorf("invalid URL scheme: %q (expected %q)",
+				u.Scheme, allowedScheme)
+		}
+		return nil
+	}
+}
+
+// parseURL parses the provided address into a *url.URL.
+// If no scheme is provided, it prepends the default scheme.
+func parseURL(address, defaultScheme string) (*url.URL, error) {
+	if address == "" {
+		return nil, fmt.Errorf("address cannot be empty")
+	}
+	if !strings.Contains(address, "://") {
+		address = defaultScheme + "://" + address
+	}
+	return url.Parse(address)
+}
+
+// GetDiagRemoteEndpointURLs returns diagnostic probe endpoint URLs configured
+// in the provided ConfigItemValueMap. It looks up both HTTP and HTTPS endpoints,
+// parses them into *url.URL values with the correct scheme enforced, and
+// returns a slice containing all successfully parsed URLs.
+func GetDiagRemoteEndpointURLs(log *base.LogObject, gcp *ConfigItemValueMap) []*url.URL {
+	if gcp == nil {
+		return nil
+	}
+	var diagURLs []*url.URL
+	httpEp := gcp.GlobalValueString(DiagProbeRemoteHTTPEndpoint)
+	if httpEp != "" {
+		httpEpURL, err := parseURL(httpEp, "http")
+		if err != nil {
+			log.Errorf("Failed to build URL for %s: %v",
+				DiagProbeRemoteHTTPEndpoint, err)
+		} else {
+			diagURLs = append(diagURLs, httpEpURL)
+		}
+	}
+	httpsEp := gcp.GlobalValueString(DiagProbeRemoteHTTPSEndpoint)
+	if httpsEp != "" {
+		httpsEpURL, err := parseURL(httpsEp, "https")
+		if err != nil {
+			log.Errorf("Failed to build URL for %s: %v",
+				DiagProbeRemoteHTTPSEndpoint, err)
+		} else {
+			diagURLs = append(diagURLs, httpsEpURL)
+		}
+	}
+	return diagURLs
 }
 
 // blankValidator - A validator that accepts any string

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -217,6 +217,8 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		NetDumpTopicPostOnboardInterval,
 		NetDumpDownloaderPCAP,
 		NetDumpDownloaderHTTPWithFieldValue,
+		DiagProbeRemoteHTTPEndpoint,
+		DiagProbeRemoteHTTPSEndpoint,
 	}
 	if len(specMap.GlobalSettings) != len(gsKeys) {
 		t.Errorf("GlobalSettings has more (%d) than expected keys (%d)",


### PR DESCRIPTION
# Description

Previously, diagnostic network connectivity checks were hardcoded to use `www.google.com` over HTTP/HTTPS. In some deployments this can be blocked by firewalls or trigger unwanted security alerts.

This change introduces two new global config options:
  - `diag.probe.remote.http.endpoint`
  - `diag.probe.remote.https.endpoint`

These define the remote endpoints (URL, bare IP is also accepted for HTTP) that EVE will query over HTTP/HTTPS when the controller is unreachable. They are used only for diagnostics (no functional impact) and can be disabled by setting them to an empty string.

Backport of https://github.com/lf-edge/eve/pull/5258, including also fix https://github.com/lf-edge/eve/pull/5270

## How to test and validate this PR

1. Onboard an edge-node and configure `diag.probe.remote.http.endpoint` and `diag.probe.remote.https.endpoint` to point to remote (e.g. from Internet) web servers other than `www.google.com`.  

2. Block connectivity between the edge-node and the controller (e.g., block the controller IP on the firewall).  

3. Check the console output (or `/run/diag.out`) to confirm that the configured endpoints are being queried instead of `www.google.com`. Example output: 
```
...
ERROR: eth0: ping failed to mydomain.adam:3333; trying http://www.shmu.sk, https://go.dev
INFO: eth0: http://www.shmu.sk StatusOK
WARNING: eth0: Can reach http://www.shmu.sk but not https://mydomain.adam:3333
INFO: eth0: https://go.dev StatusOK
WARNING: eth0: Can reach https://go.dev but not https://mydomain.adam:3333
```

4. Verify that collected nettraces correspond to the configured endpoints and not to `www.google.com`.  
On the device, unpack a `/persist/netdump/nim-fail-*` tarball created during controller connectivity failure:  
```
/persist/netdump$ tar -xvf nim-fail-2025-09-26T11-36-50.tgz
nim-fail-2025-09-26T11-36-50
nim-fail-2025-09-26T11-36-50/eve
nim-fail-2025-09-26T11-36-50/linux
nim-fail-2025-09-26T11-36-50/requests
...
nim-fail-2025-09-26T11-36-50/requests/ping-controller-eth0-0
nim-fail-2025-09-26T11-36-50/requests/ping-controller-eth0-0/nettrace.json
nim-fail-2025-09-26T11-36-50/requests/ping-controller-eth0-0/eth0.pcap
nim-fail-2025-09-26T11-36-50/requests/http-www.shmu.sk-eth0-0
nim-fail-2025-09-26T11-36-50/requests/http-www.shmu.sk-eth0-0/nettrace.json
nim-fail-2025-09-26T11-36-50/requests/http-www.shmu.sk-eth0-0/eth0.pcap
nim-fail-2025-09-26T11-36-50/requests/https-go.dev-eth0-0
nim-fail-2025-09-26T11-36-50/requests/https-go.dev-eth0-0/nettrace.json
nim-fail-2025-09-26T11-36-50/requests/https-go.dev-eth0-0/eth0.pcap
```
Check the directory names where each `nettrace.json` is stored. Optionally, inspect the JSON files themselves to confirm the target endpoints.

5. Re-enable connectivity between the edge-node and the controller.  

6. Set both configuration properties to empty strings.  

6. Block connectivity between the edge-node and the controller again.  

7. Repeat the same checks (`diag.out` + nettrace output) and confirm that there are no connectivity tests beyond the controller `/ping` request.  

8. (Optional) Capture packets on the management ports to confirm that `www.google.com` (or any previously configured remote endpoints) are no longer queried.  
With both properties empty, there should be **no HTTP (port 80) traffic** originating from EVE. 

## Changelog notes

Remote endpoints used to assess connectivity when the controller is unreachable are now configurable via properties `diag.probe.remote.http.endpoint` and `diag.probe.remote.https.endpoint`. These probes are used only for diagnostics and can be disabled by setting the properties to an empty string.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.