### PR TITLE
monitor: bump monitor-rs to v0.6.3

### DIFF
--- a/pkg/monitor/Dockerfile
+++ b/pkg/monitor/Dockerfile
@@ -1,7 +1,7 @@
-# Copyright (c) 2024 Zededa, Inc.
+# Copyright (c) 2024-2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG MONITOR_RS_VERSION=v0.6.2
+ARG MONITOR_RS_VERSION=v0.6.3
 ARG RUST_VERSION=lfedge/eve-rust:1.93.1
 FROM --platform=$BUILDPLATFORM ${RUST_VERSION} AS toolchain-base
 ARG TARGETARCH


### PR DESCRIPTION
# Description

Bump the MONITOR_RS_VERSION from v0.6.2 to v0.6.3 to pick up the latest fixes and improvements in monitor-rs.

Changes in v0.6.3:
- types: Add serde default to all IPC types
- TUI monitor: gracefully handle IPC connection failure instead of crashing

## How to test and validate this PR

Build the monitor package and verify it compiles and runs correctly:
```
make pkg/monitor
```

## Changelog notes

Bump monitor-rs to v0.6.3.

## PR Backports

- 16.0-stable: To be backported
- 14.5-stable: To be backported
- 13.4-stable: No, too old

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.