### PR TITLE
Add a flag to recreate multus link

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -104,6 +104,14 @@ assign_multus_nodeip() {
   awk -v new_ip="$ip_prefix" '{gsub("IPAddressReplaceMe", new_ip)}1' /etc/multus-daemonset.yaml > /etc/multus-daemonset-new.yaml
 }
 
+# Check for link request from k3s upgrade and create a multus link
+check_for_multus_link_request() {
+        if [ -f /var/lib/request-retouch-multus ]; then
+                rm -f /var/lib/request-retouch-multus
+                link_multus_into_k3s
+        fi
+}
+
 apply_multus_cni() {
         # remove get_default_intf_IP_prefix
         #get_default_intf_IP_prefix
@@ -988,6 +996,7 @@ if [ ! -f /var/lib/all_components_initialized ]; then
                         continue
                 fi
         fi
+        check_for_multus_link_request
         if ! pidof dhcp; then
                 # if the dhcp.sock exist, then the daemon can not be restarted
                 if [ -f /run/cni/dhcp.sock ]; then
@@ -1092,6 +1101,7 @@ else
                         fi
                         apply_multus_cni
                 fi
+                check_for_multus_link_request
                 if ! pidof dhcp; then
                         # if the dhcp.sock exist, then the daemon can not be restarted
                         if [ -f /run/cni/dhcp.sock ]; then


### PR DESCRIPTION
# Description

Provide a flag to recreate multus link for k3s upgrade using /var/lib/equest-retouch-multus

K3s upgrade will be initiated from cloud, which will result in a pod creation on the downstream cluster which performs the upgrade. After the k3s upgrade the multus link needs to be recreated. This provides a new flag to do that from k3s upgrade pod.

## PR dependencies
None

## How to test and validate this PR

Onboard an edge node with this change
unlink /var/lib/rancher/k3s/data/current/bin/multus
touch /var/lib/request-retouch-multus
After some time the link gets created again and the flag will be removed

## Changelog notes
None
## PR Backports
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
