### PR TITLE
pkg/uefi: upgrade EDK2 to edk2-stable202508.01

### DIFF
--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -10,7 +10,7 @@ ARG BUILD_PKGS_BASE="git gcc linux-headers libc-dev make linux-pam-dev m4 findut
 # we use the same image in several places
 ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36
 
-FROM lfedge/eve-uefi:557fd831485ef3e019b311c378e7ecf2b4c05f01 AS uefi-build
+FROM lfedge/eve-uefi:d34705816eae92ca6c736e92cbe56558472f6a28 AS uefi-build
 FROM lfedge/eve-dom0-ztools:41e448a70640e7b6f98d19f790cf35cf579fd0db AS zfs
 RUN mkdir /out
 # copy zfs-related files from dom0-ztools using prepared list of files

--- a/pkg/uefi/Dockerfile
+++ b/pkg/uefi/Dockerfile
@@ -28,8 +28,8 @@ COPY rpi /rpi
 
 FROM build AS build-amd64-versions
 
-ENV EDK_VERSION edk2-stable202408.01
-ENV EDK_COMMIT 4dfdca63a93497203f197ec98ba20e2327e4afe4
+ENV EDK_VERSION edk2-stable202508.01
+ENV EDK_COMMIT 3d244c3b364bd4e21261380662186d064659161c
 
 FROM build-${TARGETARCH}-versions AS build-edk2
 
@@ -43,6 +43,7 @@ RUN set -e ; [ ! -d /edk2 ] ||  [ ! -d /edk2-patches/${EDK_VERSION} ] || \
         done
 
 FROM build-edk2 AS build-amd64
+
 
 FROM build-edk2 AS build-arm64
 

--- a/pkg/uefi/edk2-patches/edk2-stable202508.01/0001-Add-Xen-spoofing-in-XenPlatformPei.patch
+++ b/pkg/uefi/edk2-patches/edk2-stable202508.01/0001-Add-Xen-spoofing-in-XenPlatformPei.patch
@@ -1,7 +1,7 @@
-From 40f36e7c4c78caf19a8367995f615139190dfbd2 Mon Sep 17 00:00:00 2001
+From 91461d1da3417069df76a231138fb310c4a24549 Mon Sep 17 00:00:00 2001
 From: Shahriyar Jalayeri <shahriyar@zededa.com>
 Date: Mon, 14 Oct 2024 16:22:11 +0300
-Subject: [PATCH] Add Xen spoofing in XenPlatformPei
+Subject: [PATCH 1/4] Add Xen spoofing in XenPlatformPei
 
 Signed-off-by: Shahriyar Jalayeri <shahriyar@zededa.com>
 ---
@@ -9,10 +9,10 @@ Signed-off-by: Shahriyar Jalayeri <shahriyar@zededa.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/OvmfPkg/XenPlatformPei/Xen.c b/OvmfPkg/XenPlatformPei/Xen.c
-index 7f00eef11e..6b51154f39 100644
+index a54fd55c70..09cc3bf02d 100644
 --- a/OvmfPkg/XenPlatformPei/Xen.c
 +++ b/OvmfPkg/XenPlatformPei/Xen.c
-@@ -261,6 +261,9 @@ XenDetect (
+@@ -240,6 +240,9 @@ XenDetect (
      if (!AsciiStrCmp ((CHAR8 *)Signature, "XenVMMXenVMM")) {
        return TRUE;
      }
@@ -23,5 +23,5 @@ index 7f00eef11e..6b51154f39 100644
  
    mXenLeaf = 0;
 -- 
-2.34.1
+2.43.0
 

--- a/pkg/uefi/edk2-patches/edk2-stable202508.01/0002-OvmfPkg-Add-EveBootOrderLib.patch
+++ b/pkg/uefi/edk2-patches/edk2-stable202508.01/0002-OvmfPkg-Add-EveBootOrderLib.patch
@@ -1,7 +1,7 @@
-From 9a1bb2cd356a920bfa431cd0aa482daa97a9bac4 Mon Sep 17 00:00:00 2001
+From 17914348290544cb3a6a447de7d8c013aa9f6feb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Tue, 20 May 2025 17:37:24 +0200
-Subject: [PATCH] OvmfPkg: Add EveBootOrderLib
+Subject: [PATCH 2/4] OvmfPkg: Add EveBootOrderLib
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -299,10 +299,10 @@ index 0000000000..5e11df7242
 +  gEfiDevicePathProtocolGuid                            ## CONSUMES
 +  gEfiPciRootBridgeIoProtocolGuid                       ## CONSUMES
 diff --git a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
-index d9f61757cf..1fbc0d7a75 100644
+index b696f1b338..593483f074 100644
 --- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
 +++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
-@@ -1854,6 +1854,7 @@ PlatformBootManagerAfterConsole (
+@@ -1709,6 +1709,7 @@ PlatformBootManagerAfterConsole (
  
    RemoveStaleFvFileOptions ();
    SetBootOrderFromQemu ();
@@ -311,7 +311,7 @@ index d9f61757cf..1fbc0d7a75 100644
    PlatformBmPrintScRegisterHandler ();
  }
 diff --git a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.h b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.h
-index 18b3deb9db..b507284236 100644
+index e238dda9e1..ca67c31271 100644
 --- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.h
 +++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.h
 @@ -44,6 +44,7 @@ Abstract:
@@ -323,7 +323,7 @@ index 18b3deb9db..b507284236 100644
  #include <Protocol/Decompress.h>
  #include <Protocol/PciIo.h>
 diff --git a/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf b/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
-index c6ffc1ed9e..38536dae5d 100644
+index 8257862662..9523890c49 100644
 --- a/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
 +++ b/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
 @@ -51,6 +51,7 @@
@@ -335,7 +335,7 @@ index c6ffc1ed9e..38536dae5d 100644
    UefiLib
    PlatformBmPrintScLib
 diff --git a/OvmfPkg/OvmfPkg.dec b/OvmfPkg/OvmfPkg.dec
-index c1c8198061..38c355198a 100644
+index 0a1a09fb70..37d6a5bad1 100644
 --- a/OvmfPkg/OvmfPkg.dec
 +++ b/OvmfPkg/OvmfPkg.dec
 @@ -96,6 +96,11 @@
@@ -347,23 +347,23 @@ index c1c8198061..38c355198a 100644
 +  #
 +  EveBootOrderLib|Include/Library/EveBootOrderLib.h
 +
-   ##  @libraryclass  Load a kernel image and command line passed to QEMU via
-   #                  the command line
+   ##  @libraryclass Common code PlatformBootManager and PlatformBootManagerLight
    #
+   PlatformBootManagerCommonLib|Include/Library/PlatformBootManagerCommonLib.h
 diff --git a/OvmfPkg/OvmfPkgX64.dsc b/OvmfPkg/OvmfPkgX64.dsc
-index efb0eedb04..b0326707e2 100644
+index f859db6acd..da7e10ecde 100644
 --- a/OvmfPkg/OvmfPkgX64.dsc
 +++ b/OvmfPkg/OvmfPkgX64.dsc
-@@ -416,6 +416,7 @@
+@@ -444,6 +444,7 @@
    PlatformBootManagerLib|OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
    PlatformBmPrintScLib|OvmfPkg/Library/PlatformBmPrintScLib/PlatformBmPrintScLib.inf
    QemuBootOrderLib|OvmfPkg/Library/QemuBootOrderLib/QemuBootOrderLib.inf
 +  EveBootOrderLib|OvmfPkg/Library/EveBootOrderLib/EveBootOrderLib.inf
+   PlatformBootManagerCommonLib|OvmfPkg/Library/PlatformBootManagerCommonLib/PlatformBootManagerCommonLib.inf
    CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
  !if $(SMM_REQUIRE) == TRUE
-   LockBoxLib|MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxDxeLib.inf
 diff --git a/OvmfPkg/OvmfXen.dsc b/OvmfPkg/OvmfXen.dsc
-index c6fc3031ca..96d9590fec 100644
+index 4e99acb800..37a359eb31 100644
 --- a/OvmfPkg/OvmfXen.dsc
 +++ b/OvmfPkg/OvmfXen.dsc
 @@ -334,6 +334,7 @@
@@ -371,9 +371,9 @@ index c6fc3031ca..96d9590fec 100644
    PlatformBmPrintScLib|OvmfPkg/Library/PlatformBmPrintScLib/PlatformBmPrintScLib.inf
    QemuBootOrderLib|OvmfPkg/Library/QemuBootOrderLib/QemuBootOrderLib.inf
 +  EveBootOrderLib|OvmfPkg/Library/EveBootOrderLib/EveBootOrderLib.inf
+   PlatformBootManagerCommonLib|OvmfPkg/Library/PlatformBootManagerCommonLib/PlatformBootManagerCommonLib.inf
    CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
    LockBoxLib|OvmfPkg/Library/LockBoxLib/LockBoxDxeLib.inf
- !if $(SOURCE_DEBUG_ENABLE) == TRUE
 -- 
-2.47.2
+2.43.0
 

--- a/pkg/uefi/edk2-patches/edk2-stable202508.01/0003-MdeModulePkg-Logo-Replace-Tianocore-by-EVE-OS-Logo.patch
+++ b/pkg/uefi/edk2-patches/edk2-stable202508.01/0003-MdeModulePkg-Logo-Replace-Tianocore-by-EVE-OS-Logo.patch
@@ -1,7 +1,7 @@
-From f14761f5f76be900c571d215b9cb145250778a72 Mon Sep 17 00:00:00 2001
+From 82a556505cf48b7a2e631d93a2cd91822046cae4 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
 Date: Fri, 23 May 2025 12:58:41 +0200
-Subject: [PATCH] MdeModulePkg: Logo: Replace Tianocore by EVE-OS Logo
+Subject: [PATCH 3/4] MdeModulePkg Logo: Replace Tianocore by EVE-OS Logo
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -485,5 +485,5 @@ zBjkB`Dk*}#0I^(mR=#I)0GPAF^D>{QDF}sHt~)E=sT_nwoE4sz`4n=H=5S_p3331o
 psZq=L&dN7)FA<zw-#W7gU^y%6zRc$tP4kvvoPVFMz}sJe{{eq`w(0-?
 
 -- 
-2.47.2
+2.43.0
 

--- a/pkg/uefi/edk2-patches/edk2-stable202508.01/0004-OvmfPkg-EveBootOrderLib-Read-fw_cfg-before-reorderin.patch
+++ b/pkg/uefi/edk2-patches/edk2-stable202508.01/0004-OvmfPkg-EveBootOrderLib-Read-fw_cfg-before-reorderin.patch
@@ -1,11 +1,8 @@
-From 9eb6fdc29c6d61233eec6f78eefec8b1755fb0d1 Mon Sep 17 00:00:00 2001
+From fc68b6e0f73fe2298762f668a7e4a3778312c798 Mon Sep 17 00:00:00 2001
 From: Nikolay Martyanov <nikolay@zededa.com>
 Date: Tue, 23 Dec 2025 14:11:08 +0100
-Subject: [PATCH] OvmfPkg/EveBootOrderLib: Read fw_cfg before reordering boot
- options
-MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
-Content-Transfer-Encoding: 8bit
+Subject: [PATCH 4/4] OvmfPkg/EveBootOrderLib: Read fw_cfg before reordering
+ boot options
 
 Previously, SetBootOrderFromEve() unconditionally prioritized USB boot
 devices. This change makes USB boot order manipulation configurable via
@@ -13,12 +10,12 @@ the opt/eve.bootorder fw_cfg file, allowing the behavior to be
 controlled at runtime.
 
 A new ReadEveBootOrderFromFwCfg() helper reads the configuration from
-QEMU’s fw_cfg interface. When set to "usb", USB devices are moved to the
+QEMU's fw_cfg interface. When set to "usb", USB devices are moved to the
 front of the boot order. When set to "nousb", USB devices are removed
 from the boot order entirely. If the file is absent or contains an
 unrecognized value, the existing boot order is left unchanged.
 
-This approach is used instead of QEMU’s bootindex mechanism because EVE
+This approach is used instead of QEMU's bootindex mechanism because EVE
 attaches USB devices via dynamic hotplug using QMP device_add after VM
 startup. The bootindex parameter can only be applied to statically
 defined devices at VM launch time and cannot be specified for devices
@@ -376,5 +373,5 @@ index 5e11df7242..98a7ae715a 100644
  [Guids]
    gEfiGlobalVariableGuid
 -- 
-2.52.0
+2.43.0
 

--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023-2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-uefi:557fd831485ef3e019b311c378e7ecf2b4c05f01 AS uefi-build
+FROM lfedge/eve-uefi:d34705816eae92ca6c736e92cbe56558472f6a28 AS uefi-build
 FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS runx-build
 ENV BUILD_PKGS="mkinitfs gcc musl-dev e2fsprogs chrony agetty"
 RUN eve-alpine-deploy.sh


### PR DESCRIPTION
# Description

This PR is a preparation for iGPU work integration.

Upgrade EDK2 from edk2-stable202408.01 to edk2-stable202508.01 (commit 3d244c3b364bd4e21261380662186d064659161c).

Regenerate edk2 patches for the new EDK2 base. All four existing
patches still apply cleanly:
- 0000: Xen hypervisor spoofing in XenPlatformPei
- 0001: EveBootOrderLib addition
- 0002: EVE OS logo replacement
- 0003: EveBootOrderLib fw_cfg boot order support

## How to test and validate this PR

Build the `pkg/uefi` package for amd64 and arm64:

```
make pkgs/uefi
```

Verify the resulting OVMF firmware images boot correctly in QEMU and all EVE features work



## Changelog notes

Upgrade UEFI firmware (EDK2/OVMF) from edk2-stable202408.01 to edk2-stable202508.01.

## PR Backports

- 16.0-stable: No
- 14.5-stable: No
- 13.4-stable: No

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.