### PR TITLE
Use Yetus container from lfedge/eve-yetus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -587,7 +587,7 @@ check-docker-hashes-consistency: $(DOCKERFILE_FROM_CHECKER)
 yetus:
 	@echo Running yetus
 	mkdir -p yetus-output
-	docker run --rm -v $(CURDIR):/src:delegated,z ghcr.io/apache/yetus:0.15.1 \
+	docker run --rm -v $(CURDIR):/src:delegated,z docker.io/lfedge/eve-yetus:0.15.1-eve-1 \
 		--basedir=/src \
 		--test-parallel=true \
 		--dirty-workspace \

--- a/tools/mini-yetus.sh
+++ b/tools/mini-yetus.sh
@@ -141,7 +141,7 @@ cd "$SRC_DIR" && \
     git commit -m "Changes in the PR" >/dev/null 2>&1
 
 echo "[+] Running yetus on the changes..."
-docker run --rm -v "$SRC_DIR":/src:delegated,z ghcr.io/apache/yetus:0.15.1 \
+docker run --rm -v "$SRC_DIR":/src:delegated,z docker.io/lfedge/eve-yetus:0.15.10-eve-1 \
     --basedir=/src \
     --test-parallel=true \
     --dirty-workspace \


### PR DESCRIPTION
# Description

Start to use our Yetus container, which has dependencies already installed (e.g. ZFS lib, etc).

## How to test and validate this PR

Run the following commands and check if everything works:

1. `make yetus`
2. `make mini-yetus`

## Changelog notes

No user-facing changes.

## PR Backports

No need to backport.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.