### PR TITLE
[16.0-stable] HW inventory fixes

### DIFF
--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tatsushid/go-fastping v0.0.0-20160109021039-d7bb493dee3e
 	github.com/vishvananda/netlink v1.3.1
-	github.com/zededa/ghw v0.0.0-20260218160843-b4fc0f8a6aa5
+	github.com/zededa/ghw v0.0.0-20260427124750-9a7dc80ae71c
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.45.0
 	golang.org/x/net v0.47.0

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -859,10 +859,10 @@ github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50 h1:hlE8//ciYMzt
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f h1:ERexzlUfuTvpE74urLSbIQW0Z/6hF9t8U4NsJLaioAY=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
-github.com/zededa/ghw v0.0.0-20260218160843-b4fc0f8a6aa5 h1:XpWbH6y+ijvzerElhvg8x1VcheqouFjc2h1MqimzgbQ=
-github.com/zededa/ghw v0.0.0-20260218160843-b4fc0f8a6aa5/go.mod h1:bLYU9IrgrtEUiJ6smjXtTaej/MVO17v+kxGIC/jfj9c=
 github.com/zeebo/errs v1.4.0 h1:XNdoD/RRMKP7HD0UhJnIzUy74ISdGGxURlYG8HSWSfM=
 github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
+github.com/zededa/ghw v0.0.0-20260427124750-9a7dc80ae71c h1:zfpR6V7WZ/cMq5K98SngCHF+7cykchvsF0b2bGtB/Ko=
+github.com/zededa/ghw v0.0.0-20260427124750-9a7dc80ae71c/go.mod h1:bLYU9IrgrtEUiJ6smjXtTaej/MVO17v+kxGIC/jfj9c=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.10 h1:+BqfJTcCzTItrop8mq/lbzL8wSGtj94UO/3U31shqG0=
 go.etcd.io/bbolt v1.3.10/go.mod h1:bK3UQLPJZly7IlNmV7uVHJDxfe5aK9Ll93e/74Y9oEQ=

--- a/pkg/pillar/vendor/github.com/zededa/ghw/pkg/pci/pci_linux.go
+++ b/pkg/pillar/vendor/github.com/zededa/ghw/pkg/pci/pci_linux.go
@@ -419,17 +419,24 @@ func (info *Info) getDevices(opts *option.Options) []*Device {
 	return devs
 }
 
-// FindPCIAddress extract the pci address from a sysfs path without /sys
+// FindPCIAddress extracts the deepest (most specific) PCI BDF address from a
+// sysfs path. For devices that are themselves PCI devices (e.g. NICs behind a
+// PCIe bridge), this returns the device's own address. For non-PCI devices
+// (e.g. USB or CAN interfaces) whose paths end in non-PCI components, it
+// returns the address of the PCI controller they attach to.
 func FindPCIAddress(path string) string {
-	re := regexp.MustCompile(`\/?devices\/pci[\d:.]*\/(\d{4}:[a-f\d:\.]+)`)
-
-	matches := re.FindStringSubmatch(path)
-	// first element is the full string match like /devices/pci0000:00/0000:00:0d.0
-	// but we need the first substring match so we take the second element
-	if len(matches) != 2 {
-		return ""
+	// Match an exact BDF component: domain:bus:device.function (all hex).
+	re := regexp.MustCompile(`^[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9a-f]$`)
+	for {
+		dir, file := filepath.Split(path)
+		if re.MatchString(strings.ToLower(file)) {
+			return strings.ToLower(file)
+		}
+		dir = filepath.Clean(dir)
+		if dir == path {
+			break
+		}
+		path = dir
 	}
-	pciAddress := matches[1]
-
-	return pciAddress
+	return ""
 }

--- a/pkg/pillar/vendor/github.com/zededa/ghw/pkg/serial/serial_linux.go
+++ b/pkg/pillar/vendor/github.com/zededa/ghw/pkg/serial/serial_linux.go
@@ -10,13 +10,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/zededa/ghw/pkg/bus"
 	"github.com/zededa/ghw/pkg/linuxpath"
 	"github.com/zededa/ghw/pkg/option"
+	"github.com/zededa/ghw/pkg/pci"
 	pciAddress "github.com/zededa/ghw/pkg/pci/address"
 	"github.com/zededa/ghw/pkg/usb"
 	usbAddress "github.com/zededa/ghw/pkg/usb/address"
@@ -36,20 +36,15 @@ func (i *Info) load(opts *option.Options) error {
 func serials(opts *option.Options) ([]*Device, []error) {
 	paths := linuxpath.New(opts)
 	ttyClass := paths.SysClassTty
-	ttys, err := filepath.Glob(filepath.Join(ttyClass, "ttyS*"))
+	entries, err := os.ReadDir(ttyClass)
 	if err != nil {
 		return nil, []error{err}
 	}
 
-	// Deterministic order: ttyS0, ttyS1, ...
-	sort.Slice(ttys, func(i, j int) bool {
-		return filepath.Base(ttys[i]) < filepath.Base(ttys[j])
-	})
-
 	var out []*Device
 	id := 1
-	for _, ttyDir := range ttys {
-		tty := filepath.Base(ttyDir) // ttyS1
+	for _, entry := range entries {
+		tty := entry.Name() // ttyS1
 		sp, ok, err := serialPortFromTTY(paths.SysRoot, ttyClass, tty)
 		if err != nil {
 			continue
@@ -97,8 +92,9 @@ func serialPortFromTTY(sysfs, ttyClass, tty string) (*Device, bool, error) {
 		ioRange = fmt.Sprintf("%04x-%04x", start, end)
 	}
 
+	pciAddrString := pci.FindPCIAddress(devSys)
 	var parent bus.BusParent
-	if pciAddr := pciAddress.FromString(devSys); pciAddr != nil {
+	if pciAddr := pciAddress.FromString(pciAddrString); pciAddr != nil {
 		parent.PCI = pciAddr
 	}
 	bus, port, err := usb.ExtractUSBBusnumPort(devSys)

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -1197,7 +1197,7 @@ github.com/xlab/treeprint
 # github.com/yusufpapurcu/wmi v1.2.4
 ## explicit; go 1.16
 github.com/yusufpapurcu/wmi
-# github.com/zededa/ghw v0.0.0-20260218160843-b4fc0f8a6aa5
+# github.com/zededa/ghw v0.0.0-20260427124750-9a7dc80ae71c
 ## explicit; go 1.21
 github.com/zededa/ghw
 github.com/zededa/ghw/pkg/accelerator


### PR DESCRIPTION
# Description

This only takes one commit from the original PR: update ghw library

to include several fixes

(cherry picked from commit 86dd10726d94e3e75683a9492e4ecd52e7c1f250)

Updated Regex for finding PCI addresses in sysfs paths (https://github.com/zededa/ghw/commit/4df35e354b3bf31532e9fbe73ae62edbf6f136b4)

Backport of https://github.com/lf-edge/eve/pull/5861

## How to test and validate this PR

Check that USB-Passthrough works as before

## Changelog notes

Update ghw library


## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
