### PR TITLE
fix eve-k  arm64 builds

### DIFF
--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -39,7 +39,12 @@ ifneq ($(TAGS),)
 	TAGS:=-tags "$(TAGS)"
 endif
 
-LDFLAGS=-extldflags=-fuse-ld=bfd
+ifneq ($(HV),)
+       LDFLAGS=-extldflags '-fuse-ld=bfd -no-pie'
+else
+       LDFLAGS=-extldflags=-fuse-ld=bfd
+endif
+
 ifneq ($(DEV),y)
 	LDFLAGS+=-s -w
 endif


### PR DESCRIPTION
It looks like when we compile eve-k (aka kubevirt eve) on arm64 some go modules are bringing in the position independant code compilation flags and causing linker to build PIE executable.

So zedbox is build as PIE exectuable and that is crashing as soon as it is launched. I am not sure zedbox is designed to run at random addresses every time. Also arm64 or amd64 kvm eve does not generate PIE zedbox.

So for eve-k tell linker to use -no-pie flag.


## How to test and validate this PR

compile eve without this fix and do USB install or just do docker run  eve-pillar-kube container and notice that zedbox process keeps crashing as soon as it is launched.

You also check with "file /opt/zededa/bin/zedbox " and see that the binary is PIE executable.

/opt/zededa/bin # file zedbox
zedbox: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-aarch64.so.1, BuildID[sha1]=d58e99ffb0bc24aa46175b26cfbd3e3b3ad38144, stripped

With this fix we no longer load pie executable and eve starts fine.

## PR Backports

No back port required. eve-k is not supported in older versions of eve.

## Checklist

- [x] I've provided a proper description
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions




And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
