### PR TITLE
ci: bump guyarb/golang-test-annotations to v0.9.0

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -63,7 +63,7 @@ jobs:
           bash tests/tpm/prep-and-test.sh
       - name: Report test results as Annotations
         if: ${{ always() }}
-        uses: guyarb/golang-test-annoations@2941118d7ef622b1b3771d1ff6eae9e90659eb26  # v0.8.0
+        uses: guyarb/golang-test-annoations@96fc379b171c49932041d6c789e73331a7bdeec1  # v0.9.0
         with:
           test-results: dist/amd64/results.json
       - name: Store raw test results


### PR DESCRIPTION
# Description

Update `guyarb/golang-test-annoations` from v0.8.0 to v0.9.0 to resolve the Node.js 20 deprecation warning in GitHub Actions.

Node.js 20 actions will be forced to run with Node.js 24 starting June 2nd, 2026, and Node.js 20 will be removed from runners on September 16th, 2026. The action is pinned by commit SHA for reproducibility.

## How to test and validate this PR

1. Trigger the `go-tests` workflow (e.g. by pushing to a PR).
2. Verify the Node.js 20 deprecation warning no longer appears.
3. Verify test result annotations still appear correctly on the PR.

## Changelog notes

No user-facing changes.

## PR Backports

- 16.0-stable: No, CI-only change
- 14.5-stable: No, CI-only change
- 13.4-stable: No, CI-only change

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
