### PR TITLE
alpine 3.22: fix bpftrace

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -60,6 +60,8 @@ jobs:
           bash tests/tpm/prep-and-test.sh
       - name: Test
         run: |
+          make pkg/bpftrace
+          make ZARCH=arm64 pkg/bpftrace
           make test
       - name: Report test results as Annotations
         if: ${{ always() }}

--- a/Makefile
+++ b/Makefile
@@ -560,7 +560,7 @@ $(DOCKERFILE_FROM_CHECKER): $(DOCKERFILE_FROM_CHECKER_DIR)/*.go $(DOCKERFILE_FRO
 # For example, one Dockerfile has foo:abc and the next has foo:def, it will flag them.
 # These are the packages that we are ignoring for now
 IGNORE_DOCKERFILE_HASHES_PKGS=alpine cross-compilers
-IGNORE_DOCKERFILE_HASHES_EVE_TOOLS=bpftrace-compiler
+IGNORE_DOCKERFILE_HASHES_EVE_TOOLS=
 
 IGNORE_DOCKERFILE_DOT_GO_DIR=$(shell find .go/ -name Dockerfile -exec echo "-i {}" \;)
 IGNORE_DOCKERFILE_DIST_DIR=$(shell find dist/ -name Dockerfile -exec echo "-i {}" \;)

--- a/eve-tools/bpftrace-compiler/Dockerfile
+++ b/eve-tools/bpftrace-compiler/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM alpine:3.21
+FROM alpine:3.22
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache qemu-system-x86_64 qemu-system-aarch64 go make git docker

--- a/eve-tools/bpftrace-compiler/examples/opensnoop_arm64.bt
+++ b/eve-tools/bpftrace-compiler/examples/opensnoop_arm64.bt
@@ -1,0 +1,44 @@
+#!/usr/bin/bpftrace
+/*
+ * opensnoop	Trace open() syscalls.
+ *		For Linux, uses bpftrace and eBPF.
+ *
+ * Also a basic example of bpftrace.
+ *
+ * USAGE: opensnoop.bt
+ *
+ * This is a bpftrace version of the bcc tool of the same name.
+ *
+ * Copyright 2018 Netflix, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ *
+ * 08-Sep-2018	Brendan Gregg	Created this.
+ */
+
+BEGIN
+{
+	printf("Tracing open syscalls... Hit Ctrl-C to end.\n");
+	printf("%-6s %-16s %4s %3s %s\n", "PID", "COMM", "FD", "ERR", "PATH");
+}
+
+tracepoint:syscalls:sys_enter_openat
+{
+	@filename[tid] = args.filename;
+}
+
+tracepoint:syscalls:sys_exit_openat
+/@filename[tid]/
+{
+	$ret = args.ret;
+	$fd = $ret >= 0 ? $ret : -1;
+	$errno = $ret >= 0 ? 0 : - $ret;
+
+	printf("%-6d %-16s %4d %3d %s\n", pid, comm, $fd, $errno,
+	    str(@filename[tid]));
+	delete(@filename[tid]);
+}
+
+END
+{
+	clear(@filename);
+}

--- a/eve-tools/bpftrace-compiler/examples/sslsnoop-debug-container.bt
+++ b/eve-tools/bpftrace-compiler/examples/sslsnoop-debug-container.bt
@@ -22,17 +22,17 @@ BEGIN
 	       "COMM", "LAT(us)", "RET", "FUNC");
 }
 
-uprobe:/containers/services/debug/lower/lib/libssl.so.1.1:SSL_read,
-uprobe:/containers/services/debug/lower/lib/libssl.so.1.1:SSL_write,
-uprobe:/containers/services/debug/lower/lib/libssl.so.1.1:SSL_do_handshake
+uprobe:/containers/services/debug/lower/usr/lib/libssl.so.3:SSL_read,
+uprobe:/containers/services/debug/lower/usr/lib/libssl.so.3:SSL_write,
+uprobe:/containers/services/debug/lower/usr/lib/libssl.so.3:SSL_do_handshake
 {
 	@start_ssl[tid] = nsecs;
 	@func_ssl[tid] = func; // store for uretprobe
 }
 
-uretprobe:/containers/services/debug/lower/lib/libssl.so.1.1:SSL_read,
-uretprobe:/containers/services/debug/lower/lib/libssl.so.1.1:SSL_write,
-uretprobe:/containers/services/debug/lower/lib/libssl.so.1.1:SSL_do_handshake
+uretprobe:/containers/services/debug/lower/usr/lib/libssl.so.3:SSL_read,
+uretprobe:/containers/services/debug/lower/usr/lib/libssl.so.3:SSL_write,
+uretprobe:/containers/services/debug/lower/usr/lib/libssl.so.3:SSL_do_handshake
 /@start_ssl[tid] != 0/
 {
 	printf("%-10u %-8d %-8s %7u %5d %s\n", elapsed/1000, tid, comm,
@@ -41,29 +41,29 @@ uretprobe:/containers/services/debug/lower/lib/libssl.so.1.1:SSL_do_handshake
 }
 
 // need debug symbol for ossl local functions
-uprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:rsa_ossl_public_encrypt,
-uprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:rsa_ossl_public_decrypt,
-uprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:rsa_ossl_private_encrypt,
-uprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:rsa_ossl_private_decrypt,
-uprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:RSA_sign,
-uprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:RSA_verify,
-uprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:ossl_ecdsa_sign,
-uprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:ossl_ecdsa_verify,
-uprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:ossl_ecdh_compute_key
+uprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:rsa_ossl_public_encrypt,
+uprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:rsa_ossl_public_decrypt,
+uprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:rsa_ossl_private_encrypt,
+uprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:rsa_ossl_private_decrypt,
+uprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:RSA_sign,
+uprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:RSA_verify,
+uprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:ossl_ecdsa_sign,
+uprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:ossl_ecdsa_verify,
+uprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:ossl_ecdh_compute_key
 {
 	@start_crypto[tid] = nsecs;
 	@func_crypto[tid] = func; // store for uretprobe
 }
 
-uretprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:rsa_ossl_public_encrypt,
-uretprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:rsa_ossl_public_decrypt,
-uretprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:rsa_ossl_private_encrypt,
-uretprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:rsa_ossl_private_decrypt,
-uretprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:RSA_sign,
-uretprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:RSA_verify,
-uretprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:ossl_ecdsa_sign,
-uretprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:ossl_ecdsa_verify,
-uretprobe:/containers/services/debug/lower/lib/libcrypto.so.1.1:ossl_ecdh_compute_key
+uretprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:rsa_ossl_public_encrypt,
+uretprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:rsa_ossl_public_decrypt,
+uretprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:rsa_ossl_private_encrypt,
+uretprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:rsa_ossl_private_decrypt,
+uretprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:RSA_sign,
+uretprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:RSA_verify,
+uretprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:ossl_ecdsa_sign,
+uretprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:ossl_ecdsa_verify,
+uretprobe:/containers/services/debug/lower/usr/lib/libcrypto.so.3:ossl_ecdh_compute_key
 /@start_crypto[tid] != 0/
 {
 	printf("%-10u %-8d %-8s %7u %5d %s\n", elapsed/1000, tid, comm,

--- a/eve-tools/bpftrace-compiler/examples/sslsnoop-pillar-container.bt
+++ b/eve-tools/bpftrace-compiler/examples/sslsnoop-pillar-container.bt
@@ -22,17 +22,17 @@ BEGIN
 	       "COMM", "LAT(us)", "RET", "FUNC");
 }
 
-uprobe:/containers/services/pillar/rootfs/lib/libssl.so.1.1:SSL_read,
-uprobe:/containers/services/pillar/rootfs/lib/libssl.so.1.1:SSL_write,
-uprobe:/containers/services/pillar/rootfs/lib/libssl.so.1.1:SSL_do_handshake
+uprobe:/containers/services/pillar/rootfs/usr/lib/libssl.so.3:SSL_read,
+uprobe:/containers/services/pillar/rootfs/usr/lib/libssl.so.3:SSL_write,
+uprobe:/containers/services/pillar/rootfs/usr/lib/libssl.so.3:SSL_do_handshake
 {
 	@start_ssl[tid] = nsecs;
 	@func_ssl[tid] = func; // store for uretprobe
 }
 
-uretprobe:/containers/services/pillar/rootfs/lib/libssl.so.1.1:SSL_read,
-uretprobe:/containers/services/pillar/rootfs/lib/libssl.so.1.1:SSL_write,
-uretprobe:/containers/services/pillar/rootfs/lib/libssl.so.1.1:SSL_do_handshake
+uretprobe:/containers/services/pillar/rootfs/usr/lib/libssl.so.3:SSL_read,
+uretprobe:/containers/services/pillar/rootfs/usr/lib/libssl.so.3:SSL_write,
+uretprobe:/containers/services/pillar/rootfs/usr/lib/libssl.so.3:SSL_do_handshake
 /@start_ssl[tid] != 0/
 {
 	printf("%-10u %-8d %-8s %7u %5d %s\n", elapsed/1000, tid, comm,
@@ -41,29 +41,29 @@ uretprobe:/containers/services/pillar/rootfs/lib/libssl.so.1.1:SSL_do_handshake
 }
 
 // need debug symbol for ossl local functions
-uprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:rsa_ossl_public_encrypt,
-uprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:rsa_ossl_public_decrypt,
-uprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:rsa_ossl_private_encrypt,
-uprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:rsa_ossl_private_decrypt,
-uprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:RSA_sign,
-uprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:RSA_verify,
-uprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:ossl_ecdsa_sign,
-uprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:ossl_ecdsa_verify,
-uprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:ossl_ecdh_compute_key
+uprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:rsa_ossl_public_encrypt,
+uprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:rsa_ossl_public_decrypt,
+uprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:rsa_ossl_private_encrypt,
+uprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:rsa_ossl_private_decrypt,
+uprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:RSA_sign,
+uprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:RSA_verify,
+uprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:ossl_ecdsa_sign,
+uprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:ossl_ecdsa_verify,
+uprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:ossl_ecdh_compute_key
 {
 	@start_crypto[tid] = nsecs;
 	@func_crypto[tid] = func; // store for uretprobe
 }
 
-uretprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:rsa_ossl_public_encrypt,
-uretprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:rsa_ossl_public_decrypt,
-uretprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:rsa_ossl_private_encrypt,
-uretprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:rsa_ossl_private_decrypt,
-uretprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:RSA_sign,
-uretprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:RSA_verify,
-uretprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:ossl_ecdsa_sign,
-uretprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:ossl_ecdsa_verify,
-uretprobe:/containers/services/pillar/rootfs/lib/libcrypto.so.1.1:ossl_ecdh_compute_key
+uretprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:rsa_ossl_public_encrypt,
+uretprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:rsa_ossl_public_decrypt,
+uretprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:rsa_ossl_private_encrypt,
+uretprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:rsa_ossl_private_decrypt,
+uretprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:RSA_sign,
+uretprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:RSA_verify,
+uretprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:ossl_ecdsa_sign,
+uretprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:ossl_ecdsa_verify,
+uretprobe:/containers/services/pillar/rootfs/usr/lib/libcrypto.so.3:ossl_ecdh_compute_key
 /@start_crypto[tid] != 0/
 {
 	printf("%-10u %-8d %-8s %7u %5d %s\n", elapsed/1000, tid, comm,

--- a/eve-tools/bpftrace-compiler/root/Dockerfile
+++ b/eve-tools/bpftrace-compiler/root/Dockerfile
@@ -5,9 +5,9 @@ ARG EVE_KERNEL
 # hadolint ignore=DL3006
 FROM ${EVE_KERNEL} AS kernel
 
-FROM lfedge/eve-bpftrace:c08d714db34b7cde90d20c56e74d2c11afe483df AS eve-bpftrace
+FROM lfedge/eve-bpftrace:03c26b968615b09b491f71e61e35d3f2675835ef AS eve-bpftrace
 
-FROM lfedge/eve-alpine:745ae9066273c73b0fd879c4ba4ff626a8392d04 AS bpftrace
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS bpftrace
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache --initdb binutils make gcc g++ git perl musl-dev cmake zlib-dev bcc-dev libbpf-dev cereal flex bison llvm17-libs llvm17-dev llvm17-static clang17-dev clang17-static pahole gtest-dev bash

--- a/eve-tools/bpftrace-compiler/root/Dockerfile
+++ b/eve-tools/bpftrace-compiler/root/Dockerfile
@@ -10,7 +10,7 @@ FROM lfedge/eve-bpftrace:c08d714db34b7cde90d20c56e74d2c11afe483df AS eve-bpftrac
 FROM lfedge/eve-alpine:745ae9066273c73b0fd879c4ba4ff626a8392d04 AS bpftrace
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache --initdb make gcc g++ git perl musl-dev cmake zlib-dev bcc-dev libbpf-dev cereal flex bison llvm13-libs llvm13-dev llvm13-static clang-dev clang-static pahole gtest-dev bash
+RUN apk add --no-cache --initdb binutils make gcc g++ git perl musl-dev cmake zlib-dev bcc-dev libbpf-dev cereal flex bison llvm17-libs llvm17-dev llvm17-static clang17-dev clang17-static pahole gtest-dev bash
 WORKDIR /
 COPY copy-out.sh /
 RUN mkdir /out
@@ -30,9 +30,13 @@ COPY bpftrace-helper /usr/src/bpftrace-helper
 WORKDIR /usr/src/bpftrace-helper
 RUN CGO_ENABLED=0 GOARCH=${TARGETARCH} go build -o /bpftrace-helper
 
+RUN touch /bpftrace-aotrt # bpftrace wants to call this binary, but does not care about outcome
+RUN chmod a+x /bpftrace-aotrt
+
 FROM scratch
 WORKDIR /
 COPY --from=bpftrace /out /
 # init
 COPY --from=bpftrace /bpftrace-helper /sbin/init
+COPY --from=bpftrace /bpftrace-aotrt /usr/bin/bpftrace-aotrt
 COPY --from=alpine:3.21 /bin/busybox /usr/bin/busybox

--- a/eve-tools/bpftrace-compiler/ssh-client.go
+++ b/eve-tools/bpftrace-compiler/ssh-client.go
@@ -149,7 +149,9 @@ func (s *eveSSHClient) startSSHClient(sshHost string, privKey string) {
 }
 
 func (s *eveSSHClient) close() {
-	s.rStdout.Close()
+	if s.rStdout != nil {
+		s.rStdout.Close()
+	}
 	if s.sftpClient != nil {
 		s.sftpClient.Close()
 	}

--- a/pkg/alpine/mirrors/3.22/community
+++ b/pkg/alpine/mirrors/3.22/community
@@ -30,7 +30,6 @@ libvirt-qemu
 libvncserver
 libvncserver-dev
 ossp-uuid
-ossp-uuid-libs
 perf
 py3-cachecontrol
 py3-colorama

--- a/pkg/alpine/mirrors/3.22/main
+++ b/pkg/alpine/mirrors/3.22/main
@@ -455,7 +455,6 @@ libxi-dev
 libxinerama
 libxinerama-dev
 libxml2
-libxml2-dev
 libxml2-utils
 libxrandr
 libxrandr-dev
@@ -472,13 +471,8 @@ linux-pam-dev
 lua5.3
 lua5.3-lzlib
 llvm18-libs
-llvm20
-llvm20-dev
-llvm20-gtest
 llvm20-libs
 llvm20-linker-tools
-llvm20-static
-llvm20-test-utils
 lm-sensors
 lm-sensors-libs
 lua5.4-libs

--- a/pkg/alpine/mirrors/3.22/main
+++ b/pkg/alpine/mirrors/3.22/main
@@ -158,6 +158,13 @@ clang20-headers
 clang20-libclang
 clang20-libs
 clang20-static
+clang17
+clang17-dev
+clang17-extra-tools
+clang17-headers
+clang17-libclang
+clang17-libs
+clang17-static
 cmake
 coreutils
 coreutils-env
@@ -223,6 +230,7 @@ gawk
 gc
 gcc
 gcompat
+gdb
 gdbm
 gettext
 gettext-asprintf
@@ -473,6 +481,13 @@ lua5.3-lzlib
 llvm18-libs
 llvm20-libs
 llvm20-linker-tools
+llvm17
+llvm17-dev
+llvm17-libs
+llvm17-linker-tools
+llvm17-static
+llvm17-test-utils
+llvm17-gtest
 lm-sensors
 lm-sensors-libs
 lua5.4-libs

--- a/pkg/apparmor/Dockerfile
+++ b/pkg/apparmor/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 ENV BUILD_PKGS linux-headers musl-dev musl-utils musl-libintl git gcc g++ \
                autoconf autoconf-archive automake libtool make flex bison \
                bash sed gettext

--- a/pkg/bpftrace/Dockerfile
+++ b/pkg/bpftrace/Dockerfile
@@ -4,9 +4,25 @@
 # SPDX-License-Identifier: Apache-2.0
 FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 
-ENV BUILD_PKGS make gcc g++ git perl linux-headers musl-dev cmake zlib-dev bcc-dev libbpf-dev cereal flex bison llvm13-libs llvm13-dev llvm13-static clang-dev clang-static pahole gtest-dev bash
+ENV BUILD_PKGS libbpf-dev make gcc g++ git perl linux-headers musl-dev cmake elfutils-dev llvm17-libs llvm17-dev llvm17-gtest llvm17-static cereal flex bison clang17-extra-tools clang17-dev clang17-static pahole gtest-dev bash py3-setuptools zip zlib-dev
 
 RUN eve-alpine-deploy.sh
+
+RUN ln -s /usr/lib/cmake/clang17 /usr/lib/cmake/clang
+
+# compile bcc from source as alpine's bcc crashes in bcc_elf_is_shared_obj(rel_path.c_str()); during bpftrace test
+WORKDIR /usr/src
+# bcc compilation process needs .git directory
+ADD --keep-git-dir=true https://github.com/iovisor/bcc.git#v0.27.0 /usr/src/bcc
+RUN mkdir /usr/src/bcc/build
+WORKDIR /usr/src/bcc/build
+RUN perl -pni.bak -e 's/CMAKE_CXX_STANDARD 14/CMAKE_CXX_STANDARD 17/g' ../CMakeLists.txt
+RUN perl -pni.bak -e 's!llvm-c/Transforms/IPO.h!llvm/Transforms/IPO.h!g' ../src/cc/bpf_module.cc
+RUN perl -pni.bak -e 's/#pragma GCC poison reallocarray strlcpy//g' ../src/cc/libbpf/src/libbpf_internal.h
+RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_COMPILER=clang++-17 -DCMAKE_C_COMPILER=clang-17 -DENABLE_EXAMPLES=OFF -DENABLE_MAN=OFF ..
+RUN make -j "$(getconf _NPROCESSORS_ONLN)"
+RUN make install
+
 
 RUN mkdir -p /usr/src
 ADD https://github.com/bpftrace/bpftrace.git#v0.20.3 /usr/src/bpftrace
@@ -15,12 +31,12 @@ WORKDIR /usr/src/bpftrace
 RUN for i in patches/*.patch; do git apply "$i"; done
 RUN mkdir build
 WORKDIR /usr/src/bpftrace/build
-RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
+RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_COMPILER=clang++-17 -DCMAKE_C_COMPILER=clang-17 ..
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN make install
+
 # portability analyser is disabled, therefore skip those tests
 # skip file exist test - probably broken because of container
-
 # unfortunately /proc/cpuinfo on docker on M1 mac is not telling much, so let's use the bogomips
 ARG TARGETARCH
 ARG BUILDARCH
@@ -37,15 +53,19 @@ RUN if [ "$TARGETARCH" = "$BUILDARCH" ]; then \
 
 FROM scratch AS bin
 COPY --from=build /usr/bin/bpftrace /bpftrace/usr/bin/bpftrace
-
 COPY --from=build /usr/bin/bpftrace-aotrt /bpftrace-aotrt/usr/bin/bpftrace-aotrt
-COPY --from=build /usr/lib/libbpf.so.0 /bpftrace-aotrt/usr/lib/libbpf.so.0
-COPY --from=build /usr/lib/libelf.so.1 /bpftrace-aotrt/usr/lib/libelf.so.1
-COPY --from=build /usr/lib/libz.so.1.3.2 /bpftrace-aotrt/usr/lib/libz.so.1.3.2
-COPY --from=build /usr/lib/libz.so.1 /bpftrace-aotrt/usr/lib/libz.so.1
-COPY --from=build /usr/lib/libbcc_bpf.so.0 /bpftrace-aotrt/usr/lib/libbcc_bpf.so.0
-COPY --from=build /usr/lib/libstdc++.so.6 /bpftrace-aotrt/usr/lib/libstdc++.so.6
-COPY --from=build /usr/lib/libgcc_s.so.1 /bpftrace-aotrt/usr/lib/libgcc_s.so.1
+
+COPY --from=build /usr/lib/libbpf.so.1 /bpftrace-aotrt//usr/lib/libbpf.so.1
+COPY --from=build /usr/lib/libz.so.1 /bpftrace-aotrt//usr/lib/libz.so.1
+COPY --from=build /usr/lib/libbcc_bpf.so.0 /bpftrace-aotrt//usr/lib/libbcc_bpf.so.0
+COPY --from=build /usr/lib/libdw.so.1 /bpftrace-aotrt//usr/lib/libdw.so.1
+COPY --from=build /usr/lib/libstdc++.so.6 /bpftrace-aotrt//usr/lib/libstdc++.so.6
+COPY --from=build /usr/lib/libgcc_s.so.1 /bpftrace-aotrt//usr/lib/libgcc_s.so.1
+COPY --from=build /usr/lib/libelf.so.1 /bpftrace-aotrt//usr/lib/libelf.so.1
+COPY --from=build /usr/lib/liblzma.so.5 /bpftrace-aotrt//usr/lib/liblzma.so.5
+COPY --from=build /usr/lib/libfts.so.0 /bpftrace-aotrt//usr/lib/libfts.so.0
+COPY --from=build /usr/lib/libzstd.so.1 /bpftrace-aotrt//usr/lib/libzstd.so.1
+COPY --from=build /usr/lib/libbz2.so.1 /bpftrace-aotrt//usr/lib/libbz2.so.1
 
 FROM bin AS bin-amd64
 FROM bin AS bin-arm64

--- a/pkg/bpftrace/Dockerfile
+++ b/pkg/bpftrace/Dockerfile
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 
 ENV BUILD_PKGS libbpf-dev make gcc g++ git perl linux-headers musl-dev cmake elfutils-dev llvm17-libs llvm17-dev llvm17-gtest llvm17-static cereal flex bison clang17-extra-tools clang17-dev clang17-static pahole gtest-dev bash py3-setuptools zip zlib-dev
 

--- a/pkg/bpftrace/Dockerfile
+++ b/pkg/bpftrace/Dockerfile
@@ -4,18 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0
 FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 
-ENV BUILD_PKGS make gcc g++ git perl linux-headers musl-dev cmake zlib-dev bcc-dev libbpf-dev cereal flex bison llvm20-libs llvm20-dev llvm20-static llvm20-gtest clang-dev clang-static pahole gtest-dev bash libxml2-dev curl-dev binutils-dev libpcap-dev
+ENV BUILD_PKGS make gcc g++ git perl linux-headers musl-dev cmake zlib-dev bcc-dev libbpf-dev cereal flex bison llvm13-libs llvm13-dev llvm13-static clang-dev clang-static pahole gtest-dev bash
 
 RUN eve-alpine-deploy.sh
 
 RUN mkdir -p /usr/src
-ADD https://github.com/bpftrace/bpftrace.git#v0.23.3 /usr/src/bpftrace
+ADD https://github.com/bpftrace/bpftrace.git#v0.20.3 /usr/src/bpftrace
 COPY patches /usr/src/bpftrace/patches
 WORKDIR /usr/src/bpftrace
 RUN for i in patches/*.patch; do git apply "$i"; done
 RUN mkdir build
 WORKDIR /usr/src/bpftrace/build
-
 RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN make install
@@ -40,9 +39,7 @@ FROM scratch AS bin
 COPY --from=build /usr/bin/bpftrace /bpftrace/usr/bin/bpftrace
 
 COPY --from=build /usr/bin/bpftrace-aotrt /bpftrace-aotrt/usr/bin/bpftrace-aotrt
-COPY --from=build /usr/lib/libbpf.so.1.5.1 /bpftrace-aotrt/usr/lib/libbpf.so.1.5.1
-COPY --from=build /usr/lib/libbpf.so.1 /bpftrace-aotrt/usr/lib/libbpf.so.1
-COPY --from=build /usr/lib/libbpf.so /bpftrace-aotrt/usr/lib/libbpf.so
+COPY --from=build /usr/lib/libbpf.so.0 /bpftrace-aotrt/usr/lib/libbpf.so.0
 COPY --from=build /usr/lib/libelf.so.1 /bpftrace-aotrt/usr/lib/libelf.so.1
 COPY --from=build /usr/lib/libz.so.1.3.2 /bpftrace-aotrt/usr/lib/libz.so.1.3.2
 COPY --from=build /usr/lib/libz.so.1 /bpftrace-aotrt/usr/lib/libz.so.1

--- a/pkg/bpftrace/patches/0001-AOT-keep-intermediate-code.patch
+++ b/pkg/bpftrace/patches/0001-AOT-keep-intermediate-code.patch
@@ -1,44 +1,39 @@
-From 62a4445b3aea4c72cefbed245168fd28d5f553e9 Mon Sep 17 00:00:00 2001
-From: "Gerald (Bob) Lee" <bob@famleehouse.net>
-Date: Wed, 12 Nov 2025 17:37:55 -0800
-Subject: [PATCH 1/2] AOT: keep intermediate code
+From bd8c7a1e1f8547e9756c817daf335693bec88d85 Mon Sep 17 00:00:00 2001
+From: Christoph Ostarek <christoph@zededa.com>
+Date: Wed, 28 Feb 2024 15:20:03 +0100
+Subject: [PATCH 1/3] AOT: keep intermediate code
 
 this code will be passed to bpftrace-aotrt
-port from v0.20.3 by christoph@zededa.com
 
-Signed-off-by: Gerald (Bob) Lee <bob@famleehouse.net>
+Signed-off-by: Christoph Ostarek <christoph@zededa.com>
 ---
- src/aot/aot.cpp | 10 +++++-----
- 1 file changed, 5 insertions(+), 5 deletions(-)
+ src/aot/aot.cpp | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/src/aot/aot.cpp b/src/aot/aot.cpp
-index bc7e7e9e..f547a971 100644
+index d0154781..0e2ef381 100644
 --- a/src/aot/aot.cpp
 +++ b/src/aot/aot.cpp
 @@ -26,7 +26,7 @@
-
  #define AOT_ELF_SECTION ".btaot"
  static constexpr auto AOT_MAGIC = 0xA07;
+ static constexpr auto AOT_SHIM_NAME = "bpftrace-aotrt";
 -static constexpr auto AOT_SECDATA_TEMPFILE = ".temp_btaot";
 +static constexpr auto AOT_SECDATA_TEMPFILE = "temp_btaot";
 
  // AOT payload will have this header at the beginning. We don't worry about
  // versioning the header b/c we enforce that an AOT compiled script may only
-@@ -173,10 +173,10 @@ int build_binary(const std::filesystem::path &shim,
-   }
+@@ -221,8 +221,8 @@ bool build_binary(const std_filesystem::path &shim,
 
+   ret = true;
  out:
--  if (!std::filesystem::remove(AOT_SECDATA_TEMPFILE, ec) || ec) {
--    ret = 1;
+-  if (!std_filesystem::remove(AOT_SECDATA_TEMPFILE, ec) || ec)
 -    LOG(ERROR) << "Failed to remove " << AOT_SECDATA_TEMPFILE << ": " << ec;
--  }
-+//if (!std::filesystem::remove(AOT_SECDATA_TEMPFILE, ec) || ec) {
-+//  ret = 1;
-+//  LOG(ERROR) << "Failed to remove " << AOT_SECDATA_TEMPFILE << ": " << ec;
-+//}
++  //if (!std_filesystem::remove(AOT_SECDATA_TEMPFILE, ec) || ec)
++  //  LOG(ERROR) << "Failed to remove " << AOT_SECDATA_TEMPFILE << ": " << ec;
    return ret;
  }
 
 --
-2.43.0
+2.45.1
 

--- a/pkg/bpftrace/patches/0002-AOT-disable-compatability-restrictions.patch
+++ b/pkg/bpftrace/patches/0002-AOT-disable-compatability-restrictions.patch
@@ -1,30 +1,28 @@
-From 9000fd73b576451761b12ceacf5c14d03f53d20b Mon Sep 17 00:00:00 2001
-From: "Gerald (Bob) Lee" <bob@famleehouse.net>
-Date: Wed, 12 Nov 2025 17:42:20 -0800
-Subject: [PATCH 2/2] AOT: disable compatability restrictions
+From 98e7fbe94420452d5274372340c78be2c3f4c62e Mon Sep 17 00:00:00 2001
+From: Christoph Ostarek <christoph@zededa.com>
+Date: Mon, 4 Mar 2024 16:26:32 +0100
+Subject: [PATCH 2/3] AOT: disable compatability restrictions
 
 these don't apply to EVE as we create the code on
 the same kernel as on the destination device
 
-port from v0.20.3 by christoph@zededa.com
-- BTF_KIND_ENUM64 not present in v0.23.3
-  so patch 3 to remove it not needed
-
-Signed-off-by: Gerald (Bob) Lee <bob@famleehouse.net>
+Signed-off-by: Christoph Ostarek <christoph@zededa.com>
 ---
- src/ast/passes/portability_analyser.cpp | 10 ++++++++--
- 1 file changed, 8 insertions(+), 2 deletions(-)
+ src/ast/passes/portability_analyser.cpp | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
 
 diff --git a/src/ast/passes/portability_analyser.cpp b/src/ast/passes/portability_analyser.cpp
-index 1c8399f5..f78aa206 100644
+index e83a6e44..05e39f0b 100644
 --- a/src/ast/passes/portability_analyser.cpp
 +++ b/src/ast/passes/portability_analyser.cpp
-@@ -45,10 +45,12 @@ void PortabilityAnalyser::visit(Builtin &builtin)
+@@ -47,11 +47,12 @@ void PortabilityAnalyser::visit(Builtin &builtin)
    // `struct task_struct` is unstable across kernel versions and configurations.
    // This makes it inherently unportable. We must block it until we support
    // field access relocations.
+-  if (builtin.ident == "curtask")
+-  {
 +  /*
-   if (builtin.ident == "curtask") {
++  if (builtin.ident == "curtask") {
      LOG(ERROR, builtin.loc, err_)
          << "AOT does not yet support accessing `curtask`";
    }
@@ -32,12 +30,13 @@ index 1c8399f5..f78aa206 100644
  }
 
  void PortabilityAnalyser::visit(Call &call)
-@@ -65,10 +67,12 @@ void PortabilityAnalyser::visit(Call &call)
+@@ -71,11 +72,13 @@ void PortabilityAnalyser::visit(Call &call)
    // resolved during codegen and the value embedded into the bytecode.  For AOT
    // to support cgroupid(), the cgroupid must be resolved at runtime and fixed
    // up during load time.
 +  /*
-   if (call.func == "kaddr" || call.func == "uaddr" || call.func == "cgroupid") {
+   if (call.func == "kaddr" || call.func == "uaddr" || call.func == "cgroupid")
+   {
      LOG(ERROR, call.loc, err_)
          << "AOT does not yet support " << call.func << "()";
    }
@@ -45,7 +44,7 @@ index 1c8399f5..f78aa206 100644
  }
 
  void PortabilityAnalyser::visit(Cast &cast)
-@@ -80,7 +84,7 @@ void PortabilityAnalyser::visit(Cast &cast)
+@@ -87,7 +90,7 @@ void PortabilityAnalyser::visit(Cast &cast)
    // portable. `args` for k[ret]funcs are type checked by the kernel and may
    // also be considered stable. For AOT to fully support field accesses, we
    // need to relocate field access at runtime.
@@ -54,26 +53,27 @@ index 1c8399f5..f78aa206 100644
  }
 
  void PortabilityAnalyser::visit(AttachPoint &ap)
-@@ -92,16 +96,18 @@ void PortabilityAnalyser::visit(AttachPoint &ap)
+@@ -99,17 +102,19 @@ void PortabilityAnalyser::visit(AttachPoint &ap)
    // and offsets and type information is embedded into the bytecode. For AOT
    // support, this analyzing must be done during runtime and fixed up during
    // load time.
 +  /*
-   if (type == ProbeType::usdt) {
+   if (type == ProbeType::usdt)
+   {
      LOG(ERROR, ap.loc, err_) << "AOT does not yet support USDT probes";
    }
 +  */
    // While userspace watchpoint probes are technically portable from codegen
    // point of view, they require a PID or path via cmdline to resolve address.
    // watchpoint probes are also API-unstable and need a further change
-   // (see https://github.com/bpftrace/bpftrace/issues/1683).
+   // (see https://github.com/iovisor/bpftrace/issues/1683).
    //
    // So disable for now and re-evalulate at another point.
--  else if (type == ProbeType::watchpoint ||
-+  if (type == ProbeType::watchpoint ||
-            type == ProbeType::asyncwatchpoint) {
+-  else if (type == ProbeType::watchpoint || type == ProbeType::asyncwatchpoint)
++  if (type == ProbeType::watchpoint || type == ProbeType::asyncwatchpoint)
+   {
      LOG(ERROR, ap.loc, err_) << "AOT does not yet support watchpoint probes";
    }
 --
-2.43.0
+2.45.1
 

--- a/pkg/bpftrace/patches/0002-AOT-disable-compatability-restrictions.patch
+++ b/pkg/bpftrace/patches/0002-AOT-disable-compatability-restrictions.patch
@@ -12,62 +12,57 @@ port from v0.20.3 by christoph@zededa.com
 
 Signed-off-by: Gerald (Bob) Lee <bob@famleehouse.net>
 ---
- src/ast/passes/portability_analyser.cpp | 27 +------------------------
- 1 file changed, 1 insertion(+), 26 deletions(-)
+ src/ast/passes/portability_analyser.cpp | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/src/ast/passes/portability_analyser.cpp b/src/ast/passes/portability_analyser.cpp
-index 1c8399f..5ba80cd 100644
+index 1c8399f5..f78aa206 100644
 --- a/src/ast/passes/portability_analyser.cpp
 +++ b/src/ast/passes/portability_analyser.cpp
-@@ -42,33 +42,12 @@ void PortabilityAnalyser::visit(PositionalParameter &param)
- 
- void PortabilityAnalyser::visit(Builtin &builtin)
- {
--  // `struct task_struct` is unstable across kernel versions and configurations.
--  // This makes it inherently unportable. We must block it until we support
--  // field access relocations.
--  if (builtin.ident == "curtask") {
--    LOG(ERROR, builtin.loc, err_)
--        << "AOT does not yet support accessing `curtask`";
--  }
+@@ -45,10 +45,12 @@ void PortabilityAnalyser::visit(Builtin &builtin)
+   // `struct task_struct` is unstable across kernel versions and configurations.
+   // This makes it inherently unportable. We must block it until we support
+   // field access relocations.
++  /*
+   if (builtin.ident == "curtask") {
+     LOG(ERROR, builtin.loc, err_)
+         << "AOT does not yet support accessing `curtask`";
+   }
++  */
  }
- 
+
  void PortabilityAnalyser::visit(Call &call)
- {
-   for (Expression *expr : call.vargs)
-     visit(*expr);
--
--  // kaddr() and uaddr() both resolve symbols -> address during codegen and
--  // embeds the values into the bytecode. For AOT to support kaddr()/uaddr(),
--  // the addresses must be resolved at runtime and fixed up during load time.
--  //
--  // cgroupid can vary across systems just like how a process does not
--  // necessarily share the same PID across multiple systems. cgroupid() is also
--  // resolved during codegen and the value embedded into the bytecode.  For AOT
--  // to support cgroupid(), the cgroupid must be resolved at runtime and fixed
--  // up during load time.
--  if (call.func == "kaddr" || call.func == "uaddr" || call.func == "cgroupid") {
--    LOG(ERROR, call.loc, err_)
--        << "AOT does not yet support " << call.func << "()";
--  }
+@@ -65,10 +67,12 @@ void PortabilityAnalyser::visit(Call &call)
+   // resolved during codegen and the value embedded into the bytecode.  For AOT
+   // to support cgroupid(), the cgroupid must be resolved at runtime and fixed
+   // up during load time.
++  /*
+   if (call.func == "kaddr" || call.func == "uaddr" || call.func == "cgroupid") {
+     LOG(ERROR, call.loc, err_)
+         << "AOT does not yet support " << call.func << "()";
+   }
++  */
  }
- 
+
  void PortabilityAnalyser::visit(Cast &cast)
-@@ -80,7 +59,6 @@ void PortabilityAnalyser::visit(Cast &cast)
+@@ -80,7 +84,7 @@ void PortabilityAnalyser::visit(Cast &cast)
    // portable. `args` for k[ret]funcs are type checked by the kernel and may
    // also be considered stable. For AOT to fully support field accesses, we
    // need to relocate field access at runtime.
 -  LOG(ERROR, cast.loc, err_) << "AOT does not yet support struct casts";
++//  LOG(ERROR, cast.loc, err_) << "AOT does not yet support struct casts";
  }
- 
+
  void PortabilityAnalyser::visit(AttachPoint &ap)
-@@ -92,16 +70,13 @@ void PortabilityAnalyser::visit(AttachPoint &ap)
+@@ -92,16 +96,18 @@ void PortabilityAnalyser::visit(AttachPoint &ap)
    // and offsets and type information is embedded into the bytecode. For AOT
    // support, this analyzing must be done during runtime and fixed up during
    // load time.
--  if (type == ProbeType::usdt) {
--    LOG(ERROR, ap.loc, err_) << "AOT does not yet support USDT probes";
--  }
++  /*
+   if (type == ProbeType::usdt) {
+     LOG(ERROR, ap.loc, err_) << "AOT does not yet support USDT probes";
+   }
++  */
    // While userspace watchpoint probes are technically portable from codegen
    // point of view, they require a PID or path via cmdline to resolve address.
    // watchpoint probes are also API-unstable and need a further change
@@ -79,5 +74,6 @@ index 1c8399f..5ba80cd 100644
             type == ProbeType::asyncwatchpoint) {
      LOG(ERROR, ap.loc, err_) << "AOT does not yet support watchpoint probes";
    }
--- 
-2.49.1
+--
+2.43.0
+

--- a/pkg/bpftrace/patches/0003-bpfbytecode-disable-BTF_KIND_ENUM64.patch
+++ b/pkg/bpftrace/patches/0003-bpfbytecode-disable-BTF_KIND_ENUM64.patch
@@ -1,0 +1,36 @@
+From ec81a44599c974b8882737918fb1643e9f3e008c Mon Sep 17 00:00:00 2001
+From: Christoph Ostarek <christoph@zededa.com>
+Date: Tue, 7 May 2024 18:18:57 +0200
+Subject: [PATCH 3/3] bpfbytecode: disable BTF_KIND_ENUM64
+
+it is not supported yet by our kernel
+
+Signed-off-by: Christoph Ostarek <christoph@zededa.com>
+---
+ src/bpfbytecode.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/bpfbytecode.cpp b/src/bpfbytecode.cpp
+index c6291c8b..a0249401 100644
+--- a/src/bpfbytecode.cpp
++++ b/src/bpfbytecode.cpp
+@@ -50,6 +50,7 @@ static int btf_type_size(const struct btf_type *t)
+       return base_size + sizeof(__u32);
+     case BTF_KIND_ENUM:
+       return base_size + vlen * sizeof(struct btf_enum);
++    #if 0
+     case BTF_KIND_ENUM64:
+       /* struct btf_enum64 is not available in UAPI header until v6.0,
+        * calculate its size with array instead. Its definition is:
+@@ -60,7 +61,7 @@ static int btf_type_size(const struct btf_type *t)
+        *	__u32	val_hi32;
+        * };
+        */
+-      return base_size + vlen * sizeof(__u32[3]);
++    #endif
+     case BTF_KIND_ARRAY:
+       return base_size + sizeof(struct btf_array);
+     case BTF_KIND_STRUCT:
+--
+2.45.1
+

--- a/pkg/bsp-imx/Dockerfile
+++ b/pkg/bsp-imx/Dockerfile
@@ -4,10 +4,10 @@
 ARG BUILD_PKGS_BASE="bash binutils-dev build-base bc bison flex openssl-dev util-linux-dev swig gnutls-dev perl python3 python3-dev py3-setuptools py3-pycryptodome py3-elftools"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3
 
 # OPTEE-OS images
-FROM lfedge/eve-optee-os:c67d22abf143aa550378fce60a625be54eb555a8 AS optee-os
+FROM lfedge/eve-optee-os:3c441f553d0037cbd49689e35b695632c2c8a9b4 AS optee-os
 
 # hadolint ignore=DL3006
 FROM ${EVE_ALPINE_IMAGE} AS build-native

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -8,9 +8,9 @@
 # has a fast path for stack unwinding. This also happens
 # to be a perfect place to put any other kind of debug info
 # into the package: see abuild/etc/abuild.conf.
-FROM lfedge/eve-recovertpm:c64a9d8154737b63e500e6e2c62f0636f43118f9 AS recovertpm
-FROM lfedge/eve-bpftrace:87c1d8f49d9b872c95e99b873c0e96a58fc83142 AS bpftrace
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-recovertpm:b08b8875687bc363e4368427ffff64a4e5684205 AS recovertpm
+FROM lfedge/eve-bpftrace:03c26b968615b09b491f71e61e35d3f2675835ef AS bpftrace
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 ENV BUILD_PKGS="abuild curl tar make linux-headers patch g++ git gcc gpg gettext gettext-static ncurses-dev jq autoconf openssl-dev zlib-dev zlib-static gpg-agent"
 # Feel free to add additional packages here, but be aware that
 # EVE's rootfs image can be no larger than 300Mb (and don't

--- a/pkg/dnsmasq/Dockerfile
+++ b/pkg/dnsmasq/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 ENV BUILD_PKGS gcc make patch libc-dev linux-headers tar xz coreutils
 RUN eve-alpine-deploy.sh
 

--- a/pkg/dom0-ztools/Dockerfile
+++ b/pkg/dom0-ztools/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS zfs
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS zfs
 ENV BUILD_PKGS="git patch ca-certificates util-linux build-base gettext-dev libtirpc-dev automake autoconf \
     libtool linux-headers attr-dev e2fsprogs-dev glib-dev openssl-dev util-linux-dev coreutils"
 ENV PKGS="ca-certificates util-linux libintl libuuid libtirpc libblkid libcrypto3 zlib"

--- a/pkg/edgeview/Dockerfile
+++ b/pkg/edgeview/Dockerfile
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # hadolint ignore=DL3006
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS runtime
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS runtime
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables
 RUN eve-alpine-deploy.sh
 
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 ARG TARGETARCH
 
 COPY src/  /edge-view/.

--- a/pkg/eve/Dockerfile.in
+++ b/pkg/eve/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS tools
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS tools
 ENV PKGS="qemu-img tar u-boot-tools coreutils dosfstools"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/fscrypt/Dockerfile
+++ b/pkg/fscrypt/Dockerfile
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build-base
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build-base
 
 FROM build-base AS build-amd64
 FROM build-base AS build-arm64

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 ARG PLATFORM=generic
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build-base
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build-base
 
 ARG TARGETARCH
 
@@ -102,7 +102,7 @@ ADD https://hailo-hailort.s3.eu-west-2.amazonaws.com/Hailo8/${HAILO_FW_VERSION}/
 
 # generate initrd for Intel's and AMD's microcode
 # it makes sense only for x86_64 platform
-FROM --platform=${TARGETPLATFORM} lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS ucode-build-common
+FROM --platform=${TARGETPLATFORM} lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS ucode-build-common
 RUN mkdir -p /boot /tmp/ucode/intel /tmp/ucode/amd /usr/share/licenses/ucode
 
 FROM ucode-build-common AS ucode-build-amd64
@@ -143,7 +143,7 @@ FROM ucode-build-common AS ucode-build-arm64
 FROM ucode-build-common AS ucode-build-riscv64
 FROM ucode-build-${TARGETARCH} AS ucode-build
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS compactor-common
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS compactor-common
 ENTRYPOINT []
 WORKDIR /
 COPY --from=build /lib/firmware/regulatory* /lib/firmware/
@@ -221,7 +221,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
     fi
 
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS compactor-full
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS compactor-full
 # get all possible FW
 COPY --from=build /lib/firmware/ /lib/firmware/
 

--- a/pkg/gpt-tools/Dockerfile
+++ b/pkg/gpt-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 ENV BUILD_PKGS="gcc make file patch libc-dev linux-headers openssl-dev g++ tar coreutils"
 # util-linux-static on riscv64 is broken; we build libuuid from source instead (see below).
 ENV BUILD_PKGS_amd64="util-linux-static util-linux-dev"

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) 2025-2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS grub-build-base
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS grub-build-base
 ENV BUILD_PKGS="automake \
                make \
                bison \

--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 ENV BUILD_PKGS cairo-dev jpeg-dev libpng-dev gcc make libc-dev openssl-dev libvncserver-dev file patch
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs p11-kit cairo jpeg libpng libvncserver
 RUN eve-alpine-deploy.sh

--- a/pkg/installer/Dockerfile
+++ b/pkg/installer/Dockerfile
@@ -28,10 +28,10 @@ RUN cargo sbom > sbom.spdx.json
 
 RUN cp "/usr/local/my-installer/target/$CARGO_BUILD_TARGET/release/installer" /usr/local/my-installer/target/installer
 
-FROM lfedge/eve-debug:3d261056ab79eaee0758ad9bbbd6a26343c41d7b AS debug
+FROM lfedge/eve-debug:c926f68b25446c7cf9e4a66a1da446aa6155edba AS debug
 
 # Dockerfile to build installer img initrd
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 ENV BUILD_PKGS="mkinitfs grep patch make coreutils musl-dev gcc g++ perl \
     autoconf automake libtool file bsd-compat-headers libc-dev \

--- a/pkg/ipxe/Dockerfile
+++ b/pkg/ipxe/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 
 ENV BUILD_PKGS="patch make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev"
 RUN eve-alpine-deploy.sh

--- a/pkg/kdump/Dockerfile
+++ b/pkg/kdump/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 
 ENV BUILD_PKGS patch curl make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev elfutils-dev libbz2
 ENV PKGS xz-libs elfutils-dev libbz2

--- a/pkg/kexec/Dockerfile
+++ b/pkg/kexec/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 
 ENV BUILD_PKGS patch curl make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev elfutils-dev libbz2
 ENV PKGS xz-libs util-linux elfutils-dev libbz2

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables curl openrc \
          open-iscsi libvirt libvirt-client util-linux grep findutils jq \
          cni-plugins nfs-utils inotify-tools

--- a/pkg/measure-config/Dockerfile
+++ b/pkg/measure-config/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 ARG TARGETARCH
 
 COPY src/  /measure-config/.

--- a/pkg/memory-monitor/Dockerfile
+++ b/pkg/memory-monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS memory-monitor-build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS memory-monitor-build
 
 ENV BUILD_PKGS gcc musl-dev make linux-headers cmake build-base
 ENV PKGS alpine-baselayout curl strace

--- a/pkg/mkconf/Dockerfile
+++ b/pkg/mkconf/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 
 ENV PKGS mtools dosfstools
 RUN eve-alpine-deploy.sh

--- a/pkg/mkimage-iso-efi/Dockerfile
+++ b/pkg/mkimage-iso-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 
 ENV PKGS="dosfstools libarchive-tools binutils mtools xorriso mkinitfs squashfs-tools"
 RUN eve-alpine-deploy.sh

--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -5,7 +5,7 @@
 #   /EFI/BOOT/grub.cfg - Chainloads main bootloader
 #   /UsbInvocationScript.txt - Enables USB boot on Dell 3000 series
 #
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 ENV BUILD_PKGS="grep patch git make gcc linux-headers musl-dev autoconf automake pkgconfig kmod-dev util-linux-dev cryptsetup-dev lddtree libgcc mkinitfs"
 ENV PKGS="mtools dosfstools libarchive-tools sgdisk e2fsprogs util-linux squashfs-tools coreutils tar dmidecode \

--- a/pkg/mkrootfs-ext4/Dockerfile
+++ b/pkg/mkrootfs-ext4/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools sfdisk sgdisk xfsprogs \
          e2fsprogs util-linux coreutils multipath-tools squashfs-tools

--- a/pkg/mkrootfs-squash/Dockerfile
+++ b/pkg/mkrootfs-squash/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools sfdisk sgdisk \
     xfsprogs e2fsprogs util-linux coreutils multipath-tools squashfs-tools

--- a/pkg/monitor/Dockerfile
+++ b/pkg/monitor/Dockerfile
@@ -49,7 +49,7 @@ RUN cargo sbom > sbom.spdx.json
 RUN cp /app/target/$CARGO_BUILD_TARGET/release/monitor /app/target/
 
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS runtime
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS runtime
 ENV PKGS="kbd pciutils usbutils"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # hadolint ignore=DL3006
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS runtime
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS runtime
 ENV PKGS coreutils
 RUN eve-alpine-deploy.sh
 
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 ARG TARGETARCH
 
 COPY go.mod /newlog/

--- a/pkg/nvidia/Dockerfile
+++ b/pkg/nvidia/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG PLATFORM=generic
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build-base
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build-base
 ENV BUILD_PKGS="autoconf automake build-base coreutils gettext git glib-dev libtool libmd-dev ncurses-dev tar xz-dev yq zstd-dev dpkg"
 
 RUN eve-alpine-deploy.sh

--- a/pkg/optee-os/Dockerfile
+++ b/pkg/optee-os/Dockerfile
@@ -4,7 +4,7 @@
 ARG BUILD_PKGS_BASE="autoconf automake bash binutils binutils-dev build-base bc bison curl dtc expat flex openssl-dev util-linux-dev swig gnutls-dev perl python3 python3-dev py3-setuptools py3-pycryptodome py3-elftools py3-cryptography"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3
 
 # hadolint ignore=DL3006
 FROM ${EVE_ALPINE_IMAGE} AS build-native

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -8,10 +8,10 @@ ARG BUILD_PKGS_BASE="git gcc linux-headers libc-dev make linux-pam-dev m4 findut
                      libintl libuuid libtirpc libblkid libcrypto3 zlib tar"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3
 
-FROM lfedge/eve-uefi:d34705816eae92ca6c736e92cbe56558472f6a28 AS uefi-build
-FROM lfedge/eve-dom0-ztools:41e448a70640e7b6f98d19f790cf35cf579fd0db AS zfs
+FROM lfedge/eve-uefi:382a7a614c0414cefabde13505f87b705a0a044c AS uefi-build
+FROM lfedge/eve-dom0-ztools:12f3be8183942a1134241414bc265f624dbaad51 AS zfs
 RUN mkdir /out
 # copy zfs-related files from dom0-ztools using prepared list of files
 RUN while read -r x; do \
@@ -133,9 +133,9 @@ RUN --mount=type=cache,target=/root/.cache/go-build if [ "${TEST_TOOLS}" = "y" ]
     GOBIN=/final/opt/ GOFLAGS="" go install gotest.tools/gotestsum@v1.7.0; \
 fi
 
-FROM lfedge/eve-fscrypt:33875411fe54615d0c0c1f9637616c8012f488da AS fscrypt
-FROM lfedge/eve-dnsmasq:fe6241610dc17be349b02ed4c160c8b7bee9d05a AS dnsmasq
-FROM lfedge/eve-gpt-tools:cd4cfc1cac9885c35453bdc4ac88ab60eb667d05 AS gpttools
+FROM lfedge/eve-fscrypt:e6a8b9da0aa85206bf84cbebd3a2c6e8df959216 AS fscrypt
+FROM lfedge/eve-dnsmasq:960948b6a5627ec1d3815d58235d6f2ca64642bc AS dnsmasq
+FROM lfedge/eve-gpt-tools:36b9660038be7724ef1a7d2e0458a33fe4489b45 AS gpttools
 
 # dhcpcd: Alpine 3.21+ ships a sufficiently up-to-date version (10.x with required IPv6 fixes).
 # No --platform means Docker BuildKit uses the target platform, giving us the correct binary arch.

--- a/pkg/recovertpm/Dockerfile
+++ b/pkg/recovertpm/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 ARG TARGETARCH
 
 # build the tpm-recovery tool

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 ENV BUILD_PKGS gcc musl-dev linux-headers
 RUN eve-alpine-deploy.sh
 

--- a/pkg/sources/Dockerfile
+++ b/pkg/sources/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS tools
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS tools
 
 COPY collected_sources.tar.gz /var/collected_sources.tar.gz
 RUN mkdir -p /var/sources && tar -C /var/sources -xzf /var/collected_sources.tar.gz

--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 ENV PKGS="alpine-baselayout musl-utils bash glib squashfs-tools util-linux e2fsprogs e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/u-boot/Dockerfile
+++ b/pkg/u-boot/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build-base
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build-base
 ENV BUILD_PKGS bash binutils-dev build-base bc bison flex openssl-dev python3 swig dtc
 ENV BUILD_PKGS_amd64 python3-dev py-pip
 RUN eve-alpine-deploy.sh

--- a/pkg/udev/Dockerfile
+++ b/pkg/udev/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 ENV PKGS="udev kmod"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/uefi/Dockerfile
+++ b/pkg/uefi/Dockerfile
@@ -10,7 +10,7 @@
 #   git clone https://git.linaro.org/uefi/uefi-tools.git
 #   ./uefi-tools/edk2-build.sh -b DEBUG -b RELEASE all
 #
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 ENV BUILD_PKGS make gcc g++ python3 libuuid nasm util-linux-dev bash git util-linux patch
 ENV BUILD_PKGS_amd64 iasl
 ENV BUILD_PKGS_arm64 iasl

--- a/pkg/vector/Dockerfile
+++ b/pkg/vector/Dockerfile
@@ -65,7 +65,7 @@ RUN llvm-strip "/app/target/$CARGO_BUILD_TARGET/release/vector"
 RUN cargo sbom > sbom.spdx.json
 RUN cp "/app/target/$CARGO_BUILD_TARGET/release/vector" /app/target/
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS runtime
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS runtime
 ENV PKGS="inotify-tools"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -3,14 +3,14 @@
 # Copyright (c) 2023-2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-dom0-ztools:41e448a70640e7b6f98d19f790cf35cf579fd0db AS dom0
+FROM lfedge/eve-dom0-ztools:12f3be8183942a1134241414bc265f624dbaad51 AS dom0
 
 # ===========================================================================
 # C builds (libtpms, swtpm, tpm2-tss, tpm2-tools, ptpm)
 # These use autoconf/automake with many -dev dependencies, so for now they
 # remain under QEMU emulation when cross-building.
 # ===========================================================================
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build-c
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build-c
 ENV BUILD_PKGS="gcc g++ autoconf automake libtool make openssl-dev libtasn1-dev \
     json-glib-dev gnutls bash expect gawk socat libseccomp-dev gmp-dev \
     musl-utils autoconf-archive git json-c json-c-dev libcurl curl-dev \
@@ -83,7 +83,7 @@ RUN rm /out/usr/lib/libprotoc.so*
 # This avoids QEMU, which is known to deadlock on go vet / go build.
 # ===========================================================================
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build-go
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build-go
 ARG TARGETARCH
 
 WORKDIR /vtpm-build

--- a/pkg/watchdog/Dockerfile
+++ b/pkg/watchdog/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS watchdog-build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS watchdog-build
 ENV BUILD_PKGS build-base file libtirpc-dev linux-headers tar util-linux
 ENV PKGS alpine-baselayout musl-utils libsmartcols
 RUN eve-alpine-deploy.sh

--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023-2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 ENV BUILD_PKGS meson ninja git libc-dev glib-dev make gcc udev dbus-dev libgudev-dev
 ENV PKGS alpine-baselayout dbus glib kmod-dev libgudev
 RUN eve-alpine-deploy.sh

--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -3,8 +3,8 @@
 # Copyright (c) 2023-2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-uefi:d34705816eae92ca6c736e92cbe56558472f6a28 AS uefi-build
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS runx-build
+FROM lfedge/eve-uefi:382a7a614c0414cefabde13505f87b705a0a044c AS uefi-build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS runx-build
 ENV BUILD_PKGS="mkinitfs gcc musl-dev e2fsprogs chrony agetty"
 RUN eve-alpine-deploy.sh
 
@@ -20,7 +20,7 @@ RUN gcc -s -o /chroot2 /tmp/chroot2.c -Wall -Werror
 RUN gcc -s -o /hacf /tmp/hacf.c -Wall -Werror
 RUN mkinitfs -n -F base -i /init-initrd -o /runx-initrd
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
 ENV BUILD_PKGS="\
     gcc make libc-dev dev86 xz-dev perl bash python3-dev \
     gettext iasl util-linux-dev ncurses-dev glib-dev \

--- a/pkg/xen/Dockerfile
+++ b/pkg/xen/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS kernel-build
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS kernel-build
 
 ENV BUILD_PKGS argp-standalone automake bash bc binutils-dev bison build-base \
                diffutils flex git gmp-dev gnupg installkernel kmod \


### PR DESCRIPTION
# Description

Switch back to good old bpftrace.

    Questions? Answers!
    1. Why not update to newer bpftrace?
     -> Unfortunately the format to exchange data between bpftrace and
        bpftrace-aotrt was drastically changed; now an executable file
        is created by bpftrace that has to be copied to the guest.
        Also this allows to use current bpftrace-compiler with older EVE
        versions.
    
    2. Why are we not using bcc from the alpine repository?
      -> Although during e2e tests I saw no crashes, one of the
         tests in bpftrace crashes in bcc (utils.resolve_binary_path)


## How to test and validate this PR

on arm64 and on amd64:
* compile and run EVE in qemu
* add ssh key to `/root/.ssh/authorized_keys` in debug container
* build bpftrace-compiler and run:
  * `./bpftrace-compiler rs 127.1:2222 examples/opensnoop.bt` -> check that there is some output
  * `./bpftrace-compiler rs 127.1:2222 -u service,debug -t 5m examples/sslsnoop-debug-container.bt` and while bpftrace is running on EVE create some TLS traffic with curl (e.g. `curl https://www.google.com`) -> check that the output is legitimate

## Changelog notes

Fix bpftrace for alpine 3.22

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 16.0-stable: no, because it is still using old alpine
- 14.5-stable: same
- 13.4-stable: same

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
