### PR TITLE
github/workflows: Run zizmor only on EVE's GH workflows

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4  # v0.2.0
+        with:
+          inputs: |
+            .github/workflows/


### PR DESCRIPTION
# Description

Currently zizmor is running over the whole repo and checking vendor GitHub actions, leading to the following error:

https://github.com/lf-edge/eve/actions/runs/19866372624/job/56930203462?pr=5471#step:3:149

```
fatal: no audit was performed
ref-confusion failed on file://./pkg/installer/vendor/shlex/.github/workflows/test.yml
```

This PR configures zizmor action to run only over .github/workflows of EVE repo.

## How to test and validate this PR

Run GH zizmore action.

## Changelog notes

No user-facing changes.

## PR Backports

No since it's only on master.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.