### PR TITLE
Add log rotation for swtpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -536,6 +536,7 @@ test: $(LINUXKIT) pkg/pillar | $(DIST)
 	make -C pkg/debug test
 	make -C pkg/vtpm test
 	go test -C pkg/newlog/cmd/ -v -race
+	go test -C pkg/edgeview/src/ -v -race
 	$(QUIET): $@: Succeeded
 
 test-profiling:

--- a/Makefile
+++ b/Makefile
@@ -534,6 +534,7 @@ test: $(LINUXKIT) pkg/pillar | $(DIST)
 	make -C eve-tools/bpftrace-compiler test
 	make -C pkg/dnsmasq test
 	make -C pkg/debug test
+	make -C pkg/vtpm test
 	go test -C pkg/newlog/cmd/ -v -race
 	$(QUIET): $@: Succeeded
 

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -99,6 +99,18 @@ RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
     go build -ldflags "-s -w -X=main.Version=${GOPKGVERSION}" \
     -mod=vendor -o /out/usr/bin/vtpm .
 
+FROM build-go AS test
+# -race requires cgo, which needs a C compiler and libc headers.
+# swtpm needs its runtime shared libraries.
+RUN apk add --no-cache gcc musl-dev \
+    libseccomp glib json-glib gnutls libtasn1 json-c libffi
+# copy swtpm, its modules, and libtpms from the C build stage
+COPY --from=build-c /out/usr/bin/swtpm /usr/bin/swtpm
+COPY --from=build-c /out/usr/lib/ /usr/lib/
+WORKDIR /vtpm-build
+COPY swtpm-vtpm/src/ /vtpm-build/.
+COPY swtpm-vtpm/ /vtpm-build/.
+
 # ===========================================================================
 # Final image
 # ===========================================================================

--- a/pkg/vtpm/Makefile
+++ b/pkg/vtpm/Makefile
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+.PHONY: test
+
+test:
+	make -C ../../ vtpm-cache-export-docker-load
+	docker run --rm \
+		-v $$(pwd):/output \
+		$$(docker build --target=test -q .) \
+		env CGO_ENABLED=1 go test -v -race -timeout 30m \
+		-coverprofile="/output/vtpm.coverage.txt" \
+		-covermode=atomic

--- a/pkg/vtpm/swtpm-vtpm/src/fifolog.go
+++ b/pkg/vtpm/swtpm-vtpm/src/fifolog.go
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type logForwarder struct {
+	fifoPath      string
+	logPath       string
+	logFileHandle *os.File
+	logSize       int64
+	mu            sync.Mutex
+	cancel        context.CancelFunc
+	done          chan struct{}
+}
+
+func newLogForwarder(fifoPath, logPath string) (*logForwarder, error) {
+	// remove stale FIFO from a previous run, if any
+	os.Remove(fifoPath)
+
+	if err := syscall.Mkfifo(fifoPath, 0600); err != nil {
+		return nil, fmt.Errorf("failed to create log FIFO: %w", err)
+	}
+
+	logFileHandle, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		os.Remove(fifoPath)
+		return nil, fmt.Errorf("failed to open swtpm log file: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	lf := &logForwarder{
+		fifoPath:      fifoPath,
+		logPath:       logPath,
+		logFileHandle: logFileHandle,
+		cancel:        cancel,
+		done:          make(chan struct{}),
+	}
+	go lf.run(ctx)
+	return lf, nil
+}
+
+// openFIFO polls until a writer opens the FIFO
+func (lf *logForwarder) openFIFO(ctx context.Context) (*os.File, error) {
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		f, err := os.OpenFile(lf.fifoPath, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+		if err == nil {
+			return f, nil
+		}
+		// if no writer yet, OK, otherswise report error.
+		if !errors.Is(err, syscall.ENXIO) {
+			return nil, fmt.Errorf("failed to open log FIFO: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func (lf *logForwarder) run(ctx context.Context) {
+	defer close(lf.done)
+	defer func() {
+		lf.mu.Lock()
+		if lf.logFileHandle != nil {
+			lf.logFileHandle.Close()
+			lf.logFileHandle = nil
+		}
+		lf.mu.Unlock()
+	}()
+
+	buf := make([]byte, 4096)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		fifo, err := lf.openFIFO(ctx)
+		if err != nil {
+			return
+		}
+		// drain FIFO until EOF (writer closed).
+		for {
+			n, readErr := fifo.Read(buf)
+			if n > 0 {
+				lf.writeToLog(buf[:n])
+			}
+			if readErr != nil {
+				break
+			}
+		}
+		fifo.Close()
+	}
+}
+
+func (lf *logForwarder) writeToLog(data []byte) {
+	lf.mu.Lock()
+	defer lf.mu.Unlock()
+	if lf.logFileHandle == nil {
+		return
+	}
+	n, err := lf.logFileHandle.Write(data)
+	if err != nil {
+		log.Errorf("swtpm log write error: %v", err)
+		return
+	}
+	lf.logSize += int64(n)
+	if lf.logSize >= swtpmLogMaxSize {
+		lf.rotate()
+	}
+}
+
+func (lf *logForwarder) rotate() {
+	for i := swtpmLogMaxBackups - 1; i >= 1; i-- {
+		os.Rename(fmt.Sprintf("%s.%d.gz", lf.logPath, i),
+			fmt.Sprintf("%s.%d.gz", lf.logPath, i+1))
+	}
+	if err := compressFile(lf.logPath, lf.logPath+".1.gz"); err != nil {
+		log.Errorf("log compress error: %v", err)
+		return
+	}
+	if err := lf.logFileHandle.Truncate(0); err != nil {
+		log.Errorf("log truncate error: %v", err)
+		return
+	}
+	if _, err := lf.logFileHandle.Seek(0, io.SeekStart); err != nil {
+		log.Errorf("log seek error: %v", err)
+		return
+	}
+	lf.logSize = 0
+}
+
+func (lf *logForwarder) stop() {
+	lf.cancel()
+	<-lf.done
+	os.Remove(lf.fifoPath)
+}
+
+// compressFile gzip-compresses src into dst.
+func compressFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	gz := gzip.NewWriter(out)
+	if _, err := io.Copy(gz, in); err != nil {
+		gz.Close()
+		out.Close()
+		os.Remove(dst)
+		return err
+	}
+	if err := gz.Close(); err != nil {
+		out.Close()
+		os.Remove(dst)
+		return err
+	}
+	return out.Close()
+}

--- a/pkg/vtpm/swtpm-vtpm/src/main.go
+++ b/pkg/vtpm/swtpm-vtpm/src/main.go
@@ -28,21 +28,31 @@ import (
 )
 
 const (
-	swtpmPath      = "/usr/bin/swtpm"
-	maxInstances   = 32
-	maxPidWaitTime = 5 //seconds
+	swtpmPath          = "/usr/bin/swtpm"
+	maxInstances       = 32
+	swtpmLogMaxSize    = 10 * 1024 * 1024 // 10MB
+	swtpmLogMaxBackups = 3
 )
 
+type swtpmInstance struct {
+	pid int
+	lf  *logForwarder
+}
+
 var (
-	liveInstances int
-	m             sync.Mutex
-	log           *base.LogObject
-	pids          = make(map[uuid.UUID]int, 0)
+	maxPidWaitTime = 5 // seconds; overridden in tests
+	liveInstances  int
+	m              sync.Mutex
+	log            *base.LogObject
+	instances      = make(map[uuid.UUID]*swtpmInstance)
 	// XXX : move the paths to types so we have everything EVE creates in one place.
 	// These are defined as vars to be able to mock them in tests
-	stateEncryptionKey   = "/run/swtpm/%s.binkey"
-	swtpmIsEncryptedPath = "/persist/swtpm/%s.encrypted"
-	swtpmStatePath       = "/persist/swtpm/tpm-state-%s"
+	stateDir             = "/persist/swtpm"
+	runDir               = "/run/swtpm"
+	stateEncryptionKey   = path.Join(runDir, "%s.binkey")
+	stateIsEncryptedPath = path.Join(stateDir, "%s.encrypted")
+	workDir              = path.Join(stateDir, "tpm-state-%s")
+	instanceLogFifoPath  = path.Join(runDir, "%s-swtpm.log.fifo")
 	vtpmdCtrlSockPath    = types.VtpmdCtrlSocket
 	swtpmCtrlSockPath    = types.SwtpmCtrlSocketPath
 	swtpmPidPath         = types.SwtpmPidPath
@@ -65,10 +75,18 @@ func isAlive(pid int) bool {
 
 func cleanupFiles(uuid uuid.UUID) {
 	id := uuid.String()
-	os.RemoveAll(fmt.Sprintf(swtpmStatePath, id))
+
+	if inst, ok := instances[uuid]; ok {
+		if inst.lf != nil {
+			inst.lf.stop()
+		}
+		delete(instances, uuid)
+		liveInstances--
+	}
+	os.RemoveAll(fmt.Sprintf(workDir, id))
 	os.Remove(fmt.Sprintf(swtpmCtrlSockPath, id))
 	os.Remove(fmt.Sprintf(swtpmPidPath, id))
-	os.Remove(fmt.Sprintf(swtpmIsEncryptedPath, id))
+	os.Remove(fmt.Sprintf(stateIsEncryptedPath, id))
 }
 
 func makeDirs(dir string) error {
@@ -116,11 +134,11 @@ func getSwtpmPid(pidPath string, timeoutSeconds uint) (int, error) {
 
 func checkSwtpmState(uuid uuid.UUID) error {
 	id := uuid.String()
-	statePath := fmt.Sprintf(swtpmStatePath, id)
+	wd := fmt.Sprintf(workDir, id)
 	ctrlSockPath := fmt.Sprintf(swtpmCtrlSockPath, id)
 	pidPath := fmt.Sprintf(swtpmPidPath, id)
 
-	if _, err := os.Stat(statePath); err != nil {
+	if _, err := os.Stat(wd); err != nil {
 		return fmt.Errorf("failed to check SWTPM state directory: %w", err)
 	}
 
@@ -159,56 +177,71 @@ func checkSwtpmState(uuid uuid.UUID) error {
 	return nil
 }
 
-func runSwtpm(uuid uuid.UUID) (int, error) {
+func runSwtpm(uuid uuid.UUID) (int, *logForwarder, error) {
 	id := uuid.String()
-	statePath := fmt.Sprintf(swtpmStatePath, id)
+	wd := fmt.Sprintf(workDir, id)
 	ctrlSockPath := fmt.Sprintf(swtpmCtrlSockPath, id)
 	binKeyPath := fmt.Sprintf(stateEncryptionKey, id)
 	pidPath := fmt.Sprintf(swtpmPidPath, id)
-	isEncryptedPath := fmt.Sprintf(swtpmIsEncryptedPath, id)
-	logFile := path.Join(fmt.Sprintf(swtpmStatePath, id), "swtpm.log")
+	isEncryptedPath := fmt.Sprintf(stateIsEncryptedPath, id)
+	fifoPath := fmt.Sprintf(instanceLogFifoPath, id)
+	logPath := path.Join(wd, "swtpm.log")
+
+	if err := makeDirs(wd); err != nil {
+		return 0, nil, fmt.Errorf("failed to create SWTPM state directory: %w", err)
+	}
+	if err := makeDirs(path.Dir(fifoPath)); err != nil {
+		return 0, nil, fmt.Errorf("failed to create SWTPM run directory: %w", err)
+	}
+
+	// create a log forwarder for this SWTPM instance
+	lf, err := newLogForwarder(fifoPath, logPath)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to create log forwarder: %w", err)
+	}
+
 	swtpmArgs := []string{"socket", "--tpm2",
-		"--tpmstate", "dir=" + statePath + ",backup",
+		"--tpmstate", "dir=" + wd + ",backup",
 		"--ctrl", "type=unixio,path=" + ctrlSockPath + ",terminate",
 		"--pid", "file=" + pidPath,
-		"--log", "level=3,truncate,file=" + logFile,
+		"--log", "level=3,file=" + lf.fifoPath,
 		"--daemon"}
-
-	// If state directory already exists, this call will do nothing.
-	if err := makeDirs(statePath); err != nil {
-		return 0, fmt.Errorf("failed to create SWTPM state directory: %w", err)
-	}
 
 	if !isTPMAvailable() {
 		log.Noticef("TPM is not available, starting SWTPM without state encryption!")
 		// if SWTPM state for app marked as as encrypted, and TPM is not available
 		// anymore, fail because this might corrupt the SWTPM state.
 		if utils.FileExists(log, isEncryptedPath) {
-			return 0, fmt.Errorf("state encryption was enabled for SWTPM, but TPM is no longer available")
+			lf.stop()
+			return 0, nil, fmt.Errorf("state encryption was enabled for SWTPM, but TPM is no longer available")
 		}
 
 		cmd := exec.Command(swtpmPath, swtpmArgs...)
 		if err := cmd.Run(); err != nil {
-			return 0, fmt.Errorf("failed to start SWTPM: %w", err)
+			lf.stop()
+			return 0, nil, fmt.Errorf("failed to start SWTPM: %w", err)
 		}
 	} else {
 		log.Noticef("TPM is available, starting SWTPM with state encryption")
 
 		key, err := getEncryptionKey()
 		if err != nil {
-			return 0, fmt.Errorf("failed to get SWTPM state encryption key : %w", err)
+			lf.stop()
+			return 0, nil, fmt.Errorf("failed to get SWTPM state encryption key : %w", err)
 		}
 
 		// we are about to write the key to the disk, so mark the SWTPM state
 		// as encrypted
 		if !utils.FileExists(log, isEncryptedPath) {
 			if err := utils.WriteRename(isEncryptedPath, []byte("Y")); err != nil {
-				return 0, fmt.Errorf("failed to mark the app SWTPM state as encrypted: %w", err)
+				lf.stop()
+				return 0, nil, fmt.Errorf("failed to mark the app SWTPM state as encrypted: %w", err)
 			}
 		}
 
 		if err := os.WriteFile(binKeyPath, key, 0644); err != nil {
-			return 0, fmt.Errorf("failed to write key to file: %w", err)
+			lf.stop()
+			return 0, nil, fmt.Errorf("failed to write key to file: %w", err)
 		}
 
 		swtpmArgs = append(swtpmArgs, "--key", "file="+binKeyPath+",format=binary,mode=aes-256-cbc,remove=true")
@@ -216,19 +249,21 @@ func runSwtpm(uuid uuid.UUID) (int, error) {
 		if err := cmd.Run(); err != nil {
 			// this shall not fail 🧙🏽‍♂️
 			rmErr := os.Remove(binKeyPath)
+			lf.stop()
 			if rmErr != nil {
-				return 0, fmt.Errorf("failed to start SWTPM: %w, failed to remove key file %w", err, rmErr)
+				return 0, nil, fmt.Errorf("failed to start SWTPM: %w, failed to remove key file %w", err, rmErr)
 			}
-			return 0, fmt.Errorf("failed to start SWTPM: %w", err)
+			return 0, nil, fmt.Errorf("failed to start SWTPM: %w", err)
 		}
 	}
 
-	pid, err := getSwtpmPid(pidPath, maxPidWaitTime)
+	pid, err := getSwtpmPid(pidPath, uint(maxPidWaitTime))
 	if err != nil {
-		return 0, fmt.Errorf("failed to get SWTPM pid: %w", err)
+		lf.stop()
+		return 0, nil, fmt.Errorf("failed to get SWTPM pid: %w", err)
 	}
 
-	return pid, nil
+	return pid, lf, nil
 }
 
 // Domain manager is requesting to launch a new VM/App, run a new SWTPM
@@ -261,12 +296,12 @@ func handleLaunch(w http.ResponseWriter, r *http.Request) {
 	// check if it's still alive. if it is alive, refuse to launch a new
 	// instance, even though for dir backend lock is always enabled,
 	// better be safe than sorry and not gamble with state corruption.
-	if _, ok := pids[id]; ok {
+	if inst, ok := instances[id]; ok {
 		pidPath := fmt.Sprintf(swtpmPidPath, id)
 		// if pid file does not exist, it means the SWTPM instance gracefully
 		// terminated and we can start a new one.
 		if _, err := os.Stat(pidPath); err == nil {
-			pid, err := getSwtpmPid(pidPath, maxPidWaitTime)
+			pid, err := getSwtpmPid(pidPath, uint(maxPidWaitTime))
 			if err != nil {
 				err := fmt.Sprintf("vTPM failed to read pid file of SWTPM with id %s", id)
 				http.Error(w, err, http.StatusExpectationFailed)
@@ -276,7 +311,7 @@ func handleLaunch(w http.ResponseWriter, r *http.Request) {
 			// if the SWTPM instance is still alive, we can move on. Maybe we should do a health check
 			// here too? but state should be already loaded in memory :-/
 			if isAlive(pid) {
-				log.Noticef("vTPM SWTPM instance with id %s is already running with pid %d", id, pid)
+				log.Noticef("vTPM SWTPM instance with id %s is already running with pid %d", id, inst.pid)
 				w.WriteHeader(http.StatusOK)
 				return
 			}
@@ -286,13 +321,17 @@ func handleLaunch(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		if inst.lf != nil {
+			inst.lf.stop()
+		}
+
 		liveInstances--
-		delete(pids, id)
+		delete(instances, id)
 	}
 
 	// Run SWTPM for the health check first, if there is no backup state or
 	// both normal state and backup are corrupted, we do a state reset with a warning.
-	pid, err := runSwtpm(id)
+	pid, lf, err := runSwtpm(id)
 	if err != nil {
 		err := fmt.Sprintf("vTPM failed to start SWTPM instance for health check: %v", err)
 		http.Error(w, err, http.StatusFailedDependency)
@@ -300,7 +339,7 @@ func handleLaunch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// check SWTPM health
-	err = checkSwtpmState(id)
+	checkErr := checkSwtpmState(id)
 	// wait for SWTPM instance to get terminated then check for errors
 	for i := 0; i < maxPidWaitTime; i++ {
 		if !isAlive(pid) {
@@ -308,14 +347,18 @@ func handleLaunch(w http.ResponseWriter, r *http.Request) {
 		}
 		time.Sleep(1 * time.Second)
 	}
-	if err != nil {
+
+	// The health-check run is done; stop its log forwarder before the next run.
+	lf.stop()
+
+	if checkErr != nil {
 		log.Warnf("SWTPM instance state with id %s is corrupted, resetting the state...", id)
 		// remove the state directory and start a new SWTPM instance
-		isEncryptedPath := fmt.Sprintf(swtpmIsEncryptedPath, id)
+		isEncryptedPath := fmt.Sprintf(stateIsEncryptedPath, id)
 		if utils.FileExists(log, isEncryptedPath) {
 			os.Remove(isEncryptedPath)
 		}
-		if err := os.RemoveAll(fmt.Sprintf(swtpmStatePath, id)); err != nil {
+		if err := os.RemoveAll(fmt.Sprintf(workDir, id)); err != nil {
 			err := fmt.Sprintf("failed to remove SWTPM state directory: %v", err)
 			http.Error(w, err, http.StatusFailedDependency)
 			return
@@ -327,7 +370,7 @@ func handleLaunch(w http.ResponseWriter, r *http.Request) {
 	// Run SWTPM again, since we run SWTPM with the "terminate" flag, it will
 	// terminate itself when the control socket is closed in checkSwtpmState.
 	// in any case, this should work.
-	pid, err = runSwtpm(id)
+	pid, lf, err = runSwtpm(id)
 	if err != nil {
 		err := fmt.Sprintf("vTPM failed to start SWTPM instance: %v", err)
 		http.Error(w, err, http.StatusFailedDependency)
@@ -337,7 +380,7 @@ func handleLaunch(w http.ResponseWriter, r *http.Request) {
 	log.Noticef("vTPM launched SWTPM instance with id: %s, pid: %d", id, pid)
 
 	// Send a success response.
-	pids[id] = pid
+	instances[id] = &swtpmInstance{pid: pid, lf: lf}
 	liveInstances++
 	w.WriteHeader(http.StatusOK)
 }
@@ -363,15 +406,20 @@ func handleTerminate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err, http.StatusBadRequest)
 		return
 	}
-	pid, ok := pids[id]
+	inst, ok := instances[id]
 	if ok {
-		if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+		if err := syscall.Kill(inst.pid, syscall.SIGTERM); err != nil {
 			if err != syscall.ESRCH {
 				// This should not happen, but log it just in case.
 				log.Errorf("vTPM failed to kill SWTPM instance (terminate request): %v", err)
 			}
 		}
-		delete(pids, id)
+
+		if inst.lf != nil {
+			inst.lf.stop()
+		}
+
+		delete(instances, id)
 		liveInstances--
 	} else {
 		err := fmt.Sprintf("vTPM terminate request failed, SWTPM instance with id %s not found", id)
@@ -379,7 +427,7 @@ func handleTerminate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Noticef("vTPM terminated SWTPM instance with id: %s, pid: %d", id, pid)
+	log.Noticef("vTPM terminated SWTPM instance with id: %s, pid: %d", id, inst.pid)
 
 	// send a success response.
 	w.WriteHeader(http.StatusOK)
@@ -410,19 +458,24 @@ func handlePurge(w http.ResponseWriter, r *http.Request) {
 	// either sends CMD_SHUTDOWN through the control socket or in case of qemu
 	// crashing, SWTPM terminates itself when the control socket is closed since
 	// we run it with the "terminate" flag. but just in case send a term signal
-	pid, ok := pids[id]
+	inst, ok := instances[id]
 	if ok {
-		if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+		if err := syscall.Kill(inst.pid, syscall.SIGTERM); err != nil {
 			if err != syscall.ESRCH {
 				// This should not happen, but log it just in case.
 				log.Errorf("failed to kill SWTPM instance (purge request): %v", err)
 			}
 		}
-		delete(pids, id)
+
+		if inst.lf != nil {
+			inst.lf.stop()
+		}
+
+		log.Noticef("vTPM purged SWTPM instance with id: %s, pid: %d", id, inst.pid)
+
+		delete(instances, id)
 		liveInstances--
 	}
-
-	log.Noticef("vTPM purged SWTPM instance with id: %s, pid: %d", id, pid)
 
 	// clean up the files and send a success response.
 	cleanupFiles(id)

--- a/pkg/vtpm/swtpm-vtpm/src/main.go
+++ b/pkg/vtpm/swtpm-vtpm/src/main.go
@@ -29,7 +29,6 @@ import (
 
 const (
 	swtpmPath          = "/usr/bin/swtpm"
-	maxInstances       = 32
 	swtpmLogMaxSize    = 10 * 1024 * 1024 // 10MB
 	swtpmLogMaxBackups = 3
 )
@@ -40,7 +39,8 @@ type swtpmInstance struct {
 }
 
 var (
-	maxPidWaitTime = 5 // seconds; overridden in tests
+	maxPidWaitTime = 5  // seconds; overridden in tests
+	maxInstances   = 32 // overridden in tests
 	liveInstances  int
 	m              sync.Mutex
 	log            *base.LogObject

--- a/pkg/vtpm/swtpm-vtpm/src/vtpm_test.go
+++ b/pkg/vtpm/swtpm-vtpm/src/vtpm_test.go
@@ -11,7 +11,8 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path"
+	"os/exec"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -28,18 +29,21 @@ var client = &http.Client{}
 
 func TestMain(m *testing.M) {
 	log = base.NewSourceLogObject(logrus.StandardLogger(), "vtpm", os.Getpid())
+	maxPidWaitTime = 15
+	maxInstances = 3
 	os.MkdirAll(baseDir, 0755)
 
 	stateEncryptionKey = baseDir + "/%s.binkey"
-	swtpmIsEncryptedPath = baseDir + "/%s.encrypted"
-	swtpmStatePath = baseDir + "/tpm-state-%s"
+	stateIsEncryptedPath = baseDir + "/%s.encrypted"
+	workDir = baseDir + "/tpm-state-%s"
+	instanceLogFifoPath = baseDir + "/%s.log.fifo"
 	swtpmCtrlSockPath = baseDir + "/%s.ctrl.sock"
 	swtpmPidPath = baseDir + "/%s.pid"
 	vtpmdCtrlSockPath = baseDir + "/vtpmd.ctrl.sock"
 
 	client = &http.Client{
 		Transport: UnixSocketTransport(vtpmdCtrlSockPath),
-		Timeout:   5 * time.Second,
+		Timeout:   60 * time.Second,
 	}
 
 	go startServing()
@@ -93,6 +97,74 @@ func sendPurgeRequest(id uuid.UUID) (string, int, error) {
 
 func sendTerminateRequest(id uuid.UUID) (string, int, error) {
 	return makeRequest(client, "terminate", id.String())
+}
+
+func simulateVMAttach(t *testing.T, id uuid.UUID) net.Conn {
+	t.Helper()
+	sockPath := fmt.Sprintf(swtpmCtrlSockPath, id.String())
+
+	addr, err := net.ResolveUnixAddr("unix", sockPath)
+	if err != nil {
+		t.Fatalf("simulateVMAttach: resolve: %v", err)
+	}
+	ctrl, err := net.DialUnix("unix", nil, addr)
+	if err != nil {
+		t.Fatalf("simulateVMAttach: dial ctrl: %v", err)
+	}
+
+	// CMD_INIT = 0x02, flags = 0
+	if _, err := ctrl.Write([]byte{0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00}); err != nil {
+		ctrl.Close()
+		t.Fatalf("simulateVMAttach: CMD_INIT write: %v", err)
+	}
+	buf := make([]byte, 4)
+	ctrl.Read(buf)
+
+	// Create a socketpair: fds[0] goes to swtpm, fds[1] is our data channel.
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		ctrl.Close()
+		t.Fatalf("simulateVMAttach: socketpair: %v", err)
+	}
+
+	// CMD_SET_DATAFD = 0x10; pass fds[0] to swtpm via SCM_RIGHTS.
+	oob := syscall.UnixRights(fds[0])
+	if _, _, err := ctrl.WriteMsgUnix([]byte{0x00, 0x00, 0x00, 0x10}, oob, nil); err != nil {
+		syscall.Close(fds[0])
+		syscall.Close(fds[1])
+		ctrl.Close()
+		t.Fatalf("simulateVMAttach: CMD_SET_DATAFD: %v", err)
+	}
+	syscall.Close(fds[0]) // swtpm owns this end now
+	ctrl.Read(buf)
+
+	// Open our end of the data channel and send TPM2_Startup(SU_CLEAR).
+	// tag=0x8001, size=12, cc=TPM2_CC_Startup=0x144, startupType=SU_CLEAR=0x0000
+	dataFile := os.NewFile(uintptr(fds[1]), "tpm-data")
+	dataConn, err := net.FileConn(dataFile)
+	dataFile.Close()
+	if err != nil {
+		ctrl.Close()
+		t.Fatalf("simulateVMAttach: FileConn: %v", err)
+	}
+	defer dataConn.Close()
+	startup := []byte{0x80, 0x01, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x01, 0x44, 0x00, 0x00}
+	if _, err := dataConn.Write(startup); err != nil {
+		ctrl.Close()
+		t.Fatalf("simulateVMAttach: TPM2_Startup write: %v", err)
+	}
+	dataConn.Read(make([]byte, 1024))
+
+	time.Sleep(500 * time.Millisecond)
+	return ctrl
+}
+
+func swtpmSupportsBackup() bool {
+	out, err := exec.Command(swtpmPath, "socket", "--tpm2", "--print-capabilities").Output()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(out), "tpmstate-dir-backend-opt-backup")
 }
 
 func testLaunchAndPurge(t *testing.T, id uuid.UUID) {
@@ -156,7 +228,7 @@ func testExhaustSwtpmInstances(t *testing.T) {
 	}
 
 	// clean up
-	for i := 0; i < maxInstances; i++ {
+	for i := 1; i < maxInstances; i++ {
 		b, _, err := sendPurgeRequest(ids[i])
 		if err != nil {
 			t.Fatalf("failed to send request: %v, body : %s", err, b)
@@ -258,7 +330,10 @@ func TestSwtpmStateChange(t *testing.T) {
 	}
 }
 
-func TestSwtpmStateBakcupWithStateEncryption(t *testing.T) {
+func TestSwtpmStateBackupWithStateEncryption(t *testing.T) {
+	if !swtpmSupportsBackup() {
+		t.Skip("swtpm does not support tpmstate-dir-backend-opt-backup")
+	}
 	id := generateUUID()
 	key := make([]byte, 32)
 	_, _ = rand.Read(key)
@@ -277,19 +352,23 @@ func TestSwtpmStateBakcupWithStateEncryption(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// get the normal and backup state file path
-	normalState := path.Join(fmt.Sprintf(swtpmStatePath, id.String(), "tpm2-00.permall"))
-	backupState := path.Join(fmt.Sprintf(swtpmStatePath, id.String(), "tpm2-00.permall.bak"))
+	normalState := fmt.Sprintf(workDir, id.String()) + "/tpm2-00.permall"
+	backupState := fmt.Sprintf(workDir, id.String()) + "/tpm2-00.permall.bak"
 
-	// check for backup file to be present
-	if _, err := os.Stat(backupState); os.IsNotExist(err) {
-		t.Fatalf("backup file %s does not exist", backupState)
-	}
+	// trigger state change to get both normal and backup state file
+	vmConn := simulateVMAttach(t, id)
+	vmConn.Close()
 
 	b, _, err = sendTerminateRequest(id)
 	if err != nil {
 		t.Fatalf("failed to send request: %v, body : %s", err, b)
 	}
 	time.Sleep(1 * time.Second)
+
+	// check for backup file to be present (swtpm writes backup on shutdown)
+	if _, err := os.Stat(backupState); os.IsNotExist(err) {
+		t.Fatalf("backup file %s does not exist", backupState)
+	}
 
 	// corrup the normal state file, by writing some data
 	f1, err := os.OpenFile(normalState, os.O_WRONLY|os.O_TRUNC, 0644)
@@ -309,6 +388,10 @@ func TestSwtpmStateBakcupWithStateEncryption(t *testing.T) {
 	}
 	time.Sleep(1 * time.Second)
 
+	// trigger again
+	vmConn = simulateVMAttach(t, id)
+	vmConn.Close()
+
 	b, _, err = sendTerminateRequest(id)
 	if err != nil {
 		t.Fatalf("failed to send request: %v, body : %s", err, b)
@@ -326,6 +409,10 @@ func TestSwtpmStateBakcupWithStateEncryption(t *testing.T) {
 		t.Fatalf("failed to send request: %v, body : %s", err, b)
 	}
 	time.Sleep(1 * time.Second)
+
+	// trigger again
+	vmConn = simulateVMAttach(t, id)
+	vmConn.Close()
 
 	b, _, err = sendTerminateRequest(id)
 	if err != nil {
@@ -366,7 +453,10 @@ func TestSwtpmStateBakcupWithStateEncryption(t *testing.T) {
 	}
 }
 
-func TestSwtpmStateBakcup(t *testing.T) {
+func TestSwtpmStateBackup(t *testing.T) {
+	if !swtpmSupportsBackup() {
+		t.Skip("swtpm does not support tpmstate-dir-backend-opt-backup")
+	}
 	id := generateUUID()
 	defer cleanupFiles(id)
 	isTPMAvailable = func() bool {
@@ -380,19 +470,23 @@ func TestSwtpmStateBakcup(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// get the normal and backup state file path
-	normalState := path.Join(fmt.Sprintf(swtpmStatePath, id.String(), "tpm2-00.permall"))
-	backupState := path.Join(fmt.Sprintf(swtpmStatePath, id.String(), "tpm2-00.permall.bak"))
+	normalState := fmt.Sprintf(workDir, id.String()) + "/tpm2-00.permall"
+	backupState := fmt.Sprintf(workDir, id.String()) + "/tpm2-00.permall.bak"
 
-	// check for backup file to be present
-	if _, err := os.Stat(backupState); os.IsNotExist(err) {
-		t.Fatalf("backup file %s does not exist", backupState)
-	}
+	// trigger state change to get both normal and backup state file
+	vmConn := simulateVMAttach(t, id)
+	vmConn.Close()
 
 	b, _, err = sendTerminateRequest(id)
 	if err != nil {
 		t.Fatalf("failed to send request: %v, body : %s", err, b)
 	}
 	time.Sleep(1 * time.Second)
+
+	// check for backup file to be present (swtpm writes backup on shutdown)
+	if _, err := os.Stat(backupState); os.IsNotExist(err) {
+		t.Fatalf("backup file %s does not exist", backupState)
+	}
 
 	// corrup the normal state file, by writing some data
 	f1, err := os.OpenFile(normalState, os.O_WRONLY|os.O_TRUNC, 0644)
@@ -412,6 +506,10 @@ func TestSwtpmStateBakcup(t *testing.T) {
 	}
 	time.Sleep(1 * time.Second)
 
+	// trigger again
+	vmConn = simulateVMAttach(t, id)
+	vmConn.Close()
+
 	b, _, err = sendTerminateRequest(id)
 	if err != nil {
 		t.Fatalf("failed to send request: %v, body : %s", err, b)
@@ -429,6 +527,10 @@ func TestSwtpmStateBakcup(t *testing.T) {
 		t.Fatalf("failed to send request: %v, body : %s", err, b)
 	}
 	time.Sleep(1 * time.Second)
+
+	// trigger again
+	vmConn = simulateVMAttach(t, id)
+	vmConn.Close()
 
 	b, _, err = sendTerminateRequest(id)
 	if err != nil {
@@ -564,7 +666,7 @@ func TestLaunchWithRealTPMEncryption(t *testing.T) {
 	etpm.TpmDevicePath = etpm.SimTpmPath
 	isTPMAvailable = func() bool { return true }
 	binKeyPath := fmt.Sprintf(stateEncryptionKey, id.String())
-	isEncryptedPath := fmt.Sprintf(swtpmIsEncryptedPath, id.String())
+	isEncryptedPath := fmt.Sprintf(stateIsEncryptedPath, id.String())
 	defer func() { etpm.TpmDevicePath = origTpmPath }()
 
 	// Seal a key into TPM NV storage so UnsealDiskKeyWithRecovery can retrieve it


### PR DESCRIPTION
# Description

This PR adds log rotation for swtpm instances and and the necessary build and packaging changes to make sure vtpm unit tests are run in CI.

The swtpm process writes its logs to a FIFO, and a log forwarder reads from that FIFO and writes to a log file on disk. When the log file exceeds 10MB it is automatically rotated and the old copy is compressed with gzip. This prevents swtpm logs from growing without bound on long-running systems. A simpler approach using `logrotate` was considered first but swtpm never resets its file position after rotation, so it would seek to the last offset and leave the new log file with a large gap of zeros. This could still cause issues with the disk monitoring service.

The vtpm unit tests were never included in the `make test` target, so they were never picked up by CI either. Commit 688a02c79e05fee213aa8a7d25dec04c75c235a9 fixes that.

## PR dependencies

None

## How to test and validate this PR

### Manual test

1. Deploy an Ubuntu VM with a virtual TPM enabled (this is the default).

2. Inside the VM, generate continuous TPM traffic:
   ```bash
   while true; do tpm2_getcap properties-fixed >/dev/null 2>&1; done
   ```

3. While that loop is running, SSH into the EVE host and inspect the swtpm log directory:
   ```bash
   ls -lh /persist/swtpm/tpm-state-<uuid>/swtpm.log*
   ```

4. Verify:
   - `swtpm.log` exists and is actively being written to (size and timestamp change).
   - Rotated logs are present (e.g. `swtpm.log.1`, `swtpm.log.2.gz`, etc.).
   - The active log file is bounded in size and it never grows indefinitely.
   - Older rotated logs are overwritten on each rotation cycle, not accumulated forever.

### Automated test

There is a self-contained test harness. It builds EVE from a PR branch, and runs the test automatically:

```bash
# as a one-liner (downloads everything to a temp dir, runs the test, reports, cleans up after) or clone https://github.com/shjala/eve-with-a-bullet.git and execute ru.sh without `--standalone` arg.
curl -sL https://raw.githubusercontent.com/shjala/eve-with-a-bullet/main/run.sh \
  | bash -s -- --standalone --pr 5838 --test vtpm-log-rotation
```

The `vtpm-log-rotation` test:

1. Launches an swtpm instance through vtpmd interface (same way we do it for VMs).
2. Initializes the TPM (`CMD_INIT`) using ctrl socket (like what qemu does).
3. Repeatedly sends `CMD_GET_CAPABILITY` to generate log output.
4. Waits until 3 rotated log files appear in the state directory.
5. Continues spamming for several more rotation cycles, verifying on each iteration that:
   - The rotated log count never exceeds 3.
   - The active log file is truncated on rotation (never grows unbounded).
6. Reports PASS only if rotation stays correctly bounded through the entire run.

## Changelog notes

Add log rotation for swtpm to prevent unbounded log growth.

## PR Backports

- 16.0-stable: To be backported.
- 14.5-stable: To be backported, as part of https://github.com/lf-edge/eve/pull/5797
- 13.4-stable: To be backported, as part of https://github.com/lf-edge/eve/pull/5796

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
