### PR TITLE
pkg: exclude Dockerfile from COPY in all packages

### DIFF
--- a/pkg/memory-monitor/.dockerignore
+++ b/pkg/memory-monitor/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/pkg/mkimage-iso-efi/.dockerignore
+++ b/pkg/mkimage-iso-efi/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/pkg/mkrootfs-ext4/.dockerignore
+++ b/pkg/mkrootfs-ext4/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/pkg/mkrootfs-squash/.dockerignore
+++ b/pkg/mkrootfs-squash/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/pkg/pillar/.dockerignore
+++ b/pkg/pillar/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile


### PR DESCRIPTION
# Description

Use COPY --exclude=Dockerfile to prevent the Dockerfile itself from being copied into the image. Add syntax=docker/dockerfile:1.19.0 directive to Dockerfiles that lacked it to enable the --exclude flag.

This way the docker hashes bumper does not have to run several times anymore.

## How to test and validate this PR

Check that the image still compiles correctly.

## Changelog notes

Build improvement

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 16.0-stable: no
- 14.5-stable: no
- 13.4-stable: no


## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
