### PR TITLE
Fix the removal of edgeview singing cert file

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseedgeview.go
+++ b/pkg/pillar/cmd/zedagent/parseedgeview.go
@@ -295,4 +295,9 @@ func removeEvFiles() {
 	if err == nil {
 		os.Remove(types.EdgeviewCfgFile)
 	}
+
+	_, err = os.Stat(types.EdgeviewSigningCertFile)
+	if err == nil {
+		os.Remove(types.EdgeviewSigningCertFile)
+	}
 }


### PR DESCRIPTION

# Description

- make sure we remove the edgeview signing cert after the edgeview session is disabled

## PR dependencies

## How to test and validate this PR

after disabled Edgeview from the controller, make sure on the device
the '/run/edgeview' directory has no files left

## Changelog notes

Fix the removal of edgeview singing cert file

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
