### PR TITLE
tui: update to release 0.6.2

### DIFF
--- a/pkg/monitor/Dockerfile
+++ b/pkg/monitor/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG MONITOR_RS_VERSION=v0.6.1
+ARG MONITOR_RS_VERSION=v0.6.2
 ARG RUST_VERSION=lfedge/eve-rust:1.85.1-2
 FROM --platform=$BUILDPLATFORM ${RUST_VERSION} AS toolchain-base
 ARG TARGETARCH


### PR DESCRIPTION
# Description

- this release introduces support for DPC types that have "omitempty" annotations. 
- see https://github.com/lf-edge/eve/pull/5369

## PR dependencies

https://github.com/lf-edge/eve/pull/5369

## How to test and validate this PR

- run eve
- switch ti TUI and observe network interfaces have sane information

## Changelog notes

None

## PR Backports


```text
- 14.5-stable: To be backported.
- 13.4-stable: No, as the feature is not available there.
```

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

