### PR TITLE
tools/collect-sources.sh: Exclude var/lock from tarball extraction

### DIFF
--- a/tools/collect-sources.sh
+++ b/tools/collect-sources.sh
@@ -24,9 +24,11 @@ manifest=${tmpout}/collected_sources_manifest.csv
 
 tar_opts="$(tar --version | grep -qi 'GNU tar' && echo --warning=no-unknown-keyword || echo)"
 
-# this is a bit of a hack, but we need to extract the rootfs tar to a directory, and it fails if
+# This is a bit of a hack, but we need to extract the rootfs tar to a directory, and it fails if
 # we try to extract character devices, block devices or pipes, so we just exclude the dir.
-tar "${tar_opts}" -xf "$rootfs" -C "$tmproot" --exclude "dev/*"
+# Same issue for var/lock, that comes from linuxkit/runc image and it's a symbolic link to
+# ../run/lock directory.
+tar "${tar_opts}" -xf "$rootfs" -C "$tmproot" --exclude "dev/*" --exclude "var/lock"
 echo "${tmpout}"
 echo "${outfile}"
 {


### PR DESCRIPTION
# Description

Commit aa18688626ab8d1fb5298d4107f74de351f76de1 updated runc to fix critical CVEs. In this new runc image, var/lock is not a file but a directory instead, which is leading collect-sources.sh fail with the following error:

tar: var/lock: Cannot unlink: Is a directory

This PR fixes this issue by excluding var/lock (not need for collect sources) from extraction.

## How to test and validate this PR

This PR can be validated by running GH Publish workflow.

## Changelog notes

No user-facing changes.

## PR Backports

- [ ] 16.0
- [ ] 14.5-stable
- [ ] 13.4-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.