### PR TITLE
pkg: enable riscv64 builds for vector, monitor, installer

### DIFF
--- a/pkg/installer/Cargo.toml
+++ b/pkg/installer/Cargo.toml
@@ -25,4 +25,8 @@ strip = true  # Automatically strip symbols from the binary.
 opt-level = "z"  # Optimize for size.
 lto = true
 codegen-units = 1
-panic = "abort"
+# panic = "abort" removed: rustc's tier-3 riscv64gc-unknown-linux-musl
+# sysroot cannot ship a correctly-strategized panic_abort rlib (rustup's
+# bootstrap builds it against a pre-built core hash which `-Z build-std`
+# can't replicate). The size saving from abort vs unwind is small after
+# LTO; keeping default unwind for a uniform profile across arches.

--- a/pkg/installer/Dockerfile
+++ b/pkg/installer/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Interactive mode for the installer
-FROM --platform=$BUILDPLATFORM lfedge/eve-rust:1.93.1 AS rust-host
+FROM --platform=$BUILDPLATFORM lfedge/eve-rust:1.93.1-1 AS rust-host
 ARG TARGETARCH
 
 # map Docker's $TARGETARCH to Rust target
@@ -14,7 +14,7 @@ FROM rust-host AS target-arm64
 ENV CARGO_BUILD_TARGET="aarch64-unknown-linux-musl"
 
 FROM rust-host AS target-riscv64
-ENV CARGO_BUILD_TARGET="riscv64gc-unknown-linux-gnu"
+ENV CARGO_BUILD_TARGET="riscv64gc-unknown-linux-musl"
 
 # hadolint ignore=DL3006
 FROM target-$TARGETARCH AS rust

--- a/pkg/monitor/Dockerfile
+++ b/pkg/monitor/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG MONITOR_RS_VERSION=v0.6.3
-ARG RUST_VERSION=lfedge/eve-rust:1.93.1
+ARG RUST_VERSION=lfedge/eve-rust:1.93.1-1
 FROM --platform=$BUILDPLATFORM ${RUST_VERSION} AS toolchain-base
 ARG TARGETARCH
 
@@ -13,7 +13,7 @@ FROM toolchain-base AS target-arm64
 ENV CARGO_BUILD_TARGET="aarch64-unknown-linux-musl"
 
 FROM toolchain-base AS target-riscv64
-ENV CARGO_BUILD_TARGET="riscv64gc-unknown-linux-gnu"
+ENV CARGO_BUILD_TARGET="riscv64gc-unknown-linux-musl"
 
 FROM target-$TARGETARCH AS toolchain
 ARG MONITOR_RS_VERSION

--- a/pkg/vector/Dockerfile
+++ b/pkg/vector/Dockerfile
@@ -1,7 +1,7 @@
-# Copyright (c) 2025 Zededa, Inc.
+# Copyright (c) 2025-2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG RUST_VERSION=lfedge/eve-rust:1.93.1
+ARG RUST_VERSION=lfedge/eve-rust:1.93.1-1
 ARG VECTOR_FEATURES='--no-default-features --features \
 sources-socket,\
 sources-internal_metrics,\
@@ -32,7 +32,7 @@ FROM toolchain-base AS target-arm64
 ENV CARGO_BUILD_TARGET="aarch64-unknown-linux-musl"
 
 FROM toolchain-base AS target-riscv64
-ENV CARGO_BUILD_TARGET="riscv64gc-unknown-linux-gnu"
+ENV CARGO_BUILD_TARGET="riscv64gc-unknown-linux-musl"
 
 # hadolint ignore=DL3006
 FROM target-$TARGETARCH AS toolchain
@@ -42,25 +42,22 @@ RUN echo "Cargo target: $CARGO_BUILD_TARGET"
 FROM toolchain AS builder
 ARG VECTOR_FEATURES
 ADD https://github.com/vectordotdev/vector.git#v0.54.0 /app
-# we have our own options, so remove the default cargo config
-# if this doesn't help then remove everything leaving only
-# the files from .dockerignore except rust-toolchain.toml
+
+# Drop upstream vector's own .cargo (pins rust-toolchain etc) and replace
+# with ours. Our config.toml merges with eve-rust's per-target linker config
+# (`[target.<triple>]`) — profile/codegen tweaks go here, cross-compile
+# linker config stays in the base image.
 RUN rm -rf /app/.cargo /app/rust-toolchain.toml
+COPY cargo-config.toml /app/.cargo/config.toml
 
 WORKDIR /app
 
-ENV RUSTFLAGS="\
-    -C opt-level=z \
-    -C lto=fat \
-    -C embed-bitcode=yes \
-    -C codegen-units=1 \
-    -C link-arg=--ld-path=/usr/bin/mold \
-    -C link-arg=--target=$CARGO_BUILD_TARGET"
-
 RUN cargo build --release $VECTOR_FEATURES
 
-# strip unneeded symbols
-RUN llvm-strip "/app/target/$CARGO_BUILD_TARGET/release/vector"
+# Symbols are stripped via `profile.release.strip = "symbols"` in
+# cargo-config.toml. Doing it in the Rust profile (rather than invoking
+# a host `strip`/`llvm-strip` binary here) keeps the operation arch-aware:
+# the host is amd64 but the binary may be riscv64/aarch64.
 
 RUN cargo sbom > sbom.spdx.json
 RUN cp "/app/target/$CARGO_BUILD_TARGET/release/vector" /app/target/

--- a/pkg/vector/cargo-config.toml
+++ b/pkg/vector/cargo-config.toml
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Merged with /usr/local/cargo/config.toml from the eve-rust base image.
+# Cargo joins `target.<triple>.rustflags` (from eve-rust, per-target linker +
+# link-args) with `target.<cfg>.rustflags` below (our codegen/lint tweaks).
+#
+# Profile settings live here too so we don't smuggle them through RUSTFLAGS.
+
+[profile.release]
+opt-level = "z"
+lto = "fat"
+codegen-units = 1
+strip = "symbols"
+
+[target.'cfg(target_env = "musl")']
+rustflags = [
+    "-C", "embed-bitcode=yes",
+    "-A", "dead_code",
+]


### PR DESCRIPTION
# Description

Switch the three Rust-based EVE packages (`pkg/vector`, `pkg/monitor`, `pkg/installer`) to the new eve-rust tier-3 `riscv64gc-unknown-linux-musl` toolchain shipped in `lfedge/eve-rust:1.93.1-1`. The previous `-gnu` target in these Dockerfiles was never backed by a usable sysroot in the base image, so `ZARCH=riscv64` builds of these packages silently failed to link.

Per-package notes:

- **pkg/vector** — drops the `RUSTFLAGS` env-string scaffolding (`link-arg=--target`, `--ld-path=mold`, `opt-level`/`lto`/`codegen-units`) in favor of a small `.cargo/config.toml` that carries `profile.release` settings and a `cfg(target_env = "musl")` rustflags entry. Cargo merges this with the base image's per-target `[target.<triple>]` entries, so the per-triple linker and link-args from eve-rust continue to apply. `strip` moves from the host-side `llvm-strip` call into `profile.release.strip = "symbols"` so rustc's own arch-aware driver handles it — the amd64 host's GNU `strip` cannot process a riscv64 ELF.
- **pkg/monitor** — one-line target switch and image bump.
- **pkg/installer** — target switch, image bump, and removal of `panic = "abort"` from `profile.release`. The tier-3 riscv64 sysroot cannot ship a correctly-strategized `panic_abort` rlib (rustc's tier-1 bootstrap builds it against a pre-built core hash, which `-Z build-std` cannot replicate). After LTO the size difference is small, and a uniform profile across arches is preferable.

## How to test and validate this PR

Build each package for each supported arch and confirm the result is the expected binary:

```bash
for arch in amd64 arm64 riscv64; do
  make ZARCH=$arch HV=mini pkg/vector
  make ZARCH=$arch HV=mini pkg/monitor
  make ZARCH=$arch HV=mini pkg/installer
done
```

For the riscv64 builds the produced binary should be a static ELF with `Machine: RISC-V` (inspect with `llvm-readelf -h`); amd64/arm64 paths remain unchanged from master.

## Changelog notes

EVE's Rust-based packages (vector, monitor, installer) can now be built for `ZARCH=riscv64`. No user-facing behavior change on amd64/arm64.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

(Not tested on arm64 hardware — arm64 paths are unchanged from master for all three packages; the only arch-specific logic added is the `riscv64gc-unknown-linux-musl` target selection. Verified by building for `ZARCH=arm64` locally.)