### PR TITLE
[16.0-stable] Fix DevicePortConfig.MostlyEqual ignoring L2 (VLAN/bond) config changes

### DIFF
--- a/pkg/pillar/types/dpc.go
+++ b/pkg/pillar/types/dpc.go
@@ -535,6 +535,9 @@ func (config *DevicePortConfig) MostlyEqual(config2 *DevicePortConfig) bool {
 			!reflect.DeepEqual(p1.WirelessCfg, p2.WirelessCfg) {
 			return false
 		}
+		if !p1.L2LinkConfig.Equal(p2.L2LinkConfig) {
+			return false
+		}
 		if p1.IgnoreDhcpNtpServers != p2.IgnoreDhcpNtpServers ||
 			p1.IgnoreDhcpIPAddresses != p2.IgnoreDhcpIPAddresses ||
 			p1.IgnoreDhcpGateways != p2.IgnoreDhcpGateways ||
@@ -1177,6 +1180,21 @@ type L2LinkConfig struct {
 	Bond   BondConfig `json:",omitempty"`
 }
 
+// Equal compares two L2LinkConfig values for equality.
+func (l L2LinkConfig) Equal(l2 L2LinkConfig) bool {
+	if l.L2Type != l2.L2Type {
+		return false
+	}
+	switch l.L2Type {
+	case L2LinkTypeVLAN:
+		return l.VLAN == l2.VLAN
+	case L2LinkTypeBond:
+		return l.Bond.Equal(l2.Bond)
+	default:
+		return true
+	}
+}
+
 // VLANConfig - VLAN sub-interface configuration.
 type VLANConfig struct {
 	// Logical name of the parent port.
@@ -1252,6 +1270,15 @@ type BondArpMonitor struct {
 	Enabled   bool     `json:",omitempty"`
 	Interval  uint32   `json:",omitempty"`
 	IPTargets []net.IP `json:",omitempty"`
+}
+
+// Equal compares two BondConfig values for equality.
+func (b BondConfig) Equal(b2 BondConfig) bool {
+	return b.Mode == b2.Mode &&
+		b.LacpRate == b2.LacpRate &&
+		generics.EqualSets(b.AggregatedPorts, b2.AggregatedPorts) &&
+		b.MIIMonitor == b2.MIIMonitor &&
+		b.ARPMonitor.Equal(b2.ARPMonitor)
 }
 
 // Equal compares two BondArpMonitor configs for equality.


### PR DESCRIPTION
# Description

`DevicePortConfig.MostlyEqual` did not compare the `L2LinkConfig` field of each port, so changes to VLAN or bond configuration (e.g. changing VLAN ID, bond mode, bond monitoring settings, or bond aggregated ports) were silently ignored. EVE would therefore not detect that the DPC had changed and would not apply the updated L2 configuration.

(cherry picked from commit 07ff36d44e5964a4738945a014350705a5b1976b)

Backport of https://github.com/lf-edge/eve/pull/5820

## How to test and validate this PR

Configure a device with a VLAN sub-interface or a bond interface as a management or app-shared port. After the device is onboarded and connected, push a controller update that changes one of the following without altering any other port fields:
                                                                                                                                                                                       
  - VLAN: change the VLAN ID. SSH to the device and verify the new ID is reflected in `/proc/net/vlan/<vlan-interface-name>` (the VID field).
  - Bond mode: e.g. switch from active-backup to balance-tlb. SSH to the device and verify the new mode is reflected in `/proc/net/bonding/<bond-name>` (the `Bonding Mode` field).
  - Bond monitoring: enable/disable MII or ARP monitoring, or change the polling interval. SSH to the device and verify the updated settings in `/proc/net/bonding/<bond-name>` (fields `MII Polling Interval`, `ARP Polling Interval`, etc.).                                                                                                                                   
  - Bond aggregated ports: add or remove a slave from the bond. SSH to the device and verify the updated slave list in `/proc/net/bonding/<bond-name>` (the `Slave Interface` sections).
                                                                                                                                                                                       
In each case, confirm that EVE detects the configuration change, re-applies the L2 configuration, and the port comes back up with the updated settings. Without the fix, EVE would have left the old configuration in place with no error or indication of a missed change.

## Changelog notes

Fixed a bug where EVE would not detect and apply controller-pushed changes to VLAN or bond port configuration (VLAN ID, bond mode, bond monitoring settings, aggregated ports).

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.