### PR TITLE
Delete cpu_manager_state file on every reboot

### DIFF
--- a/pkg/kube/cluster-utils.sh
+++ b/pkg/kube/cluster-utils.sh
@@ -46,6 +46,9 @@ check_network_connection () {
         done
 }
 
+# Check if file exists and delete it. The cpu manager policy can change between releases
+# which is set in config-k3s.yaml file. If previous config policy is different than new policy
+# k3s will not start. So deleting on every reboot is safe approach and this file gets created again from config.
 check_and_clean_cpu_manager_state() {
       local state_file="/var/lib/kubelet/cpu_manager_state"
 
@@ -53,19 +56,8 @@ check_and_clean_cpu_manager_state() {
         logmsg "$(date '+%Y-%m-%d %H:%M:%S') ${state_file} not found, nothing to do"
         return
       fi
-
-      local policy
-      if ! policy=$(jq -r '.policyName' "${state_file}" 2>/dev/null) || [ -z "${policy}" ] || [ "${policy}" = "null" ]; then
-        logmsg "$(date '+%Y-%m-%d %H:%M:%S') Failed to parse ${state_file}, file may be corrupt" >&2
-        return
-      fi
-
-      if [ "${policy}" = "none" ]; then
-        logmsg "$(date '+%Y-%m-%d %H:%M:%S') cpu_manager_state has policyName=none, deleting stale state file: ${state_file}"
-        rm -f "${state_file}"
-      else
-        logmsg "$(date '+%Y-%m-%d %H:%M:%S') [INFO] cpu_manager_state policyName=${policy}, no action needed"
-      fi
+      logmsg "$(date '+%Y-%m-%d %H:%M:%S')  deleting state file: ${state_file}"
+      rm -f "${state_file}"
 
       return
 }


### PR DESCRIPTION
CPU manager policy is set in the k3s config.yaml and could change between releases. The static file /var/lib/kubelet/cpu_manager_state contains the current policy. k3s tries to use that file it exists and then checks the policy in the config, any mismatch will not start k3s server. If that file does not exists, creates with policy set in config.

So, delete that file on every node reboot so that it gets created with policy set in the config.




## How to test and validate this PR

This issue will be seen when you downgrade eve-k to the previous versions from the current version in master.
Though we don't officially support downgrades but in QA and dev we do many downgrades. In such cases after downgrade k3s fails to start. This fix addresses that.

## Changelog notes

None


## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
