### PR TITLE
[16.0] eve-k: don't block during kubevirt-operator delete

### DIFF
--- a/pkg/kube/kubevirt-utils.sh
+++ b/pkg/kube/kubevirt-utils.sh
@@ -41,8 +41,7 @@ Kubevirt_uninstall() {
         kubectl delete mutatingwebhookconfigurations virt-api-mutator
         kubectl delete validatingwebhookconfigurations virt-operator-validator
         kubectl delete validatingwebhookconfigurations virt-api-validator
-        kubectl delete -f /etc/kubevirt-operator.yaml
-        kubectl delete -f /etc/kubevirt-features.yaml
+        kubectl delete -f /etc/kubevirt-operator.yaml --wait=false
     } >> "$INSTALL_LOG" 2>&1
 
     # Kubevirt applies a large amount of labels to nodes detailing available cpu flags, remove them


### PR DESCRIPTION
# Description

This has been seen to lead to extended blocking,
allow this to complete in the background.

Remove redundant features delete, already deleted in the top deletion: "kubectl delete -n kubevirt kubevirt kubevirt --wait=true"


(cherry picked from commit 13b98bbeb7ffecb759f8ff2f4c310e6712bafb55)

Backport of #5375 

## PR dependencies

None

## How to test and validate this PR

- deploy 3 HV=k eve nodes, onboard to a controller, deploy an EdgeNodeClusterConfig including a registration manifest.
- Verify all cluster nodes are visible in "kubectl get node" and that the registration manifest exists on one node.
- `eve enter kube; ls /var/lib/rancher/k3s/server/manifests/persist-registration.yaml`

## Changelog notes

None

## PR Backports

This is the backport.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
