### PR TITLE
Fix SCEP CA trust anchor certs being silently skipped

### DIFF
--- a/pkg/pillar/cmd/scepclient/scep.go
+++ b/pkg/pillar/cmd/scepclient/scep.go
@@ -283,19 +283,19 @@ func (c *SCEPClient) enrollOrRenewCertificate(profile types.SCEPProfile,
 
 	// Parse configured trust anchor CA certificates.
 	// These are the root/intermediate CA certs from the SCEP profile configuration.
-	// Errors are ignored here because configuration was validated earlier.
 	var trustAnchors []*x509.Certificate
 	for _, certBytes := range profile.CACertPEM {
-		block, err := pem.Decode(certBytes)
-		if err != nil {
-			// Should be unreachable (otherwise there is a bug in zedagent or scepclient).
-			c.log.Errorf("Unexpected CA cert decoding error: %v", err)
+		// Parsing errors should be unreachable because zedagent already validated
+		// config, including trusted certificates.
+		block, _ := pem.Decode(certBytes)
+		if block == nil {
+			c.log.Errorf("Failed to PEM-decode a configured SCEP CA cert")
 			continue
 		}
-		if block != nil {
-			if caCert, _ := x509.ParseCertificate(block.Bytes); caCert != nil {
-				trustAnchors = append(trustAnchors, caCert)
-			}
+		if caCert, err := x509.ParseCertificate(block.Bytes); err == nil {
+			trustAnchors = append(trustAnchors, caCert)
+		} else {
+			c.log.Errorf("Failed to parse a configured SCEP CA cert: %v", err)
 		}
 	}
 


### PR DESCRIPTION
# Description

`pem.Decode` returns `(block, rest []byte)`, not `(block, error)`. The previous code assigned `rest` to a variable named `err` and checked `err != nil` -- but an empty (non-nil) `rest` slice from a valid PEM block always satisfied that condition, causing every configured trust anchor cert to be skipped and leaving the trust pool empty. This made all SCEP CA cert chain verifications fail with `certificate signed by unknown authority`.

## How to test and validate this PR

Configure a SCEP profile, including the trusted CA certificate, and verify that the tested EVE device successfully enrolls a certificate. Previously, this would fail with the error `certificate signed by unknown authority` (indicating that the SCEP CA was not trusted).

## Changelog notes

Fix SCEP enrollment failure caused by CA trust anchors not being properly parsed.

## PR Backports

```text
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.