### PR TITLE
k3s-base mode should uninstall any remaining longhorn storage classes

### DIFF
--- a/pkg/kube/longhorn-utils.sh
+++ b/pkg/kube/longhorn-utils.sh
@@ -63,6 +63,11 @@ Longhorn_uninstall() {
     kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/uninstall/uninstall.yaml
     logmsg "longhorn_uninstall job deletion"
 
+    lhScs=$(kubectl get sc -o jsonpath='{range .items[?(@.provisioner=="driver.longhorn.io")]}{.metadata.name}{" "}{end}')
+    for sc in $lhScs; do
+        kubectl delete sc "$sc" >> "$INSTALL_LOG" 2>&1
+    done
+
     rm /var/lib/longhorn_initialized
     return 0
 }


### PR DESCRIPTION
## Description

An eve node which receives a cluster config including a
registration manifest will begin uninstalling longhorn.
    
As part of that longhorn uninstall process there are
one or more storage classes left over, these need to
be deleted.
    
Filter by provisioner: driver.longhorn.io and delete them.

## PR dependencies

None

## How to test and validate this PR

- install eve HV=k and onboard one or three nodes to a controller
- configure the controller to create a cluster from the nodes and send a registration manifest
- verify all nodes follow the uninstall process and remove all kubernetes storage classes.

## Changelog notes

Remove all longhorn storage classes when HV=k eve is in k3s-base mode.

## PR Backports

- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
