### PR TITLE
newlog: prevent kernel log loss under heavy system load

### DIFF
--- a/pkg/newlog/cmd/getKernelMsg.go
+++ b/pkg/newlog/cmd/getKernelMsg.go
@@ -12,15 +12,34 @@ import (
 )
 
 // getKernelMsg - goroutine to get from /dev/kmsg
-func getKernelMsg(loggerChan chan inputEntry) {
+// Writes to a dedicated kernelChan to decouple kernel log reading from
+// the main pipeline. This ensures that backpressure from downstream
+// processing (vector sockets, disk I/O, gzip compression) does not
+// prevent reading /dev/kmsg, which would cause the kernel ring buffer
+// to overflow and silently drop early messages.
+func getKernelMsg(kernelChan chan inputEntry) {
 	parser, err := kmsgparser.NewParser()
 	if err != nil {
 		log.Fatalf("unable to create kmsg parser: %v", err)
 	}
 	defer parser.Close()
 
+	lastSeqNum := -1
+
 	kmsg := parser.Parse()
 	for msg := range kmsg {
+		// Detect gaps in kernel message sequence numbers.
+		// /dev/kmsg assigns a monotonically increasing sequence number
+		// to each message. A gap means the kernel ring buffer overflowed
+		// and messages were lost (EPIPE from the reader's perspective).
+		if lastSeqNum >= 0 && msg.SequenceNumber > lastSeqNum+1 {
+			gap := uint64(msg.SequenceNumber - lastSeqNum - 1)
+			logmetrics.NumKmsgDropped += gap
+			log.Warnf("getKernelMsg: detected kernel log gap: %d messages lost (seq %d -> %d)",
+				gap, lastSeqNum, msg.SequenceNumber)
+		}
+		lastSeqNum = msg.SequenceNumber
+
 		entry := inputEntry{
 			source:    "kernel",
 			severity:  types.SyslogKernelDefaultLogLevel,
@@ -40,6 +59,18 @@ func getKernelMsg(loggerChan chan inputEntry) {
 		logmetrics.DevMetrics.NumInputEvent++
 		log.Tracef("getKmessages (%d) entry msg %s", logmetrics.NumKmessages, entry.content)
 
-		loggerChan <- entry
+		// Non-blocking send to the dedicated kernel buffer channel.
+		// If the kernel buffer is full (extremely unlikely with 500 slots),
+		// log the drop and count it — but never block, so we keep
+		// draining /dev/kmsg and prevent ring buffer overflow.
+		select {
+		case kernelChan <- entry:
+		default:
+			logmetrics.NumKmsgDropped++
+			log.Warnf("getKernelMsg: kernel buffer channel full, dropping message: %s", entry.content)
+		}
 	}
+	// If we get here, the kmsg parser channel was closed (read error or EOF).
+	// Log this as an error — no more kernel messages will be collected.
+	log.Errorf("getKernelMsg: kmsg parser channel closed, kernel log collection stopped")
 }

--- a/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/types/newlogtypes.go
+++ b/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/types/newlogtypes.go
@@ -70,6 +70,7 @@ type NewlogMetrics struct {
 	NumBreakGZipFile      uint32            // total number of gzip file too large needs breakup
 	NumSkipUploadAppFile  uint32            // total number of gzip app file skipped upload
 	NumKmessages          uint64            // total input kmessages
+	NumKmsgDropped        uint64            // total kmsg messages dropped due to kernel ring buffer overflow
 	NumSyslogMessages     uint64            // total input syslog message
 	DevTop10InputBytesPCT map[string]uint32 // top 10 sources device log input in percentage
 	TotalSizeLogs         uint64            // total size of logs on device


### PR DESCRIPTION
# Description

Under heavy system load, `newlogd` loses the beginning of kernel logs. The root cause is a cascading backpressure chain and slow system boot that prevents `getKernelMsg` from reading `/dev/kmsg`, causing the kernel ring buffer
(128KB, `CONFIG_LOG_BUF_SHIFT=17`) to overflow and silently drop the earliest messages — exactly the ones needed to diagnose the problem.

The backpressure chain:

```
doMoveCompressFile slow (disk I/O) --> movefileChan full (cap 5) --> 
trigMoveToGzip blocks in writelogFile --> unbuffered downstream channels block --> 
sendLogsToVector blocks --> loggerChan full (cap 10) --> getKernelMsg blocks --> 
/dev/kmsg not read → kernel ring buffer overflows --> EPIPE --> early messages gone
```

This PR fixes all choke points:

1. **Dedicated kernel buffer channel (cap 500):** `getKernelMsg` now   writes to its own channel with non-blocking sends, so it always   drains `/dev/kmsg` regardless of downstream backpressure. A merge   goroutine forwards messages to the main pipeline.

2. **Sequence number gap detection:** track `/dev/kmsg` sequence numbers   to detect and count ring buffer overflows. Populate the new   `NumKmsgDropped` metric so kernel log loss becomes observable via   the controller.

3. **Buffer downstream channels:** `appLogChan`, `uploadLogChan`,   `keepLogChan` changed from unbuffered to cap 100. A single blocked   app log send could previously freeze the entire pipeline.

4. **Increase `loggerChan`** from 10 to 500 and `movefileChan` from 5
   to 20.

5. **Non-blocking gzip handoff:** `trigMoveToGzip` uses non-blocking   send to `moveChan`. If the main goroutine is busy compressing, the   log file grows beyond the size limit until the next attempt succeeds,   rather than blocking the entire write pipeline.

Kernel message timestamps come from the kernel's own monotonic clock (not from when `newlogd` reads them), so buffering does not affect timestamp correctness — logs can still be sorted chronologically.

**Note:** the vendored copy of `newlogtypes.go` is manually updated to include the `NumKmsgDropped` field. This should be re-vendored properly after the companion pillar PR is merged.

## PR dependencies

Depends on #5625 (`pillar/types: add NumKmsgDropped metric to NewlogMetrics`) — the vendored copy needs to be regenerated after that PR is merged.

## How to test and validate this PR

1. Build and run tests: `cd pkg/newlog && go test ./cmd/` — all 15
   tests pass.
2. Deploy on a device under heavy load (multiple VMs with I/O, CPU
   stress).
3. Check that kernel logs (especially early boot messages or OOM events)
   are no longer truncated at the beginning.
4. Monitor `NumKmsgDropped` in newlog metrics — if non-zero, it
   indicates the kernel ring buffer overflowed but the loss was
   detected and counted (previously invisible).
5. Check for `getKernelMsg: detected kernel log gap` warning messages
   in device logs.

## Changelog notes

Fixed kernel log loss under heavy system load. Previously, when the device was under heavy I/O or CPU load, the beginning of kernel logs (dmesg) could be silently lost due to backpressure in the logging pipeline causing the kernel ring buffer to overflow. Kernel log loss is now detected and reported via the `NumKmsgDropped` metric.

## PR Backports

- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
