### PR TITLE
Makefile: lower rootfs size limit to 285MB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,7 +476,7 @@ else
             ROOTFS_MAXSIZE_MB=9999
         # nvidia platform requires more space
         else ifeq (, $(findstring nvidia,$(PLATFORM)))
-            ROOTFS_MAXSIZE_MB=290
+            ROOTFS_MAXSIZE_MB=285
         else
             ROOTFS_MAXSIZE_MB=450
         endif


### PR DESCRIPTION
# Description

The upgrade to Alpine 3.22 reduced the image size, so the ROOTFS_MAXSIZE_MB constraint can be tightened from 290MB to 285MB to reflect the new baseline.

## How to test and validate this PR

`make pkgs live` compiles without error

## Changelog notes

Build improvement

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 16.0-stable: no
- 14.5-stable: no
- 13.4-stable: no



## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR


And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
