### PR TITLE
[16.0] Delete VMPersistentState support for EFI bootloader

### DIFF
--- a/pkg/kube/kubevirt-features.yaml
+++ b/pkg/kube/kubevirt-features.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: kubevirt
 spec:
   configuration:
-    vmStateStorageClass: longhorn
     permittedHostDevices:
       pciHostDevices:   # <- PCIe passthrough devices like nvme drives/NIC
       mediatedDevices:  # <- GPUs
@@ -18,4 +17,3 @@ spec:
         - Snapshot
         - HostDevices
         - GPU
-        - VMPersistentState

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -1863,7 +1863,7 @@ func addEFIBootLoader(spec *v1.VirtualMachineInstanceSpec) {
 	spec.Domain.Firmware.Bootloader = &v1.Bootloader{
 		EFI: &v1.EFI{
 			SecureBoot: ptrBool(false), // For this we need SMM CPU feature enabled
-			Persistent: ptrBool(true),
+			Persistent: ptrBool(false),
 		},
 	}
 }


### PR DESCRIPTION
When a EFI bootloader is started with persist state, a PVC is created with RWX mode by kubevirt upstream code. In eve-k we did not support RWX volumes yet since they require nfs server deployed and working. So since RWX volumes are not in good state, kubevirt virt-launcher pod keeps crashing every few hours which bounces the VMs. Ideally virt-launcher should error out not segfault if volumes are not accessible, thats a kubevirt bug and I reported this issue to the community and they are working on it. Until that issue is fixed, disable the persist state.


(cherry picked from commit 7667b697fbac8b2ed01ee645af2436814c1e9fd4)

# Description

Backport of #5340 

