### PR TITLE
[14.5-stable] Fix rungetty.sh to strip non-numeric suffix from console speed parameter

### DIFF
--- a/pkg/dom0-ztools/rootfs/usr/bin/rungetty.sh
+++ b/pkg/dom0-ztools/rootfs/usr/bin/rungetty.sh
@@ -9,11 +9,13 @@ infinite_loop() {
 # run getty on all known consoles
 start_getty() {
 	tty=${1%,*}
-	speed=${1#*,}
+	# Extract speed after comma and strip non-numeric suffix (e.g., "n8" from "115200n8")
+	speed=${1#*,}; speed=${speed%%[!0-9]*}
 	securetty="$2"
 	line=
 	term="linux"
-	[ "$speed" = "$1" ] && speed=115200
+	# Default to 115200 if no comma was present or speed is empty/invalid
+	[ -z "$speed" ] && speed=115200
 
 	# if console=tty0 is specified on the kernel command line, we should not start a getty on tty0
 	# but instead start it on the first available tty. tty0 points to the current console, so if


### PR DESCRIPTION
# Description

Backport of #5404 

## How to test and validate this PR

see original PR

## Changelog notes

None

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.


