### PR TITLE
Tune iscsid.conf for better performance

### DIFF
--- a/pkg/kube/iscsid.conf
+++ b/pkg/kube/iscsid.conf
@@ -1,5 +1,4 @@
 # From open-iscsi package
-# With node.session.queue_depth decreased to 1 temporarily
 
 #
 # Open-iSCSI default configuration.
@@ -188,7 +187,7 @@ node.session.cmds_max = 128
 
 # To control the device's queue depth set node.session.queue_depth
 # to a value between 1 and 1024. The default is 32.
-node.session.queue_depth = 1
+node.session.queue_depth = 16
 
 ##################################
 # MISC SYSTEM PERFORMANCE SETTINGS


### PR DESCRIPTION
During a POC with a customer this regression was found that queue depth was set to 1 in initial development phase of eve-k and never fixed back.

So set it SSD devices, which we expect as a minimum spec for clustering nodes.

HDD spinning disks:
  queue_depth = 64    ← HDDs can't handle deep queues well
  cmds_max    = 128

SSD (SATA):
  queue_depth = 128   ← SSDs handle deeper queues well
  cmds_max    = 256

NVMe:
  queue_depth = 256   ← NVMe has native deep queue support
  cmds_max    = 512






## How to test and validate this PR


1) Create 3 node cluster
2) Deploy multiple VMs.
3) Run some activity in the VMs and watch the performance.
4) Do few failovers and see how fast the replicas are syncing.

You should see response times improved before and after this PR


## Changelog notes

None


## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
