### PR TITLE
cross-compilers: ignore pkg hash inconsistencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -558,7 +558,7 @@ $(DOCKERFILE_FROM_CHECKER): $(DOCKERFILE_FROM_CHECKER_DIR)/*.go $(DOCKERFILE_FRO
 # this next section checks that the FROM hashes for any image in any dockerfile anywhere here are consistent.
 # For example, one Dockerfile has foo:abc and the next has foo:def, it will flag them.
 # These are the packages that we are ignoring for now
-IGNORE_DOCKERFILE_HASHES_PKGS=alpine
+IGNORE_DOCKERFILE_HASHES_PKGS=alpine cross-compilers
 IGNORE_DOCKERFILE_HASHES_EVE_TOOLS=bpftrace-compiler
 
 IGNORE_DOCKERFILE_DOT_GO_DIR=$(shell find .go/ -name Dockerfile -exec echo "-i {}" \;)


### PR DESCRIPTION
# Description

as no files of this package end up in the final EVE image, it does not matter to have older versions of files (because squashfs can compress same files better)

but this relieves us from bumping cross-compilers everytime we change something in pkg/alpine

## How to test and validate this PR

change something in `pkg/alpine`, run `make check-docker-hashes-consistency`, fix all other inconsistencies, and ensure that no inconsistency was reported for `pkg/cross-compilers`.

## Changelog notes

Build improvements

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 16.0-stable: no
- 14.5-stable: no
- 13.4-stable: no



## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
