### PR TITLE
github/workflows: Fix go-tests Docker login

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -25,6 +25,9 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   test:
     runs-on: zededa-ubuntu-2204
+    env:
+      REPO_NAME: ${{ github.event.repository.full_name }}
+      GH_REF: ${{ github.ref }}
     steps:
       - name: Starting Report
         run: |
@@ -34,9 +37,6 @@ jobs:
           df -h
           echo Memory
           free -m
-        env:
-          REPO_NAME: ${{ github.event.repository.full_name }}
-          GH_REF: ${{ github.ref }}
       - name: Clear repository
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"


### PR DESCRIPTION
# Description

Commit 86c4e1b6fc87c8e29210f4c34dd9c868faf4c244 was suppose to fix the Docker login tests. However, the variable introduced was defined in the scope of the first step and not globally for the job, making the if that checks for the repo name not work. This commit fixes this issue.

## How to test and validate this PR

Tested on: https://github.com/rene/eve/actions/runs/19567697667/job/56033589803?pr=120#step:5:11

Run GH go-tests and check Docker login step is working.

## Changelog notes

None.

## PR Backports

None (issue is only on master).

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.