### PR TITLE
eve-k: Enable ext4 vault support

### DIFF
--- a/docs/EVE-K.md
+++ b/docs/EVE-K.md
@@ -13,7 +13,10 @@ make HV=k ZARCH=amd64 clean pkgs eve
 Installation of `HV=k` eve is installed from an `installer-raw` image in a similar method as
 `HV=kvm` eve is, there are a few details:
 
-- all installs use zfs for the vault
+"eve-k" supports ext4 and zfs vaults.  Default installation uses ext4 on a single disk.
+To use a zfs vault specify the config grub parameter `eve_install_zfs_with_raid_level`
+with the requested raid level or use multiple persist disk with `eve_persist_disk`
+which will use zfs automatically.
 
 ## Upgrades
 

--- a/pkg/installer/install
+++ b/pkg/installer/install
@@ -391,9 +391,16 @@ RAID_LEVEL="none"
 eve_flavor=$(cat /root/etc/eve-hv-type)
 
 if [ "$eve_flavor" = "k" ]; then
-   INSTALL_CLUSTERED_STORAGE=true
-   INSTALL_ZFS=true
-   logmsg "Kubevirt image installing ZFS"
+   if echo "$INSTALL_PERSIST"| grep -q ","; then
+      # Multiple persist disk on HV=k should default to zfs
+      INSTALL_ZFS=true
+   fi
+   if [ "$INSTALL_ZFS" = "true" ]; then
+      INSTALL_CLUSTERED_STORAGE=true
+      logmsg "Kubevirt image installing ZFS"
+   else
+      logmsg "Kubevirt image installing ext4"
+   fi
 fi
 
 eve_platform=$(cat /root/etc/eve-platform)

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -74,12 +74,6 @@ INSTALL_CLUSTERED_STORAGE=false
 INSTALL_ZFS=false
 eve_flavor=$(cat /hostfs/etc/eve-hv-type)
 
-if [ "$eve_flavor" = "k" ]; then
-   INSTALL_CLUSTERED_STORAGE=true
-   INSTALL_ZFS=true
-   echo "$(date -Ins -u) Kubevirt image - might recreate ZFS /persist"
-fi
-
 # the following is here just for compatibility reasons and it should go away soon
 ln -s "$CONFIGDIR" "/var/$CONFIGDIR"
 ln -s "$PERSISTDIR" "/var/$PERSISTDIR"
@@ -111,6 +105,14 @@ if grep -q 'eve_install_zfs_with_raid_level' /proc/cmdline; then
    P3_FS_TYPE_DEFAULT=zfs
 elif [ "$INSTALL_ZFS" = true ]; then
    P3_FS_TYPE_DEFAULT=zfs
+fi
+
+if [ "$eve_flavor" = "k" ]; then
+   if [ "$P3_FS_TYPE_DEFAULT" = "zfs" ]; then
+      INSTALL_CLUSTERED_STORAGE=true
+      INSTALL_ZFS=true
+      echo "$(date -Ins -u) Kubevirt image - might recreate ZFS /persist"
+   fi
 fi
 
 # First lets see if we're running with the disk that hasn't been properly


### PR DESCRIPTION
# Description

- New location for kube service container /var/lib/ items: a bind mount in /persist/vault/kube.
- Enables no ZFS in io path.
- Installer default is changed to use ext4 instead of zfs, this follows the default behavior in HV=kvm eve.
- A single cluster can contain nodes with mixed persist types.
- Multiple eve_persist_disk disk will default to zfs persist.

EXT4 Persist Testing Completed:
- USB install and BaseOS updates on amd64 systems.
- Cluster create
- VM App Instances deployed
- VM App Failover between nodes
- `make HV=k live run-live` with ZARCH=amd64 and ZARCH=arm64

ZFS Persist Testing Completed:
- Regression testing of USB install of existing ZFS persist type with `eve_install_zfs_with_raid_level=none`

Mixed Testing:
- Cluster create of two ext4-persist nodes and 1 zfs-persist node, deployed 3 VMs evenly distributed across nodes.  

## PR dependencies

None

## How to test and validate this PR

- Install HV=k eve without grub option "eve_install_zfs_with_raid_level"
- eve enter kube
- Verify /var/lib/all_components_initialized file is present.
- Verify node is present in "kubectl get node"
- Deploy a VM app instance to the edge node and verify app instance meets running state.

## Changelog notes

Enable eve-k on ext4 persist.

## PR Backports

- 16.0-stable: Yes, To be backported.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
