### PR TITLE
Interleave DNS servers across interfaces inside resolv.conf to mitigate resolver limit issues

### DIFF
--- a/pkg/pillar/dpcreconciler/genericitems/resolvconf.go
+++ b/pkg/pillar/dpcreconciler/genericitems/resolvconf.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/lf-edge/eve-libs/depgraph"
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
+	"github.com/lf-edge/eve/pkg/pillar/utils/netutils"
 )
 
 const (
@@ -108,41 +110,49 @@ func (c *ResolvConfConfigurator) generateResolvConf(item depgraph.Item) error {
 		c.Log.Error(err)
 		return err
 	}
-	var written []net.IP
+
+	// Collect interface names (for deterministic order) and max DNS count.
+	ifNames := make([]string, 0, len(config.DNSServers))
+	maxServers := 0
 	for ifName, dnsServers := range config.DNSServers {
+		ifNames = append(ifNames, ifName)
+		if len(dnsServers) > maxServers {
+			maxServers = len(dnsServers)
+		}
 		c.Log.Functionf("generateResolvConf: %s has %d servers: %v",
 			ifName, len(dnsServers), dnsServers)
-		_, err = destfile.WriteString(fmt.Sprintf("# From %s\n", ifName))
-		if err != nil {
-			c.Log.Error(err)
-			return err
-		}
-		// Avoid duplicate IP addresses for nameservers.
-		for _, server := range dnsServers {
-			duplicate := false
-			for _, a := range written {
-				if a.Equal(server) {
-					duplicate = true
-				}
+	}
+
+	// Interleave nameservers across interfaces
+	var written []net.IP
+	for i := range maxServers {
+		for _, ifName := range ifNames {
+			dnsServers := config.DNSServers[ifName]
+			if i >= len(dnsServers) {
+				continue
 			}
+			server := dnsServers[i]
+			duplicate := generics.ContainsItemFn(written, server, netutils.EqualIPs)
 			if duplicate {
 				_, err = destfile.WriteString(
-					fmt.Sprintf("# nameserver %s\n", server))
+					fmt.Sprintf("# From %s (duplicate)\n# nameserver %s\n",
+						ifName, server))
 				if err != nil {
 					c.Log.Error(err)
 					return err
 				}
-			} else {
-				_, err = destfile.WriteString(
-					fmt.Sprintf("nameserver %s\n", server))
-				if err != nil {
-					c.Log.Error(err)
-					return err
-				}
-				written = append(written, server)
+				continue
 			}
+			_, err = destfile.WriteString(
+				fmt.Sprintf("# From %s\nnameserver %s\n", ifName, server))
+			if err != nil {
+				c.Log.Error(err)
+				return err
+			}
+			written = append(written, server)
 		}
 	}
+
 	if _, err = destfile.WriteString("options rotate\n"); err != nil {
 		c.Log.Error(err)
 		return err


### PR DESCRIPTION
# Description

[The Go](https://github.com/golang/go/blob/go1.22.0/src/net/dnsconfig_unix.go#L51) (and also [system](https://github.com/kraj/musl/blob/kraj/master/src/network/resolvconf.c#L63)) resolver only use up to 3 nameservers from `resolv.conf`.
Previously, we wrote all nameservers for one interface before moving to the
next, which could result in a single interface with 3 DNS entries consuming
the entire limit. This caused other interfaces to fail DNS lookups with
error `no DNS server available`.
    
To mitigate this, change the `resolv.conf` generation logic to interleave
nameservers across interfaces: first nameserver from each interface, then the
second from each, and so on. For up to 3 management ports, this ensures that each
interface gets at least one usable DNS entry within the resolver's limit.
    
Duplicate nameservers are still commented out as before. The order of
interfaces is kept deterministic to maintain stable output.
    
This is a temporary mitigation of the underlying issue; the long-term plan
is to implement our own resolver that can use all configured DNS servers
without this 3-entry limit.

## How to test and validate this PR

1. Prepare the environment
  - Onboard an EVE device with **at least two management interfaces**.
  - Ensure that:
      - The first interface has **three or more DNS servers** configured (via DHCP or static IP configuration).
      - The second interface has **one or more DNS servers** configured, **distinct** from those on the first interface.

2. Deploy and verify
  - Let the device complete onboarding and network configuration.
  - Check the port status for both management interfaces for any reported errors:
      - On the controller side, inspect published `ZInfoDevice` message (port info is under `systemAdapter`)
      - Alternatively, SSH into the device and review `/run/nim/DeviceNetworkStatus/global.json`, looking at the `LastError` field for each interface.

3. Expected result
  - Both management interfaces should report **no errors**.
  - In particular, you should not see any `no DNS server available` messages.
  - This confirms that DNS servers from multiple interfaces are being correctly interleaved (round-robin merged) in `/etc/resolv.conf`.

## Changelog notes

Interleave DNS servers across interfaces in `resolv.conf` to mitigate resolver 3-entry limit issues.

## PR Backports

- 16.0-stable: https://github.com/lf-edge/eve/pull/5385
- 14.5-stable: https://github.com/lf-edge/eve/pull/5387
- 13.4-stable: https://github.com/lf-edge/eve/pull/5389

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.