### PR TITLE
Update linuxkit/sysctl

### DIFF
--- a/eve-tools/bpftrace-compiler/util_test.go
+++ b/eve-tools/bpftrace-compiler/util_test.go
@@ -18,7 +18,7 @@ onboot:
   - /sbin/rngd
   - "-1"
 - name: sysctl
-  image: docker.io/linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
+  image: docker.io/linuxkit/sysctl:43ac1d39da329c3567fcb9689e5ca99de6d169b6
   capabilities:
   - CAP_SYS_ADMIN
   - CAP_NET_ADMIN

--- a/images/installer.yml.in
+++ b/images/installer.yml.in
@@ -14,7 +14,7 @@ init:
   - UDEV_TAG
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
+    image: linuxkit/sysctl:43ac1d39da329c3567fcb9689e5ca99de6d169b6
     binds:
       - /etc/sysctl.d:/etc/sysctl.d
     capabilities:

--- a/images/rootfs.yml.in
+++ b/images/rootfs.yml.in
@@ -21,7 +21,7 @@ onboot:
     image: RNGD_TAG
     command: ["/sbin/rngd", "-1"]
   - name: sysctl
-    image: linuxkit/sysctl:c6f23919b8610c7645a89a89f863c6209bc84bee
+    image: linuxkit/sysctl:43ac1d39da329c3567fcb9689e5ca99de6d169b6
     binds:
       - /etc/sysctl.d:/etc/sysctl.d
     capabilities:


### PR DESCRIPTION
# Description

The original linuxkit/sysctl accidentally copied all of the apk /etc and /lib into the final container. This update removes it.

## How to test and validate this PR

CI. Either it passes or it does not. There is no functional change.

## Changelog notes

Update linuxkit/sysctl to latest

## PR Backports

I don't think this needs to be backported. But open to it.

## Checklist

- [X] I've provided a proper description
- [X] I've added the proper documentation
- [X] I've written the test verification instructions
- [X] I've set the proper labels to this PR

