### PR TITLE
Bump eden version to 1.0.12

### DIFF
--- a/.github/workflows/eden-trusted.yml
+++ b/.github/workflows/eden-trusted.yml
@@ -179,14 +179,14 @@ jobs:
     name: ${{ needs.context.outputs.eden_parent_job_title }}
     needs: context
     if: needs.context.outputs.skip_run == 'false'
-    uses: lf-edge/eden/.github/workflows/test.yml@1.0.11
+    uses: lf-edge/eden/.github/workflows/test.yml@1.0.12
     secrets: inherit
     with:
       eve_image: "evebuild/pr:${{ needs.context.outputs.pr_id }}"
       eve_log_level: "debug"
       eve_artifact_name: "eve-${{ needs.context.outputs.hv }}-${{ needs.context.outputs.arch }}-${{ needs.context.outputs.platform }}"
       artifact_run_id: ${{ needs.context.outputs.original_run_id }}
-      eden_version: "1.0.11"
+      eden_version: "1.0.12"
 
   finalize:
     name: Finalize Eden Runner status


### PR DESCRIPTION
# Description

This eden release includes minor updates to the eden framework to remove reliance on the deprecated `ZInfoDevice.Network` for network status. It also adds a new test for the LPS `/api/v1/network` endpoint.

Additionally, neoeden tests have been temporarily disabled until they are stabilized and will be reintroduced in a future eden release.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.