### PR TITLE
Bug : Use random IV in EncryptDecryptUsingTpm

### DIFF
--- a/pkg/pillar/cmd/evalmgr/evaluation_flow_test.go
+++ b/pkg/pillar/cmd/evalmgr/evaluation_flow_test.go
@@ -392,7 +392,7 @@ func runEvaluationCycle(t *testing.T, tc *TestContext, params EvaluationCyclePar
 	t.Logf("Phase 1: Waiting for stability check to start for %s", params.CurrentSlot)
 	status1, ok := tc.StatusSubscriber.WaitForCondition(func(s types.EvalStatus) bool {
 		return s.Phase == types.EvalPhaseTesting && s.CurrentSlot == params.CurrentSlot
-	}, 1*time.Second)
+	}, 5*time.Second)
 	require.True(t, ok, "Should receive testing phase status for %s", params.CurrentSlot)
 	assert.Equal(t, types.EvalPhaseTesting, status1.Phase)
 	assert.Equal(t, params.CurrentSlot, status1.CurrentSlot)
@@ -403,7 +403,7 @@ func runEvaluationCycle(t *testing.T, tc *TestContext, params EvaluationCyclePar
 	t.Logf("Phase 1.5: Waiting for inventory collection status for %s", params.CurrentSlot)
 	inventoryStatus, ok := tc.StatusSubscriber.WaitForCondition(func(s types.EvalStatus) bool {
 		return s.InventoryCollected && s.InventoryDir != ""
-	}, 2*time.Second)
+	}, 5*time.Second)
 	require.True(t, ok, "Should receive inventory collection status for %s", params.CurrentSlot)
 	assert.True(t, inventoryStatus.InventoryCollected, "InventoryCollected should be true")
 	assert.NotEmpty(t, inventoryStatus.InventoryDir, "InventoryDir should be set")

--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -6,21 +6,17 @@ package tpmmgr
 import (
 	"bytes"
 	"crypto"
-	"crypto/aes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/pem"
 	"flag"
 	"fmt"
-	"io"
 	"math/big"
 	"os"
-	"reflect"
 	"time"
 
 	"github.com/google/go-tpm/legacy/tpm2"
@@ -370,119 +366,6 @@ func printPCRs() {
 		}
 		fmt.Printf("Quote: %x\n", quote)
 		fmt.Printf("Signature: %x\n", signature)
-	}
-}
-
-func testTpmEcdhSupport() error {
-	rw, err := tpm2.OpenTPM(etpm.TpmDevicePath)
-	if err != nil {
-		log.Errorln(err)
-		return err
-	}
-	defer rw.Close()
-
-	z, p, err := tpm2.ECDHKeyGen(rw, etpm.TpmDeviceKeyHdl)
-	if err != nil {
-		fmt.Printf("generating Shared Secret failed: %s", err)
-		return err
-	}
-	tpmOwnerPasswd, err := etpm.ReadOwnerCrdl()
-	if err != nil {
-		log.Errorf("Reading owner credential failed: %s", err)
-		return err
-	}
-
-	z1, err := tpm2.ECDHZGen(rw, etpm.TpmDeviceKeyHdl, tpmOwnerPasswd, *p)
-	if err != nil {
-		fmt.Printf("recovering Shared Secret failed: %s", err)
-		return err
-	}
-	fmt.Println(reflect.DeepEqual(z, z1))
-	return nil
-}
-
-// Test ECDH key exchange and a symmetric cipher based on ECDH
-func testEcdhAES() error {
-	//Simulate Controller generating an ephemeral key
-	privateA, publicAX, publicAY, err := elliptic.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		fmt.Printf("Failed to generate A private/public key pair: %s\n", err)
-	}
-
-	//read public key from ecdh certificate
-	certBytes, err := os.ReadFile(ecdhCertFile)
-	if err != nil {
-		fmt.Printf("error in reading ecdh cert file: %v", err)
-		return err
-	}
-	block, _ := pem.Decode(certBytes)
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		fmt.Printf("error in parsing ecdh cert file: %v", err)
-		return err
-	}
-	publicB := cert.PublicKey.(*ecdsa.PublicKey)
-
-	//multiply privateA with publicB (Controller Part)
-	X, Y := elliptic.P256().Params().ScalarMult(publicB.X, publicB.Y, privateA)
-
-	fmt.Printf("publicAX, publicAY, X/Y = %v, %v, %v, %v\n", publicAX, publicAY, X, Y)
-	encryptKey, err := etpm.Sha256FromECPoint(X, Y, publicB)
-	if err != nil {
-		fmt.Printf("Sha256FromECPoint failed with error: %v", err)
-		return err
-	}
-	iv := make([]byte, aes.BlockSize)
-	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
-		fmt.Printf("Unable to generate Initial Value %v\n", err)
-	}
-
-	msg := []byte("this is the secret")
-	ciphertext := make([]byte, len(msg))
-	etpm.AESEncrypt(ciphertext, msg, encryptKey[:], iv)
-
-	recoveredMsg := make([]byte, len(ciphertext))
-	certHash, err := getCertHash(certBytes, types.CertHashTypeSha256First16)
-	if err != nil {
-		fmt.Printf("getCertHash failed with error: %v", err)
-		return err
-	}
-
-	isTpm := true
-	if !etpm.IsTpmEnabled() || fileutils.FileExists(log, etpm.EcdhKeyFile) {
-		isTpm = false
-	}
-
-	ecdhCert := &types.EdgeNodeCert{
-		HashAlgo: types.CertHashTypeSha256First16,
-		CertID:   certHash,
-		CertType: types.CertTypeEcdhXchange,
-		Cert:     certBytes,
-		IsTpm:    isTpm,
-	}
-	err = etpm.DecryptSecretWithEcdhKey(log, publicAX, publicAY, ecdhCert, iv, ciphertext, recoveredMsg)
-	if err != nil {
-		fmt.Printf("Decryption failed with error %v\n", err)
-		return err
-	}
-	if reflect.DeepEqual(msg, recoveredMsg) == true {
-		return nil
-	} else {
-		return fmt.Errorf("want %v, but got %v", msg, recoveredMsg)
-	}
-}
-
-func testEncryptDecrypt() error {
-	plaintext := []byte("This is the Secret Key")
-	ciphertext, err := etpm.EncryptDecryptUsingTpm(plaintext, types.EncryptionLegacy, true)
-	if err != nil {
-		return err
-	}
-	decryptedtext, err := etpm.EncryptDecryptUsingTpm(ciphertext, types.EncryptionLegacy, false)
-	if reflect.DeepEqual(plaintext, decryptedtext) == true {
-		return nil
-	} else {
-		return fmt.Errorf("want %v, but got %v", plaintext, decryptedtext)
 	}
 }
 
@@ -1147,16 +1030,6 @@ func readEdgeNodeCert(certPath string) ([]byte, error) {
 	return certBytes, nil
 }
 
-func getCertHash(cert []byte, hashAlgo types.CertHashType) ([]byte, error) {
-	certHash := sha256.Sum256(cert)
-	switch hashAlgo {
-	case types.CertHashTypeSha256First16:
-		return certHash[:16], nil
-	default:
-		return []byte{}, fmt.Errorf("Unsupported cert hash type: %d\n", hashAlgo)
-	}
-}
-
 func publishEdgeNodeCertToController(ctx *tpmMgrContext, certFile string, certType types.CertType, isTpm bool, metaDataItems []types.CertMetaData) {
 	log.Functionf("publishEdgeNodeCertToController started")
 	if !fileutils.FileExists(log, certFile) {
@@ -1169,7 +1042,7 @@ func publishEdgeNodeCertToController(ctx *tpmMgrContext, certFile string, certTy
 		log.Error(errStr)
 		return
 	}
-	certHash, err := getCertHash(certBytes, types.CertHashTypeSha256First16)
+	certHash, err := etpm.GetCertHash(certBytes, types.CertHashTypeSha256First16)
 	if err != nil {
 		errStr := fmt.Sprintf("publishEdgeNodeCertToController failed: %v", err)
 		log.Error(errStr)
@@ -1512,24 +1385,6 @@ func runCommand(command string, args []string) int {
 		printCapability()
 	case "printPCRs":
 		printPCRs()
-	case "testTpmEcdhSupport":
-		if err := testTpmEcdhSupport(); err != nil {
-			fmt.Printf("failed with error %v", err)
-		} else {
-			fmt.Print("test passed")
-		}
-	case "testEcdhAES":
-		if err := testEcdhAES(); err != nil {
-			fmt.Printf("failed with error %v", err)
-		} else {
-			fmt.Print("test passed")
-		}
-	case "testEncryptDecrypt":
-		if err := testEncryptDecrypt(); err != nil {
-			fmt.Printf("failed with error %v", err)
-		} else {
-			fmt.Print("test passed")
-		}
 	case "createCerts":
 		// Create required directories if not present
 		initializeDirs()

--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -474,11 +474,11 @@ func testEcdhAES() error {
 
 func testEncryptDecrypt() error {
 	plaintext := []byte("This is the Secret Key")
-	ciphertext, err := etpm.EncryptDecryptUsingTpm(plaintext, true)
+	ciphertext, err := etpm.EncryptDecryptUsingTpm(plaintext, types.EncryptionLegacy, true)
 	if err != nil {
 		return err
 	}
-	decryptedtext, err := etpm.EncryptDecryptUsingTpm(ciphertext, false)
+	decryptedtext, err := etpm.EncryptDecryptUsingTpm(ciphertext, types.EncryptionLegacy, false)
 	if reflect.DeepEqual(plaintext, decryptedtext) == true {
 		return nil
 	} else {
@@ -1670,14 +1670,14 @@ func tpmSanityCheck() *tpmSanityCheckError {
 	// encrypt/decrypt the vualt key and send/received it from controller.
 	// this can prevent the device from being upgraded.
 	message := []byte("TPM Sanity Check, may god have mercy on us")
-	encrypted, err := etpm.EncryptDecryptUsingTpm(message, true)
+	encrypted, err := etpm.EncryptDecryptUsingTpm(message, types.EncryptionAEAD, true)
 	if err != nil {
 		return &tpmSanityCheckError{
 			fmt.Errorf("failed to encrypt key using TPM: %w", err),
 			types.MaintenanceModeReasonTpmEncFailure,
 		}
 	}
-	decrypted, err := etpm.EncryptDecryptUsingTpm(encrypted, false)
+	decrypted, err := etpm.EncryptDecryptUsingTpm(encrypted, types.EncryptionAEAD, false)
 	if err != nil {
 		return &tpmSanityCheckError{
 			fmt.Errorf("failed to decrypt key using TPM: %w", err),

--- a/pkg/pillar/cmd/tpmmgr/tpmmgr_test.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr_test.go
@@ -122,10 +122,6 @@ func TestSoftEcdh(t *testing.T) {
 		t.Errorf("Failed to create test key file: %v", err)
 	}
 	defer os.Remove(ecdhKeyFile)
-
-	if err = testEcdhAES(); err != nil {
-		t.Errorf("%v", err)
-	}
 }
 
 // Test ECDH key exchange and a symmetric cipher based on ECDH, with software based keys

--- a/pkg/pillar/evetpm/encryptdecrypt_test.go
+++ b/pkg/pillar/evetpm/encryptdecrypt_test.go
@@ -1,0 +1,313 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package evetpm
+
+import (
+	"bytes"
+	"crypto/rand"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func TestAESGCMEncryptDecrypt(t *testing.T) {
+	testCases := []struct {
+		name      string
+		plaintext []byte
+	}{
+		{
+			name:      "Empty plaintext",
+			plaintext: []byte{},
+		},
+		{
+			name:      "plaintext",
+			plaintext: []byte("This is test message with more content to encrypt and decrypt."),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Generate a random 32-byte key
+			key := make([]byte, 32)
+			if _, err := rand.Read(key); err != nil {
+				t.Fatalf("Failed to generate random key: %v", err)
+			}
+
+			// Encrypt the plaintext
+			ciphertext, err := AESGCMEncrypt(tc.plaintext, key)
+			if err != nil {
+				t.Fatalf("AESGCMEncrypt failed: %v", err)
+			}
+
+			// Verify ciphertext format: [4 bytes nonce size][nonce][encrypted data]
+			if len(ciphertext) < 4 {
+				t.Fatalf("Ciphertext too short, expected at least 4 bytes, got %d", len(ciphertext))
+			}
+
+			// Decrypt the ciphertext
+			decrypted, err := AESGCMDecrypt(ciphertext, key)
+			if err != nil {
+				t.Fatalf("AESGCMDecrypt failed: %v", err)
+			}
+
+			// Verify the decrypted plaintext matches the original
+			if !bytes.Equal(decrypted, tc.plaintext) {
+				t.Errorf("Decrypted plaintext does not match original.\nExpected: %v\nGot: %v",
+					tc.plaintext, decrypted)
+			}
+		})
+	}
+}
+
+func TestAESGCMDecryptInvalidInput(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("Failed to generate random key: %v", err)
+	}
+
+	testCases := []struct {
+		name       string
+		ciphertext []byte
+		expectErr  bool
+	}{
+		{
+			name:       "Empty ciphertext",
+			ciphertext: []byte{},
+			expectErr:  true,
+		},
+		{
+			name:       "Too short ciphertext (less than 4 bytes)",
+			ciphertext: []byte{0x01, 0x02},
+			expectErr:  true,
+		},
+		{
+			name:       "Invalid nonce size (larger than available data)",
+			ciphertext: []byte{0x00, 0x00, 0x01, 0x00}, // nonce size = 256, but no data follows
+			expectErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := AESGCMDecrypt(tc.ciphertext, key)
+			if tc.expectErr && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !tc.expectErr && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestAESGCMDecryptWithWrongKey(t *testing.T) {
+	plaintext := []byte("Secret message")
+	key1 := make([]byte, 32)
+	key2 := make([]byte, 32)
+
+	if _, err := rand.Read(key1); err != nil {
+		t.Fatalf("Failed to generate key1: %v", err)
+	}
+	if _, err := rand.Read(key2); err != nil {
+		t.Fatalf("Failed to generate key2: %v", err)
+	}
+
+	// Encrypt with key1
+	ciphertext, err := AESGCMEncrypt(plaintext, key1)
+	if err != nil {
+		t.Fatalf("AESGCMEncrypt failed: %v", err)
+	}
+
+	// Try to decrypt with key2 (wrong key)
+	_, err = AESGCMDecrypt(ciphertext, key2)
+	if err == nil {
+		t.Errorf("Expected decryption to fail with wrong key, but it succeeded")
+	}
+}
+
+func TestAESGCMEncryptDifferentNonces(t *testing.T) {
+	plaintext := []byte("Test message")
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("Failed to generate key: %v", err)
+	}
+
+	// Encrypt the same plaintext multiple times
+	ciphertext1, err := AESGCMEncrypt(plaintext, key)
+	if err != nil {
+		t.Fatalf("AESGCMEncrypt failed: %v", err)
+	}
+
+	ciphertext2, err := AESGCMEncrypt(plaintext, key)
+	if err != nil {
+		t.Fatalf("AESGCMEncrypt failed: %v", err)
+	}
+
+	// The ciphertexts should be different because of random nonces
+	if bytes.Equal(ciphertext1, ciphertext2) {
+		t.Errorf("Expected different ciphertexts with random nonces, but got identical ones")
+	}
+
+	// Both should decrypt to the same plaintext
+	decrypted1, err := AESGCMDecrypt(ciphertext1, key)
+	if err != nil {
+		t.Fatalf("AESGCMDecrypt failed for ciphertext1: %v", err)
+	}
+
+	decrypted2, err := AESGCMDecrypt(ciphertext2, key)
+	if err != nil {
+		t.Fatalf("AESGCMDecrypt failed for ciphertext2: %v", err)
+	}
+
+	if !bytes.Equal(decrypted1, plaintext) {
+		t.Errorf("Decrypted1 does not match plaintext")
+	}
+
+	if !bytes.Equal(decrypted2, plaintext) {
+		t.Errorf("Decrypted2 does not match plaintext")
+	}
+}
+
+func TestAESGCMCiphertextFormat(t *testing.T) {
+	plaintext := []byte("Test")
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("Failed to generate key: %v", err)
+	}
+
+	ciphertext, err := AESGCMEncrypt(plaintext, key)
+	if err != nil {
+		t.Fatalf("AESGCMEncrypt failed: %v", err)
+	}
+
+	// Check format: [4 bytes nonce size][nonce][encrypted data]
+	if len(ciphertext) < 4 {
+		t.Fatalf("Ciphertext too short: %d bytes", len(ciphertext))
+	}
+
+	// Extract and verify nonce size
+	nonceSize := uint32(ciphertext[0])<<24 | uint32(ciphertext[1])<<16 | uint32(ciphertext[2])<<8 | uint32(ciphertext[3])
+
+	// Standard GCM nonce size is 12 bytes
+	if nonceSize != 12 {
+		t.Errorf("Expected nonce size to be 12, got %d", nonceSize)
+	}
+
+	// Verify total size is at least: 4 (size) + 12 (nonce) + some encrypted data
+	minExpectedSize := 4 + 12
+	if len(ciphertext) < minExpectedSize {
+		t.Errorf("Ciphertext size too small: expected at least %d bytes, got %d", minExpectedSize, len(ciphertext))
+	}
+}
+
+func TestEncryptDecryptUsingTpm(t *testing.T) {
+	testCases := []struct {
+		name       string
+		version    types.VaultKeyEncVersion
+		plaintext  []byte
+		shouldFail bool
+	}{
+		{
+			name:      "Legacy mode with zero IV",
+			version:   types.EncryptionLegacy,
+			plaintext: []byte("This is the Secret Key"),
+		},
+		{
+			name:      "AEAD mode with random nonce",
+			version:   types.EncryptionAEAD,
+			plaintext: []byte("This is the Secret Key"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Encrypt
+			ciphertext, err := EncryptDecryptUsingTpm(tc.plaintext, tc.version, true)
+			if err != nil {
+				if !tc.shouldFail {
+					t.Fatalf("Encryption failed: %v", err)
+				}
+				return
+			}
+
+			// Verify ciphertext is different from plaintext
+			if len(tc.plaintext) > 0 && reflect.DeepEqual(tc.plaintext, ciphertext) {
+				t.Fatal("Ciphertext should not equal plaintext")
+			}
+
+			// For AEAD mode, verify the ciphertext includes nonce information
+			if tc.version == types.EncryptionAEAD && len(ciphertext) < 4 {
+				t.Fatal("AEAD ciphertext should include nonce size prefix")
+			}
+
+			// Decrypt
+			decrypted, err := EncryptDecryptUsingTpm(ciphertext, tc.version, false)
+			if err != nil {
+				t.Fatalf("Decryption failed: %v", err)
+			}
+
+			// Verify decrypted text matches original plaintext
+			if !reflect.DeepEqual(tc.plaintext, decrypted) {
+				t.Fatalf("Decrypted text does not match original.\nExpected: %v\nGot: %v",
+					tc.plaintext, decrypted)
+			}
+		})
+	}
+}
+
+// TestEncryptDecryptUsingTpm_MultipleEncryptions ensures that encrypting
+// the same plaintext multiple times produces different ciphertexts in AEAD mode
+func TestEncryptDecryptUsingTpm_MultipleEncryptions(t *testing.T) {
+	plaintext := []byte("Same plaintext encrypted multiple times")
+
+	// Encrypt same plaintext multiple times with AEAD mode
+	ciphertext1, err := EncryptDecryptUsingTpm(plaintext, types.EncryptionAEAD, true)
+	if err != nil {
+		t.Fatalf("First encryption failed: %v", err)
+	}
+
+	ciphertext2, err := EncryptDecryptUsingTpm(plaintext, types.EncryptionAEAD, true)
+	if err != nil {
+		t.Fatalf("Second encryption failed: %v", err)
+	}
+
+	// Verify the two ciphertexts are different (due to random nonce)
+	if reflect.DeepEqual(ciphertext1, ciphertext2) {
+		t.Fatal("Multiple encryptions of same plaintext should produce different ciphertexts in AEAD mode")
+	}
+
+	// Both should decrypt to the same plaintext
+	decrypted1, err := EncryptDecryptUsingTpm(ciphertext1, types.EncryptionAEAD, false)
+	if err != nil {
+		t.Fatalf("First decryption failed: %v", err)
+	}
+
+	decrypted2, err := EncryptDecryptUsingTpm(ciphertext2, types.EncryptionAEAD, false)
+	if err != nil {
+		t.Fatalf("Second decryption failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(plaintext, decrypted1) || !reflect.DeepEqual(plaintext, decrypted2) {
+		t.Fatal("Both ciphertexts should decrypt to the same plaintext")
+	}
+}
+
+// TestEncryptDecryptUsingTpm_InvalidVersion tests error handling for unsupported versions
+func TestEncryptDecryptUsingTpm_InvalidVersion(t *testing.T) {
+	deviceCertPath := "/tmp/eve-tpm/device.cert.pem"
+	if _, err := os.Stat(deviceCertPath); os.IsNotExist(err) {
+		t.Skipf("Device certificate not found at %s, skipping test", deviceCertPath)
+	}
+
+	plaintext := []byte("Test data")
+	invalidVersion := types.VaultKeyEncVersion(999)
+
+	// Try to encrypt with invalid version
+	_, err := EncryptDecryptUsingTpm(plaintext, invalidVersion, true)
+	if err == nil {
+		t.Fatal("Encryption with invalid version should fail")
+	}
+}

--- a/pkg/pillar/evetpm/tpm.go
+++ b/pkg/pillar/evetpm/tpm.go
@@ -1565,3 +1565,14 @@ func readDiskKeySealingPCRs() (map[int][]byte, error) {
 
 	return readPCRs, nil
 }
+
+// GetCertHash computes sha256 hash of the given certificate
+func GetCertHash(cert []byte, hashAlgo types.CertHashType) ([]byte, error) {
+	certHash := sha256.Sum256(cert)
+	switch hashAlgo {
+	case types.CertHashTypeSha256First16:
+		return certHash[:16], nil
+	default:
+		return []byte{}, fmt.Errorf("Unsupported cert hash type: %d\n", hashAlgo)
+	}
+}

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -52,8 +52,6 @@ const (
 	IdentityDirname = "/config"
 	// ServerFileName - server file
 	ServerFileName = IdentityDirname + "/server"
-	// DeviceCertName - device certificate
-	DeviceCertName = IdentityDirname + "/device.cert.pem"
 	// DeviceKeyName - device private key (if not in TPM)
 	DeviceKeyName = IdentityDirname + "/device.key.pem"
 	// OnboardCertName - Onboard certificate
@@ -183,9 +181,12 @@ var (
 	// EtcdZvol - zvol encrypted for etcd storage
 	EtcdZvol = PersistDataset + "/etcd-storage"
 	// TpmMeasurementLogFile is a kernel exposed variable that contains the
-	// TPM measurements and events log. it is not a constant so tests can override it.
+	// TPM measurements and events log. Declared as a variable for test overrides.
 	TpmMeasurementLogFile = "/hostfs/sys/kernel/security/tpm0/binary_bios_measurements"
 	// TpmMeasurefsEventLog is the file containing the event log from the measure-config.
-	// it is not a constant so tests can override it.
+	// Declared as a variable for test overrides.
 	TpmMeasurefsEventLog = PersistStatusDir + "/measurefs_tpm_event_log"
+	// DeviceCertName - device certificate.
+	// Declared as a variable for test overrides.
+	DeviceCertName = IdentityDirname + "/device.cert.pem"
 )

--- a/pkg/pillar/types/vaultmgrtypes.go
+++ b/pkg/pillar/types/vaultmgrtypes.go
@@ -22,6 +22,16 @@ type VaultStatus struct {
 	ErrorAndTime
 }
 
+// VaultKeyEncVersion indicates the version of encryption used for vault key
+type VaultKeyEncVersion int
+
+const (
+	// EncryptionLegacy indicates no specific encryption version; used for backward compatibility
+	EncryptionLegacy VaultKeyEncVersion = iota
+	// EncryptionAEAD indicates AES GCM encryption
+	EncryptionAEAD
+)
+
 // VaultConfig represents vault key to be used
 type VaultConfig struct {
 	TpmKeyOnly bool

--- a/tests/tpm/prep-and-run.sh
+++ b/tests/tpm/prep-and-run.sh
@@ -1,8 +1,11 @@
 
 #!/bin/bash
 #
-# Copyright (c) 2025 Zededa, Inc.
+# Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
+#
+# This is a helper script to prepare a software TPM environment
+# for debugging vComLink TPM related functions.
 
 
 CWD=$(pwd)
@@ -11,12 +14,19 @@ TPM_CTR_PORT=$((TPM_SRV_PORT + 1))
 EK_HANDLE=0x81000001
 SRK_HANDLE=0x81000002
 AIK_HANDLE=0x81000003
+QUOTE_KEY_HANDLE=0x81000004
 ECDH_HANDLE=0x81000005
+DEVICE_KEY_HANDLE=0x817FFFFF
+EK_CERT_HANDLE=0x01C00002
 EVE_TPM_STATE=/tmp/eve-tpm
 EVE_TPM_CTRL="$EVE_TPM_STATE/ctrl.sock"
 # this path is hardcoded in the pkg/pillar/evetpm/testhelper.go, so if you change
 # it here, change it there too.
 EVE_TPM_SRV="$EVE_TPM_STATE/srv.sock"
+
+echo "[+] Installing swtpm and tpm2-tools ..."
+sudo apt-get -qq update -y > /dev/null
+sudo apt-get install openssl curl swtpm tpm2-tools -y -qq > /dev/null
 
 echo "[+] preparing the environment ..."
 rm -rf $EVE_TPM_STATE
@@ -46,10 +56,11 @@ tpm2 clear
 # The ek, srk and aik are created here based on what we do in createOtherKeys
 # in pkg/pillar/cmd/tpmmgr/tpmmgr.go.
 # create Endorsement Key
-tpm2 createek -c ek.ctx
+tpm2 createprimary -C e -G rsa2048:aes128cfb -g sha256 -c ek.ctx \
+  -a 'fixedtpm|fixedparent|sensitivedataorigin|adminwithpolicy|restricted|decrypt|userwithauth'
 
-# this setup seems very fragile, and quickly errors out with
-# "out of memory for object contexts", so flush everything to be safe.
+# this setup is fragile because we are not using a resource manager,
+# so flush everything to be safe to not face "out of memory for object contexts" errors.
 flushtpm
 
 # create srk
@@ -62,22 +73,64 @@ tpm2 createprimary -C o -G rsa:rsassa-sha256:null -g sha256 -c aik.ctx \
                    -a 'fixedtpm|fixedparent|sensitivedataorigin|userwithauth|restricted|sign|noda'
 flushtpm
 
+# create quote key (same as aik but at different handle for attestation)
+tpm2 createprimary -C o -G rsa:rsassa-sha256:null -g sha256 -c quotekey.ctx \
+                   -a 'fixedtpm|fixedparent|sensitivedataorigin|userwithauth|restricted|sign|noda'
+flushtpm
+
 # create ecdh key
 tpm2 createprimary -C o -G ecc256:ecdh-sha256 -c ecdh.ctx \
                    -a 'noda|decrypt|sensitivedataorigin|userwithauth'
 flushtpm
 
-# make persisted know-good-handles out of ek, srk, aik and ecdh keys.
+# create device key (used for device certificate and EncryptDecryptUsingTpm)
+tpm2 createprimary -C o -G ecc256 -g sha256 -c device.ctx \
+                   -a 'sign|noda|decrypt|sensitivedataorigin|userwithauth'
+flushtpm
+
+# create and store a self signed EK certificate in NV index
+openssl genrsa -out ek_temp.key 2048 2>/dev/null
+openssl req -new -x509 -key ek_temp.key \
+        -out ek_cert.pem -days 3650 \
+        -subj "/CN=TPM Endorsement Key" 2>/dev/null
+
+
+# store it
+openssl x509 -in ek_cert.pem -outform DER -out ek_cert.der 2>/dev/null
+EK_CERT_SIZE=$(wc -c < ek_cert.der)
+tpm2 nvdefine $EK_CERT_HANDLE -C o -s $EK_CERT_SIZE \
+    -a "ownerread|ownerwrite|authread|policywrite|ppwrite" 2>/dev/null || true
+tpm2 nvwrite $EK_CERT_HANDLE -C o -i ek_cert.der 2>/dev/null
+flushtpm
+
+# make persisted know-good-handles out of ek, srk, aik, quotekey, ecdh and device keys.
 tpm2 evictcontrol -C o -c ek.ctx $EK_HANDLE;flushtpm
 tpm2 evictcontrol -C o -c srk.ctx $SRK_HANDLE;flushtpm
 tpm2 evictcontrol -C o -c aik.ctx $AIK_HANDLE;flushtpm
+tpm2 evictcontrol -C o -c quotekey.ctx $QUOTE_KEY_HANDLE;flushtpm
 tpm2 evictcontrol -C o -c ecdh.ctx $ECDH_HANDLE;flushtpm
+tpm2 evictcontrol -C o -c device.ctx $DEVICE_KEY_HANDLE;flushtpm
+
+# create device certificate (required by EncryptDecryptUsingTpm)
+# The EncryptDecryptUsingTpm function only needs to extract the ECC public key
+# from the certificate, so for testing we create a simple self-signed cert.
+# In production, EVE signs this with the TPM device key, but for tests
+# the signature verification is not part of EncryptDecryptUsingTpm functionality.
+openssl ecparam -genkey -name prime256v1 -out "$EVE_TPM_STATE/device.key.pem" 2>/dev/null
+openssl req -new -x509 -key "$EVE_TPM_STATE/device.key.pem" \
+        -out "$EVE_TPM_STATE/device.cert.pem" \
+        -days 3650 -subj "/O=The Linux Foundation/CN=EVE" \
+        -set_serial 1 2>/dev/null
 
 # clean up
-rm ek.ctx srk.ctx aik.ctx ecdh.ctx
+rm -f ek.ctx srk.ctx aik.ctx quotekey.ctx ecdh.ctx device.ctx ek_temp.key ek_cert.pem ek_cert.der
 
 # kill swtpm, we are going to start it again with unix sockets
 kill $PID
+
+echo "========================================================"
+echo "[+] TPM setup done."
+echo "========================================================"
 
 # start swtpm again, but this time with unix sockets for tests to use.
 # in case we need to debug this, cat the log file.

--- a/tests/tpm/prep-and-test.sh
+++ b/tests/tpm/prep-and-test.sh
@@ -3,6 +3,9 @@
 #
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
+#
+# This is a helper script to prepare a software TPM environment
+# for running TPM related tests in CI.
 
 
 CWD=$(pwd)
@@ -11,7 +14,10 @@ TPM_CTR_PORT=$((TPM_SRV_PORT + 1))
 EK_HANDLE=0x81000001
 SRK_HANDLE=0x81000002
 AIK_HANDLE=0x81000003
+QUOTE_KEY_HANDLE=0x81000004
 ECDH_HANDLE=0x81000005
+DEVICE_KEY_HANDLE=0x817FFFFF
+EK_CERT_HANDLE=0x01C00002
 EVE_TPM_STATE=/tmp/eve-tpm
 EVE_TPM_CTRL="$EVE_TPM_STATE/ctrl.sock"
 # this path is hardcoded in the pkg/pillar/evetpm/testhelper.go, so if you change
@@ -20,7 +26,7 @@ EVE_TPM_SRV="$EVE_TPM_STATE/srv.sock"
 
 echo "[+] Installing swtpm and tpm2-tools ..."
 sudo apt-get -qq update -y > /dev/null
-sudo apt-get install curl swtpm tpm2-tools -y -qq > /dev/null
+sudo apt-get install openssl curl swtpm tpm2-tools -y -qq > /dev/null
 
 echo "[+] Installing zfs (pillar dependency)..."
 ZFS_URL="https://github.com/openzfs/zfs/archive/refs/tags/zfs-2.3.3.tar.gz"
@@ -72,10 +78,11 @@ tpm2 clear
 # The ek, srk and aik are created here based on what we do in createOtherKeys
 # in pkg/pillar/cmd/tpmmgr/tpmmgr.go.
 # create Endorsement Key
-tpm2 createek -c ek.ctx
+tpm2 createprimary -C e -G rsa2048:aes128cfb -g sha256 -c ek.ctx \
+  -a 'fixedtpm|fixedparent|sensitivedataorigin|adminwithpolicy|restricted|decrypt|userwithauth'
 
-# this setup seems very fragile, and quickly errors out with
-# "out of memory for object contexts", so flush everything to be safe.
+# this setup is fragile because we are not using a resource manager,
+# so flush everything to be safe to not face "out of memory for object contexts" errors.
 flushtpm
 
 # create srk
@@ -88,22 +95,81 @@ tpm2 createprimary -C o -G rsa:rsassa-sha256:null -g sha256 -c aik.ctx \
                    -a 'fixedtpm|fixedparent|sensitivedataorigin|userwithauth|restricted|sign|noda'
 flushtpm
 
+# create quote key (same as aik but at different handle for attestation)
+tpm2 createprimary -C o -G rsa:rsassa-sha256:null -g sha256 -c quotekey.ctx \
+                   -a 'fixedtpm|fixedparent|sensitivedataorigin|userwithauth|restricted|sign|noda'
+flushtpm
+
 # create ecdh key
 tpm2 createprimary -C o -G ecc256:ecdh-sha256 -c ecdh.ctx \
                    -a 'noda|decrypt|sensitivedataorigin|userwithauth'
 flushtpm
 
-# make persisted know-good-handles out of ek, srk, aik and ecdh keys.
+# create device key (used for device certificate and EncryptDecryptUsingTpm)
+tpm2 createprimary -C o -G ecc256 -g sha256 -c device.ctx \
+                   -a 'sign|noda|decrypt|sensitivedataorigin|userwithauth'
+flushtpm
+
+# create and store a self signed EK certificate in NV index
+openssl genrsa -out ek_temp.key 2048 2>/dev/null
+openssl req -new -x509 -key ek_temp.key \
+        -out ek_cert.pem -days 3650 \
+        -subj "/CN=TPM Endorsement Key" 2>/dev/null
+
+
+# store it
+openssl x509 -in ek_cert.pem -outform DER -out ek_cert.der 2>/dev/null
+EK_CERT_SIZE=$(wc -c < ek_cert.der)
+tpm2 nvdefine $EK_CERT_HANDLE -C o -s $EK_CERT_SIZE \
+    -a "ownerread|ownerwrite|authread|policywrite|ppwrite" 2>/dev/null || true
+tpm2 nvwrite $EK_CERT_HANDLE -C o -i ek_cert.der 2>/dev/null
+flushtpm
+
+# make persisted know-good-handles out of ek, srk, aik, quotekey, ecdh and device keys.
 tpm2 evictcontrol -C o -c ek.ctx $EK_HANDLE;flushtpm
 tpm2 evictcontrol -C o -c srk.ctx $SRK_HANDLE;flushtpm
 tpm2 evictcontrol -C o -c aik.ctx $AIK_HANDLE;flushtpm
+tpm2 evictcontrol -C o -c quotekey.ctx $QUOTE_KEY_HANDLE;flushtpm
 tpm2 evictcontrol -C o -c ecdh.ctx $ECDH_HANDLE;flushtpm
+tpm2 evictcontrol -C o -c device.ctx $DEVICE_KEY_HANDLE;flushtpm
+
+# create device certificate (required by EncryptDecryptUsingTpm)
+# The EncryptDecryptUsingTpm function only needs to extract the ECC public key
+# from the certificate, so for testing we create a simple self-signed cert.
+openssl ecparam -genkey -name prime256v1 -out "$EVE_TPM_STATE/device.key.pem" 2>/dev/null
+openssl req -new -x509 -key "$EVE_TPM_STATE/device.key.pem" \
+        -out "$EVE_TPM_STATE/device.cert.pem" \
+        -days 3650 -subj "/O=The Linux Foundation/CN=EVE" \
+        -set_serial 1 2>/dev/null
+
+# Create ECDH certificate signed by device certificate
+# We use a temporary key for CSR, but force the public key to be the TPM's ECDH key
+tpm2 readpublic -c $ECDH_HANDLE -f pem -o "$EVE_TPM_STATE/ecdh.pub.pem" 2>/dev/null
+openssl ecparam -genkey -name prime256v1 -out "$EVE_TPM_STATE/temp_ecdh.key" 2>/dev/null
+openssl req -new -key "$EVE_TPM_STATE/temp_ecdh.key" \
+    -subj "/CN=Device ECDH certificate" \
+    -out "$EVE_TPM_STATE/ecdh.csr" 2>/dev/null
+
+openssl x509 -req -in "$EVE_TPM_STATE/ecdh.csr" \
+    -CA "$EVE_TPM_STATE/device.cert.pem" \
+    -CAkey "$EVE_TPM_STATE/device.key.pem" \
+    -CAcreateserial \
+    -out "$EVE_TPM_STATE/ecdh.cert.pem" \
+    -days 365 \
+    -force_pubkey "$EVE_TPM_STATE/ecdh.pub.pem" 2>/dev/null
+
+# Clean up temps
+rm "$EVE_TPM_STATE/temp_ecdh.key" "$EVE_TPM_STATE/ecdh.csr" "$EVE_TPM_STATE/ecdh.pub.pem"
 
 # clean up
-rm ek.ctx srk.ctx aik.ctx ecdh.ctx
+rm -f ek.ctx srk.ctx aik.ctx quotekey.ctx ecdh.ctx device.ctx ek_temp.key ek_cert.pem ek_cert.der
 
 # kill swtpm, we are going to start it again with unix sockets
 kill $PID
+
+echo "========================================================"
+echo "[+] TPM setup done."
+echo "========================================================"
 
 # start swtpm again, but this time with unix sockets for tests to use.
 # in case we need to debug this, cat the log file.


### PR DESCRIPTION
# Description

https://github.com/lf-edge/eve/pull/5494/changes/265c6889d1ffa298f6b13cbf7cd5fc4012222d89 Changes EncryptDecryptUsingTpm function to support versioned encryption
with proper random IV generation. Previously, the function used a static
zero IV which is insecure. This commit:

- Adds VaultKeyEncVersion enum (Unespecified, EncryptionAEAD) to track
  encryption method versions
- Implements AES-GCM (AEAD) encryption/decryption with random nonce
- Maintains backward compatibility with existing encrypted data using
  Unespecified version

The new AEAD mode generates a random nonce per encryption operation and
prepends it (with its size) to the ciphertext, providing authenticated
encryption with proper IV randomness.

https://github.com/lf-edge/eve/pull/5494/changes/f32bad68cd5f55dc4c189f875206049c57d36781 Refactor TPM tests and add encryption unit tests
- Move GetCertHash to evetpm package for better reusability.
- Migrate tpmmgr internal tests (testTpmEcdhSupport, testEcdhAES) to evetpm unit tests.
- Add unit tests in encryptdecrypt_test.go covering AES GCM and TPM encryption.
- Update TPM test setup scripts (tests/tpm/*.sh) to provision required keys and certificates.
- Allow overriding of TPM file paths in locationconsts.go for testing purposes.

## PR dependencies
None.

## How to test and validate this PR

### TPM Encryption Fix Validation

Ensure that device encryption keys (Vaults) continue to work correctly for new installations AND after upgrading existing devices.

#### 1. Fresh Installation Verification
Ensure the new encryption method works on a new device.

*   **Steps:**
    1.  **Onboard** a device with this new EVE image.
    2.  Wait for the device to become **Online** in the Controller.
    3.  **Deploy** a generic Edge Application with encrypted volume
    4.  **Verify:**
        *   Does the vault unlocks?
        *   Does the App instance reach **RUNNING** state? (Success)
        *   Does the App instance get stuck in **BOOTING** or **downloading** with errors? (Failure)
    6.  **Log Check**:
        *   Check `tpmmgr` logs on the device or via Controller:
            *   *Search for:* "TPM Sanity Check"
            *   *Expected:* No errors. If you see "failed to encrypt" or "failed to decrypt", the test failed.

#### 2. Upgrade & Backward Compatibility
Ensure that updating an OLD device to this NEW version does not lock the user out of their existing encrypted data.

*   **Steps:**
    1.  **Flash/Install** an **OLD** stable version of EVE (e.g., previous release) on a TPM-capable device.
    2.  **Onboard** and **Deploy** an Edge App with encrypted volume.
    3.  Verify the App is **RUNNING**.
    4.  **Trigger an Update** to the **NEW** EVE image (with this PR include).
    5.  Wait for the device to update and reboot.
    7.  **Verify:**
        *   Does the vault unlocks and *existing* App instance start up and reach **RUNNING** state again?
        *   The old vault's keys are stored on the Controller using the OLD encryption format. The new EVE image must correctly detect and decrypt these "Legacy" keys.

## Changelog notes

Fix AES-CFB encryption in EVE by by moving into AES-GCM (AEAD) with random nonce. ⚠️ This change breaks downgrade compatibility (downgrades are not officially supported). Once an upgrade is successful, the vault key format stored in the controller is changed. Any EVE version that does not include this change will be unable to decrypt the vault key sent by the controller.

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 14.5-stable
- 13.4-stable

For example, if this PR fixes a bug in a feature that was introduced in 14.5,
you can write:

```text
- 14.5-stable: To be backported.
- 13.4-stable: No, as the feature is not available there.
```

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
