### PR TITLE
tools/collect-sources.sh: Fix comment

### DIFF
--- a/tools/collect-sources.sh
+++ b/tools/collect-sources.sh
@@ -26,7 +26,7 @@ tar_opts="$(tar --version | grep -qi 'GNU tar' && echo --warning=no-unknown-keyw
 
 # This is a bit of a hack, but we need to extract the rootfs tar to a directory, and it fails if
 # we try to extract character devices, block devices or pipes, so we just exclude the dir.
-# Same issue for var/lock, that comes from linuxkit/runc image and it's a symbolic link to
+# Same issue for var/lock, that comes from linuxkit/init image and it's a symbolic link to
 # ../run/lock directory.
 tar "${tar_opts}" -xf "$rootfs" -C "$tmproot" --exclude "dev/*" --exclude "var/lock"
 echo "${tmpout}"


### PR DESCRIPTION
# Description

The image meant in the comment is linuxkit/init and not linuxkit/runc.

## How to test and validate this PR

Nothing to validate, is just a comment fix.

## Changelog notes

None.

## PR Backports

None since it's only on master.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.