### PR TITLE
pkg/pillar: Disable vmx for FML virtualization mode

### DIFF
--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -671,7 +671,7 @@ func newKvm() Hypervisor {
 			dmExec:       "/usr/lib/xen/bin/qemu-system-x86_64",
 			dmArgs:       []string{"-display", "none", "-S", "-no-user-config", "-nodefaults", "-no-shutdown", "-serial", "chardev:charserial0", "-machine", "hpet=off"},
 			dmCPUArgs:    []string{"-cpu", "host"},
-			dmFmlCPUArgs: []string{"-cpu", "host,hv_time,hv_relaxed,hv_vendor_id=eveitis,hypervisor=off,kvm=off"},
+			dmFmlCPUArgs: []string{"-cpu", "host,hv_time,hv_relaxed,hv_vendor_id=eveitis,hypervisor=off,kvm=off,vmx=off"},
 		}
 	}
 	return nil


### PR DESCRIPTION
# Description

Currently the following options are passed to QEMU for VMs under FML virtualization mode:

* hypervisor=off
* kvm=off

These options try to make Windows Guests believe they are running on bare-metal and have been used to avoid several issues specially on non-modern versions. However, since "-cpu host" is used and we don't disable the VMX (Virtual Machine Extensions) flag, on Intel machines Guests will see the vmx flag supported by the CPU without the full knowledge that they are running virtualized. This setup can confuse the VBS (Virtualization-Based Security) system from Windows and lead to failures after the Guest joining an Active Directory domain.

This commit disables the vmx flag for Guests so it makes more consistent with the flags already passed (both hypervisor and kvm off).

For now this change fixes the issue, but we should revisit this in the future to test a better setup and perhaps make Guest fully aware about virtualization.

## How to test and validate this PR

Run regular tests to ensure we don't have any regression should be enough. For the particular issue, an active directory setup is required.

## Changelog notes

Do not pass VMX cpu flag for guests on FML Virtualization Mode. It fixes issues using Active Directory on Windows Guests.

## PR Backports

- [x] 16.0-stable (required by users of this version)

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.