### PR TITLE
github/workflows: Fix build.yml workflow

### DIFF
--- a/.github/actions/build-eve/action.yml
+++ b/.github/actions/build-eve/action.yml
@@ -18,17 +18,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Clear repository
-      shell: bash
-      run: |
-        sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
-        rm -fr ~/.linuxkit
-        docker system prune --all --force --volumes
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      with:
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        ref: ${{ github.event.pull_request.head.ref }}
-        fetch-depth: 0
     - name: Login to Docker Hub
       if: ${{ github.event.repository.full_name == 'lf-edge/eve' }}
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,17 @@ jobs:
     runs-on: zededa-ubuntu-2204
     timeout-minutes: 1440
     steps:
+      - name: Clear repository
+        shell: bash
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - uses: ./.github/actions/build-eve
         with:
           arch: amd64
@@ -131,6 +142,17 @@ jobs:
     runs-on: zededa-ubuntu-2204
     timeout-minutes: 1440
     steps:
+      - name: Clear repository
+        shell: bash
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - uses: ./.github/actions/build-eve
         with:
           arch: amd64
@@ -146,6 +168,17 @@ jobs:
     runs-on: zededa-ubuntu-2204
     timeout-minutes: 1440
     steps:
+      - name: Clear repository
+        shell: bash
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - uses: ./.github/actions/build-eve
         with:
           arch: amd64
@@ -161,6 +194,17 @@ jobs:
     runs-on: zededa-ubuntu-2204
     timeout-minutes: 1440
     steps:
+      - name: Clear repository
+        shell: bash
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - uses: ./.github/actions/build-eve
         with:
           arch: amd64
@@ -176,6 +220,17 @@ jobs:
     runs-on: zededa-ubuntu-2204
     timeout-minutes: 1440
     steps:
+      - name: Clear repository
+        shell: bash
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - uses: ./.github/actions/build-eve
         with:
           arch: amd64
@@ -191,6 +246,17 @@ jobs:
     runs-on: zededa-ubuntu-2204-arm64
     timeout-minutes: 1440
     steps:
+      - name: Clear repository
+        shell: bash
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - uses: ./.github/actions/build-eve
         with:
           arch: arm64
@@ -204,6 +270,17 @@ jobs:
     runs-on: zededa-ubuntu-2204-arm64
     timeout-minutes: 1440
     steps:
+      - name: Clear repository
+        shell: bash
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - uses: ./.github/actions/build-eve
         with:
           arch: arm64
@@ -219,6 +296,17 @@ jobs:
     runs-on: zededa-ubuntu-2204-arm64
     timeout-minutes: 1440
     steps:
+      - name: Clear repository
+        shell: bash
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - uses: ./.github/actions/build-eve
         with:
           arch: arm64
@@ -232,6 +320,17 @@ jobs:
     runs-on: zededa-ubuntu-2204-arm64
     timeout-minutes: 1440
     steps:
+      - name: Clear repository
+        shell: bash
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - uses: ./.github/actions/build-eve
         with:
           arch: arm64
@@ -248,6 +347,11 @@ jobs:
     runs-on: zededa-ubuntu-2204
     timeout-minutes: 1440
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - name: Starting Report
         run: |
           echo "Build target: mini-riscv64-generic (cross-build)"


### PR DESCRIPTION
# Description

Commit e47130320ddcfc0f767b7702d377ecf3d94d1c48 replaced build-eve reusable workflow with composite action. However, since the build-eve action comes from eve repo, we need to first checkout the code so the action yml file is present.

This commit moves the Clear and the Checkout steps from the action to the build workflow so we don't get duplicated tasks and let the build action run all other steps.

Tested on my repo: https://github.com/rene/eve/actions/runs/24506455388?pr=241

## How to test and validate this PR

Just let the build workflow run and complete successfully.

## Changelog notes

None. (CI/CD stuff).

## PR Backports

No backports needed (issue is only on master).

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.