### PR TITLE
Flexible install changes for kube components

### DIFF
--- a/pkg/kube/kubevirt-utils.sh
+++ b/pkg/kube/kubevirt-utils.sh
@@ -34,6 +34,10 @@ Kubevirt_tie_breaker_config_apply() {
 }
 
 Kubevirt_uninstall() {
+    if ! kubectl get namespace/kubevirt; then
+        return 0
+    fi
+
     logmsg "Removing patched Kubevirt"
     {
         kubectl delete -n kubevirt kubevirt kubevirt --wait=true
@@ -62,6 +66,9 @@ Cdi_install() {
 }
 
 Cdi_uninstall() {
+    if ! kubectl get namespace/cdi; then
+        return 0
+    fi
     #CDI (containerzed data importer) is need to convert qcow2/raw formats to Persistent Volumes and Data volumes
     logmsg "Removing CDI version $CDI_VERSION"
     kubectl delete -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml

--- a/pkg/kube/longhorn-utils.sh
+++ b/pkg/kube/longhorn-utils.sh
@@ -32,6 +32,9 @@ longhorn_install() {
 }
 
 Longhorn_uninstall() {
+    if ! kubectl get namespace/longhorn-system; then
+        return 0
+    fi
     logmsg "longhorn_uninstall ${LONGHORN_VERSION} beginning"
     while ! kubectl apply -f /etc/longhorn_uninstall_settings.yaml; do
         sleep 5


### PR DESCRIPTION
## Description

Skip longhorn if the kernel module did not insert.
	This is seen on some arm devices with alternative kernels.
Skip uninstall steps if namespaces are missing.
	cdi and kubevirt are currently skipped during first boot
	install on arm devices.

## PR dependencies

None

## How to test and validate this PR

TBD

## Changelog notes

TBD

## PR Backports

- 16.0-stable: ?
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
