### PR TITLE
[16.0] Fixed issue with threshold column in SMART Attributes

### DIFF
--- a/pkg/pillar/cmd/zedagent/hardwareinfo.go
+++ b/pkg/pillar/cmd/zedagent/hardwareinfo.go
@@ -136,6 +136,7 @@ func getSmartAttr(diskData []*types.DAttrTable) []*info.SmartAttr {
 			Id:            uint32(attr.ID),
 			AttributeName: attr.AttributeName,
 			RawValue:      uint64(attr.RawValue),
+			Thresh:        uint64(attr.Threshold),
 			Worst:         uint64(attr.Worst),
 			Value:         uint64(attr.Value),
 			Type:          attr.Type,


### PR DESCRIPTION
# Description

Backport of https://github.com/lf-edge/eve/pull/5337

## How to test and validate this PR

1. Onboard the device to the controller
2. Navigate to the information about the edge node in ZedUI
3. Then go to storage tab
4. Click the more details icon below the SMART status
5. Verify that the threshold column is populated with values other than 0

## Changelog notes

Properly show the threshold data of the SMART attributes of storage devices in ZedUI

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
