### PR TITLE
Move kube-save-var-lib under vault

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -214,6 +214,7 @@ setup_prereqs () {
         wait_for_device_name
         chmod o+rw /dev/null
         wait_for_vault
+        migrate_var_lib
         mount_kube_root
         # We need /var/lib to be mounted before we go for network connection check.
         check_network_connection

--- a/pkg/kube/cluster-utils.sh
+++ b/pkg/kube/cluster-utils.sh
@@ -8,7 +8,8 @@
 
 LOG_SIZE=$((5*1024*1024))
 K3s_LOG_FILE="k3s.log"
-SAVE_KUBE_VAR_LIB_DIR="/persist/kube-save-var-lib"
+LEGACY_SAVE_KUBE_VAR_LIB_DIR="/persist/kube-save-var-lib"
+SAVE_KUBE_VAR_LIB_DIR="/persist/vault/kube-save-var-lib"
 K3S_SERVER_CMD="k3s server"
 # shellcheck disable=SC2034
 K3S_STOP_FLAG="/var/lib/k3s-stop"
@@ -238,6 +239,25 @@ restore_var_lib() {
         ## the saved files are missing, have do install again
         Update_CheckNodeComponents
   fi
+}
+
+# Migrate to secure vault
+migrate_var_lib() {
+        if [ ! -d "$LEGACY_SAVE_KUBE_VAR_LIB_DIR" ]; then
+                return
+        fi
+        if [ -d "$SAVE_KUBE_VAR_LIB_DIR" ]; then
+                return
+        fi
+        logmsg "migrating $LEGACY_SAVE_KUBE_VAR_LIB_DIR to $SAVE_KUBE_VAR_LIB_DIR"
+        if ! cp -a "$LEGACY_SAVE_KUBE_VAR_LIB_DIR" "$SAVE_KUBE_VAR_LIB_DIR"; then
+                logmsg "ERROR: failed to migrate $LEGACY_SAVE_KUBE_VAR_LIB_DIR to $SAVE_KUBE_VAR_LIB_DIR"
+                rm -rf "$SAVE_KUBE_VAR_LIB_DIR"
+                return
+        fi
+        logmsg "migrated  $LEGACY_SAVE_KUBE_VAR_LIB_DIR to $SAVE_KUBE_VAR_LIB_DIR"
+        rm -r "$LEGACY_SAVE_KUBE_VAR_LIB_DIR"
+        logmsg "removed $LEGACY_SAVE_KUBE_VAR_LIB_DIR"
 }
 
 # when transitioning from single node to cluster mode, the k3s.yaml file may need


### PR DESCRIPTION
In kube service container startup (setup_prereqs), after vault is ready begin
migrating kube-save-var-lib with the same process used to snapshot and restore
it currently.

Cannot perform a simple rename as src and dest can be on separate fs.
Copy with archive to preserve mode, ownership and timestamps.

## PR dependencies

None

## How to test and validate this PR

- Deploy eve-k node before this change, wait until /var/lib/all_components_initialized visible (after `eve enter kube`)
- confirm /persist/kube-save-var-lib exists
- upgrade to release including this
- Confirm /persist/kube-save-var-lib no longer exists, and is moved to /persist/vault/kube-save-var-lib

## Changelog notes



## PR Backports

- 16.0-stable: To be backported.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
