### PR TITLE
fix missed LonghornDiskReservedGB in global_test.go

### DIFF
--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -208,6 +208,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		MemoryMonitorEnabled,
 		InternalMemoryMonitorStoreEnabled,
 		InternalMemoryMonitorAnalyzeEnabled,
+		LonghornDiskReservedGB,
 		// TriState Items
 		NetworkFallbackAnyEth,
 		MaintenanceMode,


### PR DESCRIPTION
## Description

Resolve go test failure

## PR dependencies

None

## How to test and validate this PR

automated test: CI pillar go tests

## Changelog notes

None

## PR Backports

- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
