### PR TITLE
Fix a bug where edgeview tcp/kube set port number incorrectly

### DIFF
--- a/pkg/edgeview/src/tcp.go
+++ b/pkg/edgeview/src/tcp.go
@@ -298,7 +298,16 @@ func setAndStartProxyTCP(opt string) {
 
 	var hasProxy, hasKube bool
 	var proxyDNSIP, kubeAddrPort string
+	// In multiple edgeview instances, for the first instance the 'edgeviewInstID' is assigned as '1',
+	// but in single instance case, this 'edgeviewInstID' is not assigned so default is '0'.
+	// To calculate the kube port used by the client side, we have this logic below:
+	// 9001 + i + kubenum*types.EdgeviewMaxInstNum
+	// So, for both single instance and for the 1st instance in multi-instance case, the assigned
+	// port number needs to be '9001'.
 	kubenum := edgeviewInstID - 1
+	if kubenum < 0 {
+		kubenum = 0
+	}
 	if strings.Contains(opt, "/") {
 		var gotProxy, gotKube bool
 		params := strings.Split(opt, "/")


### PR DESCRIPTION

# Description

- when edgeview is run in single instance, the instance number in server is not set explicitly. this breaks the tcp/kube when it will not get the TCP port number correctly

## PR dependencies

## How to test and validate this PR

Configure the Edgeview as a single instance for the project/device, and run the eve-k image, start the edgeview.sh
with 'tcp/kube' option, and use 'kubectl --kubeonconfig=/tmp/download/kube-config.yaml get node' to make
sure this is successful.

## Changelog notes

Fix a bug where edgeview tcp/kube set port number incorrectly

## PR Backports

- 16.x-stable

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

