### PR TITLE
.golangci.yml: Update config to newer versions of golangci-lint

### DIFF
--- a/pkg/pillar/.golangci.yml
+++ b/pkg/pillar/.golangci.yml
@@ -9,18 +9,18 @@ linters-settings:
         list-mode: lax  # allow unless explicitly denied
         files:
           - $all
+        allow:
+          - $gostd
+          - $ven
 
 linters:
   enable-all: true
   disable:
     - gochecknoglobals  # unreliable
-    - golint            # covered by revive
-    - interfacer        # deprecated
     - lll               # line length check
     - mnd               # troublesome with little value
     - stylecheck        # covered by revive
     - typecheck         # See golangci/golangci-lint#419
-    - varcheck          # unreliable
     - varnamelen        # Too opinionated about var length
     - funlen            # function length checks
     - godot             # Don't mandate periods at end of comments
@@ -29,23 +29,18 @@ linters:
     - whitespace        # Too opinionated about whitespace
     - wrapcheck         # XXX should we switch to wrapped errors etc?
     - err113            # Too opinioned about error handling (also yetus probably doesn't run it correctly)
-    - exhaustivestruct  # Too opinionated
     - gofumpt           # Too opinionated about whitespace
-    - gomnd             # We use plenty of magic constants
-    - scopelint         # Obsoleted
     - gocognit          # Too opinionated on existing code
     - gocyclo           # Too opinionated on existing code
-    - maligned          # Too opinionated on existing structs
     - nestif            # Too opinionated on existing code
     - exhaustruct       # Too opinionated on existing code
-    - nosnakecase       # Uppercase with underscores is in some cases used for enum values
     - nonamedreturns    # Named return is not a bad practice
     - cyclop            # Raises warnings even for relatively simple functions
     - ireturn           # Returning interfaces is a common practise for constructors in defensive programming
     - exhaustive        # Complains even if struct has default branch
     - musttag           # pillar uses implicit tags for all structs
     - maintidx          # Disable maintainability index
-    - ifshort
+    - tenv              # Deprecated
     - dupl
 
 issues:
@@ -56,4 +51,4 @@ issues:
 # that is we should return all errors
 # not only the first hit
 output:
-  uniq-by-line: false
+  issues.uniq-by-line: false


### PR DESCRIPTION
# Description

This PR updates the configuration to match newer versions of golangci-lint. It will remove warnings about deprecated linters and the the following errors:

```
WARN [config_reader] The configuration option `output.uniq-by-line` is deprecated, please use `issues.uniq-by-line` 
WARN [lintersdb] The linter "golint" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle 
WARN [lintersdb] The linter "interfacer" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle 
WARN [lintersdb] The linter "varcheck" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle 
WARN [lintersdb] The linter "exhaustivestruct" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle 
WARN [lintersdb] The linter "gomnd" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle 
WARN [lintersdb] The linter "scopelint" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle 
WARN [lintersdb] The linter "maligned" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle 
WARN [lintersdb] The linter "nosnakecase" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle 
WARN [lintersdb] The linter "ifshort" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle 
WARN The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature another linter. Replaced by usetesting. 
ERRO [linters_context] create analyzer: must have an Allow and/or Deny package list 
WARN [runner] Can't run linter goanalysis_metalinter: depguard: must have an Allow and/or Deny package list 
ERRO Running error: can't run linter goanalysis_metalinter
depguard: must have an Allow and/or Deny package list 
```

## How to test and validate this PR

Run yetus GH action.

## Changelog notes

None.

## PR Backports

- [x] 16.0
- [x] 14.5-stable
- [x] 13.4-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.