### PR TITLE
pubsub: switch from unixpacket to framed stream sockets

### DIFF
--- a/pkg/pillar/pubsub/checkmaxsize_test.go
+++ b/pkg/pillar/pubsub/checkmaxsize_test.go
@@ -43,9 +43,11 @@ func TestCheckMaxSize(t *testing.T) {
 	}
 	ps := pubsub.New(&driver, logger, log)
 
-	// The values 48000 and 49122 have been determined experimentally
-	// to be what fits and not for this particular struct and string
-	// content.
+	// With framed big frames (32-bit length prefix) the IPC message size
+	// limit is now 10MB, so the old 65KB boundary tests no longer apply.
+	// We add new test cases that exceed the 10MB limit to verify it.
+	// The "large tag" mechanism (pubsub-large-*) still has its own 1MB
+	// limit enforced by large.go, so those cases remain.
 	myCtx := context{}
 	testMatrix := map[string]struct {
 		agentName   string
@@ -74,20 +76,20 @@ func TestCheckMaxSize(t *testing.T) {
 		"File too large": {
 			agentName: "",
 			//			agentScope: "testscope1",
-			stringSize: 49122,
+			stringSize: 8 * 1024 * 1024,
 			expectFail: true,
 		},
 		"IPC too large": {
 			agentName: "testagent1",
 			//			agentScope: "testscope",
-			stringSize: 49122,
+			stringSize: 8 * 1024 * 1024,
 			expectFail: true,
 		},
 		"IPC with persistent too large": {
 			agentName: "testagent2",
 			//			agentScope: "testscope",
 			persistent: true,
-			stringSize: 49122,
+			stringSize: 8 * 1024 * 1024,
 			expectFail: true,
 		},
 		"File using large tag": {

--- a/pkg/pillar/pubsub/reverse/publish.go
+++ b/pkg/pillar/pubsub/reverse/publish.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
 )
 
 // Publish publishes data to
@@ -36,7 +37,7 @@ func Publish(log *base.LogObject, agent string, data interface{}) error {
 		return err
 	}
 
-	conn, err := net.Dial("unixpacket", sockName)
+	conn, err := net.Dial("unix", sockName)
 	if err != nil {
 		err := fmt.Errorf("publish(%s): exception while dialing socket. %s",
 			sockName, err.Error())
@@ -45,7 +46,8 @@ func Publish(log *base.LogObject, agent string, data interface{}) error {
 	}
 	defer conn.Close()
 
-	if _, err := conn.Write(byteData); err != nil {
+	writer := socketdriver.NewFramedWriter(conn)
+	if _, err := writer.Write(byteData); err != nil {
 		err := fmt.Errorf("publish(%s): exception while writing data to the socket. %s",
 			sockName, err.Error())
 		log.Error(err.Error())

--- a/pkg/pillar/pubsub/reverse/subscribe.go
+++ b/pkg/pillar/pubsub/reverse/subscribe.go
@@ -70,10 +70,10 @@ func startSubscriber(log *base.LogObject, agent string, topic interface{}, retCh
 // serveConnection processes a single connection and sends received
 // notifications as a string on the retChan
 func serveConnection(log *base.LogObject, conn net.Conn, retChan chan<- string, name string) {
-	reader := socketdriver.NewFramedReader(conn)
+	reader := socketdriver.NewFrameReader(conn)
 
 	for {
-		frame, err := socketdriver.ReadFrame(reader)
+		frame, err := reader.ReadFrame()
 		if err != nil {
 			if err != io.EOF {
 				log.Errorf("serveConnection: Error on read: %s",

--- a/pkg/pillar/pubsub/reverse/subscribe.go
+++ b/pkg/pillar/pubsub/reverse/subscribe.go
@@ -63,14 +63,18 @@ func startSubscriber(log *base.LogObject, agent string, topic interface{}, retCh
 			log.Errorf("connectAndRead(%s) failed %s\n", sockName, err)
 			continue
 		}
-		go serveConnection(log, c, retChan, sockName)
+		go serveConnection(log, c, retChan)
 	}
 }
 
 // serveConnection processes a single connection and sends received
 // notifications as a string on the retChan
-func serveConnection(log *base.LogObject, conn net.Conn, retChan chan<- string, name string) {
-	reader := socketdriver.NewFrameReader(conn)
+func serveConnection(log *base.LogObject, conn net.Conn, retChan chan<- string) {
+	// Ensure the connection is always closed, even if retChan blocks forever.
+	defer conn.Close()
+	// The reverse subscriber accepts one connection at a time; use a stats-free
+	// reader to avoid key collisions when multiple publishers reconnect.
+	reader := socketdriver.NewFrameReaderInternal(conn)
 
 	for {
 		frame, err := reader.ReadFrame()
@@ -79,9 +83,8 @@ func serveConnection(log *base.LogObject, conn net.Conn, retChan chan<- string, 
 				log.Errorf("serveConnection: Error on read: %s",
 					err)
 			}
-			break
+			return
 		}
 		retChan <- string(frame)
 	}
-	conn.Close()
 }

--- a/pkg/pillar/pubsub/reverse/subscribe.go
+++ b/pkg/pillar/pubsub/reverse/subscribe.go
@@ -13,7 +13,6 @@ import (
 	"path"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
-	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
 )
 
@@ -42,7 +41,7 @@ func startSubscriber(log *base.LogObject, agent string, topic interface{}, retCh
 		// This could either be a left-over in the filesystem
 		// or some other process (or ourselves) using the same
 		// name to publish. Try connect to see if it is the latter.
-		_, err := net.Dial("unixpacket", sockName)
+		_, err := net.Dial("unix", sockName)
 		if err == nil {
 			log.Fatalf("connectAndRead(%s): Can not publish %s since its already used",
 				agent, sockName)
@@ -52,7 +51,7 @@ func startSubscriber(log *base.LogObject, agent string, topic interface{}, retCh
 				agent, sockName, err)
 		}
 	}
-	listener, err := net.Listen("unixpacket", sockName)
+	listener, err := net.Listen("unix", sockName)
 	if err != nil {
 		log.Fatalf("connectAndRead(%s): Exception while listening at sock %s. %s",
 			agent, sockName, err)
@@ -71,21 +70,10 @@ func startSubscriber(log *base.LogObject, agent string, topic interface{}, retCh
 // serveConnection processes a single connection and sends received
 // notifications as a string on the retChan
 func serveConnection(log *base.LogObject, conn net.Conn, retChan chan<- string, name string) {
+	reader := socketdriver.NewFramedReader(conn)
 
 	for {
-		// wait for readable conn
-		if err := pubsub.ConnReadCheck(conn); err != nil {
-			if err != io.EOF {
-				log.Errorf("serveConnection: Error on connReadCheck: %s",
-					err)
-			}
-			break
-		}
-
-		buf, doneFunc := socketdriver.GetBuffer()
-		defer doneFunc()
-
-		count, err := conn.Read(buf)
+		frame, err := socketdriver.ReadFrame(reader)
 		if err != nil {
 			if err != io.EOF {
 				log.Errorf("serveConnection: Error on read: %s",
@@ -93,7 +81,7 @@ func serveConnection(log *base.LogObject, conn net.Conn, retChan chan<- string, 
 			}
 			break
 		}
-		retChan <- string(buf[:count])
+		retChan <- string(frame)
 	}
 	conn.Close()
 }

--- a/pkg/pillar/pubsub/socketdriver/driver.go
+++ b/pkg/pillar/pubsub/socketdriver/driver.go
@@ -4,8 +4,10 @@
 package socketdriver
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path"
@@ -46,7 +48,10 @@ const (
 	// being directory in /run/global
 	fixedName = "global"
 	fixedDir  = "/run/" + fixedName
-	maxsize   = 10 * 1024 * 1024 // Max size for json which can be read or written (10MB with framed big frames)
+	// maxsize is the application-level limit on framed message size.
+	// Messages are base64-encoded before this check, so the effective raw JSON
+	// payload limit is approximately maxsize * 3/4 ≈ 7.5 MB.
+	maxsize = 10 * 1024 * 1024
 )
 
 // SocketDriver driver for pubsub using local unix-domain socket and files
@@ -242,29 +247,58 @@ func NewFramedWriter(conn net.Conn) *framed.Writer {
 	return w
 }
 
-// NewFramedReader wraps a net.Conn with a framed.Reader that uses big frames
-// (32-bit length prefix). Callers must use readFrame() instead of calling
-// ReadFrame() directly, to enforce the maxsize limit and prevent unbounded
-// memory allocation from a buggy peer.
-func NewFramedReader(conn net.Conn) *framed.Reader {
-	r := framed.NewReader(conn)
-	r.EnableBigFrames()
-	return r
+// initialBufSize is the initial size of the reusable read buffer.
+// It will grow as needed up to maxsize.
+const initialBufSize = 1024
+
+// FrameReader reads length-prefixed frames from a stream using a reusable
+// buffer that grows as needed up to maxsize. This avoids per-read allocations
+// (unlike framed.ReadFrame) and avoids wasting memory with fixed large buffers.
+// The wire format is identical to framed with EnableBigFrames: 4-byte
+// little-endian length prefix followed by payload.
+type FrameReader struct {
+	r   io.Reader
+	hdr [4]byte
+	buf []byte
 }
 
-// ReadFrame reads a single frame from the framed.Reader and rejects frames
-// that exceed maxsize. This protects against unbounded memory allocation
-// from a buggy or malicious peer sending a large length prefix.
-func ReadFrame(r *framed.Reader) ([]byte, error) {
-	frame, err := r.ReadFrame()
-	if err != nil {
+// NewFrameReader creates a FrameReader over conn with an initial buffer of
+// initialBufSize bytes. The buffer grows on demand up to maxsize.
+func NewFrameReader(conn net.Conn) *FrameReader {
+	return &FrameReader{
+		r:   conn,
+		buf: make([]byte, initialBufSize),
+	}
+}
+
+// ReadFrame reads a single frame. The returned slice is valid only until the
+// next call to ReadFrame (it aliases the internal buffer).
+func (fr *FrameReader) ReadFrame() ([]byte, error) {
+	// Read 4-byte length header
+	if _, err := io.ReadFull(fr.r, fr.hdr[:]); err != nil {
 		return nil, err
 	}
-	if len(frame) > maxsize {
+	nraw := binary.LittleEndian.Uint32(fr.hdr[:])
+	// Validate as uint32 before converting to int: on 32-bit platforms a large
+	// prefix would wrap negative, bypass the check, and panic on buf[:n].
+	if nraw > uint32(maxsize) {
 		return nil, fmt.Errorf("received frame of %d bytes exceeds max %d",
-			len(frame), maxsize)
+			nraw, maxsize)
 	}
-	return frame, nil
+	n := int(nraw)
+	// Grow buffer if needed with 25% headroom to reduce future
+	// re-allocations; never shrink.
+	if n > len(fr.buf) {
+		newSize := n + n/4
+		if newSize > maxsize {
+			newSize = maxsize
+		}
+		fr.buf = make([]byte, newSize)
+	}
+	if _, err := io.ReadFull(fr.r, fr.buf[:n]); err != nil {
+		return nil, err
+	}
+	return fr.buf[:n], nil
 }
 
 // Poll to check if we should go away

--- a/pkg/pillar/pubsub/socketdriver/driver.go
+++ b/pkg/pillar/pubsub/socketdriver/driver.go
@@ -5,13 +5,19 @@ package socketdriver
 
 import (
 	"encoding/binary"
+	"encoding/csv"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"path"
+	"sort"
+	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/getlantern/framed"
 	"github.com/lf-edge/eve/pkg/pillar/base"
@@ -251,23 +257,311 @@ func NewFramedWriter(conn net.Conn) *framed.Writer {
 // It will grow as needed up to maxsize.
 const initialBufSize = 1024
 
+// Size buckets for frame statistics. Each bucket counts frames with size
+// up to the bucket boundary. The last bucket catches everything above.
+var frameSizeBuckets = []int{
+	256,
+	1024,
+	4 * 1024,
+	16 * 1024,
+	64 * 1024,
+	256 * 1024,
+	1024 * 1024,
+	10 * 1024 * 1024,
+}
+
+// frameSizeBucketLabels are human-readable labels matching frameSizeBuckets.
+var frameSizeBucketLabels = []string{
+	"<=256B",
+	"<=1KB",
+	"<=4KB",
+	"<=16KB",
+	"<=64KB",
+	"<=256KB",
+	"<=1MB",
+	"<=10MB",
+	">10MB",
+}
+
+// readerStats holds per-FrameReader accumulated statistics.
+type readerStats struct {
+	framesRead   uint64 // total frames read
+	bytesRead    uint64 // total payload bytes read
+	grows        uint64 // number of buffer grow events
+	maxFrameSize uint64 // largest frame seen
+	bufSize      uint64 // current buffer capacity
+	buckets      [9]uint64
+}
+
+// classifyFrame increments the appropriate size bucket counter.
+func (s *readerStats) classifyFrame(n int) {
+	for i, boundary := range frameSizeBuckets {
+		if n <= boundary {
+			atomic.AddUint64(&s.buckets[i], 1)
+			return
+		}
+	}
+	atomic.AddUint64(&s.buckets[len(frameSizeBuckets)], 1)
+}
+
+// globalReaderStats provides a system-wide aggregate view.
+// Protected by globalStatsMu.
+var (
+	globalStatsMu     sync.Mutex
+	globalReaderStats = make(map[string]*readerStats) // key is topic name
+)
+
+// registerReader registers a FrameReader's stats under the given topic.
+func registerReader(topic string, stats *readerStats) {
+	globalStatsMu.Lock()
+	defer globalStatsMu.Unlock()
+	globalReaderStats[topic] = stats
+}
+
+// unregisterReader removes a FrameReader's stats.
+func unregisterReader(topic string) {
+	globalStatsMu.Lock()
+	defer globalStatsMu.Unlock()
+	delete(globalReaderStats, topic)
+}
+
+// ReaderStatsEntry is a snapshot of one FrameReader's statistics.
+type ReaderStatsEntry struct {
+	Topic        string
+	FramesRead   uint64
+	BytesRead    uint64
+	Grows        uint64
+	MaxFrameSize uint64
+	BufSize      uint64
+	Buckets      [9]uint64
+}
+
+// GetAllReaderStats returns a snapshot of per-topic reader statistics.
+// Safe to call from any goroutine.
+func GetAllReaderStats() []ReaderStatsEntry {
+	globalStatsMu.Lock()
+	defer globalStatsMu.Unlock()
+	entries := make([]ReaderStatsEntry, 0, len(globalReaderStats))
+	for topic, s := range globalReaderStats {
+		var buckets [9]uint64
+		for i := range buckets {
+			buckets[i] = atomic.LoadUint64(&s.buckets[i])
+		}
+		entries = append(entries, ReaderStatsEntry{
+			Topic:        topic,
+			FramesRead:   atomic.LoadUint64(&s.framesRead),
+			BytesRead:    atomic.LoadUint64(&s.bytesRead),
+			Grows:        atomic.LoadUint64(&s.grows),
+			MaxFrameSize: atomic.LoadUint64(&s.maxFrameSize),
+			BufSize:      atomic.LoadUint64(&s.bufSize),
+			Buckets:      buckets,
+		})
+	}
+	return entries
+}
+
+// LogReaderStats logs a summary of all reader stats using size buckets.
+// Includes a comparison line showing old pool memory vs current arena memory.
+func LogReaderStats(log *base.LogObject) {
+	entries := GetAllReaderStats()
+	if len(entries) == 0 {
+		return
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Topic < entries[j].Topic
+	})
+	var totalOldPoolMem, totalArenaMem, totalFrames, totalBytes, totalGrows uint64
+	var totalReaders int
+	for _, e := range entries {
+		totalReaders++
+		totalFrames += e.FramesRead
+		totalBytes += e.BytesRead
+		totalGrows += e.Grows
+		// Old pool: every reader used a fixed 65536-byte buffer
+		totalOldPoolMem += 65536
+		totalArenaMem += e.BufSize
+
+		log.Functionf("FrameReader[%s]: frames=%d bytes=%d grows=%d maxFrame=%d buf=%d",
+			e.Topic, e.FramesRead, e.BytesRead, e.Grows, e.MaxFrameSize, e.BufSize)
+		for i, label := range frameSizeBucketLabels {
+			if e.Buckets[i] > 0 {
+				log.Functionf("  %s: %d", label, e.Buckets[i])
+			}
+		}
+	}
+	// Arena allocs = initial make per reader + grows. After warmup, grows stop.
+	// Old sync.Pool: best case 0 allocs after warmup, worst case 1 per read
+	// when GC reclaims idle buffers between Get/Put cycles.
+	totalArenaAllocs := uint64(totalReaders) + totalGrows
+	log.Functionf("FrameReader totals: readers=%d frames=%d bytes=%d "+
+		"oldPoolMem=%d arenaMem=%d savedBytes=%d "+
+		"arenaAllocs=%d grows=%d",
+		totalReaders, totalFrames, totalBytes,
+		totalOldPoolMem, totalArenaMem,
+		int64(totalOldPoolMem)-int64(totalArenaMem),
+		totalArenaAllocs, totalGrows)
+}
+
+// writeStatsCSV appends one row per topic plus a "__totals__" row to the given
+// CSV file. The file is created with a header on first call.
+// CSV columns:
+//
+//	timestamp, topic, frames, bytes, grows, max_frame, buf_size,
+//	old_pool_mem, arena_mem, saved_bytes, arena_allocs,
+//	bucket_<=256B, bucket_<=1KB, bucket_<=4KB, bucket_<=16KB,
+//	bucket_<=64KB, bucket_<=256KB, bucket_<=1MB, bucket_<=10MB, bucket_>10MB
+func writeStatsCSV(filePath string) error {
+	entries := GetAllReaderStats()
+	if len(entries) == 0 {
+		return nil
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Topic < entries[j].Topic
+	})
+
+	needHeader := false
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		needHeader = true
+	}
+
+	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("writeStatsCSV: open %s: %w", filePath, err)
+	}
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+	defer w.Flush()
+
+	if needHeader {
+		header := []string{
+			"timestamp", "topic", "frames", "bytes", "grows",
+			"max_frame", "buf_size", "old_pool_mem", "arena_mem",
+			"saved_bytes", "arena_allocs",
+		}
+		for _, label := range frameSizeBucketLabels {
+			header = append(header, "bucket_"+label)
+		}
+		if err := w.Write(header); err != nil {
+			return err
+		}
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	u := strconv.FormatUint
+
+	var totalOldPoolMem, totalArenaMem, totalFrames, totalBytes, totalGrows uint64
+	for _, e := range entries {
+		totalFrames += e.FramesRead
+		totalBytes += e.BytesRead
+		totalGrows += e.Grows
+		oldPool := uint64(65536)
+		totalOldPoolMem += oldPool
+		totalArenaMem += e.BufSize
+
+		row := []string{
+			now, e.Topic,
+			u(e.FramesRead, 10), u(e.BytesRead, 10), u(e.Grows, 10),
+			u(e.MaxFrameSize, 10), u(e.BufSize, 10),
+			u(oldPool, 10), u(e.BufSize, 10),
+			strconv.FormatInt(int64(oldPool)-int64(e.BufSize), 10),
+			u(1+e.Grows, 10),
+		}
+		for _, b := range e.Buckets {
+			row = append(row, u(b, 10))
+		}
+		if err := w.Write(row); err != nil {
+			return err
+		}
+	}
+
+	// Totals row
+	totalArenaAllocs := uint64(len(entries)) + totalGrows
+	totRow := []string{
+		now, "__totals__",
+		u(totalFrames, 10), u(totalBytes, 10), u(totalGrows, 10),
+		"0", u(totalArenaMem, 10),
+		u(totalOldPoolMem, 10), u(totalArenaMem, 10),
+		strconv.FormatInt(int64(totalOldPoolMem)-int64(totalArenaMem), 10),
+		u(totalArenaAllocs, 10),
+	}
+	for range frameSizeBucketLabels {
+		totRow = append(totRow, "0")
+	}
+	return w.Write(totRow)
+}
+
+// StartStatsLogger starts a goroutine that periodically writes FrameReader
+// statistics to a CSV file and optionally also logs them.
+// csvPath is the output CSV file (e.g. "/persist/pubsub-frame-stats.csv").
+// Returns a stop function to cancel the logging goroutine.
+// If interval is <= 0 a no-op stop function is returned.
+func StartStatsLogger(log *base.LogObject, interval time.Duration, csvPath string) func() {
+	if interval <= 0 {
+		return func() {}
+	}
+	done := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := writeStatsCSV(csvPath); err != nil {
+					log.Errorf("FrameReader stats CSV: %v", err)
+				}
+				LogReaderStats(log)
+			case <-done:
+				return
+			}
+		}
+	}()
+	return func() { close(done) }
+}
+
 // FrameReader reads length-prefixed frames from a stream using a reusable
 // buffer that grows as needed up to maxsize. This avoids per-read allocations
 // (unlike framed.ReadFrame) and avoids wasting memory with fixed large buffers.
 // The wire format is identical to framed with EnableBigFrames: 4-byte
 // little-endian length prefix followed by payload.
 type FrameReader struct {
-	r   io.Reader
-	hdr [4]byte
-	buf []byte
+	r     io.Reader
+	hdr   [4]byte
+	buf   []byte
+	topic string
+	stats readerStats
 }
 
 // NewFrameReader creates a FrameReader over conn with an initial buffer of
 // initialBufSize bytes. The buffer grows on demand up to maxsize.
-func NewFrameReader(conn net.Conn) *FrameReader {
+// The topic is used for stats reporting; the reader is registered in the
+// global stats map. Call Close when done to unregister.
+func NewFrameReader(conn net.Conn, topic string) *FrameReader {
+	fr := &FrameReader{
+		r:     conn,
+		buf:   make([]byte, initialBufSize),
+		topic: topic,
+		stats: readerStats{bufSize: initialBufSize},
+	}
+	registerReader(topic, &fr.stats)
+	return fr
+}
+
+// NewFrameReaderInternal creates a FrameReader without registering it in the
+// global stats map. Use this for short-lived readers that read only a single
+// handshake frame (e.g. the publisher-side reader in serveConnection).
+func NewFrameReaderInternal(conn net.Conn) *FrameReader {
 	return &FrameReader{
 		r:   conn,
 		buf: make([]byte, initialBufSize),
+	}
+}
+
+// Close unregisters this reader's stats. Should be called when the
+// connection is done. No-op if the reader was created with NewFrameReaderInternal.
+func (fr *FrameReader) Close() {
+	if fr.topic != "" {
+		unregisterReader(fr.topic)
 	}
 }
 
@@ -294,10 +588,23 @@ func (fr *FrameReader) ReadFrame() ([]byte, error) {
 			newSize = maxsize
 		}
 		fr.buf = make([]byte, newSize)
+		atomic.AddUint64(&fr.stats.grows, 1)
+		atomic.StoreUint64(&fr.stats.bufSize, uint64(newSize))
 	}
 	if _, err := io.ReadFull(fr.r, fr.buf[:n]); err != nil {
 		return nil, err
 	}
+	// Update stats
+	atomic.AddUint64(&fr.stats.framesRead, 1)
+	atomic.AddUint64(&fr.stats.bytesRead, uint64(n))
+	un := uint64(n)
+	for {
+		old := atomic.LoadUint64(&fr.stats.maxFrameSize)
+		if un <= old || atomic.CompareAndSwapUint64(&fr.stats.maxFrameSize, old, un) {
+			break
+		}
+	}
+	fr.stats.classifyFrame(n)
 	return fr.buf[:n], nil
 }
 

--- a/pkg/pillar/pubsub/socketdriver/driver.go
+++ b/pkg/pillar/pubsub/socketdriver/driver.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"path"
 	"strings"
-	"sync"
-	"sync/atomic"
 
+	"github.com/getlantern/framed"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/sirupsen/logrus"
@@ -47,7 +46,7 @@ const (
 	// being directory in /run/global
 	fixedName = "global"
 	fixedDir  = "/run/" + fixedName
-	maxsize   = 65535 // Max size for json which can be read or written
+	maxsize   = 10 * 1024 * 1024 // Max size for json which can be read or written (10MB with framed big frames)
 )
 
 // SocketDriver driver for pubsub using local unix-domain socket and files
@@ -119,7 +118,7 @@ func (s *SocketDriver) Publisher(global bool, name, topic string, persistent boo
 			// This could either be a left-over in the filesystem
 			// or some other process (or ourselves) using the same
 			// name to publish. Try connect to see if it is the latter.
-			sock, err := net.Dial("unixpacket", sockName)
+			sock, err := net.Dial("unix", sockName)
 			if err == nil {
 				sock.Close()
 				s.Log.Fatalf("Cannot publish %s since it is already used",
@@ -131,7 +130,7 @@ func (s *SocketDriver) Publisher(global bool, name, topic string, persistent boo
 				return nil, errors.New(errStr)
 			}
 		}
-		listener, err = net.Listen("unixpacket", sockName)
+		listener, err = net.Listen("unix", sockName)
 		if err != nil {
 			errStr := fmt.Sprintf("Publish(%s): failed %s",
 				name, err)
@@ -234,39 +233,38 @@ func (s *SocketDriver) persistentDirName(name string) string {
 	return fmt.Sprintf("%s/%s/status/%s", s.RootDir, "/persist", name)
 }
 
-// Use a buffer pool to minimize memory usage
-var bufPool = &sync.Pool{
-	New: func() interface{} {
-		buffer := make([]byte, maxsize+1)
-		return buffer
-	},
+// NewFramedWriter wraps a net.Conn with a framed.Writer that uses big frames
+// (32-bit length prefix), supporting messages up to maxsize.
+// The actual application-level limit is enforced by the send* methods.
+func NewFramedWriter(conn net.Conn) *framed.Writer {
+	w := framed.NewWriter(conn)
+	w.EnableBigFrames()
+	return w
 }
 
-// Track allocations for debug
-var allocated uint32
-
-// GetBuffer returns a buffer and a done func to call at defer.
-func GetBuffer() ([]byte, func()) {
-	buf := bufPool.Get().([]byte)
-	atomic.AddUint32(&allocated, 1)
-	return buf, func() {
-		bufPool.Put(buf)
-		atomic.AddUint32(&allocated, ^uint32(0))
-	}
+// NewFramedReader wraps a net.Conn with a framed.Reader that uses big frames
+// (32-bit length prefix). Callers must use readFrame() instead of calling
+// ReadFrame() directly, to enforce the maxsize limit and prevent unbounded
+// memory allocation from a buggy peer.
+func NewFramedReader(conn net.Conn) *framed.Reader {
+	r := framed.NewReader(conn)
+	r.EnableBigFrames()
+	return r
 }
 
-// logs a message if the allocation changed
-var lastLoggedAllocated uint32
-
-func maybeLogAllocated(log *base.LogObject) {
-	currentAllocated := atomic.LoadUint32(&allocated)
-	currentLastAllocated := atomic.LoadUint32(&lastLoggedAllocated)
-	if currentLastAllocated == currentAllocated {
-		return
+// ReadFrame reads a single frame from the framed.Reader and rejects frames
+// that exceed maxsize. This protects against unbounded memory allocation
+// from a buggy or malicious peer sending a large length prefix.
+func ReadFrame(r *framed.Reader) ([]byte, error) {
+	frame, err := r.ReadFrame()
+	if err != nil {
+		return nil, err
 	}
-	log.Functionf("pubsub buffer allocation changed from %d to  %d",
-		currentLastAllocated, currentAllocated)
-	atomic.StoreUint32(&lastLoggedAllocated, currentAllocated)
+	if len(frame) > maxsize {
+		return nil, fmt.Errorf("received frame of %d bytes exceeds max %d",
+			len(frame), maxsize)
+	}
+	return frame, nil
 }
 
 // Poll to check if we should go away

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -280,7 +280,7 @@ func (s *Publisher) serveConnection(conn net.Conn, instance int) {
 	s.log.Functionf("serveConnection(%s/%d)\n", s.name, instance)
 	defer conn.Close()
 
-	reader := NewFramedReader(conn)
+	reader := NewFrameReader(conn)
 	writer := NewFramedWriter(conn)
 
 	// Track the set of keys/values we are sending to the peer
@@ -288,7 +288,7 @@ func (s *Publisher) serveConnection(conn net.Conn, instance int) {
 	sentRestartCounter := 0
 
 	// Read request
-	frame, err := ReadFrame(reader)
+	frame, err := reader.ReadFrame()
 	if err != nil {
 		// Peer process could have died
 		s.log.Errorf("serveConnection(%s/%d) error: %v", s.name, instance, err)
@@ -411,7 +411,7 @@ func (s *Publisher) sendUpdate(writer *framed.Writer, key string,
 	sendKey := base64.StdEncoding.EncodeToString([]byte(key))
 	sendVal := base64.StdEncoding.EncodeToString(val)
 	buf := fmt.Sprintf("update %s %s %s", s.topic, sendKey, sendVal)
-	if len(buf) >= maxsize {
+	if len(buf) > maxsize {
 		return fmt.Errorf("too large message (%d bytes) for %s topic %s key %s",
 			len(buf), s.name, s.topic, key)
 	}
@@ -424,7 +424,7 @@ func (s *Publisher) sendDelete(writer *framed.Writer, key string) error {
 	// base64-encode to avoid having spaces in the key
 	sendKey := base64.StdEncoding.EncodeToString([]byte(key))
 	buf := fmt.Sprintf("delete %s %s", s.topic, sendKey)
-	if len(buf) >= maxsize {
+	if len(buf) > maxsize {
 		return fmt.Errorf("too large message (%d bytes) for %s topic %s key %s",
 			len(buf), s.name, s.topic, key)
 	}
@@ -435,7 +435,7 @@ func (s *Publisher) sendDelete(writer *framed.Writer, key string) error {
 func (s *Publisher) sendRestarted(writer *framed.Writer, restartCounter int) error {
 	s.log.Functionf("sendRestarted(%s)\n", s.name)
 	buf := fmt.Sprintf("restarted %s %d", s.topic, restartCounter)
-	if len(buf) >= maxsize {
+	if len(buf) > maxsize {
 		return fmt.Errorf("too large message (%d bytes) for %s topic %s",
 			len(buf), s.name, s.topic)
 	}
@@ -446,7 +446,7 @@ func (s *Publisher) sendRestarted(writer *framed.Writer, restartCounter int) err
 func (s *Publisher) sendComplete(writer *framed.Writer) error {
 	s.log.Functionf("sendComplete(%s)\n", s.name)
 	buf := fmt.Sprintf("complete %s", s.topic)
-	if len(buf) >= maxsize {
+	if len(buf) > maxsize {
 		return fmt.Errorf("too large message (%d bytes) for %s topic %s",
 			len(buf), s.name, s.topic)
 	}
@@ -463,7 +463,7 @@ func (s *Publisher) CheckMaxSize(key string, val []byte) error {
 	sendKey := base64.StdEncoding.EncodeToString([]byte(key))
 	sendVal := base64.StdEncoding.EncodeToString(val)
 	buf := fmt.Sprintf("update %s %s %s", s.topic, sendKey, sendVal)
-	if len(buf) >= maxsize {
+	if len(buf) > maxsize {
 		return fmt.Errorf("key %s serialized to size %d exceeds max %d",
 			key, len(buf), maxsize)
 	}

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -280,7 +280,8 @@ func (s *Publisher) serveConnection(conn net.Conn, instance int) {
 	s.log.Functionf("serveConnection(%s/%d)\n", s.name, instance)
 	defer conn.Close()
 
-	reader := NewFrameReader(conn)
+	// The publisher reads only one handshake frame; use a stats-free reader.
+	reader := NewFrameReaderInternal(conn)
 	writer := NewFramedWriter(conn)
 
 	// Track the set of keys/values we are sending to the peer

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/getlantern/framed"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
@@ -226,7 +227,6 @@ func (s *Publisher) Start() error {
 			}
 			s.log.Functionf("Creating %s at %s", "s.serveConnection", logutils.GetMyStack())
 			go s.serveConnection(c, instance)
-			maybeLogAllocated(s.log)
 			instance++
 		}
 		s.log.Warnf("Start(%s) acceptor goroutine exiting", s.name)
@@ -280,35 +280,29 @@ func (s *Publisher) serveConnection(conn net.Conn, instance int) {
 	s.log.Functionf("serveConnection(%s/%d)\n", s.name, instance)
 	defer conn.Close()
 
+	reader := NewFramedReader(conn)
+	writer := NewFramedWriter(conn)
+
 	// Track the set of keys/values we are sending to the peer
 	sendToPeer := make(pubsub.LocalCollection)
 	sentRestartCounter := 0
 
-	// Small buffer since we only read "request <topic>"
-	buf := make([]byte, 256)
-
 	// Read request
-	res, err := conn.Read(buf)
+	frame, err := ReadFrame(reader)
 	if err != nil {
 		// Peer process could have died
 		s.log.Errorf("serveConnection(%s/%d) error: %v", s.name, instance, err)
 		return
 	}
-	if res == len(buf) {
-		// Likely truncated
-		// Peer process could have died
-		s.log.Errorf("serveConnection(%s/%d) request likely truncated\n", s.name, instance)
-		return
-	}
 
-	request := strings.Split(string(buf[0:res]), " ")
+	request := strings.Split(string(frame), " ")
 	s.log.Functionf("serveConnection read %d: %v\n", len(request), request)
 	if len(request) != 2 || request[0] != "request" || request[1] != s.topic {
 		s.log.Errorf("Invalid request message: %v\n", request)
 		return
 	}
 
-	_, err = conn.Write([]byte(fmt.Sprintf("hello %s", s.topic)))
+	_, err = writer.Write([]byte(fmt.Sprintf("hello %s", s.topic)))
 	if err != nil {
 		s.log.Errorf("serveConnection(%s/%d) failed %s\n", s.name, instance, err)
 		return
@@ -324,18 +318,18 @@ func (s *Publisher) serveConnection(conn net.Conn, instance int) {
 	keys := s.differ.DetermineDiffs(sendToPeer)
 
 	// Send the keys we just determined; all since this is the initial
-	err = s.serialize(conn, keys, sendToPeer)
+	err = s.serialize(writer, keys, sendToPeer)
 	if err != nil {
 		s.log.Errorf("serveConnection(%s/%d) serialize failed %s\n", s.name, instance, err)
 		return
 	}
-	err = s.sendComplete(conn)
+	err = s.sendComplete(writer)
 	if err != nil {
 		s.log.Errorf("serveConnection(%s/%d) sendComplete failed %s\n", s.name, instance, err)
 		return
 	}
 	if s.restarted.RestartCounter() != sentRestartCounter {
-		err = s.sendRestarted(conn, s.restarted.RestartCounter())
+		err = s.sendRestarted(writer, s.restarted.RestartCounter())
 		if err != nil {
 			s.log.Errorf("serveConnection(%s/%d) sendRestarted failed %s\n", s.name, instance, err)
 			return
@@ -367,14 +361,14 @@ func (s *Publisher) serveConnection(conn net.Conn, instance int) {
 		keys := s.differ.DetermineDiffs(sendToPeer)
 
 		// Send the updates and deletes for those keys
-		err = s.serialize(conn, keys, sendToPeer)
+		err = s.serialize(writer, keys, sendToPeer)
 		if err != nil {
 			s.log.Errorf("serveConnection(%s/%d) serialize failed %s\n", s.name, instance, err)
 			return
 		}
 
 		if newRestartCounter != sentRestartCounter {
-			err = s.sendRestarted(conn, newRestartCounter)
+			err = s.sendRestarted(writer, newRestartCounter)
 			if err != nil {
 				s.log.Errorf("serveConnection(%s/%d) sendRestarted failed %s\n", s.name, instance, err)
 				return
@@ -385,7 +379,7 @@ func (s *Publisher) serveConnection(conn net.Conn, instance int) {
 	s.log.Warnf("serveConnection(%s) goroutine exiting", s.name)
 }
 
-func (s *Publisher) serialize(sock net.Conn, keys []string,
+func (s *Publisher) serialize(writer *framed.Writer, keys []string,
 	sendToPeer pubsub.LocalCollection) error {
 
 	s.log.Tracef("serialize(%s, %v)\n", s.name, keys)
@@ -393,13 +387,13 @@ func (s *Publisher) serialize(sock net.Conn, keys []string,
 	for _, key := range keys {
 		val, ok := sendToPeer[key]
 		if ok {
-			err := s.sendUpdate(sock, key, val)
+			err := s.sendUpdate(writer, key, val)
 			if err != nil {
 				s.log.Errorf("serialize(%s) sendUpdate failed %s\n", s.name, err)
 				return err
 			}
 		} else {
-			err := s.sendDelete(sock, key)
+			err := s.sendDelete(writer, key)
 			if err != nil {
 				s.log.Errorf("serialize(%s) sendDelete failed %s\n", s.name, err)
 				return err
@@ -409,7 +403,7 @@ func (s *Publisher) serialize(sock net.Conn, keys []string,
 	return nil
 }
 
-func (s *Publisher) sendUpdate(sock net.Conn, key string,
+func (s *Publisher) sendUpdate(writer *framed.Writer, key string,
 	val []byte) error {
 
 	s.log.Tracef("sendUpdate(%s): key %s\n", s.name, key)
@@ -418,49 +412,51 @@ func (s *Publisher) sendUpdate(sock net.Conn, key string,
 	sendVal := base64.StdEncoding.EncodeToString(val)
 	buf := fmt.Sprintf("update %s %s %s", s.topic, sendKey, sendVal)
 	if len(buf) >= maxsize {
-		s.log.Fatalf("Too large message (%d bytes) sent to %s topic %s key %s",
+		return fmt.Errorf("too large message (%d bytes) for %s topic %s key %s",
 			len(buf), s.name, s.topic, key)
 	}
-	_, err := sock.Write([]byte(buf))
+	_, err := writer.Write([]byte(buf))
 	return err
 }
 
-func (s *Publisher) sendDelete(sock net.Conn, key string) error {
+func (s *Publisher) sendDelete(writer *framed.Writer, key string) error {
 	s.log.Tracef("sendDelete(%s): key %s\n", s.name, key)
 	// base64-encode to avoid having spaces in the key
 	sendKey := base64.StdEncoding.EncodeToString([]byte(key))
 	buf := fmt.Sprintf("delete %s %s", s.topic, sendKey)
 	if len(buf) >= maxsize {
-		s.log.Fatalf("Too large message (%d bytes) sent to %s topic %s key %s",
+		return fmt.Errorf("too large message (%d bytes) for %s topic %s key %s",
 			len(buf), s.name, s.topic, key)
 	}
-	_, err := sock.Write([]byte(buf))
+	_, err := writer.Write([]byte(buf))
 	return err
 }
 
-func (s *Publisher) sendRestarted(sock net.Conn, restartCounter int) error {
+func (s *Publisher) sendRestarted(writer *framed.Writer, restartCounter int) error {
 	s.log.Functionf("sendRestarted(%s)\n", s.name)
 	buf := fmt.Sprintf("restarted %s %d", s.topic, restartCounter)
 	if len(buf) >= maxsize {
-		s.log.Fatalf("Too large message (%d bytes) sent to %s topic %s",
+		return fmt.Errorf("too large message (%d bytes) for %s topic %s",
 			len(buf), s.name, s.topic)
 	}
-	_, err := sock.Write([]byte(buf))
+	_, err := writer.Write([]byte(buf))
 	return err
 }
 
-func (s *Publisher) sendComplete(sock net.Conn) error {
+func (s *Publisher) sendComplete(writer *framed.Writer) error {
 	s.log.Functionf("sendComplete(%s)\n", s.name)
 	buf := fmt.Sprintf("complete %s", s.topic)
 	if len(buf) >= maxsize {
-		s.log.Fatalf("Too large message (%d bytes) sent to %s topic %s",
+		return fmt.Errorf("too large message (%d bytes) for %s topic %s",
 			len(buf), s.name, s.topic)
 	}
-	_, err := sock.Write([]byte(buf))
+	_, err := writer.Write([]byte(buf))
 	return err
 }
 
-// CheckMaxSize returns an error if too large
+// CheckMaxSize returns an error if the serialized message exceeds maxsize.
+// Even though the framed transport can support ~4GB frames, this driver enforces
+// a much smaller application-level limit (currently 10MB) to protect memory/IPC.
 func (s *Publisher) CheckMaxSize(key string, val []byte) error {
 	s.log.Tracef("CheckMaxSize(%s): key %s\n", s.name, key)
 	// base64-encode to avoid having spaces in the key and val

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/getlantern/framed"
@@ -28,6 +29,7 @@ import (
 // and directory-based persistence.
 type Subscriber struct {
 	sockName         string         // there is one socket per publishing agent
+	sockMu           sync.Mutex     // protects sock against Stop() vs connectAndRead() race
 	sock             net.Conn       // For socket subscriptions
 	reader           *FrameReader   // frame reader for the socket
 	writer           *framed.Writer // framed writer for the socket
@@ -151,11 +153,16 @@ func (s *Subscriber) Stop() error {
 	} else if subscribeFromSock {
 		// Tell watchSock to finish
 		close(s.doneChan)
-		if s.sock != nil {
-			// Force connectAndRead to terminate
-			s.log.Warnf("Stop(%s): forcing socket closed",
-				s.name)
-			s.sock.Close()
+		// Snapshot s.sock under the lock: connectAndRead writes s.sock from
+		// a different goroutine, so a naked read here is a data race.
+		s.sockMu.Lock()
+		sock := s.sock
+		s.sockMu.Unlock()
+		if sock != nil {
+			// Force connectAndRead to terminate by closing the socket,
+			// which causes the blocking ReadFrame to return an error.
+			s.log.Warnf("Stop(%s): forcing socket closed", s.name)
+			sock.Close()
 		}
 		return nil
 	} else {
@@ -229,9 +236,14 @@ func (s *Subscriber) connectAndRead() (string, string, []byte) {
 				delay = 10 * time.Second
 				continue
 			}
+			s.sockMu.Lock()
 			s.sock = sock
+			s.sockMu.Unlock()
 			s.writer = NewFramedWriter(sock)
-			s.reader = NewFrameReader(sock)
+			// Use s.name (agentName/topicType) as the stats key so that
+			// multiple subscriptions to the same topic type from different
+			// publisher agents don't collide in the global stats registry.
+			s.reader = NewFrameReader(sock, s.name)
 			req := fmt.Sprintf("request %s", s.topic)
 			_, err = s.writer.Write([]byte(req))
 			if err != nil {
@@ -239,8 +251,13 @@ func (s *Subscriber) connectAndRead() (string, string, []byte) {
 					s.name, err)
 				s.log.Errorln(errStr)
 				s.sock.Close()
+				s.sockMu.Lock()
 				s.sock = nil
-				s.reader = nil
+				s.sockMu.Unlock()
+				if s.reader != nil {
+					s.reader.Close()
+					s.reader = nil
+				}
 				s.writer = nil
 				continue
 			}
@@ -272,8 +289,13 @@ func (s *Subscriber) read() (string, string, []byte) {
 			s.name, err)
 		s.log.Errorln(errStr)
 		s.sock.Close()
+		s.sockMu.Lock()
 		s.sock = nil
-		s.reader = nil
+		s.sockMu.Unlock()
+		if s.reader != nil {
+			s.reader.Close()
+			s.reader = nil
+		}
 		s.writer = nil
 		return "", "", nil
 	}
@@ -365,7 +387,7 @@ func (s *Subscriber) read() (string, string, []byte) {
 // translate takes file notifications from a file watcher and converts them
 // pubsub operations. Normally this is 1-1 but since the file watcher can not
 // ensure ordering for the restarted file we delay those until a bit to ensure
-// they are delivered after any notifictions for other files.
+// they are delivered after any notifications for other files.
 func (s *Subscriber) translate(in <-chan string, out chan<- pubsub.Change) {
 	statusDirName := s.dirName
 	gotRestarted := false

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/getlantern/framed"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/flextimer"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
@@ -26,9 +27,11 @@ import (
 // Implements Unix-domain socket or directory subscription,
 // and directory-based persistence.
 type Subscriber struct {
-	sockName         string   // there is one socket per publishing agent
-	sock             net.Conn // For socket subscriptions
-	subscribeFromDir bool     // Handle special case of file only info
+	sockName         string         // there is one socket per publishing agent
+	sock             net.Conn       // For socket subscriptions
+	reader           *framed.Reader // framed reader for the socket
+	writer           *framed.Writer // framed writer for the socket
+	subscribeFromDir bool           // Handle special case of file only info
 	name             string
 	topic            string
 	dirName          string
@@ -170,7 +173,6 @@ func (s *Subscriber) LargeDirName() string {
 func (s *Subscriber) watchSock() {
 	for {
 		msg, key, val := s.connectAndRead()
-		maybeLogAllocated(s.log)
 		switch msg {
 		case "hello":
 			// Do nothing
@@ -216,7 +218,7 @@ func (s *Subscriber) connectAndRead() (string, string, []byte) {
 			}
 		}
 		if s.sock == nil {
-			sock, err := net.Dial("unixpacket", s.sockName)
+			sock, err := net.Dial("unix", s.sockName)
 			if err != nil {
 				errStr := fmt.Sprintf("connectAndRead(%s): Dial failed %s",
 					s.name, err)
@@ -228,14 +230,18 @@ func (s *Subscriber) connectAndRead() (string, string, []byte) {
 				continue
 			}
 			s.sock = sock
+			s.writer = NewFramedWriter(sock)
+			s.reader = NewFramedReader(sock)
 			req := fmt.Sprintf("request %s", s.topic)
-			_, err = sock.Write([]byte(req))
+			_, err = s.writer.Write([]byte(req))
 			if err != nil {
 				errStr := fmt.Sprintf("connectAndRead(%s): sock write failed %s",
 					s.name, err)
 				s.log.Errorln(errStr)
 				s.sock.Close()
 				s.sock = nil
+				s.reader = nil
+				s.writer = nil
 				continue
 			}
 		}
@@ -244,17 +250,9 @@ func (s *Subscriber) connectAndRead() (string, string, []byte) {
 			return "done", "", nil
 		}
 
-		// wait for readable conn
+		// ReadFrame will block until a complete frame is available.
 		// We close s.sock when we close s.doneChan to make sure
-		// ConnReadCheck unblocks
-		if err := pubsub.ConnReadCheck(s.sock); err != nil {
-			errStr := fmt.Sprintf("connectAndRead(%s) ConnReadCheck failed: %s",
-				s.name, err)
-			s.log.Errorln(errStr)
-			s.sock.Close()
-			s.sock = nil
-			continue
-		}
+		// ReadFrame unblocks.
 		msg, key, val := s.read()
 		if msg == "" {
 			continue
@@ -268,26 +266,19 @@ func (s *Subscriber) connectAndRead() (string, string, []byte) {
 // msg is "" if there is nothing to process
 func (s *Subscriber) read() (string, string, []byte) {
 
-	buf, doneFunc := GetBuffer()
-	defer doneFunc()
-
-	res, err := s.sock.Read(buf)
+	frame, err := ReadFrame(s.reader)
 	if err != nil {
 		errStr := fmt.Sprintf("connectAndRead(%s): sock read failed %s",
 			s.name, err)
 		s.log.Errorln(errStr)
 		s.sock.Close()
 		s.sock = nil
+		s.reader = nil
+		s.writer = nil
 		return "", "", nil
 	}
 
-	if res == len(buf) {
-		// Likely truncated
-		// Peer process could have died
-		s.log.Errorf("connectAndRead(%s) request likely truncated\n", s.name)
-		return "", "", nil
-	}
-	reply := strings.Split(string(buf[0:res]), " ")
+	reply := strings.Split(string(frame), " ")
 	count := len(reply)
 	if count < 2 {
 		errStr := fmt.Sprintf("connectAndRead(%s): too short read", s.name)

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -29,7 +29,7 @@ import (
 type Subscriber struct {
 	sockName         string         // there is one socket per publishing agent
 	sock             net.Conn       // For socket subscriptions
-	reader           *framed.Reader // framed reader for the socket
+	reader           *FrameReader   // frame reader for the socket
 	writer           *framed.Writer // framed writer for the socket
 	subscribeFromDir bool           // Handle special case of file only info
 	name             string
@@ -231,7 +231,7 @@ func (s *Subscriber) connectAndRead() (string, string, []byte) {
 			}
 			s.sock = sock
 			s.writer = NewFramedWriter(sock)
-			s.reader = NewFramedReader(sock)
+			s.reader = NewFrameReader(sock)
 			req := fmt.Sprintf("request %s", s.topic)
 			_, err = s.writer.Write([]byte(req))
 			if err != nil {
@@ -266,7 +266,7 @@ func (s *Subscriber) connectAndRead() (string, string, []byte) {
 // msg is "" if there is nothing to process
 func (s *Subscriber) read() (string, string, []byte) {
 
-	frame, err := ReadFrame(s.reader)
+	frame, err := s.reader.ReadFrame()
 	if err != nil {
 		errStr := fmt.Sprintf("connectAndRead(%s): sock read failed %s",
 			s.name, err)

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -413,6 +413,11 @@ const (
 	// TUIMonitorLogLevel: log level for TUI monitor
 	TUIMonitorLogLevel GlobalSettingKey = "debug.tui.loglevel"
 
+	// PubsubStatsInterval sets the interval in seconds for pubsub FrameReader
+	// stats collection (0 = disabled). Useful for observing per-topic message
+	// size distributions and buffer growth on a running device.
+	PubsubStatsInterval GlobalSettingKey = "debug.pubsub.stats.interval"
+
 	// MsrvPrometheusMetricsRequestPerSecond: limit the number of requests per second
 	MsrvPrometheusMetricsRequestPerSecond GlobalSettingKey = "msrv.prometheus.metrics.rps"
 	// MsrvPrometheusMetricsBurst: limit the burst of requests
@@ -1114,6 +1119,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddStringItem(AppBootOrder, "", validateBootOrder)
 	configItemSpecMap.AddStringItem(TUIMonitorLogLevel, "info", blankValidator)
 	configItemSpecMap.AddStringItem(EdgeviewPublicKeys, "", blankValidator)
+	configItemSpecMap.AddIntItem(PubsubStatsInterval, 1, 0, 3600) // tmp: default 1s for profiling run
 
 	// Log deduplication and filtering settings
 	configItemSpecMap.AddIntItem(LogDedupWindowSize, 0, 0, 0xFFFFFFFF)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -250,6 +250,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		K3sConfigOverride,
 		AppBootOrder,
 		K3sVersionOverride,
+		PubsubStatsInterval,
 	}
 	if len(specMap.GlobalSettings) != len(gsKeys) {
 		t.Errorf("GlobalSettings has more (%d) than expected keys (%d)",

--- a/pkg/pillar/zedbox/zedbox.go
+++ b/pkg/pillar/zedbox/zedbox.go
@@ -54,15 +54,17 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub/reverse"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+
 	_ "github.com/lf-edge/eve/pkg/pillar/rstats"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/sirupsen/logrus"
 )
 
 const (
-	agentName   = "zedbox"
-	errorTime   = 3 * time.Minute
-	warningTime = 40 * time.Second
+	agentName    = "zedbox"
+	errorTime    = 3 * time.Minute
+	warningTime  = 40 * time.Second
+	statsCSVPath = "/persist/pubsub-frame-stats.csv"
 )
 
 type zedboxInline uint8
@@ -182,6 +184,55 @@ func runService(serviceName string, sep entrypoint, inline bool) int {
 	return 0
 }
 
+// zedboxContext holds per-run state for the zedbox main loop.
+type zedboxContext struct {
+	stopStats func() // non-nil when stats logger is running
+	log       *base.LogObject
+}
+
+func handleGlobalConfigCreate(ctxArg interface{}, key string, statusArg interface{}) {
+	if key != "global" {
+		return
+	}
+	ctx := ctxArg.(*zedboxContext)
+	gcp, ok := statusArg.(types.ConfigItemValueMap)
+	if !ok {
+		return
+	}
+	updateStatsLogger(ctx, gcp.GlobalValueInt(types.PubsubStatsInterval))
+}
+
+func handleGlobalConfigModify(ctxArg interface{}, key string, statusArg interface{}, _ interface{}) {
+	handleGlobalConfigCreate(ctxArg, key, statusArg)
+}
+
+func handleGlobalConfigDelete(ctxArg interface{}, key string, _ interface{}) {
+	if key != "global" {
+		return
+	}
+	ctx := ctxArg.(*zedboxContext)
+	updateStatsLogger(ctx, 0)
+}
+
+// updateStatsLogger starts, stops, or restarts the FrameReader stats logger
+// based on the configured interval (0 = disabled).
+func updateStatsLogger(ctx *zedboxContext, intervalSecs uint32) {
+	if intervalSecs == 0 {
+		if ctx.stopStats != nil {
+			ctx.stopStats()
+			ctx.stopStats = nil
+			ctx.log.Noticef("FrameReader stats logger stopped")
+		}
+		return
+	}
+	d := time.Duration(intervalSecs) * time.Second
+	if ctx.stopStats != nil {
+		ctx.stopStats()
+	}
+	ctx.stopStats = socketdriver.StartStatsLogger(ctx.log, d, statsCSVPath)
+	ctx.log.Noticef("FrameReader stats logger started: interval=%v csv=%s", d, statsCSVPath)
+}
+
 // runZedbox is the built-in starting of the main process
 func runZedbox(ps *pubsub.PubSub, logger *logrus.Logger, log *base.LogObject, arguments []string, baseDir string) int {
 	//Start zedbox
@@ -194,10 +245,32 @@ func runZedbox(ps *pubsub.PubSub, logger *logrus.Logger, log *base.LogObject, ar
 	stillRunning := time.NewTicker(15 * time.Second)
 	ps.StillRunning(agentName, warningTime, errorTime)
 
+	ctx := &zedboxContext{log: log}
+	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "zedagent",
+		MyAgentName:   agentName,
+		TopicImpl:     types.ConfigItemValueMap{},
+		Activate:      false,
+		Ctx:           ctx,
+		Persistent:    true,
+		CreateHandler: handleGlobalConfigCreate,
+		ModifyHandler: handleGlobalConfigModify,
+		DeleteHandler: handleGlobalConfigDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		log.Fatalf("Failed to subscribe to GlobalConfig: %v", err)
+	}
+	subGlobalConfig.Activate()
+
 	subChan := reverse.NewSubscriber(log, agentName,
 		types.ServiceInitStatus{})
 	for {
 		select {
+		case change := <-subGlobalConfig.MsgChan():
+			subGlobalConfig.ProcessChange(change)
+
 		case subData := <-subChan:
 			subData = strings.TrimSpace(subData)
 			var serviceInitStatus types.ServiceInitStatus

--- a/tools/plot_frame_stats.py
+++ b/tools/plot_frame_stats.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Plot FrameReader statistics from CSV produced by socketdriver.StartStatsLogger.
+
+Usage:
+    # Copy CSV from device:
+    scp device:/persist/pubsub-frame-stats.csv .
+
+    # Plot all graphs:
+    python3 plot_frame_stats.py pubsub-frame-stats.csv
+
+    # Plot specific topics only:
+    python3 plot_frame_stats.py pubsub-frame-stats.csv \
+        --topics DeviceNetworkStatus AppInstanceStatus
+
+    # Save to file instead of showing:
+    python3 plot_frame_stats.py pubsub-frame-stats.csv -o stats.png
+
+Produces a multi-panel figure with:
+    1. Total arena memory vs old pool memory over time (log/log axes)
+    2. Per-topic buffer sizes over time
+    3. Cumulative buffer reallocations (grows) over time
+    4. Size bucket distribution (stacked bar per topic)
+"""
+
+import argparse
+import csv
+import sys
+from collections import defaultdict
+from datetime import datetime
+
+try:
+    import matplotlib.dates as mdates
+    import matplotlib.pyplot as plt
+    _HAVE_MATPLOTLIB = True
+except ImportError:
+    _HAVE_MATPLOTLIB = False
+
+try:
+    import numpy as np
+except ImportError:
+    _HAVE_MATPLOTLIB = False  # numpy is also required; reuse the same flag
+
+
+def parse_csv(path):
+    """Parse the stats CSV into per-topic timeseries and totals timeseries."""
+    topics = defaultdict(
+        lambda: {
+            "timestamps": [],
+            "frames": [],
+            "bytes": [],
+            "grows": [],
+            "max_frame": [],
+            "buf_size": [],
+            "old_pool_mem": [],
+            "arena_mem": [],
+            "saved_bytes": [],
+            "arena_allocs": [],
+            "buckets": [],
+        }
+    )
+
+    with open(path, newline="", encoding="utf-8") as csvfile:
+        reader = csv.DictReader(csvfile)
+        bucket_cols = [col for col in reader.fieldnames if col.startswith("bucket_")]
+        for row in reader:
+            topic = row["topic"]
+            timestamp = datetime.fromisoformat(row["timestamp"].replace("Z", "+00:00"))
+            data = topics[topic]
+            data["timestamps"].append(timestamp)
+            data["frames"].append(int(row["frames"]))
+            data["bytes"].append(int(row["bytes"]))
+            data["grows"].append(int(row["grows"]))
+            data["max_frame"].append(int(row["max_frame"]))
+            data["buf_size"].append(int(row["buf_size"]))
+            data["old_pool_mem"].append(int(row["old_pool_mem"]))
+            data["arena_mem"].append(int(row["arena_mem"]))
+            data["saved_bytes"].append(int(row["saved_bytes"]))
+            data["arena_allocs"].append(int(row["arena_allocs"]))
+            data["buckets"].append({col: int(row[col]) for col in bucket_cols})
+
+    return dict(topics), bucket_cols
+
+
+def human_bytes(nbytes):
+    """Format bytes as human-readable string."""
+    for unit in ("B", "KB", "MB", "GB"):
+        if abs(nbytes) < 1024:
+            return f"{nbytes:.1f}{unit}"
+        nbytes /= 1024
+    return f"{nbytes:.1f}TB"
+
+
+def _plot_memory(axis, totals):
+    """Panel 1: total arena vs old-pool memory (log/log axes)."""
+    if not totals:
+        return
+    start_time = totals["timestamps"][0]
+    elapsed = [(ts - start_time).total_seconds() + 1 for ts in totals["timestamps"]]
+    axis.plot(
+        elapsed,
+        [mem / 1024 for mem in totals["old_pool_mem"]],
+        label="Old pool (65KB × readers)",
+        color="red",
+        linestyle="--",
+        linewidth=2,
+    )
+    axis.plot(
+        elapsed,
+        [mem / 1024 for mem in totals["arena_mem"]],
+        label="Arena (actual)",
+        color="green",
+        linewidth=2,
+    )
+    axis.fill_between(
+        elapsed,
+        [mem / 1024 for mem in totals["arena_mem"]],
+        [mem / 1024 for mem in totals["old_pool_mem"]],
+        alpha=0.15,
+        color="green",
+        label="Saved",
+    )
+    axis.set_title("Total Buffer Memory: Arena vs Old Pool")
+    axis.set_xlabel("Elapsed time (s)")
+    axis.set_ylabel("Memory (KB)")
+    axis.set_xscale("log")
+    axis.set_yscale("log")
+    axis.legend(loc="upper left", fontsize=8)
+    axis.grid(True, alpha=0.3, which="both")
+
+
+def _plot_buf_sizes(axis, sorted_topics, topics, date_fmt):
+    """Panel 2: per-topic buffer sizes over time."""
+    for topic in sorted_topics:
+        data = topics[topic]
+        if not data["timestamps"]:
+            continue
+        # Only label topics that grew beyond the initial 1 KB buffer;
+        # flat topics clutter the legend without adding information.
+        grew = data["buf_size"] and max(data["buf_size"]) > 1024
+        axis.plot(
+            data["timestamps"],
+            [mem / 1024 for mem in data["buf_size"]],
+            label=topic if grew else "_nolegend_",
+            linewidth=1.5 if grew else 0.8,
+            alpha=1.0 if grew else 0.3,
+        )
+    axis.set_title("Per-Topic Buffer Size Over Time")
+    axis.set_ylabel("Buffer Size (KB)")
+    axis.axhline(y=64, color="red", linestyle=":", alpha=0.5, label="Old pool (64KB)")
+    axis.legend(bbox_to_anchor=(1.01, 1), loc="upper left", fontsize=7, borderaxespad=0)
+    axis.grid(True, alpha=0.3)
+    axis.xaxis.set_major_formatter(date_fmt)
+
+
+def _plot_grows(axis, sorted_topics, topics, totals, date_fmt):
+    """Panel 3: cumulative buffer reallocations over time."""
+    if totals:
+        axis.plot(
+            totals["timestamps"],
+            totals["grows"],
+            label="Total grows",
+            color="orange",
+            linewidth=2,
+        )
+        ax2 = axis.twinx()
+        ax2.plot(
+            totals["timestamps"],
+            totals["arena_allocs"],
+            label="Total allocs (initial+grows)",
+            color="blue",
+            linewidth=1.5,
+            linestyle="--",
+        )
+        ax2.set_ylabel("Total Allocations", color="blue")
+        ax2.tick_params(axis="y", labelcolor="blue")
+        ax2.legend(loc="upper right", fontsize=8)
+    for topic in sorted_topics:
+        data = topics[topic]
+        if not data["timestamps"] or max(data["grows"]) == 0:
+            continue
+        axis.plot(data["timestamps"], data["grows"], label=topic, linewidth=1, alpha=0.7)
+    axis.set_title("Buffer Reallocations (GC Pressure)")
+    axis.set_ylabel("Cumulative Grows")
+    axis.set_xlabel("Time")
+    axis.legend(loc="upper left", fontsize=6, ncol=2)
+    axis.grid(True, alpha=0.3)
+    axis.xaxis.set_major_formatter(date_fmt)
+
+
+def _plot_buckets(axis, sorted_topics, topics, bucket_cols):  # pylint: disable=too-many-locals
+    """Panel 4: frame size bucket distribution (last snapshot, stacked bar)."""
+    bucket_labels = [col.replace("bucket_", "") for col in bucket_cols]
+
+    # Collect data and sort by total frame count descending so the busiest
+    # topics appear first. Use only the topic type (strip agent/ prefix) as
+    # the x-axis label to keep bars readable.
+    rows = []
+    for topic in sorted_topics:
+        data = topics[topic]
+        if not data["buckets"]:
+            continue
+        last_buckets = data["buckets"][-1]
+        total = sum(last_buckets.values())
+        if total == 0:
+            continue
+        short_name = topic.split("/")[-1]
+        rows.append((total, short_name, last_buckets))
+    rows.sort(key=lambda row: row[0], reverse=True)
+
+    # Keep only the top 20 busiest topics; fold the rest into "other".
+    top_n = 20
+    top_rows = rows[:top_n]
+    rest_rows = rows[top_n:]
+
+    topic_names = [row[1] for row in top_rows]
+    bucket_data = defaultdict(list)
+    for _, _, last_buckets in top_rows:
+        for col, label in zip(bucket_cols, bucket_labels):
+            bucket_data[label].append(last_buckets[col])
+
+    if rest_rows:
+        topic_names.append(f"other ({len(rest_rows)})")
+        for col, label in zip(bucket_cols, bucket_labels):
+            bucket_data[label].append(sum(row[2][col] for row in rest_rows))
+
+    if topic_names:
+        xpos = np.arange(len(topic_names))
+        bottom = np.zeros(len(topic_names))
+        colors = plt.cm.viridis(np.linspace(0.1, 0.9, len(bucket_labels)))
+        for label, color in zip(bucket_labels, colors):
+            values = np.array(bucket_data[label], dtype=float)
+            if values.sum() == 0:
+                continue
+            axis.bar(xpos, values, 0.7, bottom=bottom, label=label, color=color)
+            bottom += values
+        axis.set_xticks(xpos)
+        axis.set_xticklabels(topic_names, rotation=60, ha="right", fontsize=6)
+    axis.set_title("Frame Size Distribution (Last Snapshot)")
+    axis.set_ylabel("Frame Count")
+    axis.legend(loc="upper right", fontsize=7, title="Size Bucket")
+    axis.grid(True, alpha=0.3, axis="y")
+
+
+def plot(topics, bucket_cols, filter_topics=None, output=None):
+    """Produce the four-panel stats figure."""
+    if not _HAVE_MATPLOTLIB:
+        print(
+            "ERROR: matplotlib and numpy are required. "
+            "Install with: pip install matplotlib numpy",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if output:
+        plt.switch_backend("Agg")
+
+    totals = topics.pop("__totals__", None)
+    if filter_topics:
+        topics = {key: val for key, val in topics.items() if key in filter_topics}
+
+    if not topics and not totals:
+        print("No data to plot.", file=sys.stderr)
+        sys.exit(1)
+
+    sorted_topics = sorted(
+        topics.keys(),
+        key=lambda topic: topics[topic]["buf_size"][-1] if topics[topic]["buf_size"] else 0,
+        reverse=True,
+    )
+
+    fig, axes = plt.subplots(2, 2, figsize=(18, 12))
+    fig.suptitle("PubSub FrameReader Statistics", fontsize=14, fontweight="bold")
+    date_fmt = mdates.DateFormatter("%H:%M:%S")
+
+    _plot_memory(axes[0][0], totals)
+    _plot_buf_sizes(axes[0][1], sorted_topics, topics, date_fmt)
+    _plot_grows(axes[1][0], sorted_topics, topics, totals, date_fmt)
+    _plot_buckets(axes[1][1], sorted_topics, topics, bucket_cols)
+
+    plt.tight_layout()
+
+    if output:
+        fig.savefig(output, dpi=150, bbox_inches="tight")
+        print(f"Saved to {output}")
+    else:
+        plt.show()
+
+
+def main():
+    """Parse arguments, load CSV, and produce the stats plot."""
+    parser = argparse.ArgumentParser(description="Plot FrameReader stats from CSV")
+    parser.add_argument("csv", help="Path to pubsub-frame-stats.csv")
+    parser.add_argument(
+        "--topics", nargs="*", help="Only show these topics (default: all)"
+    )
+    parser.add_argument(
+        "-o", "--output", help="Save plot to file instead of showing (e.g. stats.png)"
+    )
+    args = parser.parse_args()
+
+    topics, bucket_cols = parse_csv(args.csv)
+    if not topics:
+        print("No data found in CSV.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Loaded {len(topics)} topics from {args.csv}")
+    for topic in sorted(topics.keys()):
+        if topic == "__totals__":
+            continue
+        data = topics[topic]
+        num_samples = len(data["timestamps"])
+        last_buf = human_bytes(data["buf_size"][-1]) if data["buf_size"] else "N/A"
+        last_grows = data["grows"][-1] if data["grows"] else 0
+        print(f"  {topic}: {num_samples} samples, buf={last_buf}, grows={last_grows}")
+
+    plot(topics, bucket_cols, filter_topics=args.topics, output=args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# pubsub: switch from unixpacket to framed stream sockets

## Summary

Replaces raw `unixpacket` (SOCK_SEQPACKET) sockets with `unix` (SOCK_STREAM) sockets using the `getlantern/framed` library with 4-byte little-endian length-prefix framing (`EnableBigFrames()`). This removes the hard OS-level 65 KB per-message limit and replaces it with a configurable 10 MB application-level limit.

This is three commits:
1. **Switch to framed stream sockets** — wire protocol change
2. **FrameReader arena + maxsize enforcement** — per-reader reusable buffer (avoids 65 KB pool alloc per subscriber); enforces maxsize on both send and receive
3. **FrameReader stats via GlobalConfig** — optional per-topic instrumentation (disabled by default; enabled via `debug.pubsub.stats.interval` controller key)

## What Changed

### Commit 1: Wire protocol
- `unixpacket` → `unix` stream sockets in socketdriver and reverse pubsub
- Wrap connections with `framed.Reader`/`framed.Writer` + `EnableBigFrames()` (4-byte length prefix, little-endian)
- Raise `maxsize` from 65535 to 10 MB (applies after base64 encoding, so effective raw JSON limit ≈ 7.5 MB)
- Remove `ConnReadCheck` — `framed.ReadFrame()` blocks correctly on stream sockets

### Commit 2: FrameReader arena + maxsize
- `FrameReader`: per-reader buffer starting at 1 KB, growing 25% on demand, never shrinking
  - Replaces global `sync.Pool` of 65 KB fixed buffers → ~95% memory reduction (measured: 63 KB arena vs 1.3 MB old pool for 21 active topics)
- Enforce `maxsize` consistently on both send (`> maxsize`) and receive (`> maxsize`)
- `CheckMaxSize` helper for callers to validate before publishing

### Commit 3: Stats instrumentation via GlobalConfig
- Per-`FrameReader` atomic counters: frames, bytes, grows, max frame size, 9-bucket size histogram
- Global registry (topic → stats); exported via `GetAllReaderStats()`
- Optional CSV logger (`StartStatsLogger`) + matplotlib visualizer (`plot-frame-stats.py`)
- Activated dynamically from the controller via `debug.pubsub.stats.interval` (seconds; 0 = off)
- `newFrameReaderInternal` (no stats) used for publisher's single handshake read to avoid stats key collision
- Bucket atomics use `sync/atomic` to avoid data race between reader and stats goroutines

## Stats Run Results (4-minute boot on QEMU)

<img width="2683" height="1771" alt="pubsub-frame-stats" src="https://github.com/user-attachments/assets/df174846-8d2f-492d-833e-fd435392a649" />


![FrameReader stats after 4-minute EVE boot](
<img width="2683" height="1771" alt="pubsub-frame-stats" src="https://github.com/user-attachments/assets/606fc700-1909-4fa7-960e-2eff6449c9e0" />
)

Key findings:
- **Memory**: Arena uses ~63 KB vs old pool's ~1.3 MB (21 topics × 65 KB) — **95% reduction**
- **18 of 21 topics** never grow beyond the 1 KB initial buffer
- **3 topics that grow**: `ConfigItemValueMap` (24.4 KB, 1 grow), `DeviceNetworkStatus` (7.0 KB, 2 grows), `DevicePortConfigList` (2.7 KB, 1 grow)
- **All frames ≤ 4 KB** during boot — well within the 10 MB limit
- **Conclusion**: 1 KB default buffer size is correct; no tuning needed

> **Note**: The current branch has `debug.pubsub.stats.interval` default set to 1s temporarily for continued profiling while onboarding a real device. Will be set back to 0 (off by default) before merge.

## How to Test

```bash
# Unit tests
cd pkg/pillar && make test

# Enable stats on a running device (via controller or local override):
# Set debug.pubsub.stats.interval = 30 (seconds)
# Stats CSV written to /persist/pubsub-frame-stats.csv
# Visualize with:
python3 pkg/pillar/pubsub/socketdriver/plot-frame-stats.py /persist/pubsub-frame-stats.csv
```

## Changelog Notes

Increased pubsub IPC message size limit from 65 KB to 10 MB by switching from raw `unixpacket` datagram sockets to length-prefixed stream sockets. Memory usage reduced ~95% via per-reader arena buffers. Optional per-topic stats collection available via `debug.pubsub.stats.interval` controller key.

## PR Backports

- 16.0-stable: No backport.
- 14.5-stable: No backport.
- 13.4-stable: No backport.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device (QEMU + onboarding in progress)
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.