### PR TITLE
Makefile: Fix eve-k build for nvidia-jp6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1106,11 +1106,12 @@ endif
 get_pkg_build_yml = $(if $(filter k,$(HV)), $(call get_pkg_build_k_yml,$1), \
                     $(if $(filter y,$(RSTATS)), $(call get_pkg_build_rstats_yml,$1), \
                     $(if $(filter y,$(DEV)), $(call get_pkg_build_dev_yml,$1), \
-                    $(if $(wildcard pkg/$1/build-$(PLATFORM).yml),build-$(PLATFORM).yml,build.yml))))
+                    $(call get_pkg_build_plat_yml,$1))))
+get_pkg_build_plat_yml = $(if $(wildcard pkg/$1/build-$(PLATFORM).yml),build-$(PLATFORM).yml,build.yml)
 get_pkg_build_dev_yml = $(if $(wildcard pkg/$1/build-dev.yml),build-dev.yml,build.yml)
 get_pkg_build_rstats_yml = $(if $(wildcard pkg/$1/build-rstats.yml),build-rstats.yml,build.yml)
 get_pkg_build_k_yml = $(if $(and $(filter y,$(DEV)),$(wildcard pkg/$1/build-k-dev.yml)),build-k-dev.yml, \
-                             $(if $(wildcard pkg/$1/build-k.yml),build-k.yml,build.yml))
+                             $(if $(wildcard pkg/$1/build-k.yml),build-k.yml,$(call get_pkg_build_plat_yml,$1)))
 
 eve-%: pkg/%/Dockerfile $(LINUXKIT) $(RESCAN_DEPS)
 	$(QUIET): "$@: Begin: LINUXKIT_PKG_TARGET=$(LINUXKIT_PKG_TARGET)"


### PR DESCRIPTION
# Description

Makefile is not taking into account `build-<PLATFORM>.yml` files when `HV=k`. For example:

`make ZARCH=arm64 HV=k PLATFORM=nvidia-jp6 pkg/nvidia`

Should build pkg/nvidia for nvidia-jp6 platform, but currently it uses build.yml, which builds for nvidia-jp5. This commit fixes this issue.

## How to test and validate this PR

Run:

`make ZARCH=arm64 HV=k PLATFORM=nvidia-jp6 pkg/nvidia`

Ensure is going to build `pkg/nvidia` for `nvidia-jp6`, not `nvidia-jp5`.

## Changelog notes

Fix platform build variants for eve-k.

## PR Backports

- [ ] 14.5-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.