### PR TITLE
Bump eden version to 1.0.11

### DIFF
--- a/.github/workflows/eden-trusted.yml
+++ b/.github/workflows/eden-trusted.yml
@@ -179,14 +179,14 @@ jobs:
     name: ${{ needs.context.outputs.eden_parent_job_title }}
     needs: context
     if: needs.context.outputs.skip_run == 'false'
-    uses: lf-edge/eden/.github/workflows/test.yml@1.0.10
+    uses: lf-edge/eden/.github/workflows/test.yml@1.0.11
     secrets: inherit
     with:
       eve_image: "evebuild/pr:${{ needs.context.outputs.pr_id }}"
       eve_log_level: "debug"
       eve_artifact_name: "eve-${{ needs.context.outputs.hv }}-${{ needs.context.outputs.arch }}-${{ needs.context.outputs.platform }}"
       artifact_run_id: ${{ needs.context.outputs.original_run_id }}
-      eden_version: "1.0.10"
+      eden_version: "1.0.11"
 
   finalize:
     name: Finalize Eden Runner status


### PR DESCRIPTION
Bump eden version to 1.0.11, this version disables VCOM tests, since the new test is failing on eden CI. 