### PR TITLE
zedmanager: report app status from DNID when no pod in cluster

### DIFF
--- a/pkg/pillar/agentbase/apptracker.go
+++ b/pkg/pillar/agentbase/apptracker.go
@@ -222,7 +222,7 @@ func GetApplicationInfo(rootRun, persistKubelog, AppUUID string) AppTrackerInfo 
 			UUID:     AppUUID,
 			Exist:    true,
 			DNidNode: boolToTriState(enClusterAppStatus.IsDNidNode),
-			Content:  fmt.Sprintf("Scheduled on this node %v, StatusRunning %v", enClusterAppStatus.ScheduledOnThisNode, enClusterAppStatus.StatusRunning),
+			Content:  fmt.Sprintf("Scheduled on this node %v, AppKubeStatus %v", enClusterAppStatus.ScheduledOnThisNode, enClusterAppStatus.AppKubeStatus),
 		}
 		appInfo = append(appInfo, OrderedAppInfoItem{Key: structName2, Value: ai})
 	}

--- a/pkg/pillar/cmd/zedkube/applogs.go
+++ b/pkg/pillar/cmd/zedkube/applogs.go
@@ -167,13 +167,14 @@ func (z *zedkube) checkAppsStatus() {
 		return
 	}
 
+	stItems := z.pubENClusterAppStatus.GetAll()
+
 	clientset, err := getKubeClientSet()
 	if err != nil {
 		log.Errorf("checkAppsStatus: can't get clientset %v", err)
+		z.handleKubeAPIError(items, stItems)
 		return
 	}
-
-	stItems := z.pubENClusterAppStatus.GetAll()
 
 	podsCtx, podsCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
 	defer podsCancel()
@@ -181,7 +182,7 @@ func (z *zedkube) checkAppsStatus() {
 	if err != nil {
 		log.Errorf("checkAppsStatus: can't get pods %v", err)
 		// If we can't get pods, process the error and return
-		z.handleKubePodsGetError(items, stItems)
+		z.handleKubeAPIError(items, stItems)
 		return
 	}
 
@@ -192,8 +193,9 @@ func (z *zedkube) checkAppsStatus() {
 	for _, item := range items {
 		aiconfig := item.(types.AppInstanceConfig)
 		encAppStatus := types.ENClusterAppStatus{
-			AppUUID:    aiconfig.UUIDandVersion.UUID,
-			IsDNidNode: aiconfig.IsDesignatedNodeID,
+			AppUUID:       aiconfig.UUIDandVersion.UUID,
+			IsDNidNode:    aiconfig.IsDesignatedNodeID,
+			AppKubeStatus: types.AppKubeStatusNotInCluster, // overridden below if a pod is found
 		}
 		contName := base.GetAppKubeNameWithPurge(aiconfig.DisplayName, aiconfig.UUIDandVersion.UUID, aiconfig.PurgeCmd.Counter+aiconfig.LocalPurgeCmd.Counter)
 
@@ -224,7 +226,11 @@ func (z *zedkube) checkAppsStatus() {
 					encAppStatus.ScheduledOnThisNode = true
 				}
 				if pod.Status.Phase == corev1.PodRunning {
-					encAppStatus.StatusRunning = true
+					encAppStatus.AppKubeStatus = types.AppKubeStatusRunningState
+				} else if encAppStatus.AppKubeStatus != types.AppKubeStatusRunningState {
+					// Pod found but not in PodRunning phase. Don't downgrade if
+					// a previous matching pod was already observed running.
+					encAppStatus.AppKubeStatus = types.AppKubeStatusNotRunningState
 				}
 				if foundVMIPod {
 					encAppStatus.AppIsVMI = true
@@ -261,11 +267,11 @@ func (z *zedkube) checkAppsStatus() {
 	}
 }
 
-func (z *zedkube) handleKubePodsGetError(items, stItems map[string]interface{}) {
+func (z *zedkube) handleKubeAPIError(items, stItems map[string]interface{}) {
 	if z.getKubePodsError.getKubePodsErrorTime.IsZero() {
 		now := time.Now()
 		z.getKubePodsError.getKubePodsErrorTime = now
-		log.Noticef("handleKubePodsGetError: can't get pods, set error time")
+		log.Noticef("handleKubeAPIError: kube API error, set error time")
 	} else if time.Since(z.getKubePodsError.getKubePodsErrorTime) > 2*time.Minute {
 		// The settings of kubernetes the node is 'NotReady' after unreachable for 1 minute,
 		// and the replicaSet policy for POD/VMI is after 30 seconds post the 'NotReady' node
@@ -277,13 +283,22 @@ func (z *zedkube) handleKubePodsGetError(items, stItems map[string]interface{}) 
 				for _, st := range stItems {
 					aiStatus := st.(types.ENClusterAppStatus)
 					if aiStatus.AppUUID == aiconfig.UUIDandVersion.UUID {
-						// if we used to publish the status, of this app is scheduled on this node
-						// need to reset this, since we have lost the connection to the kubernetes
-						// for longer time than the app is to be migrated to other node
+						// We have lost the connection to the kubernetes API for longer
+						// than the failover threshold. Mark APIUnreachable so consumers
+						// know not to trust ScheduledOnThisNode / a stale Running view,
+						// and clear those fields since we have no fresh evidence.
+						changed := false
+						if aiStatus.AppKubeStatus != types.AppKubeStatusAPIUnreachable {
+							aiStatus.AppKubeStatus = types.AppKubeStatusAPIUnreachable
+							changed = true
+						}
 						if aiStatus.ScheduledOnThisNode {
 							aiStatus.ScheduledOnThisNode = false
+							changed = true
+						}
+						if changed {
 							z.pubENClusterAppStatus.Publish(aiconfig.Key(), aiStatus)
-							log.Noticef("handleKubePodsGetError: can't get pods set ScheduledOnThisNode off for %s, ", aiconfig.DisplayName)
+							log.Noticef("handleKubeAPIError: marked %s APIUnreachable", aiconfig.DisplayName)
 						}
 					}
 				}

--- a/pkg/pillar/cmd/zedkube/failover.go
+++ b/pkg/pillar/cmd/zedkube/failover.go
@@ -109,7 +109,7 @@ func (z *zedkube) checkAppsFailover(wdFunc func()) {
 					encAppStatus.ScheduledOnThisNode = true
 				}
 				if pod.Status.Phase == corev1.PodRunning {
-					encAppStatus.StatusRunning = true
+					encAppStatus.AppKubeStatus = types.AppKubeStatusRunningState
 				}
 				if foundVMIPod {
 					encAppStatus.AppIsVMI = true
@@ -125,7 +125,7 @@ func (z *zedkube) checkAppsFailover(wdFunc func()) {
 		//
 		// If the app is running, nothing to do.
 		//
-		if (terminatingVirtLauncherPod == "") && encAppStatus.StatusRunning {
+		if (terminatingVirtLauncherPod == "") && encAppStatus.AppKubeStatus == types.AppKubeStatusRunningState {
 			// No need to failover
 			log.Functionf("aiDisplayName:%s aiUUID:%s no terminating virtLauncher and reporting status running",
 				aiconfig.DisplayName, aiconfig.UUIDandVersion.UUID)

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -780,17 +780,36 @@ func publishAppInstanceStatus(ctx *zedmanagerContext,
 		st, _ := sub.Get(key)
 		if st != nil {
 			clusterStatus := st.(types.ENClusterAppStatus)
-			// To avoid publishing the stats to controller by multiple nodes, we set this flag here
-			// and zedagent will not publish the stats to controller for this App.
-			if !clusterStatus.ScheduledOnThisNode {
-				log.Functionf("publishAppInstanceStatus(%s) not scheduled on this node, don't publish to controller", key)
-				status.NoUploadStatsToController = true
-			} else {
-				status.NoUploadStatsToController = false
+			// Report from this node only if:
+			//   1) the pod is scheduled on this node (running or pending here), OR
+			//   2) we are the DNID and the cluster authoritatively shows no pod
+			//      exists for this app anywhere - so no peer will report it.
+			// All other cases suppress: a peer owns it (running there, or merely
+			// scheduled there with a Pending pod), or we cannot see the cluster
+			// (APIUnreachable / Unknown) and must not assume the app is silent
+			// on every peer.
+			canReport := clusterStatus.ScheduledOnThisNode ||
+				(clusterStatus.IsDNidNode &&
+					clusterStatusAllowsDNIDUpload(clusterStatus))
+			status.NoUploadStatsToController = !canReport
+			if !canReport {
+				log.Functionf("publishAppInstanceStatus(%s) suppressed: IsDNidNode=%v ScheduledOnThisNode=%v AppKubeStatus=%v",
+					key, clusterStatus.IsDNidNode, clusterStatus.ScheduledOnThisNode, clusterStatus.AppKubeStatus)
 			}
 		}
+		// st == nil: leave flag at its prior value (defaults to false on a fresh
+		// AppInstanceStatus). Cold-start reporting goes through; a later ENClusterAppStatus
+		// update re-publishes AppInstanceStatus through handleENClusterAppStatusImpl.
 	}
 	pub.Publish(key, *status)
+}
+
+func clusterStatusAllowsDNIDUpload(clusterStatus types.ENClusterAppStatus) bool {
+	// NotRunningState is intentionally NOT admitted here: that state means a
+	// pod exists somewhere in the cluster, so the node it is scheduled on
+	// already owns reporting via rule (1) above. Admitting it would cause
+	// duplicate uploads during the peer-Pending window of a failover.
+	return clusterStatus.AppKubeStatus == types.AppKubeStatusNotInCluster
 }
 
 func unpublishAppInstanceStatus(ctx *zedmanagerContext,
@@ -1827,7 +1846,7 @@ func getKubeAppActivateStatus(ctx *zedmanagerContext, aiConfig types.AppInstance
 	for _, item := range items {
 		status := item.(types.ENClusterAppStatus)
 		if status.AppUUID == aiConfig.UUIDandVersion.UUID {
-			statusRunning = status.StatusRunning
+			statusRunning = status.AppKubeStatus == types.AppKubeStatusRunningState
 			if status.IsDNidNode {
 				onTheDevice = true
 				break

--- a/pkg/pillar/types/clustertypes.go
+++ b/pkg/pillar/types/clustertypes.go
@@ -93,15 +93,53 @@ type EdgeNodeClusterConfig struct {
 	LBInterfaces []LBInterfaceConfig
 }
 
+// AppKubeStatus represents this node's last view of an app's lifecycle in the
+// kubernetes cluster. Each value comes from a distinct branch in zedkube's
+// periodic poll. Consumers should treat any value other than
+// AppKubeStatusRunning as "no authoritative evidence the app is running on a
+// peer" and fail open accordingly.
+type AppKubeStatus uint8
+
+const (
+	// AppKubeStatusUnknown - never polled (cold start; zero value).
+	AppKubeStatusUnknown AppKubeStatus = iota
+	// AppKubeStatusAPIUnreachable - kube API not reachable past the grace window.
+	AppKubeStatusAPIUnreachable
+	// AppKubeStatusNotInCluster - API ok, no pod found for this app.
+	AppKubeStatusNotInCluster
+	// AppKubeStatusNotRunningState - pod found, kubernetes phase != PodRunning.
+	AppKubeStatusNotRunningState
+	// AppKubeStatusRunningState - pod found, kubernetes phase == PodRunning.
+	AppKubeStatusRunningState
+)
+
+// String returns a human-readable name for the AppKubeStatus.
+func (s AppKubeStatus) String() string {
+	switch s {
+	case AppKubeStatusUnknown:
+		return "Unknown"
+	case AppKubeStatusAPIUnreachable:
+		return "APIUnreachable"
+	case AppKubeStatusNotInCluster:
+		return "NotInCluster"
+	case AppKubeStatusNotRunningState:
+		return "NotRunningState"
+	case AppKubeStatusRunningState:
+		return "RunningState"
+	default:
+		return "Invalid"
+	}
+}
+
 // ENClusterAppStatus - Status of an App Instance in the multi-node cluster
 type ENClusterAppStatus struct {
-	AppUUID             uuid.UUID // UUID of the appinstance
-	IsDNidNode          bool      // DesignatedNodeID is set on the App for this node
-	ScheduledOnThisNode bool      // App is running on this device
-	StatusRunning       bool      // Status of the app in "Running" state
-	AppIsVMI            bool      // Is this a VMI app, vs a Pod app
-	VMIName             string    // Kube name of the VMI
-	VNCPort             uint32    // VNC port for the VMI (e.g., 5901)
+	AppUUID             uuid.UUID     // UUID of the appinstance
+	IsDNidNode          bool          // DesignatedNodeID is set on the App for this node
+	ScheduledOnThisNode bool          // Pod for this app is scheduled on this node
+	AppKubeStatus       AppKubeStatus // This node's view of the app's kube lifecycle
+	AppIsVMI            bool          // Is this a VMI app, vs a Pod app
+	VMIName             string        // Kube name of the VMI
+	VNCPort             uint32        // VNC port for the VMI (e.g., 5901)
 }
 
 // Equal returns true if all ENClusterAppStatus fields are equal


### PR DESCRIPTION

# Description

  - In eve-k cluster mode, an app that failed before kubernetes ever scheduled it (e.g. zedmanager rejected the DomainConfig due to a portmap collision) had its error silently dropped

  - Replace the StatusRunning bool on ENClusterAppStatus with an AppKubeStatus enum that captures what zedkube actually knows from its poll: Unknown / APIUnreachable / NotInCluster / NotRunningState / RunningState.
  - The reporting gate becomes two rules: 1) the pod is scheduled on this node (running or pending here), OR 2) we are the DNID and AppKubeStatus == NotInCluster (no pod anywhere, so no peer will report it).

## PR dependencies

## How to test and validate this PR

Configure the eve-k cluster mode, and applied apps w/ port-mapping.
then add another same add on the same network instance, it show show
why the 2nd app failed in the controller's UI for the app.

## Changelog notes

zedmanager: report app status from DNID when no pod in cluster

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
