### PR TITLE
bpftrace-compiler: Remove full path from qemu command

### DIFF
--- a/eve-tools/bpftrace-compiler/runQemu.go
+++ b/eve-tools/bpftrace-compiler/runQemu.go
@@ -256,7 +256,7 @@ func (qemuArchArgsArm64) verboseArchAppendLineArgs() []string {
 
 func (qemuArchArgsArm64) archArgs() []string {
 	args := []string{
-		"/usr/bin/qemu-system-aarch64",
+		"qemu-system-aarch64",
 		"-smp", "1",
 		"-nographic",
 		"-m", "256",
@@ -279,7 +279,7 @@ func (qemuArchArgsAmd64) verboseArchAppendLineArgs() []string {
 
 func (qemuArchArgsAmd64) archArgs() []string {
 	args := []string{
-		"/usr/bin/qemu-system-x86_64",
+		"qemu-system-x86_64",
 		"-smp", "1",
 		"-nographic",
 		"-m", "256",


### PR DESCRIPTION
# Description

We don't need to provide the full path for the qemu command. Also, we should not assume it will be always present at /usr/bin. On macOS this is not true and bpftrace-compiler with fail with the following error:

```txt
running qemu failed: fork/exec /usr/bin/qemu-system-aarch64: no such file or directory
```

Removing the full path and just using the command name fixes this issue.

## How to test and validate this PR

Go-tests workflow should ensure there is no regression. Run bpftrace-compiler on macOS will fully validate the fix.

## Changelog notes

Fix bpftrace-compiler to run on macOS.

## PR Backports

This is a minimal change that doesn't impact any of our workflows, so I don't think we need to backport.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.