### PR TITLE
Fix lost NTP telemetry

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlentp.go
+++ b/pkg/pillar/cmd/zedagent/handlentp.go
@@ -162,7 +162,7 @@ func publishNTPSourcesToDest(ctx *zedagentContext,
 // createNTPSource() returns `info.NTPSource`. The code is based on the
 // https://github.com/facebook/time/blob/main/cmd/ntpcheck/checker
 func createNTPSource(s *chrony.ReplySourceData,
-	p *chrony.ReplyNTPData,
+	p *chrony.NTPData,
 	n *chrony.ReplyNTPSourceName) (*info.NTPSource, error) {
 
 	// Clear auth and interleaved flag
@@ -222,8 +222,9 @@ func createNTPSource(s *chrony.ReplySourceData,
 		ntpSource.RootDisp = p.RootDispersion
 	}
 	if n != nil {
-		// This field is zero padded in chrony, so we need to trim it
-		ntpSource.Hostname = string(bytes.TrimRight(n.Name[:], "\x00"))
+		// chrony-go used to expose Name as a null-padded [256]byte; it now
+		// returns an already-trimmed string, so no post-processing needed.
+		ntpSource.Hostname = n.Name
 	}
 
 	return &ntpSource, nil
@@ -299,19 +300,23 @@ func getNTPSourcesInfo(ctx *zedagentContext) *info.ZInfoNTPSources {
 		}
 
 		// get ntpdata when using a unix socket
-		var ntpData *chrony.ReplyNTPData
+		var ntpData *chrony.NTPData
 		if sourceData.Mode != chrony.SourceModeRef {
 			ntpDataReq := chrony.NewNTPDataPacket(sourceData.IPAddr)
 			packet, err = client.Communicate(ntpDataReq)
 			if err != nil {
-				log.Errorf("getNTPSourcesInfo: failed to get 'ntpdata' response for source #%d", i)
+				log.Errorf("getNTPSourcesInfo: failed to get 'ntpdata' response for source #%d: %v", i, err)
 				return nil
 			}
-			ntpData, ok = packet.(*chrony.ReplyNTPData)
+			// chrony 4.6+ replies with RPY_NTP_DATA2 (pillar's bundled
+			// chrony is always 4.6+ now). ReplyNTPData2 embeds NTPData2
+			// which embeds NTPData — the fields createNTPSource needs.
+			ntpDataReply, ok := packet.(*chrony.ReplyNTPData2)
 			if !ok {
 				log.Errorf("getNTPSourcesInfo: got wrong 'ntpdata' response %+v", packet)
 				return nil
 			}
+			ntpData = &ntpDataReply.NTPData2.NTPData
 		}
 		var ntpSourceName *chrony.ReplyNTPSourceName
 		if sourceData.Mode != chrony.SourceModeRef {

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/eriknordmark/ipinfo v0.0.0-20230728132417-2d8f4da903d7
 	github.com/eshard/uevent v1.0.2-0.20220110110621-d8d2be286cec
-	github.com/facebook/time v0.0.0-20240605113323-bdee26e8523f
+	github.com/facebook/time v0.0.0-20260421154427-cee44983d290
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/getlantern/framed v0.0.0-20190601192238-ceb6431eeede
 	github.com/go-chi/chi/v5 v5.2.2

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -293,6 +293,8 @@ github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
 github.com/facebook/time v0.0.0-20240605113323-bdee26e8523f h1:qEpaI5a4QYn7voX3z4pa4Fkyuk7PQ7CUHpargUHZkYE=
 github.com/facebook/time v0.0.0-20240605113323-bdee26e8523f/go.mod h1:2UFAomOuD2vAK1x68czUtCVjAqmyWCEnAXOlmGqf+G0=
+github.com/facebook/time v0.0.0-20260421154427-cee44983d290 h1:a3F8X/BGWlQiLN3SA+HdOkAiZF+wvnfaNdBOkgZ0bOE=
+github.com/facebook/time v0.0.0-20260421154427-cee44983d290/go.mod h1:Qg59tcudM5sQRrjvm4FxlAHsuNSxbAVBbOEXX3/o/Ag=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/pkg/pillar/vendor/github.com/facebook/time/ntp/chrony/client.go
+++ b/pkg/pillar/vendor/github.com/facebook/time/ntp/chrony/client.go
@@ -17,32 +17,48 @@ limitations under the License.
 package chrony
 
 import (
+	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
-
-	log "github.com/sirupsen/logrus"
+	"sync"
+	"sync/atomic"
 )
 
 // Client talks to chronyd
 type Client struct {
 	Connection io.ReadWriter
 	Sequence   uint32
+	sync.Mutex
 }
 
 // Communicate sends the packet to chronyd, parse response into something usable
 func (n *Client) Communicate(packet RequestPacket) (ResponsePacket, error) {
-	n.Sequence++
-	var err error
-	packet.SetSequence(n.Sequence)
-	err = binary.Write(n.Connection, binary.BigEndian, packet)
-	if err != nil {
-		return nil, err
+	seq := atomic.AddUint32(&n.Sequence, 1)
+	packet.SetSequence(seq)
+
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.BigEndian, packet); err != nil {
+		return nil, fmt.Errorf("failed to encode packet: %w", err)
 	}
+
 	response := make([]uint8, 1024)
-	read, err := n.Connection.Read(response)
-	if err != nil {
-		return nil, err
+
+	n.Lock()
+	if _, err := n.Connection.Write(buf.Bytes()); err != nil {
+		n.Unlock()
+		return nil, fmt.Errorf("failed to write packet to connection: %w", err)
 	}
-	log.Debugf("Read %d bytes", read)
+
+	read, err := n.Connection.Read(response)
+	n.Unlock()
+	if err != nil {
+		return nil, fmt.Errorf("connection.Read failed: %w", err)
+	}
+
+	if read == 0 {
+		return nil, fmt.Errorf("no data received")
+	}
+
 	return decodePacket(response[:read])
 }

--- a/pkg/pillar/vendor/github.com/facebook/time/ntp/chrony/helpers.go
+++ b/pkg/pillar/vendor/github.com/facebook/time/ntp/chrony/helpers.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"strconv"
 	"time"
-	"unicode"
 )
 
 // ChronySocketPath is the default path to chronyd socket
@@ -34,10 +34,13 @@ const ChronyPortV6Regexp = "[0-9]+: [0-9A-Z]+:0143 .*"
 // This is used in timeSpec.SecHigh for 32-bit timestamps
 const noHighSec uint32 = 0x7fffffff
 
-// ip stuff
+// IPAddr family constants - corresponds to IPAddr_Family in chrony's addressing.h
+// https://gitlab.com/chrony/chrony/-/blob/master/addressing.h
 const (
-	ipAddrInet4 uint16 = 1
-	ipAddrInet6 uint16 = 2
+	IPAddrUnspec uint16 = 0
+	IPAddrInet4  uint16 = 1
+	IPAddrInet6  uint16 = 2
+	IPAddrID     uint16 = 3
 )
 
 // magic numbers to convert chronyFloat to normal float
@@ -46,29 +49,46 @@ const (
 	floatCoefBits = (4*8 - floatExpBits)
 )
 
-type ipAddr struct {
+// IPAddr represents a chrony IP address which can be IPv4, IPv6, or an
+// unresolved ID (for sources that haven't been resolved yet).
+// The struct layout matches chrony's wire format for binary serialization.
+type IPAddr struct {
 	IP     [16]uint8
 	Family uint16
 	Pad    uint16
 }
 
-func (ip *ipAddr) ToNetIP() net.IP {
-	if ip.Family == ipAddrInet4 {
+// ToNetIP returns the underlying net.IP for resolved addresses.
+// Returns nil for unresolved addresses (IPAddrID family) or unspecified addresses.
+func (ip *IPAddr) ToNetIP() net.IP {
+	switch ip.Family {
+	case IPAddrInet4:
 		return net.IP(ip.IP[:4])
+	case IPAddrInet6:
+		return net.IP(ip.IP[:])
+	default:
+		// IPAddrUnspec (0) and IPAddrID (3) don't represent actual IP addresses.
+		// IPAddrID is used for unresolved addresses identified by an ID number.
+		return nil
 	}
-	return net.IP(ip.IP[:])
 }
 
-func newIPAddr(ip net.IP) *ipAddr {
-	family := ipAddrInet6
-	if ip.To4() != nil {
-		family = ipAddrInet4
-	}
-	var nIP [16]byte
-	copy(nIP[:], ip)
-	return &ipAddr{
-		IP:     nIP,
-		Family: family,
+// String returns a human-readable representation of the IP address.
+// For IPAddrID family (unresolved addresses), it returns "ID#XXXXXXXXXX" format
+// similar to chronyc's output with the -a flag.
+func (ip *IPAddr) String() string {
+	switch ip.Family {
+	case IPAddrInet4:
+		return net.IP(ip.IP[:4]).String()
+	case IPAddrInet6:
+		return net.IP(ip.IP[:]).String()
+	case IPAddrID:
+		// Format like chronyc: "ID#XXXXXXXXXX" (10 hex digits)
+		// The ID is stored in the first 4 bytes of the IP field as big-endian uint32
+		id := uint32(ip.IP[0])<<24 | uint32(ip.IP[1])<<16 | uint32(ip.IP[2])<<8 | uint32(ip.IP[3])
+		return fmt.Sprintf("ID#%010X", id)
+	default:
+		return ""
 	}
 }
 
@@ -124,10 +144,15 @@ func RefidAsHEX(refID uint32) string {
 func RefidToString(refID uint32) string {
 	result := []rune{}
 
-	for i := 0; i < 4 && i < 64-1; i++ {
+	for i := range 4 {
 		c := rune((refID >> (24 - uint(i)*8)) & 0xff)
-		if unicode.IsPrint(c) {
+		if c == 0 {
+			continue
+		}
+		if strconv.IsPrint(c) {
 			result = append(result, c)
+		} else {
+			return RefidAsHEX(refID)
 		}
 	}
 
@@ -191,4 +216,17 @@ func ReadNTPTestFlags(flags uint16) []string {
 		}
 	}
 	return results
+}
+
+// IPToBytes converts a net.IP to a [16]uint8 array for use in IPAddr structs.
+// For IPv4, it stores the 4 bytes at the beginning of the array.
+// For IPv6, it uses all 16 bytes.
+func IPToBytes(ip net.IP) [16]uint8 {
+	var result [16]uint8
+	if ip4 := ip.To4(); ip4 != nil {
+		copy(result[:], ip4)
+	} else {
+		copy(result[:], ip)
+	}
+	return result
 }

--- a/pkg/pillar/vendor/github.com/facebook/time/ntp/chrony/logger.go
+++ b/pkg/pillar/vendor/github.com/facebook/time/ntp/chrony/logger.go
@@ -1,0 +1,36 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chrony
+
+// LoggerInterface is an interface for debug logging.
+type LoggerInterface interface {
+	Printf(format string, v ...interface{})
+}
+
+type noopLogger struct{}
+
+func (noopLogger) Printf(_ string, _ ...interface{}) {}
+
+// Logger is a default debug logger which simply discards all messages.
+// It can be overridden by setting the global variable to a different implementation, like std log
+//
+//	chrony.Logger = log.New(os.Stderr, "", 0)
+//
+// or logrus
+//
+//	chrony.Logger = logrus.StandardLogger()
+var Logger LoggerInterface = &noopLogger{}

--- a/pkg/pillar/vendor/github.com/facebook/time/ntp/chrony/packet.go
+++ b/pkg/pillar/vendor/github.com/facebook/time/ntp/chrony/packet.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"net"
 	"time"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // original C++ versions of those consts/structs
@@ -78,20 +76,24 @@ const (
 	reqServerStats   CommandType = 54
 	reqNTPData       CommandType = 57
 	reqNTPSourceName CommandType = 65
+	reqSelectData    CommandType = 69
 )
 
 // reply types
 const (
-	rpyNSources      ReplyType = 2
-	rpySourceData    ReplyType = 3
-	rpyTracking      ReplyType = 5
-	rpySourceStats   ReplyType = 6
-	rpyActivity      ReplyType = 12
-	rpyServerStats   ReplyType = 14
-	rpyNTPData       ReplyType = 16
-	rpyNTPSourceName ReplyType = 19
-	rpyServerStats2  ReplyType = 22
-	rpyServerStats3  ReplyType = 24
+	RpyNSources      ReplyType = 2
+	RpySourceData    ReplyType = 3
+	RpyTracking      ReplyType = 5
+	RpySourceStats   ReplyType = 6
+	RpyActivity      ReplyType = 12
+	RpyServerStats   ReplyType = 14
+	RpyNTPData       ReplyType = 16
+	RpyNTPSourceName ReplyType = 19
+	RpyServerStats2  ReplyType = 22
+	RpySelectData    ReplyType = 23
+	RpyServerStats3  ReplyType = 24
+	RpyServerStats4  ReplyType = 25
+	RpyNTPData2      ReplyType = 26
 )
 
 // source modes
@@ -117,6 +119,14 @@ const (
 	FlagPrefer   uint16 = 0x2
 	FlagTrust    uint16 = 0x4
 	FlagRequire  uint16 = 0x8
+)
+
+// select data flags
+const (
+	FlagSDOptionNoSelect uint16 = 0x1
+	FlagSDOptionPrefer   uint16 = 0x2
+	FlagSDOptionTrust    uint16 = 0x4
+	FlagSDOptionRequire  uint16 = 0x8
 )
 
 // ntpdata flags
@@ -245,7 +255,7 @@ type RequestPacket interface {
 // ResponsePacket is an interface to abstract all different incoming packets
 type ResponsePacket interface {
 	GetCommand() CommandType
-	GetType() PacketType
+	GetType() ReplyType
 	GetStatus() ResponseStatusType
 }
 
@@ -269,7 +279,7 @@ type RequestSourceData struct {
 // As of now, it's only allowed by Chrony over unix socket connection.
 type RequestNTPData struct {
 	RequestHead
-	IPAddr ipAddr
+	IPAddr IPAddr
 	EOR    int32
 	// we pass at max ipv6 addr - 16 bytes
 	data [maxDataLen - 16]uint8
@@ -278,7 +288,7 @@ type RequestNTPData struct {
 // RequestNTPSourceName - packet to request source name for peer IP.
 type RequestNTPSourceName struct {
 	RequestHead
-	IPAddr ipAddr
+	IPAddr IPAddr
 	EOR    int32
 	// we pass at max ipv6 addr - 16 bytes
 	data [maxDataLen - 16]uint8
@@ -314,6 +324,15 @@ type RequestActivity struct {
 	data [maxDataLen]uint8
 }
 
+// RequestSelectData - packet to request 'selectdata' data
+type RequestSelectData struct {
+	RequestHead
+	Index int32
+	EOR   int32
+	// we pass i32 - 4 bytes
+	data [maxDataLen - 4]uint8
+}
+
 // ReplyHead is the first (common) part of the reply packet,
 // in a format that can be directly passed to binary.Read
 type ReplyHead struct {
@@ -338,8 +357,8 @@ func (r *ReplyHead) GetCommand() CommandType {
 }
 
 // GetType returns reply packet type
-func (r *ReplyHead) GetType() PacketType {
-	return r.PKTType
+func (r *ReplyHead) GetType() ReplyType {
+	return r.Reply
 }
 
 // GetStatus returns reply packet status
@@ -358,7 +377,7 @@ type ReplySources struct {
 }
 
 type replySourceDataContent struct {
-	IPAddr         ipAddr
+	IPAddr         IPAddr
 	Poll           int16
 	Stratum        uint16
 	State          SourceStateType
@@ -373,7 +392,7 @@ type replySourceDataContent struct {
 
 // SourceData contains parsed version of 'source data' reply
 type SourceData struct {
-	IPAddr         net.IP
+	IPAddr         *IPAddr
 	Poll           int16
 	Stratum        uint16
 	State          SourceStateType
@@ -388,7 +407,7 @@ type SourceData struct {
 
 func newSourceData(r *replySourceDataContent) *SourceData {
 	return &SourceData{
-		IPAddr:         r.IPAddr.ToNetIP(),
+		IPAddr:         &r.IPAddr,
 		Poll:           r.Poll,
 		Stratum:        r.Stratum,
 		State:          r.State,
@@ -410,7 +429,7 @@ type ReplySourceData struct {
 
 type replyTrackingContent struct {
 	RefID              uint32
-	IPAddr             ipAddr // our current sync source
+	IPAddr             IPAddr // our current sync source
 	Stratum            uint16
 	LeapStatus         uint16
 	RefTime            timeSpec
@@ -470,7 +489,7 @@ type ReplyTracking struct {
 
 type replySourceStatsContent struct {
 	RefID              uint32
-	IPAddr             ipAddr
+	IPAddr             IPAddr
 	NSamples           uint32
 	NRuns              uint32
 	SpanSeconds        uint32
@@ -484,7 +503,7 @@ type replySourceStatsContent struct {
 // SourceStats contains stats about the source
 type SourceStats struct {
 	RefID              uint32
-	IPAddr             net.IP
+	IPAddr             *IPAddr
 	NSamples           uint32
 	NRuns              uint32
 	SpanSeconds        uint32
@@ -498,7 +517,7 @@ type SourceStats struct {
 func newSourceStats(r *replySourceStatsContent) *SourceStats {
 	return &SourceStats{
 		RefID:              r.RefID,
-		IPAddr:             r.IPAddr.ToNetIP(),
+		IPAddr:             &r.IPAddr,
 		NSamples:           r.NSamples,
 		NRuns:              r.NRuns,
 		SpanSeconds:        r.SpanSeconds,
@@ -517,8 +536,8 @@ type ReplySourceStats struct {
 }
 
 type replyNTPDataContent struct {
-	RemoteAddr      ipAddr
-	LocalAddr       ipAddr
+	RemoteAddr      IPAddr
+	LocalAddr       IPAddr
 	RemotePort      uint16
 	Leap            uint8
 	Version         uint8
@@ -607,18 +626,109 @@ type ReplyNTPData struct {
 	NTPData
 }
 
+type replyNTPData2Content struct {
+	RemoteAddr      IPAddr
+	LocalAddr       IPAddr
+	RemotePort      uint16
+	Leap            uint8
+	Version         uint8
+	Mode            uint8
+	Stratum         uint8
+	Poll            int8
+	Precision       int8
+	RootDelay       chronyFloat
+	RootDispersion  chronyFloat
+	RefID           uint32
+	RefTime         timeSpec
+	Offset          chronyFloat
+	PeerDelay       chronyFloat
+	PeerDispersion  chronyFloat
+	ResponseTime    chronyFloat
+	JitterAsymmetry chronyFloat
+	Flags           uint16
+	TXTssChar       uint8
+	RXTssChar       uint8
+	TotalTXCount    uint32
+	TotalRXCount    uint32
+	TotalValidCount uint32
+	TotalKernelTXts uint32
+	TotalKernelRXts uint32
+	TotalHWTXts     uint32
+	TotalHWRXts     uint32
+	Reserved        [4]int32
+}
+
+// NTPData2 contains parsed version of a new 'ntpdata' reply
+type NTPData2 struct {
+	NTPData
+
+	TotalKernelTXts uint32
+	TotalKernelRXts uint32
+	TotalHWTXts     uint32
+	TotalHWRXts     uint32
+}
+
+func newNTPData2(r *replyNTPData2Content) *NTPData2 {
+	return &NTPData2{
+		NTPData: NTPData{
+			RemoteAddr:      r.RemoteAddr.ToNetIP(),
+			LocalAddr:       r.LocalAddr.ToNetIP(),
+			RemotePort:      r.RemotePort,
+			Leap:            r.Leap,
+			Version:         r.Version,
+			Mode:            r.Mode,
+			Stratum:         r.Stratum,
+			Poll:            r.Poll,
+			Precision:       r.Precision,
+			RootDelay:       r.RootDelay.ToFloat(),
+			RootDispersion:  r.RootDispersion.ToFloat(),
+			RefID:           r.RefID,
+			RefTime:         r.RefTime.ToTime(),
+			Offset:          r.Offset.ToFloat(),
+			PeerDelay:       r.PeerDelay.ToFloat(),
+			PeerDispersion:  r.PeerDispersion.ToFloat(),
+			ResponseTime:    r.ResponseTime.ToFloat(),
+			JitterAsymmetry: r.JitterAsymmetry.ToFloat(),
+			Flags:           r.Flags,
+			TXTssChar:       r.TXTssChar,
+			RXTssChar:       r.RXTssChar,
+			TotalTXCount:    r.TotalTXCount,
+			TotalRXCount:    r.TotalRXCount,
+			TotalValidCount: r.TotalValidCount,
+		},
+		TotalKernelTXts: r.TotalKernelTXts,
+		TotalKernelRXts: r.TotalKernelRXts,
+		TotalHWTXts:     r.TotalHWTXts,
+		TotalHWRXts:     r.TotalHWRXts,
+	}
+}
+
+// ReplyNTPData2 is a what end user will get in 'ntp data' response
+type ReplyNTPData2 struct {
+	ReplyHead
+	NTPData2
+}
+
 type replyNTPSourceNameContent struct {
 	Name [256]uint8
 }
 
 // NTPSourceName contains parsed version of 'sourcename' reply
 type NTPSourceName struct {
-	Name [256]uint8
+	Name string
 }
 
 func newNTPSourceName(r *replyNTPSourceNameContent) *NTPSourceName {
+	// Find the first null terminator to avoid reading garbage
+	nullIndex := bytes.IndexByte(r.Name[:], 0)
+	if nullIndex >= 0 {
+		return &NTPSourceName{
+			Name: string(r.Name[:nullIndex]),
+		}
+	}
+
 	return &NTPSourceName{
-		Name: r.Name,
+		Name: string(r.Name[:]),
 	}
 }
 
@@ -697,6 +807,85 @@ type ReplyServerStats3 struct {
 	ServerStats3
 }
 
+// ServerStats4 contains parsed version of 'serverstats4' reply
+type ServerStats4 struct {
+	NTPHits               uint64
+	NKEHits               uint64
+	CMDHits               uint64
+	NTPDrops              uint64
+	NKEDrops              uint64
+	CMDDrops              uint64
+	LogDrops              uint64
+	NTPAuthHits           uint64
+	NTPInterleavedHits    uint64
+	NTPTimestamps         uint64
+	NTPSpanSeconds        uint64
+	NTPDaemonRxtimestamps uint64
+	NTPDaemonTxtimestamps uint64
+	NTPKernelRxtimestamps uint64
+	NTPKernelTxtimestamps uint64
+	NTPHwRxTimestamps     uint64
+	NTPHwTxTimestamps     uint64
+}
+
+// ReplyServerStats4 is a usable version of 'serverstats4' response
+type ReplyServerStats4 struct {
+	ReplyHead
+	ServerStats4
+}
+
+type replySelectData struct {
+	RefID          uint32
+	IPAddr         IPAddr
+	StateChar      uint8
+	Authentication uint8
+	Leap           uint8
+	Pad            uint8
+	ConfOptions    uint16
+	EFFOptions     uint16
+	LastSampleAgo  uint32
+	Score          chronyFloat
+	LoLimit        chronyFloat
+	HiLimit        chronyFloat
+}
+
+// SelectData contains parsed version of 'selectdata' reply
+type SelectData struct {
+	RefID          uint32
+	IPAddr         net.IP
+	StateChar      uint8
+	Authentication uint8
+	Leap           uint8
+	ConfOptions    uint16
+	EFFOptions     uint16
+	LastSampleAgo  uint32
+	Score          float64
+	LoLimit        float64
+	HiLimit        float64
+}
+
+// ReplySelectData is a usable version of 'selectdata' response
+type ReplySelectData struct {
+	ReplyHead
+	SelectData
+}
+
+func newSelectData(r *replySelectData) *SelectData {
+	return &SelectData{
+		RefID:          r.RefID,
+		IPAddr:         r.IPAddr.ToNetIP(),
+		StateChar:      r.StateChar,
+		Authentication: r.Authentication,
+		Leap:           r.Leap,
+		ConfOptions:    r.ConfOptions,
+		EFFOptions:     r.EFFOptions,
+		LastSampleAgo:  r.LastSampleAgo,
+		Score:          r.Score.ToFloat(),
+		LoLimit:        r.LoLimit.ToFloat(),
+		HiLimit:        r.HiLimit.ToFloat(),
+	}
+}
+
 // here go request constructors
 
 // NewSourcesPacket creates new packet to request number of sources (peers)
@@ -750,27 +939,27 @@ func NewSourceDataPacket(sourceID int32) *RequestSourceData {
 }
 
 // NewNTPDataPacket creates new packet to request 'ntp data' information for given peer IP
-func NewNTPDataPacket(ip net.IP) *RequestNTPData {
+func NewNTPDataPacket(ip *IPAddr) *RequestNTPData {
 	return &RequestNTPData{
 		RequestHead: RequestHead{
 			Version: protoVersionNumber,
 			PKTType: pktTypeCmdRequest,
 			Command: reqNTPData,
 		},
-		IPAddr: *newIPAddr(ip),
+		IPAddr: *ip,
 		data:   [maxDataLen - 16]uint8{},
 	}
 }
 
 // NewNTPSourceNamePacket creates new packet to request 'source name' information for given peer IP
-func NewNTPSourceNamePacket(ip net.IP) *RequestNTPSourceName {
+func NewNTPSourceNamePacket(ip *IPAddr) *RequestNTPSourceName {
 	return &RequestNTPSourceName{
 		RequestHead: RequestHead{
 			Version: protoVersionNumber,
 			PKTType: pktTypeCmdRequest,
 			Command: reqNTPSourceName,
 		},
-		IPAddr: *newIPAddr(ip),
+		IPAddr: *ip,
 		data:   [maxDataLen - 16]uint8{},
 	}
 }
@@ -799,7 +988,49 @@ func NewActivityPacket() *RequestActivity {
 	}
 }
 
-// decodePacket decodes bytes to valid response packet
+// NewSelectDataPacket creates new packet to request 'selectdata' information
+func NewSelectDataPacket(sourceID int32) *RequestSelectData {
+	return &RequestSelectData{
+		RequestHead: RequestHead{
+			Version: protoVersionNumber,
+			PKTType: pktTypeCmdRequest,
+			Command: reqSelectData,
+		},
+		Index: sourceID,
+		data:  [maxDataLen - 4]uint8{},
+	}
+}
+
+// possible clock sources
+const (
+	ClockSourceUnspec     = "unspec"
+	ClockSourcePPS        = "pps"
+	ClockSourceLFRadio    = "lf_radio"
+	ClockSourceHFRadio    = "hf_radio"
+	ClockSourceUHFRadio   = "uhf_radio"
+	ClockSourceLocal      = "local"
+	ClockSourceNTP        = "ntp"
+	ClockSourceOther      = "other"
+	ClockSourceWristWatch = "wristwatch"
+	ClockSourceTelephone  = "telephone"
+)
+
+// ClockSourceDesc stores human-readable descriptions of ClockSource field
+var ClockSourceDesc = [10]string{
+	ClockSourceUnspec,     // 00
+	ClockSourcePPS,        // 01
+	ClockSourceLFRadio,    // 02
+	ClockSourceHFRadio,    // 03
+	ClockSourceUHFRadio,   // 04
+	ClockSourceLocal,      // 05
+	ClockSourceNTP,        // 06
+	ClockSourceOther,      // 07
+	ClockSourceWristWatch, // 08
+	ClockSourceTelephone,  // 09
+}
+
+// decodePacket decodes bytes to valid response packet.
+// an easy way to test this is to use 'testchrony' tool we have.
 func decodePacket(response []byte) (ResponsePacket, error) {
 	var err error
 	r := bytes.NewReader(response)
@@ -807,110 +1038,140 @@ func decodePacket(response []byte) (ResponsePacket, error) {
 	if err = binary.Read(r, binary.BigEndian, head); err != nil {
 		return nil, err
 	}
-	log.Debugf("response head: %+v", head)
+	Logger.Printf("response head: %+v", head)
 	if head.Status != sttSuccess {
 		return nil, fmt.Errorf("got status %s (%d)", head.Status, head.Status)
 	}
 	switch head.Reply {
-	case rpyNSources:
+	case RpyNSources:
 		data := new(replySourcesContent)
 		if err = binary.Read(r, binary.BigEndian, data); err != nil {
 			return nil, err
 		}
-		log.Debugf("response data: %+v", data)
+		Logger.Printf("response data: %+v", data)
 		return &ReplySources{
 			ReplyHead: *head,
 			NSources:  int(data.NSources),
 		}, nil
-	case rpySourceData:
+	case RpySourceData:
 		data := new(replySourceDataContent)
 		if err = binary.Read(r, binary.BigEndian, data); err != nil {
 			return nil, err
 		}
-		log.Debugf("response data: %+v", data)
+		Logger.Printf("response data: %+v", data)
 		return &ReplySourceData{
 			ReplyHead:  *head,
 			SourceData: *newSourceData(data),
 		}, nil
-	case rpyTracking:
+	case RpyTracking:
 		data := new(replyTrackingContent)
 		if err = binary.Read(r, binary.BigEndian, data); err != nil {
 			return nil, err
 		}
-		log.Debugf("response data: %+v", data)
+		Logger.Printf("response data: %+v", data)
 		return &ReplyTracking{
 			ReplyHead: *head,
 			Tracking:  *newTracking(data),
 		}, nil
-	case rpySourceStats:
+	case RpySourceStats:
 		data := new(replySourceStatsContent)
 		if err = binary.Read(r, binary.BigEndian, data); err != nil {
 			return nil, err
 		}
-		log.Debugf("response data: %+v", data)
+		Logger.Printf("response data: %+v", data)
 		return &ReplySourceStats{
 			ReplyHead:   *head,
 			SourceStats: *newSourceStats(data),
 		}, nil
-	case rpyActivity:
+	case RpyActivity:
 		data := new(Activity)
 		if err = binary.Read(r, binary.BigEndian, data); err != nil {
 			return nil, err
 		}
-		log.Debugf("response data: %+v", data)
+		Logger.Printf("response data: %+v", data)
 		return &ReplyActivity{
 			ReplyHead: *head,
 			Activity:  *data,
 		}, nil
-	case rpyServerStats:
+	case RpyServerStats:
 		data := new(ServerStats)
 		if err = binary.Read(r, binary.BigEndian, data); err != nil {
 			return nil, err
 		}
-		log.Debugf("response data: %+v", data)
+		Logger.Printf("response data: %+v", data)
 		return &ReplyServerStats{
 			ReplyHead:   *head,
 			ServerStats: *data,
 		}, nil
-	case rpyNTPData:
+	case RpyNTPData:
 		data := new(replyNTPDataContent)
 		if err = binary.Read(r, binary.BigEndian, data); err != nil {
 			return nil, err
 		}
-		log.Debugf("response data: %+v", data)
+		Logger.Printf("response data: %+v", data)
 		return &ReplyNTPData{
 			ReplyHead: *head,
 			NTPData:   *newNTPData(data),
 		}, nil
-	case rpyNTPSourceName:
+	case RpyNTPData2:
+		data := new(replyNTPData2Content)
+		if err = binary.Read(r, binary.BigEndian, data); err != nil {
+			return nil, err
+		}
+		Logger.Printf("response data: %+v", data)
+		return &ReplyNTPData2{
+			ReplyHead: *head,
+			NTPData2:  *newNTPData2(data),
+		}, nil
+	case RpyNTPSourceName:
 		data := new(replyNTPSourceNameContent)
 		if err = binary.Read(r, binary.BigEndian, data); err != nil {
 			return nil, err
 		}
-		log.Debugf("response data: %+v", data)
+		Logger.Printf("response data: %+v", data)
 		return &ReplyNTPSourceName{
 			ReplyHead:     *head,
 			NTPSourceName: *newNTPSourceName(data),
 		}, nil
-	case rpyServerStats2:
+	case RpyServerStats2:
 		data := new(ServerStats2)
 		if err = binary.Read(r, binary.BigEndian, data); err != nil {
 			return nil, err
 		}
-		log.Debugf("response data: %+v", data)
+		Logger.Printf("response data: %+v", data)
 		return &ReplyServerStats2{
 			ReplyHead:    *head,
 			ServerStats2: *data,
 		}, nil
-	case rpyServerStats3:
+	case RpyServerStats3:
 		data := new(ServerStats3)
 		if err = binary.Read(r, binary.BigEndian, data); err != nil {
 			return nil, err
 		}
-		log.Debugf("response data: %+v", data)
+		Logger.Printf("response data: %+v", data)
 		return &ReplyServerStats3{
 			ReplyHead:    *head,
 			ServerStats3: *data,
+		}, nil
+	case RpyServerStats4:
+		data := new(ServerStats4)
+		if err = binary.Read(r, binary.BigEndian, data); err != nil {
+			return nil, err
+		}
+		Logger.Printf("response data: %+v", data)
+		return &ReplyServerStats4{
+			ReplyHead:    *head,
+			ServerStats4: *data,
+		}, nil
+	case RpySelectData:
+		data := new(replySelectData)
+		if err = binary.Read(r, binary.BigEndian, data); err != nil {
+			return nil, err
+		}
+		Logger.Printf("response data: %+v", data)
+		return &ReplySelectData{
+			ReplyHead:  *head,
+			SelectData: *newSelectData(data),
 		}, nil
 	default:
 		return nil, fmt.Errorf("not implemented reply type %d from %+v", head.Reply, head)

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -598,8 +598,8 @@ github.com/eshard/uevent
 # github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f
 ## explicit; go 1.15
 github.com/exponent-io/jsonpath
-# github.com/facebook/time v0.0.0-20240605113323-bdee26e8523f
-## explicit; go 1.21
+# github.com/facebook/time v0.0.0-20260421154427-cee44983d290
+## explicit; go 1.24.0
 github.com/facebook/time/ntp/chrony
 # github.com/felixge/httpsnoop v1.0.4
 ## explicit; go 1.13


### PR DESCRIPTION
# Description

Fixes a regression introduced in EVE **16.12.0**: after the pillar Alpine base image was bumped from 3.16 to 3.22, the bundled `chronyd` went from 4.2 to 4.6.1. chrony 4.6 switched `REQ_NTP_DATA` to a new reply type `RPY_NTP_DATA2` (id 26) that adds kernel/hardware timestamp counters. The chrony-go library vendored at the old hash didn't know reply type 26, so `decodePacket` fell through to its default arm and returned `"not implemented reply type 26"` to `getNTPSourcesInfo`. That error surfaced as

```
getNTPSourcesInfo: failed to get 'ntpdata' response for source #0
```

repeating every 10 s forever. Because the code returned `nil` for the whole batch on any single source failure, **zero** NTP telemetry reached the controller and the UI showed *"No NTP server information available"* even though `chronyd` was synced and the clock was fine. This affects every 16.12.0+ device with one or more NTP sources configured — regardless of whether those sources came from the pool fallback, DHCP option 42, or the controller's `NTPServers` override.

The PR bumps `github.com/facebook/time` to a version that understands `RPY_NTP_DATA2` (the upstream library already has the decoder, plus a few adjacent API changes: `NTPSourceName.Name` is now `string`, `SourceData.IPAddr` is now `*chrony.IPAddr`, `NewNTPDataPacket` takes `*IPAddr`), and updates `zedagent/handlentp.go` to parse the new reply via `ReplyNTPData2` (the fields we need are reachable through its embedded `NTPData`). The `Communicate` error is now also included in the error log so future protocol drift is debuggable from logs alone instead of by reading source.

The existing all-or-nothing behavior of returning `nil` on any single failed source is left intact here; hardening it to skip-and-continue can be done in a follow-up.

## PR dependencies

None.

## How to test and validate this PR

Run a device with this build and confirm the NTP status shows up in the controller UI. That's the main end-to-end check.

On the device itself you can also spot-check with:

```sh
# expect 0 matches; baseline pre-fix was one match every ~10 s
logread 2>&1 | grep -c "getNTPSourcesInfo: failed to get 'ntpdata' response"

# should list the active NTP sources (pool members, DHCP-provided,
# or override-configured — any source at all)
eve exec pillar chronyc -n sources -a -v
eve exec pillar chronyc -n tracking
```

**Validated locally** on an amd64 KVM EVE guest running this fix: 30 minutes uptime, **zero** "failed to get 'ntpdata' response" errors where baseline would have produced ~180, chrony synced to stratum-3 pool members, controller UI showed NTP sources correctly.

Not yet validated on arm64. Any arm64 reviewer can re-run the steps above.

No new automated test is added (no unit-test harness covers this call; it's exercised only against a live chronyd).

## Changelog notes

Fix regression on EVE 16.12.0+ where devices stopped publishing NTP source telemetry to the controller. The device clock was synced correctly, but the UI showed "No NTP server information available".

## PR Backports

- 16.0-stable: **No.** This branch still uses `eve-alpine:745ae906` (Alpine 3.16 / chrony 4.2), which sends the old `RPY_NTP_DATA` reply type — the bug doesn't reproduce there.
- 14.5-stable: **No.** Same reason — older Alpine / chrony, unaffected.
- 13.4-stable: **No.** Same reason.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation *(n/a — internal code paths only, no user-facing doc)*
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device *(architecture-independent bug and fix; welcome arm64 verification from any reviewer)*
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.