### PR TITLE
vtpm,vector: fix cross-compilation and runtime issues

### DIFF
--- a/pkg/vector/Dockerfile
+++ b/pkg/vector/Dockerfile
@@ -41,7 +41,7 @@ RUN echo "Cargo target: $CARGO_BUILD_TARGET"
 # building the final image
 FROM toolchain AS builder
 ARG VECTOR_FEATURES
-ADD https://github.com/vectordotdev/vector.git#v0.50.0 /app
+ADD https://github.com/vectordotdev/vector.git#v0.54.0 /app
 # we have our own options, so remove the default cargo config
 # if this doesn't help then remove everything leaving only
 # the files from .dockerignore except rust-toolchain.toml
@@ -54,11 +54,13 @@ ENV RUSTFLAGS="\
     -C lto=fat \
     -C embed-bitcode=yes \
     -C codegen-units=1 \
-    -A dead_code"
+    -C link-arg=--ld-path=/usr/bin/mold \
+    -C link-arg=--target=$CARGO_BUILD_TARGET"
+
 RUN cargo build --release $VECTOR_FEATURES
 
 # strip unneeded symbols
-RUN strip "/app/target/$CARGO_BUILD_TARGET/release/vector"
+RUN llvm-strip "/app/target/$CARGO_BUILD_TARGET/release/vector"
 
 RUN cargo sbom > sbom.spdx.json
 RUN cp "/app/target/$CARGO_BUILD_TARGET/release/vector" /app/target/

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -81,7 +81,7 @@ RUN strip --strip-unneeded /out/usr/bin/ptpm
 RUN find /out/usr/lib/ -name '*.la' -delete
 RUN find /out/usr/lib/ -name '*.a' -delete
 
-RUN rm /out/usr/lib/libprotoc.so* /out/usr/lib/libprotobuf*
+RUN rm /out/usr/lib/libprotoc.so*
 
 FROM scratch
 COPY --from=build /out/ /

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -4,7 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM lfedge/eve-dom0-ztools:41e448a70640e7b6f98d19f790cf35cf579fd0db AS dom0
-FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build
+
+# ===========================================================================
+# C builds (libtpms, swtpm, tpm2-tss, tpm2-tools, ptpm)
+# These use autoconf/automake with many -dev dependencies, so for now they
+# remain under QEMU emulation when cross-building.
+# ===========================================================================
+FROM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build-c
 ENV BUILD_PKGS="gcc g++ autoconf automake libtool make openssl-dev libtasn1-dev \
     json-glib-dev gnutls bash expect gawk socat libseccomp-dev gmp-dev \
     musl-utils autoconf-archive git json-c json-c-dev libcurl curl-dev \
@@ -23,7 +29,7 @@ RUN strip --strip-unneeded /out/usr/lib/libtpms.so.*
 
 # build swtpm
 WORKDIR /swtpm
-# This poinst to the latest commit that implements state backup functionality.
+# This points to the latest commit that implements state backup functionality.
 # TODO: revert this when there is a new release in swtpm
 ADD https://github.com/stefanberger/swtpm.git#732bbd6ad3a52b9552b5a1620e03a9f6449a1aab /swtpm
 RUN ./autogen.sh --prefix=/out/usr
@@ -58,20 +64,7 @@ RUN cp lib/.libs/libcommon.so* /out/usr/lib/
 RUN cp tools/.libs/tpm2 /out/usr/bin/
 RUN strip --strip-unneeded /out/usr/lib/*.so*
 
-# Build vtpm
-WORKDIR /vtpm-build
-COPY swtpm-vtpm/src/ /vtpm-build/.
-COPY swtpm-vtpm/ /vtpm-build/.
-ARG GOPKGVERSION
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-# hadolint ignore=SC2046
-RUN echo "Running go vet" && go vet ./... && echo "Running go fmt" && \
-    ERR=$(gofmt -e -l -s $(find . -name \*.go | grep -v /vendor/)) && \
-    if [ -n "$ERR" ] ; then echo "go fmt Failed - ERR: $ERR"; exit 1 ; fi
-RUN GO111MODULE=on CGO_ENABLED=0 go build -ldflags "-s -w -X=main.Version=${GOPKGVERSION}" \
-    -mod=vendor -o /out/usr/bin/vtpm .
-
-# Build ptpm
+# Build ptpm (C++)
 WORKDIR /ptpm-build
 ADD ptpm/ /ptpm-build
 RUN make -j$(nproc) && cp ptpm /out/usr/bin/
@@ -83,8 +76,35 @@ RUN find /out/usr/lib/ -name '*.a' -delete
 
 RUN rm /out/usr/lib/libprotoc.so*
 
+# ===========================================================================
+# Go build (vtpm)
+# Go has first-class cross-compilation support, so we run this natively on
+# the build host using --platform=$BUILDPLATFORM and set GOARCH to target.
+# This avoids QEMU, which is known to deadlock on go vet / go build.
+# ===========================================================================
+# hadolint ignore=DL3029
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:47d267f35e4832f639bf65bbe8a2e7b2f31e3e36 AS build-go
+ARG TARGETARCH
+
+WORKDIR /vtpm-build
+COPY swtpm-vtpm/src/ /vtpm-build/.
+COPY swtpm-vtpm/ /vtpm-build/.
+ARG GOPKGVERSION
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+# hadolint ignore=SC2046
+RUN echo "Running go vet" && GOARCH=${TARGETARCH} go vet ./... && echo "Running go fmt" && \
+    ERR=$(gofmt -e -l -s $(find . -name \*.go | grep -v /vendor/)) && \
+    if [ -n "$ERR" ] ; then echo "go fmt Failed - ERR: $ERR"; exit 1 ; fi
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
+    go build -ldflags "-s -w -X=main.Version=${GOPKGVERSION}" \
+    -mod=vendor -o /out/usr/bin/vtpm .
+
+# ===========================================================================
+# Final image
+# ===========================================================================
 FROM scratch
-COPY --from=build /out/ /
+COPY --from=build-c /out/ /
+COPY --from=build-go /out/usr/bin/vtpm /usr/bin/vtpm
 COPY init.sh /usr/bin/
 COPY --from=dom0 /etc/group /etc/group
 COPY --from=dom0 /etc/passwd /etc/passwd


### PR DESCRIPTION
# Description

This PR fixes several build and runtime issues in `vtpm` and `vector` packages that surfaced after the move to Alpine 3.22 / newer Rust toolchain.

**vtpm: keep libprotobuf in runtime image**

Alpine 3.22 protobuf links dynamically (`libprotobuf.so.29`) whereas Alpine 3.16 protobuf was statically linked into `ptpm`. The Dockerfile was explicitly deleting libprotobuf from `/out/`, which used to be harmless but now causes runtime symbol resolution failures. Keep `libprotobuf.so` in the runtime image and only remove `libprotoc.so` (the compiler, not needed at runtime).

**vtpm: fix cross-compilation by splitting Go and C builds**

Split the single build stage into `build-c` and `build-go`:

- `build-c`: C/C++ builds (libtpms, swtpm, tpm2-tss, tpm2-tools, ptpm) remain under QEMU emulation due to autoconf/automake dependencies.
- `build-go`: runs natively on the build host using `--platform=$BUILDPLATFORM` with `GOARCH=$TARGETARCH`. Go has first-class cross-compilation support and `CGO_ENABLED=0`, so no C toolchain is needed. This avoids QEMU which is known to deadlock on `go vet`.

Both stages run in parallel under BuildKit.

**vector: fix cross-compilation for all platforms**

`RUSTFLAGS` env var was overriding target-specific rustflags from eve-rust's `/usr/local/cargo/config.toml`, silently dropping the mold linker (`--ld-path=/usr/bin/mold`) and the cross-compilation `--target` flag passed to clang. These flags are now added to `RUSTFLAGS` explicitly.

Replace `strip` with `llvm-strip` since the native GNU strip cannot recognize cross-compiled binaries (e.g. aarch64 binary on x86_64 host). `llvm-strip` is architecture-agnostic and already available in the eve-rust image.

Bump vector from v0.47.0 to v0.54.0 to be compilable with Rust 1.93.

## How to test and validate this PR

- Cross-compile EVE for both amd64 and arm64 from the same host and verify that:
  - `pkg/vtpm` builds successfully and the resulting image contains a working `ptpm` binary (no missing `libprotobuf.so.29` symbol resolution errors at runtime).
  - `pkg/vector` builds successfully on both architectures and produces stripped binaries.
- Boot EVE on a target device and confirm `vtpm` and `vector` services start without runtime linker errors.

## Changelog notes

No user-facing changes.

## PR Backports

- 16.0-stable: No
- 14.5-stable: No
- 13.4-stable: No

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.