### PR TITLE
eve-k: fix cluster delete regression

### DIFF
--- a/pkg/kube/lib/config.sh
+++ b/pkg/kube/lib/config.sh
@@ -58,7 +58,11 @@ Config_k3s_override_apply() {
 
 Config_cluster_exists() {
     if [ -f "$ENCC_FILE_PATH" ]; then
-        return 0
+        # Non-persistent ENCC will publish an empty config
+        null_cluster_id=$(jq -r '.ClusterID.UUID=="00000000-0000-0000-0000-000000000000"' < "$ENCC_FILE_PATH")
+        if [ "$null_cluster_id" != "true" ]; then
+            return 0
+        fi
     fi
     return 1
 }


### PR DESCRIPTION
# Description

ENCC is no longer persistent and will be published as an empty object for no config.

## PR dependencies

None

## How to test and validate this PR

Covered by existing tests.

## Changelog notes

Resolve cluster delete regression in 16.12

## PR Backports

```text
- 16.0-stable: No, as the non-persistent ENCC is not there.
- 14.5-stable: No, as the non-persistent ENCC is not there.
- 13.4-stable: No, as the non-persistent ENCC is not there.
```

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
