### PR TITLE
Disable app logs and set Firmware UUID

### DIFF
--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sapitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	metricsv "k8s.io/metrics/pkg/client/clientset/versioned"
@@ -353,9 +354,16 @@ func (ctx kubevirtContext) CreateReplicaVMIConfig(domainName string, config type
 		Type: "virtio",
 	}
 
-	// Disable the guest-console-log sidecar container in the virt-launcher pod.
-	// EVE collects logs through its own mechanisms; the extra container is unnecessary.
-	vmi.Spec.Domain.Devices.LogSerialConsole = ptrBool(false)
+	// Disable app log collection if user asked for it
+	if config.DisableLogs {
+		vmi.Spec.Domain.Devices.LogSerialConsole = ptrBool(false)
+	}
+
+	// Set Firmware UUID from app UUID so the guest always sees a stable SMBIOS UUID.
+	// This is required for Firewall kind of apps that needs a stable UUID to work with during failover and keep licenses valid.
+	vmi.Spec.Domain.Firmware = &v1.Firmware{
+		UUID: k8sapitypes.UID(config.UUIDandVersion.UUID.String()),
+	}
 
 	// If FML type, set the firmware bootloader to EFI
 	if config.VirtualizationMode == types.FML {


### PR DESCRIPTION
This commit addresses couple of issues.
1) If DisableLogs was set in DomainConfig, then do not start guest-console container. 
2) Always pass in app UUID as Firmware UUID. That is required for some apps to keep license during failover.





## How to test and validate this PR

1) Disable app logging in controller and verify logs are not shown and vice versa
2) Install FireWall app, register the license with app Firmware UUID, do failovers and verify license is not corrupted.





## Changelog notes

None


## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR



- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
