### PR TITLE
Bpftrace compiler increase timeout

### DIFF
--- a/eve-tools/bpftrace-compiler/runQemu.go
+++ b/eve-tools/bpftrace-compiler/runQemu.go
@@ -45,7 +45,7 @@ func newQemuAmd64Runner(imageDir, bpfPath, aotPath string) *qemuRunner {
 		qemuArgs:     map[string]string{},
 		appendArgs:   map[string]struct{}{},
 		qemuArchArgs: qemuArchArgsAmd64{},
-		timeout:      2 * time.Minute,
+		timeout:      8 * time.Minute,
 	}
 }
 
@@ -57,7 +57,7 @@ func newQemuArm64Runner(imageDir, bpfPath, aotPath string) *qemuRunner {
 		units:        []string{},
 		qemuArchArgs: qemuArchArgsArm64{},
 		appendArgs:   map[string]struct{}{},
-		timeout:      2 * time.Minute,
+		timeout:      8 * time.Minute,
 	}
 }
 


### PR DESCRIPTION
# Description

    bpftrace-compiler: increase timeout
    
    Some very slow machines take more than two minutes to
    do certain operations, like listing bpftrace hooks.
    
    We noticed this when switching to a new machine to run
    the tests.
    Examples tests that takes longer:
    * TestListKernelProbesAmd64WithModules (218.60s)
    * TestListKernelProbesAmd64 (206.69s)
    * TestCompileArm64 (193.23s)


## How to test and validate this PR

Run `make test` on a slow machine (i.e. slow CPU cores), we noticed this problem on a
Intel(R) Xeon(R) CPU E5-2698 v3 @ 2.30GHz.

## Changelog notes

Increased timeout for bpftrace compiler for slower machines.

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 14.5-stable: to be backported
- 13.4-stable: to be backported
- 16.0-stable: to be backported



Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR



- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
