### PR TITLE
[13.4-stable] fix riscv debug build

### DIFF
--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -31,23 +31,21 @@ ENV OPENSSH_VERSION 9.8p1
 
 # setting up building account
 RUN adduser -G abuild -D builder || :
-RUN su builder -c 'abuild-keygen -a -n'
+RUN abuild-keygen -a -n
 
 COPY --chown=builder:abuild abuild/ /
 ENV MUSL_VERSION="1.2.3"
 ENV DISTFILES_MIRROR="/tmp/mirror"
 RUN mkdir -p ${DISTFILES_MIRROR}
 ADD --chown=builder:abuild http://ftp.us.debian.org/debian/pool/main/m/musl/musl_${MUSL_VERSION}.orig.tar.gz /var/cache/distfiles//musl-v${MUSL_VERSION}.tar.gz
-USER builder
 WORKDIR /musl
-RUN abuild checksum
-RUN abuild -r
+RUN abuild -F checksum
+RUN abuild -r -F
 
-USER root
 WORKDIR /
 # now install it locally so we can pick it up later on below
 # hadolint ignore=DL3019,DL3018
-RUN apk add -p /out --allow-untrusted /home/builder/packages/*/musl-1.2*.apk
+RUN apk add -p /out --allow-untrusted /root/packages/*/musl-1.2*.apk
 
 # hadolint ignore=DL4006
 ADD https://www.ezix.org/software/files/lshw-B.${LSHW_VERSION}.tar.gz lshw.tar.gz


### PR DESCRIPTION
  pkg/debug: fix riscv build
    
    `abuild -r` fails with:
    ```
    149599 openat(3</>, "lib/apk/db/lock", O_RDWR|O_CREAT|O_CLOEXEC, 0600) =
    -1 EACCES (Permission denied)
    ```
    
    so, let's just build as root to fix this issue

original PR: https://github.com/lf-edge/eve/pull/5263

## How to test and validate this PR

make PLATFORM=generic ZARCH=riscv64 pkg/debug

## Changelog notes

Fix riscv build

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 14.5-stable
- 13.4-stable

For example, if this PR fixes a bug in a feature that was introduced in 14.5,
you can write:

```text
- 14.5-stable: already done
- 13.4-stable: that is this one
```

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
