### PR TITLE
pillar container: set proper root overlayf

### DIFF
--- a/pkg/pillar/containerd/oci_linux.go
+++ b/pkg/pillar/containerd/oci_linux.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+// +build linux
+
+package containerd
+
+import (
+	"fmt"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
+)
+
+// mountOverlay mount an overlay filesystem at the specified mount point
+func mountOverlay(lowerdir, upperdir, workdir, mountPoint string) error {
+	overlayOptions := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s,index=off",
+		lowerdir, upperdir, workdir)
+	if err := unix.Mount("overlay", mountPoint, "overlay", 0, overlayOptions); err != nil {
+		return fmt.Errorf("failed to mount overlay filesystem: %w", err)
+	}
+	return nil
+}
+
+// getDeviceInfo retrieves device information for the specified path
+func getDeviceInfo(path string) (specs.LinuxDevice, error) {
+	var statInfo unix.Stat_t
+	var devType string
+	ociDev := specs.LinuxDevice{}
+
+	err := unix.Stat(path, &statInfo)
+	if err != nil {
+		return ociDev, err
+	}
+
+	switch statInfo.Mode & unix.S_IFMT {
+	case unix.S_IFBLK:
+		devType = "b"
+	case unix.S_IFCHR:
+		devType = "c"
+	case unix.S_IFDIR:
+		devType = "d"
+	case unix.S_IFIFO:
+		devType = "p"
+	case unix.S_IFLNK:
+		devType = "l"
+	case unix.S_IFSOCK:
+		devType = "s"
+	}
+
+	ociDev.Path = path
+	ociDev.Type = devType
+	ociDev.Major = int64(unix.Major(statInfo.Rdev))
+	ociDev.Minor = int64(unix.Minor(statInfo.Rdev))
+	return ociDev, nil
+}

--- a/pkg/pillar/containerd/oci_unsupported.go
+++ b/pkg/pillar/containerd/oci_unsupported.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2025 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+// +build !linux
+
+package containerd
+
+import (
+	"fmt"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// mountOverlay is not supported on non-Linux platforms
+func mountOverlay(lowerdir, upperdir, workdir, mountPoint string) error {
+	return fmt.Errorf("overlay mounting is only supported on Linux")
+}
+
+// getDeviceInfo is not supported on non-Linux platforms
+func getDeviceInfo(path string) (specs.LinuxDevice, error) {
+	return specs.LinuxDevice{}, fmt.Errorf("getting device info is only supported on Linux")
+}


### PR DESCRIPTION
# Description

We previously had no real root for containers, and then mounted a target overlayfs from xen-root to / in the container. Newer versions of runc properly disallow this. Instead, we create an explicit overlayfs with xen-root as the lower, and then make the merged filesystem be the root of the container.

This got in the way of merging in #5409, which is required to address certain critical CVEs.

## How to test and validate this PR

Given that no functionality has changed, but that the way we mount the filesystems for containers has, then any user workload container should use this, and it either succeeds or fails. Therefore, eden tests should catch this.

## Changelog notes

Explicitly set VM-wrapped container root as an overlay, rather than trying to set it as a separate mount.

## PR Backports

```text
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.
- 16.0-stable: To be back ported.
```

## Checklist

- [X] I've provided a proper description
- [X] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [X] I've written the test verification instructions
- [X] I've set the proper labels to this PR

Only thing missing is local tests. I am not 100% sure we need those, given that CI should catch these. Up for input.