### PR TITLE
[16.0] Use Pubsub Large to handle large KubeClusterInfo structures.

### DIFF
--- a/pkg/pillar/types/zedkubetypes.go
+++ b/pkg/pillar/types/zedkubetypes.go
@@ -232,9 +232,9 @@ func (kvi KubeVMIInfo) ZKubeVMIInfo() *info.KubeVMIInfo {
 // KubeClusterInfo - Information about a Kubernetes cluster
 type KubeClusterInfo struct {
 	Nodes     []KubeNodeInfo         // List of nodes in the cluster
-	AppPods   []KubePodInfo          // List of EVE application pods
-	AppVMIs   []KubeVMIInfo          // List of VirtualMachineInstance
-	Storage   KubeStorageInfo        // Distributed storage info
+	AppPods   []KubePodInfo          `json:"pubsub-large-AppPods"` // List of EVE application pods
+	AppVMIs   []KubeVMIInfo          `json:"pubsub-large-AppVMIs"` // List of VirtualMachineInstance
+	Storage   KubeStorageInfo        `json:"pubsub-large-Storage"` // Distributed storage info
 	PodNsInfo []KubePodNameSpaceInfo // General namespace pod running/failed count
 }
 


### PR DESCRIPTION
# Description

Pods, VMIs, Volumes, and Replicas have the potential to grow this structure past the 64k pubsub limit.

(cherry picked from commit 58ce32e98beab94258bdf8f8a5652f9f628a4461)

Backport of #5336 

## PR dependencies

None

## How to test and validate this PR

- deploy at least one hv=k node
- deploy a large number of volume instances, they can be empty
- Verify /run/zedkube/KubeClusterInfo/global.json is over 65K

## Changelog notes

None

## PR Backports

This is the backport.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
