### PR TITLE
diag: restore setting of ctx.globalConfig in handleGlobalConfigImpl

### DIFF
--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -1531,6 +1531,9 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 	log.Functionf("handleGlobalConfigImpl for %s", key)
 	gcp := agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
 		ctx.CLIParams().DebugOverride, logger)
+	if gcp != nil {
+		ctx.globalConfig = gcp
+	}
 	ctx.remoteProbes = types.GetDiagRemoteEndpointURLs(log, gcp)
 	ctx.GCInitialized = true
 	log.Functionf("handleGlobalConfigImpl done for %s", key)


### PR DESCRIPTION
# Description

This reverts code [accidentally removed](https://github.com/lf-edge/eve/commit/b2ac0139a1bf268ad1d29517ac590790fe77c231#diff-3f83aa8632045ee44d99814f85003df47fe15c4462f50693624f85b8841bdd25L1533-L1535) in b2ac0139a1bf268ad1d29517ac590790fe77c231
("diag: make remote probe endpoints configurable").

Without this assignment, `ctx.globalConfig` was left unset after applying global config, causing some timer interval values used by diag to ignore user-specified settings and instead always remain at default values.

## How to test and validate this PR

No need to test anything. This PR just reverts accidentally removed code. A mistake that was only temporarily in the master branch and didn't get released.

## Changelog notes

None

## PR Backports

No need to backport anything. Backports of the PR which the mistake introduced already have this fix applied (https://github.com/lf-edge/eve/pull/5269, https://github.com/lf-edge/eve/pull/5266)

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.