### PR TITLE
[16.0-stable] Fix a race condition when eve-k app restart app lost IP address

### DIFF
--- a/pkg/pillar/cmd/zedrouter/cni.go
+++ b/pkg/pillar/cmd/zedrouter/cni.go
@@ -204,6 +204,18 @@ func (z *zedrouter) handleDisconnectPodRequest(
 		return nil
 	}
 	retval.AppUUID = appStatus.UUIDandVersion.UUID
+	// Guard against a race during app restart: the new pod calls ConnectPodAtL2
+	// first, updating appStatus.AppPod to the new pod. Then, a few seconds later,
+	// the old pod's CNI teardown fires DisconnectPod. If we let it proceed, it
+	// would clear the PodVif and remove the VIF that was just created for the new
+	// pod, leaving the running VMI with no network. Detect this by comparing the
+	// disconnecting pod's name against the currently-connected pod in AppPod.
+	if appStatus.AppPod.Name != "" && appStatus.AppPod.Name != args.Pod.Name {
+		z.log.Warnf("handleDisconnectPodRequest: ignoring stale disconnect for pod %s "+
+			"(app %v is already connected via pod %s)",
+			args.Pod.Name, appStatus.UUIDandVersion.UUID, appStatus.AppPod.Name)
+		return nil
+	}
 	var adapterStatus *types.AppNetAdapterStatus
 	for i := range appStatus.AppNetAdapterList {
 		adapterStatus = &appStatus.AppNetAdapterList[i]


### PR DESCRIPTION

# Description

- fix an issue when the app restart by the controller, the pillar side deleted the old replicaSet and recreated a new one. Due the the delay in removal of the old pod by kubernetes, we have a race condition, the newly created VIF was later deleted by the older pod removal.
- backport PR #5706

(cherry picked from commit 4e0c61d2213bc799149a806390f18c7140fb76c8)

## PR dependencies

## How to test and validate this PR

Run the eve-k image on the EVE device, and deploy a VM app over there.
Make sure it is running. and we can ssh into the app using the local NI IP address.
Then modify the app inbound port-map, add or delete or modify. save it, the update the
new app manifest to the device for the App. Wait until the app restarted and make sure the IP address
is assigned to the post restarted VMI.

## Changelog notes

[16.0-stable] Fix a race condition when eve-k app restart app lost IP address

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

