### PR TITLE
zedkube: bound k8s API calls with context timeout to prevent watchdog

### DIFF
--- a/pkg/pillar/cmd/zedkube/applogs.go
+++ b/pkg/pillar/cmd/zedkube/applogs.go
@@ -8,6 +8,7 @@ package zedkube
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -38,7 +39,9 @@ func (z *zedkube) collectAppLogs() {
 	sinceSec = logcollectInterval
 
 	// Cache all pods once and separate into virt-launcher pods (for VMI apps) and other pods (for native containers).
-	podsAllList, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(context.TODO(), metav1.ListOptions{})
+	listCtx, listCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer listCancel()
+	podsAllList, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(listCtx, metav1.ListOptions{})
 	if err != nil {
 		logrus.Errorf("collectAppLogs: can't list pods in namespace %s: %v", kubeapi.EVEKubeNameSpace, err)
 		return
@@ -113,12 +116,24 @@ func (z *zedkube) collectAppLogs() {
 		}
 
 		req := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).GetLogs(contName, opt)
-		podLogs, err := req.Stream(context.Background())
+		streamCtx, streamCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+		podLogs, err := req.Stream(streamCtx)
 		if err != nil {
 			log.Errorf("collectAppLogs: pod %s, log error %v", contName, err)
+			// Capture context error before canceling: streamCancel() sets Err() to
+			// context.Canceled regardless of whether the deadline actually fired.
+			ctxErr := streamCtx.Err()
+			streamCancel()
+			// If the context deadline fired, the API server is degraded.
+			// No point trying the remaining apps — bail out immediately.
+			// In order to avoid the waiting too long to trigger watchdog, we return here
+			// and we may lose some logs from certain pods
+			if errors.Is(ctxErr, context.DeadlineExceeded) {
+				log.Errorf("collectAppLogs: stream timeout, aborting log collection")
+				return
+			}
 			continue
 		}
-		defer podLogs.Close()
 
 		scanner := bufio.NewScanner(podLogs)
 		for scanner.Scan() {
@@ -132,6 +147,15 @@ func (z *zedkube) collectAppLogs() {
 		}
 		if err := scanner.Err(); err != nil {
 			log.Errorf("collectAppLogs: scanner error for pod %s: %v", contName, err)
+		}
+		podLogs.Close()
+		// Capture context error before canceling: streamCancel() sets Err() to
+		// context.Canceled regardless of whether the deadline actually fired.
+		ctxErr := streamCtx.Err()
+		streamCancel()
+		if errors.Is(ctxErr, context.DeadlineExceeded) {
+			log.Errorf("collectAppLogs: stream context expired mid-scan, aborting log collection")
+			return
 		}
 	}
 }
@@ -151,7 +175,9 @@ func (z *zedkube) checkAppsStatus() {
 
 	stItems := z.pubENClusterAppStatus.GetAll()
 
-	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(context.TODO(), metav1.ListOptions{})
+	podsCtx, podsCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer podsCancel()
+	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(podsCtx, metav1.ListOptions{})
 	if err != nil {
 		log.Errorf("checkAppsStatus: can't get pods %v", err)
 		// If we can't get pods, process the error and return

--- a/pkg/pillar/cmd/zedkube/failover.go
+++ b/pkg/pillar/cmd/zedkube/failover.go
@@ -42,7 +42,9 @@ func (z *zedkube) checkAppsFailover(wdFunc func()) {
 		return
 	}
 
-	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(context.TODO(), metav1.ListOptions{})
+	podsCtx, podsCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer podsCancel()
+	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(podsCtx, metav1.ListOptions{})
 	if err != nil {
 		log.Errorf("checkAppsFailover: can't get pods %v", err)
 		return

--- a/pkg/pillar/cmd/zedkube/handlenspodinfo.go
+++ b/pkg/pillar/cmd/zedkube/handlenspodinfo.go
@@ -14,13 +14,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func getAllNs() ([]string, error) {
+func getAllNs(ctx context.Context) ([]string, error) {
 	var nsNameList []string
 	clientset, err := kubeapi.GetClientSet()
 	if err != nil {
 		return nsNameList, err
 	}
-	nsList, err := clientset.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+	nsList, err := clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nsNameList, err
 	}
@@ -30,14 +30,14 @@ func getAllNs() ([]string, error) {
 	return nsNameList, nil
 }
 
-func getPodNsInfo(ns string) (types.KubePodNameSpaceInfo, error) {
+func getPodNsInfo(ctx context.Context, ns string) (types.KubePodNameSpaceInfo, error) {
 	kpnsi := types.KubePodNameSpaceInfo{Name: ns}
 
 	clientset, err := kubeapi.GetClientSet()
 	if err != nil {
 		return kpnsi, err
 	}
-	podList, err := clientset.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+	podList, err := clientset.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return kpnsi, err
 	}

--- a/pkg/pillar/cmd/zedkube/kubeservice.go
+++ b/pkg/pillar/cmd/zedkube/kubeservice.go
@@ -7,14 +7,21 @@ package zedkube
 
 import (
 	"context"
+	"errors"
 	"net"
 	"sort"
+	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
+
+// kubeAPITimeout caps every k8s API call made from the periodic timer handler.
+// It must be well under warningTime (40s) so the main event loop goroutine
+// can return and call ps.StillRunning() before the watchdog touch file goes stale.
+const kubeAPITimeout = 30 * time.Second
 
 var (
 	kubeServiceCIDR *net.IPNet
@@ -38,6 +45,11 @@ func (z *zedkube) initKubePrefixes() error {
 func (z *zedkube) collectKubeSvcs() {
 	log.Functionf("collectKubeStats: Started collecting kube stats")
 
+	// Bound all k8s API calls so that a degraded API server cannot block the
+	// main event loop goroutine long enough to stale the watchdog touch file.
+	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer cancel()
+
 	clientset, err := getKubeClientSet()
 	if err != nil {
 		log.Errorf("collectKubeSvcs: can't get clientset %v", err)
@@ -45,21 +57,21 @@ func (z *zedkube) collectKubeSvcs() {
 	}
 
 	// Get services
-	serviceInfoList, err := z.GetAllKubeServices(clientset)
+	serviceInfoList, err := z.GetAllKubeServices(ctx, clientset)
 	if err != nil {
 		log.Errorf("collectKubeSvcs: can't get services %v", err)
 		return
 	}
 
 	// Get ingresses, passing the service list to avoid redundant API calls
-	ingressInfoList, err := z.GetAllKubeIngresses(clientset, serviceInfoList)
+	ingressInfoList, err := z.GetAllKubeIngresses(ctx, clientset, serviceInfoList)
 	if err != nil {
 		log.Errorf("collectKubeSvcs: can't get ingresses %v", err)
 		// Continue anyway, we might have some services
 	}
 
 	// Collect kube-vip load balancer pool status if kubevip is deployed
-	lbPoolStatus := collectLBPoolStatus(clientset, serviceInfoList)
+	lbPoolStatus := collectLBPoolStatus(ctx, clientset, serviceInfoList)
 
 	// Create new KubeUserServices struct with collected data
 	newKubeUserServices := types.KubeUserServices{
@@ -89,9 +101,9 @@ func (z *zedkube) collectKubeSvcs() {
 // GetAllKubeServices returns a slice of KubeServiceInfo containing all Kubernetes services across namespaces,
 // excluding kube-system, kubevirt, longhorn-system, cdi namespaces,
 // and the 'kubernetes' service in the default namespace.
-func (z *zedkube) GetAllKubeServices(clientset *kubernetes.Clientset) ([]types.KubeServiceInfo, error) {
+func (z *zedkube) GetAllKubeServices(ctx context.Context, clientset *kubernetes.Clientset) ([]types.KubeServiceInfo, error) {
 	// List all services across all namespaces
-	services, err := clientset.CoreV1().Services("").List(context.Background(), metav1.ListOptions{})
+	services, err := clientset.CoreV1().Services("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		log.Errorf("GetAllKubeServices: can't get services: %v", err)
 		return nil, err
@@ -189,9 +201,9 @@ func (z *zedkube) GetAllKubeServices(clientset *kubernetes.Clientset) ([]types.K
 // GetAllKubeIngresses returns a list of all Kubernetes ingresses across namespaces,
 // excluding the same namespaces that we exclude for services.
 // It takes the serviceInfoList to avoid making redundant API calls for service information.
-func (z *zedkube) GetAllKubeIngresses(clientset *kubernetes.Clientset, serviceInfoList []types.KubeServiceInfo) ([]types.KubeIngressInfo, error) {
+func (z *zedkube) GetAllKubeIngresses(ctx context.Context, clientset *kubernetes.Clientset, serviceInfoList []types.KubeServiceInfo) ([]types.KubeIngressInfo, error) {
 	// List all ingresses across all namespaces
-	ingresses, err := clientset.NetworkingV1().Ingresses("").List(context.Background(), metav1.ListOptions{})
+	ingresses, err := clientset.NetworkingV1().Ingresses("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		log.Errorf("GetAllKubeIngresses: can't get ingresses: %v", err)
 		return nil, err
@@ -200,6 +212,11 @@ func (z *zedkube) GetAllKubeIngresses(clientset *kubernetes.Clientset, serviceIn
 	var ingressInfoList []types.KubeIngressInfo
 
 	for _, ing := range ingresses.Items {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			log.Warningf("GetAllKubeIngresses: context deadline exceeded while processing ingresses: %v", ctx.Err())
+			return ingressInfoList, ctx.Err()
+		}
+
 		// Skip ingresses in excluded namespaces
 		if _, excluded := excludedKubeNamespaces[ing.Namespace]; excluded {
 			continue
@@ -291,11 +308,17 @@ func (z *zedkube) GetAllKubeIngresses(clientset *kubernetes.Clientset, serviceIn
 				// If not found in our list (which should include all services now),
 				// try to get it directly - this might happen in rare cases like race conditions
 				if !serviceFound {
+					if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+						log.Warningf("GetAllKubeIngresses: context deadline exceeded before resolving service %s/%s: %v",
+							serviceNamespace, serviceName, ctx.Err())
+						return ingressInfoList, ctx.Err()
+					}
+
 					log.Warningf("GetAllKubeIngresses: service %s/%s not found in serviceInfoList, fetching directly",
 						serviceNamespace, serviceName)
 
 					svc, err := clientset.CoreV1().Services(serviceNamespace).Get(
-						context.Background(), serviceName, metav1.GetOptions{})
+						ctx, serviceName, metav1.GetOptions{})
 					if err != nil {
 						log.Warningf("GetAllKubeIngresses: couldn't get service %s/%s: %v",
 							serviceNamespace, serviceName, err)
@@ -330,9 +353,9 @@ func (z *zedkube) GetAllKubeIngresses(clientset *kubernetes.Clientset, serviceIn
 // collectLBPoolStatus reads the kubevip ConfigMap from kube-system to get the configured
 // load balancer pool, and gathers IPs currently allocated to LoadBalancer-type services.
 // Returns nil if the kubevip ConfigMap does not exist (kubevip not yet deployed).
-func collectLBPoolStatus(clientset *kubernetes.Clientset, services []types.KubeServiceInfo) *types.KubeLBPoolStatus {
+func collectLBPoolStatus(ctx context.Context, clientset *kubernetes.Clientset, services []types.KubeServiceInfo) *types.KubeLBPoolStatus {
 	cm, err := clientset.CoreV1().ConfigMaps("kube-system").Get(
-		context.Background(), "kubevip", metav1.GetOptions{})
+		ctx, "kubevip", metav1.GetOptions{})
 	if err != nil {
 		// kubevip ConfigMap not present — not deployed yet
 		return nil

--- a/pkg/pillar/cmd/zedkube/kubestatscollect.go
+++ b/pkg/pillar/cmd/zedkube/kubestatscollect.go
@@ -25,6 +25,11 @@ func (z *zedkube) collectKubeStats() {
 	if z.isKubeStatsLeader.Load() {
 		log.Functionf("collectKubeStats: Started collecting kube stats")
 
+		// Bound all k8s API calls so that a degraded API server cannot block the
+		// main event loop goroutine long enough to stale the watchdog touch file.
+		ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+		defer cancel()
+
 		clientset, err := getKubeClientSet()
 		if err != nil {
 			log.Errorf("collectKubeStats: can't get clientset %v", err)
@@ -36,7 +41,7 @@ func (z *zedkube) collectKubeStats() {
 		var vmisInfo []types.KubeVMIInfo
 
 		// get nodes
-		nodes, err := getKubeNodes(clientset)
+		nodes, err := getKubeNodes(ctx, clientset)
 		if err != nil {
 			log.Errorf("collectKubeStats: can't get nodes %v", err)
 			return
@@ -47,7 +52,7 @@ func (z *zedkube) collectKubeStats() {
 		}
 
 		// get app pods
-		pods, err := getAppKubePods(clientset)
+		pods, err := getAppKubePods(ctx, clientset)
 		if err != nil {
 			log.Errorf("collectKubeStats: can't get pods %v", err)
 			return
@@ -66,7 +71,7 @@ func (z *zedkube) collectKubeStats() {
 			log.Errorf("collectKubeStats: can't get virtClient %v", err)
 			return
 		}
-		vmis, err := getAppVMIs(virtClient)
+		vmis, err := getAppVMIs(ctx, virtClient)
 		if err != nil {
 			log.Errorf("collectKubeStats: can't get VMIs %v", err)
 			return
@@ -83,10 +88,10 @@ func (z *zedkube) collectKubeStats() {
 		}
 
 		var podNsInfoList []types.KubePodNameSpaceInfo
-		allNs, err := getAllNs()
+		allNs, err := getAllNs(ctx)
 		if err == nil {
 			for _, ns := range allNs {
-				nsInfo, err := getPodNsInfo(ns)
+				nsInfo, err := getPodNsInfo(ctx, ns)
 				if err == nil {
 					podNsInfoList = append(podNsInfoList, nsInfo)
 				}
@@ -111,8 +116,8 @@ func (z *zedkube) collectKubeStats() {
 	}
 }
 
-func getKubeNodes(clientset *kubernetes.Clientset) ([]corev1.Node, error) {
-	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+func getKubeNodes(ctx context.Context, clientset *kubernetes.Clientset) ([]corev1.Node, error) {
+	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		log.Errorf("getKubeNodes: can't get nodes %v", err)
 		return nil, err
@@ -207,9 +212,9 @@ func getKubeNodeInfo(node corev1.Node, z *zedkube) *types.KubeNodeInfo {
 	return &nodeInfo
 }
 
-func getAppKubePods(clientset *kubernetes.Clientset) ([]corev1.Pod, error) {
+func getAppKubePods(ctx context.Context, clientset *kubernetes.Clientset) ([]corev1.Pod, error) {
 	// List pods in the namespace
-	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(context.Background(), metav1.ListOptions{})
+	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		log.Errorf("getAppKubePods: can't get nodes %v", err)
 		return nil, err
@@ -247,9 +252,9 @@ func getKubePodInfo(pod corev1.Pod) *types.KubePodInfo {
 	return &podInfo
 }
 
-func getAppVMIs(virtClient kubecli.KubevirtClient) ([]virtv1.VirtualMachineInstance, error) {
+func getAppVMIs(ctx context.Context, virtClient kubecli.KubevirtClient) ([]virtv1.VirtualMachineInstance, error) {
 	// List pods in the namespace
-	vmiList, err := virtClient.VirtualMachineInstance(kubeapi.EVEKubeNameSpace).List(context.Background(), metav1.ListOptions{})
+	vmiList, err := virtClient.VirtualMachineInstance(kubeapi.EVEKubeNameSpace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		log.Errorf("getAppVMIs: can't get nodes %v", err)
 		return nil, err

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -38,6 +38,10 @@ const (
 	warningTime          = 40 * time.Second
 	stillRunningInterval = 25 * time.Second
 	logcollectInterval   = 10
+	// kubeStatsInterval : how often cluster stats and service health are collected (seconds).
+	// Stats are only published by the elected leader and are less latency-sensitive than
+	// app-status or log collection, so a longer interval is acceptable.
+	kubeStatsInterval = 30
 
 	inlineCmdKubeClusterUpdateStatus = "pubKubeClusterUpdateStatus"
 	inlineCmdVmiDetach               = "vmiDetach"
@@ -591,7 +595,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	if err != nil { // should never happen
 		log.Fatalf("zedkube: initKubePrefixes %v", err)
 	}
+	// Three separate periodic timers replace the former single appLogTimer.
+	// Each branch runs at most two functions with a watchdog touch in between,
+	// so no single select case can block longer than ~2*kubeAPITimeout (60s) —
+	// well within errorTime (3 min) and safely bracketed by StillRunning calls.
 	appLogTimer := time.NewTimer(logcollectInterval * time.Second)
+	appStatusTimer := time.NewTimer(logcollectInterval * time.Second)
+	kubeStatsTimer := time.NewTimer(kubeStatsInterval * time.Second)
 
 	zedkubeWdUpdate := func() {
 		ps.StillRunning(agentName, warningTime, errorTime)
@@ -607,13 +617,30 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		case change := <-subAppInstanceConfig.MsgChan():
 			subAppInstanceConfig.ProcessChange(change)
 
+		// Timer 1: app log streaming only.
+		// collectAppLogs() returns early on stream timeout so this branch
+		// is bounded by a single kubeAPITimeout, not N*kubeAPITimeout.
 		case <-appLogTimer.C:
 			zedkubeCtx.collectAppLogs()
-			zedkubeCtx.checkAppsFailover(zedkubeWdUpdate)
-			zedkubeCtx.checkAppsStatus()
-			zedkubeCtx.collectKubeStats()
-			zedkubeCtx.collectKubeSvcs()
+			zedkubeWdUpdate()
 			appLogTimer = time.NewTimer(logcollectInterval * time.Second)
+
+		// Timer 2: failover detection and per-app cluster status.
+		// zedkubeWdUpdate between the two calls resets the watchdog budget
+		// so each function gets its own kubeAPITimeout window.
+		case <-appStatusTimer.C:
+			zedkubeCtx.checkAppsFailover(zedkubeWdUpdate)
+			zedkubeWdUpdate()
+			zedkubeCtx.checkAppsStatus()
+			appStatusTimer = time.NewTimer(logcollectInterval * time.Second)
+
+		// Timer 3: cluster-wide stats and service health (leader-only, less frequent).
+		// zedkubeWdUpdate between the two calls resets the watchdog budget.
+		case <-kubeStatsTimer.C:
+			zedkubeCtx.collectKubeStats()
+			zedkubeWdUpdate()
+			zedkubeCtx.collectKubeSvcs()
+			kubeStatsTimer = time.NewTimer(kubeStatsInterval * time.Second)
 
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -353,6 +353,10 @@ func (ctx kubevirtContext) CreateReplicaVMIConfig(domainName string, config type
 		Type: "virtio",
 	}
 
+	// Disable the guest-console-log sidecar container in the virt-launcher pod.
+	// EVE collects logs through its own mechanisms; the extra container is unnecessary.
+	vmi.Spec.Domain.Devices.LogSerialConsole = ptrBool(false)
+
 	// If FML type, set the firmware bootloader to EFI
 	if config.VirtualizationMode == types.FML {
 		if runtime.GOARCH == "amd64" {

--- a/pkg/pillar/kubeapi/kubeapi.go
+++ b/pkg/pillar/kubeapi/kubeapi.go
@@ -7,6 +7,7 @@ package kubeapi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -72,8 +73,12 @@ const (
 )
 
 const (
-	errorTime   = 3 * time.Minute
-	warningTime = 40 * time.Second
+	errorTime      = 3 * time.Minute
+	warningTime    = 40 * time.Second
+	kubeAPITimeout = 30 * time.Second
+	// Bound the entire VMIRs reset workflow so failover does not sit in retry
+	// loops indefinitely when virt-api is degraded or unavailable.
+	detachUtilVmirsReplicaResetTimeout = 2 * time.Minute
 )
 
 // GetKubeConfig : Get handle to Kubernetes config
@@ -557,7 +562,11 @@ func DeleteControlPlanePodsOnNode(log *base.LogObject, kubernetesHostName string
 
 }
 
-func vmirsReplicaCountSet(log *base.LogObject, vmiRsName string, replicaCount int) error {
+func vmirsReplicaCountSet(ctx context.Context, log *base.LogObject, vmiRsName string, replicaCount int) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	config, err := GetKubeConfig()
 	if err != nil {
 		log.Errorf("vmirsReplicaCountSet: can't get kubeconfig %v", err)
@@ -570,15 +579,20 @@ func vmirsReplicaCountSet(log *base.LogObject, vmiRsName string, replicaCount in
 		return err
 	}
 
-	vmirs, err := kvClientset.ReplicaSet(EVEKubeNameSpace).Get(context.Background(), vmiRsName, metav1.GetOptions{})
-	if err == nil {
-		reps := int32(replicaCount)
-		vmirs.Spec.Replicas = &reps
-		_, err := kvClientset.ReplicaSet(EVEKubeNameSpace).Update(context.Background(), vmirs, metav1.UpdateOptions{})
-		if err != nil {
-			log.Noticef("vmirsReplicaCountSet vmirs:%s scaled to %d err:%v", vmiRsName, replicaCount, err)
-			return err
-		}
+	reqCtx, cancel := context.WithTimeout(ctx, kubeAPITimeout)
+	defer cancel()
+	vmirs, err := kvClientset.ReplicaSet(EVEKubeNameSpace).Get(reqCtx, vmiRsName, metav1.GetOptions{})
+	if err != nil {
+		log.Noticef("vmirsReplicaCountSet couldn't get vmirs:%s err:%v", vmiRsName, err)
+		return err
+	}
+
+	reps := int32(replicaCount)
+	vmirs.Spec.Replicas = &reps
+	_, err = kvClientset.ReplicaSet(EVEKubeNameSpace).Update(reqCtx, vmirs, metav1.UpdateOptions{})
+	if err != nil {
+		log.Noticef("vmirsReplicaCountSet vmirs:%s scaled to %d err:%v", vmiRsName, replicaCount, err)
+		return err
 	}
 	log.Noticef("vmirsReplicaCountSet complete for vmirs:%s", vmiRsName)
 	return nil
@@ -587,33 +601,46 @@ func vmirsReplicaCountSet(log *base.LogObject, vmiRsName string, replicaCount in
 // DetachUtilVmirsReplicaReset manages retries around scaling down and back up the replica
 // count of a vmirs to push the control plane into scheduling a new vmi
 func DetachUtilVmirsReplicaReset(log *base.LogObject, vmiRsName string) (err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), detachUtilVmirsReplicaResetTimeout)
+	defer cancel()
+
 	vmiRsResetMaxTries := 60
-	vmiRsResetTry := 0
 	// Retries to handle connection issues to virt-api
-	for {
-		vmiRsResetTry++
-		if vmiRsResetTry > vmiRsResetMaxTries {
-			log.Errorf("DetachOldWorkload vmirs scale reset timeout, breaking...")
-			break
+	for vmiRsResetTry := 1; vmiRsResetTry <= vmiRsResetMaxTries; vmiRsResetTry++ {
+		if err := ctx.Err(); err != nil {
+			log.Errorf("DetachOldWorkload vmirs scale reset canceled for vmirs:%s err:%v", vmiRsName, err)
+			return err
 		}
-		time.Sleep(time.Second * 1)
-		err = vmirsReplicaCountSet(log, vmiRsName, 0)
+
+		time.Sleep(time.Second)
+
+		err = vmirsReplicaCountSet(ctx, log, vmiRsName, 0)
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+				log.Errorf("DetachOldWorkload aborting vmirs scale reset for %s after timeout scaling to 0: %v", vmiRsName, err)
+				return err
+			}
 			log.Errorf("DetachOldWorkload retrying scale:%s to 0 err:%v", vmiRsName, err)
-			time.Sleep(time.Second * 2)
+			time.Sleep(2 * time.Second)
 			continue
 		}
 
-		err = vmirsReplicaCountSet(log, vmiRsName, 1)
+		err = vmirsReplicaCountSet(ctx, log, vmiRsName, 1)
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+				log.Errorf("DetachOldWorkload aborting vmirs scale reset for %s after timeout scaling to 1: %v", vmiRsName, err)
+				return err
+			}
 			log.Errorf("DetachOldWorkload retrying scale:%s to 1 err:%v", vmiRsName, err)
-			time.Sleep(time.Second * 2)
+			time.Sleep(2 * time.Second)
 			continue
 		}
 		log.Noticef("DetachOldWorkload vmirs:%s scale reset", vmiRsName)
 		return nil
 	}
-	return
+	err = fmt.Errorf("DetachOldWorkload vmirs scale reset timeout for vmirs:%s", vmiRsName)
+	log.Errorf("%v", err)
+	return err
 }
 
 // GetVmiRsName returns the replicated VMI object name, the parent of a vmi
@@ -648,7 +675,9 @@ func GetVmiRsName(log *base.LogObject, appDomainName string) (string, error) {
 	}
 
 	vmiRsName := ""
-	vmi, err := kvClientset.VirtualMachineInstance(EVEKubeNameSpace).Get(context.Background(), vmiName, metav1.GetOptions{})
+	vmiCtx, vmiCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer vmiCancel()
+	vmi, err := kvClientset.VirtualMachineInstance(EVEKubeNameSpace).Get(vmiCtx, vmiName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -677,7 +706,9 @@ func GetVirtLauncherPods(log *base.LogObject, appDomainName string) (*corev1.Pod
 		return nil, err
 	}
 
-	vlPods, err := clientset.CoreV1().Pods(EVEKubeNameSpace).List(context.Background(), metav1.ListOptions{
+	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer cancel()
+	vlPods, err := clientset.CoreV1().Pods(EVEKubeNameSpace).List(ctx, metav1.ListOptions{
 		LabelSelector: "kubevirt.io=virt-launcher," + EVEAppDomainNameLbl + "=" + appDomainName,
 	})
 	return vlPods, err
@@ -706,7 +737,10 @@ func kubeNodeNotReporting(log *base.LogObject, node *corev1.Node) (notreporting 
 }
 
 func tryFastDeleteVmi(log *base.LogObject, kvClientset kubecli.KubevirtClient, vmiName string) error {
-	vmi, err := kvClientset.VirtualMachineInstance(EVEKubeNameSpace).Get(context.Background(), vmiName, metav1.GetOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer cancel()
+
+	vmi, err := kvClientset.VirtualMachineInstance(EVEKubeNameSpace).Get(ctx, vmiName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -714,7 +748,7 @@ func tryFastDeleteVmi(log *base.LogObject, kvClientset kubecli.KubevirtClient, v
 	// VMI deletion can get stuck when the kubevirt control plane has been interrupted
 	// by some failover breaking access to a kubevirt api pod, remove finalizers and force the delete
 	vmi.ObjectMeta.Finalizers = []string{}
-	_, err = kvClientset.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
+	_, err = kvClientset.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(ctx, vmi, metav1.UpdateOptions{})
 	if err != nil {
 		// Not fatal, just means the delete may take longer to process
 		// Don't return an error here and disrupt the failover process
@@ -724,7 +758,7 @@ func tryFastDeleteVmi(log *base.LogObject, kvClientset kubecli.KubevirtClient, v
 	// Policy for all deletes in the failover path
 	gracePeriod := int64(0)
 	propagationPolicy := metav1.DeletePropagationForeground
-	return kvClientset.VirtualMachineInstance(EVEKubeNameSpace).Delete(context.Background(), vmiName,
+	return kvClientset.VirtualMachineInstance(EVEKubeNameSpace).Delete(ctx, vmiName,
 		metav1.DeleteOptions{
 			GracePeriodSeconds: &gracePeriod,
 			PropagationPolicy:  &propagationPolicy,
@@ -752,7 +786,9 @@ func getPodsLhVols(log *base.LogObject, pod *corev1.Pod) (lhVolNames []string) {
 		}
 		pvcName := vol.PersistentVolumeClaim.ClaimName
 
-		pvc, err := clientset.CoreV1().PersistentVolumeClaims(EVEKubeNameSpace).Get(context.Background(), pvcName, metav1.GetOptions{})
+		pvcCtx, pvcCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+		pvc, err := clientset.CoreV1().PersistentVolumeClaims(EVEKubeNameSpace).Get(pvcCtx, pvcName, metav1.GetOptions{})
+		pvcCancel()
 		if err != nil {
 			log.Errorf("DetachOldWorkload Can't get failed pod:%s PVC:%s err:%v", pod.ObjectMeta.Name, pvcName, err)
 			continue
@@ -841,7 +877,9 @@ func DetachOldWorkload(log *base.LogObject, failedNodeName string, appDomainName
 	}
 
 	// 2. Make sure the node is unreachable
-	node, err := clientset.CoreV1().Nodes().Get(context.Background(), failedNodeName, metav1.GetOptions{})
+	nodeCtx, nodeCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer nodeCancel()
+	node, err := clientset.CoreV1().Nodes().Get(nodeCtx, failedNodeName, metav1.GetOptions{})
 	if (err != nil) || (node == nil) {
 		log.Errorf("DetachOldWorkload: can't get node:%s object err:%v", failedNodeName, err)
 		return
@@ -915,11 +953,13 @@ func DetachOldWorkload(log *base.LogObject, failedNodeName string, appDomainName
 	// Delete virt-launcher pod on failed node
 	if failedNodevLPodName != "" {
 		log.Noticef("DetachOldWorkload Deleting virt-launcher pod:%s", failedNodevLPodName)
-		err = clientset.CoreV1().Pods(EVEKubeNameSpace).Delete(context.Background(), failedNodevLPodName,
+		podDelCtx, podDelCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+		err = clientset.CoreV1().Pods(EVEKubeNameSpace).Delete(podDelCtx, failedNodevLPodName,
 			metav1.DeleteOptions{
 				GracePeriodSeconds: &gracePeriod,
 				PropagationPolicy:  &propagationPolicy,
 			})
+		podDelCancel()
 		if err != nil {
 			log.Errorf("DetachOldWorkload Can't delete terminating virt-launcher pod:%s err:%v", failedNodevLPodName, err)
 		}

--- a/pkg/pillar/kubeapi/longhorninfo.go
+++ b/pkg/pillar/kubeapi/longhorninfo.go
@@ -393,7 +393,9 @@ func LonghornReplicaList(ownerNodeName string, longhornVolName string) (*lhv1bet
 	if longhornVolName != "" {
 		labelSelectors = append(labelSelectors, "longhornvolume="+longhornVolName)
 	}
-	replicas, err := lhClient.LonghornV1beta2().Replicas(longhornNamespace).List(context.Background(), metav1.ListOptions{
+	lhCtx, lhCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer lhCancel()
+	replicas, err := lhClient.LonghornV1beta2().Replicas(longhornNamespace).List(lhCtx, metav1.ListOptions{
 		LabelSelector: strings.Join(labelSelectors, ","),
 	})
 	if err != nil {


### PR DESCRIPTION

# Description

  A degraded Kubernetes API server can cause client calls to block
  indefinitely, preventing the zedkube event loop from calling
  StillRunning() and staling the watchdog touch file — which triggers an
  unintended reboot.

  This patch introduces a kubeAPITimeout constant (30 s, well under the
  ~40 s watchdog warning threshold) and replaces every
  context.Background() / context.TODO() in periodic k8s API calls across
  zedkube and kubeapi with a deadline-bounded context. For log
  streaming, early-abort logic is added so a DeadlineExceeded error
  stops the entire collection pass rather than spinning through
  remaining pods. DetachUtilVmirsReplicaReset also gains an overall
  deadline so its retry loop cannot run unbounded.

## PR dependencies

## How to test and validate this PR

This watchdog we have seen twice during heavy loaded kuberntes devices
during power-down and power-up at the same time testing. It may not be
easy to reproduce. Just need to make sure, w/ this patch, the eve-k edge-node
clustering is working properly.

## Changelog notes

zedkube: bound k8s API calls with context timeout to prevent watchdog

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
