### PR TITLE
[16.0] Kernel update - [amd64-generic]

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,5 +1,5 @@
 KERNEL_COMMIT_amd64_next_generic = 3152b8fe36ea
-KERNEL_COMMIT_amd64_v6.12.49_generic = 770b90183ee7
+KERNEL_COMMIT_amd64_v6.12.49_generic = ef7ccc4d151c
 KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = b4464b03583e
 KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 2154a157c3f4
 KERNEL_COMMIT_arm64_v6.1.155_generic = ece043d8b403


### PR DESCRIPTION
# Description

Backport of #5406 

## How to test and validate this PR

1. Run EVE
2. Check the module is not available, the following command should not return any module:
```sh
find /hostfs/lib/modules -name "intel_pch_thermal*"
```

## Changelog notes

Disable Intel PCH thermal device driver to avoid passthrough issues with USB Controllers on some devices.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.