### PR TITLE
installer: create EFI NVRAM boot entry for EVE-OS after installation

### DIFF
--- a/pkg/installer/Dockerfile
+++ b/pkg/installer/Dockerfile
@@ -47,7 +47,7 @@ ENV PKGS="mtools dosfstools libarchive-tools sgdisk e2fsprogs util-linux \
     lm-sensors acpi iw libdrm hwinfo dhcpcd e2fsprogs-extra \
     libgcc pixman libvncserver musl-utils \
     tpm2-tss-esys tpm2-tss-fapi tpm2-tss-rc \
-    kmod-libs tpm2-tss-sys tpm2-tss-tctildr tpm2-abrmd libblkid cryptsetup-libs"
+    kmod-libs tpm2-tss-sys tpm2-tss-tctildr tpm2-abrmd libblkid cryptsetup-libs efibootmgr"
 RUN eve-alpine-deploy.sh
 
 COPY src/ /src/

--- a/pkg/installer/install
+++ b/pkg/installer/install
@@ -198,6 +198,39 @@ zfs_umount() {
   umount /root/dev ||:
 }
 
+# create_efi_boot_entry creates an EFI NVRAM boot entry for the installed EVE-OS.
+# Any pre-existing "EVE-OS" entries are removed first to avoid duplicates on reinstall.
+# Usage: create_efi_boot_entry DISK
+create_efi_boot_entry() {
+   local DISK="$1"
+   local BOOTLOADER=''
+   local PLATFORM=''
+   mount -t efivarfs efivarfs /sys/firmware/efi/efivars || bail "FATAL: cannot mount efivarfs"
+   # The path to the EFI bootloader differs by architecture
+   if [ -e /root/EFI/BOOT/BOOTRISCV64.EFI ]; then
+      BOOTLOADER='BOOTRISCV64.EFI'
+      PLATFORM='RISCV64'
+   elif [ -e /root/EFI/BOOT/BOOTAA64.EFI ]; then
+      BOOTLOADER='BOOTAA64.EFI'
+      PLATFORM='ARM64'
+   elif [ -e /root/EFI/BOOT/BOOTX64.EFI ]; then
+      BOOTLOADER='BOOTX64.EFI'
+      PLATFORM='X86_64'
+   else
+      bail "FATAL: cannot find EFI bootloader"
+   fi
+   # Remove any existing EVE-OS entries before creating a new one
+   efibootmgr | grep -i "EVE-OS" | grep -o 'Boot[0-9A-Fa-f]\{4\}' | sed 's/Boot//' | while read -r num; do
+      logmsg "removing existing EVE-OS EFI entry Boot$num"
+      efibootmgr -b "$num" -B -q
+   done
+   logmsg "creating EFI boot entry for EVE-OS: ($PLATFORM) /dev/$DISK EFI\\BOOT\\$BOOTLOADER"
+   efibootmgr -c -d "/dev/$DISK" -p 1 -L "EVE-OS" -l "\\EFI\\BOOT\\$BOOTLOADER" \
+      || bail "FATAL: cannot create EFI boot entry"
+   logmsg "EFI boot entries after install:"
+   efibootmgr -v 2>&1 | while read -r line; do logmsg "$line"; done
+}
+
 # make_raw run the command /make-raw, which is the entrypoint of mkimage-raw-efi container.
 make_raw() {
    if ! command -v /mkimage/make-raw >/dev/null; then
@@ -650,6 +683,9 @@ touch /persist/installer/first-boot
 # in case of no key received from controller
 mkdir -p /persist/status
 touch /persist/status/allow-vault-clean
+
+# create an EFI boot entry for the installed EVE-OS
+create_efi_boot_entry "$INSTALL_DEV"
 
 # lets hope this is enough to flush the caches
 sync; sleep 5; sync


### PR DESCRIPTION
# Description

After writing the EFI partition to disk, the installer did not create an EFI
NVRAM boot entry. On some hardware and firmware configurations this means
EVE-OS would not appear in the boot menu after installation and the system
might not boot into EVE without manual BIOS intervention.

This change adds `create_efi_boot_entry()` to the installer script. It:
- Detects the EFI bootloader path by architecture (x86_64, ARM64, RISCV64)
  from the installer's own EFI files (available at `/root/EFI/BOOT/` via the
  linuxkit init layer)
- Removes any pre-existing "EVE-OS" NVRAM entries to avoid duplicates on
  reinstall
- Creates a new NVRAM entry pointing to the correct EFI bootloader on the
  installed disk using `efibootmgr`

`efibootmgr` is added as a runtime dependency of the installer container.

tested on QEMU.  EVE-OS entry appears in UEFI boot manager and works
<img width="883" height="609" alt="image" src="https://github.com/user-attachments/assets/503e0a20-0be3-43af-8de7-71e3da7e4519" />


## PR dependencies

- #5725 (pkg/alpine: add efibootmgr package to Alpine 3.22 mirror)

## How to test and validate this PR

1. Build an installer image: `make installer`
2. Flash to USB and boot on an EFI-capable x86_64 or ARM64 device
3. After installation completes, reboot and enter the BIOS/UEFI boot menu
4. Verify an "EVE-OS" entry is present and the system boots from it
5. Run the installer a second time on the same device and verify there is only
   one "EVE-OS" entry (no duplicates)

Alternatively, test in QEMU with OVMF:
```
make run-installer-raw   # installs to target.img
make run-target          # boots from target.img — should boot EVE without grub fallback
```

## Changelog notes

EVE-OS installer now creates an EFI NVRAM boot entry during installation,
ensuring the device boots into EVE-OS automatically after installation on
EFI-capable hardware.

## PR Backports

- 16.0-stable: No
- 14.5-stable: No
- 13.4-stable: No

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.