### PR TITLE
Makefile: Build eve-fw generic variant for evaluation platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -929,6 +929,24 @@ pkgs: RESCAN_DEPS=
 pkgs: $(LINUXKIT) $(PKGS) $(LK_POSSIBLE_BUILD_ARG_TARGETS)
 	@echo Done building packages
 
+# The evaluation platform produces 3 rootfs flavors: generic, hwe, lts.
+# The generic flavor uses a modifier (rootfs-generic.yq) that substitutes FW_TAG
+# with FW_GENERIC_TAG, which resolves to eve-fw:HASH-generic via
+# build-evaluation-generic.yml. We must build this variant in addition to the
+# default eve-fw:HASH-evaluation so the image is available locally and in CI cache.
+ifeq ($(PLATFORM),evaluation)
+.PHONY: eve-fw-evaluation-generic
+eve-fw-evaluation-generic: eve-fw
+	$(QUIET): "$@: Begin"
+	$(QUIET)$(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) $(LINUXKIT_OPTS) $(FORCE_BUILD) --platforms linux/$(ZARCH) --build-yml build-evaluation-generic.yml pkg/fw
+	$(QUIET)if [ -n "$(PRUNE)" ]; then \
+		flock $(PARALLEL_BUILD_LOCK) docker image prune -f; \
+	fi
+	$(QUIET): "$@: Succeeded"
+
+pkgs: eve-fw-evaluation-generic
+endif
+
 # No-op target for get-deps which looks at
 # external-boot-image and sees a dep for eve-kernel
 # and attempts to build pkg/kernel, which is in


### PR DESCRIPTION
# Description

The evaluation platform produces 3 rootfs flavors: generic, hwe, and lts.
The generic flavor applies a yq modifier (`images/modifiers/platform/evaluation/rootfs-generic.yq`)
that replaces `FW_TAG` with `FW_GENERIC_TAG`. `FW_GENERIC_TAG` resolves to
`eve-fw:HASH-generic` (via `pkg/fw/build-evaluation-generic.yml`), while the default
evaluation package build only produces `eve-fw:HASH-evaluation` (via
`pkg/fw/build-evaluation.yml`).

This means that `make PLATFORM=evaluation pkgs` was missing the `-generic` tagged fw
image. The evaluation eve build would then fail at rootfs generation with:

```
MANIFEST_UNKNOWN: manifest unknown; unknown tag=<hash>-generic
```

because the image was never built and doesn't exist in Docker Hub or the local
linuxkit cache.

In CI on the main repo, this happened to work when the separate `PLATFORM=generic`
packages job ran first and pushed the `-generic` image to Docker Hub, but it was
fragile and broke for forks and local builds where that image was not available.

This PR adds an `eve-fw-evaluation-generic` target (conditional on
`PLATFORM=evaluation`) as a dependency of the `pkgs` target, so both fw variants
are always built together.

## How to test and validate this PR

- Run `make PLATFORM=evaluation HV=kvm eve` on a clean machine (no prior
  `PLATFORM=generic` build). Without this fix it fails with the manifest unknown
  error above; with the fix it succeeds.
- CI: the evaluation packages job now produces both `eve-fw:HASH-evaluation` and
  `eve-fw:HASH-generic` in its cache, so the evaluation eve job is self-contained.

## Changelog notes

No user-facing changes. Fixes the evaluation platform build to include the
generic firmware package variant that was previously missing.

## PR Backports

- 16.0-stable: To be backported if evaluation builds exist there.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)