### PR TITLE
HW inventory fixes

### DIFF
--- a/pkg/pillar/cmd/tpmmgr/tpmmgr.go
+++ b/pkg/pillar/cmd/tpmmgr/tpmmgr.go
@@ -291,7 +291,7 @@ func readCredentials() error {
 }
 
 func printCapability() {
-	hwInfoStr, err := etpm.FetchTpmHwInfo()
+	hwInfoStr, err := etpm.FetchTpmHwInfoDescription()
 	if err != nil {
 		fmt.Println(err)
 	} else {
@@ -1223,7 +1223,7 @@ func getEkCertMetaData() ([]types.CertMetaData, error) {
 
 // Write TPM vendor, firmware info to given file.
 func saveTpmInfo(filename string) error {
-	info, err := etpm.FetchTpmHwInfo()
+	info, err := etpm.FetchTpmHwInfoDescription()
 	if err != nil {
 		return err
 	}

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -585,7 +585,7 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext, dest destinationBitset) {
 
 	//Operational information about TPM presence/absence/usage.
 	ReportDeviceInfo.HSMStatus = etpm.FetchTpmSwStatus()
-	ReportDeviceInfo.HSMInfo, _ = etpm.FetchTpmHwInfo()
+	ReportDeviceInfo.HSMInfo, _ = etpm.FetchTpmHwInfoDescription()
 
 	//Operational information about Data Security At Rest
 	ReportDataSecAtRestInfo := getDataSecAtRestInfo(ctx)

--- a/pkg/pillar/evetpm/tpm.go
+++ b/pkg/pillar/evetpm/tpm.go
@@ -15,6 +15,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -840,7 +841,10 @@ var vendorRegistry = map[uint32]string{
 	0x474F4F47: "Google",
 }
 
-// FetchTpmHwInfo returns TPM Hardware properties in a string
+// ErrNoTPM is returned if no TPM is found
+var ErrNoTPM = errors.New("No TPM")
+
+// FetchTpmHwInfo returns TPM Hardware properties
 func FetchTpmHwInfo() (string, error) {
 	//If we had done this earlier, return the last result
 	if tpmHwInfo != "" {
@@ -849,11 +853,8 @@ func FetchTpmHwInfo() (string, error) {
 
 	//Take care of non-TPM platforms
 	if _, err := os.Stat(TpmDevicePath); err != nil {
-		tpmHwInfo = "Not Available"
-		//nolint:nilerr
-		return tpmHwInfo, nil
+		return "", ErrNoTPM
 	}
-
 	//First time. Fetch it from TPM and cache it.
 	v1, err := GetTpmProperty(tpm2.Manufacturer)
 	if err != nil {
@@ -880,6 +881,16 @@ func FetchTpmHwInfo() (string, error) {
 		GetFirmwareVersion(v4, v5))
 
 	return tpmHwInfo, nil
+}
+
+// FetchTpmHwInfoDescription returns TPM Hardware properties in a string
+func FetchTpmHwInfoDescription() (string, error) {
+	tpmHwInfo, err := FetchTpmHwInfo()
+	if errors.Is(err, ErrNoTPM) {
+
+		return tpmHwInfo, nil
+	}
+	return tpmHwInfo, err
 }
 
 // GetSpecVersion returns TPM specification version string

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tatsushid/go-fastping v0.0.0-20160109021039-d7bb493dee3e
 	github.com/vishvananda/netlink v1.3.1
-	github.com/zededa/ghw v0.0.0-20260218160843-b4fc0f8a6aa5
+	github.com/zededa/ghw v0.0.0-20260427124750-9a7dc80ae71c
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.46.0
 	golang.org/x/net v0.48.0

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -919,8 +919,8 @@ github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-github.com/zededa/ghw v0.0.0-20260218160843-b4fc0f8a6aa5 h1:XpWbH6y+ijvzerElhvg8x1VcheqouFjc2h1MqimzgbQ=
-github.com/zededa/ghw v0.0.0-20260218160843-b4fc0f8a6aa5/go.mod h1:bLYU9IrgrtEUiJ6smjXtTaej/MVO17v+kxGIC/jfj9c=
+github.com/zededa/ghw v0.0.0-20260427124750-9a7dc80ae71c h1:zfpR6V7WZ/cMq5K98SngCHF+7cykchvsF0b2bGtB/Ko=
+github.com/zededa/ghw v0.0.0-20260427124750-9a7dc80ae71c/go.mod h1:bLYU9IrgrtEUiJ6smjXtTaej/MVO17v+kxGIC/jfj9c=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.11 h1:yGEzV1wPz2yVCLsD8ZAiGHhHVlczyC9d1rP43/VCRJ0=
 go.etcd.io/bbolt v1.3.11/go.mod h1:dksAq7YMXoljX0xu6VF5DMZGbhYYoLUalEiSySYAS4I=

--- a/pkg/pillar/hardware/inventory.go
+++ b/pkg/pillar/hardware/inventory.go
@@ -282,7 +282,7 @@ func getNetworkDevices() ([]*info.NetworkDevice, error) {
 		return nil, err
 	}
 	for _, nic := range netInfo.NICs {
-		nd := info.NetworkDevice{
+		netDev := info.NetworkDevice{
 			Ifname:     nic.Name,
 			MacAddress: nic.MACAddress,
 		}
@@ -302,25 +302,39 @@ func getNetworkDevices() ([]*info.NetworkDevice, error) {
 			}
 			if len(digits) > 0 {
 				val, _ := strconv.ParseUint(digits, 10, 32)
-				nd.SpeedMbps = uint32(val) * mult
+				netDev.SpeedMbps = uint32(val) * mult
 			}
 		}
 
 		// Type guessing
 		if strings.HasPrefix(nic.Name, "wlan") || strings.HasPrefix(nic.Name, "wl") {
-			nd.Type = info.NetworkDeviceType_NETWORK_DEVICE_TYPE_WIFI
+			netDev.Type = info.NetworkDeviceType_NETWORK_DEVICE_TYPE_WIFI
 		} else if strings.HasPrefix(nic.Name, "wwan") {
-			nd.Type = info.NetworkDeviceType_NETWORK_DEVICE_TYPE_WWAN
+			netDev.Type = info.NetworkDeviceType_NETWORK_DEVICE_TYPE_WWAN
 		} else if strings.HasPrefix(nic.Name, "eth") || strings.HasPrefix(nic.Name, "en") {
-			nd.Type = info.NetworkDeviceType_NETWORK_DEVICE_TYPE_ETHERNET
+			netDev.Type = info.NetworkDeviceType_NETWORK_DEVICE_TYPE_ETHERNET
 		}
 
-		if nic.PCIAddress != nil {
-			nd.Parent = &info.BusParent{
+		if nic.USBAddress != nil {
+			// USB address format is "{busnum}-{port}" e.g. "3-1.1"
+			parts := strings.SplitN(*nic.USBAddress, "-", 2)
+			if len(parts) == 2 {
+				busnum, err := strconv.ParseUint(parts[0], 10, 32)
+				if err == nil {
+					netDev.Parent = &info.BusParent{
+						UsbParent: &info.USBAddress{
+							Bus:  uint32(busnum),
+							Port: parts[1],
+						},
+					}
+				}
+			}
+		} else if nic.PCIAddress != nil {
+			netDev.Parent = &info.BusParent{
 				PciParent: stringToPCIAddress(*nic.PCIAddress),
 			}
 		}
-		networkDevices = append(networkDevices, &nd)
+		networkDevices = append(networkDevices, &netDev)
 	}
 	return networkDevices, nil
 }

--- a/pkg/pillar/hardware/inventory.go
+++ b/pkg/pillar/hardware/inventory.go
@@ -450,35 +450,36 @@ func watchdogPresent() (bool, error) {
 }
 
 func getTPMInfo() (*info.TPM, error) {
-	present := evetpm.IsTpmEnabled()
 	tpmInfoProto := &info.TPM{
-		Present: present,
+		Present: true,
 	}
 
-	if present {
-		tpmInfo, err := evetpm.FetchTpmHwInfo()
-		if err != nil {
-			return nil, err
-		}
-		// The string returned by FetchTpmHwInfo is formatted as:
-		// "Manufacturer-Model, FW Version Version"
-		// We try to parse it to fill the individual fields
-		parts := strings.Split(tpmInfo, ", FW Version ")
-		if len(parts) == 2 {
-			tpmInfoProto.FirmwareVersion = parts[1]
-			vendorParts := strings.Split(parts[0], "-")
-			if len(vendorParts) >= 1 {
-				tpmInfoProto.Manufacturer = vendorParts[0]
-			}
-		} else {
-			// Fallback if formatting is unexpected
-			tpmInfoProto.Manufacturer = tpmInfo
-		}
-		specVersion, err := evetpm.GetSpecVersion()
-		if err != nil {
-			return nil, err
-		}
-		tpmInfoProto.SpecVersion = specVersion
+	tpmInfo, err := evetpm.FetchTpmHwInfo()
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, evetpm.ErrNoTPM) {
+		tpmInfoProto.Present = false
+		return tpmInfoProto, nil
+	} else if err != nil {
+		return nil, err
 	}
+	// The string returned by FetchTpmHwInfo is formatted as:
+	// "Manufacturer-Model, FW Version Version"
+	// We try to parse it to fill the individual fields
+	parts := strings.Split(tpmInfo, ", FW Version ")
+	if len(parts) == 2 {
+		tpmInfoProto.FirmwareVersion = parts[1]
+		vendorParts := strings.Split(parts[0], "-")
+		if len(vendorParts) >= 1 {
+			tpmInfoProto.Manufacturer = vendorParts[0]
+		}
+	} else {
+		// Fallback if formatting is unexpected
+		tpmInfoProto.Manufacturer = tpmInfo
+	}
+	specVersion, err := evetpm.GetSpecVersion()
+	if err != nil {
+		return nil, err
+	}
+	tpmInfoProto.SpecVersion = specVersion
+
 	return tpmInfoProto, nil
 }

--- a/pkg/pillar/hardware/inventory_test.go
+++ b/pkg/pillar/hardware/inventory_test.go
@@ -4,6 +4,9 @@
 package hardware
 
 import (
+	"encoding/json"
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
@@ -14,9 +17,14 @@ func TestCreateInventory(t *testing.T) {
 	_, log := agentlog.Init("someAgent")
 
 	inventory, err := GetInventoryInfo(log)
-	if err != nil {
-		panic(err)
+	// often the tests do not run as root, do not fail in this case
+	if inventory == nil || (err != nil && !errors.Is(err, os.ErrPermission)) {
+		t.Fatalf("creating inventory failed: %v", err)
 	}
 
-	t.Log(inventory)
+	bytes, err := json.MarshalIndent(inventory, "\t", "\t")
+	if err != nil {
+		t.Fatalf("could not create json: %v", err)
+	}
+	t.Log(string(bytes))
 }

--- a/pkg/pillar/vendor/github.com/zededa/ghw/pkg/pci/pci_linux.go
+++ b/pkg/pillar/vendor/github.com/zededa/ghw/pkg/pci/pci_linux.go
@@ -419,17 +419,24 @@ func (info *Info) getDevices(opts *option.Options) []*Device {
 	return devs
 }
 
-// FindPCIAddress extract the pci address from a sysfs path without /sys
+// FindPCIAddress extracts the deepest (most specific) PCI BDF address from a
+// sysfs path. For devices that are themselves PCI devices (e.g. NICs behind a
+// PCIe bridge), this returns the device's own address. For non-PCI devices
+// (e.g. USB or CAN interfaces) whose paths end in non-PCI components, it
+// returns the address of the PCI controller they attach to.
 func FindPCIAddress(path string) string {
-	re := regexp.MustCompile(`\/?devices\/pci[\d:.]*\/(\d{4}:[a-f\d:\.]+)`)
-
-	matches := re.FindStringSubmatch(path)
-	// first element is the full string match like /devices/pci0000:00/0000:00:0d.0
-	// but we need the first substring match so we take the second element
-	if len(matches) != 2 {
-		return ""
+	// Match an exact BDF component: domain:bus:device.function (all hex).
+	re := regexp.MustCompile(`^[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9a-f]$`)
+	for {
+		dir, file := filepath.Split(path)
+		if re.MatchString(strings.ToLower(file)) {
+			return strings.ToLower(file)
+		}
+		dir = filepath.Clean(dir)
+		if dir == path {
+			break
+		}
+		path = dir
 	}
-	pciAddress := matches[1]
-
-	return pciAddress
+	return ""
 }

--- a/pkg/pillar/vendor/github.com/zededa/ghw/pkg/serial/serial_linux.go
+++ b/pkg/pillar/vendor/github.com/zededa/ghw/pkg/serial/serial_linux.go
@@ -10,13 +10,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/zededa/ghw/pkg/bus"
 	"github.com/zededa/ghw/pkg/linuxpath"
 	"github.com/zededa/ghw/pkg/option"
+	"github.com/zededa/ghw/pkg/pci"
 	pciAddress "github.com/zededa/ghw/pkg/pci/address"
 	"github.com/zededa/ghw/pkg/usb"
 	usbAddress "github.com/zededa/ghw/pkg/usb/address"
@@ -36,20 +36,15 @@ func (i *Info) load(opts *option.Options) error {
 func serials(opts *option.Options) ([]*Device, []error) {
 	paths := linuxpath.New(opts)
 	ttyClass := paths.SysClassTty
-	ttys, err := filepath.Glob(filepath.Join(ttyClass, "ttyS*"))
+	entries, err := os.ReadDir(ttyClass)
 	if err != nil {
 		return nil, []error{err}
 	}
 
-	// Deterministic order: ttyS0, ttyS1, ...
-	sort.Slice(ttys, func(i, j int) bool {
-		return filepath.Base(ttys[i]) < filepath.Base(ttys[j])
-	})
-
 	var out []*Device
 	id := 1
-	for _, ttyDir := range ttys {
-		tty := filepath.Base(ttyDir) // ttyS1
+	for _, entry := range entries {
+		tty := entry.Name() // ttyS1
 		sp, ok, err := serialPortFromTTY(paths.SysRoot, ttyClass, tty)
 		if err != nil {
 			continue
@@ -97,8 +92,9 @@ func serialPortFromTTY(sysfs, ttyClass, tty string) (*Device, bool, error) {
 		ioRange = fmt.Sprintf("%04x-%04x", start, end)
 	}
 
+	pciAddrString := pci.FindPCIAddress(devSys)
 	var parent bus.BusParent
-	if pciAddr := pciAddress.FromString(devSys); pciAddr != nil {
+	if pciAddr := pciAddress.FromString(pciAddrString); pciAddr != nil {
 		parent.PCI = pciAddr
 	}
 	bus, port, err := usb.ExtractUSBBusnumPort(devSys)

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -1208,7 +1208,7 @@ github.com/xlab/treeprint
 # github.com/yusufpapurcu/wmi v1.2.4
 ## explicit; go 1.16
 github.com/yusufpapurcu/wmi
-# github.com/zededa/ghw v0.0.0-20260218160843-b4fc0f8a6aa5
+# github.com/zededa/ghw v0.0.0-20260427124750-9a7dc80ae71c
 ## explicit; go 1.21
 github.com/zededa/ghw
 github.com/zededa/ghw/pkg/accelerator


### PR DESCRIPTION
# Description

Several fixes when reporting the hardware inventory:
* Updated Regex for finding PCI addresses in sysfs paths (https://github.com/zededa/ghw/commit/4df35e354b3bf31532e9fbe73ae62edbf6f136b4)
* include non `ttyS*` serial devices (https://github.com/zededa/ghw/pull/7 )
* fix check if TPM is available
* add correct parent device for network devices


## PR dependencies

https://github.com/zededa/ghw/pull/7

## How to test and validate this PR

Compare the created inventoy message with what `spec.sh` provides.

## Changelog notes

Fixes for hardware inventory reporting

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 16.0-stable: yes
- 14.5-stable: no, as feature is not available
- 13.4-stable: no, as feature is not available

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR




Please, check the boxes above after submitting the PR in interactive mode.
