### PR TITLE
[13.4-stable] pkg/storage-init: Fix CONFIG partition tmpfs size

### DIFF
--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -84,7 +84,7 @@ if CONFIG=$(findfs PARTLABEL=CONFIG) && [ -n "$CONFIG" ]; then
         echo "$(date -Ins -u) mount $CONFIG failed"
     fi
 
-    mount -t tmpfs -o rw,nosuid,nodev,noexec,relatime,size=256k,mode=755 tmpfs $CONFIGDIR
+    mount -t tmpfs -o rw,nosuid,nodev,noexec,relatime,size=1024k,mode=755 tmpfs $CONFIGDIR
     echo "$(date -Ins -u) Create a copy of CONFIG partition in RAM"
     cp -r $CONFIGDIR_PERSIST/* $CONFIGDIR
     umount "$CONFIG"


### PR DESCRIPTION
# Description

Backport of #5668 

## How to test and validate this PR

Run EVE and check if `/config` is mount with the correct size (1MB):

```sh
mount | grep "tmpfs on /config"
tmpfs on /config type tmpfs (ro,nosuid,nodev,noexec,relatime,size=1024k,mode=755)
```
## Changelog notes

Increase the CONFIG partition tmpfs mount size from 256KB to 1MB to match the physical partition and prevent data truncation.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.