### PR TITLE
[14.5-stable] downloader: fix SAS token corruption in constructDatastoreContext

### DIFF
--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -382,17 +382,36 @@ func constructDatastoreContext(ctx *downloaderContext, configName string, NameIs
 	downloadURL := configName
 	if !NameIsURL {
 		downloadURL = dst.Fqdn
+
+		// Split any query string (e.g. SAS token) from configName before
+		// path-joining. url.JoinPath percent-encodes '?' as '%3F' when it
+		// appears inside a path segment, which breaks SAS tokens and any
+		// other credential passed as a query string in the relative URL.
+		configPath := configName
+		configQuery := ""
+		if idx := strings.IndexByte(configName, '?'); idx >= 0 {
+			configPath = configName[:idx]
+			configQuery = configName[idx:] // includes the leading '?'
+		}
+
 		if len(dpath) > 0 {
 			downloadURL, err = url.JoinPath(downloadURL, dpath)
 			if err != nil {
 				return nil, err
 			}
 		}
-		if len(configName) > 0 {
-			downloadURL, err = url.JoinPath(downloadURL, configName)
+		if len(configPath) > 0 {
+			downloadURL, err = url.JoinPath(downloadURL, configPath)
 			if err != nil {
 				return nil, err
 			}
+		}
+
+		// Reattach the raw query string after the path has been assembled.
+		// We do not re-encode it: the caller is responsible for passing a
+		// correctly percent-encoded query string in configName.
+		if len(configQuery) > 0 {
+			downloadURL += configQuery
 		}
 	}
 


### PR DESCRIPTION
# Description

Backport of #5715 

- https://github.com/lf-edge/eve/pull/5715 — downloader: fix SAS token corruption in constructDatastoreContext

## How to test and validate this PR

- Create an HTTP datastore with only an FQDN set (e.g. https://downloads.example.com/), leave Path empty.
- Create an edge app image with a relative URL (e.g. image.qcow2) and deploy — verify download succeeds.
- Create an HTTP datastore with a SAS token in the relative URL (e.g. image.vhd?st=...&se=...&sig=...) — verify download succeeds and the SAS token is not mangled (no HTTP 409 from Azure Blob Storage).

## Changelog notes

Fixed a regression introduced in 16.0, where application image downloads
from HTTP datastores using Azure SAS tokens (query string credentials
in the relative URL field) failed with HTTP 409, leaving the application
permanently stuck in the DOWNLOADING state. The fix correctly
preserves the SAS query string when constructing the download URL.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.