### PR TITLE
Disable LED disk enforcement

### DIFF
--- a/docs/LED-INDICATION.md
+++ b/docs/LED-INDICATION.md
@@ -1,6 +1,6 @@
 # LED Indication
 
-As EVE-OS boots and progresses through various intermediate states, the LED (by default the disk LED) blinking
+As EVE-OS boots and progresses through various intermediate states, the LED blinking
 pattern changes to indicate state transitions.
 To indicate a given state, LED blinks one or more times quickly in a row, then pauses for 1200ms and repeats continuously.
 By counting the number of successive blinks one may determine the current state of the edge device.

--- a/pkg/pillar/hardware/leds.go
+++ b/pkg/pillar/hardware/leds.go
@@ -20,8 +20,6 @@ type LedStrategy string
 const (
 	// StrategyNone default
 	StrategyNone LedStrategy = ""
-	// StrategyForceDisk uses disk activity simulation
-	StrategyForceDisk LedStrategy = "ForceDisk"
 	// StrategyLedCmd uses sysfs LEDs
 	StrategyLedCmd LedStrategy = "LedCmd"
 	// StrategyDellCmd uses Dell GPIO setup
@@ -63,31 +61,31 @@ type LedModel struct {
 var LedModels = []LedModel{
 	{
 		Model:    "Supermicro.SYS-E100-9APP",
-		Strategy: StrategyForceDisk,
+		Strategy: StrategyNone,
 	},
 	{
 		Model:    "Supermicro.SYS-E100-9S",
-		Strategy: StrategyForceDisk,
+		Strategy: StrategyNone,
 	},
 	{
 		Model:    "Supermicro.SYS-E50-9AP",
-		Strategy: StrategyForceDisk,
+		Strategy: StrategyNone,
 	},
 	{ // XXX temporary fix for old BIOS
 		Model:    "Supermicro.Super Server",
-		Strategy: StrategyForceDisk,
+		Strategy: StrategyNone,
 	},
 	{
 		Model:    "Supermicro.SYS-E300-8D",
-		Strategy: StrategyForceDisk,
+		Strategy: StrategyNone,
 	},
 	{
 		Model:    "Supermicro.SYS-E300-9A-4CN10P",
-		Strategy: StrategyForceDisk,
+		Strategy: StrategyNone,
 	},
 	{
 		Model:    "Supermicro.SYS-5018D-FN8T",
-		Strategy: StrategyForceDisk,
+		Strategy: StrategyNone,
 	},
 	{
 		Model:    "PC Engines.apu2",
@@ -215,7 +213,7 @@ var LedModels = []LedModel{
 	{
 		// Last in table as a default
 		Model:    "",
-		Strategy: StrategyForceDisk,
+		Strategy: StrategyNone,
 	},
 }
 


### PR DESCRIPTION
# Description

EVE has a mechanism that tries to control the LED of disk activity when a dedicated LED is not present in the edge device. In this way we can use the disk LEDs to see the device state according the blinking pattern. Pillar does that by modulating disk read operations using "calibrated" values captured during initialization. Although this approach isn't a problem on PC and/or arm64 systems with decent NVMes/SSD disks (since nothing is written), it stills performs useless readings of the storage device. This approach was introduced several years ago, let's deprecated it since LEDs are nowadays very common on edge devices and get rid of useless I/O operations.

## How to test and validate this PR

This is code removal, so there is nothing to test actually. Default test batch should provide coverage for regression detection.

## Changelog notes

Removal of disk LED enforcement. EVE will not enforce disk I/O operations to modulate status through the disk activity LED for devices that don't have a dedicated status LED.

## PR Backports

I saw issues on some arm64 devices due to these I/O operations only on EVE 16.0.0-lts, so I want to backport to 16.0-stable (no issues were observed with EVE 14.5 or 13.4, so no need to backport).

- [x] 16.0-stable https://github.com/lf-edge/eve/pull/6405

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.