### PR TITLE
pkg/alpine: update zlib to 1.3.2-r0 from Alpine main and add efibootmanager package

### DIFF
--- a/pkg/alpine/mirrors/3.22/main
+++ b/pkg/alpine/mirrors/3.22/main
@@ -163,6 +163,7 @@ coreutils
 coreutils-env
 coreutils-fmt
 coreutils-sha512sum
+cryptsetup
 cryptsetup-dev
 cryptsetup-libs
 curl

--- a/pkg/alpine/mirrors/3.22/main
+++ b/pkg/alpine/mirrors/3.22/main
@@ -194,6 +194,8 @@ e2fsprogs
 e2fsprogs-dev
 e2fsprogs-extra
 e2fsprogs-libs
+efibootmgr
+efivar-libs
 elfutils
 elfutils-dev
 ethtool

--- a/pkg/apparmor/Dockerfile
+++ b/pkg/apparmor/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV BUILD_PKGS linux-headers musl-dev musl-utils musl-libintl git gcc g++ \
                autoconf autoconf-archive automake libtool make flex bison \
                bash sed gettext

--- a/pkg/bpftrace/Dockerfile
+++ b/pkg/bpftrace/Dockerfile
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 
 ENV BUILD_PKGS make gcc g++ git perl linux-headers musl-dev cmake zlib-dev bcc-dev libbpf-dev cereal flex bison llvm20-libs llvm20-dev llvm20-static llvm20-gtest clang-dev clang-static pahole gtest-dev bash libxml2-dev curl-dev binutils-dev libpcap-dev
 
@@ -44,7 +44,7 @@ COPY --from=build /usr/lib/libbpf.so.1.5.1 /bpftrace-aotrt/usr/lib/libbpf.so.1.5
 COPY --from=build /usr/lib/libbpf.so.1 /bpftrace-aotrt/usr/lib/libbpf.so.1
 COPY --from=build /usr/lib/libbpf.so /bpftrace-aotrt/usr/lib/libbpf.so
 COPY --from=build /usr/lib/libelf.so.1 /bpftrace-aotrt/usr/lib/libelf.so.1
-COPY --from=build /usr/lib/libz.so.1.3.1 /bpftrace-aotrt/usr/lib/libz.so.1.3.1
+COPY --from=build /usr/lib/libz.so.1.3.2 /bpftrace-aotrt/usr/lib/libz.so.1.3.2
 COPY --from=build /usr/lib/libz.so.1 /bpftrace-aotrt/usr/lib/libz.so.1
 COPY --from=build /usr/lib/libbcc_bpf.so.0 /bpftrace-aotrt/usr/lib/libbcc_bpf.so.0
 COPY --from=build /usr/lib/libstdc++.so.6 /bpftrace-aotrt/usr/lib/libstdc++.so.6

--- a/pkg/bsp-imx/Dockerfile
+++ b/pkg/bsp-imx/Dockerfile
@@ -4,10 +4,10 @@
 ARG BUILD_PKGS_BASE="bash binutils-dev build-base bc bison flex openssl-dev util-linux-dev swig gnutls-dev perl python3 python3-dev py3-setuptools py3-pycryptodome py3-elftools"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36
 
 # OPTEE-OS images
-FROM lfedge/eve-optee-os:1787c77ff84c8c4d2dc5060a6d12f839b0a285ee AS optee-os
+FROM lfedge/eve-optee-os:c67d22abf143aa550378fce60a625be54eb555a8 AS optee-os
 
 # hadolint ignore=DL3006
 FROM ${EVE_ALPINE_IMAGE} AS build-native

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -8,9 +8,9 @@
 # has a fast path for stack unwinding. This also happens
 # to be a perfect place to put any other kind of debug info
 # into the package: see abuild/etc/abuild.conf.
-FROM lfedge/eve-recovertpm:b8e2d39a50db29889a8ea2f40a920472b6e73cca AS recovertpm
-FROM lfedge/eve-bpftrace:71764d771e56a79b4af10a36d34d62e1981174c4 AS bpftrace
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-recovertpm:7f11c2f2f9d8527b7598b831b9f6e2e477b5b63a AS recovertpm
+FROM lfedge/eve-bpftrace:87c1d8f49d9b872c95e99b873c0e96a58fc83142 AS bpftrace
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV BUILD_PKGS="abuild curl tar make linux-headers patch g++ git gcc gpg gettext gettext-static ncurses-dev jq autoconf openssl-dev zlib-dev zlib-static gpg-agent"
 # Feel free to add additional packages here, but be aware that
 # EVE's rootfs image can be no larger than 300Mb (and don't

--- a/pkg/debug/Dockerfile.spec
+++ b/pkg/debug/Dockerfile.spec
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:745ae9066273c73b0fd879c4ba4ff626a8392d04
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36
 
 ENV BUILD_PKGS="jq pciutils usbutils lsblk"
 

--- a/pkg/dnsmasq/Dockerfile
+++ b/pkg/dnsmasq/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV BUILD_PKGS gcc make patch libc-dev linux-headers tar xz coreutils
 RUN eve-alpine-deploy.sh
 

--- a/pkg/dom0-ztools/Dockerfile
+++ b/pkg/dom0-ztools/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS zfs
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS zfs
 ENV BUILD_PKGS="git patch ca-certificates util-linux build-base gettext-dev libtirpc-dev automake autoconf \
     libtool linux-headers attr-dev e2fsprogs-dev glib-dev openssl-dev util-linux-dev coreutils"
 ENV PKGS="ca-certificates util-linux libintl libuuid libtirpc libblkid libcrypto3 zlib"

--- a/pkg/edgeview/Dockerfile
+++ b/pkg/edgeview/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV BUILD_PKGS git
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables
 RUN eve-alpine-deploy.sh

--- a/pkg/eve/Dockerfile.in
+++ b/pkg/eve/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS tools
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS tools
 ENV PKGS="qemu-img tar u-boot-tools coreutils dosfstools"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/fscrypt/Dockerfile
+++ b/pkg/fscrypt/Dockerfile
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build-base
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build-base
 
 FROM build-base AS build-amd64
 FROM build-base AS build-arm64

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 ARG PLATFORM=generic
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build-base
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build-base
 
 ARG TARGETARCH
 
@@ -96,7 +96,7 @@ ADD https://hailo-hailort.s3.eu-west-2.amazonaws.com/Hailo8/${HAILO_FW_VERSION}/
 
 # generate initrd for Intel's and AMD's microcode
 # it makes sense only for x86_64 platform
-FROM --platform=${TARGETPLATFORM} lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS ucode-build-common
+FROM --platform=${TARGETPLATFORM} lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS ucode-build-common
 RUN mkdir -p /boot /tmp/ucode/intel /tmp/ucode/amd /usr/share/licenses/ucode
 
 FROM ucode-build-common AS ucode-build-amd64
@@ -137,7 +137,7 @@ FROM ucode-build-common AS ucode-build-arm64
 FROM ucode-build-common AS ucode-build-riscv64
 FROM ucode-build-${TARGETARCH} AS ucode-build
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS compactor-common
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS compactor-common
 ENTRYPOINT []
 WORKDIR /
 COPY --from=build /lib/firmware/regulatory* /lib/firmware/
@@ -215,7 +215,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
     fi
 
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS compactor-full
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS compactor-full
 # get all possible FW
 COPY --from=build /lib/firmware/ /lib/firmware/
 

--- a/pkg/gpt-tools/Dockerfile
+++ b/pkg/gpt-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV BUILD_PKGS="gcc make file patch libc-dev linux-headers openssl-dev g++ tar coreutils"
 # util-linux-static on riscv64 is broken; we build libuuid from source instead (see below).
 ENV BUILD_PKGS_amd64="util-linux-static util-linux-dev"

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) 2025-2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS grub-build-base
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS grub-build-base
 ENV BUILD_PKGS="automake \
                make \
                bison \

--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV BUILD_PKGS cairo-dev jpeg-dev libpng-dev gcc make libc-dev openssl-dev libvncserver-dev file patch
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs p11-kit cairo jpeg libpng libvncserver
 RUN eve-alpine-deploy.sh

--- a/pkg/installer/Dockerfile
+++ b/pkg/installer/Dockerfile
@@ -28,10 +28,10 @@ RUN cargo sbom > sbom.spdx.json
 
 RUN cp "/usr/local/my-installer/target/$CARGO_BUILD_TARGET/release/installer" /usr/local/my-installer/target/installer
 
-FROM lfedge/eve-debug:9e8c1c103b275e54537924c65aa3da622e4c09a1 AS debug
+FROM lfedge/eve-debug:07bab7d7d72a4e89b2efd3faa5b4ece1435e1bca AS debug
 
 # Dockerfile to build installer img initrd
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 ENV BUILD_PKGS="mkinitfs grep patch make coreutils musl-dev gcc g++ perl \
     autoconf automake libtool file bsd-compat-headers libc-dev \

--- a/pkg/ipxe/Dockerfile
+++ b/pkg/ipxe/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 
 ENV BUILD_PKGS="patch make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev"
 RUN eve-alpine-deploy.sh

--- a/pkg/kdump/Dockerfile
+++ b/pkg/kdump/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 
 ENV BUILD_PKGS patch curl make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev elfutils-dev libbz2
 ENV PKGS xz-libs elfutils-dev libbz2

--- a/pkg/kexec/Dockerfile
+++ b/pkg/kexec/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 
 ENV BUILD_PKGS patch curl make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev elfutils-dev libbz2
 ENV PKGS xz-libs util-linux elfutils-dev libbz2

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables curl openrc \
          open-iscsi libvirt libvirt-client util-linux grep findutils jq \
          cni-plugins nfs-utils inotify-tools

--- a/pkg/measure-config/Dockerfile
+++ b/pkg/measure-config/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV BUILD_PKGS git
 ENV PKGS alpine-baselayout musl-utils
 RUN eve-alpine-deploy.sh

--- a/pkg/memory-monitor/Dockerfile
+++ b/pkg/memory-monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS memory-monitor-build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS memory-monitor-build
 
 ENV BUILD_PKGS gcc musl-dev make linux-headers cmake build-base
 ENV PKGS alpine-baselayout curl strace

--- a/pkg/mkconf/Dockerfile
+++ b/pkg/mkconf/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 
 ENV PKGS mtools dosfstools
 RUN eve-alpine-deploy.sh

--- a/pkg/mkimage-iso-efi/Dockerfile
+++ b/pkg/mkimage-iso-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 
 ENV PKGS="dosfstools libarchive-tools binutils mtools xorriso mkinitfs squashfs-tools"
 RUN eve-alpine-deploy.sh

--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -5,7 +5,7 @@
 #   /EFI/BOOT/grub.cfg - Chainloads main bootloader
 #   /UsbInvocationScript.txt - Enables USB boot on Dell 3000 series
 #
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 ENV BUILD_PKGS="grep patch git make gcc linux-headers musl-dev autoconf automake pkgconfig kmod-dev util-linux-dev cryptsetup-dev lddtree libgcc mkinitfs"
 ENV PKGS="mtools dosfstools libarchive-tools sgdisk e2fsprogs util-linux squashfs-tools coreutils tar dmidecode \

--- a/pkg/mkrootfs-ext4/Dockerfile
+++ b/pkg/mkrootfs-ext4/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools sfdisk sgdisk xfsprogs \
          e2fsprogs util-linux coreutils multipath-tools squashfs-tools

--- a/pkg/mkrootfs-squash/Dockerfile
+++ b/pkg/mkrootfs-squash/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools sfdisk sgdisk \
     xfsprogs e2fsprogs util-linux coreutils multipath-tools squashfs-tools

--- a/pkg/monitor/Dockerfile
+++ b/pkg/monitor/Dockerfile
@@ -49,7 +49,7 @@ RUN cargo sbom > sbom.spdx.json
 RUN cp /app/target/$CARGO_BUILD_TARGET/release/monitor /app/target/
 
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS runtime
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS runtime
 ENV PKGS="kbd pciutils usbutils"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV BUILD_PKGS git
 ENV PKGS coreutils
 RUN eve-alpine-deploy.sh

--- a/pkg/nvidia/Dockerfile
+++ b/pkg/nvidia/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG PLATFORM=generic
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build-base
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build-base
 ENV BUILD_PKGS="autoconf automake build-base coreutils gettext git glib-dev libtool libmd-dev ncurses-dev tar xz-dev yq zstd-dev dpkg"
 
 RUN eve-alpine-deploy.sh

--- a/pkg/optee-os/Dockerfile
+++ b/pkg/optee-os/Dockerfile
@@ -4,7 +4,7 @@
 ARG BUILD_PKGS_BASE="autoconf automake bash binutils binutils-dev build-base bc bison curl dtc expat flex openssl-dev util-linux-dev swig gnutls-dev perl python3 python3-dev py3-setuptools py3-pycryptodome py3-elftools py3-cryptography"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36
 
 # hadolint ignore=DL3006
 FROM ${EVE_ALPINE_IMAGE} AS build-native

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -8,10 +8,10 @@ ARG BUILD_PKGS_BASE="git gcc linux-headers libc-dev make linux-pam-dev m4 findut
                      libintl libuuid libtirpc libblkid libcrypto3 zlib tar"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36
 
-FROM lfedge/eve-uefi:08cb53bb347ac5da6752c5136543ff75af25486d AS uefi-build
-FROM lfedge/eve-dom0-ztools:a6d70d175f7a129bef5d1cac2aea9db637e3f839 AS zfs
+FROM lfedge/eve-uefi:557fd831485ef3e019b311c378e7ecf2b4c05f01 AS uefi-build
+FROM lfedge/eve-dom0-ztools:41e448a70640e7b6f98d19f790cf35cf579fd0db AS zfs
 RUN mkdir /out
 # copy zfs-related files from dom0-ztools using prepared list of files
 RUN while read -r x; do \
@@ -148,9 +148,9 @@ RUN --mount=type=cache,target=/root/.cache/go-build if [ "${TEST_TOOLS}" = "y" ]
     GOBIN=/final/opt/ GOFLAGS="" go install gotest.tools/gotestsum@v1.7.0; \
 fi
 
-FROM lfedge/eve-fscrypt:2c0a31f72c87233b31f9bc2fa166f18839484649 AS fscrypt
-FROM lfedge/eve-dnsmasq:f5a9c3cbb477cfc8b386bea4f7e743eb1c25833a AS dnsmasq
-FROM lfedge/eve-gpt-tools:e29df0ac2b84b121b5f11455d68edffeb4c97c61 AS gpttools
+FROM lfedge/eve-fscrypt:33875411fe54615d0c0c1f9637616c8012f488da AS fscrypt
+FROM lfedge/eve-dnsmasq:fe6241610dc17be349b02ed4c160c8b7bee9d05a AS dnsmasq
+FROM lfedge/eve-gpt-tools:cd4cfc1cac9885c35453bdc4ac88ab60eb667d05 AS gpttools
 
 # collector collects everything together and then does any processing like stripping binaries.
 # We use this interim "collector" so that we can do processing.

--- a/pkg/recovertpm/Dockerfile
+++ b/pkg/recovertpm/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 
 # build the tpm-recovery tool
 WORKDIR /

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV BUILD_PKGS gcc musl-dev linux-headers
 RUN eve-alpine-deploy.sh
 

--- a/pkg/sources/Dockerfile
+++ b/pkg/sources/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS tools
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS tools
 
 COPY collected_sources.tar.gz /var/collected_sources.tar.gz
 RUN mkdir -p /var/sources && tar -C /var/sources -xzf /var/collected_sources.tar.gz

--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV PKGS="alpine-baselayout musl-utils bash glib squashfs-tools util-linux e2fsprogs e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/u-boot/Dockerfile
+++ b/pkg/u-boot/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build-base
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build-base
 ENV BUILD_PKGS bash binutils-dev build-base bc bison flex openssl-dev python3 swig dtc
 ENV BUILD_PKGS_amd64 python3-dev py-pip
 RUN eve-alpine-deploy.sh

--- a/pkg/udev/Dockerfile
+++ b/pkg/udev/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV PKGS="udev kmod"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/uefi/Dockerfile
+++ b/pkg/uefi/Dockerfile
@@ -10,7 +10,7 @@
 #   git clone https://git.linaro.org/uefi/uefi-tools.git
 #   ./uefi-tools/edk2-build.sh -b DEBUG -b RELEASE all
 #
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV BUILD_PKGS make gcc g++ python3 libuuid nasm util-linux-dev bash git util-linux patch
 ENV BUILD_PKGS_amd64 iasl
 ENV BUILD_PKGS_arm64 iasl

--- a/pkg/vector/Dockerfile
+++ b/pkg/vector/Dockerfile
@@ -63,7 +63,7 @@ RUN strip "/app/target/$CARGO_BUILD_TARGET/release/vector"
 RUN cargo sbom > sbom.spdx.json
 RUN cp "/app/target/$CARGO_BUILD_TARGET/release/vector" /app/target/
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS runtime
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS runtime
 ENV PKGS="inotify-tools"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -3,8 +3,8 @@
 # Copyright (c) 2023-2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-dom0-ztools:a6d70d175f7a129bef5d1cac2aea9db637e3f839 AS dom0
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-dom0-ztools:41e448a70640e7b6f98d19f790cf35cf579fd0db AS dom0
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV BUILD_PKGS="gcc g++ autoconf automake libtool make openssl-dev libtasn1-dev \
     json-glib-dev gnutls bash expect gawk socat libseccomp-dev gmp-dev \
     musl-utils autoconf-archive git json-c json-c-dev libcurl curl-dev \

--- a/pkg/watchdog/Dockerfile
+++ b/pkg/watchdog/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS watchdog-build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS watchdog-build
 ENV BUILD_PKGS build-base file libtirpc-dev linux-headers tar util-linux
 ENV PKGS alpine-baselayout musl-utils libsmartcols
 RUN eve-alpine-deploy.sh

--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023-2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV BUILD_PKGS meson ninja git libc-dev glib-dev make gcc udev dbus-dev libgudev-dev
 ENV PKGS alpine-baselayout dbus glib kmod-dev libgudev
 RUN eve-alpine-deploy.sh

--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -3,8 +3,8 @@
 # Copyright (c) 2023-2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-uefi:08cb53bb347ac5da6752c5136543ff75af25486d AS uefi-build
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS runx-build
+FROM lfedge/eve-uefi:557fd831485ef3e019b311c378e7ecf2b4c05f01 AS uefi-build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS runx-build
 ENV BUILD_PKGS="mkinitfs gcc musl-dev e2fsprogs chrony agetty"
 RUN eve-alpine-deploy.sh
 
@@ -20,7 +20,7 @@ RUN gcc -s -o /chroot2 /tmp/chroot2.c -Wall -Werror
 RUN gcc -s -o /hacf /tmp/hacf.c -Wall -Werror
 RUN mkinitfs -n -F base -i /init-initrd -o /runx-initrd
 
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV BUILD_PKGS="\
     gcc make libc-dev dev86 xz-dev perl bash python3-dev \
     gettext iasl util-linux-dev ncurses-dev glib-dev \

--- a/pkg/xen/Dockerfile
+++ b/pkg/xen/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:7b892c4653d567eb3b6a306064c3bc7fc14f6bab AS kernel-build
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS kernel-build
 
 ENV BUILD_PKGS argp-standalone automake bash bc binutils-dev bison build-base \
                diffutils flex git gmp-dev gnupg installkernel kmod \

--- a/tools/compare-eve-alpine-mirror.sh
+++ b/tools/compare-eve-alpine-mirror.sh
@@ -1,0 +1,150 @@
+#!/bin/sh
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Compare Alpine package versions between two lfedge/eve-alpine mirror images.
+#
+# By default reads the local image hash from pkg/pillar/Dockerfile and fetches
+# the upstream (lf-edge/eve master) hash via the GitHub API.
+#
+# Usage:
+#   compare-eve-alpine-mirror.sh [LOCAL_HASH [MASTER_HASH]]
+#
+# Requires: docker
+# Optional: gh (GitHub CLI) or curl, to auto-detect the master hash
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PILLAR_DOCKERFILE="${REPO_ROOT}/pkg/pillar/Dockerfile"
+
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+# --- Resolve image hashes ---
+
+if [ -n "${1:-}" ]; then
+    LOCAL_HASH="$1"
+else
+    LOCAL_HASH=$(grep -m1 'ARG EVE_ALPINE_IMAGE=' "${PILLAR_DOCKERFILE}" \
+                 | sed 's|.*lfedge/eve-alpine:||')
+    [ -n "${LOCAL_HASH}" ] \
+        || die "Could not read local eve-alpine hash from ${PILLAR_DOCKERFILE}"
+fi
+
+if [ -n "${2:-}" ]; then
+    MASTER_HASH="$2"
+elif command -v gh >/dev/null 2>&1; then
+    MASTER_HASH=$(gh api repos/lf-edge/eve/contents/pkg/pillar/Dockerfile \
+                      --jq '.content' \
+                  | base64 -d \
+                  | grep -m1 'ARG EVE_ALPINE_IMAGE=' \
+                  | sed 's|.*lfedge/eve-alpine:||')
+    [ -n "${MASTER_HASH}" ] \
+        || die "Could not read master eve-alpine hash from lf-edge/eve via gh"
+elif command -v curl >/dev/null 2>&1; then
+    MASTER_HASH=$(curl -sf \
+        "https://raw.githubusercontent.com/lf-edge/eve/master/pkg/pillar/Dockerfile" \
+                  | grep -m1 'ARG EVE_ALPINE_IMAGE=' \
+                  | sed 's|.*lfedge/eve-alpine:||')
+    [ -n "${MASTER_HASH}" ] \
+        || die "Could not read master eve-alpine hash from lf-edge/eve via curl"
+else
+    die "Pass MASTER_HASH as the second argument, or install gh or curl"
+fi
+
+printf 'Local  lfedge/eve-alpine: %s\n' "${LOCAL_HASH}"
+printf 'Master lfedge/eve-alpine: %s\n\n' "${MASTER_HASH}"
+
+if [ "${LOCAL_HASH}" = "${MASTER_HASH}" ]; then
+    printf 'Hashes are identical — no comparison needed.\n'
+    exit 0
+fi
+
+# --- Ensure local image is available ---
+# The hash from the Dockerfile may refer to an image that exists only in the
+# linuxkit builder state (never loaded into the Docker daemon).  Fall back to
+# the most-recently-pulled local eve-alpine image in that case.
+
+if ! docker image inspect "lfedge/eve-alpine:${LOCAL_HASH}" >/dev/null 2>&1; then
+    FALLBACK=$(docker images lfedge/eve-alpine --format '{{.Tag}}' \
+               | grep -v 'amd64\|arm64\|riscv64' | head -1)
+    if [ -n "${FALLBACK}" ]; then
+        printf 'NOTE: lfedge/eve-alpine:%s not in local daemon; using %s instead.\n\n' \
+               "${LOCAL_HASH}" "${FALLBACK}"
+        LOCAL_HASH="${FALLBACK}"
+    else
+        die "Local image lfedge/eve-alpine:${LOCAL_HASH} is not available. Build pkg/alpine first."
+    fi
+fi
+
+# --- APKINDEX extraction ---
+# Outputs "name version" lines sorted by name from the mirror inside the image.
+# Returns non-zero and prints nothing if the image is unavailable.
+
+extract_pkgs() {
+    local image="$1"     # image ref without arch suffix
+    local dtag="$2"      # docker arch suffix: amd64, arm64
+    local apkarch="$3"   # apk arch dir: x86_64, aarch64
+    docker run --rm "${image}-${dtag}" sh -c \
+        "tar -xzf /mirror/3.22/${apkarch}/APKINDEX.tar.gz -O APKINDEX 2>/dev/null" \
+        2>/dev/null \
+    | awk '/^P:/{p=substr($0,3)} /^V:/{if(p){print p" "substr($0,3)}; p=""}' \
+    | sort
+}
+
+# --- Per-architecture comparison ---
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+for PAIR in "amd64:x86_64" "arm64:aarch64"; do
+    DTAG="${PAIR%%:*}"
+    APKARCH="${PAIR##*:}"
+
+    LOCAL_FILE="${WORK_DIR}/local_${APKARCH}.txt"
+    MASTER_FILE="${WORK_DIR}/master_${APKARCH}.txt"
+
+    extract_pkgs "lfedge/eve-alpine:${LOCAL_HASH}"  "${DTAG}" "${APKARCH}" > "${LOCAL_FILE}"  || true
+    extract_pkgs "lfedge/eve-alpine:${MASTER_HASH}" "${DTAG}" "${APKARCH}" > "${MASTER_FILE}" || true
+
+    LOCAL_COUNT=$(wc -l < "${LOCAL_FILE}")
+    MASTER_COUNT=$(wc -l < "${MASTER_FILE}")
+
+    if [ "${LOCAL_COUNT}" -eq 0 ] && [ "${MASTER_COUNT}" -eq 0 ]; then
+        printf '=== %s: skipped (neither image available locally) ===\n\n' "${APKARCH}"
+        continue
+    fi
+
+    printf '=== %s ===\n\n' "${APKARCH}"
+    printf 'Package count: master=%d  local=%d\n\n' "${MASTER_COUNT}" "${LOCAL_COUNT}"
+
+    DIFF_OUT=$(diff "${MASTER_FILE}" "${LOCAL_FILE}" || true)
+
+    if [ -z "${DIFF_OUT}" ]; then
+        printf 'No differences.\n\n'
+        continue
+    fi
+
+    printf '%-10s %-36s %-20s %s\n' "STATUS" "PACKAGE" "MASTER" "LOCAL"
+    printf '%-10s %-36s %-20s %s\n' "------" "-------" "------" "-----"
+    printf '%s\n' "${DIFF_OUT}" \
+    | awk '
+        /^< / { m[$2] = $3 }
+        /^> / { l[$2] = $3 }
+        END {
+            for (pkg in l) {
+                if (pkg in m) {
+                    if (l[pkg] != m[pkg])
+                        printf "CHANGED    %-36s %-20s %s\n", pkg, m[pkg], l[pkg]
+                } else {
+                    printf "NEW        %-36s %-20s %s\n", pkg, "(absent)", l[pkg]
+                }
+            }
+            for (pkg in m)
+                if (!(pkg in l))
+                    printf "REMOVED    %-36s %-20s %s\n", pkg, m[pkg], "(absent)"
+        }
+    ' | sort -k1,1 -k2,2
+    printf '\n'
+done


### PR DESCRIPTION
# Description

zlib 1.3.2-r0 addresses https://github.com/advisories/GHSA-7687-3v4j-49fr. 
This updates eve-alpine to pull in that fix and add the efibootmanager and cryptsetup packages.

These alpine packages get updated versions:
  ┌────────────────────────────────────┬───────────────┬────────────────────┐   
  │             Package(s)             │    Master     │    This branch     │   
  │                                    │  (7b892c46)   │     (a6e378f7)     │   
  ├────────────────────────────────────┼───────────────┼────────────────────┤   
  │ zlib, zlib-dev, zlib-static        │ 1.3.1-r2      │ 1.3.2-r0 ←         │   
  │                                    │               │ CVE-2026-22184     │   
  ├────────────────────────────────────┼───────────────┼────────────────────┤   
  │ libcrypto3, libssl3, openssl,      │ 3.5.5-r0      │ 3.5.6-r0           │   
  │ openssl-dev                        │               │                    │   
  ├────────────────────────────────────┼───────────────┼────────────────────┤   
  │ musl, musl-dev, musl-libintl,      │ 1.2.5-r10     │ 1.2.5-r12          │   
  │ musl-utils                         │               │                    │   
  ├────────────────────────────────────┼───────────────┼────────────────────┤   
  │ libcap, libcap2, libcap-getcap,    │ 2.76-r0       │ 2.78-r0            │   
  │ libcap-setcap, libcap-utils        │               │                    │   
  ├────────────────────────────────────┼───────────────┼────────────────────┤   
  │ libpng, libpng-dev                 │ 1.6.56-r0     │ 1.6.57-r0          │   
  ├────────────────────────────────────┼───────────────┼────────────────────┤   
  │ python3 and variants (pyc, -dev,   │ 3.12.12-r0    │ 3.12.13-r0         │
  │ -pyc, -pycache-pyc0)               │               │                    │   
  └────────────────────────────────────┴───────────────┴────────────────────┘

A new script `tools/compare-eve-alpine-mirror.sh` is included to make
this kind of comparison easy to reproduce and run after future rebuilds.
It reads the local and master eve-alpine image hashes from
`pkg/pillar/Dockerfile` and the GitHub API respectively, extracts the
APKINDEX from each image's embedded mirror, and prints a table of
CHANGED, NEW, and REMOVED packages per architecture.

## How to test and validate this PR

docker run lfedge/eve:<version> sbom >sbom.json
cat sbom.json | jq | grep zlib | grep 1.3.1-r2
should find no matches.

## Changelog notes

Update zlib to address https://github.com/advisories/GHSA-7687-3v4j-49fr.

## PR Backports

- 16.0-stable - no
- 14.5-stable - no
- 13.4-stable - no

## Checklist

- [X] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [X] I've set the proper labels to this PR

- [X] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.