### PR TITLE
feat: Add evaluation status monitoring and run-target-live-gui target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -682,6 +682,9 @@ run-live-gui: $(SWTPM) GETTY $(DEVICETREE_DTB)
 run-target: $(SWTPM) GETTY
 	$(QEMU_SYSTEM) $(QEMU_OPTS) -drive file=$(TARGET_IMG),format=$(IMG_FORMAT)
 
+run-target-live-gui: $(SWTPM) GETTY $(DEVICETREE_DTB)
+	$(QEMU_SYSTEM) $(QEMU_OPTS_GUI) -drive file=$(TARGET_IMG),format=$(IMG_FORMAT)
+
 run-rootfs%: $(SWTPM) GETTY
 	(echo 'set devicetree="(hd0,msdos1)/eve.dtb"' ; echo 'set rootfs_root=/dev/vdb' ; echo 'set root=hd1' ; echo 'export rootfs_root' ; echo 'export devicetree' ; echo 'configfile /EFI/BOOT/grub.cfg' ) > $(EFI_PART)/BOOT/grub.cfg
 	$(QEMU_SYSTEM) $(QEMU_OPTS) -drive file=$(ROOTFS_IMG_BASE)$*.img,format=raw -drive file=fat:rw:$(EFI_PART)/..,label=CONFIG,id=uefi-disk,format=vvfat
@@ -1353,6 +1356,7 @@ help:
 	@echo "   run-installer-raw    runs installer.raw (via qemu) and 'installs' EVE into (initially blank) target.img"
 	@echo "   run-installer-net    runs installer.net (via qemu/iPXE) and 'installs' EVE into (initially blank) target.img"
 	@echo "   run-target           runs a full fledged virtual device on qemu from target.img (similar to run-live)"
+	@echo "   run-target-live-gui  same as run-target but with an emulated graphics card"
 	@echo
 	@echo "make run is currently an alias for make run-live"
 	@echo

--- a/pkg/pillar/cmd/monitor/ipc_server.go
+++ b/pkg/pillar/cmd/monitor/ipc_server.go
@@ -179,15 +179,25 @@ func (s *monitorIPCServer) sendIpcMessage(t string, msg any) error {
 
 	ipcMessage := ipcMessage{Type: t, Message: json.RawMessage(data)}
 
+	// re-marshal with the ipcMessage wrapper
 	if data, err = json.Marshal(ipcMessage); err != nil {
 		log.Errorf("Failed to Marshal IPC message: %v", err)
 		return err
 	}
 
+	// Log only metadata for large messages to avoid logging system issues
 	if t == "TpmLogs" {
-		log.Noticef("Sending IPC message: %s", t)
+		log.Noticef("Sending IPC message: type=%s (TpmLogs - large binary data)", t)
+	} else if t == "EvalStatus" {
+		log.Noticef("Sending IPC message: type=%s (EvalStatus - evaluation status update)", t)
 	} else {
-		log.Noticef("Sending IPC message: %s", string(data))
+		// For smaller messages, truncate if needed
+		msgStr := string(data)
+		if len(msgStr) > 500 {
+			log.Noticef("Sending IPC message: type=%s, size=%d bytes (message truncated)", t, len(msgStr))
+		} else {
+			log.Noticef("Sending IPC message: %s", msgStr)
+		}
 	}
 
 	_, err = s.codec.Write(data)

--- a/pkg/pillar/cmd/monitor/subscriptions.go
+++ b/pkg/pillar/cmd/monitor/subscriptions.go
@@ -241,6 +241,32 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 	log.Functionf("handleGlobalConfigImpl done for %s", key)
 }
 
+func handleEvalStatusCreate(ctxArg interface{}, key string, statusArg interface{}) {
+	log.Functionf("handleEvalStatusCreate called: key=%s, type=%T", key, statusArg)
+	handleEvalStatusUpdate(ctxArg, key, statusArg)
+}
+
+func handleEvalStatusModify(ctxArg interface{}, key string, statusArg interface{}, oldStatusArg interface{}) {
+	log.Functionf("handleEvalStatusModify called: key=%s, type=%T", key, statusArg)
+	oldStatus := oldStatusArg.(types.EvalStatus)
+	newStatus := statusArg.(types.EvalStatus)
+	log.Functionf("handleEvalStatusModify: old phase=%s -> new phase=%s, allowOnboard %t -> %t",
+		oldStatus.Phase, newStatus.Phase, oldStatus.AllowOnboard, newStatus.AllowOnboard)
+	handleEvalStatusUpdate(ctxArg, key, statusArg)
+}
+
+func handleEvalStatusDelete(ctxArg interface{}, key string, statusArg interface{}) {
+	log.Functionf("handleEvalStatusDelete called: key=%s", key)
+}
+
+func handleEvalStatusUpdate(ctxArg interface{}, key string, statusArg interface{}) {
+	ctx := ctxArg.(*monitor)
+	status := statusArg.(types.EvalStatus)
+	log.Functionf("handleEvalStatusUpdate: EvalStatus details - platform=%t, slot=%s, phase=%s, allowOnboard=%t, inventory=%t",
+		status.IsEvaluationPlatform, status.CurrentSlot, status.Phase, status.AllowOnboard, status.InventoryCollected)
+	ctx.IPCServer.sendIpcMessage("EvalStatus", status)
+}
+
 func (ctx *monitor) subscribe(ps *pubsub.PubSub) error {
 	var err error
 
@@ -441,6 +467,26 @@ func (ctx *monitor) subscribe(ps *pubsub.PubSub) error {
 		ErrorTime:     errorTime,
 	})
 
+	log.Noticef("Creating subscription for EvalStatus from evalmgr")
+	subEvalStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "evalmgr",
+		MyAgentName:   agentName,
+		TopicImpl:     types.EvalStatus{},
+		Persistent:    true,
+		Activate:      false,
+		Ctx:           ctx,
+		CreateHandler: handleEvalStatusCreate,
+		ModifyHandler: handleEvalStatusModify,
+		DeleteHandler: handleEvalStatusDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		log.Errorf("Cannot create subscription for EvalStatus: %v", err)
+		return err
+	}
+	log.Noticef("Successfully created subscription for EvalStatus")
+
 	ctx.subscriptions["IOAdapters"] = subPhysicalIOAdapter
 	ctx.subscriptions["VaultStatus"] = subVaultStatus
 	ctx.subscriptions["OnboardingStatus"] = subOnboardStatus
@@ -452,6 +498,7 @@ func (ctx *monitor) subscribe(ps *pubsub.PubSub) error {
 	ctx.subscriptions["LedBlinkCounter"] = subLedBlinkCounter
 	ctx.subscriptions["ZedAgentStatus"] = subZedAgentStatus
 	ctx.subscriptions["GlobalConfig"] = subGlobalConfig
+	ctx.subscriptions["EvalStatus"] = subEvalStatus
 	return nil
 }
 


### PR DESCRIPTION
# Description

This PR adds support for monitoring evaluation status in the EVE monitor service and includes a new Makefile convenience rule for running evalEVE with the GUI.

This change enables better tracking and visibility of the EVE evaluation process through the monitor service, with improved logging for troubleshooting and monitoring purposes.

- New subscription to evalmgr's EvalStatus topic for persistent status tracking
- Added EvalStatus message type 
- Integrated EvalStatus into the monitor's centralized subscription registry
- Added a new make target that combines run-target and run-live-gui functionality

## PR dependencies

No dependencies

## How to test and validate this PR

1. Create an evaluation EVE installer image `make PLATFORM=evaluation pkgs installer-raw`
2. Create an evaluation EVE image `make run-installer-raw`
3. Run the evaluation EVE image with TUI enabled `make run-target-live-gui`
4. Check the tab about the evalEVE and verify that is updated with new info about the evaluation

## Changelog notes

- **New Makefile convenience target**: Added `make run-target-live-gui` to easily run evalEVE with 
  graphical interface support, combining the functionality of `run-target` and `run-live-gui` targets.
- Enhanced monitoring and logging of evaluation status for better troubleshooting
- Improved IPC message logging with better readability for debugging purposes

## PR Backports

```
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.