### PR TITLE
Kernel update - [arm64-nvidia-jp5, arm64-nvidia-jp6, arm64-generic, a…

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,7 +1,7 @@
 KERNEL_COMMIT_amd64_next_generic = 3152b8fe36ea
-KERNEL_COMMIT_amd64_v6.12.49_generic = 638c9c2df657
-KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = b4464b03583e
-KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 2154a157c3f4
+KERNEL_COMMIT_amd64_v6.12.49_generic = b21691f37d8d
+KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = be4828dfe4e1
+KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = dbf1688d4cb1
 KERNEL_COMMIT_arm64_v6.8.12_nvidia-jp7 = a9757a5802c2
-KERNEL_COMMIT_arm64_v6.1.155_generic = ece043d8b403
-KERNEL_COMMIT_riscv64_v6.1.112_generic = 18e1d313b90b
+KERNEL_COMMIT_arm64_v6.1.155_generic = 04d922430698
+KERNEL_COMMIT_riscv64_v6.1.112_generic = a6bc06835103


### PR DESCRIPTION
# Description

This commit changes:
eve-kernel-amd64-v6.12.49-generic
 -   b21691f37d8d: kbuild: Use objtree for module signing key path
 -  1b21d64fb6f9: Dockerfile.gcc: bump ZFS to 2.3.6
 -  8acbdf8650d3: GHA: targeted cleanup — preserve BuildKit ccache across runs
 -  9a48158418fb: GHA: pin actions to commit SHAs and bump to latest versions
 -  2bb73ddec7b5: Makefile.eve: use linuxkit pkg build for kernel build
 -  0411f1bb8ebd: Makefile.eve: pin linuxkit to upstream master tip
 -  c7f429fff280: Makefile.eve: flexible linuxkit acquisition, drop manual builder setup
 -  62283c1a4547: Add cleanup steps to CI workflows and Makefile

eve-kernel-arm64-v5.10.192-nvidia-jp5
 -  be4828dfe4e1: GHA: fix runs-on labels for ARM64 self-hosted runners
 -  7b9297346b55: GHA: targeted cleanup — preserve BuildKit ccache across runs
 -  12f5416c868f: GHA: pin actions to commit SHAs and bump to latest versions
 -  20688cbd8962: Makefile.eve: use linuxkit pkg build for kernel build
 -  c82a626397af: Makefile.eve: pin linuxkit to upstream master tip
 -  4c312ba99980: Makefile.eve: flexible linuxkit acquisition, drop manual builder setup

eve-kernel-arm64-v5.15.136-nvidia-jp6
 -  dbf1688d4cb1: configs: Enable ISCSI_TCP driver
 -  cdb39f84ac1a: Dockerfile.gcc: add -j$(nproc) to kernel and module build steps
 -  c3fc5341f6f7: GHA: fix runs-on labels for ARM64 self-hosted runners
 -  c7f5f7c54609: GHA: targeted cleanup — preserve BuildKit ccache across runs
 -  f6b595f5d82c: GHA: pin actions to commit SHAs and bump to latest versions
 -  6010b4265825: Makefile.eve: use linuxkit pkg build for kernel build
 -  56d06bf5f620: Makefile.eve: pin linuxkit to upstream master tip
 -  f020d8545bef: Makefile.eve: flexible linuxkit acquisition, drop manual builder setup
 -  ffdb53504cc1: GHA: pin actions to commit SHAs and bump to latest versions
 -  960f3d553ebc: Makefile.eve: use linuxkit pkg build for kernel build
 -  faa875954e3a: Makefile.eve: pin linuxkit to upstream master tip
 -  b691da55988c: Makefile.eve: flexible linuxkit acquisition, drop manual builder setup

eve-kernel-riscv64-v6.1.112-generic
  - a6bc06835103: GHA: targeted cleanup — preserve BuildKit ccache across runs
  - 0b5f510d8824: GHA: pin actions to commit SHAs and bump to latest versions
  - 0003f7512aed: Makefile.eve: use linuxkit pkg build for kernel build
  - b753d5c68b8d: Makefile.eve: pin linuxkit to upstream master tip
  - 2ab868ecf043: Makefile.eve: flexible linuxkit acquisition, drop manual builder setup

## PR dependencies

None 

## How to test and validate this PR


## Changelog notes

Bump ZFS to 2.3.6

## PR Backports

- 16.0-stable - No
- 14.5-stable - No
- 13.4-stable - No

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
