### PR TITLE
Copy manifests after k3s starts so dest dir exists

### DIFF
--- a/pkg/kube/longhorn-utils.sh
+++ b/pkg/kube/longhorn-utils.sh
@@ -72,6 +72,19 @@ Longhorn_uninstall() {
     return 0
 }
 
+cleanup_storageclasses() {
+        if [ -e "${KUBE_MANIFESTS_DIR}/storage-classes.yaml" ]; then
+                rm "${KUBE_MANIFESTS_DIR}/storage-classes.yaml"
+        fi
+        if kubectl -n kube-system get AddOn/storage-classes; then
+                kubectl -n kube-system delete AddOn/storage-classes >> "$INSTALL_LOG" 2>&1
+        fi
+        if kubectl get sc lh-sc-rep1; then
+                logmsg "Removing storage-classes"
+                kubectl delete -f /etc/k3s-manifests/storage-classes.yaml
+        fi
+}
+
 longhorn_node_create() {
     node="$1"
     kubectl apply -f - <<EOF

--- a/pkg/pillar/cmd/zedkube/failover.go
+++ b/pkg/pillar/cmd/zedkube/failover.go
@@ -146,12 +146,13 @@ func (z *zedkube) checkAppsFailover(wdFunc func()) {
 			continue
 		}
 
-		log.Noticef("aiDisplayName:%s aiUUID:%s newStatus:%v",
+		log.Functionf("aiDisplayName:%s aiUUID:%s newStatus:%v",
 			aiconfig.DisplayName, aiconfig.UUIDandVersion.UUID, encAppStatus)
 
 		if encAppStatus.ScheduledOnThisNode {
+			log.Noticef("checkAppsFailover: failover start for appDomainName: %s", appDomainNameLbl)
 			kubeapi.DetachOldWorkload(log, terminatingNodeName, appDomainNameLbl, wdFunc)
-			log.Noticef("checkAppsFailover: complete for appDomainName: %s", appDomainNameLbl)
+			log.Noticef("checkAppsFailover: failover complete for appDomainName: %s", appDomainNameLbl)
 			continue
 		}
 	}


### PR DESCRIPTION
# Description 

Only copy after starting k3s and allowing k3s to start up to the point of creating its manifests dir.

Handle the case of eve baseos update supplying new manifests, copy them in on every k3s start.

Downgrade a failover Notice log entry to Functionf

## PR dependencies

None

## How to test and validate this PR

- Deploy 3 HV=k EVE-OS nodes
- Configure EdgeNodeClusterConfig for the nodes to create a cluster
- Verify `kubectl get sc` displays the SCs longhorn, longhorn-static, lh-sc-rep1, lh-sc-rep2, lh-sc-rep3

## Changelog notes

Resolve missing storage classes at first boot

## PR Backports

- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
