### PR TITLE
Fix log.Errorf usage

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlevolumeref.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolumeref.go
@@ -257,7 +257,7 @@ func checkReferences(vs *types.VolumeStatus, vrs *types.VolumeRefStatus) {
 		// don't update the error time if nothing changed
 		if vrs.Error != errStr {
 			log.Functionf("updateVolumeRefStatus(%s): setting the error (previous error: %s, source: %s)", vrs.Key(), vrs.Error, vrs.ErrorSourceType)
-			log.Errorf(errStr)
+			log.Error(errStr)
 			vrs.SetErrorWithSourceAndDescription(types.ErrorDescription{Error: errStr}, types.VolumeRefConfig{})
 		}
 	} else if vrs.IsErrorSource(types.VolumeRefConfig{}) {


### PR DESCRIPTION
# Description

PR #5414 fails building to do it picking up a new version of golang and hitting: cmd/volumemgr/handlevolumeref.go:260:15: non-constant format string in call to (*github.com/lf-edge/eve/pkg/pillar/base.LogObject).Errorf This fixes that particular issue (but there might be more non-constant strings like this to fix.)

## How to test and validate this PR

N/A

## Changelog notes

None

## Checklist

- [X] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [X] I've written the test verification instructions
- [X] I've set the proper labels to this PR

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
