### PR TITLE
Unify partition layout: 2GB (EFI) + 4GB (rootfs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -462,8 +462,9 @@ endif
 # The rootfs partition size is set to 512MB after 10.2.0 release (see commit 719b4d516)
 # Before 10.2.0 it was 300MB. We must maintain compatibility with older versions so rootfs size cannot exceed 300MB.
 # 'k' and nvidia are not affected by this limitation because there no installation of kubevirt/k3s prior to 10.2.0
-# Nevertheless lets check for ROOTFS_MAXSIZE_MB not exceeding 4GB for 'k', 450MB for NVIDIA based platforms (arm64) and 285MB for x86_64 and other arm64 platforms
-# That helps in catching image size increases earlier than at later stage.
+# Even though the partition layout is now unified, let's still check for ROOTFS_MAXSIZE_MB not exceeding 4GB for 'k'
+# and NVIDIA based platforms, and 290MB for x86_64 and other arm64 platforms. That helps in catching image size
+# increases earlier than at later stage.
 # We are currently filtering out a few packages from bulk builds since they are not getting published in Docker HUB
 ifeq ($(HV),k)
         PKGS_$(ZARCH)=$(shell find pkg -maxdepth 1 -type d | grep -Ev "eve|alpine|sources$$")
@@ -478,7 +479,7 @@ else
         else ifeq (, $(findstring nvidia,$(PLATFORM)))
             ROOTFS_MAXSIZE_MB=290
         else
-            ROOTFS_MAXSIZE_MB=450
+            ROOTFS_MAXSIZE_MB=4096
         endif
 endif
 

--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -93,24 +93,13 @@ IMX8_BLOB=/parts/imx8-flash.bin
 IMX8_CONF=/parts/imx8-flash.conf
 
 # EFI partition size in bytes
-EFI_PART_SIZE=$((36 * 1024 * 1024))
+EFI_PART_SIZE=$((2 * 1024 * 1024 * 1024))
 # Min rootfs partition size in bytes
 # Warning: don't change the rootfs partition size, before
 # Warning: fixing the EVE upgrade logic, which should find
 # Warning: free space and rellocate all tables if image has
 # Warning: been bloated.
-ROOTFS_PART_SIZE_MIN=$((512 * 1024 * 1024))
-# For eve-k lets set partition size to 4GB and EFI partition size to 2GB
-# Check if file /root/etc/eve-hv-type exists.
-# make-raw will be called twice during compilation and during installation.
-# The eve-hv-type file will be present only during installation.
-if [ -f /root/etc/eve-hv-type ]; then
-   eve_flavor=$(cat /root/etc/eve-hv-type)
-   if [ "$eve_flavor" = "k" ]; then
-      EFI_PART_SIZE=$((2 * 1024 * 1024 * 1024))
-      ROOTFS_PART_SIZE_MIN=$((4 * 1024 * 1024 * 1024))
-   fi
-fi
+ROOTFS_PART_SIZE_MIN=$((4 * 1024 * 1024 * 1024))
 
 # PLATFORM can be set in environment, it means we are executed using
 # docker during build time, otherwise we are executed from EVE e.g.


### PR DESCRIPTION
# Description

In order to keep backward compatibility, the partition layout of non eve-k variants has been kept the same since version 10.2.0, where EFI and rootfs partitions (IMGA/IMGB) are partitioned as the following:

* EFI  - 36MB
* IMGA - 512MB
* IMGB - 512MB

Commit 5db29bd109b4236130c9d9615686d1253f13df66 fixed partition layout for eve-k as the following:

* EFI  - 2GB
* IMGA - 4GB
* IMGB - 4GB

This new layout allows not only the growing of rootfs but also the growing of EFI space for new features, if required.

This commit unifies partition layout across all EVE variants, so all images should have the same scheme: EFI (2GB), IMGA/IMGB (4GB).

The 300MB limitation is not changed, so generic rootfs images can still be upgraded from the remote controller. However, for NVIDIA variants the maximum size is set to 4GB. This is a requirement for the Jetpack 7.1, which has exceeded the current size limit.

## How to test and validate this PR

Run `lsblk` and verify the size of the partitions match:

1. EFI: 2G
2. IMGA: 4G
3. IMBB: 4G

## Changelog notes

Unify partition layout to a consistent 2GB (EFI) + 4GB (rootfs) scheme across all EVE variants, including eve-k and eve-kvm, eliminating per-variant differences. This applies to freshly installed devices - no impact on already deployed devices.

## PR Backports

This is a "new feature", so no backports.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.