### PR TITLE
newlog: get rid of Fatal's in vector.go

### DIFF
--- a/pkg/newlog/cmd/vector_test.go
+++ b/pkg/newlog/cmd/vector_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+)
+
+func TestCreateVectorSockets(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	// Create a temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "vector_socket_test")
+	g.Expect(err).To(gomega.BeNil())
+	defer os.RemoveAll(tmpDir)
+
+	// Create a socket path in a subdirectory that doesn't exist yet
+	nonExistentDir := filepath.Join(tmpDir, "nonexistent")
+	sockPath := filepath.Join(nonExistentDir, "test.sock")
+
+	unixListenerChan := make(chan *net.UnixListener, 1)
+	backoffPeriod := 100 * time.Millisecond
+
+	go func() {
+		unixListener := createVectorSockets(sockPath, backoffPeriod)
+		unixListenerChan <- unixListener
+	}()
+
+	time.Sleep(2 * backoffPeriod) // Wait to ensure retries happen
+
+	// Verify that the socket was not created yet
+	_, err = os.Stat(sockPath)
+	g.Expect(os.IsNotExist(err)).To(gomega.BeTrue(), "Socket file should not exist yet")
+
+	// Now create the directory
+	err = os.MkdirAll(nonExistentDir, 0755)
+	g.Expect(err).To(gomega.BeNil())
+
+	// Wait a bit to let the function succeed
+	var unixListener *net.UnixListener
+	select {
+	case unixListener = <-unixListenerChan:
+		// Successfully created the listener
+	case <-time.After(10 * backoffPeriod):
+		t.Fatal("Timeout waiting for createVectorSockets to succeed")
+	}
+
+	// verify that the listener was created
+	g.Expect(unixListener).ToNot(gomega.BeNil(), "createVectorSockets should succeed after directory creation")
+
+	// Verify the socket was created
+	info, err := os.Stat(sockPath)
+	g.Expect(err).To(gomega.BeNil(), "Socket file should be created after directory creation")
+
+	expectedMode := os.FileMode(0666)
+	g.Expect(info.Mode().Perm()).To(gomega.Equal(expectedMode), "Socket permissions should be correct")
+
+	// Verify we can connect to the socket
+	conn, err := net.Dial("unix", sockPath)
+	g.Expect(err).To(gomega.BeNil(), "Should be able to connect to socket")
+	conn.Close()
+
+	t.Log("Test passed: socket created successfully and is connectable")
+}


### PR DESCRIPTION
# Description

This addresses a promise from https://github.com/lf-edge/eve/pull/5008#issuecomment-3028328973.

Instead of fataling out when we fail to create the socket listener, we retry forever with a backoff. This is important because if newlogd exits, the watchdog will reboot the whole system, which is not what we want for a transient failure like a missing directory.

## PR dependencies

None

## How to test and validate this PR

No validation needed, the change is covered by unit and Eden tests.

## Changelog notes

N/A since it's just a home work from https://github.com/lf-edge/eve/pull/5008.

## PR Backports

No need to backport since this code was added in EVE 15.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR