### PR TITLE
github/workflows: Fix yetus when no patch-*-result.txt files are present

### DIFF
--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -65,6 +65,10 @@ jobs:
           set +e
           # Yetus writes patch-<plugin>.txt files for each plugin that found issues.
           # Each line is in the format: filename:line:message
+          if [ -z "$(ls ${{ github.workspace }}/out/patch-*-result.txt 2> /dev/null || true)" ]; then
+            echo "No result files to annotate."
+            exit 0
+          fi
           for patch_file in ${{ github.workspace }}/out/patch-*-result.txt; do
             plugin=$(basename "$patch_file" | sed "s/patch-\(.*\)-result.txt/\1/")
             while read -r line; do


### PR DESCRIPTION
# Description

Depending on the diff generated Yetus might create zero patch-*-result.txt files. In this case, annotation should just return without failing.

## How to test and validate this PR

Run Yetus workflow.

## Changelog notes

None.

## PR Backports

No backports.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.