### PR TITLE
[14.5-stable] tools/collect-sources.sh: Exclude var/lock from tarball extraction

### DIFF
--- a/tools/collect-sources.sh
+++ b/tools/collect-sources.sh
@@ -26,7 +26,7 @@ tar_opts="$(tar --version | grep -qi 'GNU tar' && echo --warning=no-unknown-keyw
 
 # This is a bit of a hack, but we need to extract the rootfs tar to a directory, and it fails if
 # we try to extract character devices, block devices or pipes, so we just exclude the dir.
-# Same issue for var/lock, that comes from linuxkit/runc image and it's a symbolic link to
+# Same issue for var/lock, that comes from linuxkit/init image and it's a symbolic link to
 # ../run/lock directory.
 tar "${tar_opts}" -xf "$rootfs" -C "$tmproot" --exclude "dev/*" --exclude "var/lock"
 echo "${tmpout}"


### PR DESCRIPTION
# Description

Backport of #5459, #5460

## How to test and validate this PR

This PR can be validated by running GH Publish workflow.

## Changelog notes

No user-facing changes.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.