### PR TITLE
Fix rungetty.sh to strip non-numeric suffix from console speed parameter

### DIFF
--- a/pkg/dom0-ztools/rootfs/usr/bin/rungetty.sh
+++ b/pkg/dom0-ztools/rootfs/usr/bin/rungetty.sh
@@ -9,11 +9,13 @@ infinite_loop() {
 # run getty on all known consoles
 start_getty() {
 	tty=${1%,*}
-	speed=${1#*,}
+	# Extract speed after comma and strip non-numeric suffix (e.g., "n8" from "115200n8")
+	speed=${1#*,}; speed=${speed%%[!0-9]*}
 	securetty="$2"
 	line=
 	term="linux"
-	[ "$speed" = "$1" ] && speed=115200
+	# Default to 115200 if no comma was present or speed is empty/invalid
+	[ -z "$speed" ] && speed=115200
 
 	# if console=tty0 is specified on the kernel command line, we should not start a getty on tty0
 	# but instead start it on the first available tty. tty0 points to the current console, so if


### PR DESCRIPTION
# Description

When console= kernel parameter includes format specifiers (e.g., console=ttyS0,115200n8), the script was passing the entire string "115200n8" to agetty

Getty fails to start on ttyS* and it causes continuous process restart and extra CPU consumption

Changes:
- Extract and strip non-numeric suffix from speed parameter (e.g., "n8")
- Ensure empty or invalid speed values default to 115200

This results in cleaner agetty invocations like:
  /sbin/agetty -a root -L 115200 ttyS0 vt100 instead of:
  /sbin/agetty -a root -L 115200n8 ttyS0 vt100

## Dependency

Not a direct dependency but to make hash consistency checker happy we may want to merge https://github.com/lf-edge/eve/pull/5405 first

## How to test and validate this PR

- add `set_global dom0_extra_args "$dom0_extra_args  console=ttyS0,115200n8"` to grub.cfg or edit command linefrom grub menu. use ttyS* that matches your device
- observe that login prompt appears on minicom or you favorite tty programm

## Changelog notes

- Fix getty login on serial port consoles 

## PR Backports

```text
- 16.0: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.
```
## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

