### PR TITLE
eve-k: reduce idle logging, ignore api outage during failover

### DIFF
--- a/pkg/pillar/cmd/zedkube/applogs.go
+++ b/pkg/pillar/cmd/zedkube/applogs.go
@@ -160,7 +160,7 @@ func (z *zedkube) checkAppsStatus() {
 		// Both Pods will be of the pattern <appname>-<uuid prefix>-<pod uuid suffix>
 		for _, pod := range pods.Items {
 			contVMIName := "virt-launcher-" + contName
-			log.Noticef("checkAppsStatus: pod %s, looking for cont %s", pod.Name, contName)
+			log.Functionf("checkAppsStatus: pod %s, looking for cont %s", pod.Name, contName)
 			foundVMIPod := strings.HasPrefix(pod.Name, contVMIName)
 			if strings.HasPrefix(pod.Name, contName) || foundVMIPod {
 				// Case 1

--- a/pkg/pillar/cmd/zedkube/failover.go
+++ b/pkg/pillar/cmd/zedkube/failover.go
@@ -76,7 +76,7 @@ func (z *zedkube) checkAppsFailover(wdFunc func()) {
 
 		for _, pod := range pods.Items {
 			contVMIName := "virt-launcher-" + contName
-			log.Noticef("checkAppsStatus: pod %s, looking for cont %s", pod.Name, contName)
+			log.Functionf("checkAppsFailover: pod %s, looking for cont %s", pod.Name, contName)
 			foundVMIPod := strings.HasPrefix(pod.Name, contVMIName)
 			if strings.HasPrefix(pod.Name, contName) || foundVMIPod {
 				// Case 1

--- a/pkg/pillar/cmd/zedkube/handlenodedrain.go
+++ b/pkg/pillar/cmd/zedkube/handlenodedrain.go
@@ -38,7 +38,6 @@ func getNodeDrainRequester(ctx *zedkube) kubeapi.DrainRequester {
 	if len(items) == 1 {
 		return kubeapi.UPDATE
 	}
-	log.Errorf("getNodeDrainRequester should never get here")
 	return kubeapi.NONE
 }
 


### PR DESCRIPTION
# Description

The 'looking for cont' log near the top of checkAppsStatus and checkAppsFailover is run when apps are running outside of any active management operations or app migration operations. Avoid logging above Functionf in this state to minimize pillar logs.

Kubevirt operations on the Hypervisor interface which either change the state of a domain or get state of a domain specific to a host/node should first call scheduledOnNode which implements vm/container handlers. Don't call the direct replicaVmiScheduledOnMe or replicaPodScheduledOnMe.

During failover multiple nodes may attempt info on a kubevirt domain. scheduledOnNode is used to skip operations for nodes where an app is not running. In cases where scheduledOnMe is unable to determine the scheduling state of an app: the caller should determine if the error is some type where the k3s api server may be temporarily unavailable. If the api server is temporarily unavailable then declare app state UNKNOWN as BROKEN signals to the controller that no further tries will be attempted.

Remove incorrect error log in getNodeDrainRequester(). Its possible to meet that error log in normal conditions:
- zedkube startup as single node mode
- zedkube recv edgenodeclusterconfig
- zedkube node delete
- zedkube cluster delete

## PR dependencies

None

## How to test and validate this PR

- onboard 3 HV=k eve nodes and configure EdgeNodeClusterConfig to create a cluster.
- deploy one or more VM app instances.
- initiate a node outage on one node (pull net interface or power).
- verify VM app instance successfully fails over to a new node.

## Changelog notes

None

## PR Backports

- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
