### PR TITLE
[16.0-stable] Backport URL join fixes and SAS token fix

### DIFF
--- a/pkg/edgeview/src/network.go
+++ b/pkg/edgeview/src/network.go
@@ -1075,7 +1075,12 @@ func getPeerCerts(subStr string) {
 		if basics.server != "" {
 			subStr = basics.server
 			if basics.proxy != "" {
-				subStr = subStr + "/" + basics.proxy
+				var err error
+				subStr, err = url.JoinPath(subStr, basics.proxy)
+				if err != nil {
+					fmt.Printf("error joining URL path: %v\n", err)
+					return
+				}
 			}
 		}
 		if subStr == "" {

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -381,15 +381,22 @@ func handleSyncOpResponse(ctx *downloaderContext, config types.DownloaderConfig,
 
 // cloud storage interface functions/APIs
 func constructDatastoreContext(ctx *downloaderContext, configName string, NameIsURL bool, dst types.DatastoreConfig) (*types.DatastoreContext, error) {
+	var err error
 	dpath := dst.Dpath
 	downloadURL := configName
 	if !NameIsURL {
 		downloadURL = dst.Fqdn
 		if len(dpath) > 0 {
-			downloadURL = downloadURL + "/" + dpath
+			downloadURL, err = url.JoinPath(downloadURL, dpath)
+			if err != nil {
+				return nil, err
+			}
 		}
 		if len(configName) > 0 {
-			downloadURL = downloadURL + "/" + configName
+			downloadURL, err = url.JoinPath(downloadURL, configName)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -386,17 +386,36 @@ func constructDatastoreContext(ctx *downloaderContext, configName string, NameIs
 	downloadURL := configName
 	if !NameIsURL {
 		downloadURL = dst.Fqdn
+
+		// Split any query string (e.g. SAS token) from configName before
+		// path-joining. url.JoinPath percent-encodes '?' as '%3F' when it
+		// appears inside a path segment, which breaks SAS tokens and any
+		// other credential passed as a query string in the relative URL.
+		configPath := configName
+		configQuery := ""
+		if idx := strings.IndexByte(configName, '?'); idx >= 0 {
+			configPath = configName[:idx]
+			configQuery = configName[idx:] // includes the leading '?'
+		}
+
 		if len(dpath) > 0 {
 			downloadURL, err = url.JoinPath(downloadURL, dpath)
 			if err != nil {
 				return nil, err
 			}
 		}
-		if len(configName) > 0 {
-			downloadURL, err = url.JoinPath(downloadURL, configName)
+		if len(configPath) > 0 {
+			downloadURL, err = url.JoinPath(downloadURL, configPath)
 			if err != nil {
 				return nil, err
 			}
+		}
+
+		// Reattach the raw query string after the path has been assembled.
+		// We do not re-encode it: the caller is responsible for passing a
+		// correctly percent-encoded query string in configName.
+		if len(configQuery) > 0 {
+			downloadURL += configQuery
 		}
 	}
 

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.5.0
 	github.com/lf-edge/edge-containers v0.0.0-20251107072102-46bed3192170
 	github.com/lf-edge/eve-api/go v0.0.0-20260114160322-5feda2767927
-	github.com/lf-edge/eve-libs v0.0.0-20260413155918-4d8a68ded9cf
+	github.com/lf-edge/eve-libs v0.0.0-20260304091825-96eaa95b9f8b
 	github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d
 	github.com/lf-edge/go-qemu v0.0.0-20231121152149-4c467eda0c56
 	github.com/linuxkit/linuxkit/src/cmd/linuxkit v0.0.0-20240507172735-6d37353ca1ee

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -568,8 +568,8 @@ github.com/lf-edge/edge-containers v0.0.0-20251107072102-46bed3192170 h1:bzTmpY7
 github.com/lf-edge/edge-containers v0.0.0-20251107072102-46bed3192170/go.mod h1:ta4JI0ank21dn8T1GFZDRLmxVZ6kWVe32cnhKkqMJJQ=
 github.com/lf-edge/eve-api/go v0.0.0-20260114160322-5feda2767927 h1:X+FcGf7U22d4SkCdb3kSwslaM4EENNMNFmlUZiBZSjE=
 github.com/lf-edge/eve-api/go v0.0.0-20260114160322-5feda2767927/go.mod h1:6HxNA/qKJVEqwpuOFkcQ0h3QyotvAs/cjHLC961FPOY=
-github.com/lf-edge/eve-libs v0.0.0-20260413155918-4d8a68ded9cf h1:xNIQEOgjOvSjjkIYeby2HpNltYxy5Vk/zR/4am3q9G8=
-github.com/lf-edge/eve-libs v0.0.0-20260413155918-4d8a68ded9cf/go.mod h1:ltvACFoIkGSeuuK+4Gl5+or3dbIxG2np6K0PQYkk6hU=
+github.com/lf-edge/eve-libs v0.0.0-20260304091825-96eaa95b9f8b h1:9aYAlHrCPf/w7SmODoT94o9PezYDl8pMFXJ6cX2VnLY=
+github.com/lf-edge/eve-libs v0.0.0-20260304091825-96eaa95b9f8b/go.mod h1:ltvACFoIkGSeuuK+4Gl5+or3dbIxG2np6K0PQYkk6hU=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d h1:tUBb9M6u42LXwHAYHyh22wJeUUQlTpDkXwRXalpRqbo=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d/go.mod h1:Nn3juMJJ1G8dyHOebdZyS4jOB/fuxAd5fIajBaWjHr8=
 github.com/lf-edge/go-qemu v0.0.0-20231121152149-4c467eda0c56 h1:LmFp0jbNSwPLuxJA+nQ+mMQrQ53ESkvHP4CVMqR0zrY=

--- a/pkg/pillar/vendor/github.com/lf-edge/eve-libs/zedUpload/datastore_aws.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve-libs/zedUpload/datastore_aws.go
@@ -300,7 +300,8 @@ func (ep *AwsTransportMethod) processS3List(req *DronaRequest) ([]string, error,
 		sc = sc.WithLogger(req.logger)
 	}
 
-	list, err := sc.ListImages(ep.bucket, prgChan)
+	prefix := req.name
+	list, err := sc.ListImagesWithPrefix(ep.bucket, prefix, prgChan)
 	if err != nil {
 		return s, err, 0
 	}

--- a/pkg/pillar/vendor/github.com/lf-edge/eve-libs/zedUpload/datastore_http.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve-libs/zedUpload/datastore_http.go
@@ -1,4 +1,4 @@
-// Copyright(c) 2017-2018 Zededa, Inc.
+// Copyright(c) 2017-2026 Zededa, Inc.
 // All rights reserved.
 
 package zedUpload
@@ -110,7 +110,10 @@ func (ep *HttpTransportMethod) GetNetTrace(description string) (
 
 // File upload to HTTP Datastore
 func (ep *HttpTransportMethod) processHttpUpload(req *DronaRequest) (error, int) {
-	postUrl := ep.hurl + "/" + ep.path
+	postUrl, err := url.JoinPath(ep.hurl, ep.path)
+	if err != nil {
+		return err, 0
+	}
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {
@@ -131,7 +134,11 @@ func (ep *HttpTransportMethod) processHttpUpload(req *DronaRequest) (error, int)
 func (ep *HttpTransportMethod) processHttpDownload(req *DronaRequest) (error, int) {
 	file := req.name
 	if ep.hurl != "" {
-		file = ep.hurl + "/" + ep.path + "/" + req.name
+		var err error
+		file, err = url.JoinPath(ep.hurl, ep.path, req.name)
+		if err != nil {
+			return err, 0
+		}
 	}
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
@@ -156,7 +163,10 @@ func (ep *HttpTransportMethod) processHttpDelete(req *DronaRequest) error {
 
 // File list from HTTP Datastore
 func (ep *HttpTransportMethod) processHttpList(req *DronaRequest) ([]string, error) {
-	listUrl := ep.hurl + "/" + ep.path
+	listUrl, err := url.JoinPath(ep.hurl, ep.path)
+	if err != nil {
+		return nil, err
+	}
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {
@@ -177,7 +187,11 @@ func (ep *HttpTransportMethod) processHttpList(req *DronaRequest) ([]string, err
 func (ep *HttpTransportMethod) processHttpObjectMetaData(req *DronaRequest) (error, int64) {
 	file := req.name
 	if ep.hurl != "" {
-		file = ep.hurl + "/" + ep.path + "/" + req.name
+		var err error
+		file, err = url.JoinPath(ep.hurl, ep.path, req.name)
+		if err != nil {
+			return err, 0
+		}
 	}
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)

--- a/pkg/pillar/vendor/github.com/lf-edge/eve-libs/zedUpload/ociutil/oci.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve-libs/zedUpload/ociutil/oci.go
@@ -1,3 +1,6 @@
+// Copyright(c) 2017-2026 Zededa, Inc.
+// All rights reserved.
+
 package ociutil
 
 import (
@@ -28,7 +31,7 @@ func Tags(registry, repository, username, apiKey string, client *http.Client, pr
 	var (
 		tags  []string
 		err   error
-		image = fmt.Sprintf("%s/%s", registry, repository)
+		image = path.Join(registry, repository)
 	)
 
 	repo, err := name.NewRepository(image)
@@ -82,7 +85,7 @@ func PullBlob(registry, repo, hash, localFile, username, apiKey string, maxsize 
 
 	// The OCI distribution spec only uses /blobs/ endpoint for layers or config, not index or manifest.
 	// I have no idea why you cannot get a manifest or index from the /blobs endpoint, but so be it.
-	image := fmt.Sprintf("%s/%s", registry, repo)
+	image := path.Join(registry, repo)
 	ref, err := name.ParseReference(image)
 	if err != nil {
 		return 0, "", fmt.Errorf("parsing reference %q: %v", image, err)

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -895,7 +895,7 @@ github.com/lf-edge/eve-api/go/metrics
 github.com/lf-edge/eve-api/go/nestedappinstancemetrics
 github.com/lf-edge/eve-api/go/profile
 github.com/lf-edge/eve-api/go/register
-# github.com/lf-edge/eve-libs v0.0.0-20260413155918-4d8a68ded9cf
+# github.com/lf-edge/eve-libs v0.0.0-20260304091825-96eaa95b9f8b
 ## explicit; go 1.24.0
 github.com/lf-edge/eve-libs/depgraph
 github.com/lf-edge/eve-libs/nettrace


### PR DESCRIPTION
# Description

Backport of #5588, #5715

- #5588 — pillar: make URL joins use url.JoinPath
- #5715 — downloader: fix SAS token corruption in constructDatastoreContext

Note: for #5588, eve-libs is updated to
`96eaa95b9f8b8b8f3c1b92214fb93f35687e2c0b` — the most recent commit
on eve-libs main that still supports go1.24 and does not pull in
docker/cli v29 (which breaks oras-go vendor code in this branch).

## How to test and validate this PR

1. Create an HTTP datastore with only an FQDN set (e.g. `https://downloads.example.com/`), leave Path empty.
2. Create an edge app image with a relative URL (e.g. `image.qcow2`) and deploy — verify download succeeds.
3. Create an HTTP datastore with a SAS token in the relative URL (e.g. `image.vhd?st=...&se=...&sig=...`) — verify download succeeds and the SAS token is not mangled (no HTTP 409 from Azure Blob Storage).

## Changelog notes

Fix EVE handling of empty path parts in edge app download URLs. Fix SAS token corruption when downloading from Azure Blob Storage via HTTP datastore.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.