### PR TITLE
fix(volumemgr): floor deferContentDelete ticker at 1 second

### DIFF
--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -897,9 +897,11 @@ func maybeUpdateConfigItems(ctx *volumemgrContext, newConfigItemValueMap *types.
 		if newDC == 0 {
 			ctx.deferDelete.Stop()
 		} else {
-			// Run ten times as often as lifetime
-			duration := time.Duration(ctx.deferContentDelete / 10)
-			ctx.deferDelete = time.NewTicker(duration * time.Second)
+			// Run ten times as often as lifetime, but at least every
+			// second: integer division truncates values 1..9 to 0,
+			// and time.NewTicker(0) panics.
+			seconds := max(uint32(1), ctx.deferContentDelete/10)
+			ctx.deferDelete = time.NewTicker(time.Duration(seconds) * time.Second)
 		}
 	}
 }

--- a/pkg/pillar/cmd/volumemgr/volumemgr_test.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/sirupsen/logrus"
+)
+
+// TestMaybeUpdateConfigItems_DeferContentDeleteValues verifies that pushing
+// any non-negative value for timer.defer.content.delete does not panic
+// time.NewTicker. The handler computes the ticker interval as
+// (deferContentDelete / 10) seconds with uint32 integer division, so any
+// value in 1..9 truncates to 0 and historically caused
+// "panic: non-positive interval for NewTicker", which crashes the entire
+// zedbox process and forces the watchdog to reboot the device.
+func TestMaybeUpdateConfigItems_DeferContentDeleteValues(t *testing.T) {
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "test-volumemgr", 0)
+
+	cases := []uint32{1, 3, 5, 9, 10, 60, 3600}
+	for _, val := range cases {
+		val := val
+		t.Run(fmt.Sprintf("DeferContentDelete=%d", val), func(t *testing.T) {
+			ctx := volumemgrContext{
+				globalConfig: types.DefaultConfigItemValueMap(),
+			}
+			// Pre-initialize deferDelete the way Run() does at startup.
+			ctx.deferDelete = time.NewTicker(time.Hour)
+			ctx.deferDelete.Stop()
+
+			newCfg := types.DefaultConfigItemValueMap()
+			newCfg.SetGlobalValueInt(types.DeferContentDelete, val)
+
+			maybeUpdateConfigItems(&ctx, newCfg)
+
+			ctx.deferDelete.Stop()
+		})
+	}
+}


### PR DESCRIPTION


# Description

Pushing a value in `1..9` for the `timer.defer.content.delete` global setting
(via `zcli edge-node update --config="timer.defer.content.delete:N"` or
equivalent) crashes `zedbox` and triggers a watchdog reboot of the device. This was reproduced in an edge node running `16.0.0-lts-kvm-amd64`. 

`maybeUpdateConfigItems` in `volumemgr` computes the ticker interval as
`ctx.deferContentDelete / 10`, where `deferContentDelete` is `uint32`. For
any value below 10 the integer division truncates to `0`, and
`time.NewTicker(0)` panics with `non-positive interval for NewTicker`.
Because all pillar agents share the `zedbox` process, this single panic
takes down every microservice and the EVE watchdog reboots the node.

## Fix

Floor the ticker period at 1 second:

```go
seconds := max(uint32(1), ctx.deferContentDelete/10)
ctx.deferDelete = time.NewTicker(time.Duration(seconds) * time.Second)
```

## How to test and validate this PR

On a running node:

```
zcli edge-node update <node> --config="timer.defer.content.delete:3"
```

Followed later by:
```
Watchdog report for IMGA EVE version 16.0.0-lts-kvm-amd64 ... 3 /run/zedbox.pid
```

## Changelog notes

- fix(volumemgr): floor deferContentDelete ticker at 1 second

## PR Backports

Should be backported to: 

- 16.0-stable


## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

The tests were done only on x86 device. 

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
