### PR TITLE
eve-k: set Longhorn node disk reserved space via global config

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -33,7 +33,7 @@
 | timer.port.testbetterinterval | timer in seconds | 600 (10 minutes) | 0 | 4294967295 (max uint32) | test a higher prio port config |
 | network.fallback.any.eth | "enabled" or "disabled" | disabled (enabled forcefully during onboarding if no network config) | - | - | if no connectivity try any Ethernet, WiFi, or LTE with DHCP client |
 | network.download.max.cost | 0-255 | 0 | 0 | 255 | [max port cost for download](DEVICE-CONNECTIVITY.md) to avoid e.g., LTE ports |
-| blob.download.max.retries | 1-10 | 5 | 1 | 10 | max download retries when image verification fails.|
+| blob.download.max.retries | 1-10 | 5 | 1 | 10 | max download retries when image verification fails. |
 | debug.enable.usb | boolean | false | - | - | allow USB e.g. keyboards on device |
 | debug.enable.vga | boolean | false | - | - | allow VGA console on device |
 | debug.enable.ssh | authorized ssh key | empty string(ssh disabled) | - | - | allow ssh to EVE |
@@ -41,7 +41,8 @@
 | debug.enable.vnc.shim.vm | boolean | false | - | - | allow VNC access to the container application shim VM (reboot required to disable) |
 | storage.dom0.disk.minusage.percent | integer percent | 20 | 20 | 80 | min. percent of persist partition reserved for dom0 |
 | storage.zfs.reserved.percent | integer percent | 20 | 1 | 99 | min. percent of persist partition reserved for zfs performance |
-| storage.apps.ignore.disk.check | boolean | false | - | - | Ignore disk usage check for Apps. Allows apps to create images bigger than available disk|
+| storage.longhorn.disk.reserved.gigabytes | integer GB | 2 | 0 | 1048576 | per-disk storage reserved by Longhorn on the local node; overrides Longhorn's default 25% reservation. 0 sets storageReserved to 0 bytes (no reservation). 1048576 disables EVE's override, leaving Longhorn's current value in place |
+| storage.apps.ignore.disk.check | boolean | false | - | - | Ignore disk usage check for Apps. Allows apps to create images bigger than available disk |
 | timer.appcontainer.stats.interval | integer in seconds | 300 (5 minutes) | 1 | 4294967295 (max uint32) | collect application container stats |
 | timer.vault.ready.cutoff | integer in seconds | 300 (5 minutes) | 60 (1 minute) | 4294967295 (max uint32) | reboot after inaccessible vault |
 | maintenance.mode | "enabled" or "disabled" | "none" | - | - | don't run applications etc |
@@ -85,7 +86,7 @@
 | msrv.prometheus.metrics.burst | integer | 10 | 1 | 4294967295 (max uint32) | The maximum burst size for the Prometheus metrics endpoint. |
 | msrv.prometheus.metrics.idletimeout.seconds | integer | 240 (4 minutes) | 1 | 4294967295 (max uint32) | The idle timeout in seconds for the Prometheus metrics endpoint. If the connection is idle for this duration, the limit is reset. |
 | edgeview.authen.publickey | string | "" | - | - | Specifies SSH public keys for Edgeview client command authentication. The user must provide the path to the SSH private key in the client script, and the device verifies the command using one of the configured public keys. Separate multiple public keys with newline characters. |
-| wwan.modem.recovery.watchdog | boolean | false | - | - | Enable watchdog for cellular modems. If a modem firmware crashes and fails to recover, the device will automatically reboot.|
+| wwan.modem.recovery.watchdog | boolean | false | - | - | Enable watchdog for cellular modems. If a modem firmware crashes and fails to recover, the device will automatically reboot. |
 | wwan.modem.recovery.reload.drivers | boolean | false | - | - | If a modem firmware crashes and fails to recover, EVE will attempt to reload the MBIM/QMI/MHI drivers as a recovery step. This occurs before the watchdog mechanism is triggered (if enabled). |
 | wwan.modem.recovery.restart.modemmanager | boolean | false | - | - | If a modem firmware crash occurs and ModemManager fails to properly recognize or manage the restarted modem, EVE will attempt to restart ModemManager as a recovery step. This occurs before the watchdog mechanism is triggered (if enabled) and can be combined with driver reload recovery mechanism. |
 | diag.probe.remote.http.endpoint | string | `"http://www.google.com"` | - | - | Remote endpoint (URL, IP instead of hostname is accepted) queried over HTTP to assess the state of network connectivity whenever the controller is not reachable. Used only for diagnostics (no functional impact). Set to an empty string to disable. |
@@ -127,7 +128,7 @@ These use the same log levels as the default log level settings (logrus).
 The per-agent settings begin with "agent.*agentname*.*setting*":
 
 | Name | Type | Default | Description |
-| ---- | ---- |---------|------------ |
+| ---- | ---- | ------- | ----------- |
 | agent.*agentname*.debug.loglevel | string | if set overrides debug.default.loglevel for this particular agent | (Legacy setting debug.*agentname*.loglevel still supported) |
 | agent.*agentname*.debug.remote.loglevel | string | if set overrides debug.default.remote.loglevel for this particular agent | (Legacy setting debug.*agentname*.remote.loglevel) |
 

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -42,6 +42,7 @@ const (
 	// Stats are only published by the elected leader and are less latency-sensitive than
 	// app-status or log collection, so a longer interval is acceptable.
 	kubeStatsInterval = 30
+	kubeCfgInterval   = 60
 
 	inlineCmdKubeClusterUpdateStatus = "pubKubeClusterUpdateStatus"
 	inlineCmdVmiDetach               = "vmiDetach"
@@ -117,6 +118,9 @@ type zedkube struct {
 	// Block 'uncordon' after running it once at bootup
 	onBootUncordonCheckComplete bool
 	receivedENCC                bool
+
+	// longhornDiskReservedSet is true once the desired reservation has been applied to the Longhorn node
+	longhornDiskReservedSet bool
 }
 
 func inlineUsage() int {
@@ -602,6 +606,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	appLogTimer := time.NewTimer(logcollectInterval * time.Second)
 	appStatusTimer := time.NewTimer(logcollectInterval * time.Second)
 	kubeStatsTimer := time.NewTimer(kubeStatsInterval * time.Second)
+	kubeCfgTimer := time.NewTimer(kubeCfgInterval * time.Second)
 
 	zedkubeWdUpdate := func() {
 		ps.StillRunning(agentName, warningTime, errorTime)
@@ -641,6 +646,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			zedkubeWdUpdate()
 			zedkubeCtx.collectKubeSvcs()
 			kubeStatsTimer = time.NewTimer(kubeStatsInterval * time.Second)
+
+		// Timer 4: cluster-wide component config application
+		case <-kubeCfgTimer.C:
+			zedkubeCtx.applyLonghornDiskReserved()
+			kubeCfgTimer = time.NewTimer(kubeCfgInterval * time.Second)
 
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -783,8 +793,41 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 
 		handleK3sConfigOverrideChanged(currentConfigItemValueMap, newConfigItemValueMap)
 		z.handleK3sVersionOverride(currentConfigItemValueMap, newConfigItemValueMap)
+
+		newReservedGB := newConfigItemValueMap.GlobalValueInt(types.LonghornDiskReservedGB)
+		existingReservedGB := currentConfigItemValueMap.GlobalValueInt(types.LonghornDiskReservedGB)
+		if newReservedGB != existingReservedGB {
+			log.Functionf("handleGlobalConfigImpl: LonghornDiskReservedGB changed %d -> %d",
+				existingReservedGB, newReservedGB)
+			z.longhornDiskReservedSet = false
+		}
+
+		z.globalConfig = newConfigItemValueMap
+		z.applyLonghornDiskReserved()
 	}
 	log.Functionf("handleGlobalConfigImpl(%s): done", key)
+}
+
+// applyLonghornDiskReserved attempts to set the per-disk reserved space on the local Longhorn
+// node. It is a no-op if the node name is not yet known or the value has already been applied.
+// Callers should retry periodically until longhornDiskReservedSet is true.
+func (z *zedkube) applyLonghornDiskReserved() {
+	if z.nodeName == "" || z.longhornDiskReservedSet {
+		return
+	}
+	reservedGB := z.globalConfig.GlobalValueInt(types.LonghornDiskReservedGB)
+	if reservedGB == types.LonghornDiskReservedGBDisabled {
+		// Operator disabled EVE's override; leave Longhorn's current value in place.
+		z.longhornDiskReservedSet = true
+		return
+	}
+	reservedBytes := int64(reservedGB) * 1024 * 1024 * 1024
+	applied, err := kubeapi.SetLonghornNodeDiskReserved(z.nodeName, reservedBytes)
+	if err != nil {
+		log.Errorf("applyLonghornDiskReserved: %v", err)
+		return
+	}
+	z.longhornDiskReservedSet = applied
 }
 
 func handleK3sConfigOverrideChanged(currentGcp *types.ConfigItemValueMap, newGcp *types.ConfigItemValueMap) {
@@ -829,7 +872,7 @@ func WriteBase64Cfg(parentDir string, filename string, base64Config string) erro
 	return nil
 }
 
-func (ctx *zedkube) handleK3sVersionOverride(currentGcp *types.ConfigItemValueMap, newGcp *types.ConfigItemValueMap) {
+func (z *zedkube) handleK3sVersionOverride(currentGcp *types.ConfigItemValueMap, newGcp *types.ConfigItemValueMap) {
 	oldVal := currentGcp.GlobalValueString(types.K3sVersionOverride)
 	newVal := newGcp.GlobalValueString(types.K3sVersionOverride)
 
@@ -840,13 +883,13 @@ func (ctx *zedkube) handleK3sVersionOverride(currentGcp *types.ConfigItemValueMa
 	// kube Update_CheckNodeComponents() will check this structure and revert
 	// the k3s version back to the baseos constant K3S_VERSION.
 	kubeConfig := types.KubeConfig{}
-	items := ctx.pubKubeConfig.GetAll()
+	items := z.pubKubeConfig.GetAll()
 	glbKubeConfig, ok := items["global"].(types.KubeConfig)
 	if ok {
 		kubeConfig = glbKubeConfig
 	}
 	kubeConfig.K3sVersion = newVal
-	ctx.pubKubeConfig.Publish("global", kubeConfig)
+	z.pubKubeConfig.Publish("global", kubeConfig)
 	currentGcp.SetGlobalValueString(types.K3sVersionOverride, newVal)
 }
 
@@ -932,20 +975,21 @@ func handleZedAgentStatusDelete(ctxArg interface{}, key string,
 
 // checkAndSaveEdgeNodeInfo checks if the device name is set in the EdgeNodeInfo
 // it returns true if we got the valid EdgeNodeInfo update
-func (ctx *zedkube) checkAndSaveEdgeNodeInfo() bool {
-	items := ctx.subEdgeNodeInfo.GetAll()
+func (z *zedkube) checkAndSaveEdgeNodeInfo() bool {
+	items := z.subEdgeNodeInfo.GetAll()
 	if len(items) > 0 {
 		for _, item := range items {
 			enInfo := item.(types.EdgeNodeInfo)
 			if enInfo.DeviceName != "" {
 				log.Noticef("checkAndSaveEdgeNodeInfo: found devicename %s", enInfo.DeviceName)
-				ctx.nodeName = strings.ReplaceAll(strings.ToLower(enInfo.DeviceName), "_", "-")
-				ctx.nodeuuid = enInfo.DeviceID.String()
-				if ctx.nodeName != "" && ctx.nodeuuid != "" {
+				z.nodeName = strings.ReplaceAll(strings.ToLower(enInfo.DeviceName), "_", "-")
+				z.nodeuuid = enInfo.DeviceID.String()
+				if z.nodeName != "" && z.nodeuuid != "" {
 					//Re-enable local node
-					if !ctx.onBootUncordonCheckComplete {
-						go nodeOnBootHealthStatusWatcher(ctx)
+					if !z.onBootUncordonCheckComplete {
+						go nodeOnBootHealthStatusWatcher(z)
 					}
+					z.applyLonghornDiskReserved()
 					return true
 				}
 			}

--- a/pkg/pillar/kubeapi/longhorninfo.go
+++ b/pkg/pillar/kubeapi/longhorninfo.go
@@ -497,6 +497,59 @@ func longhornVolumeSetNode(lhVolName string, kubeNodeName string) error {
 	return err
 }
 
+// SetLonghornNodeDiskReserved sets StorageReserved on every disk of the named Longhorn node.
+// Returns (false, nil) if the Longhorn API is absent or the node object does not exist yet,
+// so callers should retry until (true, nil) is returned.
+func SetLonghornNodeDiskReserved(nodeName string, reservedBytes int64) (bool, error) {
+	apiExists, err := longhornAPIExists()
+	if !apiExists && err == nil {
+		// Longhorn may not yet be installed on this boot yet
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	config, err := GetKubeConfig()
+	if err != nil {
+		return false, fmt.Errorf("SetLonghornNodeDiskReserved: kubeconfig: %v", err)
+	}
+	lhClient, err := versioned.NewForConfig(config)
+	if err != nil {
+		return false, fmt.Errorf("SetLonghornNodeDiskReserved: versioned client: %v", err)
+	}
+
+	lhCtx, lhCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer lhCancel()
+	node, err := lhClient.LonghornV1beta2().Nodes(longhornNamespace).Get(
+		lhCtx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("SetLonghornNodeDiskReserved: get node %s: %v", nodeName, err)
+	}
+
+	changed := false
+	for key, disk := range node.Spec.Disks {
+		if disk.StorageReserved != reservedBytes {
+			disk.StorageReserved = reservedBytes
+			node.Spec.Disks[key] = disk
+			changed = true
+		}
+	}
+	if !changed {
+		return true, nil
+	}
+
+	_, err = lhClient.LonghornV1beta2().Nodes(longhornNamespace).Update(
+		lhCtx, node, metav1.UpdateOptions{})
+	if err != nil {
+		return false, fmt.Errorf("SetLonghornNodeDiskReserved: update node %s: %v", nodeName, err)
+	}
+	return true, nil
+}
+
 // longhornAPIExists will check for longhorn components installed and set
 // a flag in this module to gate all API access.  In some configurations
 // it is possible that longhorn is not installed but this intended configuration
@@ -508,9 +561,16 @@ func longhornAPIExists() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+
+	lhCtx, lhCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer lhCancel()
+
 	// If the longhorn-system namespace exists then we should expect the longhorn api endpoint is available.
-	ns, err := cs.CoreV1().Namespaces().Get(context.Background(), longhornNamespace, metav1.GetOptions{})
+	ns, err := cs.CoreV1().Namespaces().Get(lhCtx, longhornNamespace, metav1.GetOptions{})
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
 		return false, err
 	}
 	if ns == nil {

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -215,6 +215,10 @@ const (
 	Dom0DiskUsageMaxBytes GlobalSettingKey = "storage.dom0.disk.maxusagebytes"
 	// StorageZfsReserved is the percentage reserved in a ZFS pool
 	StorageZfsReserved GlobalSettingKey = "storage.zfs.reserved.percent"
+	// LonghornDiskReservedGB is the number of GB reserved per disk on the local Longhorn node.
+	// Overrides Longhorn's default 25% reservation. 0 sets storageReserved to 0 bytes (no
+	// reservation). Set to LonghornDiskReservedGBDisabled to disable EVE's override entirely.
+	LonghornDiskReservedGB GlobalSettingKey = "storage.longhorn.disk.reserved.gigabytes"
 	// AppContainerStatsInterval - App Container Stats Collection
 	AppContainerStatsInterval GlobalSettingKey = "timer.appcontainer.stats.interval"
 	// VaultReadyCutOffTime global setting key
@@ -462,6 +466,10 @@ const (
 	// Set this to false to disable sending a vendor class ID.
 	DHCPEnableVendorClassID GlobalSettingKey = "dhcp.enable.vendorclassid"
 )
+
+// LonghornDiskReservedGBDisabled is the sentinel value for LonghornDiskReservedGB that
+// disables EVE's override, leaving the current Longhorn storageReserved value untouched.
+const LonghornDiskReservedGBDisabled uint32 = 1024 * 1024
 
 // AgentSettingKey - keys for per-agent settings
 type AgentSettingKey string
@@ -1060,6 +1068,8 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(Dom0DiskUsageMaxBytes, 2*1024*1024*1024,
 		100*1024*1024, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(StorageZfsReserved, 20, 1, 99)
+	// LonghornDiskReservedGB - Default 2 GB. 0 = no reservation. LonghornDiskReservedGBDisabled = disable override.
+	configItemSpecMap.AddIntItem(LonghornDiskReservedGB, 2, 0, LonghornDiskReservedGBDisabled)
 	configItemSpecMap.AddIntItem(ForceFallbackCounter, 0, 0, 0xFFFFFFFF)
 	//
 	// Go garbage collector configuration section


### PR DESCRIPTION
## Description

Adds storage.longhorn.disk.reserved.gigabytes (default 2 GB) to override
Longhorn's default 25% per-disk reservation, which is excessive on edge
devices with constrained storage.

- kubeapi: SetLonghornNodeDiskReserved sets StorageReserved on all disks
  of the named Longhorn node; no-ops gracefully if LH not yet installed;
  applies kubeAPITimeout to both Nodes.Get and Nodes.Update calls
- kubeapi: fix longhornAPIExists returning error on absent namespace
  (IsNotFound now returns false,nil instead of false,<404>)
- zedkube: applyLonghornDiskReserved wires the call into config-change,
  node-name-known, and 60s periodic retry paths
- types/global: LonghornDiskReservedGB key (min 0, max 1048576);
  sentinel value 1048576 disables EVE's override entirely
- docs: document new property; fix four pre-existing MD060 lint errors

## PR dependencies

None

## How to test and validate this PR

- deploy an eve-k node
- wait for node to install longhorn and come ready
- `eve enter kube`
- verify longhorn node storage reserved value meets 2GB default.

`kubectl -n longhorn-system get nodes.longhorn.io -o json | jq '.items[].spec.disks[] | .storageReserved'`

## Changelog notes

fix: eve-k nodes storage reserved value set to 2GB

## PR Backports

- 16.0-stable: TBD
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
