### PR TITLE
Enable auto compact of etcd database

### DIFF
--- a/pkg/kube/config.yaml
+++ b/pkg/kube/config.yaml
@@ -8,6 +8,9 @@ egress-selector-mode: "disabled"
 default-local-storage-path: "/persist/vault/volumes"
 etcd-arg:
   - "quota-backend-bytes=8589934592"
+  - "auto-compaction-mode=periodic"
+  - "auto-compaction-retention=1h"    # was 8h default; 1h suits edge clusters
+  - "snapshot-count=5000"             # raft snapshot every 5000 entries (default 100000)
 etcd-expose-metrics: true
 container-runtime-endpoint: "/run/containerd-user/containerd.sock"
 disable-network-policy: true


### PR DESCRIPTION
We need to enable auto compact the etcd database periodically. Setting it to 1h so that k3s stays stable and does not bounce or wait for etcd database to be available on devices with slower disks.  Also changing snapshots to keep to 5K from default 10K. So that we quickly sync the changes.



## How to test and validate this PR

Create 3 node eve-k cluster and watch the etcd database auto compaction in k3s.log
something like this one every hour.

{"level":"info","ts":"2024-03-15T02:00:00.123456Z","caller":"etcdserver/server.go:1322","msg":"starting auto compaction","mode":"periodic","period":"1h0m0s"}
{"level":"info","ts":"2024-03-15T02:00:00.134567Z","caller":"mvcc/index.go:214","msg":"compact hash index","revision":18423}
{"level":"info","ts":"2024-03-15T02:00:00.198234Z","caller":"mvcc/kvstore_compaction.go:66","msg":"finished scheduled compaction","compact-revision":18423,"took":"63.812ms"}


Snapshot sync in k3s.log

{"level":"info","ts":"2024-03-15T03:15:22.112345Z","caller":"etcdserver/server.go:1229","msg":"triggering snapshot","local-member-id":"8e9e05c52164694d","local-member-raft-applied-index":5000,"snapshot-count":5000}
{"level":"info","ts":"2024-03-15T03:15:22.234567Z","caller":"mvcc/kvstore.go:423","msg":"creating snapshot","snapshot-index":5000,"snapshot-size-byte":3354112}
{"level":"info","ts":"2024-03-15T03:15:22.445678Z","caller":"snap/snapshotter.go:66","msg":"saved snapshot","snapshot-index":5000,"snapshot-size-byte":3354112,"took":"211.311ms"}
{"level":"info","ts":"2024-03-15T03:15:22.447890Z","caller":"etcdserver/server.go:1243","msg":"saved snapshot","snapshot-index":5000}
{"level":"info","ts":"2024-03-15T03:15:22.449012Z","caller":"etcdserver/server.go:1256","msg":"compacted raft logs","local-member-id":"8e9e05c52164694d","log-index":4750}
{"level":"info","ts":"2024-03-15T03:15:22.451234Z","caller":"etcdserver/server.go:1261","msg":"removed old snapshot file","local-member-id":"8e9e05c52164694d","old-snapshot-file":"db-0000000000000001"}
## Changelog notes


## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
