### PR TITLE
[11.0-stable] Use GNU mirror for pkg/cross-compilers

### DIFF
--- a/pkg/cross-compilers/Dockerfile
+++ b/pkg/cross-compilers/Dockerfile
@@ -28,7 +28,7 @@ RUN tar -xzvf aports.tar.gz --strip-components=1 && rm -rf aports.tar.gz
 ENV BINUTILS_VERSION 2.38
 ENV MUSL_VERSION 1.2.3
 ENV GCC_VERSION 11.2.1_git20220219
-ADD --chown=builder:abuild https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.xz /var/cache/distfiles/binutils-${BINUTILS_VERSION}.tar.xz
+ADD --chown=builder:abuild https://ftp.fau.de/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.xz /var/cache/distfiles/binutils-${BINUTILS_VERSION}.tar.xz
 ADD --chown=builder:abuild https://git.musl-libc.org/cgit/musl/snapshot/v${MUSL_VERSION}.tar.gz /var/cache/distfiles/musl-v${MUSL_VERSION}.tar.gz
 ADD --chown=builder:abuild https://dev.alpinelinux.org/~nenolod/gcc-${GCC_VERSION}.tar.xz /var/cache/distfiles/gcc-${GCC_VERSION}.tar.xz
 

--- a/pkg/optee-os/Dockerfile
+++ b/pkg/optee-os/Dockerfile
@@ -17,7 +17,7 @@ ARG BUILD_PKGS_BASE
 RUN BUILD_PKGS="${BUILD_PKGS_BASE}" eve-alpine-deploy.sh
 
 # hadolint ignore=DL3029
-FROM --platform=${BUILDPLATFORM} lfedge/eve-cross-compilers:250abc77c8c39664905b66a2673102ec5cd3b056 AS cross-compilers
+FROM --platform=${BUILDPLATFORM} lfedge/eve-cross-compilers:de3d38b7650c15ec1f085dd1a83eb5c385bf6dab AS cross-compilers
 
 # will use several packages from target arch and copy them to sysroot
 # hadolint ignore=DL3006


### PR DESCRIPTION
# Description

Currently pkg/cross-compilers and pkg/optee-os images are broken on dockerhub. In order to fix them, we need to re-build using a mirror for GNU servers.

## How to test and validate this PR

No need for validation.

## Changelog notes

None.

## PR Backports

This is not a backport, master is working.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.