### PR TITLE
pillar: trust cluster recovery for kubevirt apps and add stuck-Pending VMI handler

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1127,12 +1127,20 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 				status.SetErrorDescription(errDescription)
 			}
 
-			//cleanup app instance tasks
-			if err := hyper.Task(status).Delete(status.DomainName); err != nil {
-				log.Errorf("failed to delete domain: %s (%v)", status.DomainName, err)
-			}
-			if err := hyper.Task(status).Cleanup(status.DomainName); err != nil {
-				log.Errorf("failed to cleanup domain: %s (%v)", status.DomainName, err)
+			// KubeVirt: publish State=BOOTING (deferring to cluster
+			// recovery) rather than HALTED/BROKEN, and skip Delete/
+			// Cleanup so the VMIRS is not torn down on the error path.
+			// maybeRetryBoot re-invokes Start() which handles
+			// IsAlreadyExists if the VMIRS is still present.
+			if ctx.hvTypeKube {
+				status.State = types.BOOTING
+			} else {
+				if err := hyper.Task(status).Delete(status.DomainName); err != nil {
+					log.Errorf("failed to delete domain: %s (%v)", status.DomainName, err)
+				}
+				if err := hyper.Task(status).Cleanup(status.DomainName); err != nil {
+					log.Errorf("failed to cleanup domain: %s (%v)", status.DomainName, err)
+				}
 			}
 		}
 		status.DomainId = 0
@@ -1153,6 +1161,7 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 				status.Key())
 			status.Activated = true
 			status.State = types.RUNNING
+			status.KubeTrustLoggedState = 0
 			publishDomainStatus(ctx, status)
 		} else if domainID != status.DomainId {
 			// XXX shutdown + create?
@@ -1980,13 +1989,19 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 		log.Errorf("domain start for %s: %s", status.DomainName, err)
 		status.SetErrorNow(err.Error())
 
-		// Delete
-		if err := hyper.Task(status).Delete(status.DomainName); err != nil {
-			log.Errorf("failed to delete domain: %s (%v)", status.DomainName, err)
-		}
-		// Cleanup
-		if err := hyper.Task(status).Cleanup(status.DomainName); err != nil {
-			log.Errorf("failed to cleanup domain: %s (%v)", status.DomainName, err)
+		if !ctx.hvTypeKube {
+			// Delete
+			if err := hyper.Task(status).Delete(status.DomainName); err != nil {
+				log.Errorf("failed to delete domain: %s (%v)", status.DomainName, err)
+			}
+			// Cleanup
+			if err := hyper.Task(status).Cleanup(status.DomainName); err != nil {
+				log.Errorf("failed to cleanup domain: %s (%v)", status.DomainName, err)
+			}
+		} else {
+			log.Warnf("doActivateTail(%s) KubeVirt Start failed; "+
+				"skipping Delete/Cleanup to preserve cluster state",
+				status.DomainName)
 		}
 
 		// Set BootFailed to cause retry
@@ -2017,24 +2032,42 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 		err = fmt.Errorf("The domain state is still unknown after %d retries", unknownStateRetries)
 	}
 
-	if err != nil {
-		// Immediate failure treat as above
-		status.BootFailed = true
-		status.State = state
-		status.Activated = false
-		status.SetErrorNow(err.Error())
-		log.Errorf("doActivateTail(%v) failed for %s: %s",
-			status.UUIDandVersion, status.DisplayName, err)
+	if err != nil || (ctx.hvTypeKube && state != types.RUNNING) {
+		if ctx.hvTypeKube {
+			// VMIRS exists in cluster; VMI may be PENDING/SCHEDULING/UNKNOWN.
+			// Leave Activated=false so verifyStatus recovery block promotes
+			// to RUNNING once Info() observes RUNNING on a later tick.
+			// Log only on state transitions to avoid per-retry-tick spam.
+			if status.KubeTrustLoggedState != state {
+				log.Noticef("doActivateTail(%v) KubeVirt domain %s state %s "+
+					"after Start; trusting cluster to recover (err=%v)",
+					status.UUIDandVersion, status.DisplayName,
+					state.String(), err)
+				status.KubeTrustLoggedState = state
+			}
+			status.Activated = false
+			status.State = types.BOOTING
+			publishDomainStatus(ctx, status)
+			return
+		} else {
+			// Immediate failure treat as above
+			status.BootFailed = true
+			status.State = state
+			status.Activated = false
+			status.SetErrorNow(err.Error())
+			log.Errorf("doActivateTail(%v) failed for %s: %s",
+				status.UUIDandVersion, status.DisplayName, err)
 
-		// Delete
-		if err := hyper.Task(status).Delete(status.DomainName); err != nil {
-			log.Errorf("failed to delete domain: %s (%v)", status.DomainName, err)
+			// Delete
+			if err := hyper.Task(status).Delete(status.DomainName); err != nil {
+				log.Errorf("failed to delete domain: %s (%v)", status.DomainName, err)
+			}
+			// Cleanup
+			if err := hyper.Task(status).Cleanup(status.DomainName); err != nil {
+				log.Errorf("failed to cleanup domain: %s (%v)", status.DomainName, err)
+			}
+			return
 		}
-		// Cleanup
-		if err := hyper.Task(status).Cleanup(status.DomainName); err != nil {
-			log.Errorf("failed to cleanup domain: %s (%v)", status.DomainName, err)
-		}
-		return
 	}
 	if err == nil && domainID != status.DomainId {
 		status.DomainId = domainID
@@ -2045,6 +2078,7 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 	}
 
 	status.Activated = true
+	status.KubeTrustLoggedState = 0
 	// create a new json file in the filesystem for the specific VM.
 	activeapp.CreateLocalAppActiveFile(log, status.UUIDandVersion.UUID.String())
 
@@ -2057,6 +2091,22 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 
 	log.Functionf("doInactivate(%v) for %s domainId %d",
 		status.UUIDandVersion, status.DisplayName, status.DomainId)
+
+	// Defense-in-depth: in kubevirt cluster mode, never tear down the
+	// cluster-shared VMIRS while the user still wants the app up
+	// (UserActivate=true). Bail out before any Info()/Shutdown/HALTING
+	// publish work — those are wasted (and would be visible as a spurious
+	// HALTING state if Info() ever populates DomainId for kubevirt). The
+	// legitimate teardown paths — handleDelete (impatient=true) and a real
+	// user opt-out (UserActivate=false) — bypass this guard.
+	if ctx.hvTypeKube && !impatient {
+		if cfg := lookupDomainConfig(ctx, status.Key()); cfg != nil && cfg.UserActivate {
+			log.Noticef("doInactivate(%s) kubevirt: skipping Delete/Cleanup "+
+				"(UserActivate=true); leaving VMIRS to cluster", status.Key())
+			return
+		}
+	}
+
 	domainID, _, err := hyper.Task(status).Info(status.DomainName)
 	if err == nil && domainID != status.DomainId {
 		status.DomainId = domainID
@@ -2587,7 +2637,23 @@ func handleModify(ctx *domainContext, key string,
 	} else if !config.Activate {
 		log.Functionf("handleModify(%v) NOT activating for %s",
 			config.UUIDandVersion, config.DisplayName)
-		if status.HasError() {
+		// In kubevirt mode, an Activate=false that still carries UserActivate=true
+		// is a cluster-status cascade (e.g. failover bookkeeping, transient
+		// scheduling churn), not an explicit user opt-out. The VMIRS is
+		// cluster-shared; tearing it down here would defeat cluster recovery.
+		// Clear any error, update the status, but do not call doInactivate.
+		if ctx.hvTypeKube && config.UserActivate {
+			if status.HasError() {
+				log.Noticef("handleModify(%s) kubevirt: clearing error without "+
+					"Delete (UserActivate=true): %s", status.Key(), status.Error)
+				status.ClearError()
+				publishDomainStatus(ctx, status)
+				changed = true
+			} else if status.Activated {
+				log.Noticef("handleModify(%s) kubevirt: skipping doInactivate "+
+					"(UserActivate=true); leaving VMIRS to cluster", status.Key())
+			}
+		} else if status.HasError() {
 			log.Noticef("handleModify(%s) clearing existing error: %s",
 				status.Key(), status.Error)
 			status.ClearError()

--- a/pkg/pillar/cmd/zedkube/applogs.go
+++ b/pkg/pillar/cmd/zedkube/applogs.go
@@ -250,6 +250,21 @@ func (z *zedkube) checkAppsStatus() {
 			}
 		}
 
+		// While a stuck-Pending-VMI delete is in flight, pin StatusRunning
+		// and ScheduledOnThisNode so zedmanager's getKubeAppActivateStatus
+		// does not cascade to DomainConfig.Activate=false. Non-DNid failover
+		// nodes specifically depend on ScheduledOnThisNode for onTheDevice.
+		if _, active := z.suppressedStatusRunning(aiconfig.UUIDandVersion.UUID.String()); active {
+			if encAppStatus.AppKubeStatus != types.AppKubeStatusRunningState {
+				encAppStatus.AppKubeStatus = types.AppKubeStatusRunningState
+			}
+			if !encAppStatus.ScheduledOnThisNode {
+				encAppStatus.ScheduledOnThisNode = true
+			}
+			log.Noticef("checkAppsStatus: aiUUID:%s in VMI-delete suppression window; pinning StatusRunning/ScheduledOnThisNode",
+				aiconfig.UUIDandVersion.UUID)
+		}
+
 		log.Functionf("checkAppsStatus: devname %s, pod (%d) status %+v, old %+v", z.nodeName, len(pods.Items), encAppStatus, oldStatus)
 
 		// If this is first time after zedkube started (oldstatus is nil) and I am DNid and the app is not scheduled

--- a/pkg/pillar/cmd/zedkube/failover.go
+++ b/pkg/pillar/cmd/zedkube/failover.go
@@ -84,7 +84,7 @@ func (z *zedkube) checkAppsFailover(wdFunc func()) {
 		var durationTerminating time.Duration
 
 		for _, pod := range pods.Items {
-			contVMIName := "virt-launcher-" + contName
+			contVMIName := base.VMIPodNamePrefix + contName
 			log.Functionf("checkAppsFailover: pod %s, looking for cont %s", pod.Name, contName)
 			foundVMIPod := strings.HasPrefix(pod.Name, contVMIName)
 			if strings.HasPrefix(pod.Name, contName) || foundVMIPod {
@@ -160,6 +160,11 @@ func (z *zedkube) checkAppsFailover(wdFunc func()) {
 			aiconfig.DisplayName, aiconfig.UUIDandVersion.UUID, encAppStatus)
 
 		if encAppStatus.ScheduledOnThisNode {
+			// Suppress checkStuckPendingVMI for this app while failover is
+			// landing on this node. The window is refreshed each tick as long
+			// as the Terminating pod still exists, so it self-extends.
+			appUUID := aiconfig.UUIDandVersion.UUID.String()
+			z.vmiFailoverSuppressUntil[appUUID] = time.Now().Add(failoverVMISuppressWindow)
 			log.Noticef("checkAppsFailover: failover start for appDomainName: %s", appDomainNameLbl)
 			kubeapi.DetachOldWorkload(log, terminatingNodeName, appDomainNameLbl, wdFunc)
 			log.Noticef("checkAppsFailover: failover complete for appDomainName: %s", appDomainNameLbl)

--- a/pkg/pillar/cmd/zedkube/pendingvmi.go
+++ b/pkg/pillar/cmd/zedkube/pendingvmi.go
@@ -1,0 +1,266 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package zedkube
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	virtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+)
+
+const (
+	// pendingVMIDeleteThreshold is how long a VMI must be stuck Pending with a
+	// Running virt-launcher on this node before we force-delete it.
+	pendingVMIDeleteThreshold = 3 * time.Minute
+	// pendingVMIMaxDeletes caps consecutive FastDeleteVmi attempts per app;
+	// reset when the VMI reaches Running.
+	pendingVMIMaxDeletes = 3
+	// pendingVMISuppressWindow is how long checkAppsStatus pins StatusRunning=true
+	// after a delete so zedmanager does not cascade to DomainConfig.Activate=false.
+	pendingVMISuppressWindow = 5 * time.Minute
+	// failoverVMISuppressWindow is how long checkStuckPendingVMI suppresses
+	// force-delete after checkAppsFailover detects an active failover on this
+	// node. The window is refreshed every tick while the Terminating pod
+	// exists, so it self-extends until failover completes.
+	failoverVMISuppressWindow = 15 * time.Minute
+)
+
+// checkStuckPendingVMI looks for VMIs that are Pending while their virt-launcher
+// pod is either Running or in an error state on this node (Failed, or Running
+// with a container stuck in CrashLoopBackOff / image-pull / error-waiting /
+// terminated-with-error). If the condition persists past the threshold, it
+// force-deletes the VMI (not the VMIRS) so the cluster re-creates it cleanly.
+// A per-app counter caps retries at pendingVMIMaxDeletes.
+func (z *zedkube) checkStuckPendingVMI() {
+	sub := z.subAppInstanceConfig
+	items := sub.GetAll()
+
+	// Reap entries for apps that no longer exist in config so the three
+	// maps do not leak across AppInstanceConfig deletes.
+	live := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		live[item.(types.AppInstanceConfig).UUIDandVersion.UUID.String()] = struct{}{}
+	}
+	for k := range z.vmiPendingSince {
+		if _, ok := live[k]; !ok {
+			delete(z.vmiPendingSince, k)
+		}
+	}
+	for k := range z.vmiDeleteCount {
+		if _, ok := live[k]; !ok {
+			delete(z.vmiDeleteCount, k)
+		}
+	}
+	for k := range z.vmiDeleteSuppressUntil {
+		if _, ok := live[k]; !ok {
+			delete(z.vmiDeleteSuppressUntil, k)
+		}
+	}
+	for k := range z.vmiFailoverSuppressUntil {
+		if _, ok := live[k]; !ok {
+			delete(z.vmiFailoverSuppressUntil, k)
+		}
+	}
+
+	if len(items) == 0 {
+		return
+	}
+
+	config, err := kubeapi.GetKubeConfig()
+	if err != nil {
+		log.Errorf("checkStuckPendingVMI: get kubeconfig: %v", err)
+		return
+	}
+	virtClient, err := kubecli.GetKubevirtClientFromRESTConfig(config)
+	if err != nil {
+		log.Errorf("checkStuckPendingVMI: kubevirt client: %v", err)
+		return
+	}
+
+	vmiList, err := virtClient.VirtualMachineInstance(kubeapi.EVEKubeNameSpace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("checkStuckPendingVMI: list VMIs: %v", err)
+		return
+	}
+
+	now := time.Now()
+	for _, item := range items {
+		aiconfig := item.(types.AppInstanceConfig)
+		appUUID := aiconfig.UUIDandVersion.UUID.String()
+		// VMIRS name carries the purge counter (see cbed950d8); VMI
+		// OwnerReferences[0].Name matches this exactly, and virt-launcher
+		// pod names start with this prefix.
+		appKubeName := base.GetAppKubeNameWithPurge(
+			aiconfig.DisplayName,
+			aiconfig.UUIDandVersion.UUID,
+			aiconfig.PurgeCmd.Counter+aiconfig.LocalPurgeCmd.Counter,
+		)
+
+		vmi := findAppVMI(vmiList.Items, appKubeName)
+		if vmi == nil {
+			delete(z.vmiPendingSince, appUUID)
+			delete(z.vmiDeleteCount, appUUID)
+			continue
+		}
+
+		if vmi.Status.Phase == virtv1.Running {
+			delete(z.vmiPendingSince, appUUID)
+			delete(z.vmiDeleteCount, appUUID)
+			continue
+		}
+
+		if vmi.Status.Phase != virtv1.Pending {
+			delete(z.vmiPendingSince, appUUID)
+			delete(z.vmiDeleteCount, appUUID)
+			continue
+		}
+
+		if !z.virtLauncherActiveOnThisNode(appKubeName) {
+			delete(z.vmiPendingSince, appUUID)
+			delete(z.vmiDeleteCount, appUUID)
+			continue
+		}
+
+		// If checkAppsFailover set a suppress window for this app (because a
+		// failover is actively landing on this node), skip the force-delete.
+		// The window self-extends every tick while the Terminating pod exists.
+		if until, ok := z.vmiFailoverSuppressUntil[appUUID]; ok {
+			if now.Before(until) {
+				log.Functionf("checkStuckPendingVMI: aiUUID:%s VMI:%s failover suppress active until %v; skipping",
+					appUUID, vmi.Name, until)
+				delete(z.vmiPendingSince, appUUID)
+				continue
+			}
+			delete(z.vmiFailoverSuppressUntil, appUUID)
+		}
+
+		since, ok := z.vmiPendingSince[appUUID]
+		if !ok {
+			z.vmiPendingSince[appUUID] = now
+			continue
+		}
+		if now.Sub(since) < pendingVMIDeleteThreshold {
+			continue
+		}
+
+		if z.vmiDeleteCount[appUUID] >= pendingVMIMaxDeletes {
+			log.Errorf("checkStuckPendingVMI: aiUUID:%s VMI:%s stuck Pending after %d deletes; giving up",
+				appUUID, vmi.Name, pendingVMIMaxDeletes)
+			continue
+		}
+
+		log.Noticef("checkStuckPendingVMI: aiUUID:%s VMI:%s Pending >%v on this node with active/error virt-launcher; force-deleting (attempt %d/%d)",
+			appUUID, vmi.Name, pendingVMIDeleteThreshold, z.vmiDeleteCount[appUUID]+1, pendingVMIMaxDeletes)
+		if err := kubeapi.TryFastDeleteVmi(log, virtClient, vmi.Name); err != nil {
+			log.Errorf("checkStuckPendingVMI: TryFastDeleteVmi VMI:%s err:%v", vmi.Name, err)
+			continue
+		}
+		z.vmiDeleteCount[appUUID]++
+		z.vmiDeleteSuppressUntil[appUUID] = now.Add(pendingVMISuppressWindow)
+		delete(z.vmiPendingSince, appUUID)
+	}
+}
+
+// findAppVMI returns the VMI whose replicaset prefix matches the app kube name.
+func findAppVMI(vmis []virtv1.VirtualMachineInstance, appKubeName string) *virtv1.VirtualMachineInstance {
+	for i := range vmis {
+		if len(vmis[i].OwnerReferences) == 0 {
+			continue
+		}
+		if vmis[i].OwnerReferences[0].Name == appKubeName {
+			return &vmis[i]
+		}
+	}
+	return nil
+}
+
+// virtLauncherActiveOnThisNode returns true iff a virt-launcher pod for the
+// given app is on the local node and either in Running phase or in a pod-level
+// error state (Failed, or Running with a container stuck in CrashLoopBackOff /
+// error-waiting / terminated-with-error). In all of these, the cluster has
+// placed the launcher here but the VMI is not making progress, which is the
+// signature of the kubevirt/longhorn stuck-Pending-VMI condition.
+//
+// The pod is identified by name prefix "virt-launcher-<appKubeName>" since the
+// App-Domain-Name label is set to status.DomainName (UUID.Version.AppNum)
+// rather than appKubeName and a label-selector lookup would not match.
+func (z *zedkube) virtLauncherActiveOnThisNode(appKubeName string) bool {
+	clientset, err := getKubeClientSet()
+	if err != nil {
+		log.Errorf("virtLauncherActiveOnThisNode: get clientset: %v", err)
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer cancel()
+	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("virtLauncherActiveOnThisNode: list pods: %v", err)
+		return false
+	}
+	vlPrefix := base.VMIPodNamePrefix + appKubeName
+	for _, p := range pods.Items {
+		if !strings.HasPrefix(p.Name, vlPrefix) {
+			continue
+		}
+		if p.Spec.NodeName != z.nodeName {
+			continue
+		}
+		if isPodTerminating(p) {
+			continue
+		}
+		if p.Status.Phase == corev1.PodRunning ||
+			p.Status.Phase == corev1.PodFailed ||
+			podHasContainerError(p) {
+			return true
+		}
+	}
+	return false
+}
+
+// podHasContainerError returns true if any container in the pod is in a
+// waiting state with an error-indicating reason (CrashLoopBackOff,
+// ImagePullBackOff, ErrImagePull, CreateContainerError, RunContainerError)
+// or has terminated with a non-zero exit code. These surface as "Error" or
+// similar in kubectl's STATUS column even when Pod.Status.Phase=Running.
+func podHasContainerError(p corev1.Pod) bool {
+	for _, cs := range p.Status.ContainerStatuses {
+		if w := cs.State.Waiting; w != nil {
+			switch w.Reason {
+			case "CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull",
+				"CreateContainerError", "RunContainerError":
+				return true
+			}
+		}
+		if t := cs.State.Terminated; t != nil && t.ExitCode != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// suppressedStatusRunning returns (overrideValue, active) for the given app UUID.
+// While active, checkAppsStatus pins the ENClusterAppStatus.StatusRunning field
+// to the returned value so downstream consumers (zedmanager) do not observe a
+// transient false during our own VMI delete + re-create.
+func (z *zedkube) suppressedStatusRunning(appUUID string) (bool, bool) {
+	until, ok := z.vmiDeleteSuppressUntil[appUUID]
+	if !ok {
+		return false, false
+	}
+	if time.Now().After(until) {
+		delete(z.vmiDeleteSuppressUntil, appUUID)
+		return false, false
+	}
+	return true, true
+}

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -123,6 +123,21 @@ type zedkube struct {
 
 	// longhornDiskReservedSet is true once the desired reservation has been applied to the Longhorn node
 	longhornDiskReservedSet bool
+
+	// Stuck-Pending-VMI detector state (keyed by app UUID string).
+	// vmiPendingSince: first time we observed a Pending VMI with a Running
+	// virt-launcher on this node; cleared when the VMI leaves Pending.
+	// vmiDeleteCount: consecutive FastDeleteVmi attempts; reset on Running.
+	// vmiDeleteSuppressUntil: while in the past-or-nowm window, checkAppsStatus
+	// pins StatusRunning=true so zedmanager does not flip Activate to false.
+	vmiPendingSince        map[string]time.Time
+	vmiDeleteCount         map[string]int
+	vmiDeleteSuppressUntil map[string]time.Time
+	// vmiFailoverSuppressUntil: set by checkAppsFailover when a failover is
+	// active on this node; checkStuckPendingVMI skips force-delete while the
+	// window is live, preventing a false-positive delete of a new VMI that is
+	// legitimately Pending during failover start-up.
+	vmiFailoverSuppressUntil map[string]time.Time
 }
 
 func inlineUsage() int {
@@ -223,6 +238,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		drainTimeout:                       time.Duration(time.Hour * types.DefaultDrainTimeoutHours),
 		configInterval:                     time.Duration(types.DefaultConfigItemValueMap().GlobalValueInt(types.ConfigInterval)) * time.Second,
 		clusterWideDetectWindowMultiple:    types.DefaultClusterWideDetectWindowMultiple,
+		vmiPendingSince:                    make(map[string]time.Time),
+		vmiDeleteCount:                     make(map[string]int),
+		vmiDeleteSuppressUntil:             make(map[string]time.Time),
+		vmiFailoverSuppressUntil:           make(map[string]time.Time),
 	}
 
 	// do we run a single command, or long-running service?
@@ -650,6 +669,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		// so each function gets its own kubeAPITimeout window.
 		case <-appStatusTimer.C:
 			zedkubeCtx.checkAppsFailover(zedkubeWdUpdate)
+			zedkubeCtx.checkStuckPendingVMI()
 			zedkubeWdUpdate()
 			zedkubeCtx.checkAppsStatus()
 			appStatusTimer = time.NewTimer(logcollectInterval * time.Second)

--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -48,10 +48,15 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 	}
 
 	effectiveActivate := effectiveActivateCombined(aiConfig, ctx)
+	// UserActivate carries the raw user intent (profile-resolved AppInstanceConfig.Activate)
+	// without the cluster-scheduling override applied by getKubeAppActivateStatus, so domainmgr
+	// can distinguish a real user opt-out from a transient cluster-status cascade.
+	userActivate := effectiveActivateCurrentProfile(aiConfig, ctx.currentProfile)
 	dc := types.DomainConfig{
 		UUIDandVersion:    aiConfig.UUIDandVersion,
 		DisplayName:       aiConfig.DisplayName,
 		Activate:          effectiveActivate,
+		UserActivate:      userActivate,
 		AppNum:            AppNum,
 		PurgeCounter:      aiConfig.PurgeCmd.Counter + aiConfig.LocalPurgeCmd.Counter,
 		VmConfig:          aiConfig.FixedResources,

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -616,12 +616,7 @@ func (ctx kubevirtContext) Start(domainName string) error {
 	}
 	logrus.Infof("Started Kubevirt domain replicaset %s, VMI replicaset %s", domainName, vmis.name)
 
-	err = waitForVMI(vmis, nodeName, true)
-	if err != nil {
-		logrus.Errorf("couldn't start VMI %v", err)
-		return err
-	}
-
+	// Start() returns as soon as VMIRS is created; cluster drives VMI scheduling.
 	return nil
 }
 

--- a/pkg/pillar/kubeapi/kubeapi.go
+++ b/pkg/pillar/kubeapi/kubeapi.go
@@ -745,7 +745,10 @@ func kubeNodeNotReporting(log *base.LogObject, node *corev1.Node) (notreporting 
 	return notreporting
 }
 
-func tryFastDeleteVmi(log *base.LogObject, kvClientset kubecli.KubevirtClient, vmiName string) error {
+// TryFastDeleteVmi force-deletes a VMI with 0 grace period, stripping
+// finalizers first so the delete does not hang when the kubevirt control
+// plane is impaired.
+func TryFastDeleteVmi(log *base.LogObject, kvClientset kubecli.KubevirtClient, vmiName string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
 	defer cancel()
 
@@ -977,7 +980,7 @@ func DetachOldWorkload(log *base.LogObject, failedNodeName string, appDomainName
 	// Delete vmi on failed node
 	if failedNodeVmiName != "" {
 		log.Noticef("DetachOldWorkload Deleting vmi:%s", failedNodeVmiName)
-		err := tryFastDeleteVmi(log, kvClientset, failedNodeVmiName)
+		err := TryFastDeleteVmi(log, kvClientset, failedNodeVmiName)
 		if err != nil {
 			log.Errorf("DetachOldWorkload couldn't delete the Kubevirt VMI:%s for appDomainName:%s err:%v", failedNodeVmiName, appDomainName, err)
 		}

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -33,7 +33,13 @@ type DomainConfig struct {
 	UUIDandVersion UUIDandVersion
 	DisplayName    string // Use as name for domU? DisplayName+version?
 	Activate       bool   // Actually start the domU as opposed to prepare
-	AppNum         int    // From networking; makes the name unique
+	// UserActivate is the raw user intent from AppInstanceConfig.Activate
+	// resolved through the current profile only, with no override from cluster
+	// scheduling state. In kubevirt cluster mode, domainmgr uses this to avoid
+	// tearing down the cluster-shared VMIRS when Activate=false is a transient
+	// cluster-status cascade rather than an explicit user opt-out.
+	UserActivate bool
+	AppNum       int // From networking; makes the name unique
 	VmConfig
 	DisableLogs    bool
 	GPUConfig      string
@@ -361,6 +367,10 @@ type DomainStatus struct {
 	PassthroughWindowsLicenseKey bool
 	// DeploymentType is the type of deployment for the app
 	DeploymentType AppRuntimeType
+	// KubeTrustLoggedState is the last non-RUNNING state for which domainmgr
+	// emitted the "trusting cluster to recover" log line. Used to deduplicate
+	// that log to state transitions only. Zero = not yet logged. KubeVirt only.
+	KubeTrustLoggedState SwState `json:"-"`
 }
 
 func (status DomainStatus) Key() string {


### PR DESCRIPTION

# Description

In kubevirt mode, transient errors during app bring-up were tearing down the VMIReplicaSet via hyper.Delete/Cleanup, which caused 10+ minute retry stalls and, when it hit the purge-collision bug, left the app permanently down. Instead, let the cluster drive VMI lifecycle.

domainmgr:
 - doActivateTail: on Start failure or post-Start non-RUNNING state, skip Delete/Cleanup, publish State=BOOTING with Activated=false, and let verifyStatus promote to RUNNING once Info() reports it.
 - verifyStatus: same treatment on the periodic error path.

hypervisor/kubevirt:
 - Start() returns as soon as the VMIRS is created; drop the synchronous waitForVMI wait. Scheduling is the cluster's job.

zedkube: new stuck-Pending VMI detector (pendingvmi.go)
 - If a VMI stays Pending for >3 min while its virt-launcher is Running on this node (a known kubevirt/longhorn interaction), force-delete the VMI (not the VMIRS) so the cluster re-creates it cleanly. Capped at 3 attempts per app.
 - During a 5-minute suppression window after delete, checkAppsStatus pins StatusRunning=true / ScheduledOnThisNode=true so zedmanager does not cascade DomainConfig.Activate=false and tear down the VMIRS.

domainmgr: gate VMIRS Delete on UserActivate to prevent cluster-cascade teardown in kubevirt mode

## PR dependencies

## How to test and validate this PR

run eve-k, w/ VM apps, it should start normally. the app delete should work
and do the proper cleanup. the deactivate and reactivate should start the
VMI again. the killing VMI in the patch, if we can reproduce this, when start
application, the VM is keep in pending state for very long, verify the VMI will
eventually come back due to the handling in this patch.

## Changelog notes

pillar: trust cluster recovery for kubevirt apps and add stuck-Pending VMI handler

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
