### PR TITLE
Update monitor TUI to v0.6.1

### DIFF
--- a/pkg/monitor/Dockerfile
+++ b/pkg/monitor/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG MONITOR_RS_VERSION=v0.6.0
+ARG MONITOR_RS_VERSION=v0.6.1
 ARG RUST_VERSION=lfedge/eve-rust:1.85.1-2
 FROM --platform=$BUILDPLATFORM ${RUST_VERSION} AS toolchain-base
 ARG TARGETARCH


### PR DESCRIPTION
# Description

This PR fixes a panic that can occur on some BIOSes, it also fixes incorrect display of WWAN and WLAN networks

This PR includes several improvements to UEFI device path handling and fixes for cellular/WWAN type definitions. UEFI Device Path Enhancements
1. Fix Safe Handling of Optional Node Data Fixed panic when handling device path nodes with empty data (length == 4) Added proper URI device path node handling with support for empty URIs

2. Add UFS Device Path Support Implemented Universal Flash Storage (UFS) messaging device path node (subtype 25)

3. Add SAS and SASEx Device Path Support Implemented Serial Attached SCSI (SAS) vendor-defined messaging (subtype 10) Implemented SAS Extended (SASEx) messaging (subtype 22) Added generic vendor messaging node support for unrecognized vendor GUIDs

Cellular/WWAN Type Fixes
4. Fix CellularAccessPoint Type Definition Updated CellularAccessPoint type to match EVE API changes Added/removed fields that broke deserialization

5. Fix WwanIPSettings Deserialization


## PR dependencies

None

## How to test and validate this PR

1. Configure WWAN and WLAN interfaces
2. make sure all settings are displayed correctly in UI

## Changelog notes

- Fix rare panic that can occur if boot entry contains URI
- FIx incorrect display of WWAN and WLAN networks

## PR Backports

@milan-zededa do we need this backport to 14.5? I think we do

```text
- 14.5-stable: yes
- 13.4-stable: no, TUI was not available on 13.x
```

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

