### PR TITLE
Edge apps are not activated after rolling back from a snapshot

### DIFF
--- a/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
+++ b/pkg/pillar/cmd/zedmanager/handlevolumemgr.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/lf-edge/eve/pkg/pillar/activeapp"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
@@ -302,6 +303,9 @@ func reactToSnapshotRollback(ctx *zedmanagerContext, volumesSnapshotStatus types
 	}
 	unpublishLocalAppInstanceConfig(ctx, appInstanceStatus.Key())
 	publishAppInstanceStatus(ctx, appInstanceStatus)
+	// Mark the app as active locally to ensure it immediately restarts after rollback from a snapshot.
+	// This avoids delays in app activation that can occur due to edge app priority scheduling.
+	activeapp.CreateLocalAppActiveFile(log, appInstanceStatus.UUIDandVersion.UUID.String())
 	doUpdate(ctx, *config, appInstanceStatus)
 }
 


### PR DESCRIPTION
# Description

For every user action that starts a STOPPED application or creates a new one, the system first calls doActivate and then doUpdate. doActivate is responsible for marking an application as high-priority.

During doUpdate, the system checks this priority flag:
    - If the app is high-priority, it starts immediately.
    - If not, it will only start after all higher-priority applications have started or when the startup timeout is reached.

In the snapshot-rollback flow, the application is started automatically through reactToSnapshotRollback instead of going through doActivate. Because of this, the app never receives a priority assignment. This PR ensures that priority is also set during reactToSnapshotRollback.

## PR dependencies

None.

## How to test and validate this PR

1. Onboard a device into Zedcloud.
2. Deploy an edge application to the device.
3. Create a snapshot.
4. Roll back the device to that snapshot.
5. Observe that the app only comes instantly online after the snapshotted image becomes active.

## Changelog notes

* Marked the app as high priority to ensure immediate restart following a rollback.
* Restored expected rollback behaviour - activate edge app after a rollback instant.
* No functional changes to business logic; update only affects startup/priority configuration.

## PR Backports

- 16.0: To be backported
- 14.5-stable: No
- 13.4-stable: No

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
