### PR TITLE
pkg/eve: Fix image sizes for the new partition layout

### DIFF
--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -5,13 +5,17 @@ set -e
 exec 3>&1
 exec 1>&2
 
+# For now the sizes are all the same across different variants. However,
+# they might change in the future due to custom packages, libraries, etc.
 OUTPUT_IMG=/tmp/output.img
-DEFAULT_LIVE_IMG_SIZE=592
-DEFAULT_INSTALLER_IMG_SIZE=592
-DEFAULT_NVIDIA_IMG_SIZE=2048
-DEFAULT_K_IMG_SIZE=2048
-DEFAULT_EVALUATION_INSTALLER_IMG_SIZE=3000
-DEFAULT_EVALUATION_LIVE_IMG_SIZE=2000
+DEFAULT_LIVE_IMG_SIZE=8192
+DEFAULT_INSTALLER_IMG_SIZE=4096
+DEFAULT_NVIDIA_INSTALLER_IMG_SIZE=4096
+DEFAULT_NVIDIA_LIVE_IMG_SIZE=8192
+DEFAULT_K_INSTALLER_IMG_SIZE=4096
+DEFAULT_K_LIVE_IMG_SIZE=8192
+DEFAULT_EVALUATION_INSTALLER_IMG_SIZE=4096
+DEFAULT_EVALUATION_LIVE_IMG_SIZE=8192
 
 bail() {
   echo "$@"
@@ -247,8 +251,8 @@ prepare_for_platform() {
         [ -n "$(ls /bits/bsp-imx/*.dtb 2> /dev/null)" ] && cp /bits/bsp-imx/*.dtb /bits/boot
         ;;
     nvidia-jp*)
-        DEFAULT_LIVE_IMG_SIZE=$DEFAULT_NVIDIA_IMG_SIZE
-        DEFAULT_INSTALLER_IMG_SIZE=$DEFAULT_NVIDIA_IMG_SIZE
+        DEFAULT_LIVE_IMG_SIZE=$DEFAULT_NVIDIA_LIVE_IMG_SIZE
+        DEFAULT_INSTALLER_IMG_SIZE=$DEFAULT_NVIDIA_INSTALLER_IMG_SIZE
         ;;
     evaluation)
         DEFAULT_LIVE_IMG_SIZE=$DEFAULT_EVALUATION_LIVE_IMG_SIZE
@@ -268,13 +272,11 @@ prepare_for_hv() {
     kvm|xen)
         ;;
     k)
-        # Override image sizes with the max of the two values
-        if [ "$DEFAULT_K_IMG_SIZE" -gt "$DEFAULT_INSTALLER_IMG_SIZE" ]; then
-            DEFAULT_INSTALLER_IMG_SIZE="$DEFAULT_K_IMG_SIZE"
-            DEFAULT_LIVE_IMG_SIZE="$DEFAULT_K_IMG_SIZE"
-        fi
+        # Override image sizes for eve-k
+        DEFAULT_INSTALLER_IMG_SIZE="$DEFAULT_K_INSTALLER_IMG_SIZE"
+        DEFAULT_LIVE_IMG_SIZE="$DEFAULT_K_LIVE_IMG_SIZE"
         ;;
-    *) #shellcheck disable=SC2039,SC2104
+    *)  #shellcheck disable=SC2039,SC2104
         bail "Unsupported hypervisor: $hv"
         ;;
     esac


### PR DESCRIPTION
# Description

The new partition layout (EFI 2GB + rootfs 4GB) consumes more space on the live and installer images. This commit adjusts the sizes on `runme.sh` so all the images can be generated properly when running eve image with docker.

> [!IMPORTANT]  
> Publish workflow is broken because of this bug (no release assets can be generated)

## How to test and validate this PR

Build different `eve` image variants:

```sh
make eve
make ZARCH=arm64 eve
make ZARCH=arm64 PLATFORM=nvidia-jp7 eve
make HV=k eve
```
Test the final image exported to local docker and see if installer and live images are generated successfully:
```sh
docker run --rm <final-eve-image> installer_raw > eve-installer.raw
docker run --rm <final-eve-image> live > eve-live.raw
```
The generation of the images should not fail.

## Changelog notes

This is only on master, no need to make a changelog note.

## PR Backports

No backports (it's only on master).

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.