### PR TITLE
Fix SCEPClient after removal of EVE V1 API support

### DIFF
--- a/pkg/pillar/cmd/scepclient/run.go
+++ b/pkg/pillar/cmd/scepclient/run.go
@@ -475,9 +475,7 @@ func (c *SCEPClient) handleDevNetStatus(key string, status interface{}) {
 	c.log.Functionf("handleDevNetStatus for %s", key)
 	wasTesting := c.devNetworkStatus.Testing
 	*c.devNetworkStatus = devNetStatus
-	if c.httpClient.UsingV2API() {
-		c.httpClient.UpdateTLSProxyCerts()
-	}
+	c.httpClient.UpdateTLSProxyCerts()
 	if wasTesting && !c.devNetworkStatus.Testing {
 		// Network testing has just completed (either a new configuration
 		// was applied or a fallback was selected). Retry certificate

--- a/pkg/pillar/cmd/scepclient/scep.go
+++ b/pkg/pillar/cmd/scepclient/scep.go
@@ -575,7 +575,6 @@ func (c *SCEPClient) getCACertOverProxy(
 
 	proxyURL := controllerconn.URLPathString(
 		c.controllerHostname,
-		c.httpClient.UsingV2API(),
 		c.devUUID,
 		"proxy/scep",
 	)
@@ -870,7 +869,6 @@ func (c *SCEPClient) getCACapsOverProxy(
 
 	proxyURL := controllerconn.URLPathString(
 		c.controllerHostname,
-		c.httpClient.UsingV2API(),
 		c.devUUID,
 		"proxy/scep",
 	)
@@ -940,7 +938,6 @@ func (c *SCEPClient) execPKIOperationOverProxy(profile types.SCEPProfile,
 
 	proxyURL := controllerconn.URLPathString(
 		c.controllerHostname,
-		c.httpClient.UsingV2API(),
 		c.devUUID,
 		"proxy/scep",
 	)


### PR DESCRIPTION
# Description

PR https://github.com/lf-edge/eve/pull/5691 was not rebased onto the latest master after PR https://github.com/lf-edge/eve/pull/5561 was merged. As a result, the SCEPClient build break caused by the removal of EVE V1 API support went unnoticed.

## PR Dependencies

None

## Changelog notes

None

## PR Backports

No backporting, SCEPClient was just merged to master and master only.

## Checklist

- [X] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [X] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
