### PR TITLE
tools: update_kernel_commits.py: Add support for next branches

### DIFF
--- a/tools/update_kernel_commits.py
+++ b/tools/update_kernel_commits.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
+# pylint: disable=too-many-lines
 """
-Copyright (c) 2023 Zededa, Inc.
+Copyright (c) 2023-2025 Zededa, Inc.
 SPDX-License-Identifier: Apache-2.0
 
 This script does two things:
@@ -30,6 +31,7 @@ from colorama import Fore, Style, init  # pylint: disable=import-error
 # do not force users to have pytest installed
 try:
     import pytest
+
     PYTEST_AVAILABLE = True
 except ImportError:
     PYTEST_AVAILABLE = False
@@ -53,8 +55,19 @@ def get_short_arch_flavor(branch_name):
     Returns:
     - str: A short representation of the architecture and flavor.
     """
-    _, _, arch, _, flavor = branch_name.split("-", 4)
-    return f"{arch}-{flavor}"
+    parts = branch_name.split("-", 4)
+    if len(parts) == 5:
+        # Versioned branch: eve-kernel-amd64-v5.10-generic
+        _, _, arch, _, flavor = parts
+        return f"{arch}-{flavor}"
+    if len(parts) == 4 and parts[3] == "next":
+        # Next branch: eve-kernel-amd64-next
+        _, _, arch, version = parts
+        return f"{arch}-{version}"
+    # Fallback for unexpected format
+    _, _, arch, *rest = parts
+    return f"{arch}-{'-'.join(rest)}"
+
 
 def fetch_latest_commits_from_github(user, user_token, verbose=False):
     """
@@ -62,7 +75,10 @@ def fetch_latest_commits_from_github(user, user_token, verbose=False):
     returns the commit hashes for each branch in a set. Protected branches are ignored
     """
     # pylint: disable-next=line-too-long
-    repo_url = f"https://api.github.com/repos/{user}/eve-kernel/branches?protected=false&per_page=100"
+    repo_url = (
+        f"https://api.github.com/repos/{user}/eve-kernel/branches"
+        "?protected=false&per_page=100"
+    )
     new_commits = {}
 
     headers = {"Authorization": f"token {user_token}"}
@@ -92,8 +108,11 @@ def fetch_latest_commits_from_github(user, user_token, verbose=False):
             else:
                 break
         elif response.status_code == 401:
-            print(Fore.RED + Style.BRIGHT + "Error: Unauthorized (401). Your GitHub token is invalid or"
-                                            " expired.")
+            print(
+                Fore.RED
+                + Style.BRIGHT
+                + "Error: Unauthorized (401). Your GitHub token is invalid or expired."
+            )
             print("Please enter a new GitHub personal access token.")
             if os.path.exists(config_file_path):
                 os.remove(config_file_path)
@@ -103,9 +122,12 @@ def fetch_latest_commits_from_github(user, user_token, verbose=False):
             session.headers.update({"Authorization": f"token {new_token}"})
             continue  # Retry the request with the new token
         else:
-            print(Fore.RED + Style.BRIGHT + "Error:", response.status_code, response.text)
+            print(
+                Fore.RED + Style.BRIGHT + "Error:", response.status_code, response.text
+            )
             sys.exit(1)
     return new_commits
+
 
 def is_valid_branch_format(branch_name):
     """
@@ -118,8 +140,13 @@ def is_valid_branch_format(branch_name):
     Returns:
     - bool: True if the branch name follows the expected format, False otherwise.
     """
-    match = re.fullmatch(r"eve-kernel-(amd64|arm64|riscv64){1}-v\d+\.\d+(?:\.\d+)?-.+", branch_name)
+    # Match versioned branches: eve-kernel-(arch)-v\d+\.\d+(?:\.\d+)?-.+
+    # Or next branches: eve-kernel-(arch)-next
+    match = re.fullmatch(
+        r"eve-kernel-(amd64|arm64|riscv64)-(v\d+\.\d+(?:\.\d+)?-.+|next)", branch_name
+    )
     return match is not None
+
 
 def variable_to_branch_name(variable_name):
     """
@@ -131,6 +158,16 @@ def variable_to_branch_name(variable_name):
     Returns:
     - str: The branch name in the expected format.
     """
+    # Handle next branches with flavor: KERNEL_COMMIT_amd64_next_generic -> eve-kernel-amd64-next
+    # (strip the flavor part for next branches)
+    if "_next_" in variable_name:
+        # Extract arch from variable like KERNEL_COMMIT_amd64_next_generic
+        parts = variable_name.replace("KERNEL_COMMIT_", "").split("_")
+        if len(parts) >= 2 and parts[1] == "next":
+            arch = parts[0]
+            return f"eve-kernel-{arch}-next"
+
+    # Regular branches: KERNEL_COMMIT_amd64_v6.1.112_generic -> eve-kernel-amd64-v6.1.112-generic
     branch_name = variable_name.replace("KERNEL_COMMIT_", "").replace("_", "-")
     return f"eve-kernel-{branch_name}"
 
@@ -144,33 +181,76 @@ def branch_commit_to_variable(branch_name, commit):
     - commit (str): The commit hash.
 
     Returns:
-    - str: The variable name in the expected format.
+    - str: The variable name(s) in the expected format.
+          For next branches, generates multiple variables for different flavors.
     """
     # pylint: disable-next=line-too-long
-    branch_match = re.match(r"(?P<branch>eve-kernel-(amd64|arm64|riscv64){1}-v\d+\.\d+(?:\.\d+)?)-(?P<platform>.+)", branch_name)
+    # Match versioned branches: eve-kernel-(arch)-v\d+\.\d+(?:\.\d+)?-(platform)
+    # Or next branches: eve-kernel-(arch)-next (no platform suffix)
 
-    if not branch_match:
-        sys.exit(f"Error: Invalid branch name format: {branch_name}")
+    # Try matching versioned format first (has platform suffix)
+    branch_match = re.match(
+        r"(?P<branch>eve-kernel-(amd64|arm64|riscv64)-(v\d+\.\d+(?:\.\d+)?))-(?P<platform>.+)",
+        branch_name,
+    )
 
-    branch_name = branch_match.group("branch").replace("eve-kernel-", "KERNEL_COMMIT_") \
-        .replace("-", "_")
-    variable_name = branch_name + "_" + branch_match.group("platform")
-    return f"{variable_name} = {commit}\n"
+    if branch_match:
+        branch_name = (
+            branch_match.group("branch")
+            .replace("eve-kernel-", "KERNEL_COMMIT_")
+            .replace("-", "_")
+        )
+        variable_name = branch_name + "_" + branch_match.group("platform")
+        return f"{variable_name} = {commit}\n"
+
+    # Try matching next format (no platform suffix)
+    next_match = re.match(r"eve-kernel-(amd64|arm64|riscv64)-next", branch_name)
+
+    if next_match:
+        arch = next_match.group(1)
+        # For next branches, always use generic flavor (next branches are generic by default)
+        variable_name = f"KERNEL_COMMIT_{arch}_next_generic"
+        return f"{variable_name} = {commit}\n"
+
+    sys.exit(f"Error: Invalid branch name format: {branch_name}")
+
 
 if PYTEST_AVAILABLE:
+
     def test_branch_commit_to_variable():
         """
         Test the branch_commit_to_variable function with valid branch names.
         """
 
-        assert branch_commit_to_variable("eve-kernel-amd64-v5.10.186-generic", "abcd") \
+        assert (
+            branch_commit_to_variable("eve-kernel-amd64-v5.10.186-generic", "abcd")
             == "KERNEL_COMMIT_amd64_v5.10.186_generic = abcd\n"
-        assert branch_commit_to_variable("eve-kernel-amd64-v5.10-generic", "abcd") \
+        )
+        assert (
+            branch_commit_to_variable("eve-kernel-amd64-v5.10-generic", "abcd")
             == "KERNEL_COMMIT_amd64_v5.10_generic = abcd\n"
-        assert branch_commit_to_variable("eve-kernel-arm64-v5.10.192-nvidia-jp5", "abcd") \
+        )
+        assert (
+            branch_commit_to_variable("eve-kernel-arm64-v5.10.192-nvidia-jp5", "abcd")
             == "KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = abcd\n"
-        assert branch_commit_to_variable("eve-kernel-arm64-v5.10-nvidia-jp5", "abcd") \
+        )
+        assert (
+            branch_commit_to_variable("eve-kernel-arm64-v5.10-nvidia-jp5", "abcd")
             == "KERNEL_COMMIT_arm64_v5.10_nvidia-jp5 = abcd\n"
+        )
+        # Next branches always use generic flavor
+        assert (
+            branch_commit_to_variable("eve-kernel-amd64-next", "abcd")
+            == "KERNEL_COMMIT_amd64_next_generic = abcd\n"
+        )
+        assert (
+            branch_commit_to_variable("eve-kernel-arm64-next", "abcd")
+            == "KERNEL_COMMIT_arm64_next_generic = abcd\n"
+        )
+        assert (
+            branch_commit_to_variable("eve-kernel-riscv64-next", "abcd")
+            == "KERNEL_COMMIT_riscv64_next_generic = abcd\n"
+        )
 
     def test_branch_commit_to_variable_exit():
         """
@@ -179,8 +259,10 @@ if PYTEST_AVAILABLE:
         with pytest.raises(SystemExit) as pytest_wrapped_e:
             branch_commit_to_variable("eve-kernel-arm64-v5-nvidia-jp5", "abcd")
         assert pytest_wrapped_e.type == SystemExit
-        assert pytest_wrapped_e.value.code == \
-            "Error: Invalid branch name format: eve-kernel-arm64-v5-nvidia-jp5"
+        assert (
+            pytest_wrapped_e.value.code
+            == "Error: Invalid branch name format: eve-kernel-arm64-v5-nvidia-jp5"
+        )
 
     def test_is_valid_branch_format():
         """
@@ -191,6 +273,9 @@ if PYTEST_AVAILABLE:
         assert is_valid_branch_format("eve-kernel-riscv64-v5.10.192-nvidia-jp5") is True
         assert is_valid_branch_format("eve-kernel-arm64-v5.10-nvidia-jp5") is True
         assert is_valid_branch_format("eve-kernel-arm64-v5.10-nvidia-jp5") is True
+        assert is_valid_branch_format("eve-kernel-amd64-next") is True
+        assert is_valid_branch_format("eve-kernel-arm64-next") is True
+        assert is_valid_branch_format("eve-kernel-riscv64-next") is True
 
     def test_is_invalid_branch_format():
         """
@@ -202,8 +287,8 @@ if PYTEST_AVAILABLE:
         assert is_valid_branch_format("eve-kernel-update") is False
         assert is_valid_branch_format("eve-kernel-v6.8-") is False
         assert is_valid_branch_format("eve-kernel-arm64-v6.8") is False
-
-
+        assert is_valid_branch_format("eve-kernel-amd64-next-generic") is False
+        assert is_valid_branch_format("eve-kernel-arm64-nextstuff") is False
 
 
 def parse_kernel_commits_file(file_path):
@@ -226,37 +311,272 @@ def parse_kernel_commits_file(file_path):
     return commits
 
 
-def github_fetch_commit_range(repo_owner, repo_name, old_commit, new_commit, verbose=False):
+def check_tag_exists(tag_name, repo_owner, repo_name, token=None, verbose=False):
+    """
+    Check if a specific tag exists in the repository.
+
+    Parameters:
+    - tag_name (str): The tag name to check (e.g., "v6.1.111").
+    - repo_owner (str): The owner of the GitHub repository.
+    - repo_name (str): The name of the GitHub repository.
+    - token (str): GitHub personal access token for authentication.
+    - verbose (bool): Enable verbose output.
+
+    Returns:
+    - bool: True if the tag exists, False otherwise.
+    """
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    if token:
+        headers["Authorization"] = f"token {token}"
+
+    # Check if tag exists using the git refs API
+    api_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/refs/tags/{tag_name}"
+
+    try:
+        response = requests.get(api_url, headers=headers, timeout=30)
+        if response.status_code == 200:
+            if verbose:
+                print(f"    Tag {tag_name} exists in repository")
+            return True
+        if response.status_code == 403:
+            # API rate limit - assume tag exists since we can't verify
+            if verbose:
+                print(
+                    f"    Tag {tag_name} not found in repository "
+                    f"(status: {response.status_code})"
+                )
+            return False
+        # For other status codes, assume tag doesn't exist
+        if verbose:
+            print(f"    Tag {tag_name} not found (status: {response.status_code})")
+        return False
+    except (requests.RequestException, KeyError, ValueError) as exc:
+        if verbose:
+            print(f"    Error checking tag {tag_name}: {exc}")
+        return False
+
+
+def _fetch_kernel_tags(repo_owner, repo_name, headers, verbose):
+    """Helper function to fetch kernel tags from GitHub."""
+    api_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/tags?per_page=100&page=1"
+    try:
+        response = requests.get(api_url, headers=headers, timeout=30)
+        if response.status_code != 200:
+            if verbose:
+                print(f"    Failed to fetch tags: {response.status_code}")
+            return None
+
+        page_tags = response.json()
+        # Filter for Linux kernel version tags (vX.Y.Z or vX.Y format)
+        tags = [
+            tag for tag in page_tags if re.match(r"^v\d+\.\d+(\.\d+)?$", tag["name"])
+        ]
+        return tags
+    except (requests.RequestException, KeyError, ValueError) as exc:
+        if verbose:
+            print(f"    Error fetching tags: {exc}")
+        return None
+
+
+def _check_single_tag(tag, commit_sha, repo_config, headers, verbose):
+    """Helper to check a single tag and return ahead_by count."""
+    repo_owner, repo_name = repo_config
+    tag_name = tag["name"]
+
+    api_url = (
+        f"https://api.github.com/repos/{repo_owner}/{repo_name}/"
+        f"compare/{tag_name}...{commit_sha}"
+    )
+
+    response = requests.get(api_url, headers=headers, timeout=30)
+    if response.status_code != 200:
+        return None
+
+    data = response.json()
+    ahead_by = data.get("ahead_by", float("inf"))
+
+    if verbose:
+        print(f"      {tag_name}: {ahead_by} commits ahead")
+
+    return ahead_by
+
+
+def _find_best_tag(tags, commit_sha, repo_config, headers, verbose):
+    """Helper function to find the best tag among candidates."""
+    best_tag = None
+    smallest_ahead = float("inf")
+
+    # Check only first 20 tags to limit API calls
+    for tag in tags[:20]:
+        try:
+            ahead_by = _check_single_tag(tag, commit_sha, repo_config, headers, verbose)
+            if ahead_by is None:
+                continue
+
+            if ahead_by < smallest_ahead:
+                smallest_ahead = ahead_by
+                best_tag = tag["name"]
+
+                # Early exit if we found a good match
+                if ahead_by < 100:
+                    if verbose:
+                        print("    Found good match, stopping search early")
+                    break
+        except (requests.RequestException, KeyError, ValueError) as exc:
+            if verbose:
+                print(f"      Error checking {tag.get('name', 'unknown')}: {exc}")
+
+    return best_tag, smallest_ahead
+
+
+def find_nearest_kernel_tag(
+    commit_sha, repo_owner, repo_name, token=None, verbose=False
+):
+    """
+    Find the nearest Linux kernel tag (vX.Y.Z format) that is an ancestor of the given commit.
+    This simulates 'git describe --tags' using GitHub API.
+
+    Parameters:
+    - commit_sha (str): The commit SHA to find the nearest tag for.
+    - repo_owner (str): The owner of the GitHub repository.
+    - repo_name (str): The name of the GitHub repository.
+    - token (str): GitHub personal access token for authentication.
+    - verbose (bool): Enable verbose output.
+
+    Returns:
+    - str: The nearest kernel tag, or None if not found.
+    """
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    if token:
+        headers["Authorization"] = f"token {token}"
+
+    if verbose:
+        print(f"  Searching for nearest kernel tag for commit {commit_sha[:12]}...")
+
+    # Get only the first page of tags (most recent 100)
+    tags = _fetch_kernel_tags(repo_owner, repo_name, headers, verbose)
+    if not tags:
+        if verbose:
+            print("    No kernel tags found")
+        return None
+
+    if verbose:
+        print(f"    Checking {len(tags)} recent kernel tags...")
+
+    # Find the best tag among candidates
+    best_tag, smallest_ahead = _find_best_tag(
+        tags, commit_sha, (repo_owner, repo_name), headers, verbose
+    )
+
+    if best_tag and verbose:
+        print(f"    Found nearest tag: {best_tag} ({smallest_ahead} commits ahead)")
+
+    return best_tag
+
+
+def find_merge_base_for_next_branch(
+    branch_name, all_branches, repo_config, token=None, verbose=False
+):
+    """
+    Find the actual branch point for a next branch by finding the nearest Linux kernel tag.
+
+    Parameters:
+    - branch_name (str): The next branch name (e.g., "eve-kernel-amd64-next").
+    - all_branches (dict): Dictionary of all branch names and their commit hashes.
+    - repo_config (tuple): (repo_owner, repo_name) for the GitHub repository.
+    - token (str): GitHub personal access token for authentication.
+    - verbose (bool): Enable verbose output.
+
+    Returns:
+    - str: The tag or commit to use as the starting point, or None if not found.
+    """
+    # Extract architecture from the next branch name
+    parts = branch_name.split("-")
+    if len(parts) != 4 or parts[3] != "next":
+        return None
+
+    next_commit = all_branches[branch_name]
+
+    # Find the nearest kernel tag using GitHub API
+    repo_owner, repo_name = repo_config
+    nearest_tag = find_nearest_kernel_tag(
+        next_commit, repo_owner, repo_name, token, verbose
+    )
+
+    if nearest_tag:
+        if verbose:
+            print(f"  Using {nearest_tag} as branch point for {branch_name}")
+        return nearest_tag
+
+    if verbose:
+        print(f"  Failed to find nearest tag for {branch_name}")
+
+    return None
+
+
+def _validate_old_commit(repo_owner, repo_name, old_commit, headers):
+    """Helper function to validate old commit exists."""
+    check_url = (
+        f"https://api.github.com/repos/{repo_owner}/{repo_name}/commits/{old_commit}"
+    )
+    response = requests.get(check_url, headers=headers, timeout=30)
+
+    if response.status_code == 200:
+        return
+
+    # If not found as commit, check if it's a tag (for new branches)
+    if re.match(r"^v\d+\.\d+(\.\d+)?$", old_commit):
+        tag_url = (
+            f"https://api.github.com/repos/{repo_owner}/{repo_name}"
+            f"/git/refs/tags/{old_commit}"
+        )
+        tag_response = requests.get(tag_url, headers=headers, timeout=30)
+        if tag_response.status_code == 200:
+            return
+
+        # Neither commit nor tag found
+        error_msg = f"commit '{old_commit}' is not found in the repository."
+        error_msg += (
+            " This appears to be a Linux kernel tag (vX.Y.Z format)"
+            " that must be pushed to the repository first."
+        )
+        raise LinuxKernelTagNotPushedError(error_msg)
+
+    # Not a commit and not a tag format
+    raise CommitFetchError(f"commit '{old_commit}' is not found in the repository.")
+
+
+def github_fetch_commit_range(
+    repo_config, old_commit, new_commit, token=None, verbose=False
+):
     """
     Fetch commit subjects and their corresponding commit hashes
     between old and new commits for a branch.
 
     Parameters:
-    - repo_owner (str): The owner of the GitHub repository.
-    - repo_name (str): The name of the GitHub repository.
+    - repo_config (tuple): (repo_owner, repo_name) for the GitHub repository.
     - old_commit (str): The old commit hash.
     - new_commit (str): The new commit hash.
+    - token (str): GitHub personal access token for authentication.
+    - verbose (bool): Enable verbose output.
 
     Returns:
-    - list: A list of tuples containing commit hashes and their subjects.
-    - None: If the retrieval of commit information fails.
+    - list: A list of tuples containing commit SHA prefixes and subjects.
+
+    Raises:
+    - LinuxKernelTagNotPushedError: When a kernel tag is not found in the repository.
+    - CommitFetchError: When there's an error fetching commits.
     """
+    repo_owner, repo_name = repo_config
 
-    # first check if 'old_commit' is known to gitgub. it may happen when the
-    # new branch is added the tag was not pushed to github so nothing to compare against
     headers = {"Accept": "application/vnd.github.v3+json"}
-    check_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/commits/{old_commit}"
-    response = requests.get(check_url, headers=headers, timeout=30)
-    if response.status_code != 200:
-        # check that the commit matches a tag vX.Y.Z to provide a helpful hint
-        error_msg = f"commit '{old_commit}' is not found in the repository."
-        if re.match(r'^v\d+\.\d+\.\d+$', old_commit):
-            error_msg += (
-                " This appears to be a Linux kernel tag (vX.Y.Z format)"
-                " that must be pushed to the repository first."
-            )
-        raise LinuxKernelTagNotPushedError(error_msg)
+    if token:
+        headers["Authorization"] = f"token {token}"
 
+    # Validate old commit exists
+    _validate_old_commit(repo_owner, repo_name, old_commit, headers)
+
+    # Fetch commit range
     api_url = (
         f"https://api.github.com/repos/{repo_owner}/{repo_name}"
         f"/compare/{old_commit}...{new_commit}"
@@ -274,12 +594,14 @@ def github_fetch_commit_range(repo_owner, repo_name, old_commit, new_commit, ver
 
     commit_info = []
     for commit in response.json().get("commits", []):
-        commit_info.append((commit["sha"][:12], commit["commit"]["message"].split("\n")[0]))
+        commit_info.append(
+            (commit["sha"][:12], commit["commit"]["message"].split("\n")[0])
+        )
 
     return commit_info
 
 
-def generate_commit_message(branches, repo_owner, repo_name, verbose=False):
+def generate_commit_message(branches, repo_owner, repo_name, token=None, verbose=False):
     """
     Generate a commit message with commit subjects
     and corresponding commit hashes between old and new commits.
@@ -287,6 +609,7 @@ def generate_commit_message(branches, repo_owner, repo_name, verbose=False):
     Parameters:
     - old_commits (dict): A dictionary of branch names and old commit hashes.
     - new_commits (dict): A dictionary of branch names and new commit hashes.
+    - token (str): GitHub personal access token for authentication.
 
     Returns:
     - tuple: A tuple containing (commit_message: str, errors: list)
@@ -303,14 +626,20 @@ def generate_commit_message(branches, repo_owner, repo_name, verbose=False):
             continue
 
         commit_message += f"{branch}\n"
+
+        # For new next branches (old_commit is None but new_commit exists),
+        # just show the new commit without a range
+        if old_commit is None and new_commit is not None:
+            commit_message += f"    New branch added at commit: {new_commit}\n\n"
+            continue
         # Fetch a limited number of commit subjects and their corresponding
         # commit hashes between old and new commits for the branch
         try:
             commit_infos = github_fetch_commit_range(
-                repo_owner,
-                repo_name,
+                (repo_owner, repo_name),
                 old_commit,
                 new_commit,
+                token,
                 verbose=verbose,
             )
             if commit_infos:
@@ -351,13 +680,83 @@ def pattern_to_regex(pattern):
     return regex_pattern
 
 
-def find_updated_branches(old_commits, new_commits, verbose=False):
+def _process_versioned_branch(branch, new_commit, token, verbose):
+    """Helper function to process versioned branches."""
+    parts = branch.split("-", 4)
+    _, _, _, tag, _ = parts
+
+    if verbose:
+        print(f"    New versioned branch: {branch}, commit: {new_commit}")
+        print(f"    Checking if tag {tag} exists...")
+
+    # Check if the tag exists in the repository
+    if check_tag_exists(tag, "lf-edge", "eve-kernel", token, verbose):
+        if verbose:
+            print(f"    Using tag {tag} as starting point")
+        return (tag, new_commit)
+
+    # Tag doesn't exist, try to find the nearest tag
+    if verbose:
+        print(f"    Tag {tag} not found, searching for nearest tag...")
+    nearest_tag = find_nearest_kernel_tag(
+        new_commit, "lf-edge", "eve-kernel", token, verbose
+    )
+    if nearest_tag:
+        if verbose:
+            print(f"    Using nearest tag: {nearest_tag}")
+        return (nearest_tag, new_commit)
+
+    # Last resort: skip this branch or use None
+    if verbose:
+        print("    No tag found, will add without commit range")
+    return (None, new_commit)
+
+
+def _process_next_branch(branch, new_commit, new_commits, token, verbose):
+    """Helper function to process next branches."""
+    if verbose:
+        print(f"    New next branch: {branch}, commit: {new_commit}")
+
+    # Try to find merge-base with a reference branch
+    merge_base = find_merge_base_for_next_branch(
+        branch, new_commits, ("lf-edge", "eve-kernel"), token, verbose
+    )
+
+    if merge_base:
+        if verbose:
+            print(f"    Using merge-base: {merge_base[:12]}")
+        return (merge_base, new_commit)
+
+    # Fallback: use None if we can't find a merge-base
+    if verbose:
+        print("    No merge-base found, will add without commit range")
+    return (None, new_commit)
+
+
+def _process_new_branch(branch, new_commit, new_commits, token, verbose):
+    """Helper function to process new branches."""
+    parts = branch.split("-", 4)
+
+    if len(parts) == 5:
+        # Versioned branch: eve-kernel-amd64-v5.10-generic
+        return _process_versioned_branch(branch, new_commit, token, verbose)
+    if len(parts) == 4 and parts[3] == "next":
+        # Next branch: eve-kernel-amd64-next
+        return _process_next_branch(branch, new_commit, new_commits, token, verbose)
+    # Fallback - use the last part as tag
+    tag = parts[-1]
+    return (tag, new_commit)
+
+
+def find_updated_branches(old_commits, new_commits, token=None, verbose=False):
     """
     Find the branches that have been updated.
 
     Parameters:
     - old_commits (dict): A dictionary of branch names and old commit hashes.
     - new_commits (dict): A dictionary of branch names and new commit hashes.
+    - token (str): GitHub personal access token for authentication.
+    - verbose (bool): Enable verbose output.
 
     Returns:
     - list: A list of branch names that have been updated or added.
@@ -370,6 +769,7 @@ def find_updated_branches(old_commits, new_commits, verbose=False):
     for branch, new_commit in new_commits.items():
         if verbose:
             print(f"  {branch}, current commit: {new_commit}")
+
         if branch in old_commits:
             old_commit = old_commits[branch]
             if old_commit != new_commit:
@@ -377,10 +777,11 @@ def find_updated_branches(old_commits, new_commits, verbose=False):
                 if verbose:
                     print(f"    {branch} updated from {old_commit} to {new_commit}")
         else:
-            # get tag from branch name
-            _, _, _, tag, _ = branch.split("-", 4)
-            new_commit = new_commits[branch]
-            branches_updated[branch] = (tag, new_commit)
+            # Process new branch
+            result = _process_new_branch(
+                branch, new_commit, new_commits, token, verbose
+            )
+            branches_updated[branch] = result
 
     if verbose:
         print("Checking for removed branches...")
@@ -395,7 +796,9 @@ def find_updated_branches(old_commits, new_commits, verbose=False):
     return branches_updated
 
 
-def get_kernel_tags_from_dockerhub(username, repository, search_pattern: str="", verbose=False):
+def get_kernel_tags_from_dockerhub(
+    username, repository, search_pattern: str = "", verbose=False
+):
     """
     Retrieves Docker tags from Docker Hub for a given repository.
 
@@ -411,7 +814,8 @@ def get_kernel_tags_from_dockerhub(username, repository, search_pattern: str="",
     """
     tags = []
     tags_url = (
-        f"https://hub.docker.com/v2/repositories/{username}/{repository}/tags/?page_size=1000"
+        f"https://hub.docker.com/v2/repositories/{username}/{repository}/"
+        f"tags/?page_size=1000"
     )
 
     total_tags_fetched = 0
@@ -453,7 +857,9 @@ def get_kernel_tags_from_dockerhub(username, repository, search_pattern: str="",
                 print(f"Fetching docker tags: {total_tags_fetched} / {count}")
                 break
         else:
-            print(Fore.RED + Style.BRIGHT + "Error:", response.status_code, response.text)
+            print(
+                Fore.RED + Style.BRIGHT + "Error:", response.status_code, response.text
+            )
             sys.exit(1)
     return tags
 
@@ -502,7 +908,9 @@ def fetch_docker_tags(verbose=False):
             print(branch)
             for tag, tag_last_pushed in docker_tag_list:
                 # decode date from tag. Not really needed. To make sure we can handle date format
-                date = datetime.datetime.strptime(tag_last_pushed, "%Y-%m-%dT%H:%M:%S.%fZ")
+                date = datetime.datetime.strptime(
+                    tag_last_pushed, "%Y-%m-%dT%H:%M:%S.%fZ"
+                )
                 print(f"\t{tag} : {date.isoformat()}")
 
     # and collect (branch, commit) pairs by splitting tag name by '-'
@@ -620,7 +1028,9 @@ def parse_cmd_args():
         args: An argparse.Namespace object containing the parsed arguments.
     """
     parser = argparse.ArgumentParser(description="Update kernel-commits.mk with latest")
-    parser.add_argument("-t", "--token", help="GitHub personal access token", required=False)
+    parser.add_argument(
+        "-t", "--token", help="GitHub personal access token", required=False
+    )
     parser.add_argument(
         "-v",
         "--verbose",
@@ -677,7 +1087,9 @@ def adjust_branches_by_docker_tags(new_commits, updated_branches, docker_tags):
                 + f"{latest_gh_commit}"
                 + Style.RESET_ALL
                 + " was not pushed to docker.\n"
-                "\tUsing the latest commit from docker hub: " + Fore.GREEN + f"{docker_commit}"
+                "\tUsing the latest commit from docker hub: "
+                + Fore.GREEN
+                + f"{docker_commit}"
             )
 
             print(Fore.RED + "[Error]" + Style.RESET_ALL + msg)
@@ -706,7 +1118,10 @@ def adjust_branches_by_docker_tags(new_commits, updated_branches, docker_tags):
                     + f" :{branch}: the image for commit {latest_gh_commit} was not pushed to "
                     + "docker.\n\tNo docker tag found for the branch. Is this a new branch?"
                 )
-                print(f"Deleting the branch from updated branches. {branch} will not be updated.")
+                print(
+                    f"Deleting the branch from updated branches. "
+                    f"{branch} will not be updated."
+                )
                 del updated_branches[branch]
                 del new_commits[branch]
 
@@ -743,8 +1158,9 @@ def print_commit_errors(errors):
             + clean_msg
         )
     print(
-        Fore.RED + Style.BRIGHT +
-        "\nPlease push the missing tags/commits to the repository and rerun the script."
+        Fore.RED
+        + Style.BRIGHT
+        + "\nPlease push the missing tags/commits to the repository and rerun the script."
     )
 
 
@@ -759,13 +1175,22 @@ def print_updated_branches(updated_branches):
     for branch, commits in updated_branches.items():
         if commits[0] is None and commits[1] is None:
             print(
-                Fore.YELLOW + Style.BRIGHT + "  REMOVED: "
-                + Style.RESET_ALL + Style.BRIGHT + f"{branch}"
+                Fore.YELLOW
+                + Style.BRIGHT
+                + "  REMOVED: "
+                + Style.RESET_ALL
+                + Style.BRIGHT
+                + f"{branch}"
             )
         else:
             print(
-                Fore.GREEN + Style.BRIGHT + "  UPDATED: "
-                + Style.RESET_ALL + Style.BRIGHT + f"{branch}" + Style.RESET_ALL
+                Fore.GREEN
+                + Style.BRIGHT
+                + "  UPDATED: "
+                + Style.RESET_ALL
+                + Style.BRIGHT
+                + f"{branch}"
+                + Style.RESET_ALL
                 + f" {commits[0]} -> {commits[1]}"
             )
 
@@ -786,7 +1211,9 @@ def main():
         gh_user, get_github_token(args.token), args.verbose
     )
     old_commits = parse_kernel_commits_file(kernel_commits_mk_file)
-    updated_branches = find_updated_branches(old_commits, new_commits, args.verbose)
+    updated_branches = find_updated_branches(
+        old_commits, new_commits, get_github_token(args.token), args.verbose
+    )
 
     if not updated_branches:
         print("No kernel updates available.")
@@ -795,23 +1222,30 @@ def main():
     print_updated_branches(updated_branches)
 
     # fetch tags from docker hub and convert them to branch names
-    if adjust_branches_by_docker_tags(new_commits, updated_branches,
-        fetch_docker_tags(args.verbose)):
+    if adjust_branches_by_docker_tags(
+        new_commits, updated_branches, fetch_docker_tags(args.verbose)
+    ):
         print(
-            Fore.RED + "[Error]" + Style.RESET_ALL +
-            ": Please fix the issues and rerun the script."
+            Fore.RED
+            + "[Error]"
+            + Style.RESET_ALL
+            + ": Please fix the issues and rerun the script."
         )
         return
 
     if not updated_branches:
         print(
-            Fore.YELLOW + "[warning]" + Style.RESET_ALL +
-            ":No possible kernel updates available on docker hub,"
+            Fore.YELLOW
+            + "[warning]"
+            + Style.RESET_ALL
+            + ":No possible kernel updates available on docker hub,"
             + " but github has more recent commits."
         )
         return
 
-    commit_message, errors = generate_commit_message(updated_branches, gh_user, "eve-kernel")
+    commit_message, errors = generate_commit_message(
+        updated_branches, gh_user, "eve-kernel", get_github_token(args.token)
+    )
 
     if errors:
         print_commit_errors(errors)


### PR DESCRIPTION
# Description

Add support for eve-kernel-<arch>-next branch format in addition to the existing versioned branches.

Key changes:
- Update branch format validation to accept both versioned branches (eve-kernel-<arch>-vX.Y.Z-<platform>) and next branches (eve-kernel-<arch>-next)
- Generate KERNEL_COMMIT_<arch>_next_generic variables for next branches in kernel-commits.mk
- Implement automatic nearest tag detection for next branches using GitHub API to find the actual branch point and generate accurate commit ranges
- Add authentication token support to all GitHub API calls to avoid rate limiting issues
- Optimize tag detection to limit API calls and improve performance
- Update all parsing and conversion functions to handle next branches
- Add comprehensive test coverage for next branch handling

Next branches use generic flavor by default since they are not platform-specific.



## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
