### PR TITLE
pr-gate: Needs to be updated since workflow names changed

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -88,7 +88,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ steps.meta.outputs.original_run_id }}
           GH_REPO: ${{ github.repository }}
-          BUILD_JOB_NAME: "eve (${{ matrix.arch }}, ${{ matrix.hv }}, ${{ matrix.platform }})"
+          BUILD_JOB_NAME: "eve-${{ matrix.arch }}-${{ matrix.hv }}-${{ matrix.platform }} / build"
         run: |
           build_conclusion=$(gh api \
             /repos/$GH_REPO/actions/runs/$RUN_ID/jobs \


### PR DESCRIPTION
# Description

TBD: Is this the wrong fix? Don't we use pr-gate in LTS releases? If so the name changes in PR #5782 needs to be reverted to make the old name that pr-gate is looking for.


The pr-gate workflow always fails because it is looking for the wrong BUILD_JOB_NAME. Prior to PR #5782 it was
    BUILD_JOB_NAME: eve (amd64, kvm, generic)
and post it the name seems to be
    BUILD_JOB_NAME: eve-amd64-kvm-generic / build


## How to test and validate this PR

None

## Changelog notes

None

## PR Backports

- 16.0-stable - no 
- 14.5-stable -  no
- 13.4-stable - no

## Checklist

- [X] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [X] I've written the test verification instructions
- [X] I've set the proper labels to this PR

- [X] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
