### PR TITLE
Delete VMPersistentState support for EFI bootloader

### DIFF
--- a/pkg/kube/kubevirt-features.yaml
+++ b/pkg/kube/kubevirt-features.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: kubevirt
 spec:
   configuration:
-    vmStateStorageClass: longhorn
     permittedHostDevices:
       pciHostDevices:   # <- PCIe passthrough devices like nvme drives/NIC
       mediatedDevices:  # <- GPUs
@@ -18,4 +17,3 @@ spec:
         - Snapshot
         - HostDevices
         - GPU
-        - VMPersistentState

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -1863,7 +1863,7 @@ func addEFIBootLoader(spec *v1.VirtualMachineInstanceSpec) {
 	spec.Domain.Firmware.Bootloader = &v1.Bootloader{
 		EFI: &v1.EFI{
 			SecureBoot: ptrBool(false), // For this we need SMM CPU feature enabled
-			Persistent: ptrBool(true),
+			Persistent: ptrBool(false),
 		},
 	}
 }


### PR DESCRIPTION
When a EFI bootloader is started with persist state, a PVC is created with RWX mode by kubevirt upstream code. In eve-k we did not support RWX volumes yet since they require nfs server deployed and working. So since RWX volumes are not in good state, kubevirt virt-launcher pod keeps crashing every few hours which bounces the VMs. Ideally virt-launcher should error out not segfault if volumes are not accessible, thats a kubevirt bug and I reported this issue to the community and they are working on it. Until that issue is fixed, disable the persist state.


This PR should go to 16.0.0 branch too and into LTS release.


## How to test and validate this PR

Please describe how the changes in this PR can be validated or verified. For
example:

1) Create a VM in eve-k with FML mode enabled in manifest.
2) App starts fine and creates a 10MB PVC in RWX mode to persist efi boot loader data.
3) Observe VMs keeps getting bounced randomly every few hours.
4) You should see following crash in virt-launcher pod
{"component":"virt-launcher","kind":"","level":"info","msg":"Synced vmi","name":"ubuntu-fml-a5ff12js6h","namespace":"eve-kube-app","pos":"server.go:208","timestamp":"2025-10-31T22:39:27.662602Z","uid":"4134fe1b-c1ba-4ea4-a240-152bf5741bb6"}
{"component":"virt-launcher","level":"warning","msg":"Cannot start job (modify, none, none) in API remoteDispatchDomainStartDirtyRateCalc for domain eve-kube-app_ubuntu-fml-a5ff12js6h; current job is (query, none, none) owned by (31 remoteDispatchConnectGetAllDomainStats, 0 <null>, 0 <null> (flags=0x0)) for (70s, 0s, 0s)","pos":"virDomainObjBeginJobInternal:434","subcomponent":"libvirt","thread":"30","timestamp":"2025-10-31T22:39:33.841000Z"}
{"component":"virt-launcher","level":"error","msg":"Timed out during operation: cannot acquire state change lock (held by monitor=remoteDispatchConnectGetAllDomainStats)","pos":"virDomainObjBeginJobInternal:468","subcomponent":"libvirt","thread":"30","timestamp":"2025-10-31T22:39:33.841000Z"}
{"component":"virt-launcher","level":"warning","msg":"Can't start dirty rate calc","pos":"libvirt.go:368","reason":"virError(Code=68, Domain=0, Message='Timed out during operation: cannot acquire state change lock (held by monitor=remoteDispatchConnectGetAllDomainStats)')","timestamp":"2025-10-31T22:39:33.841317Z"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x18cda04]


## PR Backports

Should be back ported to 16.0.0 release branch

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
