### PR TITLE
Fix bond link monitoring

### DIFF
--- a/pkg/pillar/dpcreconciler/linuxitems/bond.go
+++ b/pkg/pillar/dpcreconciler/linuxitems/bond.go
@@ -16,6 +16,10 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
 )
 
+// bondDefaultMiimon is the default MII monitoring interval (in milliseconds) applied
+// to failover-type bonds when no monitoring method is explicitly configured.
+const bondDefaultMiimon = 100
+
 // Bond : Bond interface.
 type Bond struct {
 	types.BondConfig
@@ -141,6 +145,11 @@ func (c *BondConfigurator) Create(ctx context.Context, item depgraph.Item) error
 	} else if bondCfg.ARPMonitor.Enabled {
 		bond.ArpInterval = int(bondCfg.ARPMonitor.Interval)
 		bond.ArpIpTargets = bondCfg.ARPMonitor.IPTargets
+	} else if isFailoverBondMode(bondCfg.Mode) {
+		// Enable MII monitoring with a default interval for failover-type bonds
+		// when no monitoring method is explicitly configured. Without link monitoring,
+		// failover bonds cannot detect slave failures and are essentially useless.
+		bond.Miimon = bondDefaultMiimon
 	}
 	bond.MTU = int(bondCfg.GetMTU())
 	err := netlink.LinkAdd(bond)
@@ -186,6 +195,19 @@ func (c *BondConfigurator) aggregateInterface(bond *netlink.Bond, ifName string)
 		return err
 	}
 	return nil
+}
+
+// isFailoverBondMode returns true for bond modes that rely on link monitoring
+// to detect slave failures and trigger failover.
+func isFailoverBondMode(mode types.BondMode) bool {
+	switch mode {
+	case types.BondModeActiveBackup,
+		types.BondModeBalanceTLB,
+		types.BondModeBalanceALB:
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *BondConfigurator) disaggregateInterface(aggrIfName string) error {

--- a/pkg/pillar/dpcreconciler/linuxitems/bond.go
+++ b/pkg/pillar/dpcreconciler/linuxitems/bond.go
@@ -134,12 +134,10 @@ func (c *BondConfigurator) Create(ctx context.Context, item depgraph.Item) error
 		c.Log.Error(err)
 		return err
 	}
-	bond.Miimon = 0
-	bond.ArpInterval = 0
 	if bondCfg.MIIMonitor.Enabled {
-		bond.DownDelay = int(bondCfg.MIIMonitor.DownDelay)
-		bond.UpDelay = int(bondCfg.MIIMonitor.UpDelay)
 		bond.Miimon = int(bondCfg.MIIMonitor.Interval)
+		bond.UpDelay = int(bondCfg.MIIMonitor.UpDelay)
+		bond.DownDelay = int(bondCfg.MIIMonitor.DownDelay)
 	} else if bondCfg.ARPMonitor.Enabled {
 		bond.ArpInterval = int(bondCfg.ARPMonitor.Interval)
 		bond.ArpIpTargets = bondCfg.ARPMonitor.IPTargets


### PR DESCRIPTION
# Description

Two commits that fix bugs in `BondConfigurator.Create` (`pkg/pillar/dpcreconciler/linuxitems/bond.go`).
                      
**Fix bond creation failure in 802.3ad (LACP) mode**
                                                                                                                                                                                       
`BondConfigurator.Create` was explicitly zeroing `bond.Miimon` and `bond.ArpInterval` before calling `netlink.LinkAdd`. The netlink library uses `-1` as a sentinel meaning "do not send this attribute", so setting those fields to `0` caused them to be included in the `RTM_NEWLINK` message. For 802.3ad (LACP) mode, the kernel's `bond_opt_check_deps` rejects `IFLA_BOND_ARP_INTERVAL` (even when zero) because ARP monitoring is not compatible with that mode -- returning `-EACCES`. The fix is to only populate monitoring attributes when they are actually configured by the user.                                                                                                                                                   

**Enable MII monitoring by default for failover bonds**

For failover bond modes (active-backup, balance-tlb, balance-alb), the bonding driver requires link monitoring to detect slave failures and perform failover. Without it, a failover bond is essentially non-functional -- all slaves look equally healthy regardless of their actual link state. When the user has not explicitly configured any monitoring method (neither MII nor ARP), MII monitoring is now enabled automatically with a 100 ms polling interval (a widely-used default). The user can always override this by setting an explicit monitoring configuration.

## How to test and validate this PR

1. Create a device network configuration with an active-backup bond and no explicit monitoring settings. Confirm via 
`/proc/net/bonding/<name>` that MII monitoring is active with Polling Interval: `100ms` after the bond is created. Disconnect the active slave port and verify that the bond detects the failure and activates another slave.

3. Create an 802.3ad (LACP) bond without any monitoring settings. Confirm that bond creation no longer fails with a permission error and that the bond interface comes up successfully.

## Changelog notes

- Fixed bond creation failure (`EACCES`) when creating an 802.3ad (LACP) bond due to spurious `IFLA_BOND_ARP_INTERVAL=0` being sent in the netlink message.                              
- For failover bond modes (active-backup, balance-tlb, balance-alb), MII link monitoring is now automatically enabled with a 100 ms interval when no monitoring method is explicitly configured by the user. 

## PR Backports

- 16.0-stable: https://github.com/lf-edge/eve/pull/5858
- 14.5-stable: to be backported
- 13.4-stable: to be backported

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.