### PR TITLE
zedkube/edgeview: fix stale vmiVNC.run blocking new VNC sessions

### DIFF
--- a/pkg/edgeview/src/edge-view.go
+++ b/pkg/edgeview/src/edge-view.go
@@ -92,6 +92,8 @@ func main() {
 	setupRegexp()
 
 	if runOnServer {
+		removeStaleVNCFile(false)
+
 		values := flag.Args()
 		for _, cmd := range values {
 			if cmd == "techsupport" {

--- a/pkg/edgeview/src/network.go
+++ b/pkg/edgeview/src/network.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/grandcat/zeroconf"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils/netutils"
 	snet "github.com/shirou/gopsutil/net"
 	"github.com/tatsushid/go-fastping"
 	"github.com/vishvananda/netlink"
@@ -583,9 +584,10 @@ func setupEveKVNC(appUUID string) (uint32, error) {
 	}
 	log.Noticef("setupEveKVNC: starting for app %s", appUUID)
 
-	// Check if file already exists (another VNC session is active)
-	if _, err := os.Stat(types.VmiVNCFileName); err == nil {
-		return 0, errors.New("VNC file already exists, another VNC session may be active")
+	if _, err := os.Stat(vncFilePath); err == nil {
+		if !removeStaleVNCFile(true) {
+			return 0, errors.New("VNC session already active")
+		}
 	}
 
 	// Verify appUUID is a valid UUID
@@ -642,6 +644,7 @@ func setupEveKVNC(appUUID string) (uint32, error) {
 	vncConfig := types.VmiVNCConfig{
 		VMIName:   encAppStatus.VMIName,
 		VNCPort:   encAppStatus.VNCPort,
+		AppUUID:   appUUID,
 		CallerPID: os.Getpid(),
 	}
 
@@ -650,20 +653,37 @@ func setupEveKVNC(appUUID string) (uint32, error) {
 		return 0, fmt.Errorf("failed to marshal VNC config: %v", err)
 	}
 
-	if err := os.WriteFile(types.VmiVNCFileName, content, 0644); err != nil {
+	if err := os.WriteFile(vncFilePath, content, 0644); err != nil {
 		return 0, fmt.Errorf("failed to write vmiVNC.run: %v", err)
 	}
 
 	log.Noticef("setupEveKVNC: wrote vmiVNC.run for VMI %s, port %d",
 		encAppStatus.VMIName, encAppStatus.VNCPort)
 
+	// Race detection: re-read to check whether a concurrent zedkube remote-console
+	// write overwrote our file between removeStaleVNCFile and WriteFile.
+	if rb, rerr := os.ReadFile(vncFilePath); rerr == nil {
+		var rbCfg types.VmiVNCConfig
+		if json.Unmarshal(rb, &rbCfg) == nil && rbCfg.CallerPID != vncConfig.CallerPID {
+			log.Errorf("setupEveKVNC: race detected — vmiVNC.run overwritten by concurrent remote-console request (CallerPID in file: %d, ours: %d); sessions may interfere",
+				rbCfg.CallerPID, vncConfig.CallerPID)
+		}
+	}
+
 	return encAppStatus.VNCPort, nil
 }
 
 // cleanupEveKVNC removes the vmiVNC.run file and notifies dispatcher that VNC session ended
 func cleanupEveKVNC() {
-	if _, err := os.Stat(types.VmiVNCFileName); err == nil {
-		if err := os.Remove(types.VmiVNCFileName); err != nil {
+	data, err := os.ReadFile(vncFilePath)
+	if err == nil {
+		var cfg types.VmiVNCConfig
+		if json.Unmarshal(data, &cfg) == nil && cfg.CallerPID != os.Getpid() {
+			// File was taken over by a newer session after our virtctl proxy was
+			// evicted — do not remove it.
+			log.Noticef("cleanupEveKVNC: file owned by pid %d (ours %d), skipping removal",
+				cfg.CallerPID, os.Getpid())
+		} else if err := os.Remove(vncFilePath); err != nil {
 			log.Errorf("cleanupEveKVNC: failed to remove vmiVNC.run: %v", err)
 		} else {
 			log.Noticef("cleanupEveKVNC: removed VNC port file")
@@ -691,18 +711,75 @@ func waitForVirtctlVNC(timeout time.Duration, vncPort int) bool {
 	return false
 }
 
-// isPortListening checks if a specific port is listening using 'ss' command
-func isPortListening(port int) bool {
-	prog := "ss"
-	args := []string{"-tln", fmt.Sprintf("sport = :%d", port)}
-	output, err := runCmd(prog, args, false)
+// isPortListening reports whether anything is bound and listening on port.
+// It is a var so tests can swap the implementation for canned responses.
+// The default delegates to netutils.IsLocalPortListening which reads
+// /proc/net/tcp[6] directly — no Dial, so a live virtctl VNC proxy is safe.
+var isPortListening = func(port int) bool {
+	return netutils.IsLocalPortListening(uint32(port))
+}
+
+// Injection seams for tests. vncFilePath points at the unified config file
+// and ownerAlive wraps VmiVNCConfig.OwnerAlive so tests can swap it.
+var (
+	vncFilePath = types.VmiVNCFileName
+	ownerAlive  = func(c types.VmiVNCConfig) bool { return c.OwnerAlive() }
+)
+
+// removeStaleVNCFile checks vmiVNC.run and removes it if no live session backs it.
+// Returns true if the caller can proceed (file absent, stale and removed).
+// Returns false if an active session owns the file (caller should block).
+//
+// evictIdleRemoteConsole controls remote-console handling (CallerPID unset):
+//   - true  (request path): remove the file unless the virtctl proxy is
+//     actually listening on VNCPort.
+//   - false (startup):      never touch remote-console files.
+//
+// Liveness is keyed off the listener, not AppInstanceConfig.RemoteConsole.
+// The config flag reflects the user's intent; the listener reflects what is
+// actually running, which is what determines whether we'd disrupt a session.
+func removeStaleVNCFile(evictIdleRemoteConsole bool) bool {
+	data, err := os.ReadFile(vncFilePath)
 	if err != nil {
-		return false
+		return true // file absent
 	}
-	// ss output will contain the port if it's listening
-	// e.g., "LISTEN  0  128  *:5900  *:*"
-	portStr := fmt.Sprintf(":%d", port)
-	return strings.Contains(output, portStr)
+	var existing types.VmiVNCConfig
+	if json.Unmarshal(data, &existing) != nil || existing.VNCPort == 0 {
+		log.Noticef("removeStaleVNCFile: unreadable VNC file, removing")
+		os.Remove(vncFilePath)
+		return true
+	}
+	if existing.CallerPID > 0 {
+		if ownerAlive(existing) {
+			if isPortListening(int(existing.VNCPort)) {
+				return false // live edgeview session with active virtctl proxy
+			}
+			// edgeview PID is alive but the virtctl port is gone — the proxy
+			// crashed. Treat the file as stale so the new request can proceed.
+			// Note: there is a short startup window between file creation and
+			// virtctl binding the port where this eviction would be premature;
+			// that window is accepted as an unlikely edge case.
+			log.Noticef("removeStaleVNCFile: edgeview pid %d alive but VNC port %d not listening, removing stale file",
+				existing.CallerPID, existing.VNCPort)
+			os.Remove(vncFilePath)
+			return true
+		}
+		log.Noticef("removeStaleVNCFile: stale edgeview VNC file (pid %d dead or reused), removing",
+			existing.CallerPID)
+		os.Remove(vncFilePath)
+		return true
+	}
+	// No CallerPID — remote-console file owned by zedkube
+	if !evictIdleRemoteConsole {
+		return true // startup: not our file to judge
+	}
+	if isPortListening(int(existing.VNCPort)) {
+		return false // virtctl proxy is live
+	}
+	log.Noticef("removeStaleVNCFile: stale remote-console VNC file (port %d not listening), removing",
+		existing.VNCPort)
+	os.Remove(vncFilePath)
+	return true
 }
 
 // getConnectivity

--- a/pkg/edgeview/src/vnc_test.go
+++ b/pkg/edgeview/src/vnc_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/sirupsen/logrus"
+)
+
+// ensureTestLog initializes the package-level log so removeStaleVNCFile's
+// Noticef calls don't nil-deref. Safe to call multiple times.
+func ensureTestLog() {
+	if log != nil {
+		return
+	}
+	lg := logrus.StandardLogger()
+	lg.SetLevel(logrus.PanicLevel)
+	log = base.NewSourceLogObject(lg, "edgeview-test", os.Getpid())
+}
+
+// setupVNCTestFile writes cfg to a tmp file (or a raw string) and points
+// vncFilePath at it. Returns the path.
+func setupVNCTestFile(t *testing.T, cfg *types.VmiVNCConfig, raw string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "vmiVNC.run")
+	switch {
+	case raw != "":
+		if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+			t.Fatalf("write raw: %v", err)
+		}
+	case cfg != nil:
+		data, err := json.Marshal(cfg)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(path, data, 0644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	orig := vncFilePath
+	vncFilePath = path
+	t.Cleanup(func() { vncFilePath = orig })
+	return path
+}
+
+// swapEdgeviewStubs swaps ownerAlive and isPortListening with canned replies.
+func swapEdgeviewStubs(t *testing.T, alive, listening bool) {
+	t.Helper()
+	origAlive := ownerAlive
+	origPort := isPortListening
+	ownerAlive = func(types.VmiVNCConfig) bool { return alive }
+	isPortListening = func(int) bool { return listening }
+	t.Cleanup(func() {
+		ownerAlive = origAlive
+		isPortListening = origPort
+	})
+}
+
+func TestRemoveStaleVNCFile(t *testing.T) {
+	ensureTestLog()
+
+	cases := []struct {
+		name       string
+		existing   *types.VmiVNCConfig
+		raw        string
+		evictIdle  bool
+		ownerAlive bool
+		listening  bool
+		wantOK     bool // canonical return value (can caller proceed)
+		wantFile   bool // file remains after the call
+	}{
+		{
+			name:      "no file - proceed",
+			evictIdle: true,
+			wantOK:    true,
+			wantFile:  false,
+		},
+		{
+			name:      "unparsable file removed",
+			raw:       "garbage",
+			evictIdle: true,
+			wantOK:    true,
+			wantFile:  false,
+		},
+		{
+			name:      "missing VNCPort treated as unreadable",
+			existing:  &types.VmiVNCConfig{VMIName: "vmi", CallerPID: 10},
+			evictIdle: true,
+			wantOK:    true,
+			wantFile:  false,
+		},
+		{
+			name:       "live edgeview blocks",
+			existing:   &types.VmiVNCConfig{VMIName: "vmi", VNCPort: 5910, CallerPID: 10},
+			evictIdle:  true,
+			ownerAlive: true,
+			listening:  true,
+			wantOK:     false,
+			wantFile:   true,
+		},
+		{
+			name:       "live edgeview pid alive but port idle is evicted",
+			existing:   &types.VmiVNCConfig{VMIName: "vmi", VNCPort: 5910, CallerPID: 10},
+			evictIdle:  true,
+			ownerAlive: true,
+			listening:  false,
+			wantOK:     true,
+			wantFile:   false,
+		},
+		{
+			name:      "dead edgeview evicted",
+			existing:  &types.VmiVNCConfig{VMIName: "vmi", VNCPort: 5910, CallerPID: 10},
+			evictIdle: true,
+			wantOK:    true,
+			wantFile:  false,
+		},
+		{
+			name:      "startup leaves remote-console file alone",
+			existing:  &types.VmiVNCConfig{VMIName: "vmi", VNCPort: 5910, AppUUID: "app"},
+			evictIdle: false, // startup mode
+			listening: false, // shouldn't even be consulted
+			wantOK:    true,
+			wantFile:  true,
+		},
+		{
+			name:      "request path blocked by live remote-console",
+			existing:  &types.VmiVNCConfig{VMIName: "vmi", VNCPort: 5910, AppUUID: "app"},
+			evictIdle: true,
+			listening: true,
+			wantOK:    false,
+			wantFile:  true,
+		},
+		{
+			name:      "request path evicts idle remote-console",
+			existing:  &types.VmiVNCConfig{VMIName: "vmi", VNCPort: 5910, AppUUID: "app"},
+			evictIdle: true,
+			listening: false,
+			wantOK:    true,
+			wantFile:  false,
+		},
+		{
+			// evictIdle is only consulted on the CallerPID==0 branch; a live
+			// edgeview file must always block and be kept, regardless of mode.
+			name:       "live edgeview blocks even at startup",
+			existing:   &types.VmiVNCConfig{VMIName: "vmi", VNCPort: 5910, CallerPID: 10},
+			evictIdle:  false,
+			ownerAlive: true,
+			listening:  true,
+			wantOK:     false,
+			wantFile:   true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := setupVNCTestFile(t, tc.existing, tc.raw)
+			swapEdgeviewStubs(t, tc.ownerAlive, tc.listening)
+
+			got := removeStaleVNCFile(tc.evictIdle)
+			if got != tc.wantOK {
+				t.Errorf("removeStaleVNCFile(%v) = %v, want %v", tc.evictIdle, got, tc.wantOK)
+			}
+			_, err := os.Stat(path)
+			fileRemains := err == nil
+			if fileRemains != tc.wantFile {
+				t.Errorf("file present = %v, want %v", fileRemains, tc.wantFile)
+			}
+		})
+	}
+}

--- a/pkg/edgeview/vendor/github.com/lf-edge/eve/pkg/pillar/types/clustertypes.go
+++ b/pkg/edgeview/vendor/github.com/lf-edge/eve/pkg/pillar/types/clustertypes.go
@@ -4,7 +4,10 @@
 package types
 
 import (
+	"fmt"
 	"net"
+	"os"
+	"strings"
 	"time"
 
 	uuid "github.com/satori/go.uuid"
@@ -216,5 +219,23 @@ type KubeLeaderElectInfo struct {
 type VmiVNCConfig struct {
 	VMIName   string `json:"VMIName"`
 	VNCPort   uint32 `json:"VNCPort"`
-	CallerPID int    `json:"CallerPID,omitempty"` // Set by edgeview to allow cleanup when it exits
+	AppUUID   string `json:"AppUUID,omitempty"`   // UUID of the app owning this session
+	CallerPID int    `json:"CallerPID,omitempty"` // Set by edgeview; absent for remote-console
+}
+
+// procPath is the root of the proc filesystem. Overridden in tests.
+var procPath = "/proc"
+
+// OwnerAlive reports whether CallerPID refers to a live edge-view process.
+// Returns false when CallerPID is unset (remote-console file), when the PID
+// is dead, or when the PID has been reused by a different program.
+func (c VmiVNCConfig) OwnerAlive() bool {
+	if c.CallerPID <= 0 {
+		return false
+	}
+	comm, err := os.ReadFile(fmt.Sprintf("%s/%d/comm", procPath, c.CallerPID))
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(comm)) == "edge-view"
 }

--- a/pkg/edgeview/vendor/github.com/lf-edge/eve/pkg/pillar/utils/netutils/portlisten.go
+++ b/pkg/edgeview/vendor/github.com/lf-edge/eve/pkg/pillar/utils/netutils/portlisten.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package netutils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// IsLocalPortListening reports whether a process is bound and listening on
+// port on localhost. It reads /proc/net/tcp[6] directly — no TCP connection
+// is made, so a live virtctl VNC proxy on that port is not disturbed.
+func IsLocalPortListening(port uint32) bool {
+	hexPort := fmt.Sprintf("%04X", port)
+	for _, f := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			continue
+		}
+		lines := strings.Split(string(data), "\n")
+		for _, line := range lines[1:] { // skip header
+			fields := strings.Fields(line)
+			if len(fields) < 4 {
+				continue
+			}
+			// fields[1] = local_address "XXXXXXXX:PPPP", fields[3] = state ("0A" = LISTEN)
+			parts := strings.SplitN(fields[1], ":", 2)
+			if len(parts) == 2 && parts[1] == hexPort && fields[3] == "0A" {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/kube/vnc-proxy.sh
+++ b/pkg/kube/vnc-proxy.sh
@@ -36,6 +36,13 @@ handle_vnc() {
             return 1
         fi
 
+        # Start PID monitor immediately if CallerPID is present (edgeview VNC).
+        # Starting here (before virtctl retry loop) ensures the monitor runs even
+        # when virtctl fails to start, so a crashed edgeview doesn't leave a stale file.
+        if [ -n "$callerPid" ]; then
+            monitor_caller_pid "$callerPid" &
+        fi
+
         # Log file uses shell PID for unique naming per session
         local virtctl_log="/tmp/virtctl-vnc.$$"
 
@@ -44,11 +51,32 @@ handle_vnc() {
         local attempt=1
 
         while [ $attempt -le $max_retries ]; do
+            # If monitor_caller_pid (or edgeview itself) removed the config file,
+            # the session is over — don't launch another virtctl on top of it.
+            if [ ! -f "$VNC_CONFIG_FILE" ]; then
+                logmsg "handle_vnc: VNC config file disappeared, aborting retry"
+                local orphan
+                orphan=$(pgrep -f "/usr/bin/virtctl.*vnc.*$vmiName.*--proxy-only")
+                if [ -n "$orphan" ]; then
+                    logmsg "handle_vnc: killing orphan virtctl PID $orphan"
+                    kill -9 "$orphan" 2>/dev/null
+                fi
+                VNC_RUNNING=false
+                return 1
+            fi
+
             # Check if a virtctl process is already running for this VMI
             local existing_pid
             existing_pid=$(pgrep -f "/usr/bin/virtctl.*vnc.*$vmiName.*--proxy-only")
 
             if [ -z "$existing_pid" ]; then
+                # Tight recheck right before launch — closes the pgrep→nohup
+                # window where monitor_caller_pid could remove the file.
+                if [ ! -f "$VNC_CONFIG_FILE" ]; then
+                    logmsg "handle_vnc: VNC config file disappeared just before launch, aborting"
+                    VNC_RUNNING=false
+                    return 1
+                fi
                 # No existing process - start a new one
                 logmsg "handle_vnc: Attempt $attempt/$max_retries: Starting virtctl vnc for $vmiName on port $vmiPort"
 
@@ -68,14 +96,19 @@ handle_vnc() {
             local port_wait=0
             local max_port_wait=5
             while [ $port_wait -lt $max_port_wait ]; do
+                # Same race: caller may have died and the monitor removed the
+                # file while we were waiting for the port. Kill virtctl and bail.
+                if [ ! -f "$VNC_CONFIG_FILE" ]; then
+                    logmsg "handle_vnc: VNC config file removed during port wait, killing virtctl PID $existing_pid"
+                    kill -9 "$existing_pid" 2>/dev/null
+                    VNC_RUNNING=false
+                    return 1
+                fi
+
                 # Check if port is listening
                 if ss -tln "sport = :$vmiPort" | grep -q ":$vmiPort"; then
                     logmsg "handle_vnc: Success: port $vmiPort is now listening (PID: $existing_pid)"
                     VNC_RUNNING=true
-                    # Start monitoring the caller PID if present (edgeview VNC)
-                    if [ -n "$callerPid" ]; then
-                        monitor_caller_pid "$callerPid" &
-                    fi
                     return 0
                 fi
 
@@ -104,6 +137,14 @@ handle_vnc() {
         logmsg "handle_vnc: Error: Failed to start virtctl vnc for $vmiName after $max_retries attempts"
         VNC_RUNNING=false
         return 1
+
+    elif [ -f "$VNC_CONFIG_FILE" ] && [ "$VNC_RUNNING" = true ] && [ -n "$virtctl_pid" ]; then
+        # File was rewritten while a VNC session is already active.
+        # This is the signature of a race between a Remote Console and an
+        # Edgeview VNC request — both passed their stale-file checks before
+        # either wrote the file.  Only one virtctl proxy is running; cleanup
+        # is now tied to whichever caller removes the file first.
+        logmsg "handle_vnc: WARNING: vmiVNC.run rewritten while VNC session already active (virtctl PID $virtctl_pid) — possible concurrent Remote Console and Edgeview VNC request; sessions are entangled"
 
     elif [ ! -f "$VNC_CONFIG_FILE" ] && [ "$VNC_RUNNING" = true ]; then
         # File removed (detected by inotifywait) - stop virtctl vnc
@@ -138,9 +179,34 @@ monitor_caller_pid() {
     while true; do
         sleep $check_interval
 
+        # Check if the VNC file was removed (normal cleanup by edgeview)
+        if [ ! -f "$VNC_CONFIG_FILE" ]; then
+            logmsg "monitor_caller_pid: VNC file removed, stopping monitor"
+            return 0
+        fi
+
+        # Guard against PID reuse: if the CallerPID in the file changed, a new
+        # edgeview session replaced this one. Exit so the new session's monitor
+        # handles cleanup and we don't interfere.
+        local current_pid
+        current_pid=$(jq -r '.CallerPID // empty' "$VNC_CONFIG_FILE" 2>/dev/null)
+        if [ -n "$current_pid" ] && [ "$current_pid" != "$caller_pid" ]; then
+            logmsg "monitor_caller_pid: CallerPID in file changed ($caller_pid -> $current_pid), stopping stale monitor"
+            return 0
+        fi
+
         # Check if caller process (edgeview) crashed
         if ! kill -0 "$caller_pid" 2>/dev/null; then
             logmsg "monitor_caller_pid: Caller PID $caller_pid is gone (crashed?), cleaning up"
+
+            # Re-check CallerPID in the file before acting, in case a new edgeview
+            # session with a different PID replaced this one after the kill -0 check.
+            local file_pid
+            file_pid=$(jq -r '.CallerPID // empty' "$VNC_CONFIG_FILE" 2>/dev/null)
+            if [ -n "$file_pid" ] && [ "$file_pid" != "$caller_pid" ]; then
+                logmsg "monitor_caller_pid: File CallerPID changed on crash check, not cleaning up"
+                return 0
+            fi
 
             # Stop virtctl vnc process
             local virtctl_pid
@@ -156,13 +222,6 @@ monitor_caller_pid() {
                 rm -f "$VNC_CONFIG_FILE"
             fi
 
-            VNC_RUNNING=false
-            return 0
-        fi
-
-        # Check if the VNC file was removed (normal cleanup by edgeview)
-        if [ ! -f "$VNC_CONFIG_FILE" ]; then
-            logmsg "monitor_caller_pid: VNC file removed, stopping monitor"
             return 0
         fi
     done

--- a/pkg/pillar/cmd/zedkube/vnc.go
+++ b/pkg/pillar/cmd/zedkube/vnc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils/netutils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"kubevirt.io/client-go/kubecli"
 )
@@ -46,10 +47,10 @@ func (z *zedkube) runAppVNC(config *types.AppInstanceConfig) {
 
 	vncPort := vmconfig.VncDisplay + 5900
 
+	appUUID := config.UUIDandVersion.UUID.String()
 	if config.RemoteConsole {
-		// Check if file already exists (another VNC session is active)
-		if _, err := os.Stat(types.VmiVNCFileName); err == nil {
-			log.Errorf("runAppVNC: VNC file already exists, another session may be active")
+		// Block only on an active session; reclaim the file otherwise.
+		if !canClaimVNCFile(appUUID) {
 			return
 		}
 
@@ -63,6 +64,7 @@ func (z *zedkube) runAppVNC(config *types.AppInstanceConfig) {
 		vncConfig := types.VmiVNCConfig{
 			VMIName: vmiName,
 			VNCPort: uint32(vncPort),
+			AppUUID: appUUID,
 			// CallerPID is not set for remote-console VNC (only edgeview sets it)
 		}
 
@@ -79,6 +81,15 @@ func (z *zedkube) runAppVNC(config *types.AppInstanceConfig) {
 		}
 		log.Noticef("runAppVNC: vmiName %s, port %d, vmiVNC file %s created",
 			vmiName, vncPort, types.VmiVNCFileName)
+		// Race detection: re-read to check whether an edgeview VNC request
+		// overwrote our file in the window between canClaimVNCFile and WriteFile.
+		if rb, rerr := os.ReadFile(types.VmiVNCFileName); rerr == nil {
+			var rbCfg types.VmiVNCConfig
+			if json.Unmarshal(rb, &rbCfg) == nil && rbCfg.CallerPID != 0 {
+				log.Errorf("runAppVNC: race detected — vmiVNC.run overwritten by concurrent edgeview VNC (CallerPID=%d); sessions may interfere",
+					rbCfg.CallerPID)
+			}
+		}
 	} else {
 		if _, err := os.Stat(types.VmiVNCFileName); err == nil {
 			log.Noticef("runAppVNC: RemoteConsole disabled, removing VNC file %s", types.VmiVNCFileName)
@@ -90,6 +101,67 @@ func (z *zedkube) runAppVNC(config *types.AppInstanceConfig) {
 		}
 	}
 	log.Noticef("runAppVNC: %s done", vmiName)
+}
+
+// canClaimVNCFile returns true if the current vmiVNC.run (if any) is safe to
+// overwrite for remote-console of appUUID. It blocks only on a session that is
+// currently live: an active edgeview instance, or a different app's
+// remote-console whose virtctl proxy is still listening. A stale file from a
+// dead edgeview or an earlier zedkube incarnation is removed so the caller can
+// proceed.
+func canClaimVNCFile(appUUID string) bool {
+	data, err := os.ReadFile(types.VmiVNCFileName)
+	if err != nil {
+		return true // absent or unreadable via Stat path upstream
+	}
+	var existing types.VmiVNCConfig
+	if err := json.Unmarshal(data, &existing); err != nil || existing.VNCPort == 0 {
+		log.Noticef("canClaimVNCFile: unreadable VNC file, removing")
+		os.Remove(types.VmiVNCFileName)
+		return true
+	}
+	if existing.CallerPID > 0 {
+		if existing.OwnerAlive() {
+			if isPortListening(existing.VNCPort) {
+				log.Errorf("canClaimVNCFile: active edgeview VNC session (pid %d), cannot start remote-console",
+					existing.CallerPID)
+				return false
+			}
+			// edgeview PID is alive but the virtctl port is gone — proxy
+			// crashed. Treat the file as stale so this request can proceed.
+			log.Noticef("canClaimVNCFile: edgeview pid %d alive but VNC port %d not listening, removing stale file",
+				existing.CallerPID, existing.VNCPort)
+			os.Remove(types.VmiVNCFileName)
+			return true
+		}
+		log.Noticef("canClaimVNCFile: removing stale edgeview VNC file (pid %d dead or reused)",
+			existing.CallerPID)
+		os.Remove(types.VmiVNCFileName)
+		return true
+	}
+	// CallerPID unset: zedkube-owned remote-console file.
+	if existing.AppUUID == appUUID {
+		log.Noticef("canClaimVNCFile: reclaiming own VNC file for app %s", appUUID)
+		os.Remove(types.VmiVNCFileName)
+		return true
+	}
+	if isPortListening(existing.VNCPort) {
+		log.Errorf("canClaimVNCFile: remote-console already active for app %s, cannot start for %s",
+			existing.AppUUID, appUUID)
+		return false
+	}
+	log.Noticef("canClaimVNCFile: removing stale remote-console VNC file for app %s",
+		existing.AppUUID)
+	os.Remove(types.VmiVNCFileName)
+	return true
+}
+
+// isPortListening reports whether something is bound and listening on port on
+// localhost. Delegates to netutils.IsLocalPortListening which reads
+// /proc/net/tcp[6] directly — no Dial, so a live virtctl VNC proxy is not
+// disturbed.
+func isPortListening(port uint32) bool {
+	return netutils.IsLocalPortListening(port)
 }
 
 func (z *zedkube) getVMIdomainName(config *types.AppInstanceConfig) (string, error) {

--- a/pkg/pillar/docs/vnc-workflows.md
+++ b/pkg/pillar/docs/vnc-workflows.md
@@ -1,0 +1,377 @@
+# EVE-K VNC Workflows: Remote Console and Edgeview
+
+## Overview
+
+EVE-K (KubeVirt) VMs do not expose a VNC port directly from QEMU. Instead, a
+`virtctl vnc --proxy-only` process must be launched in the kube container to
+bridge the KubeVirt WebSocket/SPICE protocol onto a local TCP port that clients
+can connect to.
+
+Two independent callers can trigger this proxy:
+
+| | **Remote Console** | **Edgeview VNC** |
+|---|---|---|
+| Initiator | zedkube (`runAppVNC`) | edgeview (`setAndStartProxyTCP`) |
+| Trigger | `AppInstanceConfig.RemoteConsole=true` | TCP command `appUUID:4822` |
+| Client | Guacamole (controller UI) | edgeview TCP relay to client |
+| Coordination file | `vmiVNC.run` (no `CallerPID`) | `vmiVNC.run` (with `CallerPID`) |
+| Cleanup owner | zedkube (RemoteConsole=false) | edgeview (`cleanupEveKVNC`) |
+| Crash recovery | port probe at next start | `monitor_caller_pid` in vnc-proxy.sh |
+
+Both flows write the same file and rely on the same `vnc-proxy.sh` functions in
+the kube container. The `CallerPID` field is the discriminator between them.
+
+---
+
+## Components
+
+```text
+┌───────────────────────────────────────────────────────────────────────┐
+│  pillar container                    (two independent paths)          │
+│                                                                       │
+│  ── Remote Console path ──────────────────────────────────────────    │
+│   ┌─────────┐  AppInstanceConfig   ┌──────────┐                       │
+│   │zedagent │─────────────────────►│ zedkube  │                       │
+│   └─────────┘   (RemoteConsole)    └────┬─────┘                       │
+│                                         │ runAppVNC()                 │
+│  ── Edgeview VNC path ─────────────     │ write {no CallerPID}        │
+│   ┌──────────┐  tcp/appUUID:4822        │                             │
+│   │edgeview  │◄──────────────────     ┌─┘                             │
+│   │ client   │  ┌──────────┐          │                               │
+│   └──────────┘  │ edgeview │          │                               │
+│                 │ (server) │          │                               │
+│                 └────┬─────┘          │                               │
+│                      │ setupEveKVNC() │                               │
+│                      │ write {+       │                               │
+│                      │  CallerPID}    │                               │
+│                      └────────┬───────┘                               │
+└───────────────────────────────┼───────────────────────────────────────┘
+                                │ write (either path)
+                    ┌───────────▼────────────────────────┐
+                    │ /run/edgeview/VncParams/vmiVNC.run │
+                    │ { VMIName, VNCPort, AppUUID,       │
+                    │   CallerPID? }                     │
+                    └───────────┬────────────────────────┘
+                                │ inotifywait
+┌───────────────────────────────┼───────────────────────────────────────┐
+│  kube container               │                                       │
+│                   ┌───────────▼────────┐                              │
+│                   │  vnc-proxy.sh      │                              │
+│                   │ monitor_vnc_config │                              │
+│                   │ handle_vnc         │                              │
+│                   │ monitor_caller_pid │                              │
+│                   └─────────┬──────────┘                              │
+│                             │ nohup                                   │
+│                   ┌─────────▼───────────┐                             │
+│                   │  virtctl vnc <VMI>  │                             │
+│                   │  --proxy-only       │                             │
+│                   │  --port <VNCPort>   │                             │
+│                   └──────────┬──────────┘                             │
+└──────────────────────────────┼────────────────────────────────────────┘
+                               │ WebSocket/SPICE
+                   ┌───────────▼──────────┐
+                   │   KubeVirt VMI       │
+                   └──────────────────────┘
+          connects to 127.0.0.1:VNCPort
+          ┌──────────────┐  ┌──────────────────┐
+          │  Guacamole   │  │  edgeview relay  │
+          │ (controller) │  │  to client       │
+          └──────────────┘  └──────────────────┘
+```
+
+---
+
+## vmiVNC.run — the coordination file
+
+Path: `/run/edgeview/VncParams/vmiVNC.run`
+
+```json
+{
+  "VMIName":   "ubuntu-vm-app-abc123",
+  "VNCPort":   5910,
+  "AppUUID":   "b3e2f1a0-...",
+  "CallerPID": 4827
+}
+```
+
+| Field | Remote Console | Edgeview VNC | Purpose |
+|---|---|---|---|
+| `VMIName` | set | set | virtctl target VMI |
+| `VNCPort` | set | set | local proxy port (5900 + VncDisplay) |
+| `AppUUID` | set | set | stale-file ownership check |
+| `CallerPID` | **absent** | **set** | discriminator; crash-monitor target |
+
+Rules:
+
+- `CallerPID > 0` → edgeview owns this session; liveness via `/proc/<pid>/comm` **and** port probe.
+  PID is checked first; if alive the VNC port is also checked. If the port is not listening the
+  file is treated as stale (virtctl proxy crashed) and evicted. A known edge case: there is a
+  short startup window between file creation and virtctl binding the port where an alive-PID +
+  unbound-port could trigger premature eviction; this is accepted as an unlikely race.
+- `CallerPID` absent → zedkube owns this session; liveness via port probe.
+  (exposed to startup window: virtctl must be bound for the file to be considered live)
+
+---
+
+## Workflow 1: Remote Console
+
+### Remote Console Start
+
+```text
+Controller                zedagent         zedkube            vmiVNC.run      vnc-proxy.sh      virtctl      Guacamole
+    │                        │                │                    │                │               │              │
+    │  RemoteConsole=true    │                │                    │                │               │              │
+    │───────────────────────►│                │                    │                │               │              │
+    │                        │  pub config    │                    │                │               │              │
+    │                        │───────────────►│                    │                │               │              │
+    │                        │                │ handleAppInstance  │                │               │              │
+    │                        │                │ ConfigModify()     │                │               │              │
+    │                        │                │ go runAppVNC()     │                │               │              │
+    │                        │                │ getVMIdomainName() │                │               │              │
+    │                        │                │ (retry up to 6×)   │                │               │              │
+    │                        │                │ canClaimVNCFile()  │                │               │              │
+    │                        │                │── (evict stale) ──►                 │               │              │
+    │                        │                │  write             │                │               │              │
+    │                        │                │  {VMIName,VNCPort, │                │               │              │
+    │                        │                │   AppUUID}         │                │               │              │
+    │                        │                │───────────────────►│                │               │              │
+    │                        │                │                    │ inotify CREATE │               │              │
+    │                        │                │                    │────────────────►               │              │
+    │                        │                │                    │                │ handle_vnc()  │              │
+    │                        │                │                    │                │ parse JSON    │              │
+    │                        │                │                    │                │ no CallerPID  │              │
+    │                        │                │                    │                │ nohup virtctl─►              │
+    │                        │                │                    │                │ wait port     │              │
+    │                        │                │                    │                │◄──────────────│ listening    │
+    │                        │                │                    │                │ VNC_RUNNING=  │              │
+    │                        │                │                    │                │  true         │              │
+    │                        │                │                    │                │               │◄─────────────│
+    │                        │                │                    │                │               │  connect     │
+```
+
+### Stop (RemoteConsole disabled)
+
+```text
+Controller           zedagent          zedkube          vmiVNC.run     vnc-proxy.sh     virtctl
+    │                   │                 │                  │               │              │
+    │  RemoteConsole=   │                 │                  │               │              │
+    │  false            │                 │                  │               │              │
+    │───────────────────►                 │                  │               │              │
+    │                   │  pub config     │                  │               │              │
+    │                   │────────────────►│                  │               │              │
+    │                   │                 │ go runAppVNC()   │               │              │
+    │                   │                 │ os.Remove()      │               │              │
+    │                   │                 │─────────────────►│               │              │
+    │                   │                 │                  │ inotify DELETE│              │
+    │                   │                 │                  │───────────────►              │
+    │                   │                 │                  │               │ kill -9      │
+    │                   │                 │                  │               │─────────────►│
+    │                   │                 │                  │               │ VNC_RUNNING= │
+    │                   │                 │                  │               │  false       │
+```
+
+---
+
+## Workflow 2: Edgeview VNC
+
+### Edgeview VNC Start
+
+```text
+Edgeview              edgeview          ENCluster        vmiVNC.run     vnc-proxy.sh      virtctl
+ Client               (server)         AppStatus dir          │               │              │
+    │                    │                  │                 │               │              │
+    │  tcp/appUUID:4822  │                  │                 │               │              │
+    │───────────────────►│                  │                 │               │              │
+    │                    │ setAndStart      │                 │               │              │
+    │                    │ ProxyTCP()       │                 │               │              │
+    │                    │ isEveKVNC        │                 │               │              │
+    │                    │ Request()        │                 │               │              │
+    │                    │ setupEveKVNC()   │                 │               │              │
+    │                    │ removeStale      │                 │               │              │
+    │                    │ VNCFile(true)────►─────────────────► (evict stale) │              │
+    │                    │ read appUUID     │                 │               │              │
+    │                    │ .json────────────►                 │               │              │
+    │                    │◄─────────────────│ VMIName,VNCPort │               │              │
+    │                    │ write            │                 │               │              │
+    │                    │ {VMIName,VNCPort,│                 │               │              │
+    │                    │  AppUUID,        │                 │               │              │
+    │                    │  CallerPID=self}─►                 │               │              │
+    │                    │                  │                 │ inotify CREATE│              │
+    │                    │                  │                 │───────────────►              │
+    │                    │                  │                 │               │ handle_vnc() │
+    │                    │                  │                 │               │ parse JSON   │
+    │                    │                  │                 │               │ CallerPID set│
+    │                    │                  │                 │               │ monitor_     │
+    │                    │                  │                 │               │ caller_pid() │
+    │                    │                  │                 │               │  & (bg)      │
+    │                    │                  │                 │               │ nohup virtctl►
+    │                    │                  │                 │               │ wait port────►
+    │                    │ waitForVirtctl   │                 │               │◄─────────────│
+    │                    │ VNC(30s)         │                 │               │  listening   │
+    │                    │ /proc/net/tcp    │                 │               │              │
+    │                    │ poll...          │                 │               │              │
+    │                    │ TCP relay ───────────────────────────────────────────────────────►│
+    │◄───────────────────│ to client        │                 │               │              │
+```
+
+### Normal Stop (session ends)
+
+```text
+edgeview              vmiVNC.run     vnc-proxy.sh       virtctl
+(server)                   │               │                │
+    │  TCP closed /        │               │                │
+    │  timer expired       │               │                │
+    │ cleanupEveKVNC()     │               │                │
+    │ os.Remove() ─────────►               │                │
+    │ closeMessage ─►WSS   │ inotify DELETE│                │
+    │                      │───────────────►                │
+    │                      │               │ kill -9 ───────►
+    │                      │               │ VNC_RUNNING=   │
+    │                      │               │  false         │
+    │                      │               │                │
+    │                      │ monitor_caller_pid:            │
+    │                      │ file gone → exits cleanly      │
+```
+
+### Crash Cleanup (edgeview dies without normal cleanup)
+
+```text
+edgeview           vmiVNC.run     vnc-proxy.sh           virtctl
+(crashed)              │         monitor_caller_pid          │
+    ✗                  │               │                     │
+    │                  │  sleep 5s     │                     │
+    │                  │               │                     │
+    │                  │ file still    │                     │
+    │                  │ present───────►                     │
+    │                  │               │ kill -0 CallerPID   │
+    │                  │               │  → ESRCH (dead)     │
+    │                  │               │ re-read file:       │
+    │                  │               │  CallerPID unchanged│
+    │                  │               │ kill -9 ────────────►
+    │                  │◄──────────────│ rm vmiVNC.run       │
+    │                  │               │ monitor exits       │
+```
+
+---
+
+## Stale File Resolution at Session Start
+
+Before writing `vmiVNC.run`, both callers check whether an existing file
+represents a live session. The logic branches on `CallerPID`.
+
+> **Note on atomicity:** the read-check-write sequence is not atomic. A
+> simultaneous edgeview VNC request and Remote Console activation can both
+> read an absent file and both proceed to write. The last write wins and
+> `vnc-proxy.sh` will restart virtctl for whichever file it sees. Avoiding
+> parallel VNC requests from two sources is a user/operator responsibility.
+> When this race occurs it is logged: `setupEveKVNC` and `runAppVNC` each
+> do a post-write readback and log an `Errorf` if the file was overwritten,
+> and `handle_vnc` in `vnc-proxy.sh` logs a `WARNING` when it receives a
+> file-rewrite event while a session is already active.
+
+### Edgeview: `removeStaleVNCFile(evictIdle)`
+
+Called with `evictIdle=true` on a new VNC request; with `evictIdle=false` at
+edgeview startup (where it must not disturb a remote-console session it does
+not own).
+
+```text
+read vmiVNC.run
+        │
+        ▼
+   absent? ──yes──► return true (proceed)
+        │
+        ▼ no
+   parsable &
+   VNCPort > 0? ──no──► remove file ──► return true
+        │
+        ▼ yes
+   CallerPID > 0?
+        │              yes
+        ├──────────────────► OwnerAlive()?
+        │                    (/proc/<pid>/comm == "edge-view")
+        │                         │
+        │                    alive─► port listening? ──yes──► return false (blocked)
+        │                                │ no (virtctl proxy gone)
+        │                                └──► remove file ──► return true
+        │                    dead/reused ─► remove file ──► return true
+        │
+        │ no (remote-console file)
+        ▼
+   evictIdle=false? ──yes──► return true (startup: leave it alone)
+        │
+        ▼ no (request path)
+   /proc/net/tcp: port listening?
+        │
+   yes──► return false (blocked)
+   no───► remove file ──► return true
+```
+
+### zedkube: `canClaimVNCFile(appUUID)`
+
+```text
+read vmiVNC.run
+        │
+        ▼
+   absent? ──yes──► return true (proceed)
+        │
+        ▼ no
+   parsable &
+   VNCPort > 0? ──no──► remove file ──► return true
+        │
+        ▼ yes
+   CallerPID > 0?
+        │              yes
+        ├──────────────────► OwnerAlive()?
+        │                         │
+        │                    alive─► port listening? ──yes──► return false (blocked)
+        │                                │ no (virtctl proxy gone)
+        │                                └──► remove file ──► return true
+        │                    dead/reused ─► remove file ──► return true
+        │
+        │ no (remote-console file)
+        ▼
+   same AppUUID?
+        │
+   yes──► remove own stale file ──► return true
+        │
+        ▼ no (different app)
+   /proc/net/tcp: port listening?
+        │
+   yes──► return false (blocked)
+   no───► remove file ──► return true
+```
+
+---
+
+## Port Liveness Check
+
+Both `removeStaleVNCFile` (edgeview) and `canClaimVNCFile` (zedkube) probe
+whether a virtctl proxy is actually running before declaring a file stale.
+Both delegate to `netutils.IsLocalPortListening`, which reads
+`/proc/net/tcp[6]` directly — no TCP connection is made, so a live virtctl
+VNC proxy on that port is not disrupted by the check.
+
+The port probe applies to **both** ownership cases:
+
+- **`CallerPID` absent (remote-console):** port probe is the sole liveness signal. If virtctl
+  is not listening the file is evicted.
+- **`CallerPID > 0` (edgeview):** PID liveness (`OwnerAlive`) is checked first. If the PID is
+  alive the port is also checked. A live PID with no listening port means virtctl crashed; the
+  file is evicted so the new request can proceed. (Startup-window caveat: the check could
+  falsely evict in the ~30 s between edgeview writing the file and virtctl binding the port;
+  this is accepted as an unlikely edge case.)
+
+---
+
+## Conflict Matrix
+
+| Existing session | New request | Outcome |
+|---|---|---|
+| No file | Remote Console | zedkube writes file, virtctl starts |
+| No file | Edgeview VNC | edgeview writes file, virtctl starts |
+| Active Remote Console (port listening) | Edgeview VNC | edgeview blocked (`removeStaleVNCFile` returns false) |
+| Active Edgeview VNC (CallerPID alive) | Remote Console | zedkube blocked (`canClaimVNCFile` returns false) |
+| Stale edgeview file (PID dead/reused) | Any | File evicted, new session proceeds |
+| Stale remote-console file (port not listening) | Any | File evicted, new session proceeds |
+| Same app remote-console file | Same app Remote Console | zedkube reclaims own file, restarts |

--- a/pkg/pillar/docs/zedkube.md
+++ b/pkg/pillar/docs/zedkube.md
@@ -8,76 +8,79 @@ zedkube is a service in pillar/cmd/zedkube. The main purpose of the service is t
 
 ### App VNC for remote console
 
-For Kubevirt VMs, unlike in KVM image where QEMU services the VNC port 5900s ready for connection into the VM's console, in the EVE 'k' image we need to use the 'virtctl' tool with the KubeConfig YAML file to access the VMI's console.
+For KubeVirt VMIs, unlike KVM where QEMU services the VNC port directly, the
+EVE 'k' image must use `virtctl vnc --proxy-only` to bridge the KubeVirt
+WebSocket protocol onto a local TCP port.
 
-#### Unified VNC Architecture
+Two independent paths trigger this proxy:
 
-EVE supports two methods for VNC access to Kubevirt VMIs, both using a unified file-based signaling mechanism:
+| | **Remote Console** | **Edgeview VNC** |
+|---|---|---|
+| Initiator | zedkube (`runAppVNC`) | edgeview (`setAndStartProxyTCP`) |
+| Trigger | `AppInstanceConfig.RemoteConsole=true` | TCP command `appUUID:4822` |
+| Client | Guacamole (controller UI) | edgeview TCP relay |
+| `CallerPID` in file | absent | set to edgeview PID |
+| Cleanup | zedkube on `RemoteConsole=false` | edgeview `cleanupEveKVNC()` |
+| Crash recovery | port probe at next start | `monitor_caller_pid` in vnc-proxy.sh |
 
-1. **Remote Console (via zedkube)**: Traditional remote console access through the controller UI
-2. **Edgeview VNC**: VNC access via Edgeview TCP proxy for debugging and troubleshooting
+For full sequence diagrams, stale-file resolution flowcharts, and the conflict
+matrix see [vnc-workflows.md](vnc-workflows.md).
 
-Both methods use the same VNC config file path (`/run/edgeview/VncParams/vmiVNC.run`) and JSON format, allowing the kube container to handle VNC requests uniformly.
+#### Coordination file
 
-#### VNC Config File Format
-
-The VNC config file uses JSON format with the following structure:
+Both paths signal the kube container through a single JSON file at
+`/run/edgeview/VncParams/vmiVNC.run`:
 
 ```json
 {
-  "VMIName": "ubuntu-vm-app-abc123xyz",
-  "VNCPort": 5900,
+  "VMIName":   "ubuntu-vm-app-abc123xyz",
+  "VNCPort":   5910,
+  "AppUUID":   "b3e2f1a0-...",
   "CallerPID": 12345
 }
 ```
 
-- **VMIName**: The Kubernetes VMI name (used by virtctl to connect)
-- **VNCPort**: The VNC port number (typically 5900 + VncDisplay offset)
-- **CallerPID**: (Optional) Process ID of the caller - only set by Edgeview to enable cleanup when Edgeview exits unexpectedly
+`VMIName`, `VNCPort`, and `AppUUID` are set by both paths. `CallerPID` is set
+only by edgeview and is the discriminator between the two session types: its
+presence tells `monitor_caller_pid` which PID to watch for crashes, and its
+absence marks a remote-console-owned file.
 
-#### Remote Console Flow
+#### Remote Console flow (zedkube)
 
-1. zedkube service subscribes to AppInstanceConfig and monitors the `RemoteConsole` flag
-2. When RemoteConsole is enabled, zedkube writes the VNC config file with VMIName and VNCPort
-3. The kube container's `monitor_vnc_config()` detects the file creation via inotifywait
-4. The `handle_vnc()` function parses the JSON and launches `virtctl vnc` with `--proxy-only` flag
-5. The VNC port becomes available for the guacd connection from the controller
-6. When RemoteConsole is disabled, zedkube removes the config file, triggering cleanup
+zedkube subscribes to `AppInstanceConfig` and calls `runAppVNC` on any
+`RemoteConsole` change. On enable: `canClaimVNCFile` evicts stale files (dead
+edgeview PID, idle port) and blocks on a live session; then writes the file
+without `CallerPID`. On disable: removes the file, which causes the kube
+container to kill virtctl.
 
-#### Edgeview VNC Flow
+#### Edgeview VNC flow (edgeview)
 
-1. Edgeview receives a TCP command for port 4822 (VNC) with an AppUUID parameter
-2. Edgeview reads the ENClusterAppStatus to get the VMIName and VNCPort for the app
-3. Edgeview writes the VNC config file, including its CallerPID for crash cleanup
-4. The kube container detects the file and starts virtctl vnc proxy
-5. Edgeview waits for the VNC port to be listening (using `ss` command check)
-6. Once ready, Edgeview establishes the TCP proxy connection
-7. When the VNC session ends, Edgeview removes the config file
-8. If Edgeview crashes, the kube container's `monitor_caller_pid()` detects the missing PID and cleans up
+edgeview receives a TCP command for port 4822 with an AppUUID. It reads
+`ENClusterAppStatus` for the VMI name and port, calls `removeStaleVNCFile`
+(same eviction logic), writes the file with `CallerPID=os.Getpid()`, then
+polls `/proc/net/tcp` for up to 30 s waiting for virtctl to start listening.
+The kube container also starts `monitor_caller_pid` in the background to
+handle edgeview crashes.
 
-#### Kube Container Implementation
+#### Kube container handler (`vnc-proxy.sh`)
 
-The kube container (`cluster-init.sh`) implements VNC handling with several components:
+- **`monitor_vnc_config()`** — inotifywait loop on the VncParams directory;
+  calls `handle_vnc` on any file event
+- **`handle_vnc()`** — parses JSON, launches `virtctl vnc <VMI> -n
+  eve-kube-app --port <VNCPort> --proxy-only` with up to 5 retries; aborts
+  if the file disappears mid-retry; starts `monitor_caller_pid` immediately
+  when `CallerPID` is present
+- **`monitor_caller_pid()`** — edgeview sessions only; polls every 5 s and
+  kills virtctl + removes the file if the edgeview PID is gone or reused
 
-- **monitor_vnc_config()**: Background task using inotifywait to monitor the VNC config directory for file events (create, modify, delete)
-- **handle_vnc()**: Parses the JSON config and manages virtctl vnc process lifecycle with retry logic (5 attempts with delays for transient kubevirt API errors like 503)
-- **monitor_caller_pid()**: For Edgeview VNC only - monitors the caller PID and cleans up if Edgeview crashes
+#### ENClusterAppStatus VMI fields
 
-The virtctl command used is:
+`ENClusterAppStatus` exposes VMI-specific fields populated by zedkube from
+the virt-launcher pod:
 
-```bash
-virtctl vnc <vmiName> -n eve-kube-app --port <vncPort> --proxy-only
-```
-
-#### ENClusterAppStatus Enhancement
-
-The ENClusterAppStatus now includes VMI-specific fields to support Edgeview VNC:
-
-- **VMIName**: The actual VMI name (extracted from virt-launcher pod name)
-- **VNCPort**: The VNC port for the VMI (calculated as 5900 + VncDisplay)
-- **AppIsVMI**: Boolean indicating if the app is a VMI (vs a Pod)
-
-These fields are populated by zedkube when it detects VMI pods running on the node.
+- **VMIName** — actual KubeVirt VMI name used by virtctl
+- **VNCPort** — 5900 + VncDisplay offset
+- **AppIsVMI** — distinguishes VMI apps from Pod-only apps
 
 ### Cluster Status
 

--- a/pkg/pillar/types/clustertypes.go
+++ b/pkg/pillar/types/clustertypes.go
@@ -4,7 +4,10 @@
 package types
 
 import (
+	"fmt"
 	"net"
+	"os"
+	"strings"
 	"time"
 
 	uuid "github.com/satori/go.uuid"
@@ -216,5 +219,23 @@ type KubeLeaderElectInfo struct {
 type VmiVNCConfig struct {
 	VMIName   string `json:"VMIName"`
 	VNCPort   uint32 `json:"VNCPort"`
-	CallerPID int    `json:"CallerPID,omitempty"` // Set by edgeview to allow cleanup when it exits
+	AppUUID   string `json:"AppUUID,omitempty"`   // UUID of the app owning this session
+	CallerPID int    `json:"CallerPID,omitempty"` // Set by edgeview; absent for remote-console
+}
+
+// procPath is the root of the proc filesystem. Overridden in tests.
+var procPath = "/proc"
+
+// OwnerAlive reports whether CallerPID refers to a live edge-view process.
+// Returns false when CallerPID is unset (remote-console file), when the PID
+// is dead, or when the PID has been reused by a different program.
+func (c VmiVNCConfig) OwnerAlive() bool {
+	if c.CallerPID <= 0 {
+		return false
+	}
+	comm, err := os.ReadFile(fmt.Sprintf("%s/%d/comm", procPath, c.CallerPID))
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(comm)) == "edge-view"
 }

--- a/pkg/pillar/types/clustertypes_test.go
+++ b/pkg/pillar/types/clustertypes_test.go
@@ -4,6 +4,11 @@
 package types
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,4 +43,123 @@ func TestENClusterAppStatusEqual(t *testing.T) {
 func TestEdgeNodeClusterConfigKey(t *testing.T) {
 	cfg := EdgeNodeClusterConfig{}
 	assert.Equal(t, cfg.ClusterID.UUID.String(), cfg.Key())
+}
+
+func TestVmiVNCConfig_JSONRoundTrip(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          VmiVNCConfig
+		mustContain string // substring that must appear
+		mustExclude string // substring that must NOT appear
+	}{
+		{
+			name:        "edgeview writer includes CallerPID and AppUUID",
+			in:          VmiVNCConfig{VMIName: "vmi", VNCPort: 5910, AppUUID: "app-uuid", CallerPID: 1234},
+			mustContain: `"CallerPID":1234`,
+		},
+		{
+			name:        "remote-console writer omits CallerPID",
+			in:          VmiVNCConfig{VMIName: "vmi", VNCPort: 5910, AppUUID: "app-uuid"},
+			mustExclude: "CallerPID",
+		},
+		{
+			name:        "legacy writer omits AppUUID",
+			in:          VmiVNCConfig{VMIName: "vmi", VNCPort: 5910, CallerPID: 1234},
+			mustExclude: "AppUUID",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf, err := json.Marshal(tc.in)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			s := string(buf)
+			if tc.mustContain != "" && !strings.Contains(s, tc.mustContain) {
+				t.Errorf("missing %q in %s", tc.mustContain, s)
+			}
+			if tc.mustExclude != "" && strings.Contains(s, tc.mustExclude) {
+				t.Errorf("unexpected %q in %s", tc.mustExclude, s)
+			}
+
+			var back VmiVNCConfig
+			if err := json.Unmarshal(buf, &back); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if back != tc.in {
+				t.Errorf("round-trip mismatch: got %+v want %+v", back, tc.in)
+			}
+		})
+	}
+}
+
+// withProcPath swaps procPath to a tmpdir for the duration of one test.
+func withProcPath(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig := procPath
+	procPath = dir
+	t.Cleanup(func() { procPath = orig })
+	return dir
+}
+
+// writeComm writes a fake /proc/<pid>/comm file.
+func writeComm(t *testing.T, root string, pid int, comm string) {
+	t.Helper()
+	procDir := filepath.Join(root, fmt.Sprintf("%d", pid))
+	if err := os.MkdirAll(procDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(procDir, "comm"), []byte(comm+"\n"), 0644); err != nil {
+		t.Fatalf("write comm: %v", err)
+	}
+}
+
+func TestOwnerAlive(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  VmiVNCConfig
+		comm string // "" means no comm file at that PID (dead/absent)
+		want bool
+	}{
+		{
+			name: "CallerPID unset",
+			cfg:  VmiVNCConfig{CallerPID: 0},
+			want: false,
+		},
+		{
+			name: "negative CallerPID",
+			cfg:  VmiVNCConfig{CallerPID: -1},
+			want: false,
+		},
+		{
+			name: "PID dead (no /proc entry)",
+			cfg:  VmiVNCConfig{CallerPID: 99999},
+			want: false,
+		},
+		{
+			name: "PID live but reused by another program",
+			cfg:  VmiVNCConfig{CallerPID: 12345},
+			comm: "bash",
+			want: false,
+		},
+		{
+			name: "PID live and still edge-view",
+			cfg:  VmiVNCConfig{CallerPID: 12345},
+			comm: "edge-view",
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := withProcPath(t)
+			if tc.comm != "" {
+				writeComm(t, root, tc.cfg.CallerPID, tc.comm)
+			}
+			if got := tc.cfg.OwnerAlive(); got != tc.want {
+				t.Errorf("OwnerAlive() = %v, want %v", got, tc.want)
+			}
+		})
+	}
 }

--- a/pkg/pillar/utils/netutils/portlisten.go
+++ b/pkg/pillar/utils/netutils/portlisten.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package netutils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// IsLocalPortListening reports whether a process is bound and listening on
+// port on localhost. It reads /proc/net/tcp[6] directly — no TCP connection
+// is made, so a live virtctl VNC proxy on that port is not disturbed.
+func IsLocalPortListening(port uint32) bool {
+	hexPort := fmt.Sprintf("%04X", port)
+	for _, f := range []string{"/proc/net/tcp", "/proc/net/tcp6"} {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			continue
+		}
+		lines := strings.Split(string(data), "\n")
+		for _, line := range lines[1:] { // skip header
+			fields := strings.Fields(line)
+			if len(fields) < 4 {
+				continue
+			}
+			// fields[1] = local_address "XXXXXXXX:PPPP", fields[3] = state ("0A" = LISTEN)
+			parts := strings.SplitN(fields[1], ":", 2)
+			if len(parts) == 2 && parts[1] == hexPort && fields[3] == "0A" {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION

# Description

Problem: vmiVNC.run was not being cleaned up when an edgeview instance crashed or was killed.

  Fixes:
  - clustertypes.go: Add AppUUID field to VmiVNCConfig to identify file ownership per-app. Add OwnerAlive() which reads /proc/<pid>/comm and checks the name is edge-view, guarding against PID reuse by unrelated processes.
  - zedkube/vnc.go: Replace the blind os.Stat block with canClaimVNCFile(). It evicts stale files (dead edgeview PID, reused PID, or idle virtctl port) and blocks only on a genuinely live session — a running edgeview process or a virtctl proxy still listening on the port.
  - edgeview/network.go: Replace the blind os.Stat block with removeStaleVNCFile(), the edgeview-side equivalent. Also call it at edgeview startup (runOnServer) with evictIdle=false to clear files left from a previous crash without disturbing a live remote-console session. Rewrite isPortListening to read /proc/net/tcp directly instead of spawning ss (avoids disrupting the virtctl WebSocket connection).
  - vnc-proxy.sh: Move monitor_caller_pid start to the top of handle_vnc before the virtctl retry loop

## PR dependencies

## How to test and validate this PR

run the edgeview VNC in multiple times, and verify they are not blocked by the stale config file on the device.

## Changelog notes

zedkube/edgeview: fix stale vmiVNC.run blocking new VNC sessions

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
