### PR TITLE
fix yetus golangci --out-format

### DIFF
--- a/.github/workflows/buildyetusondemand.yml
+++ b/.github/workflows/buildyetusondemand.yml
@@ -31,7 +31,7 @@ jobs:
       HEAD_REF: ${{ github.event.pull_request.head.ref }}
       REPO_NAME: ${{ github.event.repository.full_name }}
       IMG_NAME: "lfedge/eve-yetus"
-      IMG_TAG: "0.15.1-eve-1"
+      IMG_TAG: "0.15.1-eve-2"
     strategy:
       fail-fast: false
 

--- a/Makefile
+++ b/Makefile
@@ -578,7 +578,7 @@ check-docker-hashes-consistency: $(DOCKERFILE_FROM_CHECKER)
 yetus:
 	@echo Running yetus
 	mkdir -p yetus-output
-	docker run --rm -v $(CURDIR):/src:delegated,z docker.io/lfedge/eve-yetus:0.15.1-eve-1 \
+	docker run --rm -v $(CURDIR):/src:delegated,z docker.io/lfedge/eve-yetus:0.15.1-eve-2 \
 		--basedir=/src \
 		--test-parallel=true \
 		--dirty-workspace \

--- a/tools/mini-yetus.sh
+++ b/tools/mini-yetus.sh
@@ -141,7 +141,7 @@ cd "$SRC_DIR" && \
     git commit -m "Changes in the PR" >/dev/null 2>&1
 
 echo "[+] Running yetus on the changes..."
-docker run --rm -v "$SRC_DIR":/src:delegated,z docker.io/lfedge/eve-yetus:0.15.1-eve-1 \
+docker run --rm -v "$SRC_DIR":/src:delegated,z docker.io/lfedge/eve-yetus:0.15.1-eve-2 \
     --basedir=/src \
     --test-parallel=true \
     --dirty-workspace \

--- a/tools/yetus/Dockerfile
+++ b/tools/yetus/Dockerfile
@@ -45,12 +45,12 @@ RUN ./autogen.sh && \
 
 # Use upstream golangci-lint instead of the one that comes with Yetus in
 # order to fix issues regarding patching code differences.
-ADD https://github.com/golangci/golangci-lint/releases/download/v2.6.2/golangci-lint-2.6.2-linux-${TARGETARCH}.deb /golangci-lint.deb
+ADD https://github.com/golangci/golangci-lint/releases/download/v2.11.4/golangci-lint-2.11.4-linux-${TARGETARCH}.deb /golangci-lint.deb
 
-RUN dpkg -i /golangci-lint.deb && \
-      rm /usr/local/bin/golangci-lint && \
-      ln -s /usr/bin/golangci-lint /usr/local/bin/golangci-lint && \
-      rm /golangci-lint.deb
+RUN dpkg -i /golangci-lint.deb
+RUN rm /usr/local/bin/golangci-lint
+RUN ln -s /usr/bin/golangci-lint /usr/local/bin/golangci-lint
+RUN rm /golangci-lint.deb
 
 # Clean up
 RUN rm -r /tmp/zfs


### PR DESCRIPTION
# Description

golangci-lint v2 removed the --out-format flag (replaced by per-format flags like --output.text.*). Patch the Yetus plugin at build time to remove --out-format=line-number and replace --print-issued-lines=false with the v2 equivalent --output.text.print-issued-lines=false.

Bump the eve-yetus image tag to 0.15.1-eve-2.

## How to test and validate this PR

`make yetus`

and then check `yetus-output/results-full.txt` to be non-empty.

## Changelog notes

Internal Linter Fix.

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 16.0-stable: no, as path 'tools/yetus/Dockerfile' exists on disk, but not in '16.0.0'
- 14.5-stable: no
- 13.4-stable: no

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
