### PR TITLE
Handle EINVAL when enabling VLAN filtering on Linux 6.12

### DIFF
--- a/pkg/pillar/nireconciler/linuxitems/vlanbridge.go
+++ b/pkg/pillar/nireconciler/linuxitems/vlanbridge.go
@@ -123,7 +123,9 @@ func (c *VLANBridgeConfigurator) setVlanFiltering(
 	}
 	err = netlink.BridgeSetVlanFiltering(link, enable)
 	if err != nil {
-		brIsBusy = errors.Is(err, unix.EBUSY)
+		// On Linux 6.12, we get EINVAL instead of EBUSY when bridge is not yet
+		// ready for VLAN filtering to be enabled.
+		brIsBusy = errors.Is(err, unix.EBUSY) || errors.Is(err, unix.EINVAL)
 		return brIsBusy, fmt.Errorf("failed to set VLAN filtering to %t for bridge %s: %w",
 			enable, brIfName, err)
 	}


### PR DESCRIPTION
# Description

On Linux 6.12, attempting to enable VLAN filtering on a bridge that is not yet ready may return `EINVAL` instead of `EBUSY`. Update `VLANBridgeConfigurator` to treat both `EBUSY` and `EINVAL` as indications that the bridge is busy, ensuring proper retry behavior.

Note that the code retries for up to 1 minute. If `EINVAL` occurs due to an actual invalid argument, the error will eventually be returned instead of looping indefinitely.

## How to test and validate this PR

1. Onboard an edge node running an EVE version with the Linux kernel 6.12.
2. Deploy a Switch Network Instance.
3. Deploy an application connected to the Switch NI using a VLAN access port.
4. Verify that both the Network Instance and the application are reported as deployed successfully (no errors in the controller UI or logs).
5. SSH into the edge node and confirm that VLAN filtering is enabled on the bridge associated with the Switch NI.

Example (for a Switch NI attached to eth0):

```
# In this example, Switch NI is attached to eth0.
# Notice "vlan_filtering 1"

$ eve enter
$ ip -d link show dev eth0
5: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 02:fe:22:1a:87:00 brd ff:ff:ff:ff:ff:ff promiscuity 3 minmtu 68 maxmtu 65535 
    bridge forward_delay 1500 hello_time 200 max_age 2000 ageing_time 30000 stp_state 0 priority 32768 vlan_filtering 1 vlan_protocol 802.1Q bridge_id 8000.02:FE:22:1A:87:00 designated_root 8000.02:FE:22:1A:87:00 root_port 0 root_path_cost 0 topology_change 0 topology_change_detected 0 hello_timer    0.00 tcn_timer    0.00 topology_change_timer    0.00 gc_timer  284.16 vlan_default_pvid 1 vlan_stats_enabled 0 vlan_stats_per_port 0 group_fwd_mask 0 group_address 01:80:c2:00:00:00 mcast_snooping 1 mcast_vlan_snooping 0 mcast_router 1 mcast_query_use_ifaddr 0 mcast_querier 0 mcast_hash_elasticity 16 mcast_hash_max 4096 mcast_last_member_count 2 mcast_startup_query_count 2 mcast_last_member_interval 100 mcast_membership_interval 26000 mcast_querier_interval 25500 mcast_query_interval 12500 mcast_query_response_interval 1000 mcast_startup_query_interval 3125 mcast_stats_enabled 0 mcast_igmp_version 2 mcast_mld_version 1 nf_call_iptables 0 nf_call_ip6tables 0 nf_call_arptables 0 addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535
```

## Changelog notes

Support VLAN filtering on Linux 6.12

## PR Backports

Only needed for Linux kernel 6.12, which is [yet to be merged into master](https://github.com/lf-edge/eve/pull/5287).
Not to be backported to already released LTS versions.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.