### PR TITLE
[16.0] Fix issue of zedkube publish Kube Status without token

### DIFF
--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -593,6 +593,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 		case change := <-subControllerCert.MsgChan():
 			subControllerCert.ProcessChange(change)
+			// Additional controller cert updates
+			zedkubeCtx.applyControllerCerts()
 
 		case change := <-subEdgeNodeCert.MsgChan():
 			subEdgeNodeCert.ProcessChange(change)


### PR DESCRIPTION

# Description

- seen an issue of zedkube publishing EdgeNodeClusterStatus w/o the Token. Even though we check the controller cert subscription at the beginning of the process. Add the re-publish the status upon new controller-cert update
- backport PR #5368


(cherry picked from commit ccdb4683817556b0002b6e4b2496e3883b882f3d)

## PR dependencies

## How to test and validate this PR

This is to fix a timing issue, it rarely happens. Make sure when converting eve-k from single-node mode into cluster mode,
the EdgeNodeClusterStatus will eventually have the Token advertised.

## Changelog notes

Fix issue of zedkube publish Kube Status without token

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
