### PR TITLE
docs: add security policy and architecture documentation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,64 @@
+# Security Policy
+
+## Supported Versions
+
+The EVE project maintains security support for the following versions:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| master  | ✅ |
+| 14.5.x  | ✅ |
+| 13.4.x  | ✅ |
+| 12.0.x  | ✅ |
+| 11.0.x  | ✅ |
+| 10.4.x  | ✅ |
+| 9.4.x  | ⚠️ Limited |
+
+## Reporting a Vulnerability
+
+### For Security Vulnerabilities
+
+If you discover a security vulnerability in EVE, please report it privately to maintain the security of all users. **Do not create a public GitHub issue.**
+
+#### Preferred Reporting Methods
+
+1. **Email**: Send details to [eve-security@lists.lfedge.org](mailto:eve-security@lists.lfedge.org).
+2. **GitHub Security Advisory**: Use the [private vulnerability reporting](https://github.com/lf-edge/eve/security/advisories/new) feature.
+
+#### What to Include
+
+Please include the following information in your report:
+
+- **Description**: Clear description of the vulnerability
+- **Steps to Reproduce**: Detailed steps to reproduce the issue
+- **Impact Assessment**: Your assessment of the potential impact
+- **Affected Versions**: Which versions of EVE are affected
+- **Proof of Concept**: If available, a proof-of-concept or exploit code
+- **Suggested Fix**: A patch to fix the vulnerability
+
+### Response Timeline
+
+We are committed to responding to security vulnerability reports within 24 hours of receipt. The time required to develop a fix may vary depending on the severity. Any public disclosure will be coordinated with the reporter.
+
+### Security Advisory Publication
+
+Security advisories will be published:
+
+- On the [EVE Security Advisories](https://github.com/lf-edge/eve/security/advisories) page.
+- Through the [LF Edge EVE mailing lists](https://lists.lfedge.org/g/eve).
+
+### Acknowledgments
+
+We recognize and appreciate the efforts of the security research community in helping make EVE more secure. Security researchers who responsibly disclose vulnerabilities will be acknowledged.
+
+### Scope
+
+This security policy applies to:
+
+- The main EVE repository (lf-edge/eve)
+- Official EVE container images
+- Official EVE releases and distributions
+
+### Security Resources
+
+Additional information about our security model can be found in the [EVE Security Architecture](docs/SECURITY-ARCHITECTURE.md) document.

--- a/docs/SECURITY-ARCHITECTURE.md
+++ b/docs/SECURITY-ARCHITECTURE.md
@@ -1,11 +1,5 @@
 # EVE Security Overview
 
-## Reporting security issues
-
-EVE community takes security seriously. If you discover a security issue, please bring it to our attention right away!
-
-Please DO NOT file a public issue, instead send your report privately to `eve-security@lists.lfedge.org`.
-
 ## Introduction
 
 What makes EVE a secure-by-design system is that it has been developed from the ground up with security in mind. EVE doesn't rely on 3rd party or add-on components to provide trust in the system, but rather offers a set of well-defined principles on which a trust model can be built. You will notice that EVE doesn't call itself a trusted system -- but rather a trustworthy one. The distinction is subtle, but very important and was first articulated by [Joanna Rutkowska](https://www.darkreading.com/vulnerabilities---threats/rutkowska-trust-makes-us-vulnerable/d/d-id/1330587). Joanna, of course, is the architect of [Qubes OS](https://www.qubes-os.org) with which EVE shares a good deal of core security principles like [security by compartmentalization](https://www.qubes-os.org/doc/glossary/#qubes-os) and focusing on representing all user applications as VM-based abstractions. In EVE, the same VM-based approach to defining applications is built around [Edge Containers specification](ECOS.md).


### PR DESCRIPTION
Move old SECURITY.md to docs/SECURITY-ARCHITECTURE.md and create a new SECURITY.md with security policy details and no architecture information.