### PR TITLE
Set unique per-interface route metrics for components not using source-based routing

### DIFF
--- a/pkg/pillar/dpcreconciler/genericitems/dhcpcd_test.go
+++ b/pkg/pillar/dpcreconciler/genericitems/dhcpcd_test.go
@@ -151,6 +151,7 @@ func TestDhcpcdArgs(t *testing.T) {
 		name          string
 		config        types.DhcpConfig
 		ignoreDhcpGws bool
+		routeMetric   uint32
 		expOp         string
 		expArgs       []string
 	}
@@ -246,10 +247,21 @@ func TestDhcpcdArgs(t *testing.T) {
 				"--static", "ntp_servers=192.168.1.1", "--static", "ntp_servers=10.10.12.13",
 				"-f", "/etc/dhcpcd.conf", "-b", "-t", "0", "--nogateway"},
 		},
+		{
+			name: "DHCP client for IPv4 with route metric",
+			config: types.DhcpConfig{
+				Dhcp: types.DhcpTypeClient,
+				Type: types.NetworkTypeIpv4Only,
+			},
+			routeMetric: 500,
+			expOp:       "--request",
+			expArgs: []string{"-f", "/etc/dhcpcd.conf", "--noipv4ll", "--ipv4only", "-b", "-t", "0",
+				"--metric", "500"},
+		},
 	}
 	configurator := configitems.DhcpcdConfigurator{}
 	for _, test := range tests {
-		op, args := configurator.DhcpcdArgs(test.config, test.ignoreDhcpGws)
+		op, args := configurator.DhcpcdArgs(test.config, test.ignoreDhcpGws, test.routeMetric)
 		if op != test.expOp || !generics.EqualLists(args, test.expArgs) {
 			t.Errorf("TEST CASE \"%s\" FAILED - DhcpcdArgs() returned: %s %v, "+
 				"expected: %s %v", test.name, op, args, test.expOp, test.expArgs)

--- a/pkg/pillar/types/pbr.go
+++ b/pkg/pillar/types/pbr.go
@@ -36,4 +36,23 @@ const (
 	PbrKubeNetworkPrio = 13000
 	// PbrLocalOrigPrio : IP rule priority for locally (dom0) generated packets
 	PbrLocalOrigPrio = 15000
+
+	// For components that do not follow EVE's source-based routing and instead
+	// use the main routing table (e.g., pulling Kubernetes system images for eve-k),
+	// route metrics are assigned to reflect interface usage and priority.
+	//
+	// Each interface receives a unique metric to ensure deterministic ordering
+	// of default routes in the main routing table. Metrics are derived from a
+	// base value depending on interface usage and an incremental offset based on
+	// interface cost and order within the configuration.
+
+	// MgmtPortBaseMetric is the base metric value for all management ports.
+	// The final metric for each management port is calculated as:
+	//   MgmtPortBaseMetric + index_in_cost_order
+	MgmtPortBaseMetric = 5000
+
+	// AppSharedPortBaseMetric is the base metric value for all app-shared ports.
+	// The final metric for each app-shared port is calculated as:
+	//   AppSharedPortBaseMetric + index_in_cost_order
+	AppSharedPortBaseMetric = 10000
 )

--- a/pkg/pillar/types/wwan.go
+++ b/pkg/pillar/types/wwan.go
@@ -121,6 +121,8 @@ type WwanNetworkConfig struct {
 	LocationTracking bool
 	// Maximum transmission unit (IP MTU) to apply on the wwan interface.
 	MTU uint16
+	// Metric assigned to routes configured for this wwan interface.
+	RouteMetric uint32
 }
 
 // WwanAuthProtocol : authentication protocol used by cellular network.
@@ -267,7 +269,8 @@ func (wnc WwanNetworkConfig) Equal(wnc2 WwanNetworkConfig) bool {
 	}
 	if wnc.Probe != wnc2.Probe ||
 		wnc.LocationTracking != wnc2.LocationTracking ||
-		wnc.MTU != wnc2.MTU {
+		wnc.MTU != wnc2.MTU ||
+		wnc.RouteMetric != wnc2.RouteMetric {
 		return false
 	}
 	return true


### PR DESCRIPTION
# Description

EVE and application traffic primarily use source-IP–based routing with per-interface routing tables. The appropriate table is selected based on the source IP address. This mechanism covers most traffic, including downloads handled by the downloader microservice.

However, not all components adhere to this policy-based routing model. A notable exception are the Kubernetes system components running under eve-k, which rely on the traditional routing mechanism using the main routing table (for example, when containerd pulls images for kube-system, longhorn, or kubevirt pods).

To ensure that lower-cost management interfaces are preferred for such traffic, this change introduces per-interface route metrics applied via dhcpcd. Since EVE uses dhcpcd to configure both DHCP-assigned and static interfaces, these metrics apply uniformly across all interfaces.

Each interface is assigned a base metric depending on its usage:
  * `MgmtPortBaseMetric = 5000`
  * `AppSharedPortBaseMetric = 10000`

To avoid conflicts caused by identical default routes, every interface receives a unique metric computed as:
 * `base_metric + index_in_cost_order`

This guarantees that routes in the main table remain unique even when multiple ports with the same usage and cost are present. The metric ordering reflects the relative preference of interfaces while maintaining uniqueness.

_Note_: The route metric computed for cellular adapter is not yet applied by mmagent in this commit. After this change is merged upstream, mmagent will be updated in a follow-up PR to pull the latest pillar (which will then include `RouteMetric` inside `WwanNetworkConfig`) and apply the received metrics.

## How to test and validate this PR

1. Onboard an EVE device with multiple network adapters.
2. Assign different costs to each adapter (both management and app-shared).
3. SSH into the device and inspect the main routing table using:
```
ip route show table main
```
4. Verify that:
   - Default routes are ordered by interface usage (management ports before app-shared ports).
   - Within each usage group, routes are ordered by configured cost.
   - Each route has a unique metric value, ensuring no conflicts.

## Changelog notes

Introduced per-interface route metrics via dhcpcd to improve interface selection for non–policy-based routing (e.g., pulling Kubernetes system images). Metrics prefer lower-cost management ports.

## PR Backports

This change is only important for eve-k, therefore it only needs to be backported to 16.0

- 16.0-stable: https://github.com/lf-edge/eve/pull/5383

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.