### PR TITLE
[16.0] eve-k fixes app delete, tie-breaker failover

### DIFF
--- a/pkg/kube/kubevirt-utils.sh
+++ b/pkg/kube/kubevirt-utils.sh
@@ -35,8 +35,15 @@ Kubevirt_tie_breaker_config_apply() {
 
 Kubevirt_uninstall() {
     logmsg "Removing patched Kubevirt"
-    kubectl delete -f /etc/kubevirt-features.yaml
-    kubectl delete -f /etc/kubevirt-operator.yaml
+    {
+        kubectl delete -n kubevirt kubevirt kubevirt --wait=true
+        kubectl delete apiservices v1.subresources.kubevirt.io
+        kubectl delete mutatingwebhookconfigurations virt-api-mutator
+        kubectl delete validatingwebhookconfigurations virt-operator-validator
+        kubectl delete validatingwebhookconfigurations virt-api-validator
+        kubectl delete -f /etc/kubevirt-operator.yaml
+        kubectl delete -f /etc/kubevirt-features.yaml
+    } >> "$INSTALL_LOG" 2>&1
 
     # Kubevirt applies a large amount of labels to nodes detailing available cpu flags, remove them
     for n in $(kubectl get node -o NAME); do

--- a/pkg/kube/longhorn-utils.sh
+++ b/pkg/kube/longhorn-utils.sh
@@ -107,6 +107,15 @@ EOF
 Longhorn_is_ready() {
     longhorn_rdy_complete_file
 
+    # Namespace will exist while longhorn uninstall job completes.
+    # Don't get in its way, submitting node creations.
+    if [ -f /tmp/replicated-storage-uninstall-inprogress ]; then
+        return 1
+    fi
+    if [ -f /var/lib/base-k3s-mode ]; then
+        return 0
+    fi
+
     if ! kubectl get namespace/longhorn-system; then
         return 0
     fi

--- a/pkg/pillar/kubeapi/kubeapi.go
+++ b/pkg/pillar/kubeapi/kubeapi.go
@@ -877,7 +877,7 @@ func DetachOldWorkload(log *base.LogObject, failedNodeName string, appDomainName
 			log.Errorf("DetachOldWorkload Can't get failed replicas err:%v", err)
 			continue
 		}
-		volRedundant := lhVolHasRedundancyWithoutNode(log, lhVolAllReps, failedNodeName)
+		volRedundant := lhVolHasHealthyReplicaWithoutNode(log, lhVolAllReps, failedNodeName)
 		if !volRedundant {
 			appHasStorageRedundancy = false
 			break

--- a/pkg/pillar/kubeapi/longhorninfo.go
+++ b/pkg/pillar/kubeapi/longhorninfo.go
@@ -340,9 +340,9 @@ func PopulateKSI() (types.KubeStorageInfo, error) {
 	return ksi, nil
 }
 
-// lhVolHasRedundancy returns true if a volume can support losing a replica on the provided node name
+// lhVolHasHealthyReplicaWithoutNode returns true if a volume can support losing a replica on the provided node name
 // and still have an online replica
-func lhVolHasRedundancyWithoutNode(log *base.LogObject, repList *lhv1beta2.ReplicaList, ignoreRepOnNode string) (redundant bool) {
+func lhVolHasHealthyReplicaWithoutNode(log *base.LogObject, repList *lhv1beta2.ReplicaList, ignoreRepOnNode string) (hasHealthyReplica bool) {
 	var healthyReplicas []lhv1beta2.Replica
 	// filter list to replicas which are healthy
 	for _, lhReplica := range repList.Items {
@@ -360,11 +360,9 @@ func lhVolHasRedundancyWithoutNode(log *base.LogObject, repList *lhv1beta2.Repli
 		}
 		healthyReplicas = append(healthyReplicas, lhReplica)
 	}
-	if len(healthyReplicas) > 1 {
-		redundant = true
-	}
-	log.Warnf("replica count:%d redundant:%t", len(healthyReplicas), redundant)
-	return redundant
+	hasHealthyReplica = (len(healthyReplicas) > 0)
+	log.Warnf("replica healthyReplicaCount:%d hasHealthyReplica:%t", len(healthyReplicas), hasHealthyReplica)
+	return hasHealthyReplica
 }
 
 // LonghornReplicaList returns the replica for a given longhorn volume which is hosted on a given kubernetes node


### PR DESCRIPTION
# Description

Handle app object created but app unable to start due to no resources available. This app will report no node name in status and thus no scheduledOnMe()==true.  Use scheduledOnNone.

Allow failover when volume only has one replica copy remaining. To enable failover with a 'tie-breaker' cluster where healthy volumes only have two replicas.

Don't remediate longhorn lh node deployment map while we're uninstalling longhorn.

Reorder kubevirt uninstall to resolve an uncommon state where it would become stuck.


(cherry picked from commit b217f835292f903641dd66a1accc0230fc9cbccc)

Backport of #5342 

## PR dependencies

None

## How to test and validate this PR

For the hypervisor/kubevirt.go change:

- deploy 3 HV=k eve nodes, onboard to a controller and deploy an EdgeNodeClusterConfig
- deploy enough app instances to the cluster until new app instances are stuck not scheduling to a node. This will be visible as the virt-launcher pod Status=Pending and the vmi Phase=Scheduling. a kubectl describe of the virt-launcher pod will show FailedScheduling events eg. "Insufficient cpu".
- delete those stuck app instances and verify the kubernetes objects are removed.

For the tie-breaker app instance failover change:

- deploy 3 HV=k eve nodes, onboard to a controller, deploy an EdgeNodeClusterConfig where tie-breaker node uuid is set.
- deploy a vm app instance to the cluster.
- initiate an outage to one of the non-tie-breaker nodes eg. pull a network cable.
- verify the app instance correctly moves to the other non-tie-breaker node.

For the kube service container change:
- deploy 3 HV=k eve nodes, onboard to a controller, deploy an EdgeNodeClusterConfig including a registration manifest.
Verify all cluster nodes are visible in "kubectl get node" and that the registration manifest exists on one node.
eve enter kube; ls /var/lib/rancher/k3s/server/manifests/persist-registration.yaml

## Changelog notes

None

## PR Backports

This is the backport

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
