### PR TITLE
Increase the size of CONFIG partition from 1MB to 5MB

### DIFF
--- a/pkg/installer/install
+++ b/pkg/installer/install
@@ -362,9 +362,9 @@ CONFIG_PART=$(find_part CONFIG "${ROOT_DEV}")
 # - if CONFIGPART is not set, use /bits/config.img, e.g. CONFIGPART="" becomes CONFIGPART=/bits/config.img
 CONFIG_PART="${CONFIG_PART:+"/dev/"}${CONFIG_PART:-"/bits/config.img"}"
 if [ -e "$CONFIG_PART" ]; then
-   dd if="$CONFIG_PART" of=$CONFIG_IMG bs=1M
+   dd if="$CONFIG_PART" of=$CONFIG_IMG bs=5M
 else
-   mkfs.vfat -v -n CONFIG -C $CONFIG_IMG 1024
+   mkfs.vfat -v -n CONFIG -C $CONFIG_IMG 5120
    # /config is bind-mounted into here from the host
    mcopy -i $CONFIG_IMG -s /config/* ::/
 fi

--- a/pkg/mkconf/make-config
+++ b/pkg/mkconf/make-config
@@ -4,8 +4,8 @@ set -e
 [ -n "$DEBUG" ] && set -x
 
 CONFIG_FILE="$1"
-# Config is 1Mb
-CONFIG_SIZE_KB=1024
+# Config is 5Mb
+CONFIG_SIZE_KB=5120
 
 # Slurp the input in a form of a tarball
 (cd /conf/raw; tar xf -)

--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -125,7 +125,7 @@ fi
 
 
 # conf partition size in bytes
-CONF_PART_SIZE=$((1024 * 1024))
+CONF_PART_SIZE=$((5 * 1024 * 1024))
 # installer inventory partition size in bytes
 WIN_INVENTORY_PART_SIZE=$((40240 * 1024))
 # imx8 boot blob size in bytes

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -88,7 +88,7 @@ if CONFIG=$(findfs PARTLABEL=CONFIG) && [ -n "$CONFIG" ]; then
         echo "$(date -Ins -u) mount $CONFIG failed"
     fi
 
-    mount -t tmpfs -o rw,nosuid,nodev,noexec,relatime,size=1024k,mode=755 tmpfs $CONFIGDIR
+    mount -t tmpfs -o rw,nosuid,nodev,noexec,relatime,size=5120k,mode=755 tmpfs $CONFIGDIR
     echo "$(date -Ins -u) Create a copy of CONFIG partition in RAM"
     cp -r $CONFIGDIR_PERSIST/* $CONFIGDIR
     umount "$CONFIG"


### PR DESCRIPTION
# Description

A coming feature will expect fTPM provision files to be at the CONFIG partition. Unfortunately these files will exceed the current 1MB size.

This commit increases the size of CONFIG partition from 1MB to 5MB so it can support more files in the future.

## How to test and validate this PR

1. Boot eve
2. Check if the CONFIG partition size is 5M, for instance using `lsblk`:

```sh
lsblk 
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sda      8:0    0   32G  0 disk 
├─sda1   8:1    0    2G  0 part 
├─sda2   8:2    0    4G  0 part /
├─sda3   8:3    0    4G  0 part 
├─sda4   8:4    0    5M  0 part 
└─sda9   8:9    0   22G  0 part /persist
```

## Changelog notes

Increase the size of CONFIG partition from 1MB to 5MB to support more files in the future.

## PR Backports

This is a new feature, no backports.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.