### PR TITLE
Introduces the optee-client package

### DIFF
--- a/images/modifiers/platform/nvidia-jp6/nvidia-jp6.yq
+++ b/images/modifiers/platform/nvidia-jp6/nvidia-jp6.yq
@@ -1,1 +1,1 @@
-.init += ["NVIDIA_TAG"]
+.init += ["NVIDIA_TAG", "OPTEE_CLIENT_TAG"]

--- a/images/modifiers/platform/nvidia-jp7/nvidia-jp7.yq
+++ b/images/modifiers/platform/nvidia-jp7/nvidia-jp7.yq
@@ -1,1 +1,1 @@
-.init += ["NVIDIA_TAG"]
+.init += ["NVIDIA_TAG", "OPTEE_CLIENT_TAG"]

--- a/pkg/optee-client/Dockerfile
+++ b/pkg/optee-client/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
+
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build-arm64
+
+ARG BUILD_PKGS="bash binutils-dev bsd-compat-headers build-base bc bison \
+  cmake flex openssl-dev util-linux-dev linux-headers swig git gnutls-dev \
+  perl python3 python3-dev py3-setuptools py3-pycryptodome py3-elftools pkgconfig"
+
+# hadolint ignore=DL3006
+RUN eve-alpine-deploy.sh
+
+COPY patches /patches
+
+ENV OPTEE_CLIENT_VERSION=4.9.0
+ADD --keep-git-dir=true https://github.com/OP-TEE/optee_client.git#${OPTEE_CLIENT_VERSION} /optee_client
+
+WORKDIR /optee_client
+
+# Apply patches
+RUN git config --global user.name 'Project EVE' && \
+    git config --global user.email 'builder@projecteve.dev' && \
+    for x in /patches/*.patch; do \
+      git am $x; \
+    done
+
+# Build tee-supplicant
+RUN cmake -DCMAKE_INSTALL_PREFIX=/out/usr && \
+      make -j "$(getconf _NPROCESSORS_ONLN)" && \
+      make install
+
+FROM scratch AS output-amd64
+FROM scratch AS output-riscv64
+
+FROM scratch AS output-arm64
+ENTRYPOINT []
+CMD []
+ADD rootfs/ /
+COPY --from=build-arm64 /out /
+
+ARG TARGETARCH
+FROM output-${TARGETARCH}
+ENTRYPOINT []
+CMD []

--- a/pkg/optee-client/build.yml
+++ b/pkg/optee-client/build.yml
@@ -1,0 +1,8 @@
+# linuxkit build template
+#
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+image: eve-optee-client
+org: lfedge

--- a/pkg/optee-client/patches/0001-tee-suplicant-Expose-renameat2-for-musl-libc.patch
+++ b/pkg/optee-client/patches/0001-tee-suplicant-Expose-renameat2-for-musl-libc.patch
@@ -1,0 +1,61 @@
+From 2f8ee1f0fa292cbae9e13a9354fd45be27e7ccc9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ren=C3=AA=20de=20Souza=20Pinto?= <rene@renesp.com.br>
+Date: Thu, 5 Mar 2026 16:32:36 +0000
+Subject: [PATCH] tee-suplicant: Expose renameat2 for musl libc
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+musl libc (Alpine) does not expose renameat2 or RENAME_NOREPLACE,
+so we call the syscall directly.
+
+Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>
+---
+ tee-supplicant/src/tee_supplicant.h | 31 +++++++++++++++++++++++++++++
+ 1 file changed, 31 insertions(+)
+
+diff --git a/tee-supplicant/src/tee_supplicant.h b/tee-supplicant/src/tee_supplicant.h
+index 58a2ef7..4c00ffd 100644
+--- a/tee-supplicant/src/tee_supplicant.h
++++ b/tee-supplicant/src/tee_supplicant.h
+@@ -31,6 +31,37 @@
+ #include <stdbool.h>
+ #include <pthread.h>
+ 
++/* musl libc (Alpine) does not expose renameat2 or RENAME_NOREPLACE,
++ * so we call the syscall directly. */
++#ifndef RENAME_NOREPLACE
++#define RENAME_NOREPLACE (1 << 0)
++#endif
++
++#ifndef SYS_renameat2
++/* Syscall numbers for common architectures */
++#  if defined(__x86_64__)
++#    define SYS_renameat2 316
++#  elif defined(__aarch64__)
++#    define SYS_renameat2 276
++#  elif defined(__arm__)
++#    define SYS_renameat2 382
++#  elif defined(__i386__)
++#    define SYS_renameat2 353
++#  else
++#    error "SYS_renameat2 not defined for this architecture"
++#  endif
++#endif
++
++#include <sys/syscall.h>
++#include <unistd.h>
++
++static inline int renameat2(int oldfd, const char *oldpath,
++                             int newfd, const char *newpath,
++                             unsigned int flags)
++{
++    return syscall(SYS_renameat2, oldfd, oldpath, newfd, newpath, flags);
++}
++
+ /* Helpers to access memref parts of a struct tee_ioctl_param */
+ #define MEMREF_SHM_ID(p)	((p)->c)
+ #define MEMREF_SHM_OFFS(p)	((p)->a)
+-- 
+2.36.6
+

--- a/pkg/optee-client/rootfs/etc/init.d/011-tee-supplicant
+++ b/pkg/optee-client/rootfs/etc/init.d/011-tee-supplicant
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Start tee-supplicant daemon
+/usr/sbin/tee-supplicant -f /persist/coretee -d
+

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -308,6 +308,12 @@ UUID_SYMLINK_PATH="/dev/disk/by-uuid"
 mkdir -p $UUID_SYMLINK_PATH
 chmod 700 $UUID_SYMLINK_PATH
 
+# Check for tee-supplicant and create the directory for the Trustzone userspace
+# filesystem (if needed).
+if [ -f /hostfs/usr/sbin/tee-supplicant ]; then
+    mkdir -p $PERSISTDIR/coretee
+fi
+
 # create /run/edgeview early before the disk mount for edgeview container
 mkdir -p /run/edgeview
 

--- a/tools/parse-pkgs.sh
+++ b/tools/parse-pkgs.sh
@@ -151,6 +151,7 @@ RECOVERTPM_TAG=${RECOVERTPM_TAG}
 UDEV_TAG=${UDEV_TAG}
 INSTALLER_TAG=${INSTALLER_TAG}
 MONITOR_TAG=${MONITOR_TAG}
+OPTEE_CLIENT_TAG=${OPTEE_CLIENT_TAG}
 EOF
 }
 
@@ -196,6 +197,7 @@ RECOVERTPM_TAG=$(linuxkit_tag pkg/recovertpm)
 UDEV_TAG=$(linuxkit_tag pkg/udev)
 INSTALLER_TAG=$(linuxkit_tag pkg/installer)
 MONITOR_TAG=$(linuxkit_tag pkg/monitor)
+OPTEE_CLIENT_TAG=$(linuxkit_tag pkg/optee-client)
 
 # Synthetic tags: the following tags are based on hashing
 # the contents of all the Dockerfile.in that we can find.


### PR DESCRIPTION
# Description

This PR introduces the optee-client package. This package provides the optee-client libraries and the tee-supplicant, an userspace daemon responsible to provide Normal World services for the Trustzone.
    
This package is only useful for systems running a secure OS on Trustzone. Thus, it should be added to rootfs images according to the target platform (through platform .yq modifiers under images/modifiers/platform/*).

The package is added to rootfs by all NVIDIA variants.

### Notes

This is required for fTPM.

## How to test and validate this PR

Run EVE on any NVIDIA platform. Check the tee-supplicant is there:

```sh
ls /usr/sbin/tee-supplicant
# or from debug container
ls /hostfs/usr/sbin/tee-supplicant
# or check if it's running
ps aux | grep tee-supplicant
```

## Changelog notes

Introduce optee-client libraries and tee-supplicant daemon on NVIDIA images.

## PR Backports

This is a new feature. No backports.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.