### PR TITLE
[13.4-stable] Enable automatic TCP MSS clamping for forwarded app traffic

### DIFF
--- a/docs/APP-CONNECTIVITY.md
+++ b/docs/APP-CONNECTIVITY.md
@@ -554,18 +554,78 @@ the old MTU value.
 
 #### Network Instance MTU vs. Network Adapter MTU
 
-Please note that application traffic leaving or entering the device via a network
-adapter associated with the network instance is additionally limited by MTU values
-of NI ports, configured within their `NetworkConfig` objects
-(see [DEVICE-CONNECTIVITY.md](DEVICE-CONNECTIVITY.md), section "Network Adapter MTU").
-If the configured network instance MTU is higher than MTU of any of the NI ports,
-EVE will flag the network instance with an error and use the lowest MTU among
-all the NI ports for the network instance instead. This is to prevent apps from sending
-packets exceeding the path MTU. Packets entering NI via port with a higher MTU and with
-size exceeding the NI MTU will get fragmented inside EVE (if allowed by IP header).
-By default (if MTU is not configured by the user, i.e. 'mtu' is zero), EVE uses 1500
-as MTU for air-gapped network instances and the lowest MTU among NI ports for NIs with
-external connectivity.
+Application traffic leaving or entering the device via a network adapter associated
+with a network instance is also constrained by the MTU of NI ports, as configured
+in their `NetworkConfig` objects (see [DEVICE-CONNECTIVITY.md](DEVICE-CONNECTIVITY.md),
+section "Network Adapter MTU").
+
+If the user does not configure an MTU (mtu = 0), EVE automatically sets:
+
+* 1500 bytes for air-gapped network instances, and
+* The lowest MTU among NI ports for network instances with external connectivity.
+
+If the user configures an MTU, EVE verifies it against the NI port MTUs. If the configured
+network instance MTU is higher than any NI port MTU, EVE flags the network instance
+with an error and enforces the lowest MTU among all NI ports. This ensures that
+applications do not send packets larger than what the physical or virtual interfaces
+can handle.
+
+Packets larger than the effective MTU will either be fragmented, which can reduce
+performance, or, if the *Don’t Fragment* (DF) flag is set, dropped by routers along
+the path.
+
+To further reduce fragmentation and improve reliability, EVE can automatically clamp
+the TCP Maximum Segment Size (MSS) for forwarded traffic, ensuring TCP segments fit
+within the path MTU. This is described in the following section.
+
+#### TCP MSS Clamping
+
+EVE automatically applies TCP Maximum Segment Size (MSS) clamping to forwarded application
+TCP traffic to prevent IP fragmentation when the path MTU cannot be reliably propagated
+to the application.
+
+##### Why it is needed
+
+Applications running in VMs or containers often cannot receive the actual MTU of the egress
+network interface:
+
+* MTU propagation requires a DHCP client inside the app that is configured to request
+  the MTU option, or a recent virtio driver that supports MTU propagation.
+* When the network instance is rerouted to a different uplink, the new MTU is applied
+  only after the app’s DHCP lease expires.
+* Containers inside VMs may ignore propagated MTU values altogether.
+
+Without MSS clamping, applications might continue sending packets larger than the real
+path MTU, causing fragmentation or even dropped packets if *Don’t Fragment* (DF)
+flag is set. If ICMP *Fragmentation Needed* messages are filtered, the sender
+cannot detect the issue, leading to retransmissions and connection stalls.
+
+##### How it works
+
+The kernel’s Netfilter subsystem automatically adjusts (clamps) the TCP MSS
+in SYN and SYN-ACK packets to fit the path MTU.
+
+The path MTU is determined from the output interface MTU and cached ICMP feedback
+(if available). Even if ICMPs are blocked, the interface MTU still provides a safe
+upper bound (especially when device is running at the network edge).
+
+The MSS is determined by taking the minimum of the path MTUs in both directions
+of the flow, ensuring packets in either direction fit the path.
+The MSS in the packet is only ever reduced, never increased.
+
+The calculated MSS is written into the TCP options of the packet, and the TCP checksum
+is automatically recalculated to reflect the change.
+
+The rule is implemented in the mangle table (FORWARD chain) using iptables:
+
+* One rule for IPv4 (iptables)
+* One rule for IPv6 (ip6tables)
+
+##### Configuration
+
+By default, MSS clamping is enabled for all forwarded application traffic.
+It can be disabled using the global configuration property: `app.enable.tcp.mss.clamping`
+This allows to disable clamping in case it causes some undesired behaviour.
 
 ### Flow Logging
 

--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -68,6 +68,7 @@
 | memory-monitor.enabled | boolean | false | Enable external memory monitoring and memory pressure events handling |
 | diag.probe.remote.http.endpoint | string | `"http://www.google.com"` | Remote endpoint (URL, IP instead of hostname is accepted) queried over HTTP to assess the state of network connectivity whenever the controller is not reachable. Used only for diagnostics (no functional impact). Set to an empty string to disable. |
 | diag.probe.remote.https.endpoint | string | `"https://www.google.com"` | Remote endpoint (URL, IP instead of hostname is NOT accepted) queried over HTTPS to assess the state of network connectivity whenever the controller is not reachable. Used only for diagnostics (no functional impact). Set to an empty string to disable. |
+| app.enable.tcp.mss.clamping | bool | true | Configuration property that enables EVE to automatically adjust (clamp) the TCP MSS on forwarded application traffic to match the path MTU, preventing fragmentation and connectivity issues on lower-MTU links. |
 
 In addition, there can be per-agent settings.
 The Per-agent settings begin with "agent.*agentname*.*setting*"

--- a/pkg/pillar/dpcreconciler/linux.go
+++ b/pkg/pillar/dpcreconciler/linux.go
@@ -1574,7 +1574,7 @@ func (r *LinuxDpcReconciler) getIntendedACLs(
 		{Table: "filter", ChainName: "INPUT"}:       {devACLs: true, appACLs: true},
 		{Table: "filter", ChainName: "FORWARD"}:     {devACLs: true, appACLs: true},
 		{Table: "mangle", ChainName: "PREROUTING"}:  {devACLs: true, appACLs: true},
-		{Table: "mangle", ChainName: "FORWARD"}:     {devACLs: true, appACLs: false},
+		{Table: "mangle", ChainName: "FORWARD"}:     {devACLs: false, appACLs: true},
 		{Table: "mangle", ChainName: "POSTROUTING"}: {devACLs: false, appACLs: true},
 		{Table: "mangle", ChainName: "OUTPUT"}:      {devACLs: true, appACLs: false},
 		{Table: "nat", ChainName: "PREROUTING"}:     {devACLs: false, appACLs: true},

--- a/pkg/pillar/iptables/configitem.go
+++ b/pkg/pillar/iptables/configitem.go
@@ -35,7 +35,7 @@ var (
 	builtinChains = []string{"INPUT", "OUTPUT", "FORWARD", "PREROUTING", "POSTROUTING"}
 	// Used as a constant.
 	builtinTargets = []string{"ACCEPT", "DROP", "REJECT", "LOG", "DNAT", "SNAT",
-		"MASQUERADE", "CONNMARK", "MARK", "RETURN"}
+		"MASQUERADE", "CONNMARK", "MARK", "RETURN", "TCPMSS"}
 )
 
 // RegisterItems : add Items and their Configurators into the provided registry.

--- a/pkg/pillar/nireconciler/linux_acl.go
+++ b/pkg/pillar/nireconciler/linux_acl.go
@@ -72,7 +72,7 @@ var (
 	usedIptablesChains = map[string][]string{ // table -> chains
 		"raw":    {"PREROUTING"},
 		"filter": {"INPUT", "FORWARD"},
-		"mangle": {"PREROUTING", "POSTROUTING"},
+		"mangle": {"PREROUTING", "FORWARD", "POSTROUTING"},
 		"nat":    {"PREROUTING", "POSTROUTING"},
 	}
 )

--- a/pkg/pillar/nireconciler/linux_config.go
+++ b/pkg/pillar/nireconciler/linux_config.go
@@ -87,6 +87,14 @@ import (
 //  |   |      |    | IptablesChain |   |  IptablesRule |     |      |   |
 //  |   |      |    +---------------+   +---------------+     |      |   |
 //  |   |      +----------------------------------------------+      |   |
+//  |   |                                                            |   |
+//  |   |      +----------------------------------------------+      |   |
+//  |   |      |                TCPMSSClamping                |      |   |
+//  |   |      |     +--------------+   +---------------+     |      |   |
+//  |   |      |     | IptablesRule |   |  IptablesRule |     |      |   |
+//  |   |      |     |    (IPv4)    |   |     (IPv6)    |     |      |   |
+//  |   |      |     +--------------+   +---------------+     |      |   |
+//  |   |      +----------------------------------------------+      |   |
 //  |   +------------------------------------------------------------+   |
 //  |                                                                    |
 //  |   +------------------------------------------------------------+   |
@@ -242,6 +250,9 @@ const (
 	// IPv6ChainsSG : subgraph with ip6tables chains for IPv6 traffic.
 	// Used under ACLRootChains.
 	IPv6ChainsSG = "IPv6Chains"
+	// TCPMSSClampingSG : subgraph with iptables rules automatically adjusting (clamping)
+	// the TCP MSS on forwarded application traffic to match the path MTU.
+	TCPMSSClampingSG = "TCPMSSClamping"
 	// NISGPrefix : prefix used for name of the subgraph encapsulating the entire
 	// configuration of the given network instance.
 	NISGPrefix = "NI-"
@@ -350,6 +361,9 @@ func (r *LinuxNIReconciler) getIntendedGlobalState() dg.Graph {
 		Description: "Global configuration",
 	}
 	intendedCfg := dg.New(graphArgs)
+	if r.enableTCPMssClamping {
+		intendedCfg.PutSubGraph(r.getIntendedTCPMssClampingCfg())
+	}
 	intendedCfg.PutSubGraph(r.getIntendedPorts())
 	intendedCfg.PutSubGraph(r.getIntendedGlobalIPSets())
 	if r.withFlowlog() {
@@ -357,6 +371,31 @@ func (r *LinuxNIReconciler) getIntendedGlobalState() dg.Graph {
 	}
 	intendedCfg.PutSubGraph(r.getIntendedACLRootChains())
 	intendedCfg.PutSubGraph(r.getIntendedL2FwdChain())
+	return intendedCfg
+}
+
+func (r *LinuxNIReconciler) getIntendedTCPMssClampingCfg() dg.Graph {
+	graphArgs := dg.InitArgs{
+		Name: TCPMSSClampingSG,
+		Description: "Automatically adjust (clamp) the TCP MSS on forwarded " +
+			"application traffic to match the path MTU,",
+	}
+	intendedCfg := dg.New(graphArgs)
+	clampRule := iptables.Rule{
+		RuleLabel:  "Clamp TCP MSS",
+		Table:      "mangle",
+		ChainName:  appChain("FORWARD"),
+		MatchOpts:  []string{"-p", "tcp", "--tcp-flags", "SYN,RST", "SYN"},
+		Target:     "TCPMSS",
+		TargetOpts: []string{"--clamp-mss-to-pmtu"},
+		Description: "Automatically adjust the TCP MSS value on forwarded SYN packets " +
+			"to match the path MTU, preventing IP fragmentation and connectivity " +
+			"issues on links with lower MTU.",
+	}
+	intendedCfg.PutItem(clampRule, nil)
+	clampRuleV6 := clampRule
+	clampRuleV6.ForIPv6 = true
+	intendedCfg.PutItem(clampRuleV6, nil)
 	return intendedCfg
 }
 

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -334,6 +334,10 @@ const (
 	// DiagProbeRemoteHTTPSEndpoint : remote endpoint queried over **HTTPS** to assess
 	// the state of network connectivity whenever the controller is not reachable.
 	DiagProbeRemoteHTTPSEndpoint GlobalSettingKey = "diag.probe.remote.https.endpoint"
+
+	// EnableTCPMSSClamping : Configuration property to enable or disable TCP MSS clamping
+	// for application traffic forwarded by EVE.
+	EnableTCPMSSClamping GlobalSettingKey = "app.enable.tcp.mss.clamping"
 )
 
 // AgentSettingKey - keys for per-agent settings
@@ -994,6 +998,9 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	// Add diag probing settings
 	configItemSpecMap.AddStringItem(DiagProbeRemoteHTTPEndpoint, "www.google.com", makeURLValidator("http", true))
 	configItemSpecMap.AddStringItem(DiagProbeRemoteHTTPSEndpoint, "www.google.com", makeURLValidator("https", false))
+
+	// TCP MSS Clamping
+	configItemSpecMap.AddBoolItem(EnableTCPMSSClamping, true)
 	return configItemSpecMap
 }
 

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -219,6 +219,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		NetDumpDownloaderHTTPWithFieldValue,
 		DiagProbeRemoteHTTPEndpoint,
 		DiagProbeRemoteHTTPSEndpoint,
+		EnableTCPMSSClamping,
 	}
 	if len(specMap.GlobalSettings) != len(gsKeys) {
 		t.Errorf("GlobalSettings has more (%d) than expected keys (%d)",


### PR DESCRIPTION
# Description

Backport of https://github.com/lf-edge/eve/pull/5319

## How to test and validate this PR

Reproducing a scenario where TCP MSS clamping is required to prevent dropped or fragmented packets can be tricky.
The following procedure provides one possible way to validate the fix:

1. Onboard the edge node.
2. Deploy an application connected to a network instance with a device port attached (not air-gapped).
3. Reduce the MTU on the port to, for example, 1400 bytes — either manually with `ip link set mtu 1400 <port>` or through the network configuration.
4. Keep the application-side MTU at 1500.
If the application virtio driver or DHCP client automatically adopted the 1400 MTU advertised by EVE, change it back manually to 1500.
This simulates a case where MTU propagation does not occur properly.
5. Disable PMTU discovery (if enabled), or drop incoming ICMP “Fragmentation Needed” messages on the application side.
For example, on Linux:
```
sudo iptables -A INPUT -p icmp --icmp-type fragmentation-needed -j DROP
```
6. Flush any cached PMTU values to ensure a clean test. On Linux: `sudo ip route flush cache`
7. Then I recommend to use iperf3, which will try to use as large packets as allowed by the egress interface MTU to measure the maximum bandwidth.
On another device reachable from the EVE node, start an iperf3 server: `iperf3 -s`
Then, on the application side, run the client: `iperf3 -c <the-server-IP>`
8. Verify that traffic is neither dropped (the reported bandwidth is non-zero) nor fragmented.
To check that EVE is not fragmenting any packets, SSH into EVE (or use the console) and run:
```
eve enter debug
tcpdump -i any 'ip[6:2] & 0x1fff != 0 or ip[6] & 0x20 != 0' -vv -n
```
The packet capture during the iperf3 run should show no fragmented packets (i.e., output should be empty).

9. Confirm that the MSS clamping rule is applied.
After running the test, check that the iptables rule counter has incremented:
```
eve enter debug
iptables -L -v -t mangle | grep TCPMSS
```
Example output:
```
  20  1040 TCPMSS  tcp  --  any  any  anywhere  anywhere  tcp flags:SYN,RST/SYN  /* Clamp TCP MSS */ TCPMSS clamp to PMTU
```
A non-zero counter indicates that the MSS clamping rule was triggered as expected.

## Changelog notes

Enable automatic TCP MSS clamping for forwarded app traffic using the path MTU to prevent fragmentation and dropped packets; can be disabled via the configuration property `app.enable.tcp.mss.clamping`.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.

