### PR TITLE
github/workflows: Build x86 + arm64 Yetus images at once

### DIFF
--- a/.github/workflows/buildyetusondemand.yml
+++ b/.github/workflows/buildyetusondemand.yml
@@ -34,8 +34,6 @@ jobs:
       IMG_TAG: "0.15.1-eve-1"
     strategy:
       fail-fast: false
-      matrix:
-        arch: [amd64, arm64]
 
     steps:
       - name: Starting Report
@@ -52,6 +50,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         if: ${{ env.REPO_NAME == 'lf-edge/eve' }}
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
@@ -60,7 +60,7 @@ jobs:
           password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
       - name: Build and push Yetus image
         run: |
-          docker buildx build --platform linux/${{ matrix.arch }} --push --tag ${{ env.IMG_NAME }}:${{ env.IMG_TAG }} tools/yetus
+          docker buildx build --platform linux/amd64,linux/arm64 --push --tag ${{ env.IMG_NAME }}:${{ env.IMG_TAG }} tools/yetus
       - name: Post package report
         run: |
           echo Disk usage


### PR DESCRIPTION
# Description

Unfortunately the job matrix cannot be used to build Yetus image because the job that finishes last will overwrite the image pushed to dockerhub. Since only x86 runners are used to build this image, there is no need to complicate the handling of manifests. Instead, we can just build and push both images at once. There are no advantages of the current matrix implementation.

## How to test and validate this PR

This PR was tested on my repo: https://github.com/rene/eve/actions/runs/22551285945

## Changelog notes

No user-facing changes.

## PR Backports

This is a build-on-demand workflow, there is no need to backport.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.