### PR TITLE
ci: switch actionlint reporter to github-check

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -12,6 +12,10 @@ on:  # yamllint disable-line rule:truthy
     paths:
       - '.github/workflows/**'
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   actionlint:
     runs-on: ubuntu-24.04
@@ -20,5 +24,5 @@ jobs:
       - name: Run actionlint
         uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d  # v1.72.0
         with:
-          reporter: github-pr-review
+          reporter: github-check
           fail_level: error


### PR DESCRIPTION
# Description

Switch the reviewdog actionlint reporter from `github-pr-review` to `github-check`. The `github-pr-review` reporter requires `pull-requests: write` permission, which is not available for PRs from forks when using the `on: pull_request` trigger (the GITHUB_TOKEN is read-only for fork PRs regardless of the `permissions` block).

The `github-check` reporter only needs `checks: write` and works correctly for fork PRs. The output is functionally equivalent — lint findings appear as inline annotations on the diff view.

## How to test and validate this PR

1. Open a PR that modifies files under `.github/workflows/`.
2. Verify the actionlint check run appears in the Checks tab.
3. If there are lint errors, verify they appear as inline annotations   on the Files changed tab.

## Changelog notes

No user-facing changes.

## PR Backports

- 16.0-stable: No, CI-only change
- 14.5-stable: No, CI-only change
- 13.4-stable: No, CI-only change

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
