### PR TITLE
Remove patch file leftover from 161360e45

### DIFF
--- a/kubevirt-feature.yaml.diff
+++ b/kubevirt-feature.yaml.diff
@@ -1,9 +1,0 @@
-diff --git a/pkg/kube/kubevirt-features.yaml b/pkg/kube/kubevirt-features.yaml
-index 9f0aa6bd6..31dae3035 100644
---- a/pkg/kube/kubevirt-features.yaml
-+++ b/pkg/kube/kubevirt-features.yaml
-@@ -16,3 +16,4 @@ spec:
-         - Snapshot
-         - HostDevices
-         - GPU
-+        - VideoConfig


### PR DESCRIPTION
# Description

Commit 161360e45611dd7c2d723b7672c5a09e92c72e03 left a patch file on the repository. This commit removes it.

## How to test and validate this PR

No test required.

## Changelog notes

None.

## PR Backports

It's only on master. Thus, no backports.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.