### PR TITLE
[storage-init.sh] recreate /persist correctly for eve-k

### DIFF
--- a/pkg/installer/install
+++ b/pkg/installer/install
@@ -170,7 +170,7 @@ collect_black_box() {
    /tpmmgr saveTpmInfo "$1"/tpminfo.txt
 }
 
-# prepare_mounts_and_zfs_pool POOL_CREATION_COMMAND_SUFFIX_SUFFIX INSTALL_CLUSTERED_STORAGE
+# prepare_mounts_and_zfs_pool POOL_CREATION_COMMAND_SUFFIX INSTALL_CLUSTERED_STORAGE
 prepare_mounts_and_zfs_pool() {
   logmsg "Preparing ZFS pool and mounts"
   [ -e /root/sys ] || mkdir /root/sys && mount -t sysfs sysfs /root/sys


### PR DESCRIPTION
# Description

If /persist has been wiped out we normally recreate it as ext4 since we do not know what is was before. However, if eve-hv-type is 'k' we know it should be ZFS. This enables (unsupported) manual conversion from eve-kvm to eve-k as long as the IMGA/IMGB are 512 MB or larger.

## How to test and validate this PR

Find a device currently running eve-kvm with at least 16 GB memory and 100+ GB of disk.
Verify (e.g, using fdisk -l /dev/sda)  that IMGA and IMGB are at least 512 MB.

Then copy (scp, rsync) an EVE-k image with this fix to the device (e.g., in /persist).
Then manually copy the EVE-k image into the unused IMGx partition. Use zboot to check which partition and which device, and then use zboot to set the previously unused to 'updating'. For 
Please describe how the changes in this PR can be validated or verified. For
example:
# eve enter
[pillar]:/$ zboot curpart
IMGA
[pillar]:/$ zboot partstate IMGA
active
[pillar]:/$ zboot partstate IMGB
unused
[pillar]:/$ zboot partdev IMGB
/dev/sda3
[pillar]:/$ dd if=/persist/*-k-amd64 of=/dev/sda3 bs=8M
[pillar]:/$ sync
[pillar]:/$ zboot set_partstate IMGB updating

Destroy /persist (note that it is not possible to unmount it since it is in use). (This is from grep dd pkg/installer/install)
Determine where the /persist ext4 partition is, then dd over the first and last part of that partition with zeros.
Example:
[pillar]:/$ P3=sda9
[pillar]:/$ dd if=/dev/zero of="/dev/$P3" bs=512 count=10240 2>/dev/null
[pillar]:/$ dd if=/dev/zero of="/dev/$P3" bs=512 seek=$(( $(blockdev --getsz "/dev/$P3") - 10240 )) count=10240 2>/dev/null

Then reboot
[pillar]:/$ reboot

NOTE: this is not supported, but can be a useful shortcut when converting devices in the lab without requiring an in-person USB reinstall.

## Changelog notes

It is not possible to updata a device using the EVE kvm image to runni g the EVE 'k' image with k3s/ZKS using the controller due to the differences in the filesystems in /persist/ and the requirement that the IMGA/IMGB partition being at least 512 MB. However, if all the application's volumes, logs, etc are unimportant and can be discarded and the device is in a lab location where it can be manually recovered (by doing a full USB re-install) this short cut can be used to update it to an EVE 'k' image.

This is not supported and should never be tried outside of a lab environment.

## Checklist

- [X] I've provided a proper description
- [ ] I've added the proper documentation
- [X] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [X] I've written the test verification instructions
- [X] I've set the proper labels to this PR

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
