### PR TITLE
pillar/types: add NumKmsgDropped metric to NewlogMetrics

### DIFF
--- a/pkg/pillar/types/newlogtypes.go
+++ b/pkg/pillar/types/newlogtypes.go
@@ -70,6 +70,7 @@ type NewlogMetrics struct {
 	NumBreakGZipFile      uint32            // total number of gzip file too large needs breakup
 	NumSkipUploadAppFile  uint32            // total number of gzip app file skipped upload
 	NumKmessages          uint64            // total input kmessages
+	NumKmsgDropped        uint64            // total kmsg messages dropped due to kernel ring buffer overflow
 	NumSyslogMessages     uint64            // total input syslog message
 	DevTop10InputBytesPCT map[string]uint32 // top 10 sources device log input in percentage
 	TotalSizeLogs         uint64            // total size of logs on device


### PR DESCRIPTION
# Description

Add `NumKmsgDropped` field to `NewlogMetrics` to track kernel messages lost due to kernel ring buffer overflow. This makes kernel log loss observable via the controller in the future.

Under heavy system load, `newlogd` can fall behind reading `/dev/kmsg`, causing the kernel ring buffer (128KB by default, `CONFIG_LOG_BUF_SHIFT=17`) to overflow and silently drop messages — typically the earliest messages
that contain the root cause of the problem being debugged.

Currently there is no metric to detect this loss. The new field will be populated by `newlogd` using `/dev/kmsg` sequence number gap detection (in a follow-up PR to `pkg/newlog`).

## PR dependencies

None. This is the first PR in a two-PR sequence:
1. **This PR** — adds the metric field to pillar types
2. Follow-up PR to `pkg/newlog` — implements the kernel log pipeline   improvements and populates the metric (depends on this PR being  merged and vendored)

## How to test and validate this PR

This PR only adds a new field to a struct. It has no behavioral change
on its own. Validation:

- `cd pkg/pillar && go build ./types/` — passes
- No existing tests affected (additive struct field change)
- Full validation will be done with the follow-up `pkg/newlog` PR

## Changelog notes

Added `NumKmsgDropped` metric to track kernel message loss due to ring buffer overflow. This metric will be populated by newlogd once the companion newlog changes land.

## PR Backports

- 16.0-stable: To be backported (together with the follow-up newlog PR).
- 14.5-stable: To be backported (together with the follow-up newlog PR).
- 13.4-stable: To be backported (together with the follow-up newlog PR).

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
