### PR TITLE
Makefile: Signing-Off setting server to prod commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1115,7 +1115,7 @@ release:
 	    git merge origin/master ;\
 	 else \
 	    git checkout master -b $$BRANCH && echo zedcloud.zededa.net > conf/server &&\
-	    git commit -m"Setting default server to prod" conf/server ;\
+	    git commit -s -m "Setting default server to prod" conf/server ;\
 	 fi || bail "Can't create $$BRANCH branch" ;\
 	 git tag -a -m"Release $$X.$$Y.$$Z" $$X.$$Y.$$Z &&\
 	 echo "Done tagging $$X.$$Y.$$Z release. Check the branch with git log and then run" &&\


### PR DESCRIPTION
# Description

Every time a release is created through the `make release` target, a commit that sets the default server to production URL is automatically pushed. However, this commit is never Signed-off, which goes against our policy. This commit adds the -s to git command in order to enforce the commit to be Signed-off by the maintainer that is creating the new release.

## How to test and validate this PR

Create a new release and check the last commit:
```sh
make VERSION=16.14.0 release
git show HEAD
```

## Changelog notes

None.

## PR Backports

We can follow this approach moving forward, I don't think it's something worth of backport.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.