### PR TITLE
github/workflows: Add codecov to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -312,6 +312,49 @@ jobs:
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
 
+  coverage:
+    if: github.event.repository.full_name == 'lf-edge/eve'
+    runs-on: zededa-ubuntu-2204
+    steps:
+      - name: Clear repository
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Login to Docker Hub
+        run: |
+          docker login
+      - name: Test
+        run: |
+          make pkg/bpftrace
+          make ZARCH=arm64 pkg/bpftrace
+          make test
+      - name: Report test results as Annotations
+        if: ${{ always() }}
+        uses: guyarb/golang-test-annoations@96fc379b171c49932041d6c789e73331a7bdeec1  # v0.9.0
+        with:
+          test-results: dist/amd64/results.json
+      - name: Store raw test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: 'test-report'
+          path: ${{ github.workspace }}/dist
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Clean
+        if: ${{ always() }}
+        run: |
+          make clean || :
+          docker system prune -f -a || :
+          docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
+          rm -rf ~/.linuxkit || :
+
   trigger_assets:
     if: ${{ (startsWith(github.ref, 'refs/tags/')) && (github.event.repository.full_name == 'lf-edge/eve') }}
     needs: [manifest, eve]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,13 +72,12 @@ jobs:
         run: |
           SUCCESS=
           for i in 1 2 3; do
-            if make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=build pkgs; then
+            echo "Run attempt: $i"
+            if make -e V=1 HV="${{ matrix.hv }}" ZARCH="${{ matrix.arch }}" PLATFORM="${{ matrix.platform }}" LINUXKIT_PKG_TARGET=build pkgs; then
               SUCCESS=true
               break
             else
-              docker rmi -f $(docker image ls -q) || :
-              docker system prune -f -a || :
-              docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
+              docker system prune -f -a --volumes
             fi
           done
           if [ -z "$SUCCESS" ]; then echo "::error::failed to build packages" && exit 1; fi
@@ -92,13 +91,12 @@ jobs:
         run: |
           SUCCESS=
           for i in 1 2 3; do
-            if make -e V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
+            echo "Run attempt: $i"
+            if make -e V=1 HV="${{ matrix.hv }}" ZARCH="${{ matrix.arch }}" PLATFORM="${{ matrix.platform }}" LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
               SUCCESS=true
               break
             else
-              docker rmi -f $(docker image ls -q) || :
-              docker system prune -f -a || :
-              docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
+              docker system prune -f -a --volumes
             fi
           done
           if [ -z "$SUCCESS" ]; then echo "::error::failed to push packages" && exit 1; fi
@@ -113,10 +111,9 @@ jobs:
       - name: Clean
         if: ${{ always() }}
         run: |
-          make clean || :
-          docker system prune -f -a || :
-          docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
-          rm -rf ~/.linuxkit || :
+          make clean
+          docker system prune -f -a --volumes
+          rm -rf ~/.linuxkit
 
   # 2) ARM packages, serialized
   packages-arm:
@@ -182,17 +179,12 @@ jobs:
           # sadly, our build sometimes times out on network access
           # and running out of disk space: re-trying for 3 times
           for i in 1 2 3; do
-             if make -e V=1 ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=build pkgs; then
+             echo "Run attempt: $i"
+             if make -e V=1 ZARCH="${{ matrix.arch }}" PLATFORM="${{ matrix.platform }}" LINUXKIT_PKG_TARGET=build pkgs; then
                 SUCCESS=true
                 break
              else
-                # the most likely reason for 'make pkgs' to fail is
-                # the docker cache produced by the build exhausting
-                # disk space. So the following can't hurt before we
-                # retry:
-                docker rmi -f `docker image ls -q` || :
-                docker system prune -f -a || :
-                docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
+                docker system prune -f -a --volumes
              fi
           done
           if [ -z "$SUCCESS" ]; then echo "::error::failed to build packages" && exit 1; fi
@@ -208,17 +200,12 @@ jobs:
           # sadly, our build sometimes times out on network access
           # and running out of disk space: re-trying for 3 times
           for i in 1 2 3; do
-             if make -e V=1 ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push pkgs; then
+             echo "Run attempt: $i"
+             if make -e V=1 ZARCH="${{ matrix.arch }}" PLATFORM="${{ matrix.platform }}" LINUXKIT_PKG_TARGET=push pkgs; then
                 SUCCESS=true
                 break
              else
-                # the most likely reason for 'make pkgs' to fail is
-                # the docker cache produced by the build exhausting
-                # disk space. So the following can't hurt before we
-                # retry:
-                docker rmi -f `docker image ls -q` || :
-                docker system prune -f -a || :
-                docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
+                docker system prune -f -a --volumes
              fi
           done
           if [ -z "$SUCCESS" ]; then echo "::error::failed to push packages" && exit 1; fi
@@ -233,10 +220,9 @@ jobs:
       - name: Clean
         if: ${{ always() }}
         run: |
-          make clean || :
-          docker system prune -f -a || :
-          docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
-          rm -rf ~/.linuxkit || :
+          make clean
+          docker system prune -f -a --volumes
+          rm -rf ~/.linuxkit
 
   # 3) downstream jobs depend on both package jobs
   eve:
@@ -293,10 +279,9 @@ jobs:
       - name: Clean
         if: ${{ always() }}
         run: |
-          make clean || :
-          docker system prune -f -a || :
-          docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
-          rm -rf ~/.linuxkit || :
+          make clean
+          docker system prune -f -a --volumes
+          rm -rf ~/.linuxkit
 
   manifest:
     if: github.event.repository.full_name == 'lf-edge/eve'
@@ -350,10 +335,9 @@ jobs:
       - name: Clean
         if: ${{ always() }}
         run: |
-          make clean || :
-          docker system prune -f -a || :
-          docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
-          rm -rf ~/.linuxkit || :
+          make clean
+          docker system prune -f -a --volumes
+          rm -rf ~/.linuxkit
 
   trigger_assets:
     if: ${{ (startsWith(github.ref, 'refs/tags/')) && (github.event.repository.full_name == 'lf-edge/eve') }}


### PR DESCRIPTION
# Description

Codecov action on go-tests doesn't upload results since a token is required. As a consequence, the action will not have updated results to compare. This commit introduces the codecov in the publish workflow. It will run go-tests and upload the results with the token provided in the repository secrets. Thus, the codecov from regular go-tests will be able to fetch updated results.

Partially tested on: https://github.com/rene/eve/actions/runs/24932456960/job/73012348318#step:9:1

## How to test and validate this PR

Run publish workflow.

## Changelog notes

None.

## PR Backports

- [x] 16.0-stable https://github.com/lf-edge/eve/pull/6411
- [ ] 14.5-stable
- [ ] 13.4-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.