### PR TITLE
Fix Go package cross-compilation and add parallel builds

### DIFF
--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -50,10 +50,12 @@ COPY lshw/ lshw-B.${LSHW_VERSION}/
 
 WORKDIR /lshw-B.${LSHW_VERSION}
 
+# hadolint ignore=SC2046
 RUN for patch in *.patch; do \
     patch -p1 < "$patch"; \
     done && \
-    make -C src VERSION=B.${LSHW_VERSION} NO_VERSION_CHECK=1  RPM_OPT_FLAGS=-DNONLS ZLIB=1 GZIP="busybox gzip -n9" static && \
+    make -j$(nproc) -C src VERSION=B.${LSHW_VERSION} NO_VERSION_CHECK=1 RPM_OPT_FLAGS=-DNONLS ZLIB=1 core && \
+    make -j$(nproc) -C src VERSION=B.${LSHW_VERSION} NO_VERSION_CHECK=1 RPM_OPT_FLAGS=-DNONLS ZLIB=1 GZIP="busybox gzip -n9" static && \
     cp src/lshw-static /out/usr/bin/lshw && strip /out/usr/bin/lshw
 
 # building hexedit
@@ -61,7 +63,8 @@ WORKDIR /tmp/hexedit/hexedit-1.5
 # hadolint ignore=DL4006
 ADD https://github.com/pixel/hexedit/archive/refs/tags/1.5.tar.gz ../1.5.tar.gz
 RUN tar -C .. -xzvf ../1.5.tar.gz
-RUN ./autogen.sh && ./configure && make DESTDIR=/out install
+# hadolint ignore=SC2046
+RUN ./autogen.sh && ./configure && make -j$(nproc) && make DESTDIR=/out install
 
 # tweaking various bit
 WORKDIR /out

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -8,7 +8,7 @@
 # has a fast path for stack unwinding. This also happens
 # to be a perfect place to put any other kind of debug info
 # into the package: see abuild/etc/abuild.conf.
-FROM lfedge/eve-recovertpm:7f11c2f2f9d8527b7598b831b9f6e2e477b5b63a AS recovertpm
+FROM lfedge/eve-recovertpm:c64a9d8154737b63e500e6e2c62f0636f43118f9 AS recovertpm
 FROM lfedge/eve-bpftrace:87c1d8f49d9b872c95e99b873c0e96a58fc83142 AS bpftrace
 FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
 ENV BUILD_PKGS="abuild curl tar make linux-headers patch g++ git gcc gpg gettext gettext-static ncurses-dev jq autoconf openssl-dev zlib-dev zlib-static gpg-agent"

--- a/pkg/edgeview/Dockerfile
+++ b/pkg/edgeview/Dockerfile
@@ -1,9 +1,14 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
-ENV BUILD_PKGS git
+
+# hadolint ignore=DL3006
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS runtime
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables
 RUN eve-alpine-deploy.sh
+
+# hadolint ignore=DL3029
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+ARG TARGETARCH
 
 COPY src/  /edge-view/.
 COPY go.mod /edge-view/.
@@ -15,13 +20,14 @@ WORKDIR /edge-view
 ENV CGO_ENABLED=0
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 # hadolint ignore=SC2046
-RUN echo "Running go vet" && go vet ./... && echo "Running go fmt" && \
+RUN echo "Running go vet" && GOARCH=${TARGETARCH} go vet ./... && echo "Running go fmt" && \
     ERR=$(gofmt -e -l -s $(find . -name \*.go | grep -v /vendor/)) && \
     if [ -n "$ERR" ] ; then echo "go fmt Failed - ERR: $ERR"; exit 1 ; fi
 
-RUN GO111MODULE=on CGO_ENABLED=0 go build -ldflags "-s -w -X=main.Version=${GOPKGVERSION}" -mod=vendor -o /out/usr/bin/edge-view . && cp edge-view-init.sh /out/usr/bin
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags "-s -w -X=main.Version=${GOPKGVERSION}" -mod=vendor -o /out/usr/bin/edge-view . && cp edge-view-init.sh /out/usr/bin
 
 FROM scratch
+COPY --from=runtime /out/ /
 COPY --from=build /out/ /
 RUN mkdir -p /tmp && echo "hosts: files dns" > /etc/nsswitch.conf
 

--- a/pkg/installer/Dockerfile
+++ b/pkg/installer/Dockerfile
@@ -28,7 +28,7 @@ RUN cargo sbom > sbom.spdx.json
 
 RUN cp "/usr/local/my-installer/target/$CARGO_BUILD_TARGET/release/installer" /usr/local/my-installer/target/installer
 
-FROM lfedge/eve-debug:07bab7d7d72a4e89b2efd3faa5b4ece1435e1bca AS debug
+FROM lfedge/eve-debug:3d261056ab79eaee0758ad9bbbd6a26343c41d7b AS debug
 
 # Dockerfile to build installer img initrd
 FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build

--- a/pkg/measure-config/Dockerfile
+++ b/pkg/measure-config/Dockerfile
@@ -1,9 +1,8 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
-ENV BUILD_PKGS git
-ENV PKGS alpine-baselayout musl-utils
-RUN eve-alpine-deploy.sh
+# hadolint ignore=DL3029
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+ARG TARGETARCH
 
 COPY src/  /measure-config/.
 COPY go.mod /measure-config/.
@@ -16,11 +15,11 @@ WORKDIR /measure-config
 ENV CGO_ENABLED=0
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 # hadolint ignore=SC2046
-RUN echo "Running go vet" && go vet ./... && echo "Running go fmt" && \
+RUN echo "Running go vet" && GOARCH=${TARGETARCH} go vet ./... && echo "Running go fmt" && \
     ERR=$(gofmt -e -l -s $(find . -name \*.go | grep -v /vendor/)) && \
     if [ -n "$ERR" ] ; then echo "go fmt Failed - ERR: $ERR"; exit 1 ; fi
 
-RUN GO111MODULE=on CGO_ENABLED=0 go build -ldflags "-s -w -X=main.Version=${GOPKGVERSION}" -mod=vendor -o /out/usr/bin/measure-config .
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags "-s -w -X=main.Version=${GOPKGVERSION}" -mod=vendor -o /out/usr/bin/measure-config .
 
 FROM scratch
 COPY --from=build /out/ /

--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -1,9 +1,14 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
-ENV BUILD_PKGS git
+
+# hadolint ignore=DL3006
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS runtime
 ENV PKGS coreutils
 RUN eve-alpine-deploy.sh
+
+# hadolint ignore=DL3029
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+ARG TARGETARCH
 
 COPY go.mod /newlog/
 COPY go.sum /newlog/
@@ -13,12 +18,13 @@ COPY vendor /newlog/vendor
 WORKDIR /newlog
 ARG GOPKGVERSION
 
-RUN GO111MODULE=on CGO_ENABLED=0 go build -ldflags "-s -w -X=main.Version=${GOPKGVERSION}" -mod=vendor -o /out/usr/bin/newlogd ./cmd
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags "-s -w -X=main.Version=${GOPKGVERSION}" -mod=vendor -o /out/usr/bin/newlogd ./cmd
 
 # required for pubsub
 RUN rm -rf /out/var/run && mkdir -p /out/run /out/var && ln -s /run /out/var
 
 FROM scratch
+COPY --from=runtime /out/ /
 COPY --from=build /out/ /
 COPY newlogd-init.sh /newlogd-init.sh
 

--- a/pkg/recovertpm/Dockerfile
+++ b/pkg/recovertpm/Dockerfile
@@ -1,7 +1,9 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+# hadolint ignore=DL3029
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+ARG TARGETARCH
 
 # build the tpm-recovery tool
 WORKDIR /
@@ -10,10 +12,10 @@ COPY src/ recover-tpm/
 WORKDIR /recover-tpm
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 # hadolint ignore=SC2046
-RUN echo "Running go vet" && go vet ./... && echo "Running go fmt" && \
+RUN echo "Running go vet" && GOARCH=${TARGETARCH} go vet ./... && echo "Running go fmt" && \
     ERR=$(gofmt -e -l -s $(find . -name \*.go | grep -v /vendor/)) && \
     if [ -n "$ERR" ] ; then echo "go fmt Failed - ERR: $ERR"; exit 1 ; fi
-RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o recovertpm .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags "-s -w" -o recovertpm .
 
 FROM scratch
 WORKDIR /


### PR DESCRIPTION
# Description

these commits are cherry-picked from #5730 and will be removed from that PR. 

Fix cross-compilation for several pure-Go EVE packages by adding `--platform=$BUILDPLATFORM` so the Go compiler runs natively on the host instead of under QEMU emulation. Cross-compilation is achieved with
`GOARCH=$TARGETARCH` and `CGO_ENABLED=0`. Runtime dependencies are installed in separate stages without `--platform` so they resolve to the correct target architecture.

Packages fixed:
- **recovertpm**
- **measure-config**
- **newlog**
- **edgeview**

Additionally:
- **debug**: add parallel make (`-j`) for lshw and hexedit builds, with a  workaround for lshw's Makefile race condition.
- Package hashes updated to reflect the Dockerfile changes.

## How to test and validate this PR

1. Build EVE for both amd64 and arm64:
   ```
   make ZARCH=amd64 pkgs
   make ZARCH=arm64 pkgs
   ```
2. Verify that the affected packages (recovertpm, measure-config, newlog,   edgeview, debug) build successfully for both architectures without   QEMU emulation errors.
3. Boot the resulting image and verify that the services start correctly.

## Changelog notes

Speedup cross-compilation of GO applications on CI and MacOS

## PR Backports

- 16.0-stable: No, build-only improvement
- 14.5-stable: No, build-only improvement
- 13.4-stable: No, build-only improvement

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
