### PR TITLE
pkg/gpt-tools: fix cgpt static build for riscv64

### DIFF
--- a/pkg/gpt-tools/Dockerfile
+++ b/pkg/gpt-tools/Dockerfile
@@ -1,11 +1,27 @@
 FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
-ENV BUILD_PKGS gcc make file patch libc-dev util-linux-dev linux-headers openssl-dev util-linux-dev util-linux-static g++ tar coreutils
+ENV BUILD_PKGS="gcc make file patch libc-dev linux-headers openssl-dev g++ tar coreutils"
+# util-linux-static on riscv64 is broken; we build libuuid from source instead (see below).
+ENV BUILD_PKGS_amd64="util-linux-static util-linux-dev"
+ENV BUILD_PKGS_arm64="util-linux-static util-linux-dev"
+ENV BUILD_PKGS_riscv64="sqlite-dev"
 RUN eve-alpine-deploy.sh
 
-ENV POPT_VERSION 1.16
-ENV GPTFDISK_VERSION 1.0.3
-ENV VBOOT_REPO   https://github.com/coreboot/vboot.git
-ENV VBOOT_COMMIT ed6cb4054134efdd67215d9504f501cd36030d6a
+ENV POPT_VERSION=1.16
+ENV GPTFDISK_VERSION=1.0.3
+ENV VBOOT_REPO=https://github.com/coreboot/vboot.git
+ENV VBOOT_COMMIT=ed6cb4054134efdd67215d9504f501cd36030d6a
+
+ARG TARGETARCH
+ADD https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.tar.gz /tmp/ul.tar.gz
+RUN if [ "${TARGETARCH}" = "riscv64" ]; then \
+      tar -xzf /tmp/ul.tar.gz -C /tmp/ && \
+      cd /tmp/util-linux-2.41 && \
+      ./configure --enable-static --disable-shared && \
+      make libuuid.la && \
+      cp .libs/libuuid.a /usr/lib/libuuid.a && \
+      mkdir -p /usr/include/uuid && \
+      cp libuuid/src/uuid.h /usr/include/uuid/uuid.h; \
+    fi
 
 #
 # Step 1: Install SGDISK

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -150,7 +150,7 @@ fi
 
 FROM lfedge/eve-fscrypt:2c0a31f72c87233b31f9bc2fa166f18839484649 AS fscrypt
 FROM lfedge/eve-dnsmasq:f5a9c3cbb477cfc8b386bea4f7e743eb1c25833a AS dnsmasq
-FROM lfedge/eve-gpt-tools:dc06bcbe9d855bcaed4817e9dbad346d0b785529 AS gpttools
+FROM lfedge/eve-gpt-tools:e29df0ac2b84b121b5f11455d68edffeb4c97c61 AS gpttools
 
 # collector collects everything together and then does any processing like stripping binaries.
 # We use this interim "collector" so that we can do processing.


### PR DESCRIPTION
# Description

For some reason cgpt does not find a symbol from libuuid when compiling on arm64 for riscv64; so, build libuuid manually when building for riscv64

## How to test and validate this PR

Build on arm64 for riscv64 without using the docker or linuxkit cache for pkg/gpt-tools.

## Changelog notes

Fix riscv64 build

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 16.0-stable: no, because issue was introduced with bumping to alpine 3.22
- 14.5-stable
- 13.4-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
