### PR TITLE
pkg/debug: fix COM port detection

### DIFF
--- a/pkg/debug/spec.sh
+++ b/pkg/debug/spec.sh
@@ -440,16 +440,23 @@ done
 #enumerate serial ports
 ID="1"
 for TTY in /sys/class/tty/*; do
-   if [ -f "$TTY/device/resources" ]; then
-      IO=$(grep '^io ' "$TTY/device/resources" | sed -e 's#io 0x##' -e 's#0x##')
-      IRQ=$(awk '/^irq /{print $2;}' < "$TTY/device/resources")
-   elif [ "$UNAME_M" = aarch64 ] && [ -f "$TTY/irq" ]; then
+   IO=""
+   IRQ=""
+   if [ -f "$TTY/irq" ]; then
       IRQ=$(cat "$TTY/irq")
       [ "${IRQ:-0}" -gt 0 ] || IRQ=""
-      IO=""
-   else
-      IO=""
-      IRQ=""
+   fi
+   if [ "$UNAME_M" = x86_64 ] && [ -f "$TTY/port" ]; then
+      IO_RAW=$(cat "$TTY/port")
+      # A port value of 0x0 means no hardware is present; clear IRQ too
+      if [ "$IO_RAW" != "0x0" ] && [ "$IO_RAW" != "0" ]; then
+         IO_DEC=$(printf '%d' "$IO_RAW")
+         IO_START=$(printf '%x' "$IO_DEC")
+         IO_END=$(printf '%x' "$((IO_DEC + 7))")
+         IO="${IO_START}-${IO_END}"
+      else
+         IRQ=""
+      fi
    fi
    TTY=$(echo "$TTY" | cut -f5 -d/)
    if [ -n "$IO" ] || [ -n "$IRQ" ]; then

--- a/pkg/installer/Dockerfile
+++ b/pkg/installer/Dockerfile
@@ -28,7 +28,7 @@ RUN cargo sbom > sbom.spdx.json
 
 RUN cp "/usr/local/my-installer/target/$CARGO_BUILD_TARGET/release/installer" /usr/local/my-installer/target/installer
 
-FROM lfedge/eve-debug:21dabe424cdc950dc982d9c7c7233af36b5991c2 AS debug
+FROM lfedge/eve-debug:1d88d292ce45c7b16945ffb238392b228ec76520 AS debug
 
 # Dockerfile to build installer img initrd
 FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build


### PR DESCRIPTION
# Description

Newer kernels no longer expose /sys/class/tty/*/device/resources. Switch to reading port and IRQ directly from the per-tty sysfs files /sys/class/tty/*/port and /sys/class/tty/*/irq.

On x86_64, a port value of 0x0 indicates no hardware is present and the entry is skipped. The IO port range is computed as base to base+7 to match the standard 8-byte UART register window.

Qemu tests:
Effect on EVE master:
4 COM ports are detected, instead of 0

Effect on EVE 14.5:
4 COM ports are detected, instead of 1
This is because the serial port connected via PCI was detected, but not the ones via uart8250.
```
[debug] root@linuxkit-525400123456:~$ ls -l /sys/class/tty/ | grep ttyS
lrwxrwxrwx    1 root     root             0 Apr 28 10:14 ttyS0 -> ../../devices/pnp0/00:03/tty/ttyS0
lrwxrwxrwx    1 root     root             0 Apr 28 10:14 ttyS1 -> ../../devices/platform/serial8250/tty/ttyS1
lrwxrwxrwx    1 root     root             0 Apr 28 10:14 ttyS2 -> ../../devices/platform/serial8250/tty/ttyS2
lrwxrwxrwx    1 root     root             0 Apr 28 10:14 ttyS3 -> ../../devices/platform/serial8250/tty/ttyS3
```

## How to test and validate this PR

Run `spec.sh` and check that  all COM ports are printed.

## Changelog notes

Fix COM port detection in spec.sh

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 16.0-stable: yes
- 14.5-stable: yes
- 13.4-stable: yes


## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR



And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
