### PR TITLE
kube: restart standalone containerd if it dies

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -253,6 +253,8 @@ config_cluster_roles() {
 }
 
 check_start_k3s() {
+  # Ensure containerd is running
+  check_start_containerd
   if [ -f "$K3S_STOP_FLAG" ]; then
     return 1
   fi
@@ -806,7 +808,7 @@ check_cluster_config_change() {
 
             # restart k3s will run only if we are ready after the transition configs set
             terminate_k3s
-            # romove the /var/lib/rancher/k3s/server/tls directory files
+            # remove the /var/lib/rancher/k3s/server/tls directory files
             if [ "$is_bootstrap" = "false" ]; then
               rm -rf /var/lib/rancher/k3s/server/tls/*
               # redo the debugger user role binding since certs are changed


### PR DESCRIPTION

# Description
The containerd is started once at boot with no supervisor. If it dies (e.g. due to OOM ), nothing
restarts it and the main loop spins indefinitely

- Call check_start_containerd before launching k3s so containerd is always up when k3s connects to its CRI endpoint.
- Call check_start_containerd at the top of the main loop (guarded by k3s_installed_unpacked) to recover a dead containerd within one loop iteration regardless of k3s state.


## How to test and validate this PR

This fix should auto restart the containerd if it dies 

## PR Backports

```text
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
