### PR TITLE
eden-trusted: use eden master for EVE master CI

### DIFF
--- a/.github/workflows/eden-trusted.yml
+++ b/.github/workflows/eden-trusted.yml
@@ -218,7 +218,7 @@ jobs:
     name: ${{ needs.context.outputs.eden_parent_job_title }} for master
     needs: context
     if: needs.context.outputs.skip_run == 'false' && needs.context.outputs.pr_base_ref == 'master'
-    uses: lf-edge/eden/.github/workflows/test.yml@1.0.15
+    uses: lf-edge/eden/.github/workflows/test.yml@master
     secrets: inherit
     with:
       eve_image: "evebuild/pr:${{ needs.context.outputs.pr_id }}"


### PR DESCRIPTION
## Summary

- The `tests-master` job in `eden-trusted.yml` was pinned to eden tag `1.0.15`, while eden master had moved two releases ahead (`1.0.16` and beyond).
- This caused smoketest failures on PRs against EVE master when the issue was in eden, not EVE itself.
- Change the `uses:` ref for `tests-master` to `@master` so it always tracks eden master.
- The three stable-branch jobs (`tests-13-4-stable`, `tests-14-5-stable`, `tests-16-0-stable`) remain pinned to `@1.0.15` as those EVE branches require the older compatible eden version.

## Test plan

- [ ] Verify the failing smoketests in #5851 pass after this change
- [ ] Verify stable-branch CI jobs still reference `@1.0.15` and are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)