### PR TITLE
[DRAFT] Documents describing eve-k app deployment and failover

### DIFF
--- a/docs/EVE-K-3NODE-FAILOVER.md
+++ b/docs/EVE-K-3NODE-FAILOVER.md
@@ -1,0 +1,627 @@
+# EVE-K: 3-Node Full Control-Plane Cluster — Failover Scenarios
+
+## Cluster Topology
+
+All 3 nodes run: **etcd + K3s control-plane + worker + Longhorn replica**
+
+```
+  ┌───────────────────────────────────────────────────────────────┐
+  │              3-Node Full Control-Plane Cluster                │
+  │                                                               │
+  │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐        │
+  │  │    Node A    │  │    Node B    │  │    Node C    │        │
+  │  │              │  │              │  │              │        │
+  │  │ etcd ●       │  │ etcd ●       │  │ etcd ●       │        │
+  │  │ control-pln  │  │ control-pln  │  │ control-pln  │        │
+  │  │ worker       │  │ worker       │  │ worker       │        │
+  │  │ [vol-rep-1]  │  │ [vol-rep-2]  │  │ [vol-rep-3]  │        │
+  │  │ Schedulable  │  │ Schedulable  │  │ Schedulable  │        │
+  │  └──────────────┘  └──────────────┘  └──────────────┘        │
+  │                                                               │
+  │  K3s mode:  ALL nodes run `k3s server` (not `k3s agent`)      │
+  │  Longhorn:  3 replicas per volume (default storage class)     │
+  │  Quorum:    Any 2 of 3 nodes = cluster operational            │
+  │  TieBreakerNodeID: UNSET                                      │
+  │  IsWorkerNode: true on ALL nodes                              │
+  └───────────────────────────────────────────────────────────────┘
+```
+
+### Node roles vs. Tie-Breaker topology
+
+```
+  FULL 3-MASTER                   TIE-BREAKER
+  ═════════════                   ═══════════════
+
+  Node A: etcd + CP + work        Node A: etcd + CP + work
+  Node B: etcd + CP + work        Node B: etcd + CP + work
+  Node C: etcd + CP + work        Node C: etcd + CP only
+          ↑ ALL schedulable               ↑ cordoned, no workloads
+                                          ↑ lh-sc-rep2 (2 replicas)
+                                          ↑ TieBreakerNodeID set
+
+  Longhorn replicas: 3 nodes      Longhorn replicas: 2 nodes
+  Failover targets:  any 2        Failover targets:  1 remaining
+  Safe drain:        YES          Safe drain master: NO (loses quorum)
+```
+
+---
+
+## Scenario 1: Single Node Failure (Any Node)
+
+**All 3 permutations behave identically. Node C shown as example.**
+
+```
+BEFORE FAILURE
+══════════════
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │ (leader) │     │          │     │          │
+  │ etcd ●   │     │ etcd ●   │     │ etcd ●   │
+  │ [App-1]  │     │ [App-2]  │     │ [App-3]  │
+  │ [rep-1]  │     │ [rep-2]  │     │ [rep-3]  │
+  └──────────┘     └──────────┘     └──────────┘
+  etcd: 3/3 ✅  Quorum: 2/3 needed
+
+FAILURE EVENT  (Node C crashes)
+════════════════════════════════
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │ (leader) │     │          │     │  ████    │
+  │ etcd ●   │     │ etcd ●   │     │  CRASH   │
+  │ [App-1]  │     │ [App-2]  │     │          │
+  │ [rep-1]  │     │ [rep-2]  │     │ [rep-3]✗ │
+  └──────────┘     └──────────┘     └──────────┘
+  etcd: 2/3 ✅  Quorum maintained
+
+FAILOVER SEQUENCE
+═════════════════
+  t=0    Node C unreachable
+         │
+  t=60s  K8s marks Node C: Ready=False
+         │
+  t=90s  ReplicaSet evicts App-3 pod (Terminating)
+         │
+  t=120s zedkube (leader, Node A):
+         │  pod terminating >2min → DetachOldWorkload()
+         │  ├─ Remove virt-launcher finalizers
+         │  ├─ Delete PVC attachment on Node C
+         │  └─ Force VMI termination
+         │
+  t=125s Longhorn: rep-3 offline
+         │  Rebuilds 3rd replica on Node A or B
+         │  (Both eligible — no tie-breaker restrictions)
+         │
+  t=130s K8s scheduler picks Node A or B for App-3
+         │  └─ App-3: Pending → Running
+         │
+  t=140s zedkube publishes ENClusterAppStatus: App-3 Running
+
+AFTER RECOVERY  (Node A absorbs App-3 in this example)
+═══════════════════════════════════════════════════════
+  ┌──────────────────────┐     ┌──────────┐
+  │        Node A        │     │  Node B  │
+  │      (leader)        │     │          │
+  │ etcd ●               │     │ etcd ●   │
+  │ [App-1]   [App-3]    │     │ [App-2]  │
+  │ [rep-1]   [rep-3b]   │     │ [rep-2]  │
+  └──────────────────────┘     └──────────┘
+
+  ┌───────────────────────────────────────────────────────┐
+  │ Any of the 3 permutations:                            │
+  │   Node A fails → Apps & replicas move to B or C      │
+  │   Node B fails → Apps & replicas move to A or C      │
+  │   Node C fails → Apps & replicas move to A or B      │
+  │                                                       │
+  │ Advantage over tie-breaker:                           │
+  │   2 healthy nodes available as failover targets       │
+  │   (vs. only 1 in tie-breaker topology)                │
+  └───────────────────────────────────────────────────────┘
+```
+
+---
+
+## Scenario 2: Leader Node Failure
+
+**Unique to full 3-master: any of 2 remaining nodes may become the new leader.**
+
+```
+BEFORE FAILURE
+══════════════
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │ (leader) │     │          │     │          │
+  │ Lease ●  │     │          │     │          │
+  │ [App-1]  │     │ [App-2]  │     │ [App-3]  │
+  └──────────┘     └──────────┘     └──────────┘
+
+FAILURE EVENT  (Node A crashes)
+════════════════════════════════
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │  ████    │     │          │     │          │
+  │  CRASH   │     │ attempts │     │ attempts │
+  │          │     │ Lease    │     │ Lease    │
+  └──────────┘     └──────────┘     └──────────┘
+  etcd: 2/3 ✅  Quorum maintained
+
+LEADER RE-ELECTION  (race between B and C)
+══════════════════════════════════════════
+  Lease: LeaseDuration=300s, RenewDeadline=180s, RetryPeriod=15s
+
+  t=0    Node A stops renewing
+         │
+  t=180s RenewDeadline exceeded
+         │  Node B and Node C both attempt Lease acquisition
+         │  (RetryPeriod=15s, first-writer-wins in etcd)
+         │
+  t=180s One node wins (e.g. Node B)
+         │  KubeLeaderElectInfo:
+         │    IsStatsLeader  = true   (Node B)
+         │    IsStatsLeader  = false  (Node C)
+         │    LeaderIdentity = "node-b"
+         │
+  t=185s Node B: isDecisionNode=true
+         └─ Drives App-1 failover (as Scenario 1)
+            App-1 moves to Node B or Node C
+
+  ┌────────────────────────────────────────────────────────┐
+  │ Key difference vs. tie-breaker:                        │
+  │   Tie-breaker topology: only 1 candidate for leader    │
+  │   Full 3-master:        2 candidates race for Lease    │
+  │   Both topologies: Lease LeaseDuration=300s (same)     │
+  └────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Scenario 3: Two Node Failure (Quorum Loss)
+
+**Identical to Scenario 7 in tie-breaker document — any 2-node loss loses quorum.**
+
+```
+BEFORE FAILURE
+══════════════
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │ (leader) │     │          │     │          │
+  │ etcd ●   │     │ etcd ●   │     │ etcd ●   │
+  └──────────┘     └──────────┘     └──────────┘
+  etcd: 3/3 ✅
+
+FAILURE EVENT  (Nodes A+B crash)
+═════════════════════════════════
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │  ████    │     │  ████    │     │          │
+  │  CRASH   │     │  CRASH   │     │ etcd ●   │
+  └──────────┘     └──────────┘     └──────────┘
+  etcd: 1/3 ✗  QUORUM LOST
+
+  Kubernetes API: READ-ONLY
+  Leader election: STALLED
+  KubeLeaderElectInfo: InLeaderElection=false, ElectionRunning=false
+  New scheduling: BLOCKED
+
+  ┌───────────────────────────────────────────────────────┐
+  │ FULL 3-MASTER vs. TIE-BREAKER comparison:             │
+  │                                                       │
+  │ Full 3-master:                                        │
+  │   Any single-node loss: cluster survives ✅           │
+  │   Any 2-node loss:      quorum lost ✗                 │
+  │   Apps on surviving node: continue running            │
+  │                                                       │
+  │ Tie-breaker:                                          │
+  │   Any single-node loss: cluster survives ✅           │
+  │   Any 2-node loss:      quorum lost ✗                 │
+  │   Apps on surviving non-TB node: continue running     │
+  │                                                       │
+  │ Quorum threshold is IDENTICAL for both topologies     │
+  └───────────────────────────────────────────────────────┘
+
+RECOVERY PATHS
+══════════════
+  PATH A: Recover either Node A or Node B
+    etcd: 2/3 → quorum restored
+    K8s API writable again
+    Leader election: Node C or recovered node wins
+    Apps on lost nodes rescheduled on survivors
+
+  PATH B: etcd disaster recovery (last resort)
+    etcdctl member remove <failed-member-ids>
+    Bootstrap replacement nodes
+    ⚠ State and volume data may be lost
+```
+
+---
+
+## Scenario 4: Network Partition (Split-Brain)
+
+**More complex than tie-breaker because all 3 nodes run workloads.**
+
+```
+BEFORE PARTITION
+════════════════
+  ┌──────────┐         ┌──────────┐         ┌──────────┐
+  │  Node A  │─────────│  Node B  │─────────│  Node C  │
+  │ (leader) │         │          │         │          │
+  │ [App-1]  │         │ [App-2]  │         │ [App-3]  │
+  └──────────┘         └──────────┘         └──────────┘
+
+PARTITION  (Node A isolated from B+C)
+═══════════════════════════════════════
+  ┌──────────┐    ╳    ┌──────────┐─────────┌──────────┐
+  │  Node A  │◄──✗──►  │  Node B  │         │  Node C  │
+  │ (leader) │         │          │         │          │
+  │ [App-1]  │         │ [App-2]  │         │ [App-3]  │
+  └──────────┘         └──────────┘         └──────────┘
+  1/3 minority         2/3 quorum ✅
+
+ZONE A (minority)           ZONE B+C (quorum)
+─────────────────           ────────────────────────────────
+etcd: read-only             etcd: writable
+Lease cannot renew          Node B or C wins new Lease
+App-1: still running        Node A: marked NotReady at t=60s
+  (local kubelet)           App-1 rescheduled on B or C
+No new scheduling           App-2, App-3: continue normally
+KubeLeaderElectInfo:
+  InLeaderElection=false
+
+SPLIT-BRAIN STATE  (worst case)
+════════════════════════════════
+  App-1 running in BOTH zones simultaneously:
+    Zone A: App-1 (old, local kubelet keeps it alive)
+    Zone B: App-1 (new, rescheduled by cluster controller)
+
+  Longhorn volume:
+    rep-1 on Node A: still accepting writes (isolated)
+    rep-2 on Node B: receiving writes from new App-1
+    rep-3 on Node C: receiving writes from new App-1
+    ↑ DATA DIVERGENCE between rep-1 and rep-2/rep-3
+
+  ┌─────────────────────────────────────────────────────────┐
+  │ Higher risk than tie-breaker split-brain:               │
+  │   All 3 nodes have active workloads                     │
+  │   All 3 nodes have Longhorn replicas                    │
+  │   Split can diverge data on all replicas simultaneously │
+  └─────────────────────────────────────────────────────────┘
+
+NETWORK HEALS
+═════════════
+  etcd sync: Node A receives missed entries from B+C
+  Conflicting App-1 pod on A: terminated (B+C state wins)
+  Longhorn: rep-1 diverged → rebuild from rep-2/rep-3
+  App-1: single instance on B or C
+  ⚠ Data written to rep-1 during partition: LOST
+```
+
+---
+
+## Scenario 5: Manual Node Drain (Maintenance)
+
+**Key advantage of full 3-master: draining any node is safe (2/3 quorum stays intact).**
+
+```
+DRAIN WITH FULL 3-MASTER
+═════════════════════════
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │ (leader) │     │          │     │          │
+  │ [App-1]  │     │ [App-2]  │     │ [App-3]  │
+  └──────────┘     └──────────┘     └──────────┘
+
+  baseosmgr publishes NodeDrainRequest for Node C
+         │
+  t=0s   Node C CORDONED
+         │  New pods: will not schedule here
+         │
+  t=10s  App-3 evicted from Node C
+         │  K8s scheduler: Node A or B? (both available!)
+         │  └─ Let's say Node B is picked
+         │
+  t=60s  Longhorn: rep-3 moves from C to A (rebuild)
+         │
+  t=90s  Drain complete → NodeDrainStatus: COMPLETE
+         │
+  t=95s  Node C reboots for OS update
+
+  DURING DRAIN:
+  ┌──────────┐     ┌──────────────────────┐
+  │  Node A  │     │        Node B        │
+  │ (leader) │     │                      │
+  │ etcd ●   │     │ etcd ●               │
+  │ [App-1]  │     │  [App-2]   [App-3]   │
+  │ [rep-1]  │     │  [rep-2]   [rep-3]   │
+  └──────────┘     └──────────────────────┘
+  etcd: 2/3 ✅  QUORUM MAINTAINED ← KEY DIFFERENCE
+
+  ┌─────────────────────────────────────────────────────────┐
+  │ CRITICAL DIFFERENCE vs. TIE-BREAKER:                   │
+  │                                                         │
+  │ Full 3-master drain of any node:                        │
+  │   etcd quorum: 2/3 ✅ SAFE                              │
+  │   Workload failover: 2 target nodes available           │
+  │                                                         │
+  │ Tie-breaker drain of master node:                       │
+  │   etcd quorum: 1/2 ✗ UNSAFE — would lose quorum        │
+  │   (Cannot safely drain a master in tie-breaker setup    │
+  │    unless tie-breaker node is the one being drained)    │
+  └─────────────────────────────────────────────────────────┘
+
+DRAIN STATE MACHINE  (same as tie-breaker)
+══════════════════════════════════════════
+  NOTREQUESTED → STARTING → CORDONED
+    → DRAINRETRYING (if needed, 5x / 300s)
+    → COMPLETE  or  FAILEDDRAIN
+
+  Skip conditions:
+    Single-node cluster → NOTSUPPORTED
+    k3s API down >300s  → COMPLETE (skip drain)
+
+POST-REBOOT
+═══════════
+  Node C boots → nodeOnBootHealthStatusWatcher() uncordons
+  Node C schedulable again
+  App-3 may stay on Node B (no automatic failback)
+  Longhorn: rebuilds 3rd replica on Node C
+```
+
+---
+
+## Scenario 6: Longhorn Volume Failure (3-Replica Advantage)
+
+**Full 3-master uses 3-replica volumes — survives 1-node storage failure without degradation.**
+
+```
+LONGHORN REPLICA DISTRIBUTION
+══════════════════════════════
+  Full 3-master (StorageClass: longhorn, replicas=3):
+    Node A: rep-1
+    Node B: rep-2
+    Node C: rep-3
+
+  Tie-breaker (StorageClass: lh-sc-rep2, replicas=2):
+    Node A: rep-1
+    Node B: rep-2
+    Node C: NONE (excluded)
+
+FAILURE COMPARISON
+══════════════════
+
+  Case: Node B crashes
+
+  FULL 3-MASTER:                     TIE-BREAKER:
+  ──────────────                     ────────────
+  Node A: rep-1 ✅                   Node A: rep-1 ✅
+  Node B: rep-2 ✗ (offline)          Node B: rep-2 ✗ (offline)
+  Node C: rep-3 ✅                   Node C: NONE
+
+  Volume state: DEGRADED             Volume state: FAULTED
+  (2 of 3 replicas online)           (1 of 2 replicas online)
+  App continues running ✅            App pod: STUCK ✗
+  Longhorn rebuilds rep-2            Manual repair required
+    on available node
+
+  ┌───────────────────────────────────────────────┐
+  │ Full 3-master: can survive 1 storage failure  │
+  │   Volume degrades but app keeps running       │
+  │                                               │
+  │ Tie-breaker (2-replica): any storage failure  │
+  │   → volume FAULTED → app cannot run           │
+  └───────────────────────────────────────────────┘
+
+REBUILD PATH  (Full 3-master, Node B lost)
+══════════════════════════════════════════
+  rep-2 offline → Longhorn schedules rebuild on Node A or C
+         │
+  Node A has space → rebuilds rep-2b on Node A
+         │
+  Volume: 3 replicas again ✅  (A=rep-1, A=rep-2b, C=rep-3)
+         │
+  If Node B recovers:
+    Longhorn may rebalance: move rep-2b back to Node B
+```
+
+---
+
+## Scenario 7: Rolling Update (All 3 Nodes, One at a Time)
+
+**Unique to full 3-master: can safely roll updates across all nodes sequentially.**
+
+```
+ROLLING UPDATE SEQUENCE
+════════════════════════
+  Goal: Update OS/EVE on all 3 nodes without downtime
+
+  STEP 1: Drain and update Node C
+  ────────────────────────────────
+  ┌──────────┐   ┌──────────┐   ┌──────────┐
+  │  Node A  │   │  Node B  │   │  Node C  │
+  │ etcd ●   │   │ etcd ●   │   │  DRAIN   │
+  │ [App-1]  │   │ [App-2]  │   │ updating │
+  │          │   │ [App-3]  │   │          │
+  └──────────┘   └──────────┘   └──────────┘
+  etcd: 2/3 ✅ quorum
+
+  STEP 2: Node C updated, rejoin. Drain and update Node B
+  ─────────────────────────────────────────────────────────
+  ┌──────────┐   ┌──────────┐   ┌──────────┐
+  │  Node A  │   │  Node B  │   │  Node C  │
+  │ etcd ●   │   │  DRAIN   │   │ etcd ●   │
+  │ [App-1]  │   │ updating │   │ [App-3]  │
+  │ [App-2]  │   │          │   │          │
+  └──────────┘   └──────────┘   └──────────┘
+  etcd: 2/3 ✅ quorum
+
+  STEP 3: Node B updated, rejoin. Drain and update Node A
+  ─────────────────────────────────────────────────────────
+  ┌──────────┐   ┌──────────┐   ┌──────────┐
+  │  Node A  │   │  Node B  │   │  Node C  │
+  │  DRAIN   │   │ etcd ●   │   │ etcd ●   │
+  │ updating │   │ [App-1]  │   │ [App-3]  │
+  │          │   │ [App-2]  │   │          │
+  └──────────┘   └──────────┘   └──────────┘
+  etcd: 2/3 ✅ quorum  (Node A is non-leader, election ran in Step 1)
+
+  COMPLETE: All nodes updated, zero downtime ✅
+
+  ┌──────────────────────────────────────────────────────────┐
+  │ IMPORTANT: Never drain 2 nodes simultaneously            │
+  │   1 node draining → etcd: 2/3 ✅ safe                    │
+  │   2 nodes draining → etcd: 1/3 ✗ quorum loss            │
+  │                                                          │
+  │ Always wait for NodeDrainStatus=COMPLETE + node rejoins  │
+  │ before draining the next node.                           │
+  └──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Scenario 8: App CrashLoop
+
+**Identical to tie-breaker topology — node-level failover is not triggered.**
+
+```
+  App-1 CrashLoopBackOff on Node A
+         │
+  K8s exponential backoff (0→10→20→40→80s…)
+         │
+  zedkube publishes:
+    ENClusterAppStatus: StatusRunning=false, ScheduledOnThisNode=true
+         │
+  NO migration to Node B or C
+  (node is healthy; only node failures trigger migration)
+         │
+  Recovery: same as tie-breaker Scenario 8
+    - Operator updates AppInstanceConfig
+    - kubectl delete pod to reset backoff
+    - Wait for transient issue to resolve
+```
+
+---
+
+## Failover Decision Tree (Full 3-Master)
+
+```
+  Failure detected
+        │
+        ▼
+  ┌─────────────────────┐
+  │  How many nodes     │
+  │  are down?          │
+  └──────────┬──────────┘
+             │
+      ┌──────┴──────┐
+      │             │
+     1 node        2+ nodes
+      │             │
+      ▼             ▼
+  ┌─────────────┐  Quorum lost → Scenario 3
+  │ Which node? │  API read-only, manual recovery
+  └──────┬──────┘
+         │
+   ┌─────┴─────────────────┐
+   │                       │
+  Leader              Non-leader
+  (Scenario 2)         │
+  Re-election          ▼
+  first, then    ┌──────────────┐
+  workload       │ Has workloads│
+  failover       │  on node?    │
+                 └──────┬───────┘
+                        │
+                  ┌─────┴─────┐
+                 YES           NO
+                  │             │
+                  ▼             ▼
+           Reschedule      No workload
+           to Node A       impact
+           or Node B       (replica
+           (2 choices!)     rebuild
+           Scenario 1       only)
+```
+
+---
+
+## Comparison: Full 3-Master vs. Tie-Breaker
+
+```
+  TOPOLOGY             FULL 3-MASTER          TIE-BREAKER (2+1)
+  ─────────────────────────────────────────────────────────────
+  Schedulable nodes    3                      2
+  etcd members         3                      3
+  Longhorn replicas    3 (default)            2 (lh-sc-rep2)
+  Failover targets     2 nodes                1 node
+  Storage redundancy   Survive 1-node loss    0 tolerance
+  Safe drain           Any 1 node             Tie-breaker only
+  Rolling update       Yes (1-at-a-time)      No (loses quorum)
+  Resource usage       Higher (3×)            Lower (2×)
+  Disk per volume      3× replicated          2× replicated
+  Network I/O          3-way replication      2-way replication
+  Leader candidates    Any of 3 nodes         Any of 3 nodes
+  Cordoned nodes       None                   1 (tie-breaker)
+  Config complexity    Lower (no TB setup)    Higher (TB scripts)
+  Split-brain risk     Same                   Same
+  Quorum loss point    2 nodes down           2 nodes down
+  ─────────────────────────────────────────────────────────────
+  Best for             High availability      Resource-constrained
+                       production workloads   edge deployments
+```
+
+---
+
+## Key Config Fields (EdgeNodeClusterConfig)
+
+```go
+// pkg/pillar/types/clustertypes.go
+
+type EdgeNodeClusterConfig struct {
+    ClusterID        uuid.UUID         // Cluster identifier
+    ClusterInterface string            // Network interface for cluster
+    ClusterIPPrefix  net.IPNet         // Cluster IP
+    IsWorkerNode     bool              // This node runs workloads
+    BootstrapNode    bool              // First node to initialize cluster
+    TieBreakerNodeID UUIDandVersion    // UUID of tie-breaker (UNSET = full 3-master)
+    JoinServerIP     net.IP            // Existing node to join
+    EncryptedClusterToken string       // Bootstrap token
+    ClusterContext   string            // Context name in kubeconfig
+}
+```
+
+**Full 3-master setup:**
+- `IsWorkerNode = true` on all 3 nodes
+- `TieBreakerNodeID = uuid.UUID{}` (zero value, unset)
+- No tie-breaker scripts run
+- No node cordoning
+- No `lh-sc-rep2` storage class created
+
+---
+
+## Timeout Reference
+
+| Parameter | Value | Configurable | Notes |
+|-----------|-------|-------------|-------|
+| Node NotReady detection | ~60s | No | K8s default |
+| Pod eviction after NotReady | ~30s | No | K8s default |
+| DetachOldWorkload trigger | 2 min | No | Same as tie-breaker |
+| Lease LeaseDuration | 300s | No | Same as tie-breaker |
+| Lease RenewDeadline | 180s | No | 2 candidates race in 3-master |
+| Lease RetryPeriod | 15s | No | Same as tie-breaker |
+| drainSkipK8sAPINotReachableTimeout | 300s | Yes | Same as tie-breaker |
+| KubernetesDrainTimeout | 24h | Yes | Same as tie-breaker |
+| Longhorn rebuild start | ~60-120s | No | After replica offline |
+
+---
+
+## Source File Reference
+
+| File | Relevant Scenarios |
+|------|--------------------|
+| `pkg/pillar/types/clustertypes.go` | Config structure, TieBreakerNodeID field |
+| `pkg/pillar/cmd/zedkube/failover.go` | 1, 2 (identical logic to tie-breaker) |
+| `pkg/pillar/cmd/zedkube/leaderelect.go` | 2 (2 candidates race for Lease) |
+| `pkg/pillar/cmd/zedkube/drain.go` | 5, 7 (safe drain with 2/3 quorum) |
+| `pkg/pillar/cmd/zedkube/clusterstatus.go` | Node role detection via K8s labels |
+| `pkg/pillar/cmd/zedkube/applogs.go` | 8 (CrashLoop detection) |
+| `pkg/pillar/kubeapi/kubeapi.go` | 1, 6 (DetachOldWorkload, PVC ops) |
+| `pkg/kube/tie-breaker-utils.sh` | Absent in full 3-master topology |
+| `pkg/kube/cluster-init.sh` | All nodes run `k3s server` mode |

--- a/docs/EVE-K-APP-DEPLOYMENT.md
+++ b/docs/EVE-K-APP-DEPLOYMENT.md
@@ -1,0 +1,212 @@
+# EVE-K App Deployment — Microservice Flow
+
+## Overview Diagram
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────┐
+│                              CONTROLLER (cloud)                                  │
+└───────────────────────────────────┬──────────────────────────────────────────────┘
+                                    │ AppInstanceConfig (HTTPS/protobuf)
+                                    ▼
+┌──────────────────────────────────────────────────────────────────────────────────┐
+│  zedagent                                                                        │
+│  pkg/pillar/cmd/zedagent/                                                        │
+│  Receives controller config, publishes to all downstream agents                  │
+└────────┬────────────────────────────────────────────────┬────────────────────────┘
+         │ AppInstanceConfig (pubsub)                     │ AppInstanceConfig (pubsub)
+         ▼                                                ▼
+┌─────────────────────────────┐               ┌──────────────────────────────────┐
+│  zedmanager                 │               │  zedkube  (//go:build k only)    │
+│  pkg/pillar/cmd/zedmanager/ │               │  pkg/pillar/cmd/zedkube/         │
+│  Central orchestrator       │               │  K8s/KubeVirt cluster manager    │
+└──┬────────────┬─────────────┘               │                                  │
+   │            │            │                │  ┌─────────────────────────────┐ │
+   │VolumeRef   │AppNetwork  │Domain          │  │  KubeVirt API               │ │
+   │Config      │Config      │Config          │  │  Deploy VMI/Pod ReplicaSet  │ │
+   ▼            ▼            ▼                │  └─────────────────────────────┘ │
+┌──────────┐ ┌──────────┐ ┌──────────────┐   │                                  │
+│volumemgr │ │zedrouter │ │  domainmgr   │   │  Publishes:                      │
+│          │ │          │ │              │   │  • ENClusterAppStatus            │
+│Creates   │ │Creates   │ │Calls         │   │  • KubeClusterInfo               │
+│PVCs via  │ │network   │ │hypervisor    │   │  • NodeDrainStatus               │
+│kubeapi   │ │instances │ │.Setup()      │   └──────────────────────────────────┘
+│          │ │          │ │              │
+│Longhorn  │ │Multus+   │ │  kubevirt.go │            ┌───────────────────────┐
+│PVC/PV    │ │eve-bridge│ │  (HV=k path) │◄───────────│  nim                  │
+│          │ │NAD setup │ │              │  Device    │  pkg/pillar/cmd/nim/  │
+└────┬─────┘ └────┬─────┘ └──────┬───────┘  Network  │  Physical port config │
+     │VolumeRef   │AppNetwork    │Domain    Status    │  DeviceNetworkStatus  │
+     │Status      │Status        │Status              └───────────────────────┘
+     └────────────┴──────────────┘
+                  │ (all status flows back to zedmanager → zedagent → controller)
+                  ▼
+         ┌────────────────┐
+         │   zedmanager   │
+         │  AppInstance   │
+         │  Status        │
+         └────────┬───────┘
+                  │
+                  ▼
+             ┌─────────┐       ┌──────────────────────────────────────────────┐
+             │ zedagent│──────►│ CONTROLLER (reports app status)              │
+             └─────────┘       └──────────────────────────────────────────────┘
+```
+
+---
+
+## Storage Path (volumemgr → Longhorn)
+
+```
+VolumeRefConfig
+      │
+      ▼
+kubeapi.CreatePVC()                     PVC name: <uuid>-pvc-<generation>
+      │                                 Namespace: eve-kube-app
+      ▼                                 StorageClass: longhorn (or local-path)
+Kubernetes API
+      │
+      ▼
+Longhorn operator
+      ├─ Creates PersistentVolume
+      └─ Provisions replicated block storage
+            │
+            └─► kubevirt VMI spec:
+                  vmi.Spec.Volumes[].PersistentVolumeClaim.ClaimName = pvcName
+```
+
+---
+
+## Networking Path (zedrouter → Multus → eve-bridge)
+
+```
+AppNetworkConfig
+      │
+      ▼
+zedrouter
+      ├─ Creates network instance + bridge
+      └─ Creates Multus NAD "network-instance-attachment"
+                (type: eve-bridge, RPC: /run/eve-bridge/rpc.sock)
+                        │
+                        ▼
+            VMI/Pod annotation:
+            k8s.v1.cni.cncf.io/networks: "network-instance-attachment"
+                        │
+                        ▼
+            K8s calls eve-bridge CNI
+                        │
+                 RPC → zedrouter
+                        │
+                        └─► Attaches veth/tap to pod with MAC from config
+```
+
+---
+
+## Hypervisor Path (domainmgr → kubevirt.go → Kubernetes)
+
+```
+DomainConfig
+      │
+      ▼
+domainmgr  ──  hypervisor.Setup()
+                      │
+               ┌──────┴──────┐
+               │             │
+          NOHYPER           HVM/PV
+         (container)         (VM)
+               │             │
+               ▼             ▼
+      CreateReplicaPod  CreateReplicaVMI
+      Config()          Config()
+               │             │
+               └──────┬──────┘
+                      │
+                 JSON encoded
+                 ReplicaSet spec
+                      │
+                      ▼
+                  zedkube
+                      │
+              kubectl apply (via client-go)
+                      │
+                      ▼
+              ┌───────────────┐
+              │  Kubernetes   │
+              │  Scheduler    │
+              └───────┬───────┘
+                      │
+             ┌────────┴────────┐
+             │                 │
+        Pod (container)   VMI (VM via
+        appsv1.           KubeVirt
+        ReplicaSet)       VMIRS)
+             │                 │
+             └────────┬────────┘
+                      │
+              Namespace: eve-kube-app
+              Label: App-Domain-Name=<name>
+```
+
+---
+
+## State Transitions
+
+```
+AppInstanceConfig (Activate=true)
+      │
+      ▼
+zedmanager drives parallel pipelines:
+      ├─ VolumeRefConfig → volumemgr → PVC created (Longhorn)
+      ├─ AppNetworkConfig → zedrouter → NAD + bridge ready
+      └─ DomainConfig → domainmgr → kubevirt ReplicaSet spec written
+                                           │
+                                           ▼
+                                       zedkube applies to Kubernetes
+                                           │
+                                           ▼
+                                  Kubernetes Scheduler
+                                     Pending → Running
+                                           │
+                                           ▼
+                                    DomainStatus updated
+                                           │
+                                           ▼
+                               zedmanager → AppInstanceStatus
+                                           │
+                                           ▼
+                               zedagent → Controller (reported)
+```
+
+---
+
+## Pubsub Message Table
+
+| From | To | Message | Contains |
+|------|----|---------|----------|
+| zedagent | zedmanager, zedkube | `AppInstanceConfig` | App spec, volumes, nets, virtualization mode |
+| zedmanager | volumemgr | `VolumeRefConfig` | Volume UUID, size, image ref |
+| zedmanager | zedrouter | `AppNetworkConfig` | Network instance UUIDs, VIF list |
+| zedmanager | domainmgr | `DomainConfig` | vCPUs, RAM, disks (PVC names), VifList, mode |
+| volumemgr | zedmanager | `VolumeRefStatus` | PVC name as `ActiveFileLocation` |
+| zedrouter | zedmanager | `AppNetworkStatus` | VIF assignments, MACs |
+| domainmgr | zedmanager | `DomainStatus` | Running/Pending/Failed, metrics |
+| nim | zedrouter, zedkube | `DeviceNetworkStatus` | Physical port assignments |
+| zedkube | (reporting) | `ENClusterAppStatus` | Cluster-level app health |
+
+---
+
+## Key Source Files
+
+| Agent | Path | Key Function |
+|-------|------|-------------|
+| zedagent | `pkg/pillar/cmd/zedagent/zedagent.go` | Controller config reception |
+| zedmanager | `pkg/pillar/cmd/zedmanager/zedmanager.go` | Orchestration hub |
+| zedmanager | `pkg/pillar/cmd/zedmanager/handledomainmgr.go` | `MaybeAddDomainConfig()` |
+| zedmanager | `pkg/pillar/cmd/zedmanager/handlevolumemgr.go` | Publishes VolumeRefConfig |
+| volumemgr | `pkg/pillar/cmd/volumemgr/blob.go` | PVC creation for HV=k |
+| zedrouter | `pkg/pillar/cmd/zedrouter/zedrouter.go` | Network instance + CNI setup |
+| zedrouter | `pkg/pillar/cmd/zedrouter/cni.go` | eve-bridge RPC server |
+| domainmgr | `pkg/pillar/cmd/domainmgr/domainmgr.go` | HV=k detection, hypervisor call |
+| zedkube | `pkg/pillar/cmd/zedkube/zedkube.go` | KubeVirt API interaction |
+| kubevirt hypervisor | `pkg/pillar/hypervisor/kubevirt.go` | `Setup()`, `CreateReplicaVMIConfig()`, `CreateReplicaPodConfig()` |
+| kubeapi | `pkg/pillar/kubeapi/vitoapiserver.go` | `CreatePVC()`, PVC management |
+| kubeapi | `pkg/pillar/kubeapi/longhorninfo.go` | Longhorn queries |

--- a/docs/EVE-K-TIEBREAKER-FAILOVER.md
+++ b/docs/EVE-K-TIEBREAKER-FAILOVER.md
@@ -1,0 +1,707 @@
+# EVE-K Cluster Failover Scenarios
+
+Cluster topology assumed unless stated otherwise:
+- **Node A** — master + worker (leader)
+- **Node B** — master + worker
+- **Node C** — tie-breaker (etcd quorum only, no workloads)
+
+---
+
+## Scenario 1: Worker Node Crash
+
+**Trigger:** Node becomes unreachable; kubelet stops posting status (~1 min timeout).
+
+```
+BEFORE FAILURE
+══════════════
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │ (leader) │     │ (worker) │     │(tie-brkr)│
+  │          │     │          │     │          │
+  │ [App-1]  │     │ [App-2]  │     │  (etcd)  │
+  │ Running  │     │ Running  │     │          │
+  └──────────┘     └──────────┘     └──────────┘
+        ↕ etcd quorum ↕                   ↕
+        └─────────────────────────────────┘
+
+FAILURE EVENT
+═════════════
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │ (leader) │     │  ████    │     │(tie-brkr)│
+  │          │     │  CRASH   │     │          │
+  │ [App-1]  │     │ [App-2]  │     │  (etcd)  │
+  │ Running  │     │Terminatng│     │          │
+  └──────────┘     └──────────┘     └──────────┘
+
+DETECTION  (~60s)
+   zedkube (Node A, leader)
+   └─ checkAppsFailover() — runs every 10s
+      └─ detects: App-2 pod has DeletionTimestamp set
+                  Node B Ready=False
+
+FAILOVER SEQUENCE
+═════════════════
+
+  t=0s    Node B unreachable
+          │
+  t=60s   K8s marks Node B: Ready=False
+          │
+  t=90s   ReplicaSet controller evicts App-2 pod
+          │  Pod enters "Terminating" state
+          │
+  t=120s  zedkube (leader) checks:
+          │  pod terminating > 2 min? → YES
+          │  └─ DetachOldWorkload() called
+          │     ├─ Remove virt-launcher finalizers
+          │     ├─ Delete PVC attachments on Node B
+          │     └─ Force VMI termination
+          │
+  t=130s  Longhorn detaches volume from Node B
+          │  └─ Replica marked offline
+          │     Rebuild scheduled on Node A
+          │
+  t=135s  K8s scheduler places App-2 on Node A
+          │  └─ PVC reattaches
+          │     Pod transitions: Pending → Running
+          │
+  t=140s  zedkube publishes:
+          └─ ENClusterAppStatus (App-2, Running, Node A)
+
+AFTER RECOVERY
+══════════════
+  ┌──────────────────────┐     ┌──────────┐
+  │        Node A        │     │  Node C  │
+  │      (leader)        │     │(tie-brkr)│
+  │                      │     │          │
+  │  [App-1]   [App-2]   │     │  (etcd)  │
+  │  Running   Running   │     │          │
+  └──────────────────────┘     └──────────┘
+
+Key timeouts:
+  Node NotReady detection  : ~60s  (Kubernetes default)
+  Pod eviction trigger     : ~30s  after NotReady
+  getKubePodsError threshold: 2min  → mark app not running
+  DetachOldWorkload trigger : 2min  of pod terminating
+```
+
+---
+
+## Scenario 2: Leader Node Crash
+
+**Trigger:** Master/leader node crashes; etcd has 2 of 3 members (quorum maintained).
+
+```
+BEFORE FAILURE
+══════════════
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │ (leader) │◄────┤          │     │(tie-brkr)│
+  │  etcd    │     │  etcd    │     │  etcd    │
+  │ [App-1]  │     │ [App-2]  │     │          │
+  └──────────┘     └──────────┘     └──────────┘
+   Lease holder
+   "eve-kube-stats-leader"
+
+FAILURE EVENT
+═════════════
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │  ████    │     │          │     │(tie-brkr)│
+  │  CRASH   │     │  etcd    │     │  etcd    │
+  │          │     │ [App-2]  │     │          │
+  └──────────┘     └──────────┘     └──────────┘
+  etcd: 2/3 members alive → QUORUM MAINTAINED
+
+LEADER RE-ELECTION  (Kubernetes Lease mechanism)
+════════════════════════════════════════════════
+
+  Lease: LeaseDuration=300s, RenewDeadline=180s, RetryPeriod=15s
+
+  t=0s    Node A stops renewing Lease
+          │
+  t=180s  Lease renewal deadline exceeded
+          │  Node B zedkube: attempts to acquire Lease
+          │  Node C: not eligible (tie-breaker, no scheduling)
+          │
+  t=195s  Node B acquires Lease
+          │  └─ publishes KubeLeaderElectInfo:
+          │       IsStatsLeader  = true
+          │       LeaderIdentity = "node-b"
+          │       InLeaderElection = true
+          │
+  t=195s  Node B becomes isDecisionNode=true
+          └─ App-1 failover triggered (same as Scenario 1)
+             App-1 rescheduled on Node B
+
+AFTER RECOVERY
+══════════════
+  ┌──────────────────────┐     ┌──────────┐
+  │        Node B        │     │  Node C  │
+  │      (NEW leader)    │     │(tie-brkr)│
+  │                      │     │          │
+  │  [App-1]   [App-2]   │     │  (etcd)  │
+  │  Running   Running   │     │          │
+  └──────────────────────┘     └──────────┘
+
+  ┌─────────────────────────────────────────────┐
+  │ NOTE: If Node A recovers later:             │
+  │  • Rejoins etcd cluster                     │
+  │  • Node B retains leadership                │
+  │  • App-1 stays on Node B (no failback)      │
+  │  • Longhorn rebuilds 3rd replica on Node A  │
+  └─────────────────────────────────────────────┘
+```
+
+---
+
+## Scenario 3: Network Partition (Split-Brain)
+
+**Trigger:** Network splits into two isolated groups.
+
+```
+BEFORE PARTITION
+════════════════
+  ┌──────────┐         ┌──────────┐         ┌──────────┐
+  │  Node A  │◄────────┤  Node B  │◄────────┤  Node C  │
+  │ (leader) │         │          │         │(tie-brkr)│
+  │  etcd    │         │  etcd    │         │  etcd    │
+  │ [App-1]  │         │ [App-2]  │         │          │
+  └──────────┘         └──────────┘         └──────────┘
+
+PARTITION EVENT  (Node A isolated)
+═══════════════════════════════════
+  ┌──────────┐    ╳    ┌──────────┐─────────┌──────────┐
+  │  Node A  │◄──✗──►  │  Node B  │         │  Node C  │
+  │ (leader) │         │          │         │(tie-brkr)│
+  │  etcd    │         │  etcd    │         │  etcd    │
+  │ [App-1]  │         │ [App-2]  │         │          │
+  └──────────┘         └──────────┘         └──────────┘
+
+  ZONE A (minority: 1/3)    │    ZONE B+C (quorum: 2/3)
+  ─────────────────────────────────────────────────────
+
+ZONE B+C (quorum) — NORMAL OPERATION CONTINUES
+───────────────────────────────────────────────
+  • etcd quorum maintained (Node B + Node C)
+  • Kubernetes API writable
+  • Node B retains or acquires leadership
+  • Node A marked NotReady after ~60s
+  • App-1 rescheduled on Node B (as per Scenario 1)
+
+ZONE A (minority) — DEGRADED / READ-ONLY
+─────────────────────────────────────────
+  • etcd cannot commit writes (no quorum)
+  • Kubernetes API becomes read-only
+  • Lease cannot be renewed → leader election stalls
+    KubeLeaderElectInfo: InLeaderElection=false, ElectionRunning=false
+  • App-1 pod continues running (kubelet is local)
+  • No new scheduling decisions possible
+
+  ┌─────────────────────────────────────────────────────┐
+  │ SPLIT-BRAIN RISK: App-1 now runs on BOTH zones      │
+  │                                                     │
+  │  Zone A: App-1 (old, still running via local kubelet│
+  │  Zone B: App-1 (rescheduled by cluster controller)  │
+  │                                                     │
+  │  Longhorn volume: replicas split, may diverge       │
+  └─────────────────────────────────────────────────────┘
+
+NETWORK HEALS
+═════════════
+  t=0    Network restored
+         │
+  t=5s   etcd sync begins (Zone A rejoins B+C quorum)
+         │
+  t=30s  Zone A Node A receives cluster state from B+C
+         │  etcd applies missed entries
+         │  Pod on Zone A reconciled: duplicate → terminated
+         │
+  t=60s  App-1: single instance on Node B (winner)
+         Longhorn: replica on Node A re-synced from B+C
+         Leader: Node B retains leadership
+
+  ┌──────────────────────────────────────────────┐
+  │ WARNING: Persistent volume data written in   │
+  │ Zone A during partition may be LOST.         │
+  │ Longhorn resolves divergence by quorum state │
+  └──────────────────────────────────────────────┘
+```
+
+---
+
+## Scenario 4: Tie-Breaker Node Failure
+
+**Trigger:** Node C (tie-breaker, etcd-only) becomes unreachable.
+
+```
+BEFORE FAILURE
+══════════════
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │ (leader) │     │          │     │(tie-brkr)│
+  │  etcd    │     │  etcd    │     │  etcd    │
+  │ [App-1]  │     │ [App-2]  │     │  NO apps │
+  └──────────┘     └──────────┘     └──────────┘
+
+FAILURE EVENT
+═════════════
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │ (leader) │     │          │     │  ████    │
+  │  etcd    │     │  etcd    │     │  CRASH   │
+  │ [App-1]  │     │ [App-2]  │     │          │
+  └──────────┘     └──────────┘     └──────────┘
+  etcd: 2/3 members alive (A+B) → QUORUM MAINTAINED
+
+IMPACT ASSESSMENT
+═════════════════
+  Workloads:   ✅ ZERO IMPACT  (tie-breaker has no pods)
+  Scheduling:  ✅ NORMAL       (A+B schedule freely)
+  Volumes:     ✅ NORMAL       (2-replica policy: lh-sc-rep2)
+                               (only A+B needed for Longhorn)
+  etcd:        ✅ QUORUM OK    (A+B = 2/3 majority)
+  Leadership:  ✅ UNCHANGED    (Node A keeps Lease)
+  API:         ✅ WRITABLE     (quorum intact)
+
+  ┌────────────────────────────────────────────────┐
+  │ NOTE: Now in degraded quorum state.            │
+  │ If either Node A OR Node B also fails          │
+  │ → etcd drops to 1/3 → QUORUM LOST (Scenario 7)│
+  └────────────────────────────────────────────────┘
+
+RECOVERY
+═════════
+  1. Node C recovers or is replaced
+  2. Re-run tie-breaker-utils.sh: Tie_breaker_configApply()
+  3. Node rejoins etcd cluster
+  4. Labels re-applied:
+       tie-breaker-node=true
+       tie-breaker-config-applied=1
+  5. CDI, KubeVirt, Longhorn patched to exclude Node C from scheduling
+  6. Longhorn: no replica rebuild needed (C had none)
+```
+
+---
+
+## Scenario 5: Longhorn Volume Node Failure
+
+**Trigger:** A node hosting volume replicas crashes; storage degrades.
+
+```
+BEFORE FAILURE  (3-replica default)
+═════════════════════════════════════
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │ (leader) │     │          │     │(tie-brkr)│
+  │          │     │          │     │          │
+  │[vol-rep-1│     │[vol-rep-2│     │ (no vols)│
+  │  active] │     │  active] │     │          │
+  └──────────┘     └──────────┘     └──────────┘
+        ↑ App-1 attached to vol (PVC: uuid-pvc-1)
+        Longhorn: 2 replicas healthy, RWO, StorageClass: longhorn
+
+FAILURE EVENT  (Node B crashes)
+════════════════════════════════
+  ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │
+  │ (leader) │     │  ████    │
+  │          │     │  CRASH   │
+  │[vol-rep-1│     │[vol-rep-2│  ← replica OFFLINE
+  │  active] │     │  offline]│
+  └──────────┘     └──────────┘
+
+STORAGE DEGRADATION SEQUENCE
+═════════════════════════════
+
+  t=0    Node B unreachable
+         │
+  t=60s  Longhorn marks replica-2 offline
+         │  Volume state: Degraded (1/2 replicas healthy)
+         │  App-1 continues running (still attached to Node A)
+         │
+  t=65s  volumemgr publishes VolumeMgrStatus: degraded
+         │  KubeClusterInfo updated: storage_health=degraded
+         │
+  t=90s  Longhorn attempts to schedule rebuild:
+         │  Needs a node with free capacity
+         │  Node A: eligible (has space)
+         │  Node C: NOT eligible (tie-breaker, no storage)
+         │  └─ Schedules replica rebuild on Node A
+         │
+  t=120s Rebuild starts: Node A now has 2 replicas
+         Volume state: Healthy (2/2 replicas)
+
+  App-1: NEVER interrupted (attached node never failed)
+
+DRAIN-ASSISTED RECOVERY  (if node intentionally removed)
+══════════════════════════════════════════════════════════
+
+  zedkube drain.go:
+    drainAndDeleteNode():
+      1. Check if node has Longhorn replicas
+         ├─ YES → wait for rebuild on other nodes
+         │        only drain after replicas migrated
+         └─ NO  → drain immediately
+
+  Excluded from drain (remain to coordinate):
+    • csi-attacher
+    • csi-provisioner
+    • longhorn-admission-webhook
+    • longhorn-driver-deployer
+
+CRITICAL FAILURE  (both replicas lost)
+════════════════════════════════════════
+  If Node A AND Node B both fail:
+
+  Volume state: FAULTED
+  App pod: Stuck (cannot attach PVC)
+  Recovery: Manual Longhorn volume repair needed
+            OR restore from backup
+
+  ┌──────────────────────────────────────────────┐
+  │ 2-replica clusters (tie-breaker config):     │
+  │   StorageClass: lh-sc-rep2                   │
+  │   Single node failure → immediate FAULT      │
+  │   No rebuild possible (only 1 node left)     │
+  └──────────────────────────────────────────────┘
+```
+
+---
+
+## Scenario 6: Manual Node Drain (Maintenance / OS Update)
+
+**Trigger:** `baseosmgr` (OS update) or `zedagent` (reboot) publishes `NodeDrainRequest`.
+
+```
+DRAIN STATE MACHINE
+════════════════════
+
+  NodeDrainRequest received
+         │
+         ▼
+  ┌─────────────────┐
+  │  Single node?   │──YES──► NodeDrainStatus: NOTSUPPORTED
+  └────────┬────────┘         (skip drain, proceed with op)
+           │ NO
+           ▼
+  ┌─────────────────────────────┐
+  │  k3s API unreachable >300s? │──YES──► NodeDrainStatus: COMPLETE
+  └────────────┬────────────────┘         (skip drain, k3s down anyway)
+               │ NO
+               ▼
+  NodeDrainStatus: STARTING
+         │
+         ▼
+  ┌──────────────────────────────────────────┐
+  │  CORDON NODE  (mark Unschedulable=true)  │
+  │  Retry up to 10x with 5s delay           │
+  └────────┬────────────────────────────────-┘
+           │ success                   │ all retries fail
+           ▼                           ▼
+  NodeDrainStatus: CORDONED    NodeDrainStatus: FAILEDCORDON
+           │
+           ▼
+  ┌──────────────────────────────────────────────────────┐
+  │  DRAIN NODE                                          │
+  │  kubectl drain --force --grace-period=-1             │
+  │    --delete-emptydir-data                            │
+  │    --ignore-daemonsets                               │
+  │    --pod-selector=<exclude longhorn control plane>   │
+  │  Timeout: 24h (KubernetesDrainTimeout)               │
+  │  Retry up to 5x with 300s delay                      │
+  └────────┬─────────────────────────────────────────────┘
+           │ success                   │ all retries fail
+           ▼                           ▼
+  NodeDrainStatus: COMPLETE   NodeDrainStatus: FAILEDDRAIN
+           │
+           ▼
+  Device operation proceeds
+  (reboot / OS update)
+
+TIMELINE EXAMPLE  (OS update on Node A)
+══════════════════════════════════════════
+
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │ (leader) │     │          │     │(tie-brkr)│
+  │ [App-1]  │     │ [App-2]  │     │          │
+  └──────────┘     └──────────┘     └──────────┘
+
+  baseosmgr publishes NodeDrainRequest (source: baseosmgr)
+  zedkube subscribes → begins drain sequence
+         │
+  t=0s   Node A CORDONED
+         │  New pods: will not schedule here
+         │  Existing pods: continue running
+         │
+  t=10s  App-1 evicted from Node A
+         │  └─ rescheduled on Node B
+         │     Volumes: Longhorn detaches from A, reattaches on B
+         │
+  t=60s  Drain complete
+         │
+  t=65s  NodeDrainStatus: COMPLETE → baseosmgr proceeds
+         │
+  t=70s  Node A reboots for OS update
+         │
+
+  ┌──────────────────────┐     ┌──────────┐
+  │        Node B        │     │  Node C  │
+  │                      │     │(tie-brkr)│
+  │  [App-1]   [App-2]   │     │          │
+  │  Running   Running   │     │          │
+  └──────────────────────┘     └──────────┘
+
+POST-REBOOT RECOVERY
+═════════════════════
+  Node A boots:
+    nodeOnBootHealthStatusWatcher() uncordons node
+    Node A: Schedulable=true
+    Longhorn: rebuilds replica on Node A
+    App-1: may stay on Node B (no automatic failback)
+
+  ┌───────────────────────────────────────────────┐
+  │ PubSub flow:                                  │
+  │  baseosmgr/zedagent → NodeDrainRequest        │
+  │  zedkube            → NodeDrainStatus         │
+  │                        (STARTING→CORDONED     │
+  │                         →DRAINRETRYING        │
+  │                         →COMPLETE/FAILED)     │
+  └───────────────────────────────────────────────┘
+```
+
+---
+
+## Scenario 7: etcd Quorum Loss
+
+**Trigger:** 2 of 3 nodes become unavailable simultaneously.
+
+```
+BEFORE FAILURE
+══════════════
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │ (leader) │     │          │     │(tie-brkr)│
+  │  etcd    │     │  etcd    │     │  etcd    │
+  │ [App-1]  │     │ [App-2]  │     │          │
+  └──────────┘     └──────────┘     └──────────┘
+  etcd: 3/3 ✅  Quorum: 2/3 needed
+
+FAILURE EVENT  (Nodes A+B crash)
+═════════════════════════════════
+  ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │     │  Node C  │
+  │  ████    │     │  ████    │     │(tie-brkr)│
+  │  CRASH   │     │  CRASH   │     │  etcd    │
+  └──────────┘     └──────────┘     └──────────┘
+  etcd: 1/3 ✗  QUORUM LOST
+
+CLUSTER STATE  (Node C alone)
+══════════════════════════════
+  Kubernetes API: READ-ONLY (no writes committed)
+  Leader election: STALLED
+    KubeLeaderElectInfo:
+      IsStatsLeader    = false
+      InLeaderElection = false
+      ElectionRunning  = false
+      isDecisionNode() = false
+
+  Existing pods: still running (kubelet is local — but no apps on C)
+  New scheduling: BLOCKED
+  Volume operations: STALLED
+  Controller config: ConfigGetStatus ≠ success/saved
+
+RECOVERY PATHS
+══════════════
+
+  PATH A: Recover original node (preferred)
+  ─────────────────────────────────────────
+  1. Restart Node A or Node B
+  2. etcd member rejoins: 2/3 → quorum restored
+  3. Kubernetes API becomes writable
+  4. Leader election re-runs (Node B or A acquires Lease)
+  5. Apps rescheduled on recovered nodes
+  6. Normal operation resumes
+
+  PATH B: etcd disaster recovery (last resort)
+  ─────────────────────────────────────────────
+  1. Remove dead members from etcd:
+       etcdctl member remove <id-A>
+       etcdctl member remove <id-B>
+  2. Bootstrap new nodes with fresh etcd members
+  3. Add members back to cluster
+  4. ⚠ Application data/state may be lost
+  5. Longhorn volumes may need manual repair
+
+  ┌──────────────────────────────────────────────────────┐
+  │ IMPORTANT:                                           │
+  │  • Tie-breaker alone CANNOT recover quorum           │
+  │  • Must have ≥1 real master node healthy             │
+  │  • Data written during quorum loss is UNRECOVERABLE  │
+  │  • Operator alert: KubeClusterInfo reports degraded  │
+  └──────────────────────────────────────────────────────┘
+```
+
+---
+
+## Scenario 8: App-Level Failure (Pod CrashLoop)
+
+**Trigger:** Container exits with non-zero status; Kubernetes enters `CrashLoopBackOff`.
+
+```
+APP CRASH SEQUENCE
+══════════════════
+
+  ┌──────────┐     ┌──────────┐
+  │  Node A  │     │  Node B  │
+  │ (leader) │     │          │
+  │ [App-1]  │     │ [App-2]  │
+  │ Running  │     │ Running  │
+  └──────────┘     └──────────┘
+
+  App-1 container exits (non-zero)
+         │
+  K8s ReplicaSet controller:
+  Restart #1  → immediate
+  Restart #2  → 10s backoff
+  Restart #3  → 20s backoff
+  Restart #4  → 40s backoff
+  Restart #5  → 80s backoff   ← CrashLoopBackOff
+  ...         → exponential (max ~5 min)
+
+  zedkube checkAppsStatus() detects:
+    Pod.Status.Phase ≠ Running
+    └─ publishes ENClusterAppStatus:
+         StatusRunning = false
+         ScheduledOnThisNode = true (still on Node A)
+
+  ┌──────────────────────────────────────────────────────┐
+  │ KEY DIFFERENCE FROM NODE FAILURE:                    │
+  │  • Pod stays on Node A (node is healthy)             │
+  │  • NO volume detachment triggered                    │
+  │  • NO rescheduling to another node                   │
+  │  • Affinity preserved                                │
+  │  • zedkube does NOT call DetachOldWorkload()         │
+  │                                                      │
+  │  Exception: AffinityType = RequiredDuringScheduling  │
+  │    → failover.go lines 55-59 skip failover entirely  │
+  └──────────────────────────────────────────────────────┘
+
+RECOVERY OPTIONS
+════════════════
+
+  Option A: Operator fixes the app (update image/config)
+  ────────────────────────────────────────────────────
+  Controller pushes new AppInstanceConfig
+    → zedagent → zedmanager → domainmgr
+    → kubevirt: update VMI/Pod spec
+    → K8s rolling update → new pod
+
+  Option B: Manual restart (reset CrashLoopBackOff)
+  ─────────────────────────────────────────────────
+  kubectl delete pod <app-pod> -n eve-kube-app
+    → ReplicaSet recreates immediately
+    → backoff counter reset to 0
+
+  Option C: Wait (if transient issue)
+  ────────────────────────────────────
+  App may self-heal after backoff window
+  Max backoff ≈ 5 minutes between restarts
+
+  ┌──────────────────────────────────────────────────────┐
+  │ Node failover vs App failover:                       │
+  │                                                      │
+  │  Node crash  → workload MIGRATED to another node     │
+  │  App crash   → workload RESTARTED on same node       │
+  └──────────────────────────────────────────────────────┘
+```
+
+---
+
+## Combined: Failover Decision Tree
+
+```
+  Failure detected
+        │
+        ▼
+  ┌─────────────────┐
+  │  Node healthy?  │
+  └────────┬────────┘
+           │
+     ┌─────┴──────┐
+    YES            NO
+     │              │
+     ▼              ▼
+  App-level     ┌──────────────────┐
+  failure       │  etcd quorum OK? │
+  (Scenario 8)  └────────┬─────────┘
+  Restart on         │
+  same node    ┌──────┴──────┐
+              YES             NO
+               │               │
+               ▼               ▼
+         ┌──────────────┐  Quorum loss
+         │  Is it the   │  (Scenario 7)
+         │  leader?     │  API read-only
+         └──────┬───────┘  Manual recovery
+                │
+          ┌─────┴─────┐
+         YES           NO
+          │             │
+          ▼             ▼
+     Leader fails   Worker fails
+     (Scenario 2)   (Scenario 1)
+     Re-election    Reschedule
+     → then         workloads
+     Scenario 1     on healthy
+                    node
+                        │
+                        ▼
+               ┌────────────────┐
+               │  Tie-breaker?  │
+               └───────┬────────┘
+                       │
+                 ┌─────┴─────┐
+                YES           NO
+                 │             │
+                 ▼             ▼
+           Scenario 4     Scenario 5
+           (no workload   (volume
+           impact)        degraded)
+```
+
+---
+
+## Timeout Reference
+
+| Parameter | Value | Configurable | Purpose |
+|-----------|-------|-------------|---------|
+| Node NotReady detection | ~60s | No (K8s default) | Mark node unavailable |
+| Pod eviction after NotReady | ~30s | No (K8s default) | Start pod eviction |
+| getKubePodsError threshold | 2 min | No (hardcoded) | Mark app not running |
+| DetachOldWorkload trigger | 2 min | No (hardcoded) | Force volume detach |
+| Lease LeaseDuration | 300s | No | Leader holds lease |
+| Lease RenewDeadline | 180s | No | Renew before expiry |
+| Lease RetryPeriod | 15s | No | Election retry interval |
+| drainSkipK8sAPINotReachableTimeout | 300s | Yes | Skip drain if API down |
+| KubernetesDrainTimeout | 24h | Yes | Max drain wait |
+| Drain cordon retries | 10× / 5s | No | Cordon retry policy |
+| Drain eviction retries | 5× / 300s | No | Drain retry policy |
+
+---
+
+## Source File Reference
+
+| File | Scenario |
+|------|----------|
+| `pkg/pillar/cmd/zedkube/failover.go` | 1, 2, 3, 5 |
+| `pkg/pillar/cmd/zedkube/leaderelect.go` | 2, 3, 7 |
+| `pkg/pillar/cmd/zedkube/drain.go` | 5, 6 |
+| `pkg/pillar/cmd/zedkube/handlenodedrain.go` | 6 |
+| `pkg/pillar/cmd/zedkube/clusterstatus.go` | 2, 4, 7 |
+| `pkg/pillar/cmd/zedkube/applogs.go` | 1, 8 |
+| `pkg/pillar/cmd/zedkube/podutils.go` | 1, 8 |
+| `pkg/pillar/kubeapi/kubeapi.go` | 1, 5 (DetachOldWorkload) |
+| `pkg/kube/tie-breaker-utils.sh` | 4 |
+| `pkg/kube/longhorn-utils.sh` | 5 |

--- a/pkg/kube/CLUSTER-INIT-FLOW.md
+++ b/pkg/kube/CLUSTER-INIT-FLOW.md
@@ -1,0 +1,686 @@
+# cluster-init.sh — Detailed Flow Diagram
+
+Source: `pkg/kube/cluster-init.sh`
+
+---
+
+## Phase 0: Script Startup & Sourced Libraries
+
+```
+cluster-init.sh starts
+       │
+       ├─ Set globals:
+       │    RESTART_COUNT=0, current_wait_time=5s
+       │    MAX_WAIT_TIME=600s (10 min, exponential backoff cap)
+       │    TRANSITION_PIPE, TRANSITION_FLAG_FILE
+       │    KUBE_ROOT_EXT4=/persist/vault/kube
+       │    KUBE_ROOT_ZFS=/dev/zvol/persist/etcd-storage
+       │
+       └─ Source libraries:
+            config.sh          — k3s config helpers
+            pubsub.sh          — EVE pubsub helpers
+            kube/config.sh     — cluster config management
+            descheduler-utils.sh
+            longhorn-utils.sh
+            cluster-utils.sh
+            cluster-update.sh  — Update_CheckNodeComponents, Update_CheckClusterComponents
+            registration-utils.sh
+            utils.sh
+            kubevirt-utils.sh
+            tie-breaker-utils.sh
+```
+
+---
+
+## Phase 1: setup_prereqs()
+
+```
+setup_prereqs()
+       │
+       ├─ [ONCE] Record initial k3s version
+       │    → ${K3S_LOG_DIR}/initial_k3s_version
+       │    (prevents downgrades below install version)
+       │
+       ├─ Load kernel modules:
+       │    modprobe tun, vhost_net, fuse, iscsi_tcp
+       │
+       ├─ Setup filesystem:
+       │    mkdir /run/lock
+       │    rm -rf /var/log → symlink to /persist/kubelog
+       │    mkdir $K3S_CONFIG_DIR
+       │
+       ├─ Start iSCSI daemon: /usr/sbin/iscsid start
+       │
+       ├─ mount --make-rshared /
+       │
+       ├─ setup_cgroup()
+       │
+       ├─ ┌─ WAIT LOOP: wait_for_default_route() ─────────────────────┐
+       │  │  while no default route: sleep 1                          │
+       │  └──────────────────────────────────────────────────────────-┘
+       │
+       ├─ wait_for_device_name()
+       │
+       ├─ chmod o+rw /dev/null
+       │
+       ├─ ┌─ WAIT LOOP: wait_for_vault() ─────────────────────────────┐
+       │  │  while vaultmgr waitUnsealed fails: sleep 1               │
+       │  │  (blocks until TPM-backed vault is unsealed)              │
+       │  └───────────────────────────────────────────────────────────┘
+       │
+       ├─ mount_kube_root():
+       │    ├─ ZFS:  wait for /dev/zvol/persist/etcd-storage ──────────┐
+       │    │        while [ ! -b $KUBE_ROOT_ZFS ]: sleep 1            │
+       │    │        mount zvol → /var/lib                ─────────────┘
+       │    └─ EXT4: mkdir /persist/vault/kube
+       │             mount --bind → /var/lib
+       │
+       └─ ┌─ WAIT LOOP: check_network_connection() ────────────────────┐
+          │  (waits until network is reachable)                        │
+          └───────────────────────────────────────────────────────────-┘
+```
+
+---
+
+## Phase 2: One-time Pre-loop Setup
+
+```
+After setup_prereqs():
+       │
+       ├─ wait_for_item "k3s-install"    (pubsub signal)
+       ├─ Update_CheckNodeComponents()   (check if k3s binary needs update)
+       ├─ Config_k3s_override_apply()    (apply controller k3s.config.override if any)
+       │
+       ├─ CONVERSION CHECK: /var/lib/convert-to-single-node exists?
+       │    YES ──► restore_var_lib()     (restore saved single-node /var/lib snapshot)
+       │            rm -rf /persist/vault/volumes/replicas/*   (wipe replica data)
+       │            assign_multus_nodeip()  (reconfigure Multus for single-node IP)
+       │            convert_to_single_node=true
+       │            touch /var/lib/all_components_initialized
+       │
+       ├─ wait_for_item "containerd"     (pubsub signal)
+       ├─ check_start_containerd()       (start k3s user containerd if not running)
+       │
+       ├─ monitor_cluster_config_change & ◄── BACKGROUND TASK (see Section 5)
+       │
+       ├─ FIRST TIME OR RESTART CHECK:
+       │
+       │  NOT YET INITIALIZED (/var/lib/all_components_initialized missing):
+       │  ────────────────────────────────────────────────────────────────
+       │    if /var/lib/edge-node-cluster-mode:
+       │      provision_cluster_config_file(true)  → generate config.yaml
+       │    else:
+       │      "Single node mode" — use existing config.yaml
+       │    assign_multus_nodeip($cluster_node_ip)
+       │
+       │  RESTART (all_components_initialized exists):
+       │  ─────────────────────────────────────────────
+       │    if /var/lib/edge-node-cluster-mode:
+       │      ┌─ WAIT LOOP: get_enc_status() ──────────────────────────┐
+       │      │  while get_enc_status fails: sleep 10                  │
+       │      └───────────────────────────────────────────────────────-┘
+       │      provision_cluster_config_file($convert_to_single_node)
+       │    else:
+       │      Single node: append node-name to K3S_NODENAME_CONFIG_FILE
+       │
+       ├─ get_eve_os_release()
+       │
+       └─ if NOT amd64: install_kubevirt=0  (no CDI/KubeVirt on ARM)
+```
+
+---
+
+## Phase 3: Main Forever Loop (every 15s)
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+while true; do
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+┌─────────────────────────────────────────────────────────────────────┐
+│ BRANCH A: First-time Install Path                                   │
+│ (all_components_initialized does NOT exist)                         │
+└──────────────────────┬──────────────────────────────────────────────┘
+                       │
+           ┌───────────┴──────────────────────────────────────────┐
+           │  k3s_installed_unpacked missing?                     │
+           │  YES → Update_CheckNodeComponents()  ← retry loop   │
+           │        sleep 5; continue                            │
+           └───────────┬──────────────────────────────────────────┘
+                       │ (k3s binary is ready)
+                       ▼
+           ┌───────────────────────────────────────────────────────┐
+           │  check_start_k3s()         (see Section 3a)          │
+           │  fails (k3s not yet running)?                        │
+           │  → sleep 5; continue                                 │
+           └───────────┬───────────────────────────────────────────┘
+                       │ (k3s started / already running)
+                       ▼
+           ┌───────────────────────────────────────────────────────┐
+           │  external_boot_image_import()                        │
+           │  fails? → sleep 5; continue                          │
+           └───────────┬───────────────────────────────────────────┘
+                       │
+                       ▼
+           ┌──────────────────────────────────────────────────────┐
+           │  WAIT SUB-LOOP: node ready? (120s timeout)          │
+           │  while (time < 120s):                               │
+           │    kubectl get node/$HOSTNAME | grep Ready          │
+           │    node_count_ready != 1 → sleep 10; continue      │
+           │    node_count_ready == 1 → break                   │
+           │  timeout? → continue (restart outer loop)          │
+           └───────────┬──────────────────────────────────────────┘
+                       │
+                       ▼
+           ┌───────────────────────────────────────────────────────┐
+           │  node-uuid label set?                                │
+           │  NO → apply_node_uuid_label()                       │
+           └───────────┬───────────────────────────────────────────┘
+                       │
+                       ▼
+           ┌───────────────────────────────────────────────────────┐
+           │  are_all_pods_ready()?                               │
+           │  NO → All_PODS_READY=false; sleep 10; continue      │
+           └───────────┬───────────────────────────────────────────┘
+                       │ all pods ready
+                       ▼
+           ┌───────────────────────────────────────────────────────┐
+           │  multus_initialized?                                 │
+           │  NO → assign_multus_nodeip()                        │
+           │       apply_multus_cni()   → continue               │
+           │       if still not init: sleep 10; continue         │
+           │  YES → check_for_multus_link_request()              │
+           └───────────┬───────────────────────────────────────────┘
+                       │
+                       ▼
+           ┌───────────────────────────────────────────────────────┐
+           │  CNI DHCP daemon running?                            │
+           │  NO → rm /run/cni/dhcp.sock (if stale)              │
+           │       /opt/cni/bin/dhcp daemon &                    │
+           └───────────┬───────────────────────────────────────────┘
+                       │
+                       ▼
+           ┌───────────────────────────────────────────────────────┐
+           │  debuguser-initialized?                              │
+           │  NO → config_cluster_roles(); continue              │
+           └───────────┬───────────────────────────────────────────┘
+                       │
+                       ▼
+           ┌───────────────────────────────────────────────────────┐
+           │  install_kubevirt == 1 AND !kubevirt_initialized?    │
+           │  YES → wait_for_item "kubevirt"                     │
+           │        Kubevirt_install()                           │
+           │        wait_for_item "cdi"                         │
+           │        Cdi_install()                               │
+           │        touch kubevirt_initialized; continue        │
+           └───────────┬───────────────────────────────────────────┘
+                       │
+                       ▼
+           ┌───────────────────────────────────────────────────────┐
+           │  KUBE_MANIFESTS_DIR exists?                          │
+           │  NO → logmsg; continue                              │
+           └───────────┬───────────────────────────────────────────┘
+                       │
+                       ▼
+           ┌───────────────────────────────────────────────────────┐
+           │  Copy manifests:                                     │
+           │    storage-classes.yaml → KUBE_MANIFESTS_DIR        │
+           │    nvidia manifest (if NVIDIA platform)             │
+           └───────────┬───────────────────────────────────────────┘
+                       │
+                       ▼
+           ┌───────────────────────────────────────────────────────┐
+           │  wait_for_item "longhorn"                            │
+           │  longhorn_initialized?                               │
+           │  NO → longhorn_install($HOSTNAME)                   │
+           │       fails? → continue                             │
+           │       Longhorn_is_ready()?                          │
+           │       NO  → sleep 30; continue                      │
+           │       YES → touch longhorn_initialized             │
+           └───────────┬───────────────────────────────────────────┘
+                       │
+                       ▼
+           ┌───────────────────────────────────────────────────────┐
+           │  wait_for_item "descheduler"                         │
+           │  descheduler_install()                               │
+           │  fails? → continue                                  │
+           └───────────┬───────────────────────────────────────────┘
+                       │
+                       ▼
+           ┌───────────────────────────────────────────────────────┐
+           │  FINALIZE FIRST-TIME INSTALL:                        │
+           │    terminate_k3s()                                  │
+           │    sync; sleep 5                                    │
+           │    save_var_lib()  ← snapshot /var/lib for rollback │
+           │    touch node-labels-initialized                    │
+           │    touch all_components_initialized   ← GATE FLAG  │
+           └───────────────────────────────────────────────────────┘
+                       │
+                       │  (next loop iteration now takes Branch B)
+                       ▼
+
+┌─────────────────────────────────────────────────────────────────────┐
+│ BRANCH B: Steady-State / Restart Path                               │
+│ (all_components_initialized EXISTS)                                 │
+└──────────────────────┬──────────────────────────────────────────────┘
+                       │
+                       ▼
+           ┌───────────────────────────────────────────────────────┐
+           │  Config_k3s_override_apply()                         │
+           │  fails? → terminate_k3s(); (will restart on next    │
+           │           check_start_k3s call)                     │
+           └───────────┬───────────────────────────────────────────┘
+                       │
+                       ▼
+           ┌───────────────────────────────────────────────────────┐
+           │  cluster_type == REPLICATED_STORAGE?                 │
+           │  YES → Update_CheckNodeComponents()                  │
+           └───────────┬───────────────────────────────────────────┘
+                       │
+                       ▼
+           ┌───────────────────────────────────────────────────────┐
+           │  check_start_k3s()    (see Section 3a)               │
+           │  returns 1 = k3s was just (re)started?               │
+           └──────────┬────────────────────────────────────────────┘
+                      │
+           ┌──────────┴──────────┐
+           │                     │
+    K3S JUST STARTED        K3S WAS ALREADY
+    (returned 1)             RUNNING (returned 0)
+           │                     │
+           ▼                     ▼
+  WAIT SUB-LOOP             ┌──────────────────────────────┐
+  node ready? (120s)        │  node-labels-initialized?    │
+  (same as Branch A)        │  NO → reapply_node_labels()  │
+           │                └──────────────┬───────────────┘
+           │ ready                         │
+           ▼                               ▼
+  node_count_ready         ┌──────────────────────────────┐
+  == 1?                    │  external_boot_image_import()│
+  NO → continue            │  fails? → continue          │
+  YES → fall through       └──────────────┬───────────────┘
+                                          │
+                                          ▼
+                           ┌──────────────────────────────┐
+                           │  CNI binaries present?       │
+                           │  NO → copy_cni_plugin_files()│
+                           └──────────────┬───────────────┘
+                                          │
+                                          ▼
+                           ┌──────────────────────────────┐
+                           │  multus_initialized?         │
+                           │  NO → assign_multus_nodeip() │
+                           │       apply_multus_cni()     │
+                           └──────────────┬───────────────┘
+                                          │
+                                          ▼
+                           ┌──────────────────────────────┐
+                           │  check_for_multus_link_request│
+                           │  DHCP daemon running?        │
+                           │  NO → restart dhcp daemon   │
+                           └──────────────┬───────────────┘
+                                          │
+                                          ▼
+                           ┌──────────────────────────────┐
+                           │  debuguser-initialized?      │
+                           │  NO → config_cluster_roles() │
+                           │  YES → sync user.yaml to /run│
+                           └──────────────┬───────────────┘
+                                          │
+                                          ▼
+                           ┌─────────────────────────────────────┐
+                           │  Longhorn_is_ready()?               │
+                           │  YES:                               │
+                           │    check_overwrite_nsmounter()      │
+                           │    Tie_breaker_configApply()        │
+                           │                                     │
+                           │    cluster_type?                    │
+                           │    ├─ UNSPECIFIED:                  │
+                           │    │   Registration_Applied?        │
+                           │    │   NO  → copy storage-classes   │
+                           │    │   YES → cleanup_storageclasses │
+                           │    │         longhorn_post_config_clean│
+                           │    ├─ REPLICATED_STORAGE:           │
+                           │    │   copy storage-classes         │
+                           │    │   Update_CheckClusterComponents│
+                           │    │   Update_RunDeschedulerOnBoot  │
+                           │    └─ K3S_BASE:                     │
+                           │        cleanup_storageclasses       │
+                           │        longhorn_post_config_clean   │
+                           └──────────────┬──────────────────────┘
+                                          │
+                                          ▼
+                           ┌─────────────────────────────────────┐
+                           │  cluster_type == REPLICATED_STORAGE?│
+                           │  YES:                               │
+                           │    longhorn_post_install_config()   │
+                           │    Update_CheckClusterComponents()  │
+                           │    fails? → continue               │
+                           │    Update_RunDeschedulerOnBoot()    │
+                           └──────────────┬──────────────────────┘
+                                          │
+                                          ▼
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  END OF BRANCH A/B — common tail (every loop iteration):
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  check_log_file_size "k3s.log"
+  check_log_file_size "multus.log"
+  check_log_file_size "k3s-install.log"
+  check_log_file_size "eve-bridge.log"
+  check_log_file_size "containerd-user.log"
+  check_kubeconfig_yaml_files()
+  check_and_remove_excessive_k3s_logs()
+  check_and_run_vnc()        (see Section 3c)
+  wait_for_item "wait"       (pubsub throttle)
+  sleep 15
+  ↑
+  └─ loop back to top of while true
+```
+
+---
+
+## Section 3a: check_start_k3s() — Sub-Loops
+
+```
+check_start_k3s()
+       │
+       ├─ TRANSITION_FLAG_FILE exists?
+       │    YES ──► BLOCKING READ from TRANSITION_PIPE
+       │            (blocks until monitor_cluster_config_change writes "DONE")
+       │            rm TRANSITION_PIPE
+       │
+       ├─ CLUSTER_WAIT_FILE exists?
+       │    ┌─ WAIT LOOP ──────────────────────────────────────────────┐
+       │    │  while /run/kube/cluster-change-wait-ongoing exists:     │
+       │    │    sleep 5                                               │
+       │    └─────────────────────────────────────────────────────────┘
+       │
+       ├─ Is k3s server process running? (pgrep -f k3s server)
+       │
+       ├─ NOT RUNNING:
+       │    RESTART_COUNT++
+       │    sleep $current_wait_time    ← exponential backoff
+       │    current_wait_time *= 2      (caps at MAX_WAIT_TIME=600s)
+       │    save_crash_log()
+       │    ln -s /var/lib/k3s/bin/* /usr/bin
+       │    copy_cni_plugin_files() if needed
+       │    nohup /usr/bin/k3s server &   (start k3s in background)
+       │    ionice -c2 -n0 -p $k3s_pid   (prioritize etcd I/O)
+       │    │
+       │    ├─ WAIT SUB-LOOP for kubeconfig (max 600s = 120×5s) ───────┐
+       │    │  while /etc/rancher/k3s/k3s.yaml missing:               │
+       │    │    sleep 5; counter++                                    │
+       │    │    counter==120 → break  (k3s may have crashed)         │
+       │    └───────────────────────────────────────────────────────-──┘
+       │    cp k3s.yaml → /run/.kube/k3s/k3s.yaml
+       │    return 1  (k3s just started, caller must wait for node Ready)
+       │
+       └─ RUNNING:
+            current_wait_time = INITIAL_WAIT_TIME (reset backoff)
+            return 0  (k3s was already running)
+```
+
+---
+
+## Section 3b: provision_cluster_config_file() — Inner Loop (Non-Bootstrap)
+
+```
+provision_cluster_config_file(first_time):
+       │
+       ├─ if is_bootstrap == true:
+       │    first_time? → write bootstrapContent → config.yaml
+       │    else       → write serverContent    → config.yaml
+       │    return 0
+       │
+       └─ if is_bootstrap == false:
+            write serverContent → config.yaml
+            if NOT first_time: return 0 (restart, no need to wait)
+            │
+            touch CLUSTER_WAIT_FILE  ← blocks check_start_k3s
+            ping_success_count=0, ping_fail_count=0
+            │
+            ┌─ WAIT LOOP: wait for bootstrap server to be in cluster mode ──┐
+            │  counter=0                                                    │
+            │  while true:                                                  │
+            │    counter++                                                  │
+            │    curl --insecure https://$join_serverIP:6443               │
+            │    ├─ CURL OK (HTTPS reachable):                             │
+            │    │   curl http://$join_serverIP:12346/status               │
+            │    │   ├─ FAIL:      log every 30 attempts                  │
+            │    │   ├─ "cluster:<uuid>" returned:                        │
+            │    │   │   UUID matches our cluster_uuid?                   │
+            │    │   │   YES → rm CLUSTER_WAIT_FILE; break  ✅            │
+            │    │   │   NO  → log UUID mismatch warning (dup IP?)        │
+            │    │   └─ other status: log "not in cluster mode"           │
+            │    ├─ CURL FAIL (HTTPS not reachable):                      │
+            │    │   ping $join_serverIP → track ping_success/fail counts │
+            │    │   log every 30 attempts                                │
+            │    │                                                        │
+            │    ├─ enc_status_file disappeared?                          │
+            │    │   → rm CLUSTER_WAIT_FILE; return 1  ← triggers reboot  │
+            │    │                                                        │
+            │    └─ sleep 10; repeat                                      │
+            └──────────────────────────────────────────────────────────-──┘
+            return 0
+```
+
+---
+
+## Section 3c: check_and_run_vnc()
+
+```
+check_and_run_vnc()   (called each main loop iteration)
+       │
+       ├─ VMICONFIG_FILENAME (/run/zedkube/vmiVNC.run) exists
+       │   AND (VNC not running OR process dead)?
+       │     Parse file for VMINAME and VNCPORT
+       │     nohup /usr/bin/virtctl vnc $vmiName -n eve-kube-app
+       │             --port $vmiPort --proxy-only &
+       │     VNC_RUNNING=true
+       │
+       └─ VMICONFIG_FILENAME does NOT exist:
+            VNC_RUNNING==true? → kill virtctl vnc process
+            VNC_RUNNING=false
+```
+
+---
+
+## Section 3d: change_to_new_token() — Inner Loops
+
+```
+change_to_new_token()   (called during single→cluster transition, bootstrap only)
+       │
+       ├─ cluster_token provided by controller?
+       │    YES:
+       │      rotate_cluster_token($cluster_token)
+       │      starttime=$(date +%s)
+       │      │
+       │      ┌─ WAIT LOOP: confirm token rotated ────────────────────┐
+       │      │  while true:                                          │
+       │      │    grep "server:$cluster_token" /var/lib/.../token    │
+       │      │    found? → break  ✅                                 │
+       │      │    elapsed >= 60s? → retry rotate_cluster_token()     │
+       │      │                      reset starttime                  │
+       │      │    sleep 5; repeat                                    │
+       │      └───────────────────────────────────────────────────────┘
+       │
+       └─ NO cluster_token:
+            save current_token
+            k3s token rotate   (auto-generate)
+            │
+            ┌─ WAIT LOOP: confirm old token gone ───────────────────┐
+            │  while true:                                          │
+            │    grep $current_token /var/lib/.../token             │
+            │    still present → sleep 2; repeat                    │
+            │    gone → break  ✅                                   │
+            └───────────────────────────────────────────────────────┘
+```
+
+---
+
+## Section 4: uninstall_components() — Sub-Loops (Base-K3S conversion)
+
+```
+uninstall_components()   (called when converting to CLUSTER_TYPE_K3S_BASE)
+       │
+       ├─ touch /tmp/replicated-storage-uninstall-inprogress
+       │
+       ├─ ┌─ WAIT LOOP: API server available ─────────────────────────┐
+       │  │  while ! kubectl cluster-info: sleep 5                   │
+       │  └───────────────────────────────────────────────────────────┘
+       │
+       ├─ ┌─ WAIT LOOP: all nodes ready ──────────────────────────────┐
+       │  │  while not_ready_nodes != "": sleep 5                    │
+       │  └───────────────────────────────────────────────────────────┘
+       │
+       ├─ Descheduler_uninstall()
+       ├─ Longhorn_uninstall();  rm longhorn_initialized
+       ├─ Cdi_uninstall()
+       ├─ Kubevirt_uninstall();  rm kubevirt_initialized
+       ├─ Multus_uninstall();    rm multus_initialized
+       │
+       ├─ rm /tmp/replicated-storage-uninstall-inprogress
+       ├─ touch /var/lib/base-k3s-mode
+       └─ touch /var/lib/replicated-storage-uninstall-complete
+```
+
+---
+
+## Section 5: Background Task — monitor_cluster_config_change()
+
+Runs as a **separate background process** (`&`) started once before the main loop.
+
+```
+monitor_cluster_config_change()   [background process]
+       │
+       rm -f TRANSITION_FLAG_FILE    (cleanup any stale flags)
+       │
+       ┌─ FOREVER LOOP ────────────────────────────────────────────────┐
+       │  while true:                                                  │
+       │    check_cluster_config_change()   (see 5a below)            │
+       │    check_cluster_transition_done() (see 5b below)            │
+       │    sleep 15                                                   │
+       └───────────────────────────────────────────────────────────────┘
+```
+
+### Section 5a: check_cluster_config_change()
+
+```
+check_cluster_config_change()
+       │
+       ├─ all_components_initialized missing? → return 0  (not ready yet)
+       │
+       ├─ get_enc_status()  → reads /run/zedkube/EdgeNodeClusterStatus/global.json
+       │    returns 0 = valid, 1 = invalid/incomplete, 2 = file missing
+       │
+       ├─ enc_status == 2  (file MISSING = cluster config removed):
+       │    edge-node-cluster-mode flag missing? → return 0  (already single node)
+       │    Config_cluster_exists()?
+       │      YES → "waiting for zedkube to publish" → return 0
+       │    NO:
+       │      Registration_Cleanup()
+       │      rm /var/lib/base-k3s-mode
+       │      touch /var/lib/convert-to-single-node
+       │      reboot_with_reason("Transition from cluster to single node")  ← REBOOT
+       │
+       └─ enc_status == 0 + cluster_node_ip_is_ready == true:
+            edge-node-cluster-mode flag missing?  (single → cluster transition)
+            │
+            ┌─ INNER WAIT LOOP ──────────────────────────────────────────┐
+            │  while true:                                               │
+            │    get_enc_status() succeeds?                             │
+            │    YES:                                                   │
+            │      touch /var/lib/edge-node-cluster-mode               │
+            │      Config_cluster_type_get()                           │
+            │      cluster_type == K3S_BASE AND !base-k3s-mode?        │
+            │        → uninstall_components()  (see Section 4)        │
+            │      is_bootstrap == true?                               │
+            │        → change_to_new_token()  (see Section 3d)        │
+            │      remove_multus_cni()                                 │
+            │      assign_multus_nodeip($cluster_node_ip)             │
+            │      rm /var/lib/node-labels-initialized                │
+            │      mkfifo TRANSITION_PIPE                             │
+            │      touch TRANSITION_FLAG_FILE                         │
+            │      terminate_k3s()                                    │
+            │      if !bootstrap: rm -rf k3s TLS certs                │
+            │                     rm debuguser-initialized            │
+            │      provision_cluster_config_file(true)               │
+            │        returns 1? (enc_status_file disappeared)         │
+            │          → rm base-k3s-mode                            │
+            │            touch convert-to-single-node                │
+            │            reboot_with_reason("ENC file disappeared") ← REBOOT│
+            │      if !bootstrap:                                     │
+            │        echo "$(date) 0" > transition-to-cluster        │
+            │      echo "DONE" > TRANSITION_PIPE  ← unblocks check_start_k3s│
+            │      rm TRANSITION_FLAG_FILE                           │
+            │      break                                             │
+            │    NO:                                                 │
+            │      enc_status_file missing? → return 0  (try again) │
+            │      sleep 10                                          │
+            └────────────────────────────────────────────────────────┘
+            │
+            cluster_type == K3S_BASE AND base-k3s-mode exists?
+              → Registration_CheckApply()
+            else:
+              → Registration_CheckApply()
+```
+
+### Section 5b: check_cluster_transition_done()
+
+```
+check_cluster_transition_done()   (polls for non-bootstrap join success)
+       │
+       ├─ /var/lib/transition-to-cluster missing? → return 0  (nothing to do)
+       │
+       ├─ kubectl get nodes (API reachable?)
+       │    YES → count ready nodes
+       │           ready_nodes >= 2?
+       │             YES → rm transition-to-cluster; return 0  ✅
+       │
+       ├─ Read timestamp and reboot_count from transition-to-cluster
+       │
+       └─ elapsed >= 300s (5 min timeout)?
+            YES:
+              reboot_count++
+              reboot_count <= 3?
+                YES → update file: "$(date) $reboot_count"
+                      reboot_with_reason("Retry cluster join attempt $N")  ← REBOOT
+                NO  → rm transition-to-cluster  (give up after 3 reboots)
+            NO:
+              log "still waiting, Xs elapsed"
+              return 1
+```
+
+---
+
+## State Flags Reference
+
+| Flag File | Meaning |
+|-----------|---------|
+| `/var/lib/all_components_initialized` | All K3s/KubeVirt/Longhorn/Multus installed ✅ |
+| `/var/lib/k3s_installed_unpacked` | K3s binary is available |
+| `/var/lib/edge-node-cluster-mode` | Node is in cluster (not single-node) mode |
+| `/var/lib/multus_initialized` | Multus daemonset applied |
+| `/var/lib/kubevirt_initialized` | KubeVirt + CDI installed |
+| `/var/lib/longhorn_initialized` | Longhorn installed and ready |
+| `/var/lib/debuguser-initialized` | Debug user certificates/roles applied |
+| `/var/lib/node-labels-initialized` | node-uuid and Longhorn labels applied |
+| `/var/lib/base-k3s-mode` | Node is in base K3s mode (no Longhorn/KubeVirt) |
+| `/var/lib/convert-to-single-node` | Pending conversion back to single-node (triggers restore on next boot) |
+| `/var/lib/transition-to-cluster` | Non-bootstrap join in progress (contains timestamp + reboot_count) |
+| `/run/kube/cluster-change-wait-ongoing` | Blocks check_start_k3s during cluster join |
+| `/tmp/cluster_transition_flag` | Blocks check_start_k3s until transition pipe signaled |
+| `/tmp/cluster_transition_pipe$$` | FIFO pipe to coordinate k3s restart after transition |
+
+---
+
+## Reboot Scenarios Summary
+
+| Trigger | Reason |
+|---------|--------|
+| `cluster → single` | ENC status file removed while in cluster mode |
+| `single → cluster` (non-bootstrap) | ENC status file disappeared during bootstrap wait |
+| `non-bootstrap join timeout` | Ready nodes < 2 after 300s (up to 3 retries) |
+| `k3s override bad config` | terminate_k3s only (no reboot; restarts via check_start_k3s) |


### PR DESCRIPTION
These documents are generated using AI tools and seems correct. These documents cover the app deployment on eve-k, failover scenarios in 3 node and tie-breaker mode, and general overview of cluster-init.sh





## How to test and validate this PR

Nothing to test. just documentation.

## Changelog notes

None

## PR Backports



## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation


- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
