### PR TITLE
Remove LiveMigration feature gate

### DIFF
--- a/pkg/kube/kubevirt-features.yaml
+++ b/pkg/kube/kubevirt-features.yaml
@@ -13,7 +13,6 @@ spec:
       usb:              # <- USB passthrough
     developerConfiguration:
       featureGates:
-        - LiveMigration
         - HostDisk
         - Snapshot
         - HostDevices


### PR DESCRIPTION
# Description

We have LiveMigration feature gate enabled by default in eve-k. We do not support that feature so let us delete it from config. Because of that feature I see some Kubernetes stats API calls are being called frequently, just unnecessary BW.

Delete it for now, we can re-enable if and when we enable this feature.


Backport to  16.0 branch




## How to test and validate this PR

1) Install eve-k
2) eve enter kube
3) kubectl get Kubevirt -n Kubevirt -o yaml.  and look for feature gates. There should not be LiveMigration enabled.

## Changelog notes

None. 

## PR Backports

16.0 branch

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
