### PR TITLE
pkg/pillar: fix dhcpcd cross-compilation

### DIFF
--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -89,11 +89,44 @@ ARG HV
 # be necessary.
 ENV DHCPCD_VERSION=v10.1.0
 
-ENV CC=${CROSS_COMPILE_ENV}gcc
+# Configure CC for cross-compilation:
+#
+# The cross gcc (e.g. aarch64-alpine-linux-musl-gcc) was built on a different
+# host and its built-in sysroot path (e.g. /home/builder/sysroot-aarch64) does
+# not exist in this image. The Alpine target libs/headers are copied to
+# /usr/${EVE_TARGET_ARCH}-alpine-linux-musl by the build-cross-target stage,
+# so we must point gcc at that sysroot via --sysroot. Without it both the
+# native C build of dhcpcd and Go cgo builds fail with "cannot find Scrt1.o"
+# / "stdlib.h: No such file or directory".
+#
+# We key the sysroot off CROSS_COMPILE_ENV (set only by the cross build
+# stages) rather than EVE_TARGET_ARCH, because the eve-alpine base image
+# already exports EVE_TARGET_ARCH in its own environment, so it is not a
+# reliable "are we cross-compiling?" signal. CROSS_COMPILE_ENV stays unset
+# in build-native, so for native builds CC is just "gcc" with no --sysroot.
+ENV CC="${CROSS_COMPILE_ENV}gcc${CROSS_COMPILE_ENV:+ --sysroot=/usr/${EVE_TARGET_ARCH}-alpine-linux-musl}"
 
 ADD --keep-git-dir=true https://github.com/NetworkConfiguration/dhcpcd.git#${DHCPCD_VERSION} /dhcpcd
 WORKDIR /dhcpcd
-RUN ./configure --libexecdir=/usr/lib/dhcpcd --dbdir=/var/lib/dhcpcd --runstatedir=/run && \
+# Pass --build/--host/--os/--privsepuser explicitly to dhcpcd's hand-rolled
+# `./configure` script (it is not autotools). Without these flags, configure
+# derives the target triplet from the build host's `uname -m`, never
+# realizes this is a cross build, and aborts. --privsepuser=dhcpcd skips
+# looking up the dhcpcd user in the build host's /etc/passwd (the user is
+# only added to the runtime image later).
+#
+# As with CC above, we use CROSS_COMPILE_ENV (not EVE_TARGET_ARCH) to detect
+# the cross-compile case so native builds get BUILD==HOST and configure
+# does not enter its cross-compilation code path.
+RUN BUILD_TRIPLET="$(uname -m)-unknown-linux" && \
+    if [ -n "${CROSS_COMPILE_ENV}" ]; then \
+        HOST_TRIPLET="${EVE_TARGET_ARCH}-alpine-linux-musl" ; \
+    else \
+        HOST_TRIPLET="${BUILD_TRIPLET}" ; \
+    fi && \
+    ./configure --libexecdir=/usr/lib/dhcpcd --dbdir=/var/lib/dhcpcd --runstatedir=/run \
+        --build="${BUILD_TRIPLET}" --host="${HOST_TRIPLET}" --os=linux \
+        --privsepuser=dhcpcd && \
     make -j "$(getconf _NPROCESSORS_ONLN)" && make install
 
 # building with runtime stats


### PR DESCRIPTION
# Description

**THIS PR IS JSUT TO DEMONSTRATE HOW CROSS COMPILATION IS BROKEN**


Cross-compiling pillar for a non-native architecture (e.g.
`make ZARCH=arm64 pkg/pillar` on an amd64 host) fails in the `dhcpcd`
build stage with:

```
Deriving operating system from ... x86_64-unknown-linux
...
No suitable user found for Priviledge Separation!
Using compiler .. aarch64-alpine-linux-musl-gcc
aarch64-alpine-linux-musl-gcc does not create executables
```

`dhcpcd` upstream uses a hand-rolled `./configure` script (not autotools) that:

1. Derives the target triplet from the build host's `uname -m` when   `--build`/`--host` are not supplied, so it never realises this is a   cross build and tries to produce a host-arch test executable using   the cross compiler.
2. Looks up the `dhcpcd` privsep user in the build host's   `/etc/passwd`, which does not contain that user (it is only added   to the runtime image later).

Even after fixing those two, the cross gcc itself still fails to link because it was built with `--with-sysroot=/home/builder/sysroot-...` (a path baked into the toolchain at its own build time) which does not exist in this image. The Alpine target libs/headers are copied to `/usr/${EVE_TARGET_ARCH}-alpine-linux-musl` by the `build-cross-target` stage, so we point gcc at that sysroot via `--sysroot` in `CC`. The same fix unblocks Go cgo builds further down the Dockerfile (which were silently broken too — they failed with `stdlib.h: No such file or directory`).

Detecting the cross build via `EVE_TARGET_ARCH` does not work because the `eve-alpine` base image already exports that variable in its own environment, so it would also be set in native builds. This PR uses `CROSS_COMPILE_ENV`, which is set only by the cross build stages, as the cross-compile signal.

## How to test and validate this PR

On an amd64 host:

```
make ZARCH=arm64 pkg/pillar     # cross
make ZARCH=amd64 pkg/pillar     # native
```

Both should build to completion. The dhcpcd configure step should
print `Configuring dhcpcd for ... linux` with the correct target
triplet, and the Go vet / build steps should succeed.

I have verified locally:
- `make ZARCH=arm64 pkg/pillar` (amd64 host → arm64 target): OK
- `make ZARCH=amd64 pkg/pillar` (amd64 host → amd64 target): OK

## Changelog notes

No user-facing changes (build-system fix only).

## PR Backports

- 16.0-stable: No, build-system fix; backport only if the same dhcpcd build step exists there and is broken.
- 14.5-stable: No, build-system fix; backport only if the same dhcpcd build step exists there and is broken.
- 13.4-stable: No, build-system fix; backport only if the same dhcpcd build step exists there and is broken.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.