### PR TITLE
[16.0-stable] Fix an issue of edge-node clustering interface using logical-label

### DIFF
--- a/pkg/pillar/cmd/zedkube/clusterstatus.go
+++ b/pkg/pillar/cmd/zedkube/clusterstatus.go
@@ -116,7 +116,7 @@ func (z *zedkube) publishKubeConfigStatus() {
 	status := types.EdgeNodeClusterStatus{
 		ClusterName:      z.clusterConfig.ClusterName,
 		ClusterID:        z.clusterConfig.ClusterID,
-		ClusterInterface: z.clusterConfig.ClusterInterface,
+		ClusterInterface: z.resolveClusterInterfaceName(),
 		ClusterIPPrefix:  z.clusterConfig.ClusterIPPrefix,
 		ClusterIPIsReady: z.clusterIPIsReady,
 		IsWorkerNode:     z.clusterConfig.IsWorkerNode,
@@ -158,6 +158,17 @@ func (z *zedkube) publishKubeConfigStatus() {
 
 	// publish the cluster status for the kube container
 	z.pubEdgeNodeClusterStatus.Publish("global", status)
+}
+
+func (z *zedkube) resolveClusterInterfaceName() string {
+	if z.clusterConfig.ClusterInterface == "" {
+		return ""
+	}
+	port := z.deviceNetworkStatus.LookupPortByLogicallabel(z.clusterConfig.ClusterInterface)
+	if port == nil {
+		return ""
+	}
+	return port.IfName
 }
 
 func (z *zedkube) decryptClusterTokenAndManifest() (string, []byte, error) {
@@ -221,7 +232,12 @@ func (z *zedkube) updateClusterIPReadiness() (changed bool) {
 			}
 		}
 	}
-	if z.clusterIPIsReady != ready {
+	resolvedName := z.resolveClusterInterfaceName()
+	ifNameChanged := z.lastPublishedClusterIfName != resolvedName
+	if ifNameChanged {
+		z.lastPublishedClusterIfName = resolvedName
+	}
+	if z.clusterIPIsReady != ready || ifNameChanged {
 		z.clusterIPIsReady = ready
 		return true
 	}

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -78,26 +78,27 @@ type zedkube struct {
 	subNodeDrainRequestBoM pubsub.Subscription
 	pubNodeDrainStatus     pubsub.Publication
 
-	networkInstanceStatusMap sync.Map
-	ioAdapterMap             sync.Map
-	deviceNetworkStatus      types.DeviceNetworkStatus
-	clusterConfig            types.EdgeNodeClusterConfig
-	config                   *rest.Config
-	appLogStarted            bool
-	appContainerLogger       *logrus.Logger
-	clusterIPIsReady         bool
-	nodeuuid                 string
-	nodeName                 string
-	isKubeStatsLeader        atomic.Bool
-	inKubeLeaderElection     atomic.Bool
-	electionFuncRunning      atomic.Bool
-	leaderIdentity           string
-	electionStartCh          chan struct{}
-	electionStopCh           chan struct{}
-	statusServer             *http.Server
-	statusServerWG           sync.WaitGroup
-	getKubePodsError         GetKubePodsError
-	drainOverrideTimer       *time.Timer
+	networkInstanceStatusMap   sync.Map
+	ioAdapterMap               sync.Map
+	deviceNetworkStatus        types.DeviceNetworkStatus
+	clusterConfig              types.EdgeNodeClusterConfig
+	config                     *rest.Config
+	appLogStarted              bool
+	appContainerLogger         *logrus.Logger
+	clusterIPIsReady           bool
+	lastPublishedClusterIfName string
+	nodeuuid                   string
+	nodeName                   string
+	isKubeStatsLeader          atomic.Bool
+	inKubeLeaderElection       atomic.Bool
+	electionFuncRunning        atomic.Bool
+	leaderIdentity             string
+	electionStartCh            chan struct{}
+	electionStopCh             chan struct{}
+	statusServer               *http.Server
+	statusServerWG             sync.WaitGroup
+	getKubePodsError           GetKubePodsError
+	drainOverrideTimer         *time.Timer
 
 	// Config Properties for Drain
 	drainTimeout                       time.Duration

--- a/pkg/pillar/dpcreconciler/linux.go
+++ b/pkg/pillar/dpcreconciler/linux.go
@@ -840,7 +840,7 @@ func (r *LinuxDpcReconciler) updateCurrentRoutes(dpc types.DevicePortConfig,
 			r.Log.Errorf("updateCurrentRoutes: ListRoutes failed for ifIndex %d: %v",
 				ifIndex, err)
 		}
-		if r.HVTypeKube && clusterStatus.ClusterInterface == port.Logicallabel {
+		if r.HVTypeKube && clusterStatus.ClusterInterface == port.IfName {
 			k3sSvcRoutes, err := r.NetworkMonitor.ListRoutes(netmonitor.RouteFilters{
 				FilterByTable: true,
 				Table:         types.KubeSvcRT,
@@ -1188,7 +1188,7 @@ func (r *LinuxDpcReconciler) getIntendedAdapters(dpc types.DevicePortConfig,
 		}
 		var staticIPs []*net.IPNet
 		if r.HVTypeKube {
-			if port.Logicallabel == clusterStatus.ClusterInterface &&
+			if port.IfName == clusterStatus.ClusterInterface &&
 				clusterStatus.ClusterIPPrefix != nil {
 				staticIPs = append(staticIPs, clusterStatus.ClusterIPPrefix)
 			}
@@ -1348,7 +1348,7 @@ func (r *LinuxDpcReconciler) getIntendedRoutes(dpc types.DevicePortConfig,
 				AdapterLL:     port.Logicallabel,
 			}, nil)
 		}
-		if r.HVTypeKube && clusterStatus.ClusterInterface == port.Logicallabel &&
+		if r.HVTypeKube && clusterStatus.ClusterInterface == port.IfName &&
 			clusterStatus.ClusterIPPrefix != nil {
 			// Ensure that packets destined for K3s services do not use the default route,
 			// but are instead routed through the cluster port. This guarantees that traffic
@@ -1963,7 +1963,7 @@ func (r *LinuxDpcReconciler) getIntendedFilterRules(gcp types.ConfigItemValueMap
 	icmpV6Rule.MatchOpts = []string{"-p", "ipv6-icmp"}
 	inputV6Rules = append(inputV6Rules, icmpV6Rule)
 
-	clusterPort := dpc.LookupPortByLogicallabel(clusterStatus.ClusterInterface)
+	clusterPort := dpc.LookupPortByIfName(clusterStatus.ClusterInterface)
 	if r.HVTypeKube && clusterPort != nil && !clusterPort.InvalidConfig &&
 		clusterPort.IfName != "" && clusterStatus.ClusterIPPrefix != nil {
 		// LookupExtInterface in k3s/pkg/agent/flannel/flannel.go will pick

--- a/pkg/pillar/types/clustertypes.go
+++ b/pkg/pillar/types/clustertypes.go
@@ -94,8 +94,8 @@ type EdgeNodeClusterStatus struct {
 	ClusterName string
 	ClusterID   UUIDandVersion
 	// ClusterInterface - Interface to be used for kubernetes cluster for the node.
-	// This can be a Management interface or an App-Shared interface. This is a logical
-	// label of the port.
+	// This can be a Management interface or an App-Shared interface. This is the
+	// resolved Linux interface name of the port.
 	ClusterInterface string
 	// ClusterIPPrefix - IP Prefix for the kubernetes cluster Node IP. This IP prefix is
 	// applied to the ClusterInterface. It can be the only IP prefix on the interface, or


### PR DESCRIPTION

# Description

- if the device has logical-label for the interface, zedkube is converting the logical-label into the interface Ifname to be used for kubernetes flannel interface
- Backport of #5720

(cherry picked from commit 8c6bb4904f630fa2a0234ff3e1c94ca935320bac)

## PR dependencies

#5720

## How to test and validate this PR

  -  Make the device model, have the interface using logical-label which is different from the Ifname
  - onboard the devices using that model
  -  configure the edge-node clustering, and select the intf w/ logical-label to use
  -  make sure the cluster is up and working

## Changelog notes

[16.0-stable] Fix an issue of edge-node clustering interface using logical-label

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
