### PR TITLE
Fix boot measurement on grub 2.12

### DIFF
--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -26,7 +26,7 @@ RUN eve-alpine-deploy.sh
 # list of grub modules that are portable between x86_64 and aarch64
 ENV GRUB_MODULES_PORT="part_gpt fat ext2 iso9660 squash4 gzio linux acpi normal cpio crypto disk boot crc64 \
 search_disk_uuid search_part_uuid search_part_label search_label xzio xfs video gfxterm serial gptprio chain probe reboot regexp smbios \
-part_msdos cat echo test configfile loopback net tftp http true"
+part_msdos cat echo test configfile loopback net tftp http true gcry_sha256"
 
 FROM grub-build-base AS grub-build-amd64
 ENV GRUB_MODULES="multiboot multiboot2 efi_uga efi_gop gpt measurefs efinet getenv"


### PR DESCRIPTION
# Description

Enable module `gcry_sha256`. This module implements the SHA256 algorithm and is needed by the `measurefs` function.

This fixes the following error during boot measurement:

```
Setting linuxkit_cmdline from (hd0,gpt2)/boot/cmdline
measurefs: Measuring hd0,gpt2 into PCR-13
error: unknown hash algorithm.
```

## How to test and validate this PR

Should be covered by regular tests with TPM.

## Changelog notes

None. (This is just a hot fix for the last PR merged to master, no need to make any warnings on Changelog).

## PR Backports

This is only on master, no backports needed.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.