### PR TITLE
kubevirt: all_components_initialized may be missing, add it in conversion back to single node

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -865,6 +865,12 @@ if [ -f /var/lib/convert-to-single-node ]; then
         # if we immediately convert back to cluster mode, we need to wait for the
         # bootstrap status before moving on to cluster mode
         convert_to_single_node=true
+
+        #
+        # During first boot this is only set after the save var-lib process
+        # So when converting back to single node its missing, set it again here.
+        #
+        touch /var/lib/all_components_initialized
 fi
 # since we can wait for long time, always start the containerd first
 check_start_containerd


### PR DESCRIPTION
# Description

After single->cluster->single conversion, the /var/lib/all_components_initialized flag may be missing due to an earlier change to move its original creation to after the /var/lib snapshot is taken.

Earlier commit: 4621069 https://github.com/lf-edge/eve/commit/4621069290be408988e8db591c4f65e7d1a14184

## PR dependencies

None

## How to test and validate this PR

- Onboard three HV=kubevirt nodes to a controller
- Configure a cluster in the supporting controller, wait for all nodes to join.
- delete the cluster
- verify all pods move to running state on all three separate nodes.

## Changelog notes

None

## PR Backports

```text
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.