### PR TITLE
bpftrace-compiler: skip nvidia kernels in tests

### DIFF
--- a/eve-tools/bpftrace-compiler/list_test.go
+++ b/eve-tools/bpftrace-compiler/list_test.go
@@ -165,6 +165,10 @@ func testKernels() []eveKernelWithArch {
 		if semver.Compare(version, "v6.0.0") < 0 {
 			continue
 		}
+		if strings.Contains(flavor, "nvidia") {
+			// currently bpftrace for EVE on NVidia is unsupported
+			continue
+		}
 
 		kernelBranch := fmt.Sprintf("eve-kernel-%s-%s-%s", arch, version, flavor)
 


### PR DESCRIPTION
# Description

NVidia JetPack 5 and JetPack 6 are not supported for bpftrace on EVE. Skip nvidia kernel flavors in the test matrix for now. This commit can be reverted if/when support is added (e.g. for JetPack 7).

## PR dependencies

https://github.com/lf-edge/eve/pull/5768

## How to test and validate this PR

`make test` succeeds

## Changelog notes

Disable test for bpftrace for (currently) unsupported platform nvidia-jp7.

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 16.0-stable: no as nvidia-jp7 is not available
- 14.5-stable: same
- 13.4-stable: same

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
