### PR TITLE
github/workflows: Give secret access to go-tests

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -12,7 +12,7 @@ on:  # yamllint disable-line rule:truthy
     paths-ignore:
       - '**/*.md'
       - '.github/**'
-  pull_request:
+  pull_request_target:
     branches:
       - "master"
       - "[0-9]+.[0-9]+"


### PR DESCRIPTION
# Description

In order to give access to our secrets to go-tests workflow, pull_request_target must be used instead of pull_request. Secrets are required for Docker Login action.

## How to test and validate this PR

Run GitHub go-tests workflow.

## Changelog notes

None.

## PR Backports

None, the issue is only on master.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.