### PR TITLE
installer: Add option to skip device certificate generation

### DIFF
--- a/pkg/installer/install
+++ b/pkg/installer/install
@@ -26,6 +26,7 @@
 #   eve_install_zfs_with_raid_level
 #   eve_install_k3s_etcd_sizeGB
 #   eve_disable_verify
+#   eve_skip_dev_cert
 #
 
 # script to check if cmdline contains a string
@@ -615,41 +616,45 @@ TPM_DEVICE_PATH="/dev/tpmrm0"
 DEVICE_CERT_NAME="/config/device.cert.pem"
 DEVICE_KEY_NAME="/config/device.key.pem"
 
-# The device cert generation needs the current time. Some hardware
-# doesn't have a battery-backed clock so we check the year makes some sense
-# In that case we defer until first boot of EVE to run ntp and generate
-# the device certificate
-YEAR=$(date +%Y)
-if [ "$YEAR" -gt 2020 ] && [ ! -f $DEVICE_CERT_NAME ]; then
-   if [ -c $TPM_DEVICE_PATH ] && ! [ -f $DEVICE_KEY_NAME ]; then
-      logmsg "Generating TPM device certificate"
-      if ! /tpmmgr createDeviceCert; then
-         logmsg "Failed generating device certificate on TPM; fallback to soft"
-         # The future existence of /config/device.key.pem indicates not using TPM
-         sync
-      else
-         logmsg "Generated a TPM device certificate"
-         if ! /tpmmgr createCerts; then
-            logmsg "Failed to create additional certificates on TPM"
-         fi
-      fi
-   else
-      logmsg "No TPM; Generating soft device certificate"
-   fi
-   if [ ! -f $DEVICE_CERT_NAME ]; then
-      if ! /tpmmgr createSoftDeviceCert; then
-         logmsg "Failed to generate soft device certificate"
-      elif ! /tpmmgr createSoftCerts; then
-         logmsg "Failed to create additional certificates"
-      fi
-   fi
-   sync
-   mount -o remount,flush,ro /config
-   sleep 5
-fi
-# Collect the device cert
-if [ -f $DEVICE_CERT_NAME ] && [ -n "$REPORT" ]; then
-   cat $DEVICE_CERT_NAME > "$REPORT/device.cert.pem"
+if cmdline eve_skip_dev_cert; then
+    logmsg "Skipping device certificate generation. The certificate will be automatically generated on first boot."
+else
+    # The device cert generation needs the current time. Some hardware
+    # doesn't have a battery-backed clock so we check the year makes some sense
+    # In that case we defer until first boot of EVE to run ntp and generate
+    # the device certificate
+    YEAR=$(date +%Y)
+    if [ "$YEAR" -gt 2020 ] && [ ! -f $DEVICE_CERT_NAME ]; then
+       if [ -c $TPM_DEVICE_PATH ] && ! [ -f $DEVICE_KEY_NAME ]; then
+          logmsg "Generating TPM device certificate"
+          if ! /tpmmgr createDeviceCert; then
+             logmsg "Failed generating device certificate on TPM; fallback to soft"
+             # The future existence of /config/device.key.pem indicates not using TPM
+             sync
+          else
+             logmsg "Generated a TPM device certificate"
+             if ! /tpmmgr createCerts; then
+                logmsg "Failed to create additional certificates on TPM"
+             fi
+          fi
+       else
+          logmsg "No TPM; Generating soft device certificate"
+       fi
+       if [ ! -f $DEVICE_CERT_NAME ]; then
+          if ! /tpmmgr createSoftDeviceCert; then
+             logmsg "Failed to generate soft device certificate"
+          elif ! /tpmmgr createSoftCerts; then
+             logmsg "Failed to create additional certificates"
+          fi
+       fi
+       sync
+       mount -o remount,flush,ro /config
+       sleep 5
+    fi
+    # Collect the device cert
+    if [ -f $DEVICE_CERT_NAME ] && [ -n "$REPORT" ]; then
+       cat $DEVICE_CERT_NAME > "$REPORT/device.cert.pem"
+    fi
 fi
 
 # finally check whether we are collecting a black box


### PR DESCRIPTION
# Description

The device certificate is generated at the installation process or during the first boot of the device, if no certificate is present.

Installer tries to use TPM to generate the certificate and in case of absence of TPM (or any other error) it falls back into the software certificate generation.

The fTPM on NVIDIA devices should be provisioned during the first boot and not during installation phase. However, if a software certificate is already present, a new one won't be generated.

This PR adds a new option to the installer, `eve_skip_dev_cert`, that skips the device certificate during installation, so it can be generated during first boot, when the fTPM is already provisioned.

## Changelog notes

Add eve_skip_dev_cert installer option to defer device certificate generation to first boot for fTPM support on NVIDIA devices.

## PR Backports

This is a new feature, so no backports.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.