### PR TITLE
[16.0] Updated eve-libs to support resume for http datastores

### DIFF
--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.5.0
 	github.com/lf-edge/edge-containers v0.0.0-20250318135001-d53466c3f229
 	github.com/lf-edge/eve-api/go v0.0.0-20251015130922-bab09e4f470c
-	github.com/lf-edge/eve-libs v0.0.0-20250926132726-e59020478fca
+	github.com/lf-edge/eve-libs v0.0.0-20251105072030-1c066d586f1b
 	github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d
 	github.com/lf-edge/go-qemu v0.0.0-20231121152149-4c467eda0c56
 	github.com/linuxkit/linuxkit/src/cmd/linuxkit v0.0.0-20240507172735-6d37353ca1ee

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -575,8 +575,10 @@ github.com/lf-edge/eve-api/go v0.0.0-20250922144401-abfd2fa2b728 h1:MieVGF6Sp12d
 github.com/lf-edge/eve-api/go v0.0.0-20250922144401-abfd2fa2b728/go.mod h1:6HxNA/qKJVEqwpuOFkcQ0h3QyotvAs/cjHLC961FPOY=
 github.com/lf-edge/eve-api/go v0.0.0-20251015130922-bab09e4f470c h1:ZHFiYgv+N9xedVVVSl3IVQm3ot42pob1DnVRLdhPW3o=
 github.com/lf-edge/eve-api/go v0.0.0-20251015130922-bab09e4f470c/go.mod h1:6HxNA/qKJVEqwpuOFkcQ0h3QyotvAs/cjHLC961FPOY=
-github.com/lf-edge/eve-libs v0.0.0-20250926132726-e59020478fca h1:zdMDpvkuq3VJrV0NJPMTnXRHoCsUUNJZJRn2s4VLVuo=
-github.com/lf-edge/eve-libs v0.0.0-20250926132726-e59020478fca/go.mod h1:aW4soDIg+Q9FQtRrc/VWchwIryN5aV/HJdEt4IFEZgI=
+github.com/lf-edge/eve-libs v0.0.0-20251022164455-de07a00e55b4 h1:QaCrNQque+N20sUo3Z67rLcYjFVRcezbK3pWWRMqTsI=
+github.com/lf-edge/eve-libs v0.0.0-20251022164455-de07a00e55b4/go.mod h1:aW4soDIg+Q9FQtRrc/VWchwIryN5aV/HJdEt4IFEZgI=
+github.com/lf-edge/eve-libs v0.0.0-20251105072030-1c066d586f1b h1:Jx92e1MTt666EtbODjhbMc+eQ30VOZeSzKARQLt22SU=
+github.com/lf-edge/eve-libs v0.0.0-20251105072030-1c066d586f1b/go.mod h1:aW4soDIg+Q9FQtRrc/VWchwIryN5aV/HJdEt4IFEZgI=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d h1:tUBb9M6u42LXwHAYHyh22wJeUUQlTpDkXwRXalpRqbo=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d/go.mod h1:Nn3juMJJ1G8dyHOebdZyS4jOB/fuxAd5fIajBaWjHr8=
 github.com/lf-edge/go-qemu v0.0.0-20231121152149-4c467eda0c56 h1:LmFp0jbNSwPLuxJA+nQ+mMQrQ53ESkvHP4CVMqR0zrY=

--- a/pkg/pillar/vendor/github.com/lf-edge/eve-libs/zedUpload/datastore_http.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve-libs/zedUpload/datastore_http.go
@@ -120,8 +120,10 @@ func (ep *HttpTransportMethod) processHttpUpload(req *DronaRequest) (error, int)
 	if err != nil {
 		return err, 0
 	}
+
+	doneParts := req.GetDoneParts()
 	stats, resp := zedHttp.ExecCmd(req.cancelContext, "post", postUrl, req.name,
-		req.objloc, req.sizelimit, prgChan, hClient, ep.inactivityTimeout)
+		req.objloc, req.sizelimit, prgChan, doneParts, hClient, ep.inactivityTimeout)
 	return stats.Error, resp.BodyLength
 }
 
@@ -140,8 +142,10 @@ func (ep *HttpTransportMethod) processHttpDownload(req *DronaRequest) (error, in
 	if err != nil {
 		return err, 0
 	}
+
+	doneParts := req.GetDoneParts()
 	stats, resp := zedHttp.ExecCmd(req.cancelContext, "get", file, "",
-		req.objloc, req.sizelimit, prgChan, hClient, ep.inactivityTimeout)
+		req.objloc, req.sizelimit, prgChan, doneParts, hClient, ep.inactivityTimeout)
 	return stats.Error, resp.BodyLength
 }
 
@@ -162,8 +166,10 @@ func (ep *HttpTransportMethod) processHttpList(req *DronaRequest) ([]string, err
 	if err != nil {
 		return nil, err
 	}
+
+	doneParts := req.GetDoneParts()
 	stats, resp := zedHttp.ExecCmd(req.cancelContext, "ls", listUrl, "", "",
-		req.sizelimit, prgChan, hClient, ep.inactivityTimeout)
+		req.sizelimit, prgChan, doneParts, hClient, ep.inactivityTimeout)
 	return resp.List, stats.Error
 }
 
@@ -182,8 +188,10 @@ func (ep *HttpTransportMethod) processHttpObjectMetaData(req *DronaRequest) (err
 	if err != nil {
 		return err, 0
 	}
+
+	doneParts := req.GetDoneParts()
 	stats, resp := zedHttp.ExecCmd(req.cancelContext, "meta", file, "", req.objloc,
-		req.sizelimit, prgChan, hClient, ep.inactivityTimeout)
+		req.sizelimit, prgChan, doneParts, hClient, ep.inactivityTimeout)
 	return stats.Error, resp.ContentLength
 }
 func (ep *HttpTransportMethod) getContext() *DronaCtx {

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -905,7 +905,7 @@ github.com/lf-edge/eve-api/go/metrics
 github.com/lf-edge/eve-api/go/nestedappinstancemetrics
 github.com/lf-edge/eve-api/go/profile
 github.com/lf-edge/eve-api/go/register
-# github.com/lf-edge/eve-libs v0.0.0-20250926132726-e59020478fca
+# github.com/lf-edge/eve-libs v0.0.0-20251105072030-1c066d586f1b
 ## explicit; go 1.23.0
 github.com/lf-edge/eve-libs/depgraph
 github.com/lf-edge/eve-libs/nettrace


### PR DESCRIPTION
# Description

Backport of https://github.com/lf-edge/eve/pull/5370

## PR dependencies

None.

## How to test and validate this PR

1. Onboard an edge device using ZedUI.
2. Navigate to Library → Datastores and create an HTTP datastore.
3. Upload a valid Edge App image to the datastore created in Step 2.
4. In Marketplace, create a new test Edge Application that references the image uploaded in Step 3.
5. Deploy the test application to the onboarded edge device.
6. While the application image is downloading, restart the edge device.
7. After the device reboots, verify that:
    * The download resumes from where it left off, not from the beginning.
    * The download progress percentage reflects the state before the restart (i.e., close to where it was prior to reboot).

Important:
Use a sufficiently large image to ensure the download does not complete before you have time to perform the restart.
## Changelog notes

### Enhancements
- **HTTP Datastore Resume Support:**  
  Downloads initiated from HTTP datastores can now be resumed after a device reboot or unexpected interruption.  
  This improves reliability for deployments involving large Edge App images and reduces unnecessary network bandwidth and download time.

### Impact
- Edge App deployment workflows are more robust during network instability or device power cycles.
- No change is required in application configuration; resume is automatic.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
