### PR TITLE
eve-k + pillar: Fix mount points for Nvidia

### DIFF
--- a/pkg/kube/build.yml
+++ b/pkg/kube/build.yml
@@ -1,4 +1,3 @@
-# linuxkit build template 
 #
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
@@ -9,13 +8,15 @@ config:
     - /lib/modules:/lib/modules
     - /dev:/dev
     - /etc/resolv.conf:/etc/resolv.conf
+    - /etc/cdi:/etc/cdi
     - /run:/run
     - /config:/config
     - /:/hostfs
     - /persist:/persist:rshared,rbind
     - /sys/fs/cgroup:/sys/fs/cgroup
+    - /opt/vendor:/opt/vendor:ro
   capabilities:
-    - all 
+    - all
   pid: host
   rootfsPropagation: shared
   devices:

--- a/pkg/pillar/build-dev.yml
+++ b/pkg/pillar/build-dev.yml
@@ -12,11 +12,13 @@ config:
     - /lib/modules:/lib/modules
     - /dev:/dev
     - /etc/resolv.conf:/etc/resolv.conf
+    - /etc/cdi:/etc/cdi
     - /run:/run
     - /config:/config
     - /:/hostfs
     - /persist:/persist:rshared,rbind
     - /usr/bin/containerd:/usr/bin/containerd
+    - /opt/vendor:/opt/vendor:ro
   net: host
   capabilities:
     - all

--- a/pkg/pillar/build-k-dev.yml
+++ b/pkg/pillar/build-k-dev.yml
@@ -12,11 +12,13 @@ config:
     - /lib/modules:/lib/modules
     - /dev:/dev
     - /etc/resolv.conf:/etc/resolv.conf
+    - /etc/cdi:/etc/cdi
     - /run:/run
     - /config:/config
     - /:/hostfs
     - /persist:/persist:rshared,rbind
     - /usr/bin/containerd:/usr/bin/containerd
+    - /opt/vendor:/opt/vendor:ro
   net: host
   capabilities:
     - all

--- a/pkg/pillar/build-k.yml
+++ b/pkg/pillar/build-k.yml
@@ -1,8 +1,6 @@
-# linuxkit build template
 #
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-
 ---
 org: lfedge
 image: eve-pillar
@@ -12,11 +10,13 @@ config:
     - /lib/modules:/lib/modules
     - /dev:/dev
     - /etc/resolv.conf:/etc/resolv.conf
+    - /etc/cdi:/etc/cdi
     - /run:/run
     - /config:/config
     - /:/hostfs
     - /persist:/persist:rshared,rbind
     - /usr/bin/containerd:/usr/bin/containerd
+    - /opt/vendor:/opt/vendor:ro
   net: host
   capabilities:
     - all

--- a/pkg/pillar/build-rstats.yml
+++ b/pkg/pillar/build-rstats.yml
@@ -9,11 +9,13 @@ config:
     - /lib/modules:/lib/modules
     - /dev:/dev
     - /etc/resolv.conf:/etc/resolv.conf
+    - /etc/cdi:/etc/cdi
     - /run:/run
     - /config:/config
     - /:/hostfs
     - /persist:/persist:rshared,rbind
     - /usr/bin/containerd:/usr/bin/containerd
+    - /opt/vendor:/opt/vendor:ro
   capabilities:
     - all
   pid: host


### PR DESCRIPTION
# Description

The `/etc/cdi` and `/opt/vendor` directories should also be visible (mounted) for all pillar variants + eve-k in order to get access to Nvidia libraries + CDI yaml files. These mount points were missing for:

1. pkg/kube/build.yml
2. pkg/pillar/build-k.yml
3. pkg/pillar/build-k-dev.yml
4. pkg/pillar/build-dev.yml
5. pkg/pillar/build-rstats.yml

## How to test and validate this PR

These mount points are not in current use for the versions that they were added by this PR. So I don't think we need a strict validation at this moment. However, it can still be checked by building the different combinations for EVE + nvidia, for instance:

1. `make ZARCH=arm64 PLATFORM=nvidia-jp6 DEV=1 ...`
2. `make ZARCH=arm64 HV=k PLATFORM=nvidia-jp6  ...`

Then, by entering inside the containers (pillar and kube) and checking if the Nvidia files are there. For instance:

```
0f6354fb-bebc-449c-ad4f-072913e4d77f:~# eve enter pillar
[pillar] root@0f6354fb-bebc-449c-ad4f-072913e4d77f:/$ ls /opt/vendor/nvidia/
bin/          dist/         etc/          eve-platform  init.d/
[pillar] root@0f6354fb-bebc-449c-ad4f-072913e4d77f:/$ cat /opt/vendor/nvidia/eve-platform 
nvidia-jp6
[pillar] root@0f6354fb-bebc-449c-ad4f-072913e4d77f:/$ find /opt/vendor/nvidia/
....
```

## Changelog notes

Add Nvidia mount points for eve-k and pkg/pillar dev. variants.

## PR Backports

These mount points were not in use by eve-k for previous versions, so there is no need to backport.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.