### PR TITLE
pkg/kube: symlink host-local into PATH for k3s v1.34+ compatibility

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -305,6 +305,12 @@ check_start_k3s() {
         # Remove stale flannel VXLAN device before starting k3s.
         ip link del flannel.1 2>/dev/null || true
 
+        # Ensure CNI plugins are findable in PATH (required by k3s v1.34+).
+        # host-local is used by flannel for IPAM but lives only in /opt/cni/bin,
+        # which is not in the default PATH. Without this symlink k3s agent init
+        # blocks forever and cluster-reset never proceeds.
+        ln -sf /opt/cni/bin/host-local /usr/bin/host-local
+
         # start the k3s server now
         nohup /usr/bin/k3s server &
 

--- a/pkg/kube/cluster-update.sh
+++ b/pkg/kube/cluster-update.sh
@@ -79,6 +79,9 @@ update_k3s() {
     }
     logmsg "Initializing K3S version $dst_k3s_version"
     ln -s /var/lib/k3s/bin/* /usr/bin
+    # Ensure host-local CNI plugin is in PATH (required by k3s v1.34+).
+    # /opt/cni/bin is not in PATH; k3s agent init uses exec.LookPath("host-local").
+    ln -sf /opt/cni/bin/host-local /usr/bin/host-local
     trigger_k3s_selfextraction
     link_multus_into_k3s
     touch /var/lib/k3s_installed_unpacked


### PR DESCRIPTION
# Description

k3s v1.34+ validates CNI plugins via exec.LookPath() during agent init. host-local (used by flannel for IPAM) lives in /opt/cni/bin which is not in the default PATH, causing:

  failed to find host-local: executable file not found in $PATH

This blocks the k3s server from reaching ready state  prevents cluster-reset from proceeding during etcd restore, leaving the cluster permanently stuck until the symlink is manually placed.

Fix: create /usr/bin/host-local -> /opt/cni/bin/host-local before each k3s start in check_start_k3s() and after k3s binary install in update_k3s().

## How to test and validate this PR

SSH into eve-k cluster node and enter kube using "eve enter kube"

k3s-stop
k3s server --cluster-reset --cluster-reset-restore-path=/var/lib/rancher/k3s/server/db/snapshots/<snapshot-name>
k3s-start
ls -la /usr/bin/host-local

The link should exist

## Changelog notes

pkg/kube: symlink host-local into PATH for k3s v1.34+ compatibility

## PR Backports


```text
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```


## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
