### PR TITLE
Super-Linter

### DIFF
--- a/.github/linters/.golangci.yml
+++ b/.github/linters/.golangci.yml
@@ -1,0 +1,65 @@
+# Copyright (c) 2025, Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+version: "2"
+linters:
+  default: all
+  disable:
+    - cyclop
+    - dupl
+    - err113
+    - exhaustive
+    - exhaustruct
+    - funlen
+    - gochecknoglobals
+    - gocognit
+    - gocyclo
+    - godot
+    - ireturn
+    - lll
+    - maintidx
+    - mnd
+    - musttag
+    - nestif
+    - nlreturn
+    - nonamedreturns
+    - varnamelen
+    - whitespace
+    - wrapcheck
+    - wsl
+    - wsl_v5
+  settings:
+    depguard:
+      rules:
+        main:
+          list-mode: lax
+          files:
+            - $all
+          allow:
+            - $gostd
+            - $ven
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.github/linters/.hadolint.yaml
+++ b/.github/linters/.hadolint.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2025, Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+ignored:
+  - DL3059
+  - DL3002

--- a/.github/linters/.markdownlint.yaml
+++ b/.github/linters/.markdownlint.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2025, Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+default: true
+line-length: false
+commands-show-output: false

--- a/.github/linters/.shellcheckrc
+++ b/.github/linters/.shellcheckrc
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+disable=SC3043

--- a/.github/linters/.yamllint
+++ b/.github/linters/.yamllint
@@ -1,0 +1,15 @@
+# Copyright (c) 2025, Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+extends: default
+
+rules:
+    line-length:
+        max: 300
+        level: warning
+
+ignore:
+  - pkg/kube/lh-cfg-v1.6.2.yaml
+  - pkg/kube/descheduler_rbac.yaml
+  - pkg/kube/lh-cfg-v1.9.1.yaml
+  - pkg/kube/kubevirt-operator.yaml

--- a/.github/linters/os-packages.json
+++ b/.github/linters/os-packages.json
@@ -1,0 +1,8 @@
+[
+    "zfs-libs",
+    "zfs-dev",
+    "build-base",
+    "linux-headers",
+    "zfs-dev",
+    "util-linux-dev"
+]

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,85 @@
+# Copyright (c) 2025, Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# NOTE that this is the only workflow that requires access to the
+# GitHub token. However, it is safe since in EVE repo itself we
+# only trigger this workflow on pull requests and as such making
+# it effectively read-only.
+# yamllint disable rule:line-length
+#   https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
+# yamllint enable rule:line-length
+---
+name: Super Linter
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - "master"
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-stable"
+      - "feature/*"
+
+permissions: {}
+
+jobs:
+  build:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
+      statuses: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          # super-linter needs the full git history to get the
+          # list of files that changed across commits
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Super-linter
+        uses: super-linter/super-linter@2bdd90ed3262e023ac84bf8fe35dc480721fc1f2 # v8.2.1
+        env:
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Only lint changed files on PRs/pushes
+          VALIDATE_ALL_CODEBASE: false
+          # Enable only the linters we care about
+          VALIDATE_ARM: true
+          VALIDATE_BASH: true
+          VALIDATE_BASH_EXEC: true
+          VALIDATE_CPP: true
+          VALIDATE_CLANG_FORMAT: true
+          VALIDATE_DOCKERFILE_HADOLINT: true
+          VALIDATE_EDITORCONFIG: true
+          VALIDATE_ENV: true
+          VALIDATE_GIT_COMMITLINT: true
+          VALIDATE_GITHUB_ACTIONS: true
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: true
+          VALIDATE_GITLEAKS: true
+          VALIDATE_GO: true
+          VALIDATE_JSON: true
+          VALIDATE_KUBERNETES_KUBECONFORM: true
+          VALIDATE_LATEX: true
+          VALIDATE_LUA: true
+          VALIDATE_MARKDOWN: true
+          VALIDATE_NATURAL_LANGUAGE: true
+          VALIDATE_OPENAPI: true
+          VALIDATE_PROTOBUF: true
+          VALIDATE_PYTHON: true
+          VALIDATE_PYTHON_BLACK: true
+          VALIDATE_PYTHON_FLAKE8: true
+          VALIDATE_PYTHON_ISORT: true
+          VALIDATE_PYTHON_MYPY: true
+          VALIDATE_PYTHON_PYLINT: true
+          VALIDATE_RUST_2021: true
+          VALIDATE_RUST_CLIPPY: true
+          VALIDATE_SHELL_SHFMT: true
+          # VALIDATE_TRIVY: true # is useful to run sometimes, but not one every PR
+          VALIDATE_YAML: true
+          # cgo config for musl/Alpine case
+          CGO_ENABLED: "1"
+          CGO_CFLAGS: "-D_LARGEFILE64_SOURCE"


### PR DESCRIPTION
# Description

This journey started when I tried to fix yetus for the n'th time and couldn't because
1. I still don't know why it fails (as always)
2. Our way of using yetus with @rene forking the GH action, creating his own container to add ZFS, using his own docker hub - is not reproducible (not Rene's fault - it was the fastest solution at the time and we didn't evolve from it)
3. Yetus locally and yetus in CI are two different things (yetus is too smart going out of it's way to figure out if it's being run from a CI)

My proposal - let's try running another linter [Super-Linter](https://github.com/super-linter/super-linter) alongside Yetus for a while and see how we like it. I found this project when I had the please to be fixing Yetus last time, but only assembled a fully working version now. Here are the pros and cons of using Super-Linter vs Yetus:

Pros
- Super-Linter started as a project run by GitHub and has more contributors and users than Yetus
- It is still being actively developed with releases coming out multiple times a year
- It updates the linter version more often
- It is easier to configure with good documentation and simple configuration through envs
- We don't need to patch it or release our own version to support ZFS - it has support for [runtime dependencies built-in](https://github.com/super-linter/super-linter?tab=readme-ov-file#install-additional-dependencies)
- It can be run locally (although it's also not exactly the same behavior as in CI)
- It's fast - CI run took 2 mins for me vs 10 mins for Yetus
- It has support for a lot of linters that we use / need - most importantly golangci-lint, hadolint for Dockerfiles, markdown, json and yaml - check out the GH action that I created
- It also runs zizmor that we now run as standalone check

Cons
- It doesn't have all the linters that we use in Yetus (e.g. spellcheck, Makefile or revive)
- Idk if we can run it locally on a diff (like in CI) - worst case we can run it on the changed files like in the case of mini-yetus

The integration of Super-Linter is not finished with this PR. My proposal - let's just try running it alongside Yetus and see if we find it better. I provided here a working GH action can be used out of the box, but we'll still need to tweak it to be more useful for us. If we don't like it or find it useless we can just scrape it at any time.

## PR dependencies

None

## How to test and validate this PR

If you want to get a picture of how it works check out https://github.com/europaul/eve/pull/3. I put some example code there for the Super-Linter to work on and made it so that the linter finds errors.

It also runs on the current PR, but there is not much to check.

## Changelog notes

Add Super-Linter to the CI

## PR Backports

No need.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
