### PR TITLE
kube: fix cluster-init stuck loop after basek3s conversion

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -352,9 +352,8 @@ external_boot_image_import() {
 
         boot_img_path="/etc/external-boot-image.tar"
 
-        # Is containerd up?
-        if ! /var/lib/k3s/bin/k3s ctr -a /run/containerd-user/containerd.sock info > /dev/null 2>&1; then
-                logmsg "k3s-containerd not yet running for image import"
+        if ! ctr_out=$(/var/lib/k3s/bin/k3s ctr -a /run/containerd-user/containerd.sock info 2>&1); then
+                logmsg "k3s-containerd management API not yet ready for image import: $ctr_out"
                 return 1
         fi
 
@@ -1261,6 +1260,11 @@ if ! is_amd64; then
         install_kubevirt=0
 fi
 
+# In basek3s cluster mode KubeVirt has been removed; skip external boot image import
+if [ -f /var/lib/base-k3s-mode ]; then
+        install_kubevirt=0
+fi
+
 #Forever loop every 15 secs
 while true;
 do
@@ -1454,7 +1458,7 @@ else
                         reapply_node_labels
                 fi
                 if ! external_boot_image_import; then
-                        continue
+                        logmsg "external_boot_image_import failed, will retry on next loop iteration"
                 fi
 
                 # Initialize CNI after k3s reboot


### PR DESCRIPTION

# Description

- When a node converts from single-node k3s to basek3s cluster mode, in some error case, The main loop then calls external_boot_image_import() indefinitely and can not reach the rest of the tasks in the loop

- Set install_kubevirt=0 when /var/lib/base-k3s-mode exists. KubeVirt has been removed; there is no boot image to import.
- Replace `ctr info` (containerd management API) with `crictl info` Also redirect the check output to $INSTALL_LOG instead of /dev/null so failures are diagnosable.
- On external_boot_image_import failure, log and fall through instead of calling continue.

## PR dependencies

## How to test and validate this PR

it's a corner case, it happened when converting from single node mode
into a basek3s cluster mode. even though the k3s is running, but the
looping stuck at the checking container image, and spit out massive messages.

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
