### PR TITLE
Convert vtpm Dockerfile to use automatic hashes

### DIFF
--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -3,8 +3,12 @@
 # Copyright (c) 2023-2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-dom0-ztools:e2c0ed2ea3ae6cb155fa0b0ab320412e20ca0962 AS dom0
-FROM lfedge/eve-alpine:745ae9066273c73b0fd879c4ba4ff626a8392d04 AS build
+ARG REL_HASH_LFEDGE_EVE_ALPINE
+ARG REL_HASH_LFEDGE_EVE_DOM0_ZTOOLS
+
+FROM ${REL_HASH_LFEDGE_EVE_DOM0_ZTOOLS} AS dom0
+FROM ${REL_HASH_LFEDGE_EVE_ALPINE} AS build
+
 ENV BUILD_PKGS="gcc g++ autoconf automake libtool make openssl-dev libtasn1-dev \
     json-glib-dev gnutls bash expect gawk socat libseccomp-dev gmp-dev \
     musl-utils autoconf-archive git json-c json-c-dev libcurl curl-dev \

--- a/pkg/vtpm/build.yml
+++ b/pkg/vtpm/build.yml
@@ -15,3 +15,7 @@ config:
   devices:
     - path: all
       type: a
+
+buildArgs:
+  - REL_HASH_%=@lkt:pkgs:../*
+


### PR DESCRIPTION
# Description
Convert vtpm Dockerfile to use automatic hashes
the approach is the same as in
```
  e98229cf9d9aa800688a255187618ba356123d79
  pkg/pillar/Dockerfile: use automatic hashes
```

## How to test and validate this PR

no special testing is required. make sure vtpm builds if you update hash of alpine or dom0_tools container

## Changelog notes

None

## PR Backports

```text
- 14.5-stable: No
- 13.4-stable: No
```
## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

