### PR TITLE
eve-k: fix pillar 'make test' for macOS M-series (ZARCH=arm64 HV=k)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1072,6 +1072,17 @@ cache-export-docker-load: $(LINUXKIT)
 	$(MAKE) cache-export OUTFILE=${TARFILE} && cat ${TARFILE} | docker load
 	rm -rf ${TARFILE}
 
+# Explicit rule required by pkg/pillar's make test target on macOS. GNU Make 3.81
+# (shipped with macOS) selects pattern rules by first-match, so pillar-% (defined
+# earlier in this file) wins over %-cache-export-docker-load for the target name
+# pillar-cache-export-docker-load. GNU Make 4.x (Linux) uses shortest-stem and
+# picks %-cache-export-docker-load correctly. An explicit rule beats pattern rules
+# in all GNU Make versions.
+pillar-cache-export-docker-load: $(LINUXKIT) pkg/pillar
+	$(eval IMAGE_TAG := $(shell $(LINUXKIT) pkg show-tag --canonical pkg/pillar))
+	$(eval CACHE_CONTENT := $(shell $(LINUXKIT) cache ls 2>&1))
+	$(if $(filter $(IMAGE_TAG),$(CACHE_CONTENT)),$(MAKE) cache-export-docker-load IMAGE=$(IMAGE_TAG),@echo "Missing image $(IMAGE_TAG) in cache")
+
 %-cache-export-docker-load: $(LINUXKIT) pkg/%
 	$(eval IMAGE_TAG := $(shell $(LINUXKIT) pkg show-tag --canonical pkg/$*))
 	$(eval CACHE_CONTENT := $(shell $(LINUXKIT) cache ls 2>&1))

--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -10,7 +10,8 @@ ZARCH         ?= $(HOSTARCH)
 DISTDIR       := dist/$(ZARCH)
 BUILD_VERSION ?=
 
-DOCKER_LIKE_LKT:= ../../build-tools/bin/linuxkit pkg build --network --platforms linux/$(ZARCH) --dry-run --force ./ | tail -n1 | perl -pe 's/ buildx / /g'
+BUILD_YML     := $(if $(filter k,$(HV)),$(if $(and $(filter y,$(DEV)),$(wildcard build-k-dev.yml)),build-k-dev.yml,build-k.yml),build.yml)
+DOCKER_LIKE_LKT:= ../../build-tools/bin/linuxkit pkg build --network --platforms linux/$(ZARCH) --dry-run --force --build-yml $(BUILD_YML) ./ | tail -n1 | perl -pe 's/ buildx / /g'
 DOCKER_TAG:=lfedge/eve-pillar:local-$(ZARCH)
 
 APPS = zedbox
@@ -109,7 +110,7 @@ test: build-docker-test
 		--entrypoint /final/opt/gotestsum $(DOCKER_TAG) \
 		--jsonfile /pillar/results.json \
 		--junitfile /pillar/results.xml \
-		--raw-command -- go test -tags kubevirt -coverprofile=coverage.txt -covermode=atomic -race -json \
+		--raw-command -- go test -tags k -coverprofile=coverage.txt -covermode=atomic -race -json \
 		./...
 
 fuzz-test: build-docker-test


### PR DESCRIPTION
## Description

GNU Make 3.81 (macOS) selects pattern rules by first-match, so pillar-%
wins over %-cache-export-docker-load for the target pillar-cache-export-
docker-load. Add an explicit rule to the top-level Makefile that beats
all pattern rules in every Make version.

Pass --build-yml to linuxkit in pkg/pillar/Makefile so HV=k selects
build-k.yml instead of the default build.yml, and fix the test tag
from kubevirt to k.

## PR dependencies

None

## How to test and validate this PR

- cd pkg/pillar
- `make ZARCH=arm64 HV=k test`
- Completion of go tests should be seen: eg.`DONE 553 tests, 15 skipped in 374.852s`

## Changelog notes

Fix pillar make test for m series Mac, HV=k ZARCH=arm64

## PR Backports

- 16.0-stable: Unsure
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
