### PR TITLE
Kernel update - [amd64-next]

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,4 +1,4 @@
-KERNEL_COMMIT_amd64_next_generic = 693a035c10a7
+KERNEL_COMMIT_amd64_next_generic = 3152b8fe36ea
 KERNEL_COMMIT_amd64_v6.12.49_generic = 770b90183ee7
 KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = b4464b03583e
 KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 2154a157c3f4


### PR DESCRIPTION
# Description

Evaluation eve uses kernel 6.17.1 in IMGC. The makefile target that signs out-of-tree modules is broken in vanilla kernel.
It prevents ZFS module from being loaded and EVE cannot mount /persist

This commit changes:
eve-kernel-amd64-next
    3152b8fe36ea: kbuild: Use objtree for module signing key path

## PR dependencies

None

## Changelog notes

None

## How to test
- deploy Evaluation eve with ZFS raid
- Observe that IMGC is booted successfully

## PR Backports

```text
- 14.5-stable: No
- 13.4-stable: No
```

Also, to the PRs that should be back-ported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
