### PR TITLE
Make DIRSYNC for persist/vault configurable via grub option

### DIFF
--- a/docs/BOOTING.md
+++ b/docs/BOOTING.md
@@ -317,3 +317,17 @@ Access via console is enabled during initial bootstrap and will be disabled afte
 In order to have access via console you can set a `debug.enable.console` property to true as specified in [configuration properties](CONFIG-PROPERTIES.md).
 If you need console to debug some problem you can enable it for one boot of edge node from grub menu (`Set Boot Options`->`enable getty`).
 For development builds you can put `set_getty` line into `conf/grub.cfg` file.
+
+## Disabling DIRSYNC for the vault
+
+By default, EVE mounts the vault (and, for ext-based filesystems, the entire `/persist`)
+with the `DIRSYNC` flag. This forces synchronous directory updates, improving filesystem
+content consistency in the event of a power outage. On bare metal, the overhead is negligible,
+but in a virtual machine it can introduce significant I/O overhead, especially during
+container image unpacking, when many files and directories are created.
+
+To disable `DIRSYNC`, add the following line to `conf/grub.cfg`:
+
+```text
+set_no_dirsync
+```

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -457,6 +457,10 @@ function set_isolcpus {
    set_global dom0_extra_args "$dom0_extra_args isolcpus=inverse,0 nohz_full=inverse,0"
 }
 
+function set_no_dirsync {
+   set_global dom0_extra_args "$dom0_extra_args eve_no_dirsync"
+}
+
 # Read eve-kernel-extra-cmdline from EFI vars and append to dom0_extra_args
 function set_append_extra_efi_cmdline {
     insmod efi

--- a/pkg/pillar/vault/handler_zfs.go
+++ b/pkg/pillar/vault/handler_zfs.go
@@ -25,6 +25,13 @@ const (
 	zfsKeyFile                      = zfsKeyDir + "/protector.key"
 	vaultZvolPathWaitSeconds int64  = 20
 	vaultFsType              string = "ext4"
+
+	// cmdlineNoDirsync is the kernel cmdline flag to disable DIRSYNC for the vault mount.
+	// DIRSYNC improves filesystem content consistency on power outage but introduces
+	// significant I/O overhead in virtualized environments.
+	// Set this flag when EVE runs as a VM.
+	// Must be kept in sync with the grub function set_no_dirsync in pkg/grub/rootfs.cfg.
+	cmdlineNoDirsync = "eve_no_dirsync"
 )
 
 // ZFSHandler handles vault operations with ZFS
@@ -353,11 +360,28 @@ func MountVaultZvol(log *base.LogObject, datasetPath string) error {
 		}
 	}
 
-	err = unix.Mount(devPath, "/"+types.SealedDataset, vaultFsType, unix.MS_DIRSYNC|unix.MS_NOATIME, "")
+	mountFlags := uintptr(unix.MS_DIRSYNC | unix.MS_NOATIME)
+	if noDirsyncRequested() {
+		mountFlags = unix.MS_NOATIME
+	}
+	err = unix.Mount(devPath, "/"+types.SealedDataset, vaultFsType, mountFlags, "")
 	if err != nil {
 		return fmt.Errorf("mount of %s to %s err:%v", devPath, "/"+types.SealedDataset, err)
 	}
 	return nil
+}
+
+func noDirsyncRequested() bool {
+	data, err := os.ReadFile("/proc/cmdline")
+	if err != nil {
+		return false
+	}
+	for _, arg := range strings.Fields(string(data)) {
+		if arg == cmdlineNoDirsync {
+			return true
+		}
+	}
+	return false
 }
 
 // formatZvol apply an ext4 fs to the device path given

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -107,6 +107,11 @@ elif [ "$INSTALL_ZFS" = true ]; then
    P3_FS_TYPE_DEFAULT=zfs
 fi
 
+DIRSYNC_OPT=",dirsync"
+if grep -q 'eve_no_dirsync' /proc/cmdline; then
+   DIRSYNC_OPT=""
+fi
+
 if [ "$eve_flavor" = "k" ]; then
    if [ "$P3_FS_TYPE_DEFAULT" = "zfs" ]; then
       INSTALL_CLUSTERED_STORAGE=true
@@ -253,7 +258,7 @@ if P3=$(findfs PARTLABEL=P3) && [ -n "$P3" ]; then
     fi
 
     case "$P3_FS_TYPE" in
-             ext3) mount -t ext3 -o dirsync,noatime "$P3" $PERSISTDIR
+             ext3) mount -t ext3 -o noatime${DIRSYNC_OPT} "$P3" $PERSISTDIR
                    ;;
              ext4) #Use -F option twice, to avoid any user confirmation in mkfs
                    if [ "$INIT_FS" = 1 ]; then
@@ -261,7 +266,7 @@ if P3=$(findfs PARTLABEL=P3) && [ -n "$P3" ]; then
                    fi
                    # Enable encryption
                    tune2fs -O encrypt "$P3" && \
-                   mount -t ext4 -o dirsync,noatime "$P3" $PERSISTDIR
+                   mount -t ext4 -o noatime${DIRSYNC_OPT} "$P3" $PERSISTDIR
                    ;;
              zfs) if [ "$INIT_FS" = 1 ]; then
                       # note that we immediately create a zfs dataset for containerd, since otherwise the init sequence will fail


### PR DESCRIPTION
# Description

DIRSYNC improves filesystem content consistency on power outage but introduces significant
I/O overhead in virtualized environments, especially during container image unpacking.
Add a grub option (`eve_no_dirsync`) to disable it when EVE runs as a VM, while keeping
it enabled by default for baremetal.

The primary intended use case is virtualized integration testing, especially in tests that
require downloading many container images, such as cluster tests where Kubernetes must pull
many container images to establish the cluster.

## How to test and validate this PR

Test all 4 combinations of persist filesystem (ZFS / ext4) and DIRSYNC state (enabled / disabled).
To disable DIRSYNC, add `set_no_dirsync` to `conf/grub.cfg`.
Verify the mount options via `cat /proc/mounts`.

**ZFS, DIRSYNC enabled (default):**
```
$ cat /proc/mounts | grep '/persist/vault '
/dev/zvol/persist/vault /persist/vault ext4 rw,dirsync,noatime,stripe=8192 0 0
/dev/zvol/persist/vault /hostfs/persist/vault ext4 rw,dirsync,noatime,stripe=8192 0 0
```

**ZFS, DIRSYNC disabled:**
```
$ cat /proc/mounts | grep '/persist/vault '
/dev/zvol/persist/vault /persist/vault ext4 rw,noatime,stripe=8192 0 0
/dev/zvol/persist/vault /hostfs/persist/vault ext4 rw,noatime,stripe=8192 0 0
```

**ext4, DIRSYNC enabled (default):**
```
$ cat /proc/mounts | grep persist
/dev/vda9 /hostfs/persist ext4 rw,dirsync,noatime 0 0
/dev/vda9 /persist ext4 rw,dirsync,noatime 0 0
```

**ext4, DIRSYNC disabled:**
```
$ cat /proc/mounts | grep persist
/dev/vda9 /hostfs/persist ext4 rw,noatime 0 0
/dev/vda9 /persist ext4 rw,noatime 0 0
```

## Changelog notes

- Added grub option `eve_no_dirsync` to disable DIRSYNC for `/persist` and the vault.
  DIRSYNC is enabled by default (no change for baremetal); disabling it is recommended
  when EVE runs as a VM to improve I/O performance.

## PR Backports

Not to be backported.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.