### PR TITLE
mmagent: apply route metric received from NIM

### DIFF
--- a/pkg/wwan/mmagent/go.mod
+++ b/pkg/wwan/mmagent/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.1
 
 require (
 	github.com/godbus/dbus/v5 v5.1.0
-	github.com/lf-edge/eve/pkg/pillar v0.0.0-20251029075156-4a3aedeeddf7
+	github.com/lf-edge/eve/pkg/pillar v0.0.0-20251111034223-e81177b68a3e
 	github.com/miekg/dns v1.1.55
 	github.com/sirupsen/logrus v1.9.3
 	github.com/tatsushid/go-fastping v0.0.0-20160109021039-d7bb493dee3e
@@ -15,6 +15,7 @@ require (
 )
 
 require (
+	cyphar.com/go-pathrs v0.2.1 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20231105174938-2b5cbb29f3e2 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
@@ -33,6 +34,7 @@ require (
 	github.com/containerd/ttrpc v1.2.7 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect
 	github.com/containerd/typeurl/v2 v2.2.0 // indirect
+	github.com/cyphar/filepath-securejoin v0.6.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v25.0.3+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
@@ -77,7 +79,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.1.0 // indirect
 	github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626 // indirect
-	github.com/opencontainers/selinux v1.11.0 // indirect
+	github.com/opencontainers/selinux v1.13.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect

--- a/pkg/wwan/mmagent/go.sum
+++ b/pkg/wwan/mmagent/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cyphar.com/go-pathrs v0.2.1 h1:9nx1vOgwVvX1mNBWDu93+vaceedpbsDqo+XuBGL40b8=
+cyphar.com/go-pathrs v0.2.1/go.mod h1:y8f1EMG7r+hCuFf/rXsKqMJrJAUoADZGNh5/vZPKcGc=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9vkmnHYOMsOr4WLk+Vo07yKIzd94sVoIqshQ4bU=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20231105174938-2b5cbb29f3e2 h1:dIScnXFlF784X79oi7MzVT6GWqr/W1uUt0pB5CsDs9M=
@@ -54,6 +56,8 @@ github.com/containerd/typeurl v1.0.2/go.mod h1:9trJWW2sRlGub4wZJRTW83VtbOLS6hwcD
 github.com/containerd/typeurl/v2 v2.2.0 h1:6NBDbQzr7I5LHgp34xAXYF5DOTQDn05X58lsPEmzLso=
 github.com/containerd/typeurl/v2 v2.2.0/go.mod h1:8XOOxnyatxSWuG8OfsZXVnAF4iZfedjS/8UHSPJnX4g=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cyphar/filepath-securejoin v0.6.0 h1:BtGB77njd6SVO6VztOHfPxKitJvd/VPT+OFBFMOi1Is=
+github.com/cyphar/filepath-securejoin v0.6.0/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -192,8 +196,8 @@ github.com/lf-edge/eve-api/go v0.0.0-20251015130922-bab09e4f470c h1:ZHFiYgv+N9xe
 github.com/lf-edge/eve-api/go v0.0.0-20251015130922-bab09e4f470c/go.mod h1:6HxNA/qKJVEqwpuOFkcQ0h3QyotvAs/cjHLC961FPOY=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d h1:tUBb9M6u42LXwHAYHyh22wJeUUQlTpDkXwRXalpRqbo=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d/go.mod h1:Nn3juMJJ1G8dyHOebdZyS4jOB/fuxAd5fIajBaWjHr8=
-github.com/lf-edge/eve/pkg/pillar v0.0.0-20251029075156-4a3aedeeddf7 h1:HMTpRlwdgCM6ycUemH//wFahBE3J4WV+eprAFWYXmbQ=
-github.com/lf-edge/eve/pkg/pillar v0.0.0-20251029075156-4a3aedeeddf7/go.mod h1:s+JEcp4pHsuz7tEY6tiemMBuayAitNrVx0lt2ioQ4Sc=
+github.com/lf-edge/eve/pkg/pillar v0.0.0-20251111034223-e81177b68a3e h1:JFCkzvj7wR/dexuKF6QPShlhE5lh4/q5ooUjGixgTC0=
+github.com/lf-edge/eve/pkg/pillar v0.0.0-20251111034223-e81177b68a3e/go.mod h1:wTWOWLY8JaGM0W4eBrjMM2KfTeLWPUUNXvTyydzehW0=
 github.com/linuxkit/linuxkit/src/cmd/linuxkit v0.0.0-20240507172735-6d37353ca1ee h1:ASS39H/5OkVqkGSOR2xtcIsu3EZH4aDQOKhE1OfazUo=
 github.com/linuxkit/linuxkit/src/cmd/linuxkit v0.0.0-20240507172735-6d37353ca1ee/go.mod h1:UMA/+cd1QZElFCZAhuGv0TEEdWP9AgcRSXSI6S+r/KA=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -235,8 +239,8 @@ github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626 h1:DmNGcqH3WDbV5k8OJ+esPWbqUOX5rMLR2PMvziDMJi0=
 github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626/go.mod h1:BRHJJd0E+cx42OybVYSgUvZmU0B8P9gZuRXlZUP7TKI=
 github.com/opencontainers/selinux v1.9.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
-github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
-github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
+github.com/opencontainers/selinux v1.13.0 h1:Zza88GWezyT7RLql12URvoxsbLfjFx988+LGaWfbL84=
+github.com/opencontainers/selinux v1.13.0/go.mod h1:XxWTed+A/s5NNq4GmYScVy+9jzXhGBVEOAyucdRUY8s=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
 github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -290,8 +294,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tatsushid/go-fastping v0.0.0-20160109021039-d7bb493dee3e h1:nt2877sKfojlHCTOBXbpWjBkuWKritFaGIfgQwbQUls=

--- a/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/.golangci.yml
+++ b/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/.golangci.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MPL-2.0
+#
+# libpathrs: safe path resolution on Linux
+# Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
+# Copyright (C) 2019-2025 SUSE LLC
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+version: "2"
+linters:
+  enable:
+    - bidichk
+    - cyclop
+    - errname
+    - errorlint
+    - exhaustive
+    - goconst
+    - godot
+    - gomoddirectives
+    - gosec
+    - mirror
+    - misspell
+    - mnd
+    - nilerr
+    - nilnil
+    - perfsprint
+    - prealloc
+    - reassign
+    - revive
+    - unconvert
+    - unparam
+    - usestdlibvars
+    - wastedassign
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - cyphar.com/go-pathrs

--- a/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/COPYING
+++ b/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/COPYING
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/doc.go
+++ b/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/doc.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MPL-2.0
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2025 SUSE LLC
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// Package pathrs provides bindings for libpathrs, a library for safe path
+// resolution on Linux.
+package pathrs

--- a/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/handle_linux.go
+++ b/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/handle_linux.go
@@ -1,0 +1,114 @@
+//go:build linux
+
+// SPDX-License-Identifier: MPL-2.0
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2025 SUSE LLC
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package pathrs
+
+import (
+	"fmt"
+	"os"
+
+	"cyphar.com/go-pathrs/internal/fdutils"
+	"cyphar.com/go-pathrs/internal/libpathrs"
+)
+
+// Handle is a handle for a path within a given [Root]. This handle references
+// an already-resolved path which can be used for only one purpose -- to
+// "re-open" the handle and get an actual [os.File] which can be used for
+// ordinary operations.
+//
+// If you wish to open a file without having an intermediate [Handle] object,
+// you can try to use [Root.Open] or [Root.OpenFile].
+//
+// It is critical that perform all relevant operations through this [Handle]
+// (rather than fetching the file descriptor yourself with [Handle.IntoRaw]),
+// because the security properties of libpathrs depend on users doing all
+// relevant filesystem operations through libpathrs.
+//
+// [os.File]: https://pkg.go.dev/os#File
+type Handle struct {
+	inner *os.File
+}
+
+// HandleFromFile creates a new [Handle] from an existing file handle. The
+// handle will be copied by this method, so the original handle should still be
+// freed by the caller.
+//
+// This is effectively the inverse operation of [Handle.IntoRaw], and is used
+// for "deserialising" pathrs root handles.
+func HandleFromFile(file *os.File) (*Handle, error) {
+	newFile, err := fdutils.DupFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("duplicate handle fd: %w", err)
+	}
+	return &Handle{inner: newFile}, nil
+}
+
+// Open creates an "upgraded" file handle to the file referenced by the
+// [Handle]. Note that the original [Handle] is not consumed by this operation,
+// and can be opened multiple times.
+//
+// The handle returned is only usable for reading, and this is method is
+// shorthand for [Handle.OpenFile] with os.O_RDONLY.
+//
+// TODO: Rename these to "Reopen" or something.
+func (h *Handle) Open() (*os.File, error) {
+	return h.OpenFile(os.O_RDONLY)
+}
+
+// OpenFile creates an "upgraded" file handle to the file referenced by the
+// [Handle]. Note that the original [Handle] is not consumed by this operation,
+// and can be opened multiple times.
+//
+// The provided flags indicate which open(2) flags are used to create the new
+// handle.
+//
+// TODO: Rename these to "Reopen" or something.
+func (h *Handle) OpenFile(flags int) (*os.File, error) {
+	return fdutils.WithFileFd(h.inner, func(fd uintptr) (*os.File, error) {
+		newFd, err := libpathrs.Reopen(fd, flags)
+		if err != nil {
+			return nil, err
+		}
+		return os.NewFile(newFd, h.inner.Name()), nil
+	})
+}
+
+// IntoFile unwraps the [Handle] into its underlying [os.File].
+//
+// You almost certainly want to use [Handle.OpenFile] to get a non-O_PATH
+// version of this [Handle].
+//
+// This operation returns the internal [os.File] of the [Handle] directly, so
+// calling [Handle.Close] will also close any copies of the returned [os.File].
+// If you want to get an independent copy, use [Handle.Clone] followed by
+// [Handle.IntoFile] on the cloned [Handle].
+//
+// [os.File]: https://pkg.go.dev/os#File
+func (h *Handle) IntoFile() *os.File {
+	// TODO: Figure out if we really don't want to make a copy.
+	// TODO: We almost certainly want to clear r.inner here, but we can't do
+	//       that easily atomically (we could use atomic.Value but that'll make
+	//       things quite a bit uglier).
+	return h.inner
+}
+
+// Clone creates a copy of a [Handle], such that it has a separate lifetime to
+// the original (while referring to the same underlying file).
+func (h *Handle) Clone() (*Handle, error) {
+	return HandleFromFile(h.inner)
+}
+
+// Close frees all of the resources used by the [Handle].
+func (h *Handle) Close() error {
+	return h.inner.Close()
+}

--- a/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/internal/fdutils/fd_linux.go
+++ b/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/internal/fdutils/fd_linux.go
@@ -1,0 +1,75 @@
+//go:build linux
+
+// SPDX-License-Identifier: MPL-2.0
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2025 SUSE LLC
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// Package fdutils contains a few helper methods when dealing with *os.File and
+// file descriptors.
+package fdutils
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+
+	"cyphar.com/go-pathrs/internal/libpathrs"
+)
+
+// DupFd makes a duplicate of the given fd.
+func DupFd(fd uintptr, name string) (*os.File, error) {
+	newFd, err := unix.FcntlInt(fd, unix.F_DUPFD_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("fcntl(F_DUPFD_CLOEXEC): %w", err)
+	}
+	return os.NewFile(uintptr(newFd), name), nil
+}
+
+// WithFileFd is a more ergonomic wrapper around file.SyscallConn().Control().
+func WithFileFd[T any](file *os.File, fn func(fd uintptr) (T, error)) (T, error) {
+	conn, err := file.SyscallConn()
+	if err != nil {
+		return *new(T), err
+	}
+	var (
+		ret      T
+		innerErr error
+	)
+	if err := conn.Control(func(fd uintptr) {
+		ret, innerErr = fn(fd)
+	}); err != nil {
+		return *new(T), err
+	}
+	return ret, innerErr
+}
+
+// DupFile makes a duplicate of the given file.
+func DupFile(file *os.File) (*os.File, error) {
+	return WithFileFd(file, func(fd uintptr) (*os.File, error) {
+		return DupFd(fd, file.Name())
+	})
+}
+
+// MkFile creates a new *os.File from the provided file descriptor. However,
+// unlike os.NewFile, the file's Name is based on the real path (provided by
+// /proc/self/fd/$n).
+func MkFile(fd uintptr) (*os.File, error) {
+	fdPath := fmt.Sprintf("fd/%d", fd)
+	fdName, err := libpathrs.ProcReadlinkat(libpathrs.ProcDefaultRootFd, libpathrs.ProcThreadSelf, fdPath)
+	if err != nil {
+		_ = unix.Close(int(fd))
+		return nil, fmt.Errorf("failed to fetch real name of fd %d: %w", fd, err)
+	}
+	// TODO: Maybe we should prefix this name with something to indicate to
+	// users that they must not use this path as a "safe" path. Something like
+	// "//pathrs-handle:/foo/bar"?
+	return os.NewFile(fd, fdName), nil
+}

--- a/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/internal/libpathrs/error_unix.go
+++ b/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/internal/libpathrs/error_unix.go
@@ -1,0 +1,40 @@
+//go:build linux
+
+// TODO: Use "go:build unix" once we bump the minimum Go version 1.19.
+
+// SPDX-License-Identifier: MPL-2.0
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2025 SUSE LLC
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package libpathrs
+
+import (
+	"syscall"
+)
+
+// Error represents an underlying libpathrs error.
+type Error struct {
+	description string
+	errno       syscall.Errno
+}
+
+// Error returns a textual description of the error.
+func (err *Error) Error() string {
+	return err.description
+}
+
+// Unwrap returns the underlying error which was wrapped by this error (if
+// applicable).
+func (err *Error) Unwrap() error {
+	if err.errno != 0 {
+		return err.errno
+	}
+	return nil
+}

--- a/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/internal/libpathrs/libpathrs_linux.go
+++ b/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/internal/libpathrs/libpathrs_linux.go
@@ -1,0 +1,337 @@
+//go:build linux
+
+// SPDX-License-Identifier: MPL-2.0
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2025 SUSE LLC
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// Package libpathrs is an internal thin wrapper around the libpathrs C API.
+package libpathrs
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+/*
+// TODO: Figure out if we need to add support for linking against libpathrs
+//       statically even if in dynamically linked builds in order to make
+//       packaging a bit easier (using "-Wl,-Bstatic -lpathrs -Wl,-Bdynamic" or
+//       "-l:pathrs.a").
+#cgo pkg-config: pathrs
+#include <pathrs.h>
+
+// This is a workaround for unsafe.Pointer() not working for non-void pointers.
+char *cast_ptr(void *ptr) { return ptr; }
+*/
+import "C"
+
+func fetchError(errID C.int) error {
+	if errID >= C.__PATHRS_MAX_ERR_VALUE {
+		return nil
+	}
+	cErr := C.pathrs_errorinfo(errID)
+	defer C.pathrs_errorinfo_free(cErr)
+
+	var err error
+	if cErr != nil {
+		err = &Error{
+			errno:       syscall.Errno(cErr.saved_errno),
+			description: C.GoString(cErr.description),
+		}
+	}
+	return err
+}
+
+// OpenRoot wraps pathrs_open_root.
+func OpenRoot(path string) (uintptr, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	fd := C.pathrs_open_root(cPath)
+	return uintptr(fd), fetchError(fd)
+}
+
+// Reopen wraps pathrs_reopen.
+func Reopen(fd uintptr, flags int) (uintptr, error) {
+	newFd := C.pathrs_reopen(C.int(fd), C.int(flags))
+	return uintptr(newFd), fetchError(newFd)
+}
+
+// InRootResolve wraps pathrs_inroot_resolve.
+func InRootResolve(rootFd uintptr, path string) (uintptr, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	fd := C.pathrs_inroot_resolve(C.int(rootFd), cPath)
+	return uintptr(fd), fetchError(fd)
+}
+
+// InRootResolveNoFollow wraps pathrs_inroot_resolve_nofollow.
+func InRootResolveNoFollow(rootFd uintptr, path string) (uintptr, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	fd := C.pathrs_inroot_resolve_nofollow(C.int(rootFd), cPath)
+	return uintptr(fd), fetchError(fd)
+}
+
+// InRootOpen wraps pathrs_inroot_open.
+func InRootOpen(rootFd uintptr, path string, flags int) (uintptr, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	fd := C.pathrs_inroot_open(C.int(rootFd), cPath, C.int(flags))
+	return uintptr(fd), fetchError(fd)
+}
+
+// InRootReadlink wraps pathrs_inroot_readlink.
+func InRootReadlink(rootFd uintptr, path string) (string, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	size := 128
+	for {
+		linkBuf := make([]byte, size)
+		n := C.pathrs_inroot_readlink(C.int(rootFd), cPath, C.cast_ptr(unsafe.Pointer(&linkBuf[0])), C.ulong(len(linkBuf)))
+		switch {
+		case int(n) < C.__PATHRS_MAX_ERR_VALUE:
+			return "", fetchError(n)
+		case int(n) <= len(linkBuf):
+			return string(linkBuf[:int(n)]), nil
+		default:
+			// The contents were truncated. Unlike readlinkat, pathrs returns
+			// the size of the link when it checked. So use the returned size
+			// as a basis for the reallocated size (but in order to avoid a DoS
+			// where a magic-link is growing by a single byte each iteration,
+			// make sure we are a fair bit larger).
+			size += int(n)
+		}
+	}
+}
+
+// InRootRmdir wraps pathrs_inroot_rmdir.
+func InRootRmdir(rootFd uintptr, path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	err := C.pathrs_inroot_rmdir(C.int(rootFd), cPath)
+	return fetchError(err)
+}
+
+// InRootUnlink wraps pathrs_inroot_unlink.
+func InRootUnlink(rootFd uintptr, path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	err := C.pathrs_inroot_unlink(C.int(rootFd), cPath)
+	return fetchError(err)
+}
+
+// InRootRemoveAll wraps pathrs_inroot_remove_all.
+func InRootRemoveAll(rootFd uintptr, path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	err := C.pathrs_inroot_remove_all(C.int(rootFd), cPath)
+	return fetchError(err)
+}
+
+// InRootCreat wraps pathrs_inroot_creat.
+func InRootCreat(rootFd uintptr, path string, flags int, mode uint32) (uintptr, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	fd := C.pathrs_inroot_creat(C.int(rootFd), cPath, C.int(flags), C.uint(mode))
+	return uintptr(fd), fetchError(fd)
+}
+
+// InRootRename wraps pathrs_inroot_rename.
+func InRootRename(rootFd uintptr, src, dst string, flags uint) error {
+	cSrc := C.CString(src)
+	defer C.free(unsafe.Pointer(cSrc))
+
+	cDst := C.CString(dst)
+	defer C.free(unsafe.Pointer(cDst))
+
+	err := C.pathrs_inroot_rename(C.int(rootFd), cSrc, cDst, C.uint(flags))
+	return fetchError(err)
+}
+
+// InRootMkdir wraps pathrs_inroot_mkdir.
+func InRootMkdir(rootFd uintptr, path string, mode uint32) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	err := C.pathrs_inroot_mkdir(C.int(rootFd), cPath, C.uint(mode))
+	return fetchError(err)
+}
+
+// InRootMkdirAll wraps pathrs_inroot_mkdir_all.
+func InRootMkdirAll(rootFd uintptr, path string, mode uint32) (uintptr, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	fd := C.pathrs_inroot_mkdir_all(C.int(rootFd), cPath, C.uint(mode))
+	return uintptr(fd), fetchError(fd)
+}
+
+// InRootMknod wraps pathrs_inroot_mknod.
+func InRootMknod(rootFd uintptr, path string, mode uint32, dev uint64) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	err := C.pathrs_inroot_mknod(C.int(rootFd), cPath, C.uint(mode), C.dev_t(dev))
+	return fetchError(err)
+}
+
+// InRootSymlink wraps pathrs_inroot_symlink.
+func InRootSymlink(rootFd uintptr, path, target string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	cTarget := C.CString(target)
+	defer C.free(unsafe.Pointer(cTarget))
+
+	err := C.pathrs_inroot_symlink(C.int(rootFd), cPath, cTarget)
+	return fetchError(err)
+}
+
+// InRootHardlink wraps pathrs_inroot_hardlink.
+func InRootHardlink(rootFd uintptr, path, target string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	cTarget := C.CString(target)
+	defer C.free(unsafe.Pointer(cTarget))
+
+	err := C.pathrs_inroot_hardlink(C.int(rootFd), cPath, cTarget)
+	return fetchError(err)
+}
+
+// ProcBase is pathrs_proc_base_t (uint64_t).
+type ProcBase C.pathrs_proc_base_t
+
+// FIXME: We need to open-code the constants because CGo unfortunately will
+// implicitly convert any non-literal constants (i.e. those resolved using gcc)
+// to signed integers. See <https://github.com/golang/go/issues/39136> for some
+// more information on the underlying issue (though.
+const (
+	// ProcRoot is PATHRS_PROC_ROOT.
+	ProcRoot ProcBase = 0xFFFF_FFFE_7072_6F63 // C.PATHRS_PROC_ROOT
+	// ProcSelf is PATHRS_PROC_SELF.
+	ProcSelf ProcBase = 0xFFFF_FFFE_091D_5E1F // C.PATHRS_PROC_SELF
+	// ProcThreadSelf is PATHRS_PROC_THREAD_SELF.
+	ProcThreadSelf ProcBase = 0xFFFF_FFFE_3EAD_5E1F // C.PATHRS_PROC_THREAD_SELF
+
+	// ProcBaseTypeMask is __PATHRS_PROC_TYPE_MASK.
+	ProcBaseTypeMask ProcBase = 0xFFFF_FFFF_0000_0000 // C.__PATHRS_PROC_TYPE_MASK
+	// ProcBaseTypePid is __PATHRS_PROC_TYPE_PID.
+	ProcBaseTypePid ProcBase = 0x8000_0000_0000_0000 // C.__PATHRS_PROC_TYPE_PID
+
+	// ProcDefaultRootFd is PATHRS_PROC_DEFAULT_ROOTFD.
+	ProcDefaultRootFd = -int(syscall.EBADF) // C.PATHRS_PROC_DEFAULT_ROOTFD
+)
+
+func assertEqual[T comparable](a, b T, msg string) {
+	if a != b {
+		panic(fmt.Sprintf("%s ((%T) %#v != (%T) %#v)", msg, a, a, b, b))
+	}
+}
+
+// Verify that the values above match the actual C values. Unfortunately, Go
+// only allows us to forcefully cast int64 to uint64 if you use a temporary
+// variable, which means we cannot do it in a const context and thus need to do
+// it at runtime (even though it is a check that fundamentally could be done at
+// compile-time)...
+func init() {
+	var (
+		actualProcRoot       int64 = C.PATHRS_PROC_ROOT
+		actualProcSelf       int64 = C.PATHRS_PROC_SELF
+		actualProcThreadSelf int64 = C.PATHRS_PROC_THREAD_SELF
+	)
+
+	assertEqual(ProcRoot, ProcBase(actualProcRoot), "PATHRS_PROC_ROOT")
+	assertEqual(ProcSelf, ProcBase(actualProcSelf), "PATHRS_PROC_SELF")
+	assertEqual(ProcThreadSelf, ProcBase(actualProcThreadSelf), "PATHRS_PROC_THREAD_SELF")
+
+	var (
+		actualProcBaseTypeMask uint64 = C.__PATHRS_PROC_TYPE_MASK
+		actualProcBaseTypePid  uint64 = C.__PATHRS_PROC_TYPE_PID
+	)
+
+	assertEqual(ProcBaseTypeMask, ProcBase(actualProcBaseTypeMask), "__PATHRS_PROC_TYPE_MASK")
+	assertEqual(ProcBaseTypePid, ProcBase(actualProcBaseTypePid), "__PATHRS_PROC_TYPE_PID")
+
+	assertEqual(ProcDefaultRootFd, int(C.PATHRS_PROC_DEFAULT_ROOTFD), "PATHRS_PROC_DEFAULT_ROOTFD")
+}
+
+// ProcPid reimplements the PROC_PID(x) conversion.
+func ProcPid(pid uint32) ProcBase { return ProcBaseTypePid | ProcBase(pid) }
+
+// ProcOpenat wraps pathrs_proc_openat.
+func ProcOpenat(procRootFd int, base ProcBase, path string, flags int) (uintptr, error) {
+	cBase := C.pathrs_proc_base_t(base)
+
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	fd := C.pathrs_proc_openat(C.int(procRootFd), cBase, cPath, C.int(flags))
+	return uintptr(fd), fetchError(fd)
+}
+
+// ProcReadlinkat wraps pathrs_proc_readlinkat.
+func ProcReadlinkat(procRootFd int, base ProcBase, path string) (string, error) {
+	// TODO: See if we can unify this code with InRootReadlink.
+
+	cBase := C.pathrs_proc_base_t(base)
+
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	size := 128
+	for {
+		linkBuf := make([]byte, size)
+		n := C.pathrs_proc_readlinkat(
+			C.int(procRootFd), cBase, cPath,
+			C.cast_ptr(unsafe.Pointer(&linkBuf[0])), C.ulong(len(linkBuf)))
+		switch {
+		case int(n) < C.__PATHRS_MAX_ERR_VALUE:
+			return "", fetchError(n)
+		case int(n) <= len(linkBuf):
+			return string(linkBuf[:int(n)]), nil
+		default:
+			// The contents were truncated. Unlike readlinkat, pathrs returns
+			// the size of the link when it checked. So use the returned size
+			// as a basis for the reallocated size (but in order to avoid a DoS
+			// where a magic-link is growing by a single byte each iteration,
+			// make sure we are a fair bit larger).
+			size += int(n)
+		}
+	}
+}
+
+// ProcfsOpenHow is pathrs_procfs_open_how (struct).
+type ProcfsOpenHow C.pathrs_procfs_open_how
+
+const (
+	// ProcfsNewUnmasked is PATHRS_PROCFS_NEW_UNMASKED.
+	ProcfsNewUnmasked = C.PATHRS_PROCFS_NEW_UNMASKED
+)
+
+// Flags returns a pointer to the internal flags field to allow other packages
+// to modify structure fields that are internal due to Go's visibility model.
+func (how *ProcfsOpenHow) Flags() *C.uint64_t { return &how.flags }
+
+// ProcfsOpen is pathrs_procfs_open (sizeof(*how) is passed automatically).
+func ProcfsOpen(how *ProcfsOpenHow) (uintptr, error) {
+	fd := C.pathrs_procfs_open((*C.pathrs_procfs_open_how)(how), C.size_t(unsafe.Sizeof(*how)))
+	return uintptr(fd), fetchError(fd)
+}

--- a/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/procfs/procfs_linux.go
+++ b/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/procfs/procfs_linux.go
@@ -1,0 +1,246 @@
+//go:build linux
+
+// SPDX-License-Identifier: MPL-2.0
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2025 SUSE LLC
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// Package procfs provides a safe API for operating on /proc on Linux.
+package procfs
+
+import (
+	"os"
+	"runtime"
+
+	"cyphar.com/go-pathrs/internal/fdutils"
+	"cyphar.com/go-pathrs/internal/libpathrs"
+)
+
+// ProcBase is used with [ProcReadlink] and related functions to indicate what
+// /proc subpath path operations should be done relative to.
+type ProcBase struct {
+	inner libpathrs.ProcBase
+}
+
+var (
+	// ProcRoot indicates to use /proc. Note that this mode may be more
+	// expensive because we have to take steps to try to avoid leaking unmasked
+	// procfs handles, so you should use [ProcBaseSelf] if you can.
+	ProcRoot = ProcBase{inner: libpathrs.ProcRoot}
+	// ProcSelf indicates to use /proc/self. For most programs, this is the
+	// standard choice.
+	ProcSelf = ProcBase{inner: libpathrs.ProcSelf}
+	// ProcThreadSelf indicates to use /proc/thread-self. In multi-threaded
+	// programs where one thread has a different CLONE_FS, it is possible for
+	// /proc/self to point the wrong thread and so /proc/thread-self may be
+	// necessary.
+	ProcThreadSelf = ProcBase{inner: libpathrs.ProcThreadSelf}
+)
+
+// ProcPid returns a ProcBase which indicates to use /proc/$pid for the given
+// PID (or TID). Be aware that due to PID recycling, using this is generally
+// not safe except in certain circumstances. Namely:
+//
+//   - PID 1 (the init process), as that PID cannot ever get recycled.
+//   - Your current PID (though you should just use [ProcBaseSelf]).
+//   - Your current TID if you have used [runtime.LockOSThread] (though you
+//     should just use [ProcBaseThreadSelf]).
+//   - PIDs of child processes (as long as you are sure that no other part of
+//     your program incorrectly catches or ignores SIGCHLD, and that you do it
+//     *before* you call wait(2)or any equivalent method that could reap
+//     zombies).
+func ProcPid(pid int) ProcBase {
+	if pid < 0 || pid >= 1<<31 {
+		panic("invalid ProcBasePid value") // TODO: should this be an error?
+	}
+	return ProcBase{inner: libpathrs.ProcPid(uint32(pid))}
+}
+
+// ThreadCloser is a callback that needs to be called when you are done
+// operating on an [os.File] fetched using [Handle.OpenThreadSelf].
+//
+// [os.File]: https://pkg.go.dev/os#File
+type ThreadCloser func()
+
+// Handle is a wrapper around an *os.File handle to "/proc", which can be
+// used to do further procfs-related operations in a safe way.
+type Handle struct {
+	inner *os.File
+}
+
+// Close releases all internal resources for this [Handle].
+//
+// Note that if the handle is actually the global cached handle, this operation
+// is a no-op.
+func (proc *Handle) Close() error {
+	var err error
+	if proc.inner != nil {
+		err = proc.inner.Close()
+	}
+	return err
+}
+
+// OpenOption is a configuration function passed as an argument to [Open].
+type OpenOption func(*libpathrs.ProcfsOpenHow) error
+
+// UnmaskedProcRoot can be passed to [Open] to request an unmasked procfs
+// handle be created.
+//
+//	procfs, err := procfs.OpenRoot(procfs.UnmaskedProcRoot)
+func UnmaskedProcRoot(how *libpathrs.ProcfsOpenHow) error {
+	*how.Flags() |= libpathrs.ProcfsNewUnmasked
+	return nil
+}
+
+// Open creates a new [Handle] to a safe "/proc", based on the passed
+// configuration options (in the form of a series of [OpenOption]s).
+func Open(opts ...OpenOption) (*Handle, error) {
+	var how libpathrs.ProcfsOpenHow
+	for _, opt := range opts {
+		if err := opt(&how); err != nil {
+			return nil, err
+		}
+	}
+	fd, err := libpathrs.ProcfsOpen(&how)
+	if err != nil {
+		return nil, err
+	}
+	var procFile *os.File
+	if int(fd) >= 0 {
+		procFile = os.NewFile(fd, "/proc")
+	}
+	// TODO: Check that fd == PATHRS_PROC_DEFAULT_ROOTFD in the <0 case?
+	return &Handle{inner: procFile}, nil
+}
+
+// TODO: Switch to something fdutils.WithFileFd-like.
+func (proc *Handle) fd() int {
+	if proc.inner != nil {
+		return int(proc.inner.Fd())
+	}
+	return libpathrs.ProcDefaultRootFd
+}
+
+// TODO: Should we expose open?
+func (proc *Handle) open(base ProcBase, path string, flags int) (_ *os.File, Closer ThreadCloser, Err error) {
+	var closer ThreadCloser
+	if base == ProcThreadSelf {
+		runtime.LockOSThread()
+		closer = runtime.UnlockOSThread
+	}
+	defer func() {
+		if closer != nil && Err != nil {
+			closer()
+			Closer = nil
+		}
+	}()
+
+	fd, err := libpathrs.ProcOpenat(proc.fd(), base.inner, path, flags)
+	if err != nil {
+		return nil, nil, err
+	}
+	file, err := fdutils.MkFile(fd)
+	return file, closer, err
+}
+
+// OpenRoot safely opens a given path from inside /proc/.
+//
+// This function must only be used for accessing global information from procfs
+// (such as /proc/cpuinfo) or information about other processes (such as
+// /proc/1). Accessing your own process information should be done using
+// [Handle.OpenSelf] or [Handle.OpenThreadSelf].
+func (proc *Handle) OpenRoot(path string, flags int) (*os.File, error) {
+	file, closer, err := proc.open(ProcRoot, path, flags)
+	if closer != nil {
+		// should not happen
+		panic("non-zero closer returned from procOpen(ProcRoot)")
+	}
+	return file, err
+}
+
+// OpenSelf safely opens a given path from inside /proc/self/.
+//
+// This method is recommend for getting process information about the current
+// process for almost all Go processes *except* for cases where there are
+// [runtime.LockOSThread] threads that have changed some aspect of their state
+// (such as through unshare(CLONE_FS) or changing namespaces).
+//
+// For such non-heterogeneous processes, /proc/self may reference to a task
+// that has different state from the current goroutine and so it may be
+// preferable to use [Handle.OpenThreadSelf]. The same is true if a user
+// really wants to inspect the current OS thread's information (such as
+// /proc/thread-self/stack or /proc/thread-self/status which is always uniquely
+// per-thread).
+//
+// Unlike [Handle.OpenThreadSelf], this method does not involve locking
+// the goroutine to the current OS thread and so is simpler to use and
+// theoretically has slightly less overhead.
+//
+// [runtime.LockOSThread]: https://pkg.go.dev/runtime#LockOSThread
+func (proc *Handle) OpenSelf(path string, flags int) (*os.File, error) {
+	file, closer, err := proc.open(ProcSelf, path, flags)
+	if closer != nil {
+		// should not happen
+		panic("non-zero closer returned from procOpen(ProcSelf)")
+	}
+	return file, err
+}
+
+// OpenPid safely opens a given path from inside /proc/$pid/, where pid can be
+// either a PID or TID.
+//
+// This is effectively equivalent to calling [Handle.OpenRoot] with the
+// pid prefixed to the subpath.
+//
+// Be aware that due to PID recycling, using this is generally not safe except
+// in certain circumstances. See the documentation of [ProcPid] for more
+// details.
+func (proc *Handle) OpenPid(pid int, path string, flags int) (*os.File, error) {
+	file, closer, err := proc.open(ProcPid(pid), path, flags)
+	if closer != nil {
+		// should not happen
+		panic("non-zero closer returned from procOpen(ProcPidOpen)")
+	}
+	return file, err
+}
+
+// OpenThreadSelf safely opens a given path from inside /proc/thread-self/.
+//
+// Most Go processes have heterogeneous threads (all threads have most of the
+// same kernel state such as CLONE_FS) and so [Handle.OpenSelf] is
+// preferable for most users.
+//
+// For non-heterogeneous threads, or users that actually want thread-specific
+// information (such as /proc/thread-self/stack or /proc/thread-self/status),
+// this method is necessary.
+//
+// Because Go can change the running OS thread of your goroutine without notice
+// (and then subsequently kill the old thread), this method will lock the
+// current goroutine to the OS thread (with [runtime.LockOSThread]) and the
+// caller is responsible for unlocking the the OS thread with the
+// [ThreadCloser] callback once they are done using the returned file. This
+// callback MUST be called AFTER you have finished using the returned
+// [os.File]. This callback is completely separate to [os.File.Close], so it
+// must be called regardless of how you close the handle.
+//
+// [runtime.LockOSThread]: https://pkg.go.dev/runtime#LockOSThread
+// [os.File]: https://pkg.go.dev/os#File
+// [os.File.Close]: https://pkg.go.dev/os#File.Close
+func (proc *Handle) OpenThreadSelf(path string, flags int) (*os.File, ThreadCloser, error) {
+	return proc.open(ProcThreadSelf, path, flags)
+}
+
+// Readlink safely reads the contents of a symlink from the given procfs base.
+//
+// This is effectively equivalent to doing an Open*(O_PATH|O_NOFOLLOW) of the
+// path and then doing unix.Readlinkat(fd, ""), but with the benefit that
+// thread locking is not necessary for [ProcThreadSelf].
+func (proc *Handle) Readlink(base ProcBase, path string) (string, error) {
+	return libpathrs.ProcReadlinkat(proc.fd(), base.inner, path)
+}

--- a/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/root_linux.go
+++ b/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/root_linux.go
@@ -1,0 +1,367 @@
+//go:build linux
+
+// SPDX-License-Identifier: MPL-2.0
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2025 SUSE LLC
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package pathrs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+
+	"cyphar.com/go-pathrs/internal/fdutils"
+	"cyphar.com/go-pathrs/internal/libpathrs"
+)
+
+// Root is a handle to the root of a directory tree to resolve within. The only
+// purpose of this "root handle" is to perform operations within the directory
+// tree, or to get a [Handle] to inodes within the directory tree.
+//
+// At time of writing, it is considered a *VERY BAD IDEA* to open a [Root]
+// inside a possibly-attacker-controlled directory tree. While we do have
+// protections that should defend against it, it's far more dangerous than just
+// opening a directory tree which is not inside a potentially-untrusted
+// directory.
+type Root struct {
+	inner *os.File
+}
+
+// OpenRoot creates a new [Root] handle to the directory at the given path.
+func OpenRoot(path string) (*Root, error) {
+	fd, err := libpathrs.OpenRoot(path)
+	if err != nil {
+		return nil, err
+	}
+	file, err := fdutils.MkFile(fd)
+	if err != nil {
+		return nil, err
+	}
+	return &Root{inner: file}, nil
+}
+
+// RootFromFile creates a new [Root] handle from an [os.File] referencing a
+// directory. The provided file will be duplicated, so the original file should
+// still be closed by the caller.
+//
+// This is effectively the inverse operation of [Root.IntoFile].
+//
+// [os.File]: https://pkg.go.dev/os#File
+func RootFromFile(file *os.File) (*Root, error) {
+	newFile, err := fdutils.DupFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("duplicate root fd: %w", err)
+	}
+	return &Root{inner: newFile}, nil
+}
+
+// Resolve resolves the given path within the [Root]'s directory tree, and
+// returns a [Handle] to the resolved path. The path must already exist,
+// otherwise an error will occur.
+//
+// All symlinks (including trailing symlinks) are followed, but they are
+// resolved within the rootfs. If you wish to open a handle to the symlink
+// itself, use [ResolveNoFollow].
+func (r *Root) Resolve(path string) (*Handle, error) {
+	return fdutils.WithFileFd(r.inner, func(rootFd uintptr) (*Handle, error) {
+		handleFd, err := libpathrs.InRootResolve(rootFd, path)
+		if err != nil {
+			return nil, err
+		}
+		handleFile, err := fdutils.MkFile(handleFd)
+		if err != nil {
+			return nil, err
+		}
+		return &Handle{inner: handleFile}, nil
+	})
+}
+
+// ResolveNoFollow is effectively an O_NOFOLLOW version of [Resolve]. Their
+// behaviour is identical, except that *trailing* symlinks will not be
+// followed. If the final component is a trailing symlink, an O_PATH|O_NOFOLLOW
+// handle to the symlink itself is returned.
+func (r *Root) ResolveNoFollow(path string) (*Handle, error) {
+	return fdutils.WithFileFd(r.inner, func(rootFd uintptr) (*Handle, error) {
+		handleFd, err := libpathrs.InRootResolveNoFollow(rootFd, path)
+		if err != nil {
+			return nil, err
+		}
+		handleFile, err := fdutils.MkFile(handleFd)
+		if err != nil {
+			return nil, err
+		}
+		return &Handle{inner: handleFile}, nil
+	})
+}
+
+// Open is effectively shorthand for [Resolve] followed by [Handle.Open], but
+// can be slightly more efficient (it reduces CGo overhead and the number of
+// syscalls used when using the openat2-based resolver) and is arguably more
+// ergonomic to use.
+//
+// This is effectively equivalent to [os.Open].
+//
+// [os.Open]: https://pkg.go.dev/os#Open
+func (r *Root) Open(path string) (*os.File, error) {
+	return r.OpenFile(path, os.O_RDONLY)
+}
+
+// OpenFile is effectively shorthand for [Resolve] followed by
+// [Handle.OpenFile], but can be slightly more efficient (it reduces CGo
+// overhead and the number of syscalls used when using the openat2-based
+// resolver) and is arguably more ergonomic to use.
+//
+// However, if flags contains os.O_NOFOLLOW and the path is a symlink, then
+// OpenFile's behaviour will match that of openat2. In most cases an error will
+// be returned, but if os.O_PATH is provided along with os.O_NOFOLLOW then a
+// file equivalent to [ResolveNoFollow] will be returned instead.
+//
+// This is effectively equivalent to [os.OpenFile], except that os.O_CREAT is
+// not supported.
+//
+// [os.OpenFile]: https://pkg.go.dev/os#OpenFile
+func (r *Root) OpenFile(path string, flags int) (*os.File, error) {
+	return fdutils.WithFileFd(r.inner, func(rootFd uintptr) (*os.File, error) {
+		fd, err := libpathrs.InRootOpen(rootFd, path, flags)
+		if err != nil {
+			return nil, err
+		}
+		return fdutils.MkFile(fd)
+	})
+}
+
+// Create creates a file within the [Root]'s directory tree at the given path,
+// and returns a handle to the file. The provided mode is used for the new file
+// (the process's umask applies).
+//
+// Unlike [os.Create], if the file already exists an error is created rather
+// than the file being opened and truncated.
+//
+// [os.Create]: https://pkg.go.dev/os#Create
+func (r *Root) Create(path string, flags int, mode os.FileMode) (*os.File, error) {
+	unixMode, err := toUnixMode(mode, false)
+	if err != nil {
+		return nil, err
+	}
+	return fdutils.WithFileFd(r.inner, func(rootFd uintptr) (*os.File, error) {
+		handleFd, err := libpathrs.InRootCreat(rootFd, path, flags, unixMode)
+		if err != nil {
+			return nil, err
+		}
+		return fdutils.MkFile(handleFd)
+	})
+}
+
+// Rename two paths within a [Root]'s directory tree. The flags argument is
+// identical to the RENAME_* flags to the renameat2(2) system call.
+func (r *Root) Rename(src, dst string, flags uint) error {
+	_, err := fdutils.WithFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
+		err := libpathrs.InRootRename(rootFd, src, dst, flags)
+		return struct{}{}, err
+	})
+	return err
+}
+
+// RemoveDir removes the named empty directory within a [Root]'s directory
+// tree.
+func (r *Root) RemoveDir(path string) error {
+	_, err := fdutils.WithFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
+		err := libpathrs.InRootRmdir(rootFd, path)
+		return struct{}{}, err
+	})
+	return err
+}
+
+// RemoveFile removes the named file within a [Root]'s directory tree.
+func (r *Root) RemoveFile(path string) error {
+	_, err := fdutils.WithFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
+		err := libpathrs.InRootUnlink(rootFd, path)
+		return struct{}{}, err
+	})
+	return err
+}
+
+// Remove removes the named file or (empty) directory within a [Root]'s
+// directory tree.
+//
+// This is effectively equivalent to [os.Remove].
+//
+// [os.Remove]: https://pkg.go.dev/os#Remove
+func (r *Root) Remove(path string) error {
+	// In order to match os.Remove's implementation we need to also do both
+	// syscalls unconditionally and adjust the error based on whether
+	// pathrs_inroot_rmdir() returned ENOTDIR.
+	unlinkErr := r.RemoveFile(path)
+	if unlinkErr == nil {
+		return nil
+	}
+	rmdirErr := r.RemoveDir(path)
+	if rmdirErr == nil {
+		return nil
+	}
+	// Both failed, adjust the error in the same way that os.Remove does.
+	err := rmdirErr
+	if errors.Is(err, syscall.ENOTDIR) {
+		err = unlinkErr
+	}
+	return err
+}
+
+// RemoveAll recursively deletes a path and all of its children.
+//
+// This is effectively equivalent to [os.RemoveAll].
+//
+// [os.RemoveAll]: https://pkg.go.dev/os#RemoveAll
+func (r *Root) RemoveAll(path string) error {
+	_, err := fdutils.WithFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
+		err := libpathrs.InRootRemoveAll(rootFd, path)
+		return struct{}{}, err
+	})
+	return err
+}
+
+// Mkdir creates a directory within a [Root]'s directory tree. The provided
+// mode is used for the new directory (the process's umask applies).
+//
+// This is effectively equivalent to [os.Mkdir].
+//
+// [os.Mkdir]: https://pkg.go.dev/os#Mkdir
+func (r *Root) Mkdir(path string, mode os.FileMode) error {
+	unixMode, err := toUnixMode(mode, false)
+	if err != nil {
+		return err
+	}
+
+	_, err = fdutils.WithFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
+		err := libpathrs.InRootMkdir(rootFd, path, unixMode)
+		return struct{}{}, err
+	})
+	return err
+}
+
+// MkdirAll creates a directory (and any parent path components if they don't
+// exist) within a [Root]'s directory tree. The provided mode is used for any
+// directories created by this function (the process's umask applies).
+//
+// This is effectively equivalent to [os.MkdirAll].
+//
+// [os.MkdirAll]: https://pkg.go.dev/os#MkdirAll
+func (r *Root) MkdirAll(path string, mode os.FileMode) (*Handle, error) {
+	unixMode, err := toUnixMode(mode, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return fdutils.WithFileFd(r.inner, func(rootFd uintptr) (*Handle, error) {
+		handleFd, err := libpathrs.InRootMkdirAll(rootFd, path, unixMode)
+		if err != nil {
+			return nil, err
+		}
+		handleFile, err := fdutils.MkFile(handleFd)
+		if err != nil {
+			return nil, err
+		}
+		return &Handle{inner: handleFile}, err
+	})
+}
+
+// Mknod creates a new device inode of the given type within a [Root]'s
+// directory tree. The provided mode is used for the new directory (the
+// process's umask applies).
+//
+// This is effectively equivalent to [unix.Mknod].
+//
+// [unix.Mknod]: https://pkg.go.dev/golang.org/x/sys/unix#Mknod
+func (r *Root) Mknod(path string, mode os.FileMode, dev uint64) error {
+	unixMode, err := toUnixMode(mode, true)
+	if err != nil {
+		return err
+	}
+
+	_, err = fdutils.WithFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
+		err := libpathrs.InRootMknod(rootFd, path, unixMode, dev)
+		return struct{}{}, err
+	})
+	return err
+}
+
+// Symlink creates a symlink within a [Root]'s directory tree. The symlink is
+// created at path and is a link to target.
+//
+// This is effectively equivalent to [os.Symlink].
+//
+// [os.Symlink]: https://pkg.go.dev/os#Symlink
+func (r *Root) Symlink(path, target string) error {
+	_, err := fdutils.WithFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
+		err := libpathrs.InRootSymlink(rootFd, path, target)
+		return struct{}{}, err
+	})
+	return err
+}
+
+// Hardlink creates a hardlink within a [Root]'s directory tree. The hardlink
+// is created at path and is a link to target. Both paths are within the
+// [Root]'s directory tree (you cannot hardlink to a different [Root] or the
+// host).
+//
+// This is effectively equivalent to [os.Link].
+//
+// [os.Link]: https://pkg.go.dev/os#Link
+func (r *Root) Hardlink(path, target string) error {
+	_, err := fdutils.WithFileFd(r.inner, func(rootFd uintptr) (struct{}, error) {
+		err := libpathrs.InRootHardlink(rootFd, path, target)
+		return struct{}{}, err
+	})
+	return err
+}
+
+// Readlink returns the target of a symlink with a [Root]'s directory tree.
+//
+// This is effectively equivalent to [os.Readlink].
+//
+// [os.Readlink]: https://pkg.go.dev/os#Readlink
+func (r *Root) Readlink(path string) (string, error) {
+	return fdutils.WithFileFd(r.inner, func(rootFd uintptr) (string, error) {
+		return libpathrs.InRootReadlink(rootFd, path)
+	})
+}
+
+// IntoFile unwraps the [Root] into its underlying [os.File].
+//
+// It is critical that you do not operate on this file descriptor yourself,
+// because the security properties of libpathrs depend on users doing all
+// relevant filesystem operations through libpathrs.
+//
+// This operation returns the internal [os.File] of the [Root] directly, so
+// calling [Root.Close] will also close any copies of the returned [os.File].
+// If you want to get an independent copy, use [Root.Clone] followed by
+// [Root.IntoFile] on the cloned [Root].
+//
+// [os.File]: https://pkg.go.dev/os#File
+func (r *Root) IntoFile() *os.File {
+	// TODO: Figure out if we really don't want to make a copy.
+	// TODO: We almost certainly want to clear r.inner here, but we can't do
+	//       that easily atomically (we could use atomic.Value but that'll make
+	//       things quite a bit uglier).
+	return r.inner
+}
+
+// Clone creates a copy of a [Root] handle, such that it has a separate
+// lifetime to the original (while referring to the same underlying directory).
+func (r *Root) Clone() (*Root, error) {
+	return RootFromFile(r.inner)
+}
+
+// Close frees all of the resources used by the [Root] handle.
+func (r *Root) Close() error {
+	return r.inner.Close()
+}

--- a/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/utils_linux.go
+++ b/pkg/wwan/mmagent/vendor/cyphar.com/go-pathrs/utils_linux.go
@@ -1,0 +1,56 @@
+//go:build linux
+
+// SPDX-License-Identifier: MPL-2.0
+/*
+ * libpathrs: safe path resolution on Linux
+ * Copyright (C) 2019-2025 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019-2025 SUSE LLC
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package pathrs
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+//nolint:cyclop // this function needs to handle a lot of cases
+func toUnixMode(mode os.FileMode, needsType bool) (uint32, error) {
+	sysMode := uint32(mode.Perm())
+	switch mode & os.ModeType { //nolint:exhaustive // we only care about ModeType bits
+	case 0:
+		if needsType {
+			sysMode |= unix.S_IFREG
+		}
+	case os.ModeDir:
+		sysMode |= unix.S_IFDIR
+	case os.ModeSymlink:
+		sysMode |= unix.S_IFLNK
+	case os.ModeCharDevice | os.ModeDevice:
+		sysMode |= unix.S_IFCHR
+	case os.ModeDevice:
+		sysMode |= unix.S_IFBLK
+	case os.ModeNamedPipe:
+		sysMode |= unix.S_IFIFO
+	case os.ModeSocket:
+		sysMode |= unix.S_IFSOCK
+	default:
+		return 0, fmt.Errorf("invalid mode filetype %+o", mode)
+	}
+	if mode&os.ModeSetuid != 0 {
+		sysMode |= unix.S_ISUID
+	}
+	if mode&os.ModeSetgid != 0 {
+		sysMode |= unix.S_ISGID
+	}
+	if mode&os.ModeSticky != 0 {
+		sysMode |= unix.S_ISVTX
+	}
+	return sysMode, nil
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/COPYING.md
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/COPYING.md
@@ -1,0 +1,447 @@
+## COPYING ##
+
+`SPDX-License-Identifier: BSD-3-Clause AND MPL-2.0`
+
+This project is made up of code licensed under different licenses. Which code
+you use will have an impact on whether only one or both licenses apply to your
+usage of this library.
+
+Note that **each file** in this project individually has a code comment at the
+start describing the license of that particular file -- this is the most
+accurate license information of this project; in case there is any conflict
+between this document and the comment at the start of a file, the comment shall
+take precedence. The only purpose of this document is to work around [a known
+technical limitation of pkg.go.dev's license checking tool when dealing with
+non-trivial project licenses][go75067].
+
+[go75067]: https://go.dev/issue/75067
+
+### `BSD-3-Clause` ###
+
+At time of writing, the following files and directories are licensed under the
+BSD-3-Clause license:
+
+ * `doc.go`
+ * `join*.go`
+ * `vfs.go`
+ * `internal/consts/*.go`
+ * `pathrs-lite/internal/gocompat/*.go`
+ * `pathrs-lite/internal/kernelversion/*.go`
+
+The text of the BSD-3-Clause license used by this project is the following (the
+text is also available from the [`LICENSE.BSD`](./LICENSE.BSD) file):
+
+```
+Copyright (C) 2014-2015 Docker Inc & Go Authors. All rights reserved.
+Copyright (C) 2017-2024 SUSE LLC. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+### `MPL-2.0` ###
+
+All other files (unless otherwise marked) are licensed under the Mozilla Public
+License (version 2.0).
+
+The text of the Mozilla Public License (version 2.0) is the following (the text
+is also available from the [`LICENSE.MPL-2.0`](./LICENSE.MPL-2.0) file):
+
+```
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.
+```

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/LICENSE.BSD
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/LICENSE.BSD
@@ -1,0 +1,28 @@
+Copyright (C) 2014-2015 Docker Inc & Go Authors. All rights reserved.
+Copyright (C) 2017-2024 SUSE LLC. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/LICENSE.MPL-2.0
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/LICENSE.MPL-2.0
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/internal/consts/consts.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/internal/consts/consts.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Copyright (C) 2014-2015 Docker Inc & Go Authors. All rights reserved.
+// Copyright (C) 2017-2025 SUSE LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package consts contains the definitions of internal constants used
+// throughout filepath-securejoin.
+package consts
+
+// MaxSymlinkLimit is the maximum number of symlinks that can be encountered
+// during a single lookup before returning -ELOOP. At time of writing, Linux
+// has an internal limit of 40.
+const MaxSymlinkLimit = 255

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/README.md
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/README.md
@@ -1,0 +1,35 @@
+## `pathrs-lite` ##
+
+`github.com/cyphar/filepath-securejoin/pathrs-lite` provides a minimal **pure
+Go** implementation of the core bits of [libpathrs][]. This is not intended to
+be a complete replacement for libpathrs, instead it is mainly intended to be
+useful as a transition tool for existing Go projects.
+
+`pathrs-lite` also provides a very easy way to switch to `libpathrs` (even for
+downstreams where `pathrs-lite` is being used in a third-party package and is
+not interested in using CGo). At build time, if you use the `libpathrs` build
+tag then `pathrs-lite` will use `libpathrs` directly instead of the pure Go
+implementation. The two backends are functionally equivalent (and we have
+integration tests to verify this), so this migration should be very easy with
+no user-visible impact.
+
+[libpathrs]: https://github.com/cyphar/libpathrs
+
+### License ###
+
+Most of this subpackage is licensed under the Mozilla Public License (version
+2.0). For more information, see the top-level [COPYING.md][] and
+[LICENSE.MPL-2.0][] files, as well as the individual license headers for each
+file.
+
+```
+Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+Copyright (C) 2024-2025 SUSE LLC
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+```
+
+[COPYING.md]: ../COPYING.md
+[LICENSE.MPL-2.0]: ../LICENSE.MPL-2.0

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/doc.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/doc.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Package pathrs (pathrs-lite) is a less complete pure Go implementation of
+// some of the APIs provided by [libpathrs].
+//
+// [libpathrs]: https://github.com/cyphar/libpathrs
+package pathrs

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/assert/assert.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/assert/assert.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Copyright (C) 2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Package assert provides some basic assertion helpers for Go.
+package assert
+
+import (
+	"fmt"
+)
+
+// Assert panics if the predicate is false with the provided argument.
+func Assert(predicate bool, msg any) {
+	if !predicate {
+		panic(msg)
+	}
+}
+
+// Assertf panics if the predicate is false and formats the message using the
+// same formatting as [fmt.Printf].
+//
+// [fmt.Printf]: https://pkg.go.dev/fmt#Printf
+func Assertf(predicate bool, fmtMsg string, args ...any) {
+	Assert(predicate, fmt.Sprintf(fmtMsg, args...))
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/errors_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/errors_linux.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Package internal contains unexported common code for filepath-securejoin.
+package internal
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+type xdevErrorish struct {
+	description string
+}
+
+func (err xdevErrorish) Error() string        { return err.description }
+func (err xdevErrorish) Is(target error) bool { return target == unix.EXDEV }
+
+var (
+	// ErrPossibleAttack indicates that some attack was detected.
+	ErrPossibleAttack error = xdevErrorish{"possible attack detected"}
+
+	// ErrPossibleBreakout indicates that during an operation we ended up in a
+	// state that could be a breakout but we detected it.
+	ErrPossibleBreakout error = xdevErrorish{"possible breakout detected"}
+
+	// ErrInvalidDirectory indicates an unlinked directory.
+	ErrInvalidDirectory = errors.New("wandered into deleted directory")
+
+	// ErrDeletedInode indicates an unlinked file (non-directory).
+	ErrDeletedInode = errors.New("cannot verify path of deleted inode")
+)

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd/at_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd/at_linux.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package fd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat"
+)
+
+// prepareAtWith returns -EBADF (an invalid fd) if dir is nil, otherwise using
+// the dir.Fd(). We use -EBADF because in filepath-securejoin we generally
+// don't want to allow relative-to-cwd paths. The returned path is an
+// *informational* string that describes a reasonable pathname for the given
+// *at(2) arguments. You must not use the full path for any actual filesystem
+// operations.
+func prepareAt(dir Fd, path string) (dirFd int, unsafeUnmaskedPath string) {
+	dirFd, dirPath := -int(unix.EBADF), "."
+	if dir != nil {
+		dirFd, dirPath = int(dir.Fd()), dir.Name()
+	}
+	if !filepath.IsAbs(path) {
+		// only prepend the dirfd path for relative paths
+		path = dirPath + "/" + path
+	}
+	// NOTE: If path is "." or "", the returned path won't be filepath.Clean,
+	// but that's okay since this path is either used for errors (in which case
+	// a trailing "/" or "/." is important information) or will be
+	// filepath.Clean'd later (in the case of fd.Openat).
+	return dirFd, path
+}
+
+// Openat is an [Fd]-based wrapper around unix.Openat.
+func Openat(dir Fd, path string, flags int, mode int) (*os.File, error) { //nolint:unparam // wrapper func
+	dirFd, fullPath := prepareAt(dir, path)
+	// Make sure we always set O_CLOEXEC.
+	flags |= unix.O_CLOEXEC
+	fd, err := unix.Openat(dirFd, path, flags, uint32(mode))
+	if err != nil {
+		return nil, &os.PathError{Op: "openat", Path: fullPath, Err: err}
+	}
+	runtime.KeepAlive(dir)
+	// openat is only used with lexically-safe paths so we can use
+	// filepath.Clean here, and also the path itself is not going to be used
+	// for actual path operations.
+	fullPath = filepath.Clean(fullPath)
+	return os.NewFile(uintptr(fd), fullPath), nil
+}
+
+// Fstatat is an [Fd]-based wrapper around unix.Fstatat.
+func Fstatat(dir Fd, path string, flags int) (unix.Stat_t, error) {
+	dirFd, fullPath := prepareAt(dir, path)
+	var stat unix.Stat_t
+	if err := unix.Fstatat(dirFd, path, &stat, flags); err != nil {
+		return stat, &os.PathError{Op: "fstatat", Path: fullPath, Err: err}
+	}
+	runtime.KeepAlive(dir)
+	return stat, nil
+}
+
+// Faccessat is an [Fd]-based wrapper around unix.Faccessat.
+func Faccessat(dir Fd, path string, mode uint32, flags int) error {
+	dirFd, fullPath := prepareAt(dir, path)
+	err := unix.Faccessat(dirFd, path, mode, flags)
+	if err != nil {
+		err = &os.PathError{Op: "faccessat", Path: fullPath, Err: err}
+	}
+	runtime.KeepAlive(dir)
+	return err
+}
+
+// Readlinkat is an [Fd]-based wrapper around unix.Readlinkat.
+func Readlinkat(dir Fd, path string) (string, error) {
+	dirFd, fullPath := prepareAt(dir, path)
+	size := 4096
+	for {
+		linkBuf := make([]byte, size)
+		n, err := unix.Readlinkat(dirFd, path, linkBuf)
+		if err != nil {
+			return "", &os.PathError{Op: "readlinkat", Path: fullPath, Err: err}
+		}
+		runtime.KeepAlive(dir)
+		if n != size {
+			return string(linkBuf[:n]), nil
+		}
+		// Possible truncation, resize the buffer.
+		size *= 2
+	}
+}
+
+const (
+	// STATX_MNT_ID_UNIQUE is provided in golang.org/x/sys@v0.20.0, but in order to
+	// avoid bumping the requirement for a single constant we can just define it
+	// ourselves.
+	_STATX_MNT_ID_UNIQUE = 0x4000 //nolint:revive // unix.* name
+
+	// We don't care which mount ID we get. The kernel will give us the unique
+	// one if it is supported. If the kernel doesn't support
+	// STATX_MNT_ID_UNIQUE, the bit is ignored and the returned request mask
+	// will only contain STATX_MNT_ID (if supported).
+	wantStatxMntMask = _STATX_MNT_ID_UNIQUE | unix.STATX_MNT_ID
+)
+
+var hasStatxMountID = gocompat.SyncOnceValue(func() bool {
+	var stx unix.Statx_t
+	err := unix.Statx(-int(unix.EBADF), "/", 0, wantStatxMntMask, &stx)
+	return err == nil && stx.Mask&wantStatxMntMask != 0
+})
+
+// GetMountID gets the mount identifier associated with the fd and path
+// combination. It is effectively a wrapper around fetching
+// STATX_MNT_ID{,_UNIQUE} with unix.Statx, but with a fallback to 0 if the
+// kernel doesn't support the feature.
+func GetMountID(dir Fd, path string) (uint64, error) {
+	// If we don't have statx(STATX_MNT_ID*) support, we can't do anything.
+	if !hasStatxMountID() {
+		return 0, nil
+	}
+
+	dirFd, fullPath := prepareAt(dir, path)
+
+	var stx unix.Statx_t
+	err := unix.Statx(dirFd, path, unix.AT_EMPTY_PATH|unix.AT_SYMLINK_NOFOLLOW, wantStatxMntMask, &stx)
+	if stx.Mask&wantStatxMntMask == 0 {
+		// It's not a kernel limitation, for some reason we couldn't get a
+		// mount ID. Assume it's some kind of attack.
+		err = fmt.Errorf("could not get mount id: %w", err)
+	}
+	if err != nil {
+		return 0, &os.PathError{Op: "statx(STATX_MNT_ID_...)", Path: fullPath, Err: err}
+	}
+	runtime.KeepAlive(dir)
+	return stx.Mnt_id, nil
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd/fd.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd/fd.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Copyright (C) 2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Package fd provides a drop-in interface-based replacement of [*os.File] that
+// allows for things like noop-Close wrappers to be used.
+//
+// [*os.File]: https://pkg.go.dev/os#File
+package fd
+
+import (
+	"io"
+	"os"
+)
+
+// Fd is an interface that mirrors most of the API of [*os.File], allowing you
+// to create wrappers that can be used in place of [*os.File].
+//
+// [*os.File]: https://pkg.go.dev/os#File
+type Fd interface {
+	io.Closer
+	Name() string
+	Fd() uintptr
+}
+
+// Compile-time interface checks.
+var (
+	_ Fd = (*os.File)(nil)
+	_ Fd = noClose{}
+)
+
+type noClose struct{ inner Fd }
+
+func (f noClose) Name() string { return f.inner.Name() }
+func (f noClose) Fd() uintptr  { return f.inner.Fd() }
+
+func (f noClose) Close() error { return nil }
+
+// NopCloser returns an [*os.File]-like object where the [Close] method is now
+// a no-op.
+//
+// Note that for [*os.File] and similar objects, the Go garbage collector will
+// still call [Close] on the underlying file unless you use
+// [runtime.SetFinalizer] to disable this behaviour. This is up to the caller
+// to do (if necessary).
+//
+// [*os.File]: https://pkg.go.dev/os#File
+// [Close]: https://pkg.go.dev/io#Closer
+// [runtime.SetFinalizer]: https://pkg.go.dev/runtime#SetFinalizer
+func NopCloser(f Fd) Fd { return noClose{inner: f} }

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd/fd_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd/fd_linux.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package fd
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal"
+)
+
+// DupWithName creates a new file descriptor referencing the same underlying
+// file, but with the provided name instead of fd.Name().
+func DupWithName(fd Fd, name string) (*os.File, error) {
+	fd2, err := unix.FcntlInt(fd.Fd(), unix.F_DUPFD_CLOEXEC, 0)
+	if err != nil {
+		return nil, os.NewSyscallError("fcntl(F_DUPFD_CLOEXEC)", err)
+	}
+	runtime.KeepAlive(fd)
+	return os.NewFile(uintptr(fd2), name), nil
+}
+
+// Dup creates a new file description referencing the same underlying file.
+func Dup(fd Fd) (*os.File, error) {
+	return DupWithName(fd, fd.Name())
+}
+
+// Fstat is an [Fd]-based wrapper around unix.Fstat.
+func Fstat(fd Fd) (unix.Stat_t, error) {
+	var stat unix.Stat_t
+	if err := unix.Fstat(int(fd.Fd()), &stat); err != nil {
+		return stat, &os.PathError{Op: "fstat", Path: fd.Name(), Err: err}
+	}
+	runtime.KeepAlive(fd)
+	return stat, nil
+}
+
+// Fstatfs is an [Fd]-based wrapper around unix.Fstatfs.
+func Fstatfs(fd Fd) (unix.Statfs_t, error) {
+	var statfs unix.Statfs_t
+	if err := unix.Fstatfs(int(fd.Fd()), &statfs); err != nil {
+		return statfs, &os.PathError{Op: "fstatfs", Path: fd.Name(), Err: err}
+	}
+	runtime.KeepAlive(fd)
+	return statfs, nil
+}
+
+// IsDeadInode detects whether the file has been unlinked from a filesystem and
+// is thus a "dead inode" from the kernel's perspective.
+func IsDeadInode(file Fd) error {
+	// If the nlink of a file drops to 0, there is an attacker deleting
+	// directories during our walk, which could result in weird /proc values.
+	// It's better to error out in this case.
+	stat, err := Fstat(file)
+	if err != nil {
+		return fmt.Errorf("check for dead inode: %w", err)
+	}
+	if stat.Nlink == 0 {
+		err := internal.ErrDeletedInode
+		if stat.Mode&unix.S_IFMT == unix.S_IFDIR {
+			err = internal.ErrInvalidDirectory
+		}
+		return fmt.Errorf("%w %q", err, file.Name())
+	}
+	return nil
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd/mount_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd/mount_linux.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package fd
+
+import (
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+// Fsopen is an [Fd]-based wrapper around unix.Fsopen.
+func Fsopen(fsName string, flags int) (*os.File, error) {
+	// Make sure we always set O_CLOEXEC.
+	flags |= unix.FSOPEN_CLOEXEC
+	fd, err := unix.Fsopen(fsName, flags)
+	if err != nil {
+		return nil, os.NewSyscallError("fsopen "+fsName, err)
+	}
+	return os.NewFile(uintptr(fd), "fscontext:"+fsName), nil
+}
+
+// Fsmount is an [Fd]-based wrapper around unix.Fsmount.
+func Fsmount(ctx Fd, flags, mountAttrs int) (*os.File, error) {
+	// Make sure we always set O_CLOEXEC.
+	flags |= unix.FSMOUNT_CLOEXEC
+	fd, err := unix.Fsmount(int(ctx.Fd()), flags, mountAttrs)
+	if err != nil {
+		return nil, os.NewSyscallError("fsmount "+ctx.Name(), err)
+	}
+	return os.NewFile(uintptr(fd), "fsmount:"+ctx.Name()), nil
+}
+
+// OpenTree is an [Fd]-based wrapper around unix.OpenTree.
+func OpenTree(dir Fd, path string, flags uint) (*os.File, error) {
+	dirFd, fullPath := prepareAt(dir, path)
+	// Make sure we always set O_CLOEXEC.
+	flags |= unix.OPEN_TREE_CLOEXEC
+	fd, err := unix.OpenTree(dirFd, path, flags)
+	if err != nil {
+		return nil, &os.PathError{Op: "open_tree", Path: fullPath, Err: err}
+	}
+	runtime.KeepAlive(dir)
+	return os.NewFile(uintptr(fd), fullPath), nil
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd/openat2_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd/openat2_linux.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package fd
+
+import (
+	"errors"
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+func scopedLookupShouldRetry(how *unix.OpenHow, err error) bool {
+	// RESOLVE_IN_ROOT (and RESOLVE_BENEATH) can return -EAGAIN if we resolve
+	// ".." while a mount or rename occurs anywhere on the system. This could
+	// happen spuriously, or as the result of an attacker trying to mess with
+	// us during lookup.
+	//
+	// In addition, scoped lookups have a "safety check" at the end of
+	// complete_walk which will return -EXDEV if the final path is not in the
+	// root.
+	return how.Resolve&(unix.RESOLVE_IN_ROOT|unix.RESOLVE_BENEATH) != 0 &&
+		(errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EXDEV))
+}
+
+// This is a fairly arbitrary limit we have just to avoid an attacker being
+// able to make us spin in an infinite retry loop -- callers can choose to
+// retry on EAGAIN if they prefer.
+const scopedLookupMaxRetries = 128
+
+// Openat2 is an [Fd]-based wrapper around unix.Openat2, but with some retry
+// logic in case of EAGAIN errors.
+func Openat2(dir Fd, path string, how *unix.OpenHow) (*os.File, error) {
+	dirFd, fullPath := prepareAt(dir, path)
+	// Make sure we always set O_CLOEXEC.
+	how.Flags |= unix.O_CLOEXEC
+	var tries int
+	for {
+		fd, err := unix.Openat2(dirFd, path, how)
+		if err != nil {
+			if scopedLookupShouldRetry(how, err) && tries < scopedLookupMaxRetries {
+				// We retry a couple of times to avoid the spurious errors, and
+				// if we are being attacked then returning -EAGAIN is the best
+				// we can do.
+				tries++
+				continue
+			}
+			return nil, &os.PathError{Op: "openat2", Path: fullPath, Err: err}
+		}
+		runtime.KeepAlive(dir)
+		return os.NewFile(uintptr(fd), fullPath), nil
+	}
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat/README.md
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat/README.md
@@ -1,0 +1,10 @@
+## gocompat ##
+
+This directory contains backports of stdlib functions from later Go versions so
+the filepath-securejoin can continue to be used by projects that are stuck with
+Go 1.18 support. Note that often filepath-securejoin is added in security
+patches for old releases, so avoiding the need to bump Go compiler requirements
+is a huge plus to downstreams.
+
+The source code is licensed under the same license as the Go stdlib. See the
+source files for the precise license information.

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat/doc.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat/doc.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//go:build linux && go1.20
+
+// Copyright (C) 2025 SUSE LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package gocompat includes compatibility shims (backported from future Go
+// stdlib versions) to permit filepath-securejoin to be used with older Go
+// versions (often filepath-securejoin is added in security patches for old
+// releases, so avoiding the need to bump Go compiler requirements is a huge
+// plus to downstreams).
+package gocompat

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat/gocompat_errors_go120.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat/gocompat_errors_go120.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//go:build linux && go1.20
+
+// Copyright (C) 2024 SUSE LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gocompat
+
+import (
+	"fmt"
+)
+
+// WrapBaseError is a helper that is equivalent to fmt.Errorf("%w: %w"), except
+// that on pre-1.20 Go versions only errors.Is() works properly (errors.Unwrap)
+// is only guaranteed to give you baseErr.
+func WrapBaseError(baseErr, extraErr error) error {
+	return fmt.Errorf("%w: %w", extraErr, baseErr)
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat/gocompat_errors_unsupported.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat/gocompat_errors_unsupported.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux && !go1.20
+
+// Copyright (C) 2024 SUSE LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gocompat
+
+import (
+	"fmt"
+)
+
+type wrappedError struct {
+	inner   error
+	isError error
+}
+
+func (err wrappedError) Is(target error) bool {
+	return err.isError == target
+}
+
+func (err wrappedError) Unwrap() error {
+	return err.inner
+}
+
+func (err wrappedError) Error() string {
+	return fmt.Sprintf("%v: %v", err.isError, err.inner)
+}
+
+// WrapBaseError is a helper that is equivalent to fmt.Errorf("%w: %w"), except
+// that on pre-1.20 Go versions only errors.Is() works properly (errors.Unwrap)
+// is only guaranteed to give you baseErr.
+func WrapBaseError(baseErr, extraErr error) error {
+	return wrappedError{
+		inner:   baseErr,
+		isError: extraErr,
+	}
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat/gocompat_generics_go121.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat/gocompat_generics_go121.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux && go1.21
+
+// Copyright (C) 2024-2025 SUSE LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gocompat
+
+import (
+	"cmp"
+	"slices"
+	"sync"
+)
+
+// SlicesDeleteFunc is equivalent to Go 1.21's slices.DeleteFunc.
+func SlicesDeleteFunc[S ~[]E, E any](slice S, delFn func(E) bool) S {
+	return slices.DeleteFunc(slice, delFn)
+}
+
+// SlicesContains is equivalent to Go 1.21's slices.Contains.
+func SlicesContains[S ~[]E, E comparable](slice S, val E) bool {
+	return slices.Contains(slice, val)
+}
+
+// SlicesClone is equivalent to Go 1.21's slices.Clone.
+func SlicesClone[S ~[]E, E any](slice S) S {
+	return slices.Clone(slice)
+}
+
+// SyncOnceValue is equivalent to Go 1.21's sync.OnceValue.
+func SyncOnceValue[T any](f func() T) func() T {
+	return sync.OnceValue(f)
+}
+
+// SyncOnceValues is equivalent to Go 1.21's sync.OnceValues.
+func SyncOnceValues[T1, T2 any](f func() (T1, T2)) func() (T1, T2) {
+	return sync.OnceValues(f)
+}
+
+// CmpOrdered is equivalent to Go 1.21's cmp.Ordered generic type definition.
+type CmpOrdered = cmp.Ordered
+
+// CmpCompare is equivalent to Go 1.21's cmp.Compare.
+func CmpCompare[T CmpOrdered](x, y T) int {
+	return cmp.Compare(x, y)
+}
+
+// Max2 is equivalent to Go 1.21's max builtin (but only for two parameters).
+func Max2[T CmpOrdered](x, y T) T {
+	return max(x, y)
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat/gocompat_generics_unsupported.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat/gocompat_generics_unsupported.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build linux && !go1.21
+
+// Copyright (C) 2021, 2022 The Go Authors. All rights reserved.
+// Copyright (C) 2024-2025 SUSE LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.BSD file.
+
+package gocompat
+
+import (
+	"sync"
+)
+
+// These are very minimal implementations of functions that appear in Go 1.21's
+// stdlib, included so that we can build on older Go versions. Most are
+// borrowed directly from the stdlib, and a few are modified to be "obviously
+// correct" without needing to copy too many other helpers.
+
+// clearSlice is equivalent to Go 1.21's builtin clear.
+// Copied from the Go 1.24 stdlib implementation.
+func clearSlice[S ~[]E, E any](slice S) {
+	var zero E
+	for i := range slice {
+		slice[i] = zero
+	}
+}
+
+// slicesIndexFunc is equivalent to Go 1.21's slices.IndexFunc.
+// Copied from the Go 1.24 stdlib implementation.
+func slicesIndexFunc[S ~[]E, E any](s S, f func(E) bool) int {
+	for i := range s {
+		if f(s[i]) {
+			return i
+		}
+	}
+	return -1
+}
+
+// SlicesDeleteFunc is equivalent to Go 1.21's slices.DeleteFunc.
+// Copied from the Go 1.24 stdlib implementation.
+func SlicesDeleteFunc[S ~[]E, E any](s S, del func(E) bool) S {
+	i := slicesIndexFunc(s, del)
+	if i == -1 {
+		return s
+	}
+	// Don't start copying elements until we find one to delete.
+	for j := i + 1; j < len(s); j++ {
+		if v := s[j]; !del(v) {
+			s[i] = v
+			i++
+		}
+	}
+	clearSlice(s[i:]) // zero/nil out the obsolete elements, for GC
+	return s[:i]
+}
+
+// SlicesContains is equivalent to Go 1.21's slices.Contains.
+// Similar to the stdlib slices.Contains, except that we don't have
+// slices.Index so we need to use slices.IndexFunc for this non-Func helper.
+func SlicesContains[S ~[]E, E comparable](s S, v E) bool {
+	return slicesIndexFunc(s, func(e E) bool { return e == v }) >= 0
+}
+
+// SlicesClone is equivalent to Go 1.21's slices.Clone.
+// Copied from the Go 1.24 stdlib implementation.
+func SlicesClone[S ~[]E, E any](s S) S {
+	// Preserve nil in case it matters.
+	if s == nil {
+		return nil
+	}
+	return append(S([]E{}), s...)
+}
+
+// SyncOnceValue is equivalent to Go 1.21's sync.OnceValue.
+// Copied from the Go 1.25 stdlib implementation.
+func SyncOnceValue[T any](f func() T) func() T {
+	// Use a struct so that there's a single heap allocation.
+	d := struct {
+		f      func() T
+		once   sync.Once
+		valid  bool
+		p      any
+		result T
+	}{
+		f: f,
+	}
+	return func() T {
+		d.once.Do(func() {
+			defer func() {
+				d.f = nil
+				d.p = recover()
+				if !d.valid {
+					panic(d.p)
+				}
+			}()
+			d.result = d.f()
+			d.valid = true
+		})
+		if !d.valid {
+			panic(d.p)
+		}
+		return d.result
+	}
+}
+
+// SyncOnceValues is equivalent to Go 1.21's sync.OnceValues.
+// Copied from the Go 1.25 stdlib implementation.
+func SyncOnceValues[T1, T2 any](f func() (T1, T2)) func() (T1, T2) {
+	// Use a struct so that there's a single heap allocation.
+	d := struct {
+		f     func() (T1, T2)
+		once  sync.Once
+		valid bool
+		p     any
+		r1    T1
+		r2    T2
+	}{
+		f: f,
+	}
+	return func() (T1, T2) {
+		d.once.Do(func() {
+			defer func() {
+				d.f = nil
+				d.p = recover()
+				if !d.valid {
+					panic(d.p)
+				}
+			}()
+			d.r1, d.r2 = d.f()
+			d.valid = true
+		})
+		if !d.valid {
+			panic(d.p)
+		}
+		return d.r1, d.r2
+	}
+}
+
+// CmpOrdered is equivalent to Go 1.21's cmp.Ordered generic type definition.
+// Copied from the Go 1.25 stdlib implementation.
+type CmpOrdered interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
+		~float32 | ~float64 |
+		~string
+}
+
+// isNaN reports whether x is a NaN without requiring the math package.
+// This will always return false if T is not floating-point.
+// Copied from the Go 1.25 stdlib implementation.
+func isNaN[T CmpOrdered](x T) bool {
+	return x != x
+}
+
+// CmpCompare is equivalent to Go 1.21's cmp.Compare.
+// Copied from the Go 1.25 stdlib implementation.
+func CmpCompare[T CmpOrdered](x, y T) int {
+	xNaN := isNaN(x)
+	yNaN := isNaN(y)
+	if xNaN {
+		if yNaN {
+			return 0
+		}
+		return -1
+	}
+	if yNaN {
+		return +1
+	}
+	if x < y {
+		return -1
+	}
+	if x > y {
+		return +1
+	}
+	return 0
+}
+
+// Max2 is equivalent to Go 1.21's max builtin for two parameters.
+func Max2[T CmpOrdered](x, y T) T {
+	m := x
+	if y > m {
+		m = y
+	}
+	return m
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gopathrs/doc.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gopathrs/doc.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Package gopathrs is a less complete pure Go implementation of some of the
+// APIs provided by [libpathrs].
+//
+// [libpathrs]: https://github.com/cyphar/libpathrs
+package gopathrs

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gopathrs/lookup_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gopathrs/lookup_linux.go
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package gopathrs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cyphar/filepath-securejoin/internal/consts"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/linux"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/procfs"
+)
+
+type symlinkStackEntry struct {
+	// (dir, remainingPath) is what we would've returned if the link didn't
+	// exist. This matches what openat2(RESOLVE_IN_ROOT) would return in
+	// this case.
+	dir           *os.File
+	remainingPath string
+	// linkUnwalked is the remaining path components from the original
+	// Readlink which we have yet to walk. When this slice is empty, we
+	// drop the link from the stack.
+	linkUnwalked []string
+}
+
+func (se symlinkStackEntry) String() string {
+	return fmt.Sprintf("<%s>/%s [->%s]", se.dir.Name(), se.remainingPath, strings.Join(se.linkUnwalked, "/"))
+}
+
+func (se symlinkStackEntry) Close() {
+	_ = se.dir.Close()
+}
+
+type symlinkStack []*symlinkStackEntry
+
+func (s *symlinkStack) IsEmpty() bool {
+	return s == nil || len(*s) == 0
+}
+
+func (s *symlinkStack) Close() {
+	if s != nil {
+		for _, link := range *s {
+			link.Close()
+		}
+		// TODO: Switch to clear once we switch to Go 1.21.
+		*s = nil
+	}
+}
+
+var (
+	errEmptyStack         = errors.New("[internal] stack is empty")
+	errBrokenSymlinkStack = errors.New("[internal error] broken symlink stack")
+)
+
+func (s *symlinkStack) popPart(part string) error {
+	if s == nil || s.IsEmpty() {
+		// If there is nothing in the symlink stack, then the part was from the
+		// real path provided by the user, and this is a no-op.
+		return errEmptyStack
+	}
+	if part == "." {
+		// "." components are no-ops -- we drop them when doing SwapLink.
+		return nil
+	}
+
+	tailEntry := (*s)[len(*s)-1]
+
+	// Double-check that we are popping the component we expect.
+	if len(tailEntry.linkUnwalked) == 0 {
+		return fmt.Errorf("%w: trying to pop component %q of empty stack entry %s", errBrokenSymlinkStack, part, tailEntry)
+	}
+	headPart := tailEntry.linkUnwalked[0]
+	if headPart != part {
+		return fmt.Errorf("%w: trying to pop component %q but the last stack entry is %s (%q)", errBrokenSymlinkStack, part, tailEntry, headPart)
+	}
+
+	// Drop the component, but keep the entry around in case we are dealing
+	// with a "tail-chained" symlink.
+	tailEntry.linkUnwalked = tailEntry.linkUnwalked[1:]
+	return nil
+}
+
+func (s *symlinkStack) PopPart(part string) error {
+	if err := s.popPart(part); err != nil {
+		if errors.Is(err, errEmptyStack) {
+			// Skip empty stacks.
+			err = nil
+		}
+		return err
+	}
+
+	// Clean up any of the trailing stack entries that are empty.
+	for lastGood := len(*s) - 1; lastGood >= 0; lastGood-- {
+		entry := (*s)[lastGood]
+		if len(entry.linkUnwalked) > 0 {
+			break
+		}
+		entry.Close()
+		(*s) = (*s)[:lastGood]
+	}
+	return nil
+}
+
+func (s *symlinkStack) push(dir *os.File, remainingPath, linkTarget string) error {
+	if s == nil {
+		return nil
+	}
+	// Split the link target and clean up any "" parts.
+	linkTargetParts := gocompat.SlicesDeleteFunc(
+		strings.Split(linkTarget, "/"),
+		func(part string) bool { return part == "" || part == "." })
+
+	// Copy the directory so the caller doesn't close our copy.
+	dirCopy, err := fd.Dup(dir)
+	if err != nil {
+		return err
+	}
+
+	// Add to the stack.
+	*s = append(*s, &symlinkStackEntry{
+		dir:           dirCopy,
+		remainingPath: remainingPath,
+		linkUnwalked:  linkTargetParts,
+	})
+	return nil
+}
+
+func (s *symlinkStack) SwapLink(linkPart string, dir *os.File, remainingPath, linkTarget string) error {
+	// If we are currently inside a symlink resolution, remove the symlink
+	// component from the last symlink entry, but don't remove the entry even
+	// if it's empty. If we are a "tail-chained" symlink (a trailing symlink we
+	// hit during a symlink resolution) we need to keep the old symlink until
+	// we finish the resolution.
+	if err := s.popPart(linkPart); err != nil {
+		if !errors.Is(err, errEmptyStack) {
+			return err
+		}
+		// Push the component regardless of whether the stack was empty.
+	}
+	return s.push(dir, remainingPath, linkTarget)
+}
+
+func (s *symlinkStack) PopTopSymlink() (*os.File, string, bool) {
+	if s == nil || s.IsEmpty() {
+		return nil, "", false
+	}
+	tailEntry := (*s)[0]
+	*s = (*s)[1:]
+	return tailEntry.dir, tailEntry.remainingPath, true
+}
+
+// PartialLookupInRoot tries to lookup as much of the request path as possible
+// within the provided root (a-la RESOLVE_IN_ROOT) and opens the final existing
+// component of the requested path, returning a file handle to the final
+// existing component and a string containing the remaining path components.
+func PartialLookupInRoot(root fd.Fd, unsafePath string) (*os.File, string, error) {
+	return lookupInRoot(root, unsafePath, true)
+}
+
+func completeLookupInRoot(root fd.Fd, unsafePath string) (*os.File, error) {
+	handle, remainingPath, err := lookupInRoot(root, unsafePath, false)
+	if remainingPath != "" && err == nil {
+		// should never happen
+		err = fmt.Errorf("[bug] non-empty remaining path when doing a non-partial lookup: %q", remainingPath)
+	}
+	// lookupInRoot(partial=false) will always close the handle if an error is
+	// returned, so no need to double-check here.
+	return handle, err
+}
+
+func lookupInRoot(root fd.Fd, unsafePath string, partial bool) (Handle *os.File, _ string, _ error) {
+	unsafePath = filepath.ToSlash(unsafePath) // noop
+
+	// This is very similar to SecureJoin, except that we operate on the
+	// components using file descriptors. We then return the last component we
+	// managed open, along with the remaining path components not opened.
+
+	// Try to use openat2 if possible.
+	if linux.HasOpenat2() {
+		return lookupOpenat2(root, unsafePath, partial)
+	}
+
+	// Get the "actual" root path from /proc/self/fd. This is necessary if the
+	// root is some magic-link like /proc/$pid/root, in which case we want to
+	// make sure when we do procfs.CheckProcSelfFdPath that we are using the
+	// correct root path.
+	logicalRootPath, err := procfs.ProcSelfFdReadlink(root)
+	if err != nil {
+		return nil, "", fmt.Errorf("get real root path: %w", err)
+	}
+
+	currentDir, err := fd.Dup(root)
+	if err != nil {
+		return nil, "", fmt.Errorf("clone root fd: %w", err)
+	}
+	defer func() {
+		// If a handle is not returned, close the internal handle.
+		if Handle == nil {
+			_ = currentDir.Close()
+		}
+	}()
+
+	// symlinkStack is used to emulate how openat2(RESOLVE_IN_ROOT) treats
+	// dangling symlinks. If we hit a non-existent path while resolving a
+	// symlink, we need to return the (dir, remainingPath) that we had when we
+	// hit the symlink (treating the symlink as though it were a regular file).
+	// The set of (dir, remainingPath) sets is stored within the symlinkStack
+	// and we add and remove parts when we hit symlink and non-symlink
+	// components respectively. We need a stack because of recursive symlinks
+	// (symlinks that contain symlink components in their target).
+	//
+	// Note that the stack is ONLY used for book-keeping. All of the actual
+	// path walking logic is still based on currentPath/remainingPath and
+	// currentDir (as in SecureJoin).
+	var symStack *symlinkStack
+	if partial {
+		symStack = new(symlinkStack)
+		defer symStack.Close()
+	}
+
+	var (
+		linksWalked   int
+		currentPath   string
+		remainingPath = unsafePath
+	)
+	for remainingPath != "" {
+		// Save the current remaining path so if the part is not real we can
+		// return the path including the component.
+		oldRemainingPath := remainingPath
+
+		// Get the next path component.
+		var part string
+		if i := strings.IndexByte(remainingPath, '/'); i == -1 {
+			part, remainingPath = remainingPath, ""
+		} else {
+			part, remainingPath = remainingPath[:i], remainingPath[i+1:]
+		}
+		// If we hit an empty component, we need to treat it as though it is
+		// "." so that trailing "/" and "//" components on a non-directory
+		// correctly return the right error code.
+		if part == "" {
+			part = "."
+		}
+
+		// Apply the component lexically to the path we are building.
+		// currentPath does not contain any symlinks, and we are lexically
+		// dealing with a single component, so it's okay to do a filepath.Clean
+		// here.
+		nextPath := path.Join("/", currentPath, part)
+		// If we logically hit the root, just clone the root rather than
+		// opening the part and doing all of the other checks.
+		if nextPath == "/" {
+			if err := symStack.PopPart(part); err != nil {
+				return nil, "", fmt.Errorf("walking into root with part %q failed: %w", part, err)
+			}
+			// Jump to root.
+			rootClone, err := fd.Dup(root)
+			if err != nil {
+				return nil, "", fmt.Errorf("clone root fd: %w", err)
+			}
+			_ = currentDir.Close()
+			currentDir = rootClone
+			currentPath = nextPath
+			continue
+		}
+
+		// Try to open the next component.
+		nextDir, err := fd.Openat(currentDir, part, unix.O_PATH|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		switch err {
+		case nil:
+			st, err := nextDir.Stat()
+			if err != nil {
+				_ = nextDir.Close()
+				return nil, "", fmt.Errorf("stat component %q: %w", part, err)
+			}
+
+			switch st.Mode() & os.ModeType { //nolint:exhaustive // just a glorified if statement
+			case os.ModeSymlink:
+				// readlinkat implies AT_EMPTY_PATH since Linux 2.6.39. See
+				// Linux commit 65cfc6722361 ("readlinkat(), fchownat() and
+				// fstatat() with empty relative pathnames").
+				linkDest, err := fd.Readlinkat(nextDir, "")
+				// We don't need the handle anymore.
+				_ = nextDir.Close()
+				if err != nil {
+					return nil, "", err
+				}
+
+				linksWalked++
+				if linksWalked > consts.MaxSymlinkLimit {
+					return nil, "", &os.PathError{Op: "securejoin.lookupInRoot", Path: logicalRootPath + "/" + unsafePath, Err: unix.ELOOP}
+				}
+
+				// Swap out the symlink's component for the link entry itself.
+				if err := symStack.SwapLink(part, currentDir, oldRemainingPath, linkDest); err != nil {
+					return nil, "", fmt.Errorf("walking into symlink %q failed: push symlink: %w", part, err)
+				}
+
+				// Update our logical remaining path.
+				remainingPath = linkDest + "/" + remainingPath
+				// Absolute symlinks reset any work we've already done.
+				if path.IsAbs(linkDest) {
+					// Jump to root.
+					rootClone, err := fd.Dup(root)
+					if err != nil {
+						return nil, "", fmt.Errorf("clone root fd: %w", err)
+					}
+					_ = currentDir.Close()
+					currentDir = rootClone
+					currentPath = "/"
+				}
+
+			default:
+				// If we are dealing with a directory, simply walk into it.
+				_ = currentDir.Close()
+				currentDir = nextDir
+				currentPath = nextPath
+
+				// The part was real, so drop it from the symlink stack.
+				if err := symStack.PopPart(part); err != nil {
+					return nil, "", fmt.Errorf("walking into directory %q failed: %w", part, err)
+				}
+
+				// If we are operating on a .., make sure we haven't escaped.
+				// We only have to check for ".." here because walking down
+				// into a regular component component cannot cause you to
+				// escape. This mirrors the logic in RESOLVE_IN_ROOT, except we
+				// have to check every ".." rather than only checking after a
+				// rename or mount on the system.
+				if part == ".." {
+					// Make sure the root hasn't moved.
+					if err := procfs.CheckProcSelfFdPath(logicalRootPath, root); err != nil {
+						return nil, "", fmt.Errorf("root path moved during lookup: %w", err)
+					}
+					// Make sure the path is what we expect.
+					fullPath := logicalRootPath + nextPath
+					if err := procfs.CheckProcSelfFdPath(fullPath, currentDir); err != nil {
+						return nil, "", fmt.Errorf("walking into %q had unexpected result: %w", part, err)
+					}
+				}
+			}
+
+		default:
+			if !partial {
+				return nil, "", err
+			}
+			// If there are any remaining components in the symlink stack, we
+			// are still within a symlink resolution and thus we hit a dangling
+			// symlink. So pretend that the first symlink in the stack we hit
+			// was an ENOENT (to match openat2).
+			if oldDir, remainingPath, ok := symStack.PopTopSymlink(); ok {
+				_ = currentDir.Close()
+				return oldDir, remainingPath, err
+			}
+			// We have hit a final component that doesn't exist, so we have our
+			// partial open result. Note that we have to use the OLD remaining
+			// path, since the lookup failed.
+			return currentDir, oldRemainingPath, err
+		}
+	}
+
+	// If the unsafePath had a trailing slash, we need to make sure we try to
+	// do a relative "." open so that we will correctly return an error when
+	// the final component is a non-directory (to match openat2). In the
+	// context of openat2, a trailing slash and a trailing "/." are completely
+	// equivalent.
+	if strings.HasSuffix(unsafePath, "/") {
+		nextDir, err := fd.Openat(currentDir, ".", unix.O_PATH|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		if err != nil {
+			if !partial {
+				_ = currentDir.Close()
+				currentDir = nil
+			}
+			return currentDir, "", err
+		}
+		_ = currentDir.Close()
+		currentDir = nextDir
+	}
+
+	// All of the components existed!
+	return currentDir, "", nil
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gopathrs/mkdir_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gopathrs/mkdir_linux.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package gopathrs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/linux"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/procfs"
+)
+
+// ErrInvalidMode is returned from [MkdirAll] when the requested mode is
+// invalid.
+var ErrInvalidMode = errors.New("invalid permission mode")
+
+// modePermExt is like os.ModePerm except that it also includes the set[ug]id
+// and sticky bits.
+const modePermExt = os.ModePerm | os.ModeSetuid | os.ModeSetgid | os.ModeSticky
+
+//nolint:cyclop // this function needs to handle a lot of cases
+func toUnixMode(mode os.FileMode) (uint32, error) {
+	sysMode := uint32(mode.Perm())
+	if mode&os.ModeSetuid != 0 {
+		sysMode |= unix.S_ISUID
+	}
+	if mode&os.ModeSetgid != 0 {
+		sysMode |= unix.S_ISGID
+	}
+	if mode&os.ModeSticky != 0 {
+		sysMode |= unix.S_ISVTX
+	}
+	// We don't allow file type bits.
+	if mode&os.ModeType != 0 {
+		return 0, fmt.Errorf("%w %+.3o (%s): type bits not permitted", ErrInvalidMode, mode, mode)
+	}
+	// We don't allow other unknown modes.
+	if mode&^modePermExt != 0 || sysMode&unix.S_IFMT != 0 {
+		return 0, fmt.Errorf("%w %+.3o (%s): unknown mode bits", ErrInvalidMode, mode, mode)
+	}
+	return sysMode, nil
+}
+
+// MkdirAllHandle is equivalent to [MkdirAll], except that it is safer to use
+// in two respects:
+//
+//   - The caller provides the root directory as an *[os.File] (preferably O_PATH)
+//     handle. This means that the caller can be sure which root directory is
+//     being used. Note that this can be emulated by using /proc/self/fd/... as
+//     the root path with [os.MkdirAll].
+//
+//   - Once all of the directories have been created, an *[os.File] O_PATH handle
+//     to the directory at unsafePath is returned to the caller. This is done in
+//     an effectively-race-free way (an attacker would only be able to swap the
+//     final directory component), which is not possible to emulate with
+//     [MkdirAll].
+//
+// In addition, the returned handle is obtained far more efficiently than doing
+// a brand new lookup of unsafePath (such as with [SecureJoin] or openat2) after
+// doing [MkdirAll]. If you intend to open the directory after creating it, you
+// should use MkdirAllHandle.
+//
+// [SecureJoin]: https://pkg.go.dev/github.com/cyphar/filepath-securejoin#SecureJoin
+func MkdirAllHandle(root *os.File, unsafePath string, mode os.FileMode) (_ *os.File, Err error) {
+	unixMode, err := toUnixMode(mode)
+	if err != nil {
+		return nil, err
+	}
+	// On Linux, mkdirat(2) (and os.Mkdir) silently ignore the suid and sgid
+	// bits. We could also silently ignore them but since we have very few
+	// users it seems more prudent to return an error so users notice that
+	// these bits will not be set.
+	if unixMode&^0o1777 != 0 {
+		return nil, fmt.Errorf("%w for mkdir %+.3o: suid and sgid are ignored by mkdir", ErrInvalidMode, mode)
+	}
+
+	// Try to open as much of the path as possible.
+	currentDir, remainingPath, err := PartialLookupInRoot(root, unsafePath)
+	defer func() {
+		if Err != nil {
+			_ = currentDir.Close()
+		}
+	}()
+	if err != nil && !errors.Is(err, unix.ENOENT) {
+		return nil, fmt.Errorf("find existing subpath of %q: %w", unsafePath, err)
+	}
+
+	// If there is an attacker deleting directories as we walk into them,
+	// detect this proactively. Note this is guaranteed to detect if the
+	// attacker deleted any part of the tree up to currentDir.
+	//
+	// Once we walk into a dead directory, partialLookupInRoot would not be
+	// able to walk further down the tree (directories must be empty before
+	// they are deleted), and if the attacker has removed the entire tree we
+	// can be sure that anything that was originally inside a dead directory
+	// must also be deleted and thus is a dead directory in its own right.
+	//
+	// This is mostly a quality-of-life check, because mkdir will simply fail
+	// later if the attacker deletes the tree after this check.
+	if err := fd.IsDeadInode(currentDir); err != nil {
+		return nil, fmt.Errorf("finding existing subpath of %q: %w", unsafePath, err)
+	}
+
+	// Re-open the path to match the O_DIRECTORY reopen loop later (so that we
+	// always return a non-O_PATH handle). We also check that we actually got a
+	// directory.
+	if reopenDir, err := procfs.ReopenFd(currentDir, unix.O_DIRECTORY|unix.O_CLOEXEC); errors.Is(err, unix.ENOTDIR) {
+		return nil, fmt.Errorf("cannot create subdirectories in %q: %w", currentDir.Name(), unix.ENOTDIR)
+	} else if err != nil {
+		return nil, fmt.Errorf("re-opening handle to %q: %w", currentDir.Name(), err)
+	} else { //nolint:revive // indent-error-flow lint doesn't make sense here
+		_ = currentDir.Close()
+		currentDir = reopenDir
+	}
+
+	remainingParts := strings.Split(remainingPath, string(filepath.Separator))
+	if gocompat.SlicesContains(remainingParts, "..") {
+		// The path contained ".." components after the end of the "real"
+		// components. We could try to safely resolve ".." here but that would
+		// add a bunch of extra logic for something that it's not clear even
+		// needs to be supported. So just return an error.
+		//
+		// If we do filepath.Clean(remainingPath) then we end up with the
+		// problem that ".." can erase a trailing dangling symlink and produce
+		// a path that doesn't quite match what the user asked for.
+		return nil, fmt.Errorf("%w: yet-to-be-created path %q contains '..' components", unix.ENOENT, remainingPath)
+	}
+
+	// Create the remaining components.
+	for _, part := range remainingParts {
+		switch part {
+		case "", ".":
+			// Skip over no-op paths.
+			continue
+		}
+
+		// NOTE: mkdir(2) will not follow trailing symlinks, so we can safely
+		// create the final component without worrying about symlink-exchange
+		// attacks.
+		//
+		// If we get -EEXIST, it's possible that another program created the
+		// directory at the same time as us. In that case, just continue on as
+		// if we created it (if the created inode is not a directory, the
+		// following open call will fail).
+		if err := unix.Mkdirat(int(currentDir.Fd()), part, unixMode); err != nil && !errors.Is(err, unix.EEXIST) {
+			err = &os.PathError{Op: "mkdirat", Path: currentDir.Name() + "/" + part, Err: err}
+			// Make the error a bit nicer if the directory is dead.
+			if deadErr := fd.IsDeadInode(currentDir); deadErr != nil {
+				// TODO: Once we bump the minimum Go version to 1.20, we can use
+				// multiple %w verbs for this wrapping. For now we need to use a
+				// compatibility shim for older Go versions.
+				// err = fmt.Errorf("%w (%w)", err, deadErr)
+				err = gocompat.WrapBaseError(err, deadErr)
+			}
+			return nil, err
+		}
+
+		// Get a handle to the next component. O_DIRECTORY means we don't need
+		// to use O_PATH.
+		var nextDir *os.File
+		if linux.HasOpenat2() {
+			nextDir, err = openat2(currentDir, part, &unix.OpenHow{
+				Flags:   unix.O_NOFOLLOW | unix.O_DIRECTORY | unix.O_CLOEXEC,
+				Resolve: unix.RESOLVE_BENEATH | unix.RESOLVE_NO_SYMLINKS | unix.RESOLVE_NO_XDEV,
+			})
+		} else {
+			nextDir, err = fd.Openat(currentDir, part, unix.O_NOFOLLOW|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+		}
+		if err != nil {
+			return nil, err
+		}
+		_ = currentDir.Close()
+		currentDir = nextDir
+
+		// It's possible that the directory we just opened was swapped by an
+		// attacker. Unfortunately there isn't much we can do to protect
+		// against this, and MkdirAll's behaviour is that we will reuse
+		// existing directories anyway so the need to protect against this is
+		// incredibly limited (and arguably doesn't even deserve mention here).
+		//
+		// Ideally we might want to check that the owner and mode match what we
+		// would've created -- unfortunately, it is non-trivial to verify that
+		// the owner and mode of the created directory match. While plain Unix
+		// DAC rules seem simple enough to emulate, there are a bunch of other
+		// factors that can change the mode or owner of created directories
+		// (default POSIX ACLs, mount options like uid=1,gid=2,umask=0 on
+		// filesystems like vfat, etc etc). We used to try to verify this but
+		// it just lead to a series of spurious errors.
+		//
+		// We could also check that the directory is non-empty, but
+		// unfortunately some pseduofilesystems (like cgroupfs) create
+		// non-empty directories, which would result in different spurious
+		// errors.
+	}
+	return currentDir, nil
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gopathrs/open_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gopathrs/open_linux.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package gopathrs
+
+import (
+	"os"
+)
+
+// OpenatInRoot is equivalent to [OpenInRoot], except that the root is provided
+// using an *[os.File] handle, to ensure that the correct root directory is used.
+func OpenatInRoot(root *os.File, unsafePath string) (*os.File, error) {
+	handle, err := completeLookupInRoot(root, unsafePath)
+	if err != nil {
+		return nil, &os.PathError{Op: "securejoin.OpenInRoot", Path: unsafePath, Err: err}
+	}
+	return handle, nil
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gopathrs/openat2_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gopathrs/openat2_linux.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package gopathrs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/procfs"
+)
+
+func openat2(dir fd.Fd, path string, how *unix.OpenHow) (*os.File, error) {
+	file, err := fd.Openat2(dir, path, how)
+	if err != nil {
+		return nil, err
+	}
+	// If we are using RESOLVE_IN_ROOT, the name we generated may be wrong.
+	if how.Resolve&unix.RESOLVE_IN_ROOT == unix.RESOLVE_IN_ROOT {
+		if actualPath, err := procfs.ProcSelfFdReadlink(file); err == nil {
+			// TODO: Ideally we would not need to dup the fd, but you cannot
+			//       easily just swap an *os.File with one from the same fd
+			//       (the GC will close the old one, and you cannot clear the
+			//       finaliser easily because it is associated with an internal
+			//       field of *os.File not *os.File itself).
+			newFile, err := fd.DupWithName(file, actualPath)
+			if err != nil {
+				return nil, err
+			}
+			file = newFile
+		}
+	}
+	return file, nil
+}
+
+func lookupOpenat2(root fd.Fd, unsafePath string, partial bool) (*os.File, string, error) {
+	if !partial {
+		file, err := openat2(root, unsafePath, &unix.OpenHow{
+			Flags:   unix.O_PATH | unix.O_CLOEXEC,
+			Resolve: unix.RESOLVE_IN_ROOT | unix.RESOLVE_NO_MAGICLINKS,
+		})
+		return file, "", err
+	}
+	return partialLookupOpenat2(root, unsafePath)
+}
+
+// partialLookupOpenat2 is an alternative implementation of
+// partialLookupInRoot, using openat2(RESOLVE_IN_ROOT) to more safely get a
+// handle to the deepest existing child of the requested path within the root.
+func partialLookupOpenat2(root fd.Fd, unsafePath string) (*os.File, string, error) {
+	// TODO: Implement this as a git-bisect-like binary search.
+
+	unsafePath = filepath.ToSlash(unsafePath) // noop
+	endIdx := len(unsafePath)
+	var lastError error
+	for endIdx > 0 {
+		subpath := unsafePath[:endIdx]
+
+		handle, err := openat2(root, subpath, &unix.OpenHow{
+			Flags:   unix.O_PATH | unix.O_CLOEXEC,
+			Resolve: unix.RESOLVE_IN_ROOT | unix.RESOLVE_NO_MAGICLINKS,
+		})
+		if err == nil {
+			// Jump over the slash if we have a non-"" remainingPath.
+			if endIdx < len(unsafePath) {
+				endIdx++
+			}
+			// We found a subpath!
+			return handle, unsafePath[endIdx:], lastError
+		}
+		if errors.Is(err, unix.ENOENT) || errors.Is(err, unix.ENOTDIR) {
+			// That path doesn't exist, let's try the next directory up.
+			endIdx = strings.LastIndexByte(subpath, '/')
+			lastError = err
+			continue
+		}
+		return nil, "", fmt.Errorf("open subpath: %w", err)
+	}
+	// If we couldn't open anything, the whole subpath is missing. Return a
+	// copy of the root fd so that the caller doesn't close this one by
+	// accident.
+	rootClone, err := fd.Dup(root)
+	if err != nil {
+		return nil, "", err
+	}
+	return rootClone, unsafePath, lastError
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/kernelversion/kernel_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/kernelversion/kernel_linux.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Copyright (C) 2022 The Go Authors. All rights reserved.
+// Copyright (C) 2025 SUSE LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.BSD file.
+
+// The parsing logic is very loosely based on the Go stdlib's
+// src/internal/syscall/unix/kernel_version_linux.go but with an API that looks
+// a bit like runc's libcontainer/system/kernelversion.
+//
+// TODO(cyphar): This API has been copied around to a lot of different projects
+// (Docker, containerd, runc, and now filepath-securejoin) -- maybe we should
+// put it in a separate project?
+
+// Package kernelversion provides a simple mechanism for checking whether the
+// running kernel is at least as new as some baseline kernel version. This is
+// often useful when checking for features that would be too complicated to
+// test support for (or in cases where we know that some kernel features in
+// backport-heavy kernels are broken and need to be avoided).
+package kernelversion
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat"
+)
+
+// KernelVersion is a numeric representation of the key numerical elements of a
+// kernel version (for instance, "4.1.2-default-1" would be represented as
+// KernelVersion{4, 1, 2}).
+type KernelVersion []uint64
+
+func (kver KernelVersion) String() string {
+	var str strings.Builder
+	for idx, elem := range kver {
+		if idx != 0 {
+			_, _ = str.WriteRune('.')
+		}
+		_, _ = str.WriteString(strconv.FormatUint(elem, 10))
+	}
+	return str.String()
+}
+
+var errInvalidKernelVersion = errors.New("invalid kernel version")
+
+// parseKernelVersion parses a string and creates a KernelVersion based on it.
+func parseKernelVersion(kverStr string) (KernelVersion, error) {
+	kver := make(KernelVersion, 1, 3)
+	for idx, ch := range kverStr {
+		if '0' <= ch && ch <= '9' {
+			v := &kver[len(kver)-1]
+			*v = (*v * 10) + uint64(ch-'0')
+		} else {
+			if idx == 0 || kverStr[idx-1] < '0' || '9' < kverStr[idx-1] {
+				// "." must be preceded by a digit while in version section
+				return nil, fmt.Errorf("%w %q: kernel version has dot(s) followed by non-digit in version section", errInvalidKernelVersion, kverStr)
+			}
+			if ch != '.' {
+				break
+			}
+			kver = append(kver, 0)
+		}
+	}
+	if len(kver) < 2 {
+		return nil, fmt.Errorf("%w %q: kernel versions must contain at least two components", errInvalidKernelVersion, kverStr)
+	}
+	return kver, nil
+}
+
+// getKernelVersion gets the current kernel version.
+var getKernelVersion = gocompat.SyncOnceValues(func() (KernelVersion, error) {
+	var uts unix.Utsname
+	if err := unix.Uname(&uts); err != nil {
+		return nil, err
+	}
+	// Remove the \x00 from the release.
+	release := uts.Release[:]
+	return parseKernelVersion(string(release[:bytes.IndexByte(release, 0)]))
+})
+
+// GreaterEqualThan returns true if the the host kernel version is greater than
+// or equal to the provided [KernelVersion]. When doing this comparison, any
+// non-numerical suffixes of the host kernel version are ignored.
+//
+// If the number of components provided is not equal to the number of numerical
+// components of the host kernel version, any missing components are treated as
+// 0. This means that GreaterEqualThan(KernelVersion{4}) will be treated the
+// same as GreaterEqualThan(KernelVersion{4, 0, 0, ..., 0, 0}), and that if the
+// host kernel version is "4" then GreaterEqualThan(KernelVersion{4, 1}) will
+// return false (because the host version will be treated as "4.0").
+func GreaterEqualThan(wantKver KernelVersion) (bool, error) {
+	hostKver, err := getKernelVersion()
+	if err != nil {
+		return false, err
+	}
+
+	// Pad out the kernel version lengths to match one another.
+	cmpLen := gocompat.Max2(len(hostKver), len(wantKver))
+	hostKver = append(hostKver, make(KernelVersion, cmpLen-len(hostKver))...)
+	wantKver = append(wantKver, make(KernelVersion, cmpLen-len(wantKver))...)
+
+	for i := 0; i < cmpLen; i++ {
+		switch gocompat.CmpCompare(hostKver[i], wantKver[i]) {
+		case -1:
+			// host < want
+			return false, nil
+		case +1:
+			// host > want
+			return true, nil
+		case 0:
+			continue
+		}
+	}
+	// equal version values
+	return true, nil
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/linux/doc.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/linux/doc.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Package linux returns information about what features are supported on the
+// running kernel.
+package linux

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/linux/mount_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/linux/mount_linux.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package linux
+
+import (
+	"golang.org/x/sys/unix"
+
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/kernelversion"
+)
+
+// HasNewMountAPI returns whether the new fsopen(2) mount API is supported on
+// the running kernel.
+var HasNewMountAPI = gocompat.SyncOnceValue(func() bool {
+	// All of the pieces of the new mount API we use (fsopen, fsconfig,
+	// fsmount, open_tree) were added together in Linux 5.2[1,2], so we can
+	// just check for one of the syscalls and the others should also be
+	// available.
+	//
+	// Just try to use open_tree(2) to open a file without OPEN_TREE_CLONE.
+	// This is equivalent to openat(2), but tells us if open_tree is
+	// available (and thus all of the other basic new mount API syscalls).
+	// open_tree(2) is most light-weight syscall to test here.
+	//
+	// [1]: merge commit 400913252d09
+	// [2]: <https://lore.kernel.org/lkml/153754740781.17872.7869536526927736855.stgit@warthog.procyon.org.uk/>
+	fd, err := unix.OpenTree(-int(unix.EBADF), "/", unix.OPEN_TREE_CLOEXEC)
+	if err != nil {
+		return false
+	}
+	_ = unix.Close(fd)
+
+	// RHEL 8 has a backport of fsopen(2) that appears to have some very
+	// difficult to debug performance pathology. As such, it seems prudent to
+	// simply reject pre-5.2 kernels.
+	isNotBackport, _ := kernelversion.GreaterEqualThan(kernelversion.KernelVersion{5, 2})
+	return isNotBackport
+})

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/linux/openat2_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/linux/openat2_linux.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package linux
+
+import (
+	"golang.org/x/sys/unix"
+
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat"
+)
+
+// HasOpenat2 returns whether openat2(2) is supported on the running kernel.
+var HasOpenat2 = gocompat.SyncOnceValue(func() bool {
+	fd, err := unix.Openat2(unix.AT_FDCWD, ".", &unix.OpenHow{
+		Flags:   unix.O_PATH | unix.O_CLOEXEC,
+		Resolve: unix.RESOLVE_NO_SYMLINKS | unix.RESOLVE_IN_ROOT,
+	})
+	if err != nil {
+		return false
+	}
+	_ = unix.Close(fd)
+	return true
+})

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/procfs/procfs_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/procfs/procfs_linux.go
@@ -1,0 +1,544 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Package procfs provides a safe API for operating on /proc on Linux. Note
+// that this is the *internal* procfs API, mainy needed due to Go's
+// restrictions on cyclic dependencies and its incredibly minimal visibility
+// system without making a separate internal/ package.
+package procfs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/assert"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/linux"
+)
+
+// The kernel guarantees that the root inode of a procfs mount has an
+// f_type of PROC_SUPER_MAGIC and st_ino of PROC_ROOT_INO.
+const (
+	procSuperMagic = 0x9fa0 // PROC_SUPER_MAGIC
+	procRootIno    = 1      // PROC_ROOT_INO
+)
+
+// verifyProcHandle checks that the handle is from a procfs filesystem.
+// Contrast this to [verifyProcRoot], which also verifies that the handle is
+// the root of a procfs mount.
+func verifyProcHandle(procHandle fd.Fd) error {
+	if statfs, err := fd.Fstatfs(procHandle); err != nil {
+		return err
+	} else if statfs.Type != procSuperMagic {
+		return fmt.Errorf("%w: incorrect procfs root filesystem type 0x%x", errUnsafeProcfs, statfs.Type)
+	}
+	return nil
+}
+
+// verifyProcRoot verifies that the handle is the root of a procfs filesystem.
+// Contrast this to [verifyProcHandle], which only verifies if the handle is
+// some file on procfs (regardless of what file it is).
+func verifyProcRoot(procRoot fd.Fd) error {
+	if err := verifyProcHandle(procRoot); err != nil {
+		return err
+	}
+	if stat, err := fd.Fstat(procRoot); err != nil {
+		return err
+	} else if stat.Ino != procRootIno {
+		return fmt.Errorf("%w: incorrect procfs root inode number %d", errUnsafeProcfs, stat.Ino)
+	}
+	return nil
+}
+
+type procfsFeatures struct {
+	// hasSubsetPid was added in Linux 5.8, along with hidepid=ptraceable (and
+	// string-based hidepid= values). Before this patchset, it was not really
+	// safe to try to modify procfs superblock flags because the superblock was
+	// shared -- so if this feature is not available, **you should not set any
+	// superblock flags**.
+	//
+	// 6814ef2d992a ("proc: add option to mount only a pids subset")
+	// fa10fed30f25 ("proc: allow to mount many instances of proc in one pid namespace")
+	// 24a71ce5c47f ("proc: instantiate only pids that we can ptrace on 'hidepid=4' mount option")
+	// 1c6c4d112e81 ("proc: use human-readable values for hidepid")
+	// 9ff7258575d5 ("Merge branch 'proc-linus' of git://git.kernel.org/pub/scm/linux/kernel/git/ebiederm/user-namespace")
+	hasSubsetPid bool
+}
+
+var getProcfsFeatures = gocompat.SyncOnceValue(func() procfsFeatures {
+	if !linux.HasNewMountAPI() {
+		return procfsFeatures{}
+	}
+	procfsCtx, err := fd.Fsopen("proc", unix.FSOPEN_CLOEXEC)
+	if err != nil {
+		return procfsFeatures{}
+	}
+	defer procfsCtx.Close() //nolint:errcheck // close failures aren't critical here
+
+	return procfsFeatures{
+		hasSubsetPid: unix.FsconfigSetString(int(procfsCtx.Fd()), "subset", "pid") == nil,
+	}
+})
+
+func newPrivateProcMount(subset bool) (_ *Handle, Err error) {
+	procfsCtx, err := fd.Fsopen("proc", unix.FSOPEN_CLOEXEC)
+	if err != nil {
+		return nil, err
+	}
+	defer procfsCtx.Close() //nolint:errcheck // close failures aren't critical here
+
+	if subset && getProcfsFeatures().hasSubsetPid {
+		// Try to configure hidepid=ptraceable,subset=pid if possible, but
+		// ignore errors.
+		_ = unix.FsconfigSetString(int(procfsCtx.Fd()), "hidepid", "ptraceable")
+		_ = unix.FsconfigSetString(int(procfsCtx.Fd()), "subset", "pid")
+	}
+
+	// Get an actual handle.
+	if err := unix.FsconfigCreate(int(procfsCtx.Fd())); err != nil {
+		return nil, os.NewSyscallError("fsconfig create procfs", err)
+	}
+	// TODO: Output any information from the fscontext log to debug logs.
+	procRoot, err := fd.Fsmount(procfsCtx, unix.FSMOUNT_CLOEXEC, unix.MS_NODEV|unix.MS_NOEXEC|unix.MS_NOSUID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if Err != nil {
+			_ = procRoot.Close()
+		}
+	}()
+	return newHandle(procRoot)
+}
+
+func clonePrivateProcMount() (_ *Handle, Err error) {
+	// Try to make a clone without using AT_RECURSIVE if we can. If this works,
+	// we can be sure there are no over-mounts and so if the root is valid then
+	// we're golden. Otherwise, we have to deal with over-mounts.
+	procRoot, err := fd.OpenTree(nil, "/proc", unix.OPEN_TREE_CLONE)
+	if err != nil || hookForcePrivateProcRootOpenTreeAtRecursive(procRoot) {
+		procRoot, err = fd.OpenTree(nil, "/proc", unix.OPEN_TREE_CLONE|unix.AT_RECURSIVE)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("creating a detached procfs clone: %w", err)
+	}
+	defer func() {
+		if Err != nil {
+			_ = procRoot.Close()
+		}
+	}()
+	return newHandle(procRoot)
+}
+
+func privateProcRoot(subset bool) (*Handle, error) {
+	if !linux.HasNewMountAPI() || hookForceGetProcRootUnsafe() {
+		return nil, fmt.Errorf("new mount api: %w", unix.ENOTSUP)
+	}
+	// Try to create a new procfs mount from scratch if we can. This ensures we
+	// can get a procfs mount even if /proc is fake (for whatever reason).
+	procRoot, err := newPrivateProcMount(subset)
+	if err != nil || hookForcePrivateProcRootOpenTree(procRoot) {
+		// Try to clone /proc then...
+		procRoot, err = clonePrivateProcMount()
+	}
+	return procRoot, err
+}
+
+func unsafeHostProcRoot() (_ *Handle, Err error) {
+	procRoot, err := os.OpenFile("/proc", unix.O_PATH|unix.O_NOFOLLOW|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if Err != nil {
+			_ = procRoot.Close()
+		}
+	}()
+	return newHandle(procRoot)
+}
+
+// Handle is a wrapper around an *os.File handle to "/proc", which can be used
+// to do further procfs-related operations in a safe way.
+type Handle struct {
+	Inner fd.Fd
+	// Does this handle have subset=pid set?
+	isSubset bool
+}
+
+func newHandle(procRoot fd.Fd) (*Handle, error) {
+	if err := verifyProcRoot(procRoot); err != nil {
+		// This is only used in methods that
+		_ = procRoot.Close()
+		return nil, err
+	}
+	proc := &Handle{Inner: procRoot}
+	// With subset=pid we can be sure that /proc/uptime will not exist.
+	if err := fd.Faccessat(proc.Inner, "uptime", unix.F_OK, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		proc.isSubset = errors.Is(err, os.ErrNotExist)
+	}
+	return proc, nil
+}
+
+// Close closes the underlying file for the Handle.
+func (proc *Handle) Close() error { return proc.Inner.Close() }
+
+var getCachedProcRoot = gocompat.SyncOnceValue(func() *Handle {
+	procRoot, err := getProcRoot(true)
+	if err != nil {
+		return nil // just don't cache if we see an error
+	}
+	if !procRoot.isSubset {
+		return nil // we only cache verified subset=pid handles
+	}
+
+	// Disarm (*Handle).Close() to stop someone from accidentally closing
+	// the global handle.
+	procRoot.Inner = fd.NopCloser(procRoot.Inner)
+	return procRoot
+})
+
+// OpenProcRoot tries to open a "safer" handle to "/proc".
+func OpenProcRoot() (*Handle, error) {
+	if proc := getCachedProcRoot(); proc != nil {
+		return proc, nil
+	}
+	return getProcRoot(true)
+}
+
+// OpenUnsafeProcRoot opens a handle to "/proc" without any overmounts or
+// masked paths (but also without "subset=pid").
+func OpenUnsafeProcRoot() (*Handle, error) { return getProcRoot(false) }
+
+func getProcRoot(subset bool) (*Handle, error) {
+	proc, err := privateProcRoot(subset)
+	if err != nil {
+		// Fall back to using a /proc handle if making a private mount failed.
+		// If we have openat2, at least we can avoid some kinds of over-mount
+		// attacks, but without openat2 there's not much we can do.
+		proc, err = unsafeHostProcRoot()
+	}
+	return proc, err
+}
+
+var hasProcThreadSelf = gocompat.SyncOnceValue(func() bool {
+	return unix.Access("/proc/thread-self/", unix.F_OK) == nil
+})
+
+var errUnsafeProcfs = errors.New("unsafe procfs detected")
+
+// lookup is a very minimal wrapper around [procfsLookupInRoot] which is
+// intended to be called from the external API.
+func (proc *Handle) lookup(subpath string) (*os.File, error) {
+	handle, err := procfsLookupInRoot(proc.Inner, subpath)
+	if err != nil {
+		return nil, err
+	}
+	return handle, nil
+}
+
+// procfsBase is an enum indicating the prefix of a subpath in operations
+// involving [Handle]s.
+type procfsBase string
+
+const (
+	// ProcRoot refers to the root of the procfs (i.e., "/proc/<subpath>").
+	ProcRoot procfsBase = "/proc"
+	// ProcSelf refers to the current process' subdirectory (i.e.,
+	// "/proc/self/<subpath>").
+	ProcSelf procfsBase = "/proc/self"
+	// ProcThreadSelf refers to the current thread's subdirectory (i.e.,
+	// "/proc/thread-self/<subpath>"). In multi-threaded programs (i.e., all Go
+	// programs) where one thread has a different CLONE_FS, it is possible for
+	// "/proc/self" to point the wrong thread and so "/proc/thread-self" may be
+	// necessary. Note that on pre-3.17 kernels, "/proc/thread-self" doesn't
+	// exist and so a fallback will be used in that case.
+	ProcThreadSelf procfsBase = "/proc/thread-self"
+	// TODO: Switch to an interface setup so we can have a more type-safe
+	// version of ProcPid and remove the need to worry about invalid string
+	// values.
+)
+
+// prefix returns a prefix that can be used with the given [Handle].
+func (base procfsBase) prefix(proc *Handle) (string, error) {
+	switch base {
+	case ProcRoot:
+		return ".", nil
+	case ProcSelf:
+		return "self", nil
+	case ProcThreadSelf:
+		threadSelf := "thread-self"
+		if !hasProcThreadSelf() || hookForceProcSelfTask() {
+			// Pre-3.17 kernels don't have /proc/thread-self, so do it
+			// manually.
+			threadSelf = "self/task/" + strconv.Itoa(unix.Gettid())
+			if err := fd.Faccessat(proc.Inner, threadSelf, unix.F_OK, unix.AT_SYMLINK_NOFOLLOW); err != nil || hookForceProcSelf() {
+				// In this case, we running in a pid namespace that doesn't
+				// match the /proc mount we have. This can happen inside runc.
+				//
+				// Unfortunately, there is no nice way to get the correct TID
+				// to use here because of the age of the kernel, so we have to
+				// just use /proc/self and hope that it works.
+				threadSelf = "self"
+			}
+		}
+		return threadSelf, nil
+	}
+	return "", fmt.Errorf("invalid procfs base %q", base)
+}
+
+// ProcThreadSelfCloser is a callback that needs to be called when you are done
+// operating on an [os.File] fetched using [ProcThreadSelf].
+//
+// [os.File]: https://pkg.go.dev/os#File
+type ProcThreadSelfCloser func()
+
+// open is the core lookup operation for [Handle]. It returns a handle to
+// "/proc/<base>/<subpath>". If the returned [ProcThreadSelfCloser] is non-nil,
+// you should call it after you are done interacting with the returned handle.
+//
+// In general you should use prefer to use the other helpers, as they remove
+// the need to interact with [procfsBase] and do not return a nil
+// [ProcThreadSelfCloser] for [procfsBase] values other than [ProcThreadSelf]
+// where it is necessary.
+func (proc *Handle) open(base procfsBase, subpath string) (_ *os.File, closer ProcThreadSelfCloser, Err error) {
+	prefix, err := base.prefix(proc)
+	if err != nil {
+		return nil, nil, err
+	}
+	subpath = prefix + "/" + subpath
+
+	switch base {
+	case ProcRoot:
+		file, err := proc.lookup(subpath)
+		if errors.Is(err, os.ErrNotExist) {
+			// The Handle handle in use might be a subset=pid one, which will
+			// result in spurious errors. In this case, just open a temporary
+			// unmasked procfs handle for this operation.
+			proc, err2 := OpenUnsafeProcRoot() // !subset=pid
+			if err2 != nil {
+				return nil, nil, err
+			}
+			defer proc.Close() //nolint:errcheck // close failures aren't critical here
+
+			file, err = proc.lookup(subpath)
+		}
+		return file, nil, err
+
+	case ProcSelf:
+		file, err := proc.lookup(subpath)
+		return file, nil, err
+
+	case ProcThreadSelf:
+		// We need to lock our thread until the caller is done with the handle
+		// because between getting the handle and using it we could get
+		// interrupted by the Go runtime and hit the case where the underlying
+		// thread is swapped out and the original thread is killed, resulting
+		// in pull-your-hair-out-hard-to-debug issues in the caller.
+		runtime.LockOSThread()
+		defer func() {
+			if Err != nil {
+				runtime.UnlockOSThread()
+				closer = nil
+			}
+		}()
+
+		file, err := proc.lookup(subpath)
+		return file, runtime.UnlockOSThread, err
+	}
+	// should never be reached
+	return nil, nil, fmt.Errorf("[internal error] invalid procfs base %q", base)
+}
+
+// OpenThreadSelf returns a handle to "/proc/thread-self/<subpath>" (or an
+// equivalent handle on older kernels where "/proc/thread-self" doesn't exist).
+// Once finished with the handle, you must call the returned closer function
+// (runtime.UnlockOSThread). You must not pass the returned *os.File to other
+// Go threads or use the handle after calling the closer.
+func (proc *Handle) OpenThreadSelf(subpath string) (_ *os.File, _ ProcThreadSelfCloser, Err error) {
+	return proc.open(ProcThreadSelf, subpath)
+}
+
+// OpenSelf returns a handle to /proc/self/<subpath>.
+func (proc *Handle) OpenSelf(subpath string) (*os.File, error) {
+	file, closer, err := proc.open(ProcSelf, subpath)
+	assert.Assert(closer == nil, "closer for ProcSelf must be nil")
+	return file, err
+}
+
+// OpenRoot returns a handle to /proc/<subpath>.
+func (proc *Handle) OpenRoot(subpath string) (*os.File, error) {
+	file, closer, err := proc.open(ProcRoot, subpath)
+	assert.Assert(closer == nil, "closer for ProcRoot must be nil")
+	return file, err
+}
+
+// OpenPid returns a handle to /proc/$pid/<subpath> (pid can be a pid or tid).
+// This is mainly intended for usage when operating on other processes.
+func (proc *Handle) OpenPid(pid int, subpath string) (*os.File, error) {
+	return proc.OpenRoot(strconv.Itoa(pid) + "/" + subpath)
+}
+
+// checkSubpathOvermount checks if the dirfd and path combination is on the
+// same mount as the given root.
+func checkSubpathOvermount(root, dir fd.Fd, path string) error {
+	// Get the mntID of our procfs handle.
+	expectedMountID, err := fd.GetMountID(root, "")
+	if err != nil {
+		return fmt.Errorf("get root mount id: %w", err)
+	}
+	// Get the mntID of the target magic-link.
+	gotMountID, err := fd.GetMountID(dir, path)
+	if err != nil {
+		return fmt.Errorf("get subpath mount id: %w", err)
+	}
+	// As long as the directory mount is alive, even with wrapping mount IDs,
+	// we would expect to see a different mount ID here. (Of course, if we're
+	// using unsafeHostProcRoot() then an attaker could change this after we
+	// did this check.)
+	if expectedMountID != gotMountID {
+		return fmt.Errorf("%w: subpath %s/%s has an overmount obscuring the real path (mount ids do not match %d != %d)",
+			errUnsafeProcfs, dir.Name(), path, expectedMountID, gotMountID)
+	}
+	return nil
+}
+
+// Readlink performs a readlink operation on "/proc/<base>/<subpath>" in a way
+// that should be free from race attacks. This is most commonly used to get the
+// real path of a file by looking at "/proc/self/fd/$n", with the same safety
+// protections as [Open] (as well as some additional checks against
+// overmounts).
+func (proc *Handle) Readlink(base procfsBase, subpath string) (string, error) {
+	link, closer, err := proc.open(base, subpath)
+	if closer != nil {
+		defer closer()
+	}
+	if err != nil {
+		return "", fmt.Errorf("get safe %s/%s handle: %w", base, subpath, err)
+	}
+	defer link.Close() //nolint:errcheck // close failures aren't critical here
+
+	// Try to detect if there is a mount on top of the magic-link. This should
+	// be safe in general (a mount on top of the path afterwards would not
+	// affect the handle itself) and will definitely be safe if we are using
+	// privateProcRoot() (at least since Linux 5.12[1], when anonymous mount
+	// namespaces were completely isolated from external mounts including mount
+	// propagation events).
+	//
+	// [1]: Linux commit ee2e3f50629f ("mount: fix mounting of detached mounts
+	// onto targets that reside on shared mounts").
+	if err := checkSubpathOvermount(proc.Inner, link, ""); err != nil {
+		return "", fmt.Errorf("check safety of %s/%s magiclink: %w", base, subpath, err)
+	}
+
+	// readlinkat implies AT_EMPTY_PATH since Linux 2.6.39. See Linux commit
+	// 65cfc6722361 ("readlinkat(), fchownat() and fstatat() with empty
+	// relative pathnames").
+	return fd.Readlinkat(link, "")
+}
+
+// ProcSelfFdReadlink gets the real path of the given file by looking at
+// readlink(/proc/thread-self/fd/$n).
+//
+// This is just a wrapper around [Handle.Readlink].
+func ProcSelfFdReadlink(fd fd.Fd) (string, error) {
+	procRoot, err := OpenProcRoot() // subset=pid
+	if err != nil {
+		return "", err
+	}
+	defer procRoot.Close() //nolint:errcheck // close failures aren't critical here
+
+	fdPath := "fd/" + strconv.Itoa(int(fd.Fd()))
+	return procRoot.Readlink(ProcThreadSelf, fdPath)
+}
+
+// CheckProcSelfFdPath returns whether the given file handle matches the
+// expected path. (This is inherently racy.)
+func CheckProcSelfFdPath(path string, file fd.Fd) error {
+	if err := fd.IsDeadInode(file); err != nil {
+		return err
+	}
+	actualPath, err := ProcSelfFdReadlink(file)
+	if err != nil {
+		return fmt.Errorf("get path of handle: %w", err)
+	}
+	if actualPath != path {
+		return fmt.Errorf("%w: handle path %q doesn't match expected path %q", internal.ErrPossibleBreakout, actualPath, path)
+	}
+	return nil
+}
+
+// ReopenFd takes an existing file descriptor and "re-opens" it through
+// /proc/thread-self/fd/<fd>. This allows for O_PATH file descriptors to be
+// upgraded to regular file descriptors, as well as changing the open mode of a
+// regular file descriptor. Some filesystems have unique handling of open(2)
+// which make this incredibly useful (such as /dev/ptmx).
+func ReopenFd(handle fd.Fd, flags int) (*os.File, error) {
+	procRoot, err := OpenProcRoot() // subset=pid
+	if err != nil {
+		return nil, err
+	}
+	defer procRoot.Close() //nolint:errcheck // close failures aren't critical here
+
+	// We can't operate on /proc/thread-self/fd/$n directly when doing a
+	// re-open, so we need to open /proc/thread-self/fd and then open a single
+	// final component.
+	procFdDir, closer, err := procRoot.OpenThreadSelf("fd/")
+	if err != nil {
+		return nil, fmt.Errorf("get safe /proc/thread-self/fd handle: %w", err)
+	}
+	defer procFdDir.Close() //nolint:errcheck // close failures aren't critical here
+	defer closer()
+
+	// Try to detect if there is a mount on top of the magic-link we are about
+	// to open. If we are using unsafeHostProcRoot(), this could change after
+	// we check it (and there's nothing we can do about that) but for
+	// privateProcRoot() this should be guaranteed to be safe (at least since
+	// Linux 5.12[1], when anonymous mount namespaces were completely isolated
+	// from external mounts including mount propagation events).
+	//
+	// [1]: Linux commit ee2e3f50629f ("mount: fix mounting of detached mounts
+	// onto targets that reside on shared mounts").
+	fdStr := strconv.Itoa(int(handle.Fd()))
+	if err := checkSubpathOvermount(procRoot.Inner, procFdDir, fdStr); err != nil {
+		return nil, fmt.Errorf("check safety of /proc/thread-self/fd/%s magiclink: %w", fdStr, err)
+	}
+
+	flags |= unix.O_CLOEXEC
+	// Rather than just wrapping fd.Openat, open-code it so we can copy
+	// handle.Name().
+	reopenFd, err := unix.Openat(int(procFdDir.Fd()), fdStr, flags, 0)
+	if err != nil {
+		return nil, fmt.Errorf("reopen fd %d: %w", handle.Fd(), err)
+	}
+	return os.NewFile(uintptr(reopenFd), handle.Name()), nil
+}
+
+// Test hooks used in the procfs tests to verify that the fallback logic works.
+// See testing_mocks_linux_test.go and procfs_linux_test.go for more details.
+var (
+	hookForcePrivateProcRootOpenTree            = hookDummyFile
+	hookForcePrivateProcRootOpenTreeAtRecursive = hookDummyFile
+	hookForceGetProcRootUnsafe                  = hookDummy
+
+	hookForceProcSelfTask = hookDummy
+	hookForceProcSelf     = hookDummy
+)
+
+func hookDummy() bool                { return false }
+func hookDummyFile(_ io.Closer) bool { return false }

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/procfs/procfs_lookup_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/procfs/procfs_lookup_linux.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// This code is adapted to be a minimal version of the libpathrs proc resolver
+// <https://github.com/opensuse/libpathrs/blob/v0.1.3/src/resolvers/procfs.rs>.
+// As we only need O_PATH|O_NOFOLLOW support, this is not too much to port.
+
+package procfs
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cyphar/filepath-securejoin/internal/consts"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/linux"
+)
+
+// procfsLookupInRoot is a stripped down version of completeLookupInRoot,
+// entirely designed to support the very small set of features necessary to
+// make procfs handling work. Unlike completeLookupInRoot, we always have
+// O_PATH|O_NOFOLLOW behaviour for trailing symlinks.
+//
+// The main restrictions are:
+//
+//   - ".." is not supported (as it requires either os.Root-style replays,
+//     which is more bug-prone; or procfs verification, which is not possible
+//     due to re-entrancy issues).
+//   - Absolute symlinks for the same reason (and all absolute symlinks in
+//     procfs are magic-links, which we want to skip anyway).
+//   - If statx is supported (checkSymlinkOvermount), any mount-point crossings
+//     (which is the main attack of concern against /proc).
+//   - Partial lookups are not supported, so the symlink stack is not needed.
+//   - Trailing slash special handling is not necessary in most cases (if we
+//     operating on procfs, it's usually with programmer-controlled strings
+//     that will then be re-opened), so we skip it since whatever re-opens it
+//     can deal with it. It's a creature comfort anyway.
+//
+// If the system supports openat2(), this is implemented using equivalent flags
+// (RESOLVE_BENEATH | RESOLVE_NO_XDEV | RESOLVE_NO_MAGICLINKS).
+func procfsLookupInRoot(procRoot fd.Fd, unsafePath string) (Handle *os.File, _ error) {
+	unsafePath = filepath.ToSlash(unsafePath) // noop
+
+	// Make sure that an empty unsafe path still returns something sane, even
+	// with openat2 (which doesn't have AT_EMPTY_PATH semantics yet).
+	if unsafePath == "" {
+		unsafePath = "."
+	}
+
+	// This is already checked by getProcRoot, but make sure here since the
+	// core security of this lookup is based on this assumption.
+	if err := verifyProcRoot(procRoot); err != nil {
+		return nil, err
+	}
+
+	if linux.HasOpenat2() {
+		// We prefer being able to use RESOLVE_NO_XDEV if we can, to be
+		// absolutely sure we are operating on a clean /proc handle that
+		// doesn't have any cheeky overmounts that could trick us (including
+		// symlink mounts on top of /proc/thread-self). RESOLVE_BENEATH isn't
+		// strictly needed, but just use it since we have it.
+		//
+		// NOTE: /proc/self is technically a magic-link (the contents of the
+		//       symlink are generated dynamically), but it doesn't use
+		//       nd_jump_link() so RESOLVE_NO_MAGICLINKS allows it.
+		//
+		// TODO: It would be nice to have RESOLVE_NO_DOTDOT, purely for
+		//       self-consistency with the backup O_PATH resolver.
+		handle, err := fd.Openat2(procRoot, unsafePath, &unix.OpenHow{
+			Flags:   unix.O_PATH | unix.O_NOFOLLOW | unix.O_CLOEXEC,
+			Resolve: unix.RESOLVE_BENEATH | unix.RESOLVE_NO_XDEV | unix.RESOLVE_NO_MAGICLINKS,
+		})
+		if err != nil {
+			// TODO: Once we bump the minimum Go version to 1.20, we can use
+			// multiple %w verbs for this wrapping. For now we need to use a
+			// compatibility shim for older Go versions.
+			// err = fmt.Errorf("%w: %w", errUnsafeProcfs, err)
+			return nil, gocompat.WrapBaseError(err, errUnsafeProcfs)
+		}
+		return handle, nil
+	}
+
+	// To mirror openat2(RESOLVE_BENEATH), we need to return an error if the
+	// path is absolute.
+	if path.IsAbs(unsafePath) {
+		return nil, fmt.Errorf("%w: cannot resolve absolute paths in procfs resolver", internal.ErrPossibleBreakout)
+	}
+
+	currentDir, err := fd.Dup(procRoot)
+	if err != nil {
+		return nil, fmt.Errorf("clone root fd: %w", err)
+	}
+	defer func() {
+		// If a handle is not returned, close the internal handle.
+		if Handle == nil {
+			_ = currentDir.Close()
+		}
+	}()
+
+	var (
+		linksWalked   int
+		currentPath   string
+		remainingPath = unsafePath
+	)
+	for remainingPath != "" {
+		// Get the next path component.
+		var part string
+		if i := strings.IndexByte(remainingPath, '/'); i == -1 {
+			part, remainingPath = remainingPath, ""
+		} else {
+			part, remainingPath = remainingPath[:i], remainingPath[i+1:]
+		}
+		if part == "" {
+			// no-op component, but treat it the same as "."
+			part = "."
+		}
+		if part == ".." {
+			// not permitted
+			return nil, fmt.Errorf("%w: cannot walk into '..' in procfs resolver", internal.ErrPossibleBreakout)
+		}
+
+		// Apply the component lexically to the path we are building.
+		// currentPath does not contain any symlinks, and we are lexically
+		// dealing with a single component, so it's okay to do a filepath.Clean
+		// here. (Not to mention that ".." isn't allowed.)
+		nextPath := path.Join("/", currentPath, part)
+		// If we logically hit the root, just clone the root rather than
+		// opening the part and doing all of the other checks.
+		if nextPath == "/" {
+			// Jump to root.
+			rootClone, err := fd.Dup(procRoot)
+			if err != nil {
+				return nil, fmt.Errorf("clone root fd: %w", err)
+			}
+			_ = currentDir.Close()
+			currentDir = rootClone
+			currentPath = nextPath
+			continue
+		}
+
+		// Try to open the next component.
+		nextDir, err := fd.Openat(currentDir, part, unix.O_PATH|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		if err != nil {
+			return nil, err
+		}
+
+		// Make sure we are still on procfs and haven't crossed mounts.
+		if err := verifyProcHandle(nextDir); err != nil {
+			_ = nextDir.Close()
+			return nil, fmt.Errorf("check %q component is on procfs: %w", part, err)
+		}
+		if err := checkSubpathOvermount(procRoot, nextDir, ""); err != nil {
+			_ = nextDir.Close()
+			return nil, fmt.Errorf("check %q component is not overmounted: %w", part, err)
+		}
+
+		// We are emulating O_PATH|O_NOFOLLOW, so we only need to traverse into
+		// trailing symlinks if we are not the final component. Otherwise we
+		// can just return the currentDir.
+		if remainingPath != "" {
+			st, err := nextDir.Stat()
+			if err != nil {
+				_ = nextDir.Close()
+				return nil, fmt.Errorf("stat component %q: %w", part, err)
+			}
+
+			if st.Mode()&os.ModeType == os.ModeSymlink {
+				// readlinkat implies AT_EMPTY_PATH since Linux 2.6.39. See
+				// Linux commit 65cfc6722361 ("readlinkat(), fchownat() and
+				// fstatat() with empty relative pathnames").
+				linkDest, err := fd.Readlinkat(nextDir, "")
+				// We don't need the handle anymore.
+				_ = nextDir.Close()
+				if err != nil {
+					return nil, err
+				}
+
+				linksWalked++
+				if linksWalked > consts.MaxSymlinkLimit {
+					return nil, &os.PathError{Op: "securejoin.procfsLookupInRoot", Path: "/proc/" + unsafePath, Err: unix.ELOOP}
+				}
+
+				// Update our logical remaining path.
+				remainingPath = linkDest + "/" + remainingPath
+				// Absolute symlinks are probably magiclinks, we reject them.
+				if path.IsAbs(linkDest) {
+					return nil, fmt.Errorf("%w: cannot jump to / in procfs resolver -- possible magiclink", internal.ErrPossibleBreakout)
+				}
+				continue
+			}
+		}
+
+		// Walk into the next component.
+		_ = currentDir.Close()
+		currentDir = nextDir
+		currentPath = nextPath
+	}
+
+	// One final sanity-check.
+	if err := verifyProcHandle(currentDir); err != nil {
+		return nil, fmt.Errorf("check final handle is on procfs: %w", err)
+	}
+	if err := checkSubpathOvermount(procRoot, currentDir, ""); err != nil {
+		return nil, fmt.Errorf("check final handle is not overmounted: %w", err)
+	}
+	return currentDir, nil
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/mkdir.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/mkdir.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package pathrs
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// MkdirAll is a race-safe alternative to the [os.MkdirAll] function,
+// where the new directory is guaranteed to be within the root directory (if an
+// attacker can move directories from inside the root to outside the root, the
+// created directory tree might be outside of the root but the key constraint
+// is that at no point will we walk outside of the directory tree we are
+// creating).
+//
+// Effectively, MkdirAll(root, unsafePath, mode) is equivalent to
+//
+//	path, _ := securejoin.SecureJoin(root, unsafePath)
+//	err := os.MkdirAll(path, mode)
+//
+// But is much safer. The above implementation is unsafe because if an attacker
+// can modify the filesystem tree between [SecureJoin] and [os.MkdirAll], it is
+// possible for MkdirAll to resolve unsafe symlink components and create
+// directories outside of the root.
+//
+// If you plan to open the directory after you have created it or want to use
+// an open directory handle as the root, you should use [MkdirAllHandle] instead.
+// This function is a wrapper around [MkdirAllHandle].
+//
+// [SecureJoin]: https://pkg.go.dev/github.com/cyphar/filepath-securejoin#SecureJoin
+func MkdirAll(root, unsafePath string, mode os.FileMode) error {
+	rootDir, err := os.OpenFile(root, unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return err
+	}
+	defer rootDir.Close() //nolint:errcheck // close failures aren't critical here
+
+	f, err := MkdirAllHandle(rootDir, unsafePath, mode)
+	if err != nil {
+		return err
+	}
+	_ = f.Close()
+	return nil
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/mkdir_libpathrs.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/mkdir_libpathrs.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build libpathrs
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package pathrs
+
+import (
+	"os"
+
+	"cyphar.com/go-pathrs"
+)
+
+// MkdirAllHandle is equivalent to [MkdirAll], except that it is safer to use
+// in two respects:
+//
+//   - The caller provides the root directory as an *[os.File] (preferably O_PATH)
+//     handle. This means that the caller can be sure which root directory is
+//     being used. Note that this can be emulated by using /proc/self/fd/... as
+//     the root path with [os.MkdirAll].
+//
+//   - Once all of the directories have been created, an *[os.File] O_PATH handle
+//     to the directory at unsafePath is returned to the caller. This is done in
+//     an effectively-race-free way (an attacker would only be able to swap the
+//     final directory component), which is not possible to emulate with
+//     [MkdirAll].
+//
+// In addition, the returned handle is obtained far more efficiently than doing
+// a brand new lookup of unsafePath (such as with [SecureJoin] or openat2) after
+// doing [MkdirAll]. If you intend to open the directory after creating it, you
+// should use MkdirAllHandle.
+//
+// [SecureJoin]: https://pkg.go.dev/github.com/cyphar/filepath-securejoin#SecureJoin
+func MkdirAllHandle(root *os.File, unsafePath string, mode os.FileMode) (*os.File, error) {
+	rootRef, err := pathrs.RootFromFile(root)
+	if err != nil {
+		return nil, err
+	}
+	defer rootRef.Close() //nolint:errcheck // close failures aren't critical here
+
+	handle, err := rootRef.MkdirAll(unsafePath, mode)
+	if err != nil {
+		return nil, err
+	}
+	return handle.IntoFile(), nil
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/mkdir_purego.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/mkdir_purego.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux && !libpathrs
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package pathrs
+
+import (
+	"os"
+
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gopathrs"
+)
+
+// MkdirAllHandle is equivalent to [MkdirAll], except that it is safer to use
+// in two respects:
+//
+//   - The caller provides the root directory as an *[os.File] (preferably O_PATH)
+//     handle. This means that the caller can be sure which root directory is
+//     being used. Note that this can be emulated by using /proc/self/fd/... as
+//     the root path with [os.MkdirAll].
+//
+//   - Once all of the directories have been created, an *[os.File] O_PATH handle
+//     to the directory at unsafePath is returned to the caller. This is done in
+//     an effectively-race-free way (an attacker would only be able to swap the
+//     final directory component), which is not possible to emulate with
+//     [MkdirAll].
+//
+// In addition, the returned handle is obtained far more efficiently than doing
+// a brand new lookup of unsafePath (such as with [SecureJoin] or openat2) after
+// doing [MkdirAll]. If you intend to open the directory after creating it, you
+// should use MkdirAllHandle.
+//
+// [SecureJoin]: https://pkg.go.dev/github.com/cyphar/filepath-securejoin#SecureJoin
+func MkdirAllHandle(root *os.File, unsafePath string, mode os.FileMode) (*os.File, error) {
+	return gopathrs.MkdirAllHandle(root, unsafePath, mode)
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/open.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/open.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package pathrs
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// OpenInRoot safely opens the provided unsafePath within the root.
+// Effectively, OpenInRoot(root, unsafePath) is equivalent to
+//
+//	path, _ := securejoin.SecureJoin(root, unsafePath)
+//	handle, err := os.OpenFile(path, unix.O_PATH|unix.O_CLOEXEC)
+//
+// But is much safer. The above implementation is unsafe because if an attacker
+// can modify the filesystem tree between [SecureJoin] and [os.OpenFile], it is
+// possible for the returned file to be outside of the root.
+//
+// Note that the returned handle is an O_PATH handle, meaning that only a very
+// limited set of operations will work on the handle. This is done to avoid
+// accidentally opening an untrusted file that could cause issues (such as a
+// disconnected TTY that could cause a DoS, or some other issue). In order to
+// use the returned handle, you can "upgrade" it to a proper handle using
+// [Reopen].
+//
+// [SecureJoin]: https://pkg.go.dev/github.com/cyphar/filepath-securejoin#SecureJoin
+func OpenInRoot(root, unsafePath string) (*os.File, error) {
+	rootDir, err := os.OpenFile(root, unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer rootDir.Close() //nolint:errcheck // close failures aren't critical here
+	return OpenatInRoot(rootDir, unsafePath)
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/open_libpathrs.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/open_libpathrs.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build libpathrs
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package pathrs
+
+import (
+	"os"
+
+	"cyphar.com/go-pathrs"
+)
+
+// OpenatInRoot is equivalent to [OpenInRoot], except that the root is provided
+// using an *[os.File] handle, to ensure that the correct root directory is used.
+func OpenatInRoot(root *os.File, unsafePath string) (*os.File, error) {
+	rootRef, err := pathrs.RootFromFile(root)
+	if err != nil {
+		return nil, err
+	}
+	defer rootRef.Close() //nolint:errcheck // close failures aren't critical here
+
+	handle, err := rootRef.Resolve(unsafePath)
+	if err != nil {
+		return nil, err
+	}
+	return handle.IntoFile(), nil
+}
+
+// Reopen takes an *[os.File] handle and re-opens it through /proc/self/fd.
+// Reopen(file, flags) is effectively equivalent to
+//
+//	fdPath := fmt.Sprintf("/proc/self/fd/%d", file.Fd())
+//	os.OpenFile(fdPath, flags|unix.O_CLOEXEC)
+//
+// But with some extra hardenings to ensure that we are not tricked by a
+// maliciously-configured /proc mount. While this attack scenario is not
+// common, in container runtimes it is possible for higher-level runtimes to be
+// tricked into configuring an unsafe /proc that can be used to attack file
+// operations. See [CVE-2019-19921] for more details.
+//
+// [CVE-2019-19921]: https://github.com/advisories/GHSA-fh74-hm69-rqjw
+func Reopen(file *os.File, flags int) (*os.File, error) {
+	handle, err := pathrs.HandleFromFile(file)
+	if err != nil {
+		return nil, err
+	}
+	defer handle.Close() //nolint:errcheck // close failures aren't critical here
+
+	return handle.OpenFile(flags)
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/open_purego.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/open_purego.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux && !libpathrs
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package pathrs
+
+import (
+	"os"
+
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gopathrs"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/procfs"
+)
+
+// OpenatInRoot is equivalent to [OpenInRoot], except that the root is provided
+// using an *[os.File] handle, to ensure that the correct root directory is used.
+func OpenatInRoot(root *os.File, unsafePath string) (*os.File, error) {
+	return gopathrs.OpenatInRoot(root, unsafePath)
+}
+
+// Reopen takes an *[os.File] handle and re-opens it through /proc/self/fd.
+// Reopen(file, flags) is effectively equivalent to
+//
+//	fdPath := fmt.Sprintf("/proc/self/fd/%d", file.Fd())
+//	os.OpenFile(fdPath, flags|unix.O_CLOEXEC)
+//
+// But with some extra hardenings to ensure that we are not tricked by a
+// maliciously-configured /proc mount. While this attack scenario is not
+// common, in container runtimes it is possible for higher-level runtimes to be
+// tricked into configuring an unsafe /proc that can be used to attack file
+// operations. See [CVE-2019-19921] for more details.
+//
+// [CVE-2019-19921]: https://github.com/advisories/GHSA-fh74-hm69-rqjw
+func Reopen(handle *os.File, flags int) (*os.File, error) {
+	return procfs.ReopenFd(handle, flags)
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/procfs/procfs_libpathrs.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/procfs/procfs_libpathrs.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build libpathrs
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Package procfs provides a safe API for operating on /proc on Linux.
+package procfs
+
+import (
+	"os"
+	"strconv"
+
+	"cyphar.com/go-pathrs/procfs"
+	"golang.org/x/sys/unix"
+)
+
+// ProcThreadSelfCloser is a callback that needs to be called when you are done
+// operating on an [os.File] fetched using [Handle.OpenThreadSelf].
+//
+// [os.File]: https://pkg.go.dev/os#File
+type ProcThreadSelfCloser = procfs.ThreadCloser
+
+// Handle is a wrapper around an *os.File handle to "/proc", which can be used
+// to do further procfs-related operations in a safe way.
+type Handle struct {
+	inner *procfs.Handle
+}
+
+// Close close the resources associated with this [Handle]. Note that if this
+// [Handle] was created with [OpenProcRoot], on some kernels the underlying
+// procfs handle is cached and so this Close operation may be a no-op. However,
+// you should always call Close on [Handle]s once you are done with them.
+func (proc *Handle) Close() error { return proc.inner.Close() }
+
+// OpenProcRoot tries to open a "safer" handle to "/proc" (i.e., one with the
+// "subset=pid" mount option applied, available from Linux 5.8). Unless you
+// plan to do many [Handle.OpenRoot] operations, users should prefer to use
+// this over [OpenUnsafeProcRoot] which is far more dangerous to keep open.
+//
+// If a safe handle cannot be opened, OpenProcRoot will fall back to opening a
+// regular "/proc" handle.
+//
+// Note that using [Handle.OpenRoot] will still work with handles returned by
+// this function. If a subpath cannot be operated on with a safe "/proc"
+// handle, then [OpenUnsafeProcRoot] will be called internally and a temporary
+// unsafe handle will be used.
+func OpenProcRoot() (*Handle, error) {
+	proc, err := procfs.Open()
+	if err != nil {
+		return nil, err
+	}
+	return &Handle{inner: proc}, nil
+}
+
+// OpenUnsafeProcRoot opens a handle to "/proc" without any overmounts or
+// masked paths. You must be extremely careful to make sure this handle is
+// never leaked to a container and that you program cannot be tricked into
+// writing to arbitrary paths within it.
+//
+// This is not necessary if you just wish to use [Handle.OpenRoot], as handles
+// returned by [OpenProcRoot] will fall back to using a *temporary* unsafe
+// handle in that case. You should only really use this if you need to do many
+// operations with [Handle.OpenRoot] and the performance overhead of making
+// many procfs handles is an issue. If you do use OpenUnsafeProcRoot, you
+// should make sure to close the handle as soon as possible to avoid
+// known-fd-number attacks.
+func OpenUnsafeProcRoot() (*Handle, error) {
+	proc, err := procfs.Open(procfs.UnmaskedProcRoot)
+	if err != nil {
+		return nil, err
+	}
+	return &Handle{inner: proc}, nil
+}
+
+// OpenThreadSelf returns a handle to "/proc/thread-self/<subpath>" (or an
+// equivalent handle on older kernels where "/proc/thread-self" doesn't exist).
+// Once finished with the handle, you must call the returned closer function
+// ([runtime.UnlockOSThread]). You must not pass the returned *os.File to other
+// Go threads or use the handle after calling the closer.
+//
+// [runtime.UnlockOSThread]: https://pkg.go.dev/runtime#UnlockOSThread
+func (proc *Handle) OpenThreadSelf(subpath string) (*os.File, ProcThreadSelfCloser, error) {
+	return proc.inner.OpenThreadSelf(subpath, unix.O_PATH|unix.O_NOFOLLOW)
+}
+
+// OpenSelf returns a handle to /proc/self/<subpath>.
+//
+// Note that in Go programs with non-homogenous threads, this may result in
+// spurious errors. If you are monkeying around with APIs that are
+// thread-specific, you probably want to use [Handle.OpenThreadSelf] instead
+// which will guarantee that the handle refers to the same thread as the caller
+// is executing on.
+func (proc *Handle) OpenSelf(subpath string) (*os.File, error) {
+	return proc.inner.OpenSelf(subpath, unix.O_PATH|unix.O_NOFOLLOW)
+}
+
+// OpenRoot returns a handle to /proc/<subpath>.
+//
+// You should only use this when you need to operate on global procfs files
+// (such as sysctls in /proc/sys). Unlike [Handle.OpenThreadSelf],
+// [Handle.OpenSelf], and [Handle.OpenPid], the procfs handle used internally
+// for this operation will never use "subset=pid", which makes it a more juicy
+// target for [CVE-2024-21626]-style attacks (and doing something like opening
+// a directory with OpenRoot effectively leaks [OpenUnsafeProcRoot] as long as
+// the file descriptor is open).
+//
+// [CVE-2024-21626]: https://github.com/opencontainers/runc/security/advisories/GHSA-xr7r-f8xq-vfvv
+func (proc *Handle) OpenRoot(subpath string) (*os.File, error) {
+	return proc.inner.OpenRoot(subpath, unix.O_PATH|unix.O_NOFOLLOW)
+}
+
+// OpenPid returns a handle to /proc/$pid/<subpath> (pid can be a pid or tid).
+// This is mainly intended for usage when operating on other processes.
+//
+// You should not use this for the current thread, as special handling is
+// needed for /proc/thread-self (or /proc/self/task/<tid>) when dealing with
+// goroutine scheduling -- use [Handle.OpenThreadSelf] instead.
+//
+// To refer to the current thread-group, you should use prefer
+// [Handle.OpenSelf] to passing os.Getpid as the pid argument.
+func (proc *Handle) OpenPid(pid int, subpath string) (*os.File, error) {
+	return proc.inner.OpenPid(pid, subpath, unix.O_PATH|unix.O_NOFOLLOW)
+}
+
+// ProcSelfFdReadlink gets the real path of the given file by looking at
+// /proc/self/fd/<fd> with [readlink]. It is effectively just shorthand for
+// something along the lines of:
+//
+//	proc, err := procfs.OpenProcRoot()
+//	if err != nil {
+//		return err
+//	}
+//	link, err := proc.OpenThreadSelf(fmt.Sprintf("fd/%d", f.Fd()))
+//	if err != nil {
+//		return err
+//	}
+//	defer link.Close()
+//	var buf [4096]byte
+//	n, err := unix.Readlinkat(int(link.Fd()), "", buf[:])
+//	if err != nil {
+//		return err
+//	}
+//	pathname := buf[:n]
+//
+// [readlink]: https://pkg.go.dev/golang.org/x/sys/unix#Readlinkat
+func ProcSelfFdReadlink(f *os.File) (string, error) {
+	proc, err := procfs.Open()
+	if err != nil {
+		return "", err
+	}
+	defer proc.Close() //nolint:errcheck // close failures aren't critical here
+
+	fdPath := "fd/" + strconv.Itoa(int(f.Fd()))
+	return proc.Readlink(procfs.ProcThreadSelf, fdPath)
+}

--- a/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/procfs/procfs_purego.go
+++ b/pkg/wwan/mmagent/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/procfs/procfs_purego.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux && !libpathrs
+
+// Copyright (C) 2024-2025 Aleksa Sarai <cyphar@cyphar.com>
+// Copyright (C) 2024-2025 SUSE LLC
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Package procfs provides a safe API for operating on /proc on Linux.
+package procfs
+
+import (
+	"os"
+
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/internal/procfs"
+)
+
+// This package mostly just wraps internal/procfs APIs. This is necessary
+// because we are forced to export some things from internal/procfs in order to
+// avoid some dependency cycle issues, but we don't want users to see or use
+// them.
+
+// ProcThreadSelfCloser is a callback that needs to be called when you are done
+// operating on an [os.File] fetched using [Handle.OpenThreadSelf].
+//
+// [os.File]: https://pkg.go.dev/os#File
+type ProcThreadSelfCloser = procfs.ProcThreadSelfCloser
+
+// Handle is a wrapper around an *os.File handle to "/proc", which can be used
+// to do further procfs-related operations in a safe way.
+type Handle struct {
+	inner *procfs.Handle
+}
+
+// Close close the resources associated with this [Handle]. Note that if this
+// [Handle] was created with [OpenProcRoot], on some kernels the underlying
+// procfs handle is cached and so this Close operation may be a no-op. However,
+// you should always call Close on [Handle]s once you are done with them.
+func (proc *Handle) Close() error { return proc.inner.Close() }
+
+// OpenProcRoot tries to open a "safer" handle to "/proc" (i.e., one with the
+// "subset=pid" mount option applied, available from Linux 5.8). Unless you
+// plan to do many [Handle.OpenRoot] operations, users should prefer to use
+// this over [OpenUnsafeProcRoot] which is far more dangerous to keep open.
+//
+// If a safe handle cannot be opened, OpenProcRoot will fall back to opening a
+// regular "/proc" handle.
+//
+// Note that using [Handle.OpenRoot] will still work with handles returned by
+// this function. If a subpath cannot be operated on with a safe "/proc"
+// handle, then [OpenUnsafeProcRoot] will be called internally and a temporary
+// unsafe handle will be used.
+func OpenProcRoot() (*Handle, error) {
+	proc, err := procfs.OpenProcRoot()
+	if err != nil {
+		return nil, err
+	}
+	return &Handle{inner: proc}, nil
+}
+
+// OpenUnsafeProcRoot opens a handle to "/proc" without any overmounts or
+// masked paths. You must be extremely careful to make sure this handle is
+// never leaked to a container and that you program cannot be tricked into
+// writing to arbitrary paths within it.
+//
+// This is not necessary if you just wish to use [Handle.OpenRoot], as handles
+// returned by [OpenProcRoot] will fall back to using a *temporary* unsafe
+// handle in that case. You should only really use this if you need to do many
+// operations with [Handle.OpenRoot] and the performance overhead of making
+// many procfs handles is an issue. If you do use OpenUnsafeProcRoot, you
+// should make sure to close the handle as soon as possible to avoid
+// known-fd-number attacks.
+func OpenUnsafeProcRoot() (*Handle, error) {
+	proc, err := procfs.OpenUnsafeProcRoot()
+	if err != nil {
+		return nil, err
+	}
+	return &Handle{inner: proc}, nil
+}
+
+// OpenThreadSelf returns a handle to "/proc/thread-self/<subpath>" (or an
+// equivalent handle on older kernels where "/proc/thread-self" doesn't exist).
+// Once finished with the handle, you must call the returned closer function
+// ([runtime.UnlockOSThread]). You must not pass the returned *os.File to other
+// Go threads or use the handle after calling the closer.
+//
+// [runtime.UnlockOSThread]: https://pkg.go.dev/runtime#UnlockOSThread
+func (proc *Handle) OpenThreadSelf(subpath string) (*os.File, ProcThreadSelfCloser, error) {
+	return proc.inner.OpenThreadSelf(subpath)
+}
+
+// OpenSelf returns a handle to /proc/self/<subpath>.
+//
+// Note that in Go programs with non-homogenous threads, this may result in
+// spurious errors. If you are monkeying around with APIs that are
+// thread-specific, you probably want to use [Handle.OpenThreadSelf] instead
+// which will guarantee that the handle refers to the same thread as the caller
+// is executing on.
+func (proc *Handle) OpenSelf(subpath string) (*os.File, error) {
+	return proc.inner.OpenSelf(subpath)
+}
+
+// OpenRoot returns a handle to /proc/<subpath>.
+//
+// You should only use this when you need to operate on global procfs files
+// (such as sysctls in /proc/sys). Unlike [Handle.OpenThreadSelf],
+// [Handle.OpenSelf], and [Handle.OpenPid], the procfs handle used internally
+// for this operation will never use "subset=pid", which makes it a more juicy
+// target for [CVE-2024-21626]-style attacks (and doing something like opening
+// a directory with OpenRoot effectively leaks [OpenUnsafeProcRoot] as long as
+// the file descriptor is open).
+//
+// [CVE-2024-21626]: https://github.com/opencontainers/runc/security/advisories/GHSA-xr7r-f8xq-vfvv
+func (proc *Handle) OpenRoot(subpath string) (*os.File, error) {
+	return proc.inner.OpenRoot(subpath)
+}
+
+// OpenPid returns a handle to /proc/$pid/<subpath> (pid can be a pid or tid).
+// This is mainly intended for usage when operating on other processes.
+//
+// You should not use this for the current thread, as special handling is
+// needed for /proc/thread-self (or /proc/self/task/<tid>) when dealing with
+// goroutine scheduling -- use [Handle.OpenThreadSelf] instead.
+//
+// To refer to the current thread-group, you should use prefer
+// [Handle.OpenSelf] to passing os.Getpid as the pid argument.
+func (proc *Handle) OpenPid(pid int, subpath string) (*os.File, error) {
+	return proc.inner.OpenPid(pid, subpath)
+}
+
+// ProcSelfFdReadlink gets the real path of the given file by looking at
+// /proc/self/fd/<fd> with [readlink]. It is effectively just shorthand for
+// something along the lines of:
+//
+//	proc, err := procfs.OpenProcRoot()
+//	if err != nil {
+//		return err
+//	}
+//	link, err := proc.OpenThreadSelf(fmt.Sprintf("fd/%d", f.Fd()))
+//	if err != nil {
+//		return err
+//	}
+//	defer link.Close()
+//	var buf [4096]byte
+//	n, err := unix.Readlinkat(int(link.Fd()), "", buf[:])
+//	if err != nil {
+//		return err
+//	}
+//	pathname := buf[:n]
+//
+// [readlink]: https://pkg.go.dev/golang.org/x/sys/unix#Readlinkat
+func ProcSelfFdReadlink(f *os.File) (string, error) {
+	return procfs.ProcSelfFdReadlink(f)
+}

--- a/pkg/wwan/mmagent/vendor/github.com/lf-edge/eve/pkg/pillar/pubsub/memdriver.go
+++ b/pkg/wwan/mmagent/vendor/github.com/lf-edge/eve/pkg/pillar/pubsub/memdriver.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Zededa, Inc.
+// Copyright (c) 2024-2025 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package pubsub
@@ -9,9 +9,24 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
 )
 
-// MemoryDriver structure
+// MemoryDriver is an in-memory PubSub driver designed for writing tests for components
+// that use PubSub. It provides a simple, synchronous implementation without any persistence
+// or file system dependencies.
+//
+// Purpose:
+//   - Used exclusively for testing PubSub-based components in isolated environments
+//   - Enables deterministic, event-driven tests with full control over message flow
+//   - Avoids file system operations and external dependencies in test scenarios
+//
+// Limitation:
+//   - Only one subscriber is supported per topic when using notification channels
+//   - Multiple subscribers attempting to use the same topic will overwrite each other's
+//     notification channel, causing only the last registered subscriber to receive updates
+//
+// This driver should not be used in production code.
 type MemoryDriver struct {
-	status *generics.LockedMap[string, []byte]
+	status      *generics.LockedMap[string, []byte]
+	subscribers *generics.LockedMap[string, chan Change]
 }
 
 const tmpDir = "/tmp"
@@ -19,7 +34,8 @@ const tmpDir = "/tmp"
 // NewMemoryDriver to create MemoryDriver and properly initialize it
 func NewMemoryDriver() *MemoryDriver {
 	return &MemoryDriver{
-		status: generics.NewLockedMap[string, []byte](),
+		status:      generics.NewLockedMap[string, []byte](),
+		subscribers: generics.NewLockedMap[string, chan Change](),
 	}
 }
 
@@ -37,16 +53,23 @@ func decomposeStatusKey(statusKey string) (string, string) {
 // Publisher function
 func (e *MemoryDriver) Publisher(_ bool, _, topic string, _ bool, _ *Updaters, _ Restarted, _ Differ) (DriverPublisher, error) {
 	return &MemoryDriverPublisher{
-		topic:  topic,
-		status: e.status,
+		topic:       topic,
+		status:      e.status,
+		subscribers: e.subscribers,
 	}, nil
 }
 
 // Subscriber function
-func (e *MemoryDriver) Subscriber(_ bool, _, topic string, _ bool, _ chan Change) (DriverSubscriber, error) {
+func (e *MemoryDriver) Subscriber(_ bool, _, topic string, _ bool, C chan Change) (DriverSubscriber, error) {
+	// Register the subscriber channel using topic as key
+	if C != nil {
+		e.subscribers.Store(topic, C)
+	}
 	return &MemoryDriverSubscriber{
-		topic:  topic,
-		status: e.status,
+		topic:       topic,
+		status:      e.status,
+		subscribers: e.subscribers,
+		changeChan:  C,
 	}, nil
 }
 
@@ -57,8 +80,9 @@ func (e *MemoryDriver) DefaultName() string {
 
 // MemoryDriverPublisher struct
 type MemoryDriverPublisher struct {
-	topic  string
-	status *generics.LockedMap[string, []byte]
+	topic       string
+	status      *generics.LockedMap[string, []byte]
+	subscribers *generics.LockedMap[string, chan Change]
 }
 
 // Start function
@@ -89,12 +113,40 @@ func (e *MemoryDriverPublisher) CheckMaxSize(string, []byte) error {
 // Publish function
 func (e *MemoryDriverPublisher) Publish(key string, item []byte) error {
 	e.status.Store(composeStatusKey(e.topic, key), item)
+
+	// Notify subscribers if channel exists
+	if ch, ok := e.subscribers.Load(e.topic); ok {
+		select {
+		case ch <- Change{
+			Operation: Modify,
+			Key:       key,
+			Value:     item,
+		}:
+		default:
+			// Channel full or closed, skip
+		}
+	}
+
 	return nil
 }
 
 // Unpublish function
 func (e *MemoryDriverPublisher) Unpublish(key string) error {
 	e.status.Delete(composeStatusKey(e.topic, key))
+
+	// Notify subscribers if channel exists
+	if ch, ok := e.subscribers.Load(e.topic); ok {
+		select {
+		case ch <- Change{
+			Operation: Delete,
+			Key:       key,
+			Value:     nil,
+		}:
+		default:
+			// Channel full or closed, skip
+		}
+	}
+
 	return nil
 }
 
@@ -115,8 +167,10 @@ func (e *MemoryDriverPublisher) LargeDirName() string {
 
 // MemoryDriverSubscriber struct
 type MemoryDriverSubscriber struct {
-	topic  string
-	status *generics.LockedMap[string, []byte]
+	topic       string
+	status      *generics.LockedMap[string, []byte]
+	subscribers *generics.LockedMap[string, chan Change]
+	changeChan  chan Change
 }
 
 // Start function
@@ -141,10 +195,12 @@ func (e *MemoryDriverSubscriber) Load() (map[string][]byte, int, error) {
 
 // Stop function
 func (e *MemoryDriverSubscriber) Stop() error {
+	// Unregister the subscriber channel
+	e.subscribers.Delete(e.topic)
 	return nil
 }
 
 // LargeDirName where to put large fields
 func (e *MemoryDriverSubscriber) LargeDirName() string {
-	return ""
+	return tmpDir
 }

--- a/pkg/wwan/mmagent/vendor/github.com/lf-edge/eve/pkg/pillar/types/dpc.go
+++ b/pkg/wwan/mmagent/vendor/github.com/lf-edge/eve/pkg/pillar/types/dpc.go
@@ -174,16 +174,16 @@ const (
 // plus the test results for a given port. The complete status with
 // IP addresses lives in DeviceNetworkStatus
 type DevicePortConfig struct {
-	Version      DevicePortConfigVersion
-	Key          string
-	TimePriority time.Time // All zero's is fallback lowest priority
-	State        DPCState
-	ShaFile      string // File in which to write ShaValue once DevicePortConfigList published
-	ShaValue     []byte
+	Version      DevicePortConfigVersion `json:",omitempty"`
+	Key          string                  `json:",omitempty"`
+	TimePriority time.Time               `json:",omitempty"` // All zero's is fallback lowest priority
+	State        DPCState                `json:",omitempty"`
+	ShaFile      string                  `json:",omitempty"` // File in which to write ShaValue once DevicePortConfigList published
+	ShaValue     []byte                  `json:",omitempty"`
 	TestResults
-	LastIPAndDNS time.Time // Time when we got some IP addresses and DNS
+	LastIPAndDNS time.Time `json:",omitempty"` // Time when we got some IP addresses and DNS
 
-	Ports []NetworkPortConfig
+	Ports []NetworkPortConfig `json:",omitempty"`
 }
 
 // PubKey is used for pubsub. Key string plus TimePriority
@@ -622,9 +622,8 @@ func (config *DevicePortConfig) UpdatePortStatusFromIntfStatusMap(
 	}
 }
 
-// IsAnyPortInPciBack
+// IsAnyPortInPciBack checks if any of the Ports are part of IO bundles which are in PCIback.
 //
-//	Checks if any of the Ports are part of IO bundles which are in PCIback.
 //	If true, it also returns the ifName ( NOT bundle name )
 //	Also returns whether it is currently used by an application by
 //	returning a UUID. If the UUID is zero it is in PCIback but available.
@@ -660,43 +659,43 @@ func (config *DevicePortConfig) IsAnyPortInPciBack(
 // a corresponding Status struct.
 // Note that if fields are added the MostlyEqual function needs to be updated.
 type NetworkPortConfig struct {
-	IfName       string
-	USBAddr      string
-	PCIAddr      string
-	Phylabel     string // Physical name set by controller/model
-	Logicallabel string // SystemAdapter's name which is logical label in phyio
+	IfName       string `json:",omitempty"`
+	USBAddr      string `json:",omitempty"`
+	PCIAddr      string `json:",omitempty"`
+	Phylabel     string `json:",omitempty"` // Physical name set by controller/model
+	Logicallabel string `json:",omitempty"` // SystemAdapter's name which is logical label in phyio
 	// Unlike the logicallabel, which is defined in the device model and unique
 	// for each port, these user-configurable "shared" labels are potentially
 	// assigned to multiple ports so that they can be used all together with
 	// some config object (e.g. multiple ports assigned to NI).
 	// Some special shared labels, such as "uplink" or "freeuplink", are assigned
 	// to particular ports automatically.
-	SharedLabels []string
-	Alias        string // From SystemAdapter's alias
+	SharedLabels []string `json:",omitempty"`
+	Alias        string   `json:",omitempty"` // From SystemAdapter's alias
 	// Allow the local operator to make (limited) configuration changes to this
 	// network adapter using Local Profile Server.
-	AllowLocalModifications bool
+	AllowLocalModifications bool `json:",omitempty"`
 	// NetworkUUID - UUID of the Network Object configured for the port.
-	NetworkUUID uuid.UUID
-	IsMgmt      bool // Used to talk to controller
-	IsL3Port    bool // True if port is applicable to operate on the network layer
+	NetworkUUID uuid.UUID `json:",omitempty"`
+	IsMgmt      bool      `json:",omitempty"` // Used to talk to controller
+	IsL3Port    bool      `json:",omitempty"` // True if port is applicable to operate on the network layer
 	// InvalidConfig is used to flag port config which failed parsing or (static) validation
 	// checks, such as: malformed IP address, undefined required field, IP address not inside
 	// the subnet, etc.
-	InvalidConfig bool
-	Cost          uint8 // Zero is free
-	MTU           uint16
+	InvalidConfig bool   `json:",omitempty"`
+	Cost          uint8  `json:",omitempty"` // Zero is free
+	MTU           uint16 `json:",omitempty"`
 	DhcpConfig
 	ProxyConfig
 	L2LinkConfig
-	WirelessCfg WirelessConfig
+	WirelessCfg WirelessConfig `json:",omitempty"`
 	// TestResults - Errors from parsing plus success/failure from testing
 	TestResults
-	IgnoreDhcpNtpServers  bool // Ignore NTP servers from DHCP
-	IgnoreDhcpIPAddresses bool // Ignore IP addresses from DHCP
-	IgnoreDhcpGateways    bool // Ignore gateways from DHCP
-	IgnoreDhcpDNSConfig   bool // Ignore DNS config (DomainName + DNSServers) from DHCP
-	ConfigSource          PortConfigSource
+	IgnoreDhcpNtpServers  bool             `json:",omitempty"` // Ignore NTP servers from DHCP
+	IgnoreDhcpIPAddresses bool             `json:",omitempty"` // Ignore IP addresses from DHCP
+	IgnoreDhcpGateways    bool             `json:",omitempty"` // Ignore gateways from DHCP
+	IgnoreDhcpDNSConfig   bool             `json:",omitempty"` // Ignore DNS config (DomainName + DNSServers) from DHCP
+	ConfigSource          PortConfigSource `json:",omitempty"`
 }
 
 // EVE-defined port labels.
@@ -744,7 +743,7 @@ const (
 // It helps distinguish between controller-provided, locally-modified, or initial configs.
 type PortConfigSource struct {
 	// Indicates where EVE obtained the network config.
-	Origin NetworkConfigOrigin
+	Origin NetworkConfigOrigin `json:",omitempty"`
 
 	// Timestamp when the port’s configuration was originally submitted
 	// or created at its source.
@@ -766,7 +765,7 @@ type PortConfigSource struct {
 	// Note: this is a per-port timestamp. The underlying network config may
 	// cover multiple ports, but only the portion relevant to this port is
 	// reflected here.
-	SubmittedAt time.Time
+	SubmittedAt time.Time `json:",omitempty"`
 }
 
 // ToProto converts PortConfigSource into its protobuf representation.
@@ -861,18 +860,18 @@ const (
 
 // DhcpConfig : DHCP configuration for network port.
 type DhcpConfig struct {
-	Dhcp DhcpType // If DhcpTypeStatic use below; if DhcpTypeNone do nothing
+	Dhcp DhcpType `json:",omitempty"` // If DhcpTypeStatic use below; if DhcpTypeNone do nothing
 	// AddrSubnet is in CIDR format (e.g., 192.168.1.44/24).
 	// It's a string (rather than *net.IPNet) to allow unmarshalling from
 	// user-edited override.json, since *net.IPNet does not implement
 	// encoding.TextUnmarshaler. (net.IP does, and is therefore used for
 	// Gateway and DNSServers)
-	AddrSubnet string
-	Gateway    net.IP
-	DomainName string
-	NTPServers []netutils.HostnameOrIP
-	DNSServers []net.IP    // If not set we use Gateway as DNS server
-	Type       NetworkType // IPv4 or IPv6 or Dual stack
+	AddrSubnet string                  `json:",omitempty"`
+	Gateway    net.IP                  `json:",omitempty"`
+	DomainName string                  `json:",omitempty"`
+	NTPServers []netutils.HostnameOrIP `json:",omitempty"`
+	DNSServers []net.IP                `json:",omitempty"` // If not set we use Gateway as DNS server
+	Type       NetworkType             `json:",omitempty"` // IPv4 or IPv6 or Dual stack
 }
 
 // NetworkProxyType is used to differentiate proxies for different network protocols.
@@ -891,9 +890,9 @@ const (
 
 // ProxyEntry is used to store address of a single network proxy.
 type ProxyEntry struct {
-	Type   NetworkProxyType `json:"type"`
-	Server string           `json:"server"`
-	Port   uint32           `json:"port"`
+	Type   NetworkProxyType `json:"type,omitempty"`
+	Server string           `json:"server,omitempty"`
+	Port   uint32           `json:"port,omitempty"`
 }
 
 // FromProto populates a ProxyEntry from its protobuf representation.
@@ -939,14 +938,14 @@ func (pe ProxyEntry) ToProto() *evecommon.ProxyServer {
 
 // ProxyConfig : proxy configuration for a network port.
 type ProxyConfig struct {
-	Proxies    []ProxyEntry
-	Exceptions string
-	Pacfile    string
+	Proxies    []ProxyEntry `json:",omitempty"`
+	Exceptions string       `json:",omitempty"`
+	Pacfile    string       `json:",omitempty"`
 	// If Enable is set we use WPAD. If the URL is not set we try
 	// the various DNS suffixes until we can download a wpad.dat file
-	NetworkProxyEnable bool   // Enable WPAD
-	NetworkProxyURL    string // Complete URL i.e., with /wpad.dat
-	WpadURL            string // The URL determined from DNS
+	NetworkProxyEnable bool   `json:",omitempty"` // Enable WPAD
+	NetworkProxyURL    string `json:",omitempty"` // Complete URL i.e., with /wpad.dat
+	WpadURL            string `json:",omitempty"` // The URL determined from DNS
 	// List of certs which will be added to TLS trust
 	ProxyCertPEM [][]byte `json:"pubsub-large-ProxyCertPEM"` //nolint:tagliatelle
 }
@@ -1020,19 +1019,19 @@ func (wt WirelessType) String() string {
 // WirelessConfig - wireless structure
 type WirelessConfig struct {
 	// WType : Wireless Type, either Cellular or WiFi.
-	WType WirelessType
+	WType WirelessType `json:",omitempty"`
 	// CellularV2 : configuration for Cellular connectivity.
 	// This is version 2 of the cellular APIs. With the introduction of support
 	// for multiple modems and multiple SIMs, the previously used CellConfig
 	// structure was no longer suitable for storing all the new config attributes.
-	CellularV2 CellNetPortConfig
+	CellularV2 CellNetPortConfig `json:",omitempty"`
 	// Wifi : configuration for WiFi connectivity.
-	Wifi []WifiConfig
+	Wifi []WifiConfig `json:",omitempty"`
 	// Cellular : old and now deprecated structure for the cellular connectivity
 	// configuration (aka version 1).
 	// It is kept here only for backward-compatibility, i.e. to support upgrades from
 	// EVE versions which still use this structure.
-	Cellular []DeprecatedCellConfig
+	Cellular []DeprecatedCellConfig `json:",omitempty"`
 }
 
 // IsEmpty returns true if the wireless config is empty.
@@ -1049,15 +1048,15 @@ func (wc WirelessConfig) IsEmpty() bool {
 
 // WifiConfig - Wifi structure
 type WifiConfig struct {
-	SSID      string            // wifi SSID
-	KeyScheme WifiKeySchemeType // such as WPA-PSK, WPA-EAP
+	SSID      string            `json:",omitempty"` // wifi SSID
+	KeyScheme WifiKeySchemeType `json:",omitempty"` // such as WPA-PSK, WPA-EAP
 
 	// XXX: to be deprecated, use CipherBlockStatus instead
-	Identity string // identity or username for WPA-EAP
+	Identity string `json:",omitempty"` // identity or username for WPA-EAP
 
 	// XXX: to be deprecated, use CipherBlockStatus instead
-	Password string // string of pass phrase or password hash
-	Priority int32
+	Password string `json:",omitempty"` // string of pass phrase or password hash
+	Priority int32  `json:",omitempty"`
 
 	// CipherBlockStatus, for encrypted credentials
 	CipherBlockStatus
@@ -1076,21 +1075,21 @@ const (
 // network port config. It is preserved only to support upgrades from older EVE
 // versions where this is still being used (under the original struct name "CellConfig")
 type DeprecatedCellConfig struct {
-	APN              string
-	ProbeAddr        string
-	DisableProbe     bool
-	LocationTracking bool
+	APN              string `json:",omitempty"`
+	ProbeAddr        string `json:",omitempty"`
+	DisableProbe     bool   `json:",omitempty"`
+	LocationTracking bool   `json:",omitempty"`
 }
 
 // CellNetPortConfig - configuration for cellular network port (part of DPC).
 type CellNetPortConfig struct {
 	// Parameters to apply for connecting to cellular networks.
 	// Configured separately for every SIM card inserted into the modem.
-	AccessPoints []CellularAccessPoint
+	AccessPoints []CellularAccessPoint `json:",omitempty"`
 	// Probe used to detect broken connection.
-	Probe WwanProbe
+	Probe WwanProbe `json:",omitempty"`
 	// Enable to get location info from the GNSS receiver of the cellular modem.
-	LocationTracking bool
+	LocationTracking bool `json:",omitempty"`
 }
 
 // CellularAccessPoint contains config parameters for connecting to a cellular network.
@@ -1100,39 +1099,39 @@ type CellularAccessPoint struct {
 	// 1 - config for SIM card in the first slot
 	// 2 - config for SIM card in the second slot
 	// etc.
-	SIMSlot uint8
+	SIMSlot uint8 `json:",omitempty"`
 	// If true, then this configuration is currently activated.
-	Activated bool
+	Activated bool `json:",omitempty"`
 	// Access Point Network for the default bearer.
-	APN string
+	APN string `json:",omitempty"`
 	// The IP addressing type to use for the default bearer.
-	IPType WwanIPType
+	IPType WwanIPType `json:",omitempty"`
 	// Authentication protocol used for the default bearer.
-	AuthProtocol WwanAuthProtocol
+	AuthProtocol WwanAuthProtocol `json:",omitempty"`
 	// Cleartext user credentials for the default bearer.
 	// Used only for network configuration submitted via Local Profile Server.
-	CleartextCredentials WwanCleartextCredentials
+	CleartextCredentials WwanCleartextCredentials `json:",omitempty"`
 	// Encrypted user credentials for the default bearer and/or the attach bearer
 	// (when required).
 	EncryptedCredentials CipherBlockStatus
 	// The set of cellular network operators that modem should preferably try to register
 	// and connect into.
 	// Network operator should be referenced by PLMN (Public Land Mobile Network) code.
-	PreferredPLMNs []string
+	PreferredPLMNs []string `json:",omitempty"`
 	// The list of preferred Radio Access Technologies (RATs) to use for connecting
 	// to the network.
-	PreferredRATs []WwanRAT
+	PreferredRATs []WwanRAT `json:",omitempty"`
 	// If true, then modem will avoid connecting to networks with roaming.
-	ForbidRoaming bool
+	ForbidRoaming bool `json:",omitempty"`
 	// Access Point Network for the attach (aka initial) bearer.
-	AttachAPN string
+	AttachAPN string `json:",omitempty"`
 	// The IP addressing type to use for the attach bearer.
-	AttachIPType WwanIPType
+	AttachIPType WwanIPType `json:",omitempty"`
 	// Authentication protocol used for the attach bearer.
-	AttachAuthProtocol WwanAuthProtocol
+	AttachAuthProtocol WwanAuthProtocol `json:",omitempty"`
 	// Cleartext user credentials for the attach bearer.
 	// Used only for network configuration submitted via Local Profile Server.
-	AttachCleartextCredentials WwanCleartextCredentials
+	AttachCleartextCredentials WwanCleartextCredentials `json:",omitempty"`
 }
 
 // Equal compares two instances of CellularAccessPoint for equality.
@@ -1175,17 +1174,17 @@ const (
 // L2LinkConfig - contains either VLAN or Bond interface configuration,
 // depending on the L2Type.
 type L2LinkConfig struct {
-	L2Type L2LinkType
-	VLAN   VLANConfig
-	Bond   BondConfig
+	L2Type L2LinkType `json:",omitempty"`
+	VLAN   VLANConfig `json:",omitempty"`
+	Bond   BondConfig `json:",omitempty"`
 }
 
 // VLANConfig - VLAN sub-interface configuration.
 type VLANConfig struct {
 	// Logical name of the parent port.
-	ParentPort string
+	ParentPort string `json:",omitempty"`
 	// VLAN ID.
-	ID uint16
+	ID uint16 `json:",omitempty"`
 }
 
 // BondMode specifies the policy indicating how bonding slaves are used
@@ -1227,34 +1226,34 @@ const (
 // BondConfig - Bond (LAG) interface configuration.
 type BondConfig struct {
 	// Logical names of PhysicalIO network adapters aggregated by this bond.
-	AggregatedPorts []string
+	AggregatedPorts []string `json:",omitempty"`
 
 	// Bonding policy.
-	Mode BondMode
+	Mode BondMode `json:",omitempty"`
 
 	// LACPDU packets transmission rate.
 	// Applicable for BondMode802Dot3AD only.
-	LacpRate LacpRate
+	LacpRate LacpRate `json:",omitempty"`
 
 	// Link monitoring is either disabled or one of the monitors
 	// is enabled, never both at the same time.
-	MIIMonitor BondMIIMonitor
-	ARPMonitor BondArpMonitor
+	MIIMonitor BondMIIMonitor `json:",omitempty"`
+	ARPMonitor BondArpMonitor `json:",omitempty"`
 }
 
 // BondMIIMonitor : MII link monitoring parameters (see devmodel.proto for description).
 type BondMIIMonitor struct {
-	Enabled   bool
-	Interval  uint32
-	UpDelay   uint32
-	DownDelay uint32
+	Enabled   bool   `json:",omitempty"`
+	Interval  uint32 `json:",omitempty"`
+	UpDelay   uint32 `json:",omitempty"`
+	DownDelay uint32 `json:",omitempty"`
 }
 
 // BondArpMonitor : ARP-based link monitoring parameters (see devmodel.proto for description).
 type BondArpMonitor struct {
-	Enabled   bool
-	Interval  uint32
-	IPTargets []net.IP
+	Enabled   bool     `json:",omitempty"`
+	Interval  uint32   `json:",omitempty"`
+	IPTargets []net.IP `json:",omitempty"`
 }
 
 // Equal compares two BondArpMonitor configs for equality.
@@ -1269,8 +1268,8 @@ func (m BondArpMonitor) Equal(m2 BondArpMonitor) bool {
 // It includes test results hence is misnamed - should have a separate status
 // This is only published under the key "global"
 type DevicePortConfigList struct {
-	CurrentIndex   int
-	PortConfigList []DevicePortConfig
+	CurrentIndex   int                `json:",omitempty"`
+	PortConfigList []DevicePortConfig `json:",omitempty"`
 }
 
 // MostlyEqual - Equal if everything else other than timestamps is equal.
@@ -1356,9 +1355,9 @@ func (config DevicePortConfigList) LogKey() string {
 // from protobuf API into DevicePortConfig.
 // XXX replace by inline once we have device model
 type NetworkXObjectConfig struct {
-	UUID uuid.UUID
-	Type NetworkType
-	Dhcp DhcpType
+	UUID uuid.UUID   `json:",omitempty"`
+	Type NetworkType `json:",omitempty"`
+	Dhcp DhcpType    `json:",omitempty"`
 
 	// Subnet, Gateway, NTPServers, DomainName, and DNSServers can all be configured
 	// even when Dhcp == DhcpTypeClient. By default, DHCP-provided and statically
@@ -1366,28 +1365,28 @@ type NetworkXObjectConfig struct {
 	// the static value(s) to override DHCP for that field.
 
 	// IP addresses.
-	Subnet                *net.IPNet
-	DhcpRange             IPRange
-	IgnoreDhcpIPAddresses bool
+	Subnet                *net.IPNet `json:",omitempty"`
+	DhcpRange             IPRange    `json:",omitempty"`
+	IgnoreDhcpIPAddresses bool       `json:",omitempty"`
 
 	// IP gateway.
-	Gateway            net.IP
-	IgnoreDhcpGateways bool
+	Gateway            net.IP `json:",omitempty"`
+	IgnoreDhcpGateways bool   `json:",omitempty"`
 
 	// DNS configuration.
-	DomainName string
+	DomainName string `json:",omitempty"`
 	// If Dhcp=DhcpTypeStatic and DNSServers are not set, Gateway is used as DNS server.
-	DNSServers          []net.IP
-	DNSNameToIPList     []DNSNameToIP // Used for DNS and ACL ipset
-	IgnoreDhcpDNSConfig bool
+	DNSServers          []net.IP      `json:",omitempty"`
+	DNSNameToIPList     []DNSNameToIP `json:",omitempty"` // Used for DNS and ACL ipset
+	IgnoreDhcpDNSConfig bool          `json:",omitempty"`
 
 	// NTP servers.
-	NTPServers           []netutils.HostnameOrIP
-	IgnoreDhcpNtpServers bool
+	NTPServers           []netutils.HostnameOrIP `json:",omitempty"`
+	IgnoreDhcpNtpServers bool                    `json:",omitempty"`
 
-	Proxy       *ProxyConfig
-	WirelessCfg WirelessConfig
-	MTU         uint16
+	Proxy       *ProxyConfig   `json:",omitempty"`
+	WirelessCfg WirelessConfig `json:",omitempty"`
+	MTU         uint16         `json:",omitempty"`
 	// Any errors from the parser
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
@@ -1395,14 +1394,14 @@ type NetworkXObjectConfig struct {
 
 // DNSNameToIP : static mapping between hostname and IP addresses.
 type DNSNameToIP struct {
-	HostName string
-	IPs      []net.IP
+	HostName string   `json:",omitempty"`
+	IPs      []net.IP `json:",omitempty"`
 }
 
 // IPRange : range of consecutive IP addresses.
 type IPRange struct {
-	Start net.IP
-	End   net.IP
+	Start net.IP `json:",omitempty"`
+	End   net.IP `json:",omitempty"`
 }
 
 // Contains used to evaluate whether an IP address
@@ -1431,6 +1430,7 @@ func (ipRange IPRange) Size() uint32 {
 	return ip2Int - ip1Int
 }
 
+// Key : called to get the key for pubsub
 func (config NetworkXObjectConfig) Key() string {
 	return config.UUID.String()
 }

--- a/pkg/wwan/mmagent/vendor/github.com/lf-edge/eve/pkg/pillar/types/global.go
+++ b/pkg/wwan/mmagent/vendor/github.com/lf-edge/eve/pkg/pillar/types/global.go
@@ -417,6 +417,10 @@ const (
 	// DiagProbeRemoteHTTPSEndpoint : remote endpoint queried over **HTTPS** to assess
 	// the state of network connectivity whenever the controller is not reachable.
 	DiagProbeRemoteHTTPSEndpoint GlobalSettingKey = "diag.probe.remote.https.endpoint"
+
+	// EnableTCPMSSClamping : Configuration property to enable or disable TCP MSS clamping
+	// for application traffic forwarded by EVE.
+	EnableTCPMSSClamping GlobalSettingKey = "app.enable.tcp.mss.clamping"
 )
 
 // AgentSettingKey - keys for per-agent settings
@@ -1120,6 +1124,8 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddStringItem(DiagProbeRemoteHTTPEndpoint, "www.google.com", makeURLValidator("http", true))
 	configItemSpecMap.AddStringItem(DiagProbeRemoteHTTPSEndpoint, "www.google.com", makeURLValidator("https", false))
 
+	// TCP MSS Clamping
+	configItemSpecMap.AddBoolItem(EnableTCPMSSClamping, true)
 	return configItemSpecMap
 }
 

--- a/pkg/wwan/mmagent/vendor/github.com/lf-edge/eve/pkg/pillar/types/pbr.go
+++ b/pkg/wwan/mmagent/vendor/github.com/lf-edge/eve/pkg/pillar/types/pbr.go
@@ -36,4 +36,23 @@ const (
 	PbrKubeNetworkPrio = 13000
 	// PbrLocalOrigPrio : IP rule priority for locally (dom0) generated packets
 	PbrLocalOrigPrio = 15000
+
+	// For components that do not follow EVE's source-based routing and instead
+	// use the main routing table (e.g., pulling Kubernetes system images for eve-k),
+	// route metrics are assigned to reflect interface usage and priority.
+	//
+	// Each interface receives a unique metric to ensure deterministic ordering
+	// of default routes in the main routing table. Metrics are derived from a
+	// base value depending on interface usage and an incremental offset based on
+	// interface cost and order within the configuration.
+
+	// MgmtPortBaseMetric is the base metric value for all management ports.
+	// The final metric for each management port is calculated as:
+	//   MgmtPortBaseMetric + index_in_cost_order
+	MgmtPortBaseMetric = 5000
+
+	// AppSharedPortBaseMetric is the base metric value for all app-shared ports.
+	// The final metric for each app-shared port is calculated as:
+	//   AppSharedPortBaseMetric + index_in_cost_order
+	AppSharedPortBaseMetric = 10000
 )

--- a/pkg/wwan/mmagent/vendor/github.com/lf-edge/eve/pkg/pillar/types/wwan.go
+++ b/pkg/wwan/mmagent/vendor/github.com/lf-edge/eve/pkg/pillar/types/wwan.go
@@ -121,6 +121,8 @@ type WwanNetworkConfig struct {
 	LocationTracking bool
 	// Maximum transmission unit (IP MTU) to apply on the wwan interface.
 	MTU uint16
+	// Metric assigned to routes configured for this wwan interface.
+	RouteMetric uint32
 }
 
 // WwanAuthProtocol : authentication protocol used by cellular network.
@@ -267,7 +269,8 @@ func (wnc WwanNetworkConfig) Equal(wnc2 WwanNetworkConfig) bool {
 	}
 	if wnc.Probe != wnc2.Probe ||
 		wnc.LocationTracking != wnc2.LocationTracking ||
-		wnc.MTU != wnc2.MTU {
+		wnc.MTU != wnc2.MTU ||
+		wnc.RouteMetric != wnc2.RouteMetric {
 		return false
 	}
 	return true

--- a/pkg/wwan/mmagent/vendor/github.com/lf-edge/eve/pkg/pillar/types/zedkubetypes.go
+++ b/pkg/wwan/mmagent/vendor/github.com/lf-edge/eve/pkg/pillar/types/zedkubetypes.go
@@ -232,9 +232,9 @@ func (kvi KubeVMIInfo) ZKubeVMIInfo() *info.KubeVMIInfo {
 // KubeClusterInfo - Information about a Kubernetes cluster
 type KubeClusterInfo struct {
 	Nodes     []KubeNodeInfo         // List of nodes in the cluster
-	AppPods   []KubePodInfo          // List of EVE application pods
-	AppVMIs   []KubeVMIInfo          // List of VirtualMachineInstance
-	Storage   KubeStorageInfo        // Distributed storage info
+	AppPods   []KubePodInfo          `json:"pubsub-large-AppPods"` // List of EVE application pods
+	AppVMIs   []KubeVMIInfo          `json:"pubsub-large-AppVMIs"` // List of VirtualMachineInstance
+	Storage   KubeStorageInfo        `json:"pubsub-large-Storage"` // Distributed storage info
 	PodNsInfo []KubePodNameSpaceInfo // General namespace pod running/failed count
 }
 

--- a/pkg/wwan/mmagent/vendor/github.com/opencontainers/selinux/go-selinux/label/label.go
+++ b/pkg/wwan/mmagent/vendor/github.com/opencontainers/selinux/go-selinux/label/label.go
@@ -6,77 +6,10 @@ import (
 	"github.com/opencontainers/selinux/go-selinux"
 )
 
-// Deprecated: use selinux.ROFileLabel
-var ROMountLabel = selinux.ROFileLabel
-
-// SetProcessLabel takes a process label and tells the kernel to assign the
-// label to the next program executed by the current process.
-// Deprecated: use selinux.SetExecLabel
-var SetProcessLabel = selinux.SetExecLabel
-
-// ProcessLabel returns the process label that the kernel will assign
-// to the next program executed by the current process.  If "" is returned
-// this indicates that the default labeling will happen for the process.
-// Deprecated: use selinux.ExecLabel
-var ProcessLabel = selinux.ExecLabel
-
-// SetSocketLabel takes a process label and tells the kernel to assign the
-// label to the next socket that gets created
-// Deprecated: use selinux.SetSocketLabel
-var SetSocketLabel = selinux.SetSocketLabel
-
-// SocketLabel retrieves the current default socket label setting
-// Deprecated: use selinux.SocketLabel
-var SocketLabel = selinux.SocketLabel
-
-// SetKeyLabel takes a process label and tells the kernel to assign the
-// label to the next kernel keyring that gets created
-// Deprecated: use selinux.SetKeyLabel
-var SetKeyLabel = selinux.SetKeyLabel
-
-// KeyLabel retrieves the current default kernel keyring label setting
-// Deprecated: use selinux.KeyLabel
-var KeyLabel = selinux.KeyLabel
-
-// FileLabel returns the label for specified path
-// Deprecated: use selinux.FileLabel
-var FileLabel = selinux.FileLabel
-
-// PidLabel will return the label of the process running with the specified pid
-// Deprecated: use selinux.PidLabel
-var PidLabel = selinux.PidLabel
-
 // Init initialises the labeling system
 func Init() {
 	_ = selinux.GetEnabled()
 }
-
-// ClearLabels will clear all reserved labels
-// Deprecated: use selinux.ClearLabels
-var ClearLabels = selinux.ClearLabels
-
-// ReserveLabel will record the fact that the MCS label has already been used.
-// This will prevent InitLabels from using the MCS label in a newly created
-// container
-// Deprecated: use selinux.ReserveLabel
-func ReserveLabel(label string) error {
-	selinux.ReserveLabel(label)
-	return nil
-}
-
-// ReleaseLabel will remove the reservation of the MCS label.
-// This will allow InitLabels to use the MCS label in a newly created
-// containers
-// Deprecated: use selinux.ReleaseLabel
-func ReleaseLabel(label string) error {
-	selinux.ReleaseLabel(label)
-	return nil
-}
-
-// DupSecOpt takes a process label and returns security options that
-// can be used to set duplicate labels on future container processes
-// Deprecated: use selinux.DupSecOpt
-var DupSecOpt = selinux.DupSecOpt
 
 // FormatMountLabel returns a string to be used by the mount command. Using
 // the SELinux `context` mount option. Changing labels of files on mount

--- a/pkg/wwan/mmagent/vendor/github.com/opencontainers/selinux/go-selinux/label/label_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/opencontainers/selinux/go-selinux/label/label_linux.go
@@ -18,7 +18,7 @@ var validOptions = map[string]bool{
 	"level":    true,
 }
 
-var ErrIncompatibleLabel = errors.New("Bad SELinux option z and Z can not be used together")
+var ErrIncompatibleLabel = errors.New("bad SELinux option: z and Z can not be used together")
 
 // InitLabels returns the process label and file labels to be used within
 // the container.  A list of options can be passed into this function to alter
@@ -52,11 +52,11 @@ func InitLabels(options []string) (plabel string, mlabel string, retErr error) {
 				return "", selinux.PrivContainerMountLabel(), nil
 			}
 			if i := strings.Index(opt, ":"); i == -1 {
-				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable' or \n'user, role, level, type, filetype' followed by ':' and a value", opt)
+				return "", "", fmt.Errorf("bad label option %q, valid options 'disable' or \n'user, role, level, type, filetype' followed by ':' and a value", opt)
 			}
 			con := strings.SplitN(opt, ":", 2)
 			if !validOptions[con[0]] {
-				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable, user, role, level, type, filetype'", con[0])
+				return "", "", fmt.Errorf("bad label option %q, valid options 'disable, user, role, level, type, filetype'", con[0])
 			}
 			if con[0] == "filetype" {
 				mcon["type"] = con[1]
@@ -77,12 +77,6 @@ func InitLabels(options []string) (plabel string, mlabel string, retErr error) {
 		mountLabel = mcon.Get()
 	}
 	return processLabel, mountLabel, nil
-}
-
-// Deprecated: The GenLabels function is only to be used during the transition
-// to the official API. Use InitLabels(strings.Fields(options)) instead.
-func GenLabels(options string) (string, string, error) {
-	return InitLabels(strings.Fields(options))
 }
 
 // SetFileLabel modifies the "path" label to the specified file label
@@ -120,16 +114,8 @@ func Relabel(path string, fileLabel string, shared bool) error {
 		c["level"] = "s0"
 		fileLabel = c.Get()
 	}
-	if err := selinux.Chcon(path, fileLabel, true); err != nil {
-		return err
-	}
-	return nil
+	return selinux.Chcon(path, fileLabel, true)
 }
-
-// DisableSecOpt returns a security opt that can disable labeling
-// support for future container processes
-// Deprecated: use selinux.DisableSecOpt
-var DisableSecOpt = selinux.DisableSecOpt
 
 // Validate checks that the label does not include unexpected options
 func Validate(label string) error {

--- a/pkg/wwan/mmagent/vendor/github.com/opencontainers/selinux/go-selinux/label/label_stub.go
+++ b/pkg/wwan/mmagent/vendor/github.com/opencontainers/selinux/go-selinux/label/label_stub.go
@@ -6,25 +6,19 @@ package label
 // InitLabels returns the process label and file labels to be used within
 // the container.  A list of options can be passed into this function to alter
 // the labels.
-func InitLabels(options []string) (string, string, error) {
+func InitLabels([]string) (string, string, error) {
 	return "", "", nil
 }
 
-// Deprecated: The GenLabels function is only to be used during the transition
-// to the official API. Use InitLabels(strings.Fields(options)) instead.
-func GenLabels(options string) (string, string, error) {
-	return "", "", nil
-}
-
-func SetFileLabel(path string, fileLabel string) error {
+func SetFileLabel(string, string) error {
 	return nil
 }
 
-func SetFileCreateLabel(fileLabel string) error {
+func SetFileCreateLabel(string) error {
 	return nil
 }
 
-func Relabel(path string, fileLabel string, shared bool) error {
+func Relabel(string, string, bool) error {
 	return nil
 }
 
@@ -35,16 +29,16 @@ func DisableSecOpt() []string {
 }
 
 // Validate checks that the label does not include unexpected options
-func Validate(label string) error {
+func Validate(string) error {
 	return nil
 }
 
 // RelabelNeeded checks whether the user requested a relabel
-func RelabelNeeded(label string) bool {
+func RelabelNeeded(string) bool {
 	return false
 }
 
 // IsShared checks that the label includes a "shared" mark
-func IsShared(label string) bool {
+func IsShared(string) bool {
 	return false
 }

--- a/pkg/wwan/mmagent/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
@@ -17,8 +17,11 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/opencontainers/selinux/pkg/pwalkdir"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite"
+	"github.com/cyphar/filepath-securejoin/pathrs-lite/procfs"
 	"golang.org/x/sys/unix"
+
+	"github.com/opencontainers/selinux/pkg/pwalkdir"
 )
 
 const (
@@ -45,7 +48,7 @@ type selinuxState struct {
 
 type level struct {
 	cats *big.Int
-	sens uint
+	sens int
 }
 
 type mlsRange struct {
@@ -72,10 +75,6 @@ var (
 	state             = selinuxState{
 		mcsList: make(map[string]bool),
 	}
-
-	// for attrPath()
-	attrPathOnce   sync.Once
-	haveThreadSelf bool
 
 	// for policyRoot()
 	policyRootOnce sync.Once
@@ -132,12 +131,13 @@ func verifySELinuxfsMount(mnt string) bool {
 		if err == nil {
 			break
 		}
-		if err == unix.EAGAIN || err == unix.EINTR { //nolint:errorlint // unix errors are bare
+		if err == unix.EAGAIN || err == unix.EINTR {
 			continue
 		}
 		return false
 	}
 
+	//#nosec G115 -- there is no overflow here.
 	if uint32(buf.Type) != uint32(unix.SELINUX_MAGIC) {
 		return false
 	}
@@ -255,48 +255,183 @@ func readConfig(target string) string {
 	return ""
 }
 
-func isProcHandle(fh *os.File) error {
-	var buf unix.Statfs_t
-
-	for {
-		err := unix.Fstatfs(int(fh.Fd()), &buf)
-		if err == nil {
-			break
-		}
-		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
-			return &os.PathError{Op: "fstatfs", Path: fh.Name(), Err: err}
-		}
-	}
-	if buf.Type != unix.PROC_SUPER_MAGIC {
-		return fmt.Errorf("file %q is not on procfs", fh.Name())
-	}
-
-	return nil
-}
-
-func readCon(fpath string) (string, error) {
-	if fpath == "" {
-		return "", ErrEmptyPath
-	}
-
-	in, err := os.Open(fpath)
-	if err != nil {
-		return "", err
-	}
-	defer in.Close()
-
-	if err := isProcHandle(in); err != nil {
-		return "", err
-	}
-	return readConFd(in)
-}
-
 func readConFd(in *os.File) (string, error) {
 	data, err := io.ReadAll(in)
 	if err != nil {
 		return "", err
 	}
 	return string(bytes.TrimSuffix(data, []byte{0})), nil
+}
+
+func writeConFd(out *os.File, val string) error {
+	var err error
+	if val != "" {
+		_, err = out.Write([]byte(val))
+	} else {
+		_, err = out.Write(nil)
+	}
+	return err
+}
+
+// openProcThreadSelf is a small wrapper around [procfs.Handle.OpenThreadSelf]
+// and [pathrs.Reopen] to make "one-shot opens" slightly more ergonomic. The
+// provided mode must be os.O_* flags to indicate what mode the returned file
+// should be opened with (flags like os.O_CREAT and os.O_EXCL are not
+// supported).
+//
+// If no error occurred, the returned handle is guaranteed to be exactly
+// /proc/thread-self/<subpath> with no tricky mounts or symlinks causing you to
+// operate on an unexpected path (with some caveats on pre-openat2 or
+// pre-fsopen kernels).
+func openProcThreadSelf(subpath string, mode int) (*os.File, procfs.ProcThreadSelfCloser, error) {
+	if subpath == "" {
+		return nil, nil, ErrEmptyPath
+	}
+
+	proc, err := procfs.OpenProcRoot()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer proc.Close()
+
+	handle, closer, err := proc.OpenThreadSelf(subpath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open /proc/thread-self/%s handle: %w", subpath, err)
+	}
+	defer handle.Close() // we will return a re-opened handle
+
+	file, err := pathrs.Reopen(handle, mode)
+	if err != nil {
+		closer()
+		return nil, nil, fmt.Errorf("reopen /proc/thread-self/%s handle (%#x): %w", subpath, mode, err)
+	}
+	return file, closer, nil
+}
+
+// Read the contents of /proc/thread-self/<fpath>.
+func readConThreadSelf(fpath string) (string, error) {
+	in, closer, err := openProcThreadSelf(fpath, os.O_RDONLY|unix.O_CLOEXEC)
+	if err != nil {
+		return "", err
+	}
+	defer closer()
+	defer in.Close()
+
+	return readConFd(in)
+}
+
+// Write <val> to /proc/thread-self/<fpath>.
+func writeConThreadSelf(fpath, val string) error {
+	if val == "" {
+		if !getEnabled() {
+			return nil
+		}
+	}
+
+	out, closer, err := openProcThreadSelf(fpath, os.O_WRONLY|unix.O_CLOEXEC)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	defer out.Close()
+
+	return writeConFd(out, val)
+}
+
+// openProcSelf is a small wrapper around [procfs.Handle.OpenSelf] and
+// [pathrs.Reopen] to make "one-shot opens" slightly more ergonomic. The
+// provided mode must be os.O_* flags to indicate what mode the returned file
+// should be opened with (flags like os.O_CREAT and os.O_EXCL are not
+// supported).
+//
+// If no error occurred, the returned handle is guaranteed to be exactly
+// /proc/self/<subpath> with no tricky mounts or symlinks causing you to
+// operate on an unexpected path (with some caveats on pre-openat2 or
+// pre-fsopen kernels).
+func openProcSelf(subpath string, mode int) (*os.File, error) {
+	if subpath == "" {
+		return nil, ErrEmptyPath
+	}
+
+	proc, err := procfs.OpenProcRoot()
+	if err != nil {
+		return nil, err
+	}
+	defer proc.Close()
+
+	handle, err := proc.OpenSelf(subpath)
+	if err != nil {
+		return nil, fmt.Errorf("open /proc/self/%s handle: %w", subpath, err)
+	}
+	defer handle.Close() // we will return a re-opened handle
+
+	file, err := pathrs.Reopen(handle, mode)
+	if err != nil {
+		return nil, fmt.Errorf("reopen /proc/self/%s handle (%#x): %w", subpath, mode, err)
+	}
+	return file, nil
+}
+
+// Read the contents of /proc/self/<fpath>.
+func readConSelf(fpath string) (string, error) {
+	in, err := openProcSelf(fpath, os.O_RDONLY|unix.O_CLOEXEC)
+	if err != nil {
+		return "", err
+	}
+	defer in.Close()
+
+	return readConFd(in)
+}
+
+// Write <val> to /proc/self/<fpath>.
+func writeConSelf(fpath, val string) error {
+	if val == "" {
+		if !getEnabled() {
+			return nil
+		}
+	}
+
+	out, err := openProcSelf(fpath, os.O_WRONLY|unix.O_CLOEXEC)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	return writeConFd(out, val)
+}
+
+// openProcPid is a small wrapper around [procfs.Handle.OpenPid] and
+// [pathrs.Reopen] to make "one-shot opens" slightly more ergonomic. The
+// provided mode must be os.O_* flags to indicate what mode the returned file
+// should be opened with (flags like os.O_CREAT and os.O_EXCL are not
+// supported).
+//
+// If no error occurred, the returned handle is guaranteed to be exactly
+// /proc/self/<subpath> with no tricky mounts or symlinks causing you to
+// operate on an unexpected path (with some caveats on pre-openat2 or
+// pre-fsopen kernels).
+func openProcPid(pid int, subpath string, mode int) (*os.File, error) {
+	if subpath == "" {
+		return nil, ErrEmptyPath
+	}
+
+	proc, err := procfs.OpenProcRoot()
+	if err != nil {
+		return nil, err
+	}
+	defer proc.Close()
+
+	handle, err := proc.OpenPid(pid, subpath)
+	if err != nil {
+		return nil, fmt.Errorf("open /proc/%d/%s handle: %w", pid, subpath, err)
+	}
+	defer handle.Close() // we will return a re-opened handle
+
+	file, err := pathrs.Reopen(handle, mode)
+	if err != nil {
+		return nil, fmt.Errorf("reopen /proc/%d/%s handle (%#x): %w", pid, subpath, mode, err)
+	}
+	return file, nil
 }
 
 // classIndex returns the int index for an object class in the loaded policy,
@@ -328,8 +463,8 @@ func lSetFileLabel(fpath string, label string) error {
 		if err == nil {
 			break
 		}
-		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
-			return &os.PathError{Op: "lsetxattr", Path: fpath, Err: err}
+		if err != unix.EINTR {
+			return &os.PathError{Op: fmt.Sprintf("lsetxattr(label=%s)", label), Path: fpath, Err: err}
 		}
 	}
 
@@ -347,8 +482,8 @@ func setFileLabel(fpath string, label string) error {
 		if err == nil {
 			break
 		}
-		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
-			return &os.PathError{Op: "setxattr", Path: fpath, Err: err}
+		if err != unix.EINTR {
+			return &os.PathError{Op: fmt.Sprintf("setxattr(label=%s)", label), Path: fpath, Err: err}
 		}
 	}
 
@@ -392,78 +527,34 @@ func lFileLabel(fpath string) (string, error) {
 }
 
 func setFSCreateLabel(label string) error {
-	return writeCon(attrPath("fscreate"), label)
+	return writeConThreadSelf("attr/fscreate", label)
 }
 
 // fsCreateLabel returns the default label the kernel which the kernel is using
 // for file system objects created by this task. "" indicates default.
 func fsCreateLabel() (string, error) {
-	return readCon(attrPath("fscreate"))
+	return readConThreadSelf("attr/fscreate")
 }
 
 // currentLabel returns the SELinux label of the current process thread, or an error.
 func currentLabel() (string, error) {
-	return readCon(attrPath("current"))
+	return readConThreadSelf("attr/current")
 }
 
 // pidLabel returns the SELinux label of the given pid, or an error.
 func pidLabel(pid int) (string, error) {
-	return readCon(fmt.Sprintf("/proc/%d/attr/current", pid))
+	it, err := openProcPid(pid, "attr/current", os.O_RDONLY|unix.O_CLOEXEC)
+	if err != nil {
+		return "", nil
+	}
+	defer it.Close()
+	return readConFd(it)
 }
 
 // ExecLabel returns the SELinux label that the kernel will use for any programs
 // that are executed by the current process thread, or an error.
 func execLabel() (string, error) {
-	return readCon(attrPath("exec"))
-}
-
-func writeCon(fpath, val string) error {
-	if fpath == "" {
-		return ErrEmptyPath
-	}
-	if val == "" {
-		if !getEnabled() {
-			return nil
-		}
-	}
-
-	out, err := os.OpenFile(fpath, os.O_WRONLY, 0)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	if err := isProcHandle(out); err != nil {
-		return err
-	}
-
-	if val != "" {
-		_, err = out.Write([]byte(val))
-	} else {
-		_, err = out.Write(nil)
-	}
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func attrPath(attr string) string {
-	// Linux >= 3.17 provides this
-	const threadSelfPrefix = "/proc/thread-self/attr"
-
-	attrPathOnce.Do(func() {
-		st, err := os.Stat(threadSelfPrefix)
-		if err == nil && st.Mode().IsDir() {
-			haveThreadSelf = true
-		}
-	})
-
-	if haveThreadSelf {
-		return filepath.Join(threadSelfPrefix, attr)
-	}
-
-	return filepath.Join("/proc/self/task", strconv.Itoa(unix.Gettid()), "attr", attr)
+	return readConThreadSelf("exec")
 }
 
 // canonicalizeContext takes a context string and writes it to the kernel
@@ -501,14 +592,14 @@ func catsToBitset(cats string) (*big.Int, error) {
 				return nil, err
 			}
 			for i := catstart; i <= catend; i++ {
-				bitset.SetBit(bitset, int(i), 1)
+				bitset.SetBit(bitset, i, 1)
 			}
 		} else {
 			cat, err := parseLevelItem(ranges[0], category)
 			if err != nil {
 				return nil, err
 			}
-			bitset.SetBit(bitset, int(cat), 1)
+			bitset.SetBit(bitset, cat, 1)
 		}
 	}
 
@@ -516,16 +607,17 @@ func catsToBitset(cats string) (*big.Int, error) {
 }
 
 // parseLevelItem parses and verifies that a sensitivity or category are valid
-func parseLevelItem(s string, sep levelItem) (uint, error) {
+func parseLevelItem(s string, sep levelItem) (int, error) {
 	if len(s) < minSensLen || levelItem(s[0]) != sep {
 		return 0, ErrLevelSyntax
 	}
-	val, err := strconv.ParseUint(s[1:], 10, 32)
+	const bitSize = 31 // Make sure the result fits into signed int32.
+	val, err := strconv.ParseUint(s[1:], 10, bitSize)
 	if err != nil {
 		return 0, err
 	}
 
-	return uint(val), nil
+	return int(val), nil
 }
 
 // parseLevel fills a level from a string that contains
@@ -582,7 +674,8 @@ func bitsetToStr(c *big.Int) string {
 	var str string
 
 	length := 0
-	for i := int(c.TrailingZeroBits()); i < c.BitLen(); i++ {
+	i0 := int(c.TrailingZeroBits()) //#nosec G115 -- don't expect TralingZeroBits to return values with highest bit set.
+	for i := i0; i < c.BitLen(); i++ {
 		if c.Bit(i) == 0 {
 			continue
 		}
@@ -622,7 +715,7 @@ func (l *level) equal(l2 *level) bool {
 
 // String returns an mlsRange as a string.
 func (m mlsRange) String() string {
-	low := "s" + strconv.Itoa(int(m.low.sens))
+	low := "s" + strconv.Itoa(m.low.sens)
 	if m.low.cats != nil && m.low.cats.BitLen() > 0 {
 		low += ":" + bitsetToStr(m.low.cats)
 	}
@@ -631,7 +724,7 @@ func (m mlsRange) String() string {
 		return low
 	}
 
-	high := "s" + strconv.Itoa(int(m.high.sens))
+	high := "s" + strconv.Itoa(m.high.sens)
 	if m.high.cats != nil && m.high.cats.BitLen() > 0 {
 		high += ":" + bitsetToStr(m.high.cats)
 	}
@@ -639,14 +732,16 @@ func (m mlsRange) String() string {
 	return low + "-" + high
 }
 
-func max(a, b uint) uint {
+// TODO: remove these in favor of built-in min/max
+// once we stop supporting Go < 1.21.
+func maxInt(a, b int) int {
 	if a > b {
 		return a
 	}
 	return b
 }
 
-func min(a, b uint) uint {
+func minInt(a, b int) int {
 	if a < b {
 		return a
 	}
@@ -675,10 +770,10 @@ func calculateGlbLub(sourceRange, targetRange string) (string, error) {
 	outrange := &mlsRange{low: &level{}, high: &level{}}
 
 	/* take the greatest of the low */
-	outrange.low.sens = max(s.low.sens, t.low.sens)
+	outrange.low.sens = maxInt(s.low.sens, t.low.sens)
 
 	/* take the least of the high */
-	outrange.high.sens = min(s.high.sens, t.high.sens)
+	outrange.high.sens = minInt(s.high.sens, t.high.sens)
 
 	/* find the intersecting categories */
 	if s.low.cats != nil && t.low.cats != nil {
@@ -723,14 +818,27 @@ func peerLabel(fd uintptr) (string, error) {
 // setKeyLabel takes a process label and tells the kernel to assign the
 // label to the next kernel keyring that gets created
 func setKeyLabel(label string) error {
-	err := writeCon("/proc/self/attr/keycreate", label)
+	// Rather than using /proc/thread-self, we want to use /proc/self to
+	// operate on the thread-group leader.
+	err := writeConSelf("attr/keycreate", label)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 	if label == "" && errors.Is(err, os.ErrPermission) {
 		return nil
 	}
+	if errors.Is(err, unix.EACCES) && unix.Getpid() != unix.Gettid() {
+		return ErrNotTGLeader
+	}
 	return err
+}
+
+// KeyLabel retrieves the current kernel keyring label setting for this
+// thread-group.
+func keyLabel() (string, error) {
+	// Rather than using /proc/thread-self, we want to use /proc/self to
+	// operate on the thread-group leader.
+	return readConSelf("attr/keycreate")
 }
 
 // get returns the Context as a string
@@ -808,8 +916,7 @@ func enforceMode() int {
 // setEnforceMode sets the current SELinux mode Enforcing, Permissive.
 // Disabled is not valid, since this needs to be set at boot time.
 func setEnforceMode(mode int) error {
-	//nolint:gosec // ignore G306: permissions to be 0600 or less.
-	return os.WriteFile(selinuxEnforcePath(), []byte(strconv.Itoa(mode)), 0o644)
+	return os.WriteFile(selinuxEnforcePath(), []byte(strconv.Itoa(mode)), 0)
 }
 
 // defaultEnforceMode returns the systems default SELinux mode Enforcing,
@@ -1016,8 +1123,7 @@ func addMcs(processLabel, fileLabel string) (string, string) {
 
 // securityCheckContext validates that the SELinux label is understood by the kernel
 func securityCheckContext(val string) error {
-	//nolint:gosec // ignore G306: permissions to be 0600 or less.
-	return os.WriteFile(filepath.Join(getSelinuxMountPoint(), "context"), []byte(val), 0o644)
+	return os.WriteFile(filepath.Join(getSelinuxMountPoint(), "context"), []byte(val), 0)
 }
 
 // copyLevel returns a label with the MLS/MCS level from src label replaced on
@@ -1134,7 +1240,7 @@ func rchcon(fpath, label string) error { //revive:disable:cognitive-complexity
 	}
 	return pwalkdir.Walk(fpath, func(p string, _ fs.DirEntry, _ error) error {
 		if fastMode {
-			if cLabel, err := lFileLabel(fpath); err == nil && cLabel == label {
+			if cLabel, err := lFileLabel(p); err == nil && cLabel == label {
 				return nil
 			}
 		}

--- a/pkg/wwan/mmagent/vendor/github.com/opencontainers/selinux/go-selinux/selinux_stub.go
+++ b/pkg/wwan/mmagent/vendor/github.com/opencontainers/selinux/go-selinux/selinux_stub.go
@@ -3,15 +3,11 @@
 
 package selinux
 
-func attrPath(string) string {
-	return ""
-}
-
-func readCon(fpath string) (string, error) {
+func readConThreadSelf(string) (string, error) {
 	return "", nil
 }
 
-func writeCon(string, string) error {
+func writeConThreadSelf(string, string) error {
 	return nil
 }
 
@@ -21,27 +17,27 @@ func getEnabled() bool {
 	return false
 }
 
-func classIndex(class string) (int, error) {
+func classIndex(string) (int, error) {
 	return -1, nil
 }
 
-func setFileLabel(fpath string, label string) error {
+func setFileLabel(string, string) error {
 	return nil
 }
 
-func lSetFileLabel(fpath string, label string) error {
+func lSetFileLabel(string, string) error {
 	return nil
 }
 
-func fileLabel(fpath string) (string, error) {
+func fileLabel(string) (string, error) {
 	return "", nil
 }
 
-func lFileLabel(fpath string) (string, error) {
+func lFileLabel(string) (string, error) {
 	return "", nil
 }
 
-func setFSCreateLabel(label string) error {
+func setFSCreateLabel(string) error {
 	return nil
 }
 
@@ -53,7 +49,7 @@ func currentLabel() (string, error) {
 	return "", nil
 }
 
-func pidLabel(pid int) (string, error) {
+func pidLabel(int) (string, error) {
 	return "", nil
 }
 
@@ -61,38 +57,42 @@ func execLabel() (string, error) {
 	return "", nil
 }
 
-func canonicalizeContext(val string) (string, error) {
+func canonicalizeContext(string) (string, error) {
 	return "", nil
 }
 
-func computeCreateContext(source string, target string, class string) (string, error) {
+func computeCreateContext(string, string, string) (string, error) {
 	return "", nil
 }
 
-func calculateGlbLub(sourceRange, targetRange string) (string, error) {
+func calculateGlbLub(string, string) (string, error) {
 	return "", nil
 }
 
-func peerLabel(fd uintptr) (string, error) {
+func peerLabel(uintptr) (string, error) {
 	return "", nil
 }
 
-func setKeyLabel(label string) error {
+func setKeyLabel(string) error {
 	return nil
+}
+
+func keyLabel() (string, error) {
+	return "", nil
 }
 
 func (c Context) get() string {
 	return ""
 }
 
-func newContext(label string) (Context, error) {
+func newContext(string) (Context, error) {
 	return Context{}, nil
 }
 
 func clearLabels() {
 }
 
-func reserveLabel(label string) {
+func reserveLabel(string) {
 }
 
 func isMLSEnabled() bool {
@@ -103,7 +103,7 @@ func enforceMode() int {
 	return Disabled
 }
 
-func setEnforceMode(mode int) error {
+func setEnforceMode(int) error {
 	return nil
 }
 
@@ -111,7 +111,7 @@ func defaultEnforceMode() int {
 	return Disabled
 }
 
-func releaseLabel(label string) {
+func releaseLabel(string) {
 }
 
 func roFileLabel() string {
@@ -126,27 +126,27 @@ func initContainerLabels() (string, string) {
 	return "", ""
 }
 
-func containerLabels() (processLabel string, fileLabel string) {
+func containerLabels() (string, string) {
 	return "", ""
 }
 
-func securityCheckContext(val string) error {
+func securityCheckContext(string) error {
 	return nil
 }
 
-func copyLevel(src, dest string) (string, error) {
+func copyLevel(string, string) (string, error) {
 	return "", nil
 }
 
-func chcon(fpath string, label string, recurse bool) error {
+func chcon(string, string, bool) error {
 	return nil
 }
 
-func dupSecOpt(src string) ([]string, error) {
+func dupSecOpt(string) ([]string, error) {
 	return nil, nil
 }
 
-func getDefaultContextWithLevel(user, level, scon string) (string, error) {
+func getDefaultContextWithLevel(string, string, string) (string, error) {
 	return "", nil
 }
 

--- a/pkg/wwan/mmagent/vendor/github.com/opencontainers/selinux/go-selinux/xattrs_linux.go
+++ b/pkg/wwan/mmagent/vendor/github.com/opencontainers/selinux/go-selinux/xattrs_linux.go
@@ -31,7 +31,7 @@ func lgetxattr(path, attr string) ([]byte, error) {
 func doLgetxattr(path, attr string, dest []byte) (int, error) {
 	for {
 		sz, err := unix.Lgetxattr(path, attr, dest)
-		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
+		if err != unix.EINTR {
 			return sz, err
 		}
 	}
@@ -64,7 +64,7 @@ func getxattr(path, attr string) ([]byte, error) {
 func dogetxattr(path, attr string, dest []byte) (int, error) {
 	for {
 		sz, err := unix.Getxattr(path, attr, dest)
-		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
+		if err != unix.EINTR {
 			return sz, err
 		}
 	}

--- a/pkg/wwan/mmagent/vendor/github.com/opencontainers/selinux/pkg/pwalkdir/README.md
+++ b/pkg/wwan/mmagent/vendor/github.com/opencontainers/selinux/pkg/pwalkdir/README.md
@@ -28,7 +28,9 @@ Please note the following limitations of this code:
 
   * fs.SkipDir is not supported;
 
-  * no errors are ever passed to WalkDirFunc;
+  * ErrNotExist errors from filepath.WalkDir are silently ignored for any path
+    except the top directory (WalkDir argument); any other error is returned to
+    the caller of WalkDir;
 
   * once any error is returned from any walkDirFunc instance, no more calls
     to WalkDirFunc are made, and the error is returned to the caller of WalkDir;
@@ -51,4 +53,4 @@ filepath.WalkDir.
 Otherwise (if a WalkDirFunc is actually doing something) this is usually
 faster, except when the WalkDirN(..., 1) is used. Run `go test -bench .`
 to see how different operations can benefit from it, as well as how the
-level of paralellism affects the speed.
+level of parallelism affects the speed.

--- a/pkg/wwan/mmagent/vendor/modules.txt
+++ b/pkg/wwan/mmagent/vendor/modules.txt
@@ -1,3 +1,9 @@
+# cyphar.com/go-pathrs v0.2.1
+## explicit; go 1.18
+cyphar.com/go-pathrs
+cyphar.com/go-pathrs/internal/fdutils
+cyphar.com/go-pathrs/internal/libpathrs
+cyphar.com/go-pathrs/procfs
 # github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24
 ## explicit; go 1.20
 github.com/AdaLogics/go-fuzz-headers
@@ -163,6 +169,19 @@ github.com/containerd/typeurl
 # github.com/containerd/typeurl/v2 v2.2.0
 ## explicit; go 1.21
 github.com/containerd/typeurl/v2
+# github.com/cyphar/filepath-securejoin v0.6.0
+## explicit; go 1.18
+github.com/cyphar/filepath-securejoin/internal/consts
+github.com/cyphar/filepath-securejoin/pathrs-lite
+github.com/cyphar/filepath-securejoin/pathrs-lite/internal
+github.com/cyphar/filepath-securejoin/pathrs-lite/internal/assert
+github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd
+github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gocompat
+github.com/cyphar/filepath-securejoin/pathrs-lite/internal/gopathrs
+github.com/cyphar/filepath-securejoin/pathrs-lite/internal/kernelversion
+github.com/cyphar/filepath-securejoin/pathrs-lite/internal/linux
+github.com/cyphar/filepath-securejoin/pathrs-lite/internal/procfs
+github.com/cyphar/filepath-securejoin/pathrs-lite/procfs
 # github.com/distribution/reference v0.6.0
 ## explicit; go 1.20
 github.com/distribution/reference
@@ -323,7 +342,7 @@ github.com/lf-edge/eve-api/go/profile
 # github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d
 ## explicit; go 1.20
 github.com/lf-edge/eve/pkg/kube/cnirpc
-# github.com/lf-edge/eve/pkg/pillar v0.0.0-20251029075156-4a3aedeeddf7
+# github.com/lf-edge/eve/pkg/pillar v0.0.0-20251111034223-e81177b68a3e
 ## explicit; go 1.23.0
 github.com/lf-edge/eve/pkg/pillar/agentbase
 github.com/lf-edge/eve/pkg/pillar/agentlog
@@ -392,7 +411,7 @@ github.com/opencontainers/runtime-spec/specs-go
 github.com/opencontainers/runtime-tools/generate
 github.com/opencontainers/runtime-tools/generate/seccomp
 github.com/opencontainers/runtime-tools/validate/capabilities
-# github.com/opencontainers/selinux v1.11.0
+# github.com/opencontainers/selinux v1.13.0
 ## explicit; go 1.19
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label


### PR DESCRIPTION
# Description

The route metric for each network port is computed by NIM
(specifically by the DPC Reconciler) based on the port’s usage,
cost, and position within the DevicePortConfig (DPC).
This change makes mmagent apply the received route metric
to the default route configured for the corresponding wwan interface.

## How to test and validate this PR

Follow the same test instructions as defined for https://github.com/lf-edge/eve/pull/5374
In this case, use a device equipped with a cellular modem and try assigning different
usage types or costs to the wwan interface.

## Changelog notes

This PR is continuation of https://github.com/lf-edge/eve/pull/5374
The changelog notes provided there also apply to this PR.

## PR Backports

This change is only important for eve-k, which is officially supported starting with 17.0 LTS (which this PR is part of)

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
