### PR TITLE
hypervisor/kubevirt: fix CPU metrics always reporting zero

### DIFF
--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -122,12 +122,13 @@ func (metrics *kubevirtMetrics) fill(domainName, metricName string, value interf
 
 	BytesInMegabyte := int64(1024 * 1024)
 	switch metricName {
-	// add all the cpus to be Total, seconds should be from VM startup time
-	case "kubevirt_vmi_cpu_system_usage_seconds":
-	case "kubevirt_vmi_cpu_usage_seconds":
-	case "kubevirt_vmi_cpu_user_usage_seconds":
-		cpuNs := assignToInt64(value) * int64(time.Second)
-		r.CPUTotalNs = r.CPUTotalNs + uint64(cpuNs)
+	// kubevirt_vmi_cpu_usage_seconds_total is the combined total (system+user); use it alone to avoid double-counting
+	case "kubevirt_vmi_cpu_usage_seconds_total":
+		if v, ok := value.(float64); ok {
+			r.CPUTotalNs += uint64(v * float64(time.Second))
+		}
+	case "kubevirt_vmi_cpu_system_usage_seconds_total":
+	case "kubevirt_vmi_cpu_user_usage_seconds_total":
 	case "kubevirt_vmi_memory_usable_bytes":
 		// The amount of memory which can be reclaimed by balloon without pushing the guest system to swap,
 		// corresponds to ‘Available’ in /proc/meminfo
@@ -137,10 +138,6 @@ func (metrics *kubevirtMetrics) fill(domainName, metricName string, value interf
 		// The amount of memory in bytes allocated to the domain.
 		// https://kubevirt.io/monitoring/metrics.html#kubevirt
 		r.AllocatedMB = uint32(assignToInt64(value) / BytesInMegabyte)
-	case "kubevirt_vmi_memory_available_bytes": // save this temp for later
-		// Amount of usable memory as seen by the domain.
-		// https://kubevirt.io/monitoring/metrics.html#kubevirt
-		r.UsedMemory = uint32(assignToInt64(value) / BytesInMegabyte)
 	default:
 	}
 	(*metrics)[domainName] = r
@@ -1190,7 +1187,7 @@ func (ctx kubevirtContext) GetDomsCPUMem() (map[string]types.DomainMetric, error
 	res := make(kubevirtMetrics, len(ctx.vmiList))
 	virtIP, err := getVirtHandlerIPAddr(&ctx, nodeName)
 	if err != nil {
-		logrus.Debugf("GetDomsCPUMem get virthandler ip error %v", err)
+		logrus.Debugf("GetDomsCPUMem: get virthandler ip error %v", err)
 		return nil, err
 	}
 
@@ -1224,6 +1221,10 @@ func (ctx kubevirtContext) GetDomsCPUMem() (map[string]types.DomainMetric, error
 		logrus.Infof("GetDomsCPUMem: Error reading response body %v", err)
 		return nil, err
 	}
+
+	// domainAvailMB temporarily tracks kubevirt_vmi_memory_available_bytes per domain
+	// so we can compute UsedMemory = available_bytes - usable_bytes after all metrics are parsed.
+	domainAvailMB := make(map[string]uint32)
 
 	// It seems the virt-handler metrics only container the VMIs running on this node
 	scanner := bufio.NewScanner(strings.NewReader(string(body)))
@@ -1280,6 +1281,10 @@ func (ctx kubevirtContext) GetDomsCPUMem() (map[string]types.DomainMetric, error
 					}
 				}
 			}
+			if metricName == "kubevirt_vmi_memory_available_bytes" && domainName != "" {
+				const bytesInMegabyte = int64(1024 * 1024)
+				domainAvailMB[domainName] = uint32(assignToInt64(parsedValue) / bytesInMegabyte)
+			}
 			res.fill(domainName, metricName, parsedValue)
 			logrus.Debugf("GetDomsCPUMem: vmi %s, domainName %s, metric name %s, value %v", vmiName, domainName, metricName, parsedValue)
 		}
@@ -1289,8 +1294,12 @@ func (ctx kubevirtContext) GetDomsCPUMem() (map[string]types.DomainMetric, error
 		if n == "" {
 			continue
 		}
-		// used_bytes = available_bytes - usable_bytes
-		r.UsedMemory = r.UsedMemory - r.AvailableMemory
+		// used_bytes = available_bytes - usable_bytes; guard uint32 underflow when guest agent data is stale/absent
+		if domainAvailMB[n] > r.AvailableMemory {
+			r.UsedMemory = domainAvailMB[n] - r.AvailableMemory
+		} else {
+			r.UsedMemory = 0
+		}
 		if r.AllocatedMB > 0 {
 			per := float64(r.UsedMemory) / float64(r.AllocatedMB)
 			r.UsedMemoryPercent = per


### PR DESCRIPTION

# Description

  GetDomsCPUMem was matching against kubevirt_vmi_cpu_usage_seconds, but
  the virt-handler emits the metric with a _total suffix:
  kubevirt_vmi_cpu_usage_seconds_total. The mismatch caused CPUTotalNs
  to remain 0 for all app VMs regardless of load.

  Also guard against uint32 underflow in UsedMemory when guest agent
  balloon data is stale (usable_bytes > available_bytes).

## PR dependencies

## How to test and validate this PR

Configure an edge-node cluster, and deploy some VMIs on the cluster.
Monitoer the App Instance CPU usage in UI, while generate some activities,
for example, using 'stress-ng' tools.

## Changelog notes

hypervisor/kubevirt: fix CPU metrics always reporting zero

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
