### PR TITLE
Publish ZInfoKubeCluster for single-node eve-k deployments

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleedgenodecluster.go
+++ b/pkg/pillar/cmd/zedagent/handleedgenodecluster.go
@@ -176,10 +176,18 @@ func publishKubeClusterInfo(ctx *zedagentContext, dest destinationBitset) {
 	if !ok {
 		return
 	}
+	// Read cluster configuration to obtain the cluster ID.
+	// If not available (e.g. in single-node eve-k deployments),
+	// proceed and publish ClusterInfo with an empty cluster ID.
 	cfgItems := ctx.pubEdgeNodeClusterConfig.GetAll()
-	clusterCfg, ok := cfgItems["global"].(types.EdgeNodeClusterConfig)
-	if !ok {
-		return
+	var clusterID types.UUIDandVersion
+	if clusterCfgVal, haveClusterCfg := cfgItems["global"]; haveClusterCfg {
+		clusterCfg, ok := clusterCfgVal.(types.EdgeNodeClusterConfig)
+		if !ok {
+			log.Error("Unexpected type received from EdgeNodeClusterConfig publication")
+			return
+		}
+		clusterID = clusterCfg.ClusterID
 	}
 
 	// Setup Container
@@ -205,7 +213,7 @@ func publishKubeClusterInfo(ctx *zedagentContext, dest destinationBitset) {
 		kci.EveVmApps = append(kci.EveVmApps, vmi.ZKubeVMIInfo())
 	}
 	kci.Storage = psKubeClusterInfoGlb.Storage.ZKubeStorageInfo()
-	kci.ClusterId = clusterCfg.ClusterID.UUID.String()
+	kci.ClusterId = clusterID.UUID.String()
 
 	// Put it in the info msg
 	infoMsg.InfoContent = new(info.ZInfoMsg_ClusterInfo)


### PR DESCRIPTION
# Description

For single-node K3s, zedkube microservice still publishes `KubeClusterInfo` internally via pubsub, but zedagent never forwarded it to the controller because `EdgeNodeClusterConfig` (not provisioned for single-node) was required: its absence caused an early return from `publishKubeClusterInfo`.

All cluster state (node health, running apps, storage) is meaningful even on a single node and should be visible to the operator. Reporting cluster readiness is also essential for automated testing workflows that wait for the cluster to become healthy after onboarding.

Fix: when `EdgeNodeClusterConfig` is absent, fall back to a zero-value struct (zero-UUID `ClusterID`) instead of bailing out early.

## How to test and validate this PR

Deploy a single-node eve-k instance (no `EdgeNodeClusterConfig` provisioned). After onboarding, verify that the controller eventually receives a `ZInfoMsg` of type `ZInfoTypes_ZiKubeCluster`. The message should contain exactly one `KubeNodeInfo` entry whose `Conditions` list includes `KUBE_NODE_CONDITION_TYPE_READY` set to `true`, confirming that K3s is fully initialized and ready to run applications.

## Changelog notes

Publish `ZInfoKubeCluster` for single-node eve-k deployments

## PR Backports

```text
- 16.0-stable: I do not think that it is needed to backport this (?)
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```
## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
