### PR TITLE
dpcmanager: increase PNAC DHCP reacquire timeout to avoid flaky tests

### DIFF
--- a/pkg/pillar/dpcmanager/dpcmanager_test.go
+++ b/pkg/pillar/dpcmanager/dpcmanager_test.go
@@ -3502,8 +3502,9 @@ func TestPNACDHCPReacquire(test *testing.T) {
 		IsAuthenticated: true,
 	})
 
-	// First retry should occur after ~2s.
-	t.Eventually(dhcpReacquireCounterCb("eth0"), 5*time.Second, 200*time.Millisecond).
+	// First retry should occur after ~2s (backoff: 2^1).
+	// Allow 10s to cover concurrent dpcTestTimer blocking the main loop.
+	t.Eventually(dhcpReacquireCounterCb("eth0"), 10*time.Second, 200*time.Millisecond).
 		Should(Equal(1))
 
 	// Simulate the DHCP client restarting and getting the same IP from
@@ -3573,8 +3574,9 @@ func TestPNACDHCPReacquireMaxRetries(test *testing.T) {
 		IsAuthenticated: true,
 	})
 
-	// First retry should fire after ~2s.
-	t.Eventually(dhcpReacquireCounterCb("eth0"), 5*time.Second, 200*time.Millisecond).
+	// First retry should fire after ~2s (backoff: 2^1).
+	// Allow 10s to cover concurrent dpcTestTimer blocking the main loop.
+	t.Eventually(dhcpReacquireCounterCb("eth0"), 10*time.Second, 200*time.Millisecond).
 		Should(Equal(1))
 
 	// Simulate DHCP getting same-subnet IP to trigger AddrChange and schedule retry 2.
@@ -3667,7 +3669,11 @@ func TestPNACDHCPReacquireCancelledByNewDPC(test *testing.T) {
 	})
 
 	// Wait for first retry.
-	t.Eventually(dhcpReacquireCounterCb("eth0"), 5*time.Second, 200*time.Millisecond).
+	// The reacquire goroutine fires after 2s (backoff: 2^1), but the periodic
+	// dpcTestTimer (NetworkTestInterval=2s) can fire concurrently and block the
+	// main select loop for another ~2s running testConnectivityToController.
+	// Allow 10s total to cover this worst-case blocking plus scheduler jitter.
+	t.Eventually(dhcpReacquireCounterCb("eth0"), 10*time.Second, 200*time.Millisecond).
 		Should(Equal(1))
 
 	// Apply a new DPC that adds eth1 — the config change should cancel


### PR DESCRIPTION
# Description

This PR tries to fix several Go-Tests fails during timeout of dpcmanager_test, like the following:

https://github.com/lf-edge/eve/actions/runs/24859644144/job/72781692997?pr=5854#step:7:3214
https://github.com/lf-edge/eve/actions/runs/24859644144/job/72781692997?pr=5854#step:7:3213

The first-retry Eventually checks in the three PNAC DHCP reacquire tests used a 5s timeout for a reacquire that fires after ~2s backoff. This left only ~1s of margin because the periodic dpcTestTimer (NetworkTestInterval=2s) fires at roughly the same time and blocks the main select loop for another ~2s while running testConnectivityToController. Under CI load (goroutine pressure from preceding tests that do not clean up initTest state), this margin was insufficient, causing TestPNACDHCPReacquireCancelledByNewDPC to time out.

Increase the timeout from 5s to 10s across all three affected tests and add an explanatory comment in the failing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## How to test and validate this PR

Run go-tests from our CI/CD workflows.

## Changelog notes

None. This is related to our CI/CD infra.

## PR Backports

No backports. See: https://github.com/lf-edge/eve/pull/5860#pullrequestreview-4170259370

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.