### PR TITLE
Add async notification support to MemoryDriver for event-driven testing

### DIFF
--- a/pkg/pillar/pubsub/memdriver.go
+++ b/pkg/pillar/pubsub/memdriver.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Zededa, Inc.
+// Copyright (c) 2024-2025 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package pubsub
@@ -9,9 +9,24 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
 )
 
-// MemoryDriver structure
+// MemoryDriver is an in-memory PubSub driver designed for writing tests for components
+// that use PubSub. It provides a simple, synchronous implementation without any persistence
+// or file system dependencies.
+//
+// Purpose:
+//   - Used exclusively for testing PubSub-based components in isolated environments
+//   - Enables deterministic, event-driven tests with full control over message flow
+//   - Avoids file system operations and external dependencies in test scenarios
+//
+// Limitation:
+//   - Only one subscriber is supported per topic when using notification channels
+//   - Multiple subscribers attempting to use the same topic will overwrite each other's
+//     notification channel, causing only the last registered subscriber to receive updates
+//
+// This driver should not be used in production code.
 type MemoryDriver struct {
-	status *generics.LockedMap[string, []byte]
+	status      *generics.LockedMap[string, []byte]
+	subscribers *generics.LockedMap[string, chan Change]
 }
 
 const tmpDir = "/tmp"
@@ -19,7 +34,8 @@ const tmpDir = "/tmp"
 // NewMemoryDriver to create MemoryDriver and properly initialize it
 func NewMemoryDriver() *MemoryDriver {
 	return &MemoryDriver{
-		status: generics.NewLockedMap[string, []byte](),
+		status:      generics.NewLockedMap[string, []byte](),
+		subscribers: generics.NewLockedMap[string, chan Change](),
 	}
 }
 
@@ -37,16 +53,23 @@ func decomposeStatusKey(statusKey string) (string, string) {
 // Publisher function
 func (e *MemoryDriver) Publisher(_ bool, _, topic string, _ bool, _ *Updaters, _ Restarted, _ Differ) (DriverPublisher, error) {
 	return &MemoryDriverPublisher{
-		topic:  topic,
-		status: e.status,
+		topic:       topic,
+		status:      e.status,
+		subscribers: e.subscribers,
 	}, nil
 }
 
 // Subscriber function
-func (e *MemoryDriver) Subscriber(_ bool, _, topic string, _ bool, _ chan Change) (DriverSubscriber, error) {
+func (e *MemoryDriver) Subscriber(_ bool, _, topic string, _ bool, C chan Change) (DriverSubscriber, error) {
+	// Register the subscriber channel using topic as key
+	if C != nil {
+		e.subscribers.Store(topic, C)
+	}
 	return &MemoryDriverSubscriber{
-		topic:  topic,
-		status: e.status,
+		topic:       topic,
+		status:      e.status,
+		subscribers: e.subscribers,
+		changeChan:  C,
 	}, nil
 }
 
@@ -57,8 +80,9 @@ func (e *MemoryDriver) DefaultName() string {
 
 // MemoryDriverPublisher struct
 type MemoryDriverPublisher struct {
-	topic  string
-	status *generics.LockedMap[string, []byte]
+	topic       string
+	status      *generics.LockedMap[string, []byte]
+	subscribers *generics.LockedMap[string, chan Change]
 }
 
 // Start function
@@ -89,12 +113,40 @@ func (e *MemoryDriverPublisher) CheckMaxSize(string, []byte) error {
 // Publish function
 func (e *MemoryDriverPublisher) Publish(key string, item []byte) error {
 	e.status.Store(composeStatusKey(e.topic, key), item)
+
+	// Notify subscribers if channel exists
+	if ch, ok := e.subscribers.Load(e.topic); ok {
+		select {
+		case ch <- Change{
+			Operation: Modify,
+			Key:       key,
+			Value:     item,
+		}:
+		default:
+			// Channel full or closed, skip
+		}
+	}
+
 	return nil
 }
 
 // Unpublish function
 func (e *MemoryDriverPublisher) Unpublish(key string) error {
 	e.status.Delete(composeStatusKey(e.topic, key))
+
+	// Notify subscribers if channel exists
+	if ch, ok := e.subscribers.Load(e.topic); ok {
+		select {
+		case ch <- Change{
+			Operation: Delete,
+			Key:       key,
+			Value:     nil,
+		}:
+		default:
+			// Channel full or closed, skip
+		}
+	}
+
 	return nil
 }
 
@@ -115,8 +167,10 @@ func (e *MemoryDriverPublisher) LargeDirName() string {
 
 // MemoryDriverSubscriber struct
 type MemoryDriverSubscriber struct {
-	topic  string
-	status *generics.LockedMap[string, []byte]
+	topic       string
+	status      *generics.LockedMap[string, []byte]
+	subscribers *generics.LockedMap[string, chan Change]
+	changeChan  chan Change
 }
 
 // Start function
@@ -141,10 +195,12 @@ func (e *MemoryDriverSubscriber) Load() (map[string][]byte, int, error) {
 
 // Stop function
 func (e *MemoryDriverSubscriber) Stop() error {
+	// Unregister the subscriber channel
+	e.subscribers.Delete(e.topic)
 	return nil
 }
 
 // LargeDirName where to put large fields
 func (e *MemoryDriverSubscriber) LargeDirName() string {
-	return ""
+	return tmpDir
 }

--- a/pkg/pillar/pubsub/memdriver_test.go
+++ b/pkg/pillar/pubsub/memdriver_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Zededa, Inc.
+// Copyright (c) 2024-2025 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package pubsub_test
@@ -68,4 +68,322 @@ func TestMemoryDriverPubSub(t *testing.T) {
 	g.Expect(items).To(gomega.HaveLen(1))
 
 	g.Expect(items[key]).To(gomega.BeEquivalentTo(expected))
+}
+
+// TestMemoryDriverAsyncNotifications tests that MemoryDriver sends Change notifications
+// via MsgChan when Publish/Unpublish is called
+func TestMemoryDriverAsyncNotifications(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewGomegaWithT(t)
+
+	logger := logrus.StandardLogger()
+	log := base.NewSourceLogObject(logger, "test", 1234)
+	drv := pubsub.NewMemoryDriver()
+	ps := pubsub.New(drv, logger, log)
+
+	// Create publication
+	pub, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName:  "test-agent",
+		TopicType:  types.AppNetworkStatus{},
+		Persistent: false,
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Create subscription with handlers
+	receivedChanges := make([]pubsub.Change, 0)
+	sub, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName: "test-agent",
+		TopicImpl: types.AppNetworkStatus{},
+		Activate:  false,
+		CreateHandler: func(ctxArg interface{}, key string, item interface{}) {
+			// Handler called on create
+		},
+		ModifyHandler: func(ctxArg interface{}, key string, item interface{}, oldItem interface{}) {
+			// Handler called on modify
+		},
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	err = sub.Activate()
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Start goroutine to receive changes
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 3; i++ { // Expect 3 changes: 2 publishes + 1 unpublish
+			select {
+			case change := <-sub.MsgChan():
+				receivedChanges = append(receivedChanges, change)
+				sub.ProcessChange(change)
+			}
+		}
+	}()
+
+	// Publish first item
+	u1, _ := uuid.FromString("6ba7b810-9dad-11d1-80b4-000000000001")
+	item1 := types.AppNetworkStatus{
+		UUIDandVersion: types.UUIDandVersion{
+			UUID:    u1,
+			Version: "1.0",
+		},
+	}
+	err = pub.Publish("key1", item1)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Publish second item
+	u2, _ := uuid.FromString("6ba7b810-9dad-11d1-80b4-000000000002")
+	item2 := types.AppNetworkStatus{
+		UUIDandVersion: types.UUIDandVersion{
+			UUID:    u2,
+			Version: "2.0",
+		},
+	}
+	err = pub.Publish("key2", item2)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Unpublish first item
+	err = pub.Unpublish("key1")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Wait for goroutine to receive all changes
+	<-done
+
+	// Verify we received 3 changes
+	g.Expect(receivedChanges).To(gomega.HaveLen(3))
+
+	// Verify first change is Modify for key1
+	g.Expect(receivedChanges[0].Operation).To(gomega.Equal(pubsub.Modify))
+	g.Expect(receivedChanges[0].Key).To(gomega.Equal("key1"))
+	g.Expect(receivedChanges[0].Value).ToNot(gomega.BeNil())
+
+	// Verify second change is Modify for key2
+	g.Expect(receivedChanges[1].Operation).To(gomega.Equal(pubsub.Modify))
+	g.Expect(receivedChanges[1].Key).To(gomega.Equal("key2"))
+	g.Expect(receivedChanges[1].Value).ToNot(gomega.BeNil())
+
+	// Verify third change is Delete for key1
+	g.Expect(receivedChanges[2].Operation).To(gomega.Equal(pubsub.Delete))
+	g.Expect(receivedChanges[2].Key).To(gomega.Equal("key1"))
+
+	// Verify items in subscription
+	items := sub.GetAll()
+	g.Expect(items).To(gomega.HaveLen(1)) // Only key2 remains
+	g.Expect(items["key2"]).To(gomega.BeEquivalentTo(item2))
+}
+
+// TestMemoryDriverMultipleTopics tests that subscribers on different topics
+// only receive notifications for their topic
+func TestMemoryDriverMultipleTopics(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewGomegaWithT(t)
+
+	logger := logrus.StandardLogger()
+	log := base.NewSourceLogObject(logger, "test", 1234)
+	drv := pubsub.NewMemoryDriver()
+	ps := pubsub.New(drv, logger, log)
+
+	// Create publications for two different topics
+	pubTopic1, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName:  "agent1",
+		TopicType:  types.AppNetworkStatus{},
+		Persistent: false,
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	pubTopic2, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName:  "agent2",
+		TopicType:  types.DeviceNetworkStatus{},
+		Persistent: false,
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Create subscription for topic1
+	topic1Changes := make([]pubsub.Change, 0)
+	subTopic1, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName: "agent1",
+		TopicImpl: types.AppNetworkStatus{},
+		Activate:  true,
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Create subscription for topic2
+	topic2Changes := make([]pubsub.Change, 0)
+	subTopic2, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName: "agent2",
+		TopicImpl: types.DeviceNetworkStatus{},
+		Activate:  true,
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Start goroutines to receive changes
+	done1 := make(chan struct{})
+	done2 := make(chan struct{})
+
+	go func() {
+		defer close(done1)
+		for i := 0; i < 1; i++ {
+			change := <-subTopic1.MsgChan()
+			topic1Changes = append(topic1Changes, change)
+		}
+	}()
+
+	go func() {
+		defer close(done2)
+		for i := 0; i < 1; i++ {
+			change := <-subTopic2.MsgChan()
+			topic2Changes = append(topic2Changes, change)
+		}
+	}()
+
+	// Publish to topic1
+	u1, _ := uuid.FromString("6ba7b810-9dad-11d1-80b4-000000000001")
+	item1 := types.AppNetworkStatus{
+		UUIDandVersion: types.UUIDandVersion{UUID: u1, Version: "1.0"},
+	}
+	err = pubTopic1.Publish("key1", item1)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Publish to topic2
+	item2 := types.DeviceNetworkStatus{}
+	err = pubTopic2.Publish("key2", item2)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Wait for both subscribers to receive their changes
+	<-done1
+	<-done2
+
+	// Verify topic1 subscriber only received topic1 change
+	g.Expect(topic1Changes).To(gomega.HaveLen(1))
+	g.Expect(topic1Changes[0].Key).To(gomega.Equal("key1"))
+
+	// Verify topic2 subscriber only received topic2 change
+	g.Expect(topic2Changes).To(gomega.HaveLen(1))
+	g.Expect(topic2Changes[0].Key).To(gomega.Equal("key2"))
+}
+
+// TestMemoryDriverSubscriberStop tests that subscriber unregisters when Stop() is called
+func TestMemoryDriverSubscriberStop(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewGomegaWithT(t)
+
+	logger := logrus.StandardLogger()
+	log := base.NewSourceLogObject(logger, "test", 1234)
+	drv := pubsub.NewMemoryDriver()
+	ps := pubsub.New(drv, logger, log)
+
+	// Create publication
+	pub, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName:  "test-agent",
+		TopicType:  types.AppNetworkStatus{},
+		Persistent: false,
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Create subscription
+	sub, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName: "test-agent",
+		TopicImpl: types.AppNetworkStatus{},
+		Activate:  true,
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Publish item - should be received
+	u1, _ := uuid.FromString("6ba7b810-9dad-11d1-80b4-000000000001")
+	item1 := types.AppNetworkStatus{
+		UUIDandVersion: types.UUIDandVersion{UUID: u1, Version: "1.0"},
+	}
+	err = pub.Publish("key1", item1)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Receive the change
+	select {
+	case change := <-sub.MsgChan():
+		g.Expect(change.Key).To(gomega.Equal("key1"))
+	}
+
+	// Close the subscription
+	err = sub.Close()
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Publish another item - should NOT be received
+	u2, _ := uuid.FromString("6ba7b810-9dad-11d1-80b4-000000000002")
+	item2 := types.AppNetworkStatus{
+		UUIDandVersion: types.UUIDandVersion{UUID: u2, Version: "2.0"},
+	}
+	err = pub.Publish("key2", item2)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Verify no change is received (channel should not have any messages)
+	select {
+	case <-sub.MsgChan():
+		t.Fatal("Should not receive change after Close()")
+	default:
+		// Expected - no message received
+	}
+}
+
+// TestMemoryDriverChangeValueField tests that Change.Value contains the actual data
+func TestMemoryDriverChangeValueField(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewGomegaWithT(t)
+
+	logger := logrus.StandardLogger()
+	log := base.NewSourceLogObject(logger, "test", 1234)
+	drv := pubsub.NewMemoryDriver()
+	ps := pubsub.New(drv, logger, log)
+
+	// Create publication
+	pub, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName:  "test-agent",
+		TopicType:  types.AppNetworkStatus{},
+		Persistent: false,
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Create subscription
+	sub, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName: "test-agent",
+		TopicImpl: types.AppNetworkStatus{},
+		Activate:  true,
+	})
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Publish item
+	u, _ := uuid.FromString("6ba7b810-9dad-11d1-80b4-000000000001")
+	expected := types.AppNetworkStatus{
+		UUIDandVersion: types.UUIDandVersion{
+			UUID:    u,
+			Version: "1.0",
+		},
+		AppNetAdapterList: []types.AppNetAdapterStatus{
+			{
+				AssignedAddresses: types.AssignedAddrs{
+					IPv4Addrs: []types.AssignedAddr{
+						{
+							Address:    net.ParseIP("192.168.1.1"),
+							AssignedBy: types.AddressSourceInternalDHCP,
+						},
+					},
+				},
+			},
+		},
+	}
+	err = pub.Publish("key1", expected)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Receive the change
+	change := <-sub.MsgChan()
+
+	// Verify Change has Operation, Key, and Value populated
+	g.Expect(change.Operation).To(gomega.Equal(pubsub.Modify))
+	g.Expect(change.Key).To(gomega.Equal("key1"))
+	g.Expect(change.Value).ToNot(gomega.BeNil())
+	g.Expect(len(change.Value)).To(gomega.BeNumerically(">", 0))
+
+	// Process the change and verify the item is correct
+	sub.ProcessChange(change)
+	items := sub.GetAll()
+	g.Expect(items).To(gomega.HaveLen(1))
+	g.Expect(items["key1"]).To(gomega.BeEquivalentTo(expected))
 }


### PR DESCRIPTION
# Description

This functionality is needed to test evalmgr (will be in upcoming PR) 

- Add subscribers map to track MsgChan by topic
- Send Change notifications with Value field on Publish/Unpublish
- Support multiple subscribers on different topics
- Unregister subscribers on Stop()
- Fix LargeDirName() to return tmpDir for subscribers
- Add comprehensive tests for async notification functionality

This enables event-driven testing without sleep/polling, making tests faster and more reliable. Maintains backward compatibility with existing synchronous GetAll() usage.

## PR dependencies

None

## How to test and validate this PR

```bash
cd pkg/pillar && docker run --rm -v $(pwd):/pillar -w /pillar lfedge/eve-pillar:local-amd64 go test -v -timeout 10s ./pubsub -run TestMemory
```

## Changelog notes

None

## PR Backports


```text
- 14.5-stable: No
- 13.4-stable: No
```

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

