### PR TITLE
pkg/storage-init: Copy fTPM provision data

### DIFF
--- a/pkg/measure-config/src/measurefs.go
+++ b/pkg/measure-config/src/measurefs.go
@@ -146,6 +146,7 @@ func getExcludeList() []string {
 		"/config/onboard.cert.pem",
 		"/config/onboard.key.pem",
 		"/config/soft_serial",
+		"/config/ftpm.tar.xz",
 	}
 }
 

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -312,6 +312,12 @@ chmod 700 $UUID_SYMLINK_PATH
 # filesystem (if needed).
 if [ -f /hostfs/usr/sbin/tee-supplicant ]; then
     mkdir -p $PERSISTDIR/coretee
+
+    # Check for an existent fTPM provision data on CONFIG partition, if found,
+    # the data must be extracted to /persist/
+    if [ -f "$CONFIGDIR/ftpm.tar.xz" ]; then
+        tar -xJf "$CONFIGDIR/ftpm.tar.xz" -C $PERSISTDIR
+    fi
 fi
 
 # create /run/edgeview early before the disk mount for edgeview container


### PR DESCRIPTION
# Description
    
Activation of fTPM on NVIDIA devices directly from EVE is still not supported. In order to use the fTPM on EVE, the following steps should be followed:
    
- Activate fTPM on a regular Jetpack
- Pack /coretee directory into a tarball named ftpm.tar.xz
- Install EVE on the device
- Copy the tarball into the CONFIG partition
- During first boot, EVE will extract the tarball into /persist and use the fTPM.

## PR dependencies

#5839 

## How to test and validate this PR

- Activate fTPM on a regular Jetpack
- Pack /coretee directory into a tarball named ftpm.tar.xz
- Generate installer/live image (nvidia-jp6 only)
- Ensure to copy the ftpm.tar.xz to the CONFIG partition
- Install EVE on the device (on run live image)
- During first boot, EVE will extract the tarball into /persist and use the fTPM.

## Changelog notes

Provision fTPM 

## PR Backports

This is a new feature. No backports.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.