### PR TITLE
Fix edgeview encryption change issue from previous PR 5556

### DIFF
--- a/pkg/edgeview/src/crypto.go
+++ b/pkg/edgeview/src/crypto.go
@@ -420,6 +420,8 @@ func deriveKeyHKDF(secret [hkdfKeyLen]byte, salt []byte, keyLen int) ([]byte, er
 // pkg/pillar/cmd/zedagent/parseedgeview.go on the device side before this
 // Edgeview container is started.
 func encryptVarInit(jdata types.EvjwtInfo) error {
+	jwtNonce = jdata.Key
+	nonceOpEncrption = jdata.Enc
 	if jdata.Enc {
 		if _, err := rand.Read(sessionSecret[:]); err != nil {
 			return fmt.Errorf("failed to generate sessionSecret: %v", err)


### PR DESCRIPTION
# Description

- fix the PR 5556, which has a couple of issues, that breaks Edgeview compatibility
- fix the issue, previous PR mistakenly removed the assignment to jwtNonce
   and nonceOpEncrption. which breaks the Edgeview compatibility
- the encryption is still broken with this patch and we need to come
   back to fix this properly

## How to test and validate this PR

- test this patch on EVE device, w/ the Edgeview from previous docker image, Edgeview should work still
- the encryption operation will not work, we need to come back w/ proper fix.

## Changelog notes

Fix edgeview encryption change issue from previous PR 5556

## PR Backports

- [x] 16.0-stable

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
