### PR TITLE
[16.0] Remove LiveMigration feature gate

### DIFF
--- a/pkg/kube/kubevirt-features.yaml
+++ b/pkg/kube/kubevirt-features.yaml
@@ -13,7 +13,6 @@ spec:
       usb:              # <- USB passthrough
     developerConfiguration:
       featureGates:
-        - LiveMigration
         - HostDisk
         - Snapshot
         - HostDevices


### PR DESCRIPTION
We do not support livemigration, remove it to save some API BW


(cherry picked from commit 15b86d1cb1107404f9857264b1304bb3d8bd7293)

# Description

 Backport of  #5343







