### PR TITLE
Omit empty fields in dpc.go on JSON serialization

### DIFF
--- a/pkg/pillar/types/dpc.go
+++ b/pkg/pillar/types/dpc.go
@@ -622,9 +622,8 @@ func (config *DevicePortConfig) UpdatePortStatusFromIntfStatusMap(
 	}
 }
 
-// IsAnyPortInPciBack
+// IsAnyPortInPciBack checks if any of the Ports are part of IO bundles which are in PCIback.
 //
-//	Checks if any of the Ports are part of IO bundles which are in PCIback.
 //	If true, it also returns the ifName ( NOT bundle name )
 //	Also returns whether it is currently used by an application by
 //	returning a UUID. If the UUID is zero it is in PCIback but available.
@@ -1431,6 +1430,7 @@ func (ipRange IPRange) Size() uint32 {
 	return ip2Int - ip1Int
 }
 
+// Key : called to get the key for pubsub
 func (config NetworkXObjectConfig) Key() string {
 	return config.UUID.String()
 }


### PR DESCRIPTION
# Description

Add json:",omitempty" tags to all struct fields in dpc.go to omit zero/empty values from JSON serialization. This produces cleaner JSON output for device port configuration structures and prevents from creating too large messages.

## PR dependencies

None.

## How to test and validate this PR

1. Start a device with 8 physical ports (`port0`-`port7`, one named `port5-starlink`).
2. Create 12 VLAN adapters on `port5-starlink` with IDs `4001`-`4012` and labels like `port5-starlink.4001`, all using `ADAPTER_USAGE_MANAGEMENT`.
3. Create one network-instance of type switch per physical adapter.
The configuration should apply partially (some “too long” label warnings), but nim must not crash.
4. Add a 13th VLAN adapter on `port5-starlink` (ID `4013`, same usage).

Before the fix nim crashes.
After the fix nim stays alive and reports a validation error for the 13th VLAN instead of crashing.

## Changelog notes

Simplify DPC’s internal representation to avoid exceeding JSON message size limits and to support more sophisticated network configurations.

## PR Backports

- 16.0: yes
- 14.5-stable: yes
- 13.4-stable: yes

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
