### PR TITLE
[16-0-stable] edgeview: fix wwan0 excluded from websocket interface list

### DIFF
--- a/pkg/edgeview/src/edgeview_test.go
+++ b/pkg/edgeview/src/edgeview_test.go
@@ -17,6 +17,15 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// TestGetDefrouteIntfSrcs verifies that getDefrouteIntfSrcs returns nil
+// gracefully when the DeviceNetworkStatus file is absent (i.e. outside EVE).
+func TestGetDefrouteIntfSrcs(t *testing.T) {
+	g := NewWithT(t)
+	// Outside EVE the file does not exist; the function must return nil, not panic.
+	got := getDefrouteIntfSrcs()
+	g.Expect(got).To(BeNil(), "expected nil when DeviceNetworkStatus file is absent")
+}
+
 func TestWalkLogDirs(t *testing.T) {
 	g := NewWithT(t)
 

--- a/pkg/edgeview/src/websocket.go
+++ b/pkg/edgeview/src/websocket.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 	"golang.org/x/sys/unix"
 )
 
@@ -205,17 +206,34 @@ func tlsDial(isServer bool, pIP string, pport int, src []net.IP, idx int) (*webs
 	return dialer, nil
 }
 
-// get source IP addresses of ipv4 default route in main table
+// get source IP addresses from ports that have an IPv4 default router in DeviceNetworkStatus
 func getDefrouteIntfSrcs() []net.IP {
+	var devNetStatus types.DeviceNetworkStatus
+	retbytes, err := os.ReadFile("/run/nim/DeviceNetworkStatus/global.json")
+	if err != nil {
+		return nil
+	}
+	if err := json.Unmarshal(retbytes, &devNetStatus); err != nil {
+		return nil
+	}
 	var srcIPs []net.IP
-	table254 := 254
-	routes := getTableIPv4Routes(table254)
-	for _, r := range routes {
-		if r.Dst == nil && r.Gw.To4() != nil && r.Src.To4() != nil {
-			srcIPs = append(srcIPs, r.Src)
+	for _, port := range devNetStatus.Ports {
+		hasIPv4Router := false
+		for _, router := range port.DefaultRouters {
+			if router.To4() != nil {
+				hasIPv4Router = true
+				break
+			}
+		}
+		if !hasIPv4Router {
+			continue
+		}
+		for _, addrInfo := range port.AddrInfoList {
+			if addrInfo.Addr.To4() != nil {
+				srcIPs = append(srcIPs, addrInfo.Addr)
+			}
 		}
 	}
-	// if we have multiple source IPs, make sure they are returned in order always
 	if len(srcIPs) > 1 {
 		sort.Slice(srcIPs, func(i, j int) bool {
 			return bytes.Compare(srcIPs[i], srcIPs[j]) < 0


### PR DESCRIPTION

# Description

  - Static default routes (e.g. cellular/wwan) are added without a src field, causing getDefrouteIntfSrcs() to silently skip those interfaces. Change to use NIM's DeviceNetworkStatus to get the interface IP with DefaultRouters, using the same NIM-validated addresses that pillar send.go uses for management traffic.
  - backport from PR #5832

(cherry picked from commit ace3a25c1f9445b35256e64022ce05b4243a39ae)

## PR dependencies

## How to test and validate this PR

configure the mgmt interface w/ the static ip, and static default route which has no 'src' ip in the route.
start edgeview session w/ this patch, to see if it continue to work.

## Changelog notes

edgeview: fix wwan0 excluded from websocket interface list

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
