### PR TITLE
pillar: add unit tests for NIM-related packages

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -4,4 +4,4 @@
 
 [codespell]
 skip = ./.git/*,*/vendor/*,./conf/v2tlsbaseroot-certificates.pem,./pkg/gpt-tools/patches/*,./pkg/new-kernel/*,./pkg/kernel/*,./pkg/fw/*,./evetest/cert/eve_rsa*,./evetest/constants/eve.go
-ignore-words-list = uptodate,synopsys,crate,UE,ratatui,archtype
+ignore-words-list = uptodate,synopsys,crate,UE,ratatui,archtype,nd

--- a/pkg/pillar/dpcreconciler/genericitems/items_test.go
+++ b/pkg/pillar/dpcreconciler/genericitems/items_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package genericitems
+
+import (
+	"net"
+	"testing"
+
+	dg "github.com/lf-edge/eve-libs/depgraph"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// --- AdapterAddrs ---
+
+func TestAdapterAddrsDependencies(t *testing.T) {
+	a := AdapterAddrs{}
+	if deps := a.Dependencies(); deps != nil {
+		t.Errorf("expected nil deps, got %v", deps)
+	}
+}
+
+func TestAdapterAddrsEqual(t *testing.T) {
+	_, net1, _ := net.ParseCIDR("10.0.0.0/24")
+	_, net2, _ := net.ParseCIDR("10.0.1.0/24")
+	a1 := AdapterAddrs{AdapterIfName: "eth0", IPAddrs: []*net.IPNet{net1, net2}}
+	a2Same := AdapterAddrs{AdapterIfName: "eth0", IPAddrs: []*net.IPNet{net2, net1}}
+	a3Less := AdapterAddrs{AdapterIfName: "eth0", IPAddrs: []*net.IPNet{net1}}
+	a4Empty := AdapterAddrs{}
+	tests := []struct {
+		name  string
+		a     AdapterAddrs
+		other dg.Item
+		want  bool
+	}{
+		{"identical", a1, a1, true},
+		{"order-independent", a1, a2Same, true},
+		{"subset", a1, a3Less, false},
+		{"both empty", a4Empty, a4Empty, true},
+		{"wrong type", a1, ResolvConf{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.a.Equal(tc.other); got != tc.want {
+				t.Errorf("Equal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// --- Dhcpcd ---
+
+func TestDhcpcdDependencies(t *testing.T) {
+	c := Dhcpcd{AdapterIfName: "eth0"}
+	deps := c.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dep, got %d", len(deps))
+	}
+	if deps[0].RequiredItem.ItemType != AdapterTypename {
+		t.Errorf("dep type: got %q, want %q", deps[0].RequiredItem.ItemType, AdapterTypename)
+	}
+	if deps[0].RequiredItem.ItemName != "eth0" {
+		t.Errorf("dep name: got %q, want %q", deps[0].RequiredItem.ItemName, "eth0")
+	}
+}
+
+// --- NetIO ---
+
+func TestNetIOEqual(t *testing.T) {
+	n := NetIO{IfName: "eth0"}
+	// Equal always returns true regardless of the argument.
+	if !n.Equal(NetIO{IfName: "eth1"}) {
+		t.Error("NetIO.Equal should always return true")
+	}
+	if !n.Equal(ResolvConf{}) {
+		t.Error("NetIO.Equal should always return true for any item type")
+	}
+}
+
+func TestNetIODependencies(t *testing.T) {
+	n := NetIO{}
+	if deps := n.Dependencies(); deps != nil {
+		t.Errorf("expected nil deps, got %v", deps)
+	}
+}
+
+func TestResolvConfDependencies(t *testing.T) {
+	r := ResolvConf{}
+	if deps := r.Dependencies(); deps != nil {
+		t.Errorf("expected nil deps, got %v", deps)
+	}
+}
+
+func TestResolvConfEqual(t *testing.T) {
+	dns1 := net.ParseIP("8.8.8.8")
+	dns2 := net.ParseIP("1.1.1.1")
+	r1 := ResolvConf{DNSServers: map[string][]net.IP{"eth0": {dns1}}}
+	r2Same := ResolvConf{DNSServers: map[string][]net.IP{"eth0": {dns1}}}
+	r3Diff := ResolvConf{DNSServers: map[string][]net.IP{"eth0": {dns2}}}
+	r4Empty := ResolvConf{}
+	tests := []struct {
+		name  string
+		r     ResolvConf
+		other dg.Item
+		want  bool
+	}{
+		{"identical", r1, r2Same, true},
+		{"different IP", r1, r3Diff, false},
+		{"both empty", r4Empty, r4Empty, true},
+		{"one empty", r1, r4Empty, false},
+		{"wrong type", r1, NetIO{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.r.Equal(tc.other); got != tc.want {
+				t.Errorf("Equal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSSHAuthKeysDependencies(t *testing.T) {
+	s := SSHAuthKeys{}
+	if deps := s.Dependencies(); deps != nil {
+		t.Errorf("expected nil deps, got %v", deps)
+	}
+}
+
+func TestSSHAuthKeysEqual(t *testing.T) {
+	s1 := SSHAuthKeys{Keys: "ssh-rsa AAAA..."}
+	s2Same := SSHAuthKeys{Keys: "ssh-rsa AAAA..."}
+	s3Diff := SSHAuthKeys{Keys: "ssh-ed25519 BBBB..."}
+	s4Empty := SSHAuthKeys{}
+	tests := []struct {
+		name  string
+		s     SSHAuthKeys
+		other dg.Item
+		want  bool
+	}{
+		{"same keys", s1, s2Same, true},
+		{"different keys", s1, s3Diff, false},
+		{"both empty", s4Empty, s4Empty, true},
+		{"wrong type", s1, ResolvConf{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.s.Equal(tc.other); got != tc.want {
+				t.Errorf("Equal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWwanDependencies(t *testing.T) {
+	w := Wwan{}
+	if deps := w.Dependencies(); deps != nil {
+		t.Errorf("expected nil deps, got %v", deps)
+	}
+}
+
+func TestWwanEqual(t *testing.T) {
+	w1 := Wwan{Config: types.WwanConfig{}}
+	w2 := Wwan{Config: types.WwanConfig{}}
+	tests := []struct {
+		name  string
+		w     Wwan
+		other dg.Item
+		want  bool
+	}{
+		{"equal empty configs", w1, w2, true},
+		{"wrong type", w1, ResolvConf{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.w.Equal(tc.other); got != tc.want {
+				t.Errorf("Equal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/pillar/dpcreconciler/genericitems/wpa_supplicant_test.go
+++ b/pkg/pillar/dpcreconciler/genericitems/wpa_supplicant_test.go
@@ -1,0 +1,399 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package genericitems
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	dg "github.com/lf-edge/eve-libs/depgraph"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// mockAdapter implements depgraph.Item and wirelessTypeGetter for testing
+// the MustSatisfy closure inside Dependencies().
+type mockAdapter struct {
+	ifName string
+	wType  types.WirelessType
+}
+
+func (a mockAdapter) Name() string                        { return a.ifName }
+func (a mockAdapter) Label() string                       { return a.ifName }
+func (a mockAdapter) Type() string                        { return AdapterTypename }
+func (a mockAdapter) Equal(dg.Item) bool                  { return false }
+func (a mockAdapter) External() bool                      { return false }
+func (a mockAdapter) String() string                      { return a.ifName }
+func (a mockAdapter) Dependencies() []dg.Dependency       { return nil }
+func (a mockAdapter) GetWirelessType() types.WirelessType { return a.wType }
+
+func TestPNAC8021XConfigEqual(t *testing.T) {
+	t.Parallel()
+	base := &PNAC8021XConfig{
+		EAPIdentity:      "device@corp",
+		CACertBundlePath: "/certs/ca.pem",
+		ClientCertPath:   "/certs/client.pem",
+		ClientKeyPath:    "/certs/client.key",
+	}
+	type test struct {
+		name     string
+		a, b     *PNAC8021XConfig
+		expEqual bool
+	}
+	tests := []test{
+		{"both nil", nil, nil, true},
+		{"nil vs non-nil", nil, base, false},
+		{"non-nil vs nil", base, nil, false},
+		{"identical", base, &PNAC8021XConfig{
+			EAPIdentity:      "device@corp",
+			CACertBundlePath: "/certs/ca.pem",
+			ClientCertPath:   "/certs/client.pem",
+			ClientKeyPath:    "/certs/client.key",
+		}, true},
+		{"different identity", base, &PNAC8021XConfig{
+			EAPIdentity:      "other@corp",
+			CACertBundlePath: "/certs/ca.pem",
+			ClientCertPath:   "/certs/client.pem",
+			ClientKeyPath:    "/certs/client.key",
+		}, false},
+		{"different CA cert", base, &PNAC8021XConfig{
+			EAPIdentity:      "device@corp",
+			CACertBundlePath: "/certs/other-ca.pem",
+			ClientCertPath:   "/certs/client.pem",
+			ClientKeyPath:    "/certs/client.key",
+		}, false},
+		{"different client cert", base, &PNAC8021XConfig{
+			EAPIdentity:      "device@corp",
+			CACertBundlePath: "/certs/ca.pem",
+			ClientCertPath:   "/certs/other.pem",
+			ClientKeyPath:    "/certs/client.key",
+		}, false},
+		{"different client key", base, &PNAC8021XConfig{
+			EAPIdentity:      "device@corp",
+			CACertBundlePath: "/certs/ca.pem",
+			ClientCertPath:   "/certs/client.pem",
+			ClientKeyPath:    "/certs/other.key",
+		}, false},
+	}
+	for _, tc := range tests {
+		got := tc.a.Equal(tc.b)
+		if got != tc.expEqual {
+			t.Errorf("TEST CASE %q: Equal() = %v, want %v", tc.name, got, tc.expEqual)
+		}
+	}
+}
+
+func TestWpaSupplicantEqual(t *testing.T) {
+	t.Parallel()
+	psk := WifiConfig{SSID: "net1", KeyScheme: types.KeySchemeWpaPsk, PasswordHash: "hash1"}
+	eap := WifiConfig{SSID: "net2", KeyScheme: types.KeySchemeWpaEap, Identity: "u", PasswordHash: "hash2"}
+	pnac := &PNAC8021XConfig{
+		EAPIdentity:      "dev@corp",
+		CACertBundlePath: "/ca.pem",
+		ClientCertPath:   "/c.pem",
+		ClientKeyPath:    "/k.key",
+	}
+	type test struct {
+		name     string
+		a, b     WpaSupplicant
+		expEqual bool
+	}
+	tests := []test{
+		{
+			name:     "identical WiFi configs",
+			a:        WpaSupplicant{WiFiConfigs: []WifiConfig{psk, eap}},
+			b:        WpaSupplicant{WiFiConfigs: []WifiConfig{psk, eap}},
+			expEqual: true,
+		},
+		{
+			name:     "WiFi configs in different order (EqualSets)",
+			a:        WpaSupplicant{WiFiConfigs: []WifiConfig{psk, eap}},
+			b:        WpaSupplicant{WiFiConfigs: []WifiConfig{eap, psk}},
+			expEqual: true,
+		},
+		{
+			name:     "different WiFi SSID",
+			a:        WpaSupplicant{WiFiConfigs: []WifiConfig{{SSID: "A"}}},
+			b:        WpaSupplicant{WiFiConfigs: []WifiConfig{{SSID: "B"}}},
+			expEqual: false,
+		},
+		{
+			name:     "different number of WiFi configs",
+			a:        WpaSupplicant{WiFiConfigs: []WifiConfig{psk}},
+			b:        WpaSupplicant{WiFiConfigs: []WifiConfig{psk, eap}},
+			expEqual: false,
+		},
+		{
+			name:     "identical PNAC config",
+			a:        WpaSupplicant{PNACConfig: pnac},
+			b:        WpaSupplicant{PNACConfig: &PNAC8021XConfig{EAPIdentity: "dev@corp", CACertBundlePath: "/ca.pem", ClientCertPath: "/c.pem", ClientKeyPath: "/k.key"}},
+			expEqual: true,
+		},
+		{
+			name:     "different PNAC identity",
+			a:        WpaSupplicant{PNACConfig: pnac},
+			b:        WpaSupplicant{PNACConfig: &PNAC8021XConfig{EAPIdentity: "other@corp", CACertBundlePath: "/ca.pem", ClientCertPath: "/c.pem", ClientKeyPath: "/k.key"}},
+			expEqual: false,
+		},
+		{
+			name:     "one WiFi one PNAC",
+			a:        WpaSupplicant{WiFiConfigs: []WifiConfig{psk}},
+			b:        WpaSupplicant{PNACConfig: pnac},
+			expEqual: false,
+		},
+		{
+			name:     "wrong item type",
+			a:        WpaSupplicant{WiFiConfigs: []WifiConfig{psk}},
+			expEqual: false, // b is zero Resolvconf, not WpaSupplicant
+		},
+	}
+	for _, tc := range tests {
+		var other dg.Item
+		if tc.name == "wrong item type" {
+			other = ResolvConf{}
+		} else {
+			other = tc.b
+		}
+		got := tc.a.Equal(other)
+		if got != tc.expEqual {
+			t.Errorf("TEST CASE %q: Equal() = %v, want %v", tc.name, got, tc.expEqual)
+		}
+	}
+}
+
+func TestWpaSupplicantDependencies(t *testing.T) {
+	t.Parallel()
+
+	wifiSupplicant := WpaSupplicant{
+		AdapterIfName: "wlan0",
+		WiFiConfigs:   []WifiConfig{{SSID: "net"}},
+	}
+	deps := wifiSupplicant.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("Dependencies() returned %d deps, want 1", len(deps))
+	}
+	dep := deps[0]
+	if dep.RequiredItem.ItemType != AdapterTypename {
+		t.Errorf("dep.ItemType = %q, want %q", dep.RequiredItem.ItemType, AdapterTypename)
+	}
+	if dep.RequiredItem.ItemName != "wlan0" {
+		t.Errorf("dep.ItemName = %q, want %q", dep.RequiredItem.ItemName, "wlan0")
+	}
+
+	// MustSatisfy: WiFi supplicant requires WirelessTypeWifi adapter.
+	wifiAdapter := mockAdapter{ifName: "wlan0", wType: types.WirelessTypeWifi}
+	ethAdapter := mockAdapter{ifName: "wlan0", wType: types.WirelessTypeNone}
+	if !dep.MustSatisfy(wifiAdapter) {
+		t.Error("MustSatisfy(WiFi adapter) = false for WiFi supplicant, want true")
+	}
+	if dep.MustSatisfy(ethAdapter) {
+		t.Error("MustSatisfy(Ethernet adapter) = true for WiFi supplicant, want false")
+	}
+
+	// PNAC supplicant requires a wired (WirelessTypeNone) adapter.
+	pnacSupplicant := WpaSupplicant{
+		AdapterIfName: "eth0",
+		PNACConfig:    &PNAC8021XConfig{},
+	}
+	pnacDeps := pnacSupplicant.Dependencies()
+	if len(pnacDeps) != 1 {
+		t.Fatalf("PNAC Dependencies() returned %d deps, want 1", len(pnacDeps))
+	}
+	ethAdapter2 := mockAdapter{ifName: "eth0", wType: types.WirelessTypeNone}
+	wifiAdapter2 := mockAdapter{ifName: "eth0", wType: types.WirelessTypeWifi}
+	if !pnacDeps[0].MustSatisfy(ethAdapter2) {
+		t.Error("MustSatisfy(Ethernet adapter) = false for PNAC supplicant, want true")
+	}
+	if pnacDeps[0].MustSatisfy(wifiAdapter2) {
+		t.Error("MustSatisfy(WiFi adapter) = true for PNAC supplicant, want false")
+	}
+	// Non-adapter item type-asserts to wirelessTypeGetter → fails → false.
+	if pnacDeps[0].MustSatisfy(ResolvConf{}) {
+		t.Error("MustSatisfy(non-adapter) = true, want false")
+	}
+}
+
+func TestWpaSupplicantNeedsRecreate(t *testing.T) {
+	t.Parallel()
+	c := &WpaSupplicantConfigurator{}
+	old := WpaSupplicant{AdapterIfName: "wlan0", WiFiConfigs: []WifiConfig{{SSID: "A"}}}
+	updated := WpaSupplicant{AdapterIfName: "wlan0", WiFiConfigs: []WifiConfig{{SSID: "B"}}}
+	if !c.NeedsRecreate(old, updated) {
+		t.Error("NeedsRecreate() = false, want true (Modify is not implemented)")
+	}
+}
+
+func TestWpaSupplicantConfiguratorPaths(t *testing.T) {
+	t.Parallel()
+	c := &WpaSupplicantConfigurator{}
+	ifName := "wlan0"
+
+	cfgPath := c.configPath(ifName)
+	if !strings.HasSuffix(cfgPath, "wpa_supplicant-wlan0.conf") {
+		t.Errorf("configPath() = %q, want suffix wpa_supplicant-wlan0.conf", cfgPath)
+	}
+	if filepath.Dir(cfgPath) != nimRunDir {
+		t.Errorf("configPath() dir = %q, want %q", filepath.Dir(cfgPath), nimRunDir)
+	}
+
+	watcherPath := c.eventWatcherScriptPath(ifName)
+	if !strings.HasSuffix(watcherPath, "wpa_supplicant-wlan0-watcher.sh") {
+		t.Errorf("eventWatcherScriptPath() = %q, want suffix wpa_supplicant-wlan0-watcher.sh", watcherPath)
+	}
+
+	statePath := c.pnacStatePath(ifName)
+	if !strings.HasSuffix(statePath, ifName) {
+		t.Errorf("pnacStatePath() = %q, want suffix %q", statePath, ifName)
+	}
+	if filepath.Dir(statePath) != types.PNACStateDir {
+		t.Errorf("pnacStatePath() dir = %q, want %q", filepath.Dir(statePath), types.PNACStateDir)
+	}
+}
+
+func TestRenderWifiConfig(t *testing.T) {
+	t.Parallel()
+	c := &WpaSupplicantConfigurator{}
+
+	t.Run("PSK network", func(t *testing.T) {
+		t.Parallel()
+		cfgs := []WifiConfig{
+			{SSID: "MyHome", KeyScheme: types.KeySchemeWpaPsk, PasswordHash: "abc123hash"},
+		}
+		out := c.renderWifiConfig(cfgs)
+		for _, want := range []string{
+			"ctrl_interface=",
+			"ap_scan=1",
+			`ssid="MyHome"`,
+			"key_mgmt=WPA-PSK",
+			"psk=abc123hash",
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("renderWifiConfig PSK: missing %q in output:\n%s", want, out)
+			}
+		}
+		if strings.Contains(out, "WPA-EAP") {
+			t.Errorf("renderWifiConfig PSK: unexpected WPA-EAP in output:\n%s", out)
+		}
+	})
+
+	t.Run("PSK network without password hash", func(t *testing.T) {
+		t.Parallel()
+		cfgs := []WifiConfig{
+			{SSID: "OpenNet", KeyScheme: types.KeySchemeWpaPsk},
+		}
+		out := c.renderWifiConfig(cfgs)
+		if strings.Contains(out, "psk=") {
+			t.Errorf("renderWifiConfig PSK no-password: unexpected psk= in output:\n%s", out)
+		}
+	})
+
+	t.Run("EAP network", func(t *testing.T) {
+		t.Parallel()
+		cfgs := []WifiConfig{
+			{
+				SSID:         "CorpWifi",
+				KeyScheme:    types.KeySchemeWpaEap,
+				Identity:     "user@corp.com",
+				PasswordHash: "eaphash",
+			},
+		}
+		out := c.renderWifiConfig(cfgs)
+		for _, want := range []string{
+			"key_mgmt=WPA-EAP",
+			"eap=PEAP",
+			`identity="user@corp.com"`,
+			"password=hash:eaphash",
+			"phase1=",
+			"phase2=",
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("renderWifiConfig EAP: missing %q in output:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("EAP network without identity or password", func(t *testing.T) {
+		t.Parallel()
+		cfgs := []WifiConfig{
+			{SSID: "CorpWifi", KeyScheme: types.KeySchemeWpaEap},
+		}
+		out := c.renderWifiConfig(cfgs)
+		if strings.Contains(out, "identity=") {
+			t.Errorf("renderWifiConfig EAP no-identity: unexpected identity= in output:\n%s", out)
+		}
+		if strings.Contains(out, "password=") {
+			t.Errorf("renderWifiConfig EAP no-password: unexpected password= in output:\n%s", out)
+		}
+	})
+
+	t.Run("multiple networks with priority", func(t *testing.T) {
+		t.Parallel()
+		cfgs := []WifiConfig{
+			{SSID: "Primary", KeyScheme: types.KeySchemeWpaPsk, Priority: 10},
+			{SSID: "Backup", KeyScheme: types.KeySchemeWpaPsk, Priority: 0},
+		}
+		out := c.renderWifiConfig(cfgs)
+		if !strings.Contains(out, `ssid="Primary"`) {
+			t.Errorf("renderWifiConfig multi: missing Primary SSID:\n%s", out)
+		}
+		if !strings.Contains(out, `ssid="Backup"`) {
+			t.Errorf("renderWifiConfig multi: missing Backup SSID:\n%s", out)
+		}
+		if !strings.Contains(out, "priority=10") {
+			t.Errorf("renderWifiConfig multi: missing priority=10:\n%s", out)
+		}
+		// Priority 0 should not appear (zero means "don't set priority").
+		if strings.Contains(out, "priority=0") {
+			t.Errorf("renderWifiConfig multi: unexpected priority=0 in output:\n%s", out)
+		}
+	})
+}
+
+func TestRenderPNACConfig(t *testing.T) {
+	t.Parallel()
+	c := &WpaSupplicantConfigurator{}
+
+	t.Run("full PNAC config", func(t *testing.T) {
+		t.Parallel()
+		cfg := PNAC8021XConfig{
+			EAPIdentity:      "device@corp.com",
+			CACertBundlePath: "/certs/ca-bundle.pem",
+			ClientCertPath:   "/certs/device.pem",
+			ClientKeyPath:    "/certs/device.key",
+		}
+		out := c.renderPNACConfig(cfg)
+		for _, want := range []string{
+			"ctrl_interface=",
+			"ap_scan=0",
+			"key_mgmt=IEEE8021X",
+			"eap=TLS",
+			"eapol_flags=0",
+			`identity="device@corp.com"`,
+			`ca_cert="/certs/ca-bundle.pem"`,
+			`client_cert="/certs/device.pem"`,
+			`private_key="/certs/device.key"`,
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("renderPNACConfig: missing %q in output:\n%s", want, out)
+			}
+		}
+		// Must not contain ap_scan=1 (that's the WiFi path).
+		if strings.Contains(out, "ap_scan=1") {
+			t.Errorf("renderPNACConfig: unexpected ap_scan=1 in output:\n%s", out)
+		}
+	})
+
+	t.Run("empty identity", func(t *testing.T) {
+		t.Parallel()
+		cfg := PNAC8021XConfig{
+			CACertBundlePath: "/ca.pem",
+			ClientCertPath:   "/c.pem",
+			ClientKeyPath:    "/k.key",
+		}
+		out := c.renderPNACConfig(cfg)
+		if !strings.Contains(out, `identity=""`) {
+			t.Errorf("renderPNACConfig empty identity: missing empty identity field:\n%s", out)
+		}
+	})
+}

--- a/pkg/pillar/dpcreconciler/linuxitems/bond_vlan_test.go
+++ b/pkg/pillar/dpcreconciler/linuxitems/bond_vlan_test.go
@@ -1,0 +1,532 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package linuxitems
+
+import (
+	"net"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/dpcreconciler/genericitems"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// ---------------------------------------------------------------------------
+// Bond tests
+// ---------------------------------------------------------------------------
+
+func TestBondEqual(t *testing.T) {
+	t.Parallel()
+	base := Bond{
+		BondConfig: types.BondConfig{
+			Mode:     types.BondModeActiveBackup,
+			LacpRate: types.LacpRateUnspecified,
+			MIIMonitor: types.BondMIIMonitor{
+				Enabled:  true,
+				Interval: 100,
+				UpDelay:  200,
+			},
+		},
+		IfName:            "bond0",
+		AggregatedIfNames: []string{"eth0", "eth1"},
+		MTU:               1500,
+	}
+	type test struct {
+		name     string
+		a, b     Bond
+		expEqual bool
+	}
+	tests := []test{
+		{
+			name:     "identical",
+			a:        base,
+			b:        base,
+			expEqual: true,
+		},
+		{
+			name: "aggregated interfaces in different order (EqualSets)",
+			a:    base,
+			b: Bond{
+				BondConfig:        base.BondConfig,
+				IfName:            "bond0",
+				AggregatedIfNames: []string{"eth1", "eth0"},
+				MTU:               1500,
+			},
+			expEqual: true,
+		},
+		{
+			name: "different mode",
+			a:    base,
+			b: Bond{
+				BondConfig: types.BondConfig{
+					Mode: types.BondMode802Dot3AD,
+					MIIMonitor: types.BondMIIMonitor{
+						Enabled:  true,
+						Interval: 100,
+						UpDelay:  200,
+					},
+				},
+				IfName:            "bond0",
+				AggregatedIfNames: []string{"eth0", "eth1"},
+				MTU:               1500,
+			},
+			expEqual: false,
+		},
+		{
+			name: "different LacpRate",
+			a:    base,
+			b: Bond{
+				BondConfig: types.BondConfig{
+					Mode:     types.BondModeActiveBackup,
+					LacpRate: types.LacpRateFast,
+					MIIMonitor: types.BondMIIMonitor{
+						Enabled:  true,
+						Interval: 100,
+						UpDelay:  200,
+					},
+				},
+				IfName:            "bond0",
+				AggregatedIfNames: []string{"eth0", "eth1"},
+				MTU:               1500,
+			},
+			expEqual: false,
+		},
+		{
+			name: "different MII monitor interval",
+			a:    base,
+			b: Bond{
+				BondConfig: types.BondConfig{
+					Mode:     types.BondModeActiveBackup,
+					LacpRate: types.LacpRateUnspecified,
+					MIIMonitor: types.BondMIIMonitor{
+						Enabled:  true,
+						Interval: 200,
+						UpDelay:  200,
+					},
+				},
+				IfName:            "bond0",
+				AggregatedIfNames: []string{"eth0", "eth1"},
+				MTU:               1500,
+			},
+			expEqual: false,
+		},
+		{
+			name: "different MTU",
+			a:    base,
+			b: Bond{
+				BondConfig:        base.BondConfig,
+				IfName:            "bond0",
+				AggregatedIfNames: []string{"eth0", "eth1"},
+				MTU:               9000,
+			},
+			expEqual: false,
+		},
+		{
+			name: "different aggregated interfaces",
+			a:    base,
+			b: Bond{
+				BondConfig:        base.BondConfig,
+				IfName:            "bond0",
+				AggregatedIfNames: []string{"eth0"},
+				MTU:               1500,
+			},
+			expEqual: false,
+		},
+		{
+			name: "different ARP monitor",
+			a:    base,
+			b: Bond{
+				BondConfig: types.BondConfig{
+					Mode:     types.BondModeActiveBackup,
+					LacpRate: types.LacpRateUnspecified,
+					MIIMonitor: types.BondMIIMonitor{
+						Enabled:  true,
+						Interval: 100,
+						UpDelay:  200,
+					},
+					ARPMonitor: types.BondArpMonitor{
+						Enabled:   true,
+						Interval:  1000,
+						IPTargets: []net.IP{net.ParseIP("192.168.1.1")},
+					},
+				},
+				IfName:            "bond0",
+				AggregatedIfNames: []string{"eth0", "eth1"},
+				MTU:               1500,
+			},
+			expEqual: false,
+		},
+	}
+	for _, tc := range tests {
+		got := tc.a.Equal(tc.b)
+		if got != tc.expEqual {
+			t.Errorf("TEST CASE %q: Equal() = %v, want %v", tc.name, got, tc.expEqual)
+		}
+	}
+}
+
+func TestBondGetMTU(t *testing.T) {
+	t.Parallel()
+	if got := (Bond{MTU: 0}).GetMTU(); got != types.DefaultMTU {
+		t.Errorf("GetMTU() with zero MTU = %d, want DefaultMTU %d", got, types.DefaultMTU)
+	}
+	if got := (Bond{MTU: 9000}).GetMTU(); got != 9000 {
+		t.Errorf("GetMTU() with 9000 = %d, want 9000", got)
+	}
+}
+
+func TestBondDependencies(t *testing.T) {
+	t.Parallel()
+	b := Bond{
+		IfName:            "bond0",
+		AggregatedIfNames: []string{"eth0", "eth1"},
+	}
+	deps := b.Dependencies()
+	if len(deps) != 2 {
+		t.Fatalf("Dependencies() returned %d deps, want 2", len(deps))
+	}
+	names := map[string]bool{}
+	for _, dep := range deps {
+		if dep.RequiredItem.ItemType != genericitems.PhysIfTypename {
+			t.Errorf("dep.ItemType = %q, want %q", dep.RequiredItem.ItemType, genericitems.PhysIfTypename)
+		}
+		names[dep.RequiredItem.ItemName] = true
+	}
+	if !names["eth0"] || !names["eth1"] {
+		t.Errorf("deps should reference eth0 and eth1, got %v", names)
+	}
+	// MustSatisfy on the eth0 dependency: requires IOUsageBondAggrIf and
+	// MasterIfName == "bond0".
+	eth0Dep := depByName(t, deps, "eth0")
+	goodPhysIf := PhysIf{
+		PhysIfName:   "eth0",
+		Usage:        genericitems.IOUsageBondAggrIf,
+		MasterIfName: "bond0",
+	}
+	wrongUsage := PhysIf{
+		PhysIfName:   "eth0",
+		Usage:        genericitems.IOUsageAdapter,
+		MasterIfName: "bond0",
+	}
+	wrongMaster := PhysIf{
+		PhysIfName:   "eth0",
+		Usage:        genericitems.IOUsageBondAggrIf,
+		MasterIfName: "bond1",
+	}
+	if !eth0Dep.MustSatisfy(goodPhysIf) {
+		t.Error("MustSatisfy(correct physif) = false, want true")
+	}
+	if eth0Dep.MustSatisfy(wrongUsage) {
+		t.Error("MustSatisfy(wrong usage) = true, want false")
+	}
+	if eth0Dep.MustSatisfy(wrongMaster) {
+		t.Error("MustSatisfy(wrong master) = true, want false")
+	}
+}
+
+func TestBondDependenciesEmpty(t *testing.T) {
+	t.Parallel()
+	b := Bond{IfName: "bond0", AggregatedIfNames: nil}
+	if deps := b.Dependencies(); len(deps) != 0 {
+		t.Errorf("Dependencies() with no members = %d deps, want 0", len(deps))
+	}
+}
+
+func TestBondNeedsRecreate(t *testing.T) {
+	t.Parallel()
+	c := &BondConfigurator{}
+	base := Bond{
+		BondConfig: types.BondConfig{
+			Mode:     types.BondModeActiveBackup,
+			LacpRate: types.LacpRateUnspecified,
+			MIIMonitor: types.BondMIIMonitor{
+				Enabled:  true,
+				Interval: 100,
+			},
+		},
+		IfName:            "bond0",
+		AggregatedIfNames: []string{"eth0", "eth1"},
+		MTU:               1500,
+	}
+	type test struct {
+		name      string
+		old, new  Bond
+		expCreate bool
+	}
+	tests := []test{
+		{
+			name:      "no change",
+			old:       base,
+			new:       base,
+			expCreate: false,
+		},
+		{
+			name: "only aggregated interfaces changed",
+			old:  base,
+			new: Bond{
+				BondConfig:        base.BondConfig,
+				IfName:            "bond0",
+				AggregatedIfNames: []string{"eth0"},
+				MTU:               1500,
+			},
+			expCreate: false,
+		},
+		{
+			name: "only MTU changed",
+			old:  base,
+			new: Bond{
+				BondConfig:        base.BondConfig,
+				IfName:            "bond0",
+				AggregatedIfNames: base.AggregatedIfNames,
+				MTU:               9000,
+			},
+			expCreate: false,
+		},
+		{
+			name: "mode changed",
+			old:  base,
+			new: Bond{
+				BondConfig: types.BondConfig{
+					Mode:     types.BondMode802Dot3AD,
+					LacpRate: types.LacpRateUnspecified,
+					MIIMonitor: types.BondMIIMonitor{
+						Enabled:  true,
+						Interval: 100,
+					},
+				},
+				IfName:            "bond0",
+				AggregatedIfNames: base.AggregatedIfNames,
+				MTU:               1500,
+			},
+			expCreate: true,
+		},
+		{
+			name: "LacpRate changed",
+			old:  base,
+			new: Bond{
+				BondConfig: types.BondConfig{
+					Mode:     types.BondModeActiveBackup,
+					LacpRate: types.LacpRateFast,
+					MIIMonitor: types.BondMIIMonitor{
+						Enabled:  true,
+						Interval: 100,
+					},
+				},
+				IfName:            "bond0",
+				AggregatedIfNames: base.AggregatedIfNames,
+				MTU:               1500,
+			},
+			expCreate: true,
+		},
+		{
+			name: "MIIMonitor changed",
+			old:  base,
+			new: Bond{
+				BondConfig: types.BondConfig{
+					Mode:     types.BondModeActiveBackup,
+					LacpRate: types.LacpRateUnspecified,
+					MIIMonitor: types.BondMIIMonitor{
+						Enabled:  true,
+						Interval: 200,
+					},
+				},
+				IfName:            "bond0",
+				AggregatedIfNames: base.AggregatedIfNames,
+				MTU:               1500,
+			},
+			expCreate: true,
+		},
+		{
+			name: "ARPMonitor changed",
+			old:  base,
+			new: Bond{
+				BondConfig: types.BondConfig{
+					Mode:     types.BondModeActiveBackup,
+					LacpRate: types.LacpRateUnspecified,
+					ARPMonitor: types.BondArpMonitor{
+						Enabled:  true,
+						Interval: 1000,
+					},
+				},
+				IfName:            "bond0",
+				AggregatedIfNames: base.AggregatedIfNames,
+				MTU:               1500,
+			},
+			expCreate: true,
+		},
+	}
+	for _, tc := range tests {
+		got := c.NeedsRecreate(tc.old, tc.new)
+		if got != tc.expCreate {
+			t.Errorf("TEST CASE %q: NeedsRecreate() = %v, want %v", tc.name, got, tc.expCreate)
+		}
+	}
+}
+
+func TestIsFailoverBondMode(t *testing.T) {
+	t.Parallel()
+	type test struct {
+		mode       types.BondMode
+		isFailover bool
+	}
+	tests := []test{
+		{types.BondModeActiveBackup, true},
+		{types.BondModeBalanceTLB, true},
+		{types.BondModeBalanceALB, true},
+		{types.BondModeBalanceRR, false},
+		{types.BondMode802Dot3AD, false},
+		{types.BondModeBalanceXOR, false},
+		{types.BondModeBroadcast, false},
+		{types.BondModeUnspecified, false},
+	}
+	for _, tc := range tests {
+		got := isFailoverBondMode(tc.mode)
+		if got != tc.isFailover {
+			t.Errorf("isFailoverBondMode(%v) = %v, want %v", tc.mode, got, tc.isFailover)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Vlan tests
+// ---------------------------------------------------------------------------
+
+func TestVlanEqual(t *testing.T) {
+	t.Parallel()
+	base := Vlan{
+		IfName:       "eth0.100",
+		ParentIfName: "eth0",
+		ID:           100,
+		MTU:          1500,
+	}
+	type test struct {
+		name     string
+		a, b     Vlan
+		expEqual bool
+	}
+	tests := []test{
+		{
+			name:     "identical",
+			a:        base,
+			b:        base,
+			expEqual: true,
+		},
+		{
+			name:     "different parent",
+			a:        base,
+			b:        Vlan{IfName: "eth0.100", ParentIfName: "eth1", ID: 100, MTU: 1500},
+			expEqual: false,
+		},
+		{
+			name:     "different VLAN ID",
+			a:        base,
+			b:        Vlan{IfName: "eth0.100", ParentIfName: "eth0", ID: 200, MTU: 1500},
+			expEqual: false,
+		},
+		{
+			name:     "different MTU",
+			a:        base,
+			b:        Vlan{IfName: "eth0.100", ParentIfName: "eth0", ID: 100, MTU: 9000},
+			expEqual: false,
+		},
+	}
+	for _, tc := range tests {
+		got := tc.a.Equal(tc.b)
+		if got != tc.expEqual {
+			t.Errorf("TEST CASE %q: Equal() = %v, want %v", tc.name, got, tc.expEqual)
+		}
+	}
+}
+
+func TestVlanGetMTU(t *testing.T) {
+	t.Parallel()
+	if got := (Vlan{MTU: 0}).GetMTU(); got != types.DefaultMTU {
+		t.Errorf("GetMTU() with zero MTU = %d, want DefaultMTU %d", got, types.DefaultMTU)
+	}
+	if got := (Vlan{MTU: 9000}).GetMTU(); got != 9000 {
+		t.Errorf("GetMTU() with 9000 = %d, want 9000", got)
+	}
+}
+
+func TestVlanDependencies(t *testing.T) {
+	t.Parallel()
+	v := Vlan{
+		IfName:       "eth0.100",
+		ParentIfName: "eth0",
+		ID:           100,
+		MTU:          1500,
+	}
+	deps := v.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("Dependencies() returned %d deps, want 1", len(deps))
+	}
+	dep := deps[0]
+	if dep.RequiredItem.ItemType != genericitems.AdapterTypename {
+		t.Errorf("dep.ItemType = %q, want %q", dep.RequiredItem.ItemType, genericitems.AdapterTypename)
+	}
+	if dep.RequiredItem.ItemName != "eth0" {
+		t.Errorf("dep.ItemName = %q, want %q", dep.RequiredItem.ItemName, "eth0")
+	}
+
+	goodAdapter := Adapter{IfName: "eth0", UsedAsVlanParent: true, MTU: 1500}
+	notVlanParent := Adapter{IfName: "eth0", UsedAsVlanParent: false, MTU: 1500}
+	tooSmallMTU := Adapter{IfName: "eth0", UsedAsVlanParent: true, MTU: 1000}
+	// Non-Adapter item: MustSatisfy uses a type assertion with ok check → false.
+	nonAdapter := PhysIf{PhysIfName: "eth0"}
+
+	if !dep.MustSatisfy(goodAdapter) {
+		t.Error("MustSatisfy(good adapter) = false, want true")
+	}
+	if dep.MustSatisfy(notVlanParent) {
+		t.Error("MustSatisfy(not vlan parent) = true, want false")
+	}
+	if dep.MustSatisfy(tooSmallMTU) {
+		t.Error("MustSatisfy(MTU too small) = true, want false")
+	}
+	if dep.MustSatisfy(nonAdapter) {
+		t.Error("MustSatisfy(non-adapter) = true, want false")
+	}
+}
+
+func TestVlanNeedsRecreate(t *testing.T) {
+	t.Parallel()
+	c := &VlanConfigurator{}
+	base := Vlan{IfName: "eth0.100", ParentIfName: "eth0", ID: 100, MTU: 1500}
+	type test struct {
+		name      string
+		old, new  Vlan
+		expCreate bool
+	}
+	tests := []test{
+		{
+			name:      "no change",
+			old:       base,
+			new:       base,
+			expCreate: false,
+		},
+		{
+			name:      "only MTU changed",
+			old:       base,
+			new:       Vlan{IfName: "eth0.100", ParentIfName: "eth0", ID: 100, MTU: 9000},
+			expCreate: false,
+		},
+		{
+			name:      "parent changed",
+			old:       base,
+			new:       Vlan{IfName: "eth0.100", ParentIfName: "eth1", ID: 100, MTU: 1500},
+			expCreate: true,
+		},
+		{
+			name:      "VLAN ID changed",
+			old:       base,
+			new:       Vlan{IfName: "eth0.100", ParentIfName: "eth0", ID: 200, MTU: 1500},
+			expCreate: true,
+		},
+	}
+	for _, tc := range tests {
+		got := c.NeedsRecreate(tc.old, tc.new)
+		if got != tc.expCreate {
+			t.Errorf("TEST CASE %q: NeedsRecreate() = %v, want %v", tc.name, got, tc.expCreate)
+		}
+	}
+}

--- a/pkg/pillar/dpcreconciler/linuxitems/items_test.go
+++ b/pkg/pillar/dpcreconciler/linuxitems/items_test.go
@@ -1,0 +1,404 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package linuxitems
+
+import (
+	"net"
+	"testing"
+
+	dg "github.com/lf-edge/eve-libs/depgraph"
+	"github.com/lf-edge/eve/pkg/pillar/dpcreconciler/genericitems"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/vishvananda/netlink"
+)
+
+// depByType returns the first dependency on the given item type. Tests use
+// this instead of positional indexing so that reordering dependencies (which
+// is semantically irrelevant to the reconciler) does not break them.
+func depByType(t *testing.T, deps []dg.Dependency, itemType string) dg.Dependency {
+	t.Helper()
+	for _, d := range deps {
+		if d.RequiredItem.ItemType == itemType {
+			return d
+		}
+	}
+	t.Fatalf("no dependency on item type %q; got %v", itemType, deps)
+	return dg.Dependency{}
+}
+
+// depByName returns the dependency on the item with the given name, again to
+// avoid relying on the (irrelevant) order in which dependencies are returned.
+func depByName(t *testing.T, deps []dg.Dependency, itemName string) dg.Dependency {
+	t.Helper()
+	for _, d := range deps {
+		if d.RequiredItem.ItemName == itemName {
+			return d
+		}
+	}
+	t.Fatalf("no dependency on item name %q; got %v", itemName, deps)
+	return dg.Dependency{}
+}
+
+// --- Adapter ---
+
+func TestAdapterGetMTU(t *testing.T) {
+	a := Adapter{MTU: 0}
+	if got := a.GetMTU(); got != types.DefaultMTU {
+		t.Errorf("zero MTU: got %d, want %d", got, types.DefaultMTU)
+	}
+	a9k := Adapter{MTU: 9000}
+	if got := a9k.GetMTU(); got != 9000 {
+		t.Errorf("got %d, want 9000", got)
+	}
+}
+
+func TestAdapterEqual(t *testing.T) {
+	base := Adapter{
+		IfName: "eth0", LogicalLabel: "eth0",
+		L2Type: types.L2LinkTypeNone, WirelessType: types.WirelessTypeNone,
+		DhcpType: types.DhcpTypeNOOP, MTU: 1500,
+	}
+	mod := func(f func(*Adapter)) Adapter {
+		a := base
+		f(&a)
+		return a
+	}
+	tests := []struct {
+		name  string
+		other Adapter
+		want  bool
+	}{
+		{"identical", base, true},
+		{"diff L2Type", mod(func(a *Adapter) { a.L2Type = types.L2LinkTypeVLAN }), false},
+		{"diff WirelessType", mod(func(a *Adapter) { a.WirelessType = types.WirelessTypeWifi }), false},
+		{"diff UsedAsVlanParent", mod(func(a *Adapter) { a.UsedAsVlanParent = true }), false},
+		{"diff DhcpType", mod(func(a *Adapter) { a.DhcpType = types.DhcpTypeStatic }), false},
+		{"diff MTU", mod(func(a *Adapter) { a.MTU = 9000 }), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := base.Equal(tc.other); got != tc.want {
+				t.Errorf("Equal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAdapterDependenciesPhysical(t *testing.T) {
+	a := Adapter{IfName: "eth0", L2Type: types.L2LinkTypeNone}
+	deps := a.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dep, got %d", len(deps))
+	}
+	if deps[0].RequiredItem.ItemType != genericitems.PhysIfTypename {
+		t.Errorf("dep type: got %q, want %q", deps[0].RequiredItem.ItemType, genericitems.PhysIfTypename)
+	}
+	if deps[0].RequiredItem.ItemName != "eth0" {
+		t.Errorf("dep name: got %q, want %q", deps[0].RequiredItem.ItemName, "eth0")
+	}
+	physIfOK := PhysIf{PhysIfName: "eth0", Usage: genericitems.IOUsageAdapter}
+	physIfBond := PhysIf{PhysIfName: "eth0", Usage: genericitems.IOUsageBondAggrIf}
+	if !deps[0].MustSatisfy(physIfOK) {
+		t.Error("MustSatisfy: IOUsageAdapter should satisfy")
+	}
+	if deps[0].MustSatisfy(physIfBond) {
+		t.Error("MustSatisfy: IOUsageBondAggrIf should not satisfy")
+	}
+}
+
+func TestAdapterDependenciesVLAN(t *testing.T) {
+	a := Adapter{IfName: "vlan10", L2Type: types.L2LinkTypeVLAN}
+	deps := a.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dep, got %d", len(deps))
+	}
+	if deps[0].RequiredItem.ItemType != genericitems.VlanTypename {
+		t.Errorf("dep type: got %q, want %q", deps[0].RequiredItem.ItemType, genericitems.VlanTypename)
+	}
+}
+
+func TestAdapterDependenciesBond(t *testing.T) {
+	a := Adapter{IfName: "bond0", L2Type: types.L2LinkTypeBond}
+	deps := a.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dep, got %d", len(deps))
+	}
+	if deps[0].RequiredItem.ItemType != genericitems.BondTypename {
+		t.Errorf("dep type: got %q, want %q", deps[0].RequiredItem.ItemType, genericitems.BondTypename)
+	}
+}
+
+func TestAdapterDependenciesWifi(t *testing.T) {
+	a := Adapter{IfName: "wlan0", L2Type: types.L2LinkTypeNone, WirelessType: types.WirelessTypeWifi}
+	deps := a.Dependencies()
+	if len(deps) != 2 {
+		t.Fatalf("WiFi: expected 2 deps, got %d", len(deps))
+	}
+	rfDep := depByType(t, deps, RFKillTypename)
+	if !rfDep.MustSatisfy(RFKill{EnableWlanRF: true}) {
+		t.Error("MustSatisfy: enabled RF should satisfy")
+	}
+	if rfDep.MustSatisfy(RFKill{EnableWlanRF: false}) {
+		t.Error("MustSatisfy: disabled RF should not satisfy")
+	}
+}
+
+// --- Arp ---
+
+func TestArpEqual(t *testing.T) {
+	mac1, _ := net.ParseMAC("aa:bb:cc:dd:ee:ff")
+	mac2, _ := net.ParseMAC("11:22:33:44:55:66")
+	a1 := Arp{HwAddr: mac1}
+	a2 := Arp{HwAddr: mac1}
+	a3 := Arp{HwAddr: mac2}
+	if !a1.Equal(a2) {
+		t.Error("same MACs should be equal")
+	}
+	if a1.Equal(a3) {
+		t.Error("different MACs should not be equal")
+	}
+}
+
+func TestArpDependencies(t *testing.T) {
+	a := Arp{AdapterIfName: "eth0", IPAddr: net.ParseIP("10.0.0.1")}
+	deps := a.Dependencies()
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 deps, got %d", len(deps))
+	}
+	depByType(t, deps, genericitems.AdapterTypename)
+	addrsDep := depByType(t, deps, genericitems.AdapterAddrsTypename)
+	_, net1, _ := net.ParseCIDR("10.0.0.1/24")
+	addrsWithIP := genericitems.AdapterAddrs{IPAddrs: []*net.IPNet{net1}}
+	addrsEmpty := genericitems.AdapterAddrs{}
+	if !addrsDep.MustSatisfy(addrsWithIP) {
+		t.Error("MustSatisfy: addrs with IPs should satisfy")
+	}
+	if addrsDep.MustSatisfy(addrsEmpty) {
+		t.Error("MustSatisfy: empty addrs should not satisfy")
+	}
+}
+
+// --- IPRule ---
+
+func TestIPRuleDependencies(t *testing.T) {
+	r := IPRule{}
+	if deps := r.Dependencies(); deps != nil {
+		t.Errorf("expected nil deps, got %v", deps)
+	}
+}
+
+func TestIPRuleEqual(t *testing.T) {
+	_, src, _ := net.ParseCIDR("10.0.0.0/8")
+	_, dst, _ := net.ParseCIDR("192.168.0.0/16")
+	base := IPRule{Priority: 100, Table: 254, IPv6: false, Src: src, Dst: dst}
+	mod := func(f func(*IPRule)) IPRule {
+		r := base
+		f(&r)
+		return r
+	}
+	tests := []struct {
+		name  string
+		other dg.Item
+		want  bool
+	}{
+		{"identical", base, true},
+		{"diff priority", mod(func(r *IPRule) { r.Priority = 200 }), false},
+		{"diff table", mod(func(r *IPRule) { r.Table = 100 }), false},
+		{"diff IPv6", mod(func(r *IPRule) { r.IPv6 = true }), false},
+		{"nil src", mod(func(r *IPRule) { r.Src = nil }), false},
+		{"nil dst", mod(func(r *IPRule) { r.Dst = nil }), false},
+		{"wrong type", RFKill{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := base.Equal(tc.other); got != tc.want {
+				t.Errorf("Equal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPhysIfGetMTU(t *testing.T) {
+	p := PhysIf{MTU: 0}
+	if got := p.GetMTU(); got != types.DefaultMTU {
+		t.Errorf("zero MTU: got %d, want %d", got, types.DefaultMTU)
+	}
+	p9k := PhysIf{MTU: 9000}
+	if got := p9k.GetMTU(); got != 9000 {
+		t.Errorf("got %d, want 9000", got)
+	}
+}
+
+func TestPhysIfEqual(t *testing.T) {
+	base := PhysIf{
+		PhysIfName: "eth0", PhysIfLL: "eth0",
+		Usage: genericitems.IOUsageAdapter, MTU: 1500,
+	}
+	tests := []struct {
+		name  string
+		other dg.Item
+		want  bool
+	}{
+		{"identical", base, true},
+		{"diff usage", PhysIf{PhysIfName: "eth0", PhysIfLL: "eth0",
+			Usage: genericitems.IOUsageBondAggrIf, MTU: 1500}, false},
+		{"diff MTU", PhysIf{PhysIfName: "eth0", PhysIfLL: "eth0",
+			Usage: genericitems.IOUsageAdapter, MTU: 9000}, false},
+		{"diff master", PhysIf{PhysIfName: "eth0", PhysIfLL: "eth0",
+			Usage: genericitems.IOUsageAdapter, MTU: 1500, MasterIfName: "bond0"}, false},
+		{"wrong type", RFKill{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := base.Equal(tc.other); got != tc.want {
+				t.Errorf("Equal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPhysIfDependencies(t *testing.T) {
+	p := PhysIf{PhysIfName: "eth0"}
+	deps := p.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dep, got %d", len(deps))
+	}
+	if deps[0].RequiredItem.ItemType != genericitems.NetIOTypename {
+		t.Errorf("dep type: got %q, want %q", deps[0].RequiredItem.ItemType, genericitems.NetIOTypename)
+	}
+	if deps[0].RequiredItem.ItemName != "eth0" {
+		t.Errorf("dep name: got %q, want %q", deps[0].RequiredItem.ItemName, "eth0")
+	}
+}
+
+// --- RFKill ---
+
+func TestRFKillDependencies(t *testing.T) {
+	r := RFKill{}
+	if deps := r.Dependencies(); deps != nil {
+		t.Errorf("expected nil deps, got %v", deps)
+	}
+}
+
+func TestRFKillEqual(t *testing.T) {
+	r1 := RFKill{EnableWlanRF: true}
+	r2 := RFKill{EnableWlanRF: true}
+	r3 := RFKill{EnableWlanRF: false}
+	if !r1.Equal(r2) {
+		t.Error("same EnableWlanRF should be equal")
+	}
+	if r1.Equal(r3) {
+		t.Error("different EnableWlanRF should not be equal")
+	}
+	if r1.Equal(Arp{}) {
+		t.Error("wrong type should not be equal")
+	}
+}
+
+// --- Route ---
+
+func TestRouteEqual(t *testing.T) {
+	_, dst, _ := net.ParseCIDR("10.0.0.0/8")
+	gw := net.ParseIP("192.168.1.1")
+	r1 := Route{Route: netlink.Route{Family: netlink.FAMILY_V4, Table: 254, Dst: dst, Gw: gw}}
+	r2 := Route{Route: netlink.Route{Family: netlink.FAMILY_V4, Table: 254, Dst: dst, Gw: gw}}
+	r3DiffGW := Route{Route: netlink.Route{Family: netlink.FAMILY_V4, Table: 254, Dst: dst}}
+	if !r1.Equal(r2) {
+		t.Error("identical routes should be equal")
+	}
+	if r1.Equal(r3DiffGW) {
+		t.Error("different GW should not be equal")
+	}
+	if r1.Equal(Arp{}) {
+		t.Error("wrong type should not be equal")
+	}
+}
+
+func TestRouteHasDefaultDst(t *testing.T) {
+	rNil := Route{Route: netlink.Route{Dst: nil}}
+	if !rNil.hasDefaultDst() {
+		t.Error("nil Dst should be default")
+	}
+	_, anyV4, _ := net.ParseCIDR("0.0.0.0/0")
+	rAnyV4 := Route{Route: netlink.Route{Dst: anyV4}}
+	if !rAnyV4.hasDefaultDst() {
+		t.Error("0.0.0.0/0 should be default")
+	}
+	_, anyV6, _ := net.ParseCIDR("::/0")
+	rAnyV6 := Route{Route: netlink.Route{Dst: anyV6}}
+	if !rAnyV6.hasDefaultDst() {
+		t.Error("::/0 should be default")
+	}
+	_, specific, _ := net.ParseCIDR("192.168.0.0/16")
+	rSpecific := Route{Route: netlink.Route{Dst: specific}}
+	if rSpecific.hasDefaultDst() {
+		t.Error("192.168.0.0/16 should not be default")
+	}
+}
+
+func TestRouteNormalizedNetlinkRoute(t *testing.T) {
+	// nil Dst with FAMILY_V4 → 0.0.0.0/0, Flags cleared
+	r4 := Route{Route: netlink.Route{Family: netlink.FAMILY_V4, Dst: nil, Flags: 0x10}}
+	norm4 := r4.normalizedNetlinkRoute()
+	if norm4.Dst == nil {
+		t.Fatal("normalized IPv4 Dst should not be nil")
+	}
+	if !norm4.Dst.IP.IsUnspecified() {
+		t.Errorf("normalized IPv4 Dst IP should be unspecified, got %v", norm4.Dst.IP)
+	}
+	ones4, _ := norm4.Dst.Mask.Size()
+	if ones4 != 0 {
+		t.Errorf("normalized IPv4 Dst prefix length should be 0, got %d", ones4)
+	}
+	if norm4.Flags != 0 {
+		t.Errorf("normalized route should have Flags=0, got %d", norm4.Flags)
+	}
+
+	// nil Dst with FAMILY_V6 → ::/0
+	r6 := Route{Route: netlink.Route{Family: netlink.FAMILY_V6, Dst: nil}}
+	norm6 := r6.normalizedNetlinkRoute()
+	if norm6.Dst == nil {
+		t.Fatal("normalized IPv6 Dst should not be nil")
+	}
+	ones6, _ := norm6.Dst.Mask.Size()
+	if ones6 != 0 {
+		t.Errorf("normalized IPv6 Dst prefix length should be 0, got %d", ones6)
+	}
+
+	// non-nil Dst is preserved
+	_, dst, _ := net.ParseCIDR("10.0.0.0/8")
+	rDst := Route{Route: netlink.Route{Family: netlink.FAMILY_V4, Dst: dst}}
+	normDst := rDst.normalizedNetlinkRoute()
+	if normDst.Dst.String() != "10.0.0.0/8" {
+		t.Errorf("specific Dst should be preserved, got %v", normDst.Dst)
+	}
+}
+
+func TestRouteDependencies(t *testing.T) {
+	gw := net.ParseIP("192.168.1.254")
+	_, subnet, _ := net.ParseCIDR("192.168.1.0/24")
+	_, otherSubnet, _ := net.ParseCIDR("10.0.0.0/8")
+	r := Route{
+		Route:         netlink.Route{Family: netlink.FAMILY_V4, Gw: gw},
+		AdapterIfName: "eth0",
+	}
+	deps := r.Dependencies()
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 deps, got %d", len(deps))
+	}
+	depByType(t, deps, genericitems.AdapterTypename)
+	addrsDep := depByType(t, deps, genericitems.AdapterAddrsTypename)
+	addrsMatch := genericitems.AdapterAddrs{IPAddrs: []*net.IPNet{subnet}}
+	addrsNoMatch := genericitems.AdapterAddrs{IPAddrs: []*net.IPNet{otherSubnet}}
+	addrsEmpty := genericitems.AdapterAddrs{}
+	if !addrsDep.MustSatisfy(addrsMatch) {
+		t.Error("matching subnet should satisfy")
+	}
+	if addrsDep.MustSatisfy(addrsNoMatch) {
+		t.Error("non-matching subnet should not satisfy")
+	}
+	if addrsDep.MustSatisfy(addrsEmpty) {
+		t.Error("empty addrs should not satisfy")
+	}
+}

--- a/pkg/pillar/netmonitor/linux.go
+++ b/pkg/pillar/netmonitor/linux.go
@@ -30,6 +30,7 @@ import (
 const (
 	netlinkSubBufSize = 128 * 1024 // bytes
 	eventChanBufSize  = 64         // number of events
+	procNetBondingDir = "/proc/net/bonding"
 
 	// Give subscriber some time to receive notification.
 	// This is used despite the fact that the subscription channel
@@ -522,7 +523,7 @@ func (m *LinuxNetworkMonitor) GetBondStatus(ifIndex int) (BondStatus, error) {
 	// - Per-member aggregator ID (available via netlink but we parse it together)
 	// - Peer notification delay and ARP missed max (newer kernel attributes
 	//   not present in the vendored netlink library)
-	procInfo, err := parseProcBondInfo(bond.Attrs().Name)
+	procInfo, err := parseProcBondInfo(procNetBondingDir, bond.Attrs().Name)
 	if err != nil {
 		m.Log.Warnf("GetBondStatus: failed to parse /proc for %s: %v",
 			bond.Attrs().Name, err)
@@ -567,8 +568,8 @@ type procBondMemberInfo struct {
 
 // parseProcBondInfo parses /proc/net/bonding/<name> for bond-level LACP info
 // and per-member status (aggregator ID, churn states).
-func parseProcBondInfo(bondName string) (procBondInfo, error) {
-	data, err := os.ReadFile(fmt.Sprintf("/proc/net/bonding/%s", bondName))
+func parseProcBondInfo(bondingDir, bondName string) (procBondInfo, error) {
+	data, err := os.ReadFile(fmt.Sprintf("%s/%s", bondingDir, bondName))
 	if err != nil {
 		return procBondInfo{}, err
 	}
@@ -654,7 +655,7 @@ func (m *LinuxNetworkMonitor) GetBondMetrics(ifIndex int) (types.BondMetrics, er
 	// Parse /proc/net/bonding/<name> for LACP counters (not available via netlink).
 	var procMembers map[string]procBondMemberMetrics
 	if isLACP {
-		procMembers, err = parseProcBondMemberMetrics(bond.Attrs().Name)
+		procMembers, err = parseProcBondMemberMetrics(procNetBondingDir, bond.Attrs().Name)
 		if err != nil {
 			m.Log.Warnf("GetBondMetrics: failed to parse /proc for %s: %v",
 				bond.Attrs().Name, err)
@@ -703,8 +704,8 @@ type procBondMemberMetrics struct {
 
 // parseProcBondMemberMetrics parses /proc/net/bonding/<name> for per-member
 // LACP counters not available via netlink.
-func parseProcBondMemberMetrics(bondName string) (map[string]procBondMemberMetrics, error) {
-	data, err := os.ReadFile(fmt.Sprintf("/proc/net/bonding/%s", bondName))
+func parseProcBondMemberMetrics(bondingDir, bondName string) (map[string]procBondMemberMetrics, error) {
+	data, err := os.ReadFile(fmt.Sprintf("%s/%s", bondingDir, bondName))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pillar/netmonitor/netmonitor_test.go
+++ b/pkg/pillar/netmonitor/netmonitor_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package netmonitor
+
+import (
+	"net"
+	"testing"
+)
+
+// --- Route.IsDefaultRoute ---
+
+func TestRouteIsDefaultRoute(t *testing.T) {
+	tests := []struct {
+		name string
+		dst  *net.IPNet
+		want bool
+	}{
+		{"nil Dst", nil, true},
+		{"0.0.0.0/0", mustParseCIDR("0.0.0.0/0"), true},
+		{"::/0", mustParseCIDR("::/0"), true},
+		{"192.168.0.0/16", mustParseCIDR("192.168.0.0/16"), false},
+		{"10.0.0.0/8", mustParseCIDR("10.0.0.0/8"), false},
+		{"0.0.0.0/8", mustParseCIDR("0.0.0.0/8"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := Route{Dst: tc.dst}
+			if got := r.IsDefaultRoute(); got != tc.want {
+				t.Errorf("IsDefaultRoute() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func mustParseCIDR(s string) *net.IPNet {
+	_, ipnet, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return ipnet
+}
+
+// --- IfAttrs.Equal ---
+
+func TestIfAttrsEqual(t *testing.T) {
+	base := IfAttrs{
+		IfIndex: 2, IfName: "eth0", IfType: "ether",
+		IsLoopback: false, WithBroadcast: true,
+		AdminUp: true, LowerUp: true,
+		Enslaved: false, MasterIfIndex: 0,
+		MTU: 1500,
+	}
+	mod := func(f func(*IfAttrs)) IfAttrs {
+		a := base
+		f(&a)
+		return a
+	}
+	tests := []struct {
+		name  string
+		other IfAttrs
+		want  bool
+	}{
+		{"identical", base, true},
+		{"diff IfIndex", mod(func(a *IfAttrs) { a.IfIndex = 3 }), false},
+		{"diff IfName", mod(func(a *IfAttrs) { a.IfName = "eth1" }), false},
+		{"diff IfType", mod(func(a *IfAttrs) { a.IfType = "bond" }), false},
+		{"diff AdminUp", mod(func(a *IfAttrs) { a.AdminUp = false }), false},
+		{"diff LowerUp", mod(func(a *IfAttrs) { a.LowerUp = false }), false},
+		{"diff MTU", mod(func(a *IfAttrs) { a.MTU = 9000 }), false},
+		{"diff Enslaved", mod(func(a *IfAttrs) { a.Enslaved = true; a.MasterIfIndex = 5 }), false},
+		{"diff VlanID", mod(func(a *IfAttrs) { a.VlanID = 10 }), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := base.Equal(tc.other); got != tc.want {
+				t.Errorf("Equal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// --- IfChange.Equal ---
+
+func TestIfChangeEqual(t *testing.T) {
+	base := IfChange{
+		Attrs:   IfAttrs{IfIndex: 2, IfName: "eth0", MTU: 1500},
+		Added:   false,
+		Deleted: false,
+	}
+	same := IfChange{
+		Attrs:   IfAttrs{IfIndex: 2, IfName: "eth0", MTU: 1500},
+		Added:   false,
+		Deleted: false,
+	}
+	diffAdded := IfChange{
+		Attrs:   IfAttrs{IfIndex: 2, IfName: "eth0", MTU: 1500},
+		Added:   true,
+		Deleted: false,
+	}
+	diffAttrs := IfChange{
+		Attrs:   IfAttrs{IfIndex: 2, IfName: "eth1", MTU: 1500},
+		Added:   false,
+		Deleted: false,
+	}
+	if !base.Equal(same) {
+		t.Error("identical IfChange should be equal")
+	}
+	if base.Equal(diffAdded) {
+		t.Error("diff Added should not be equal")
+	}
+	if base.Equal(diffAttrs) {
+		t.Error("diff Attrs should not be equal")
+	}
+}
+
+// --- isNetworkEvent marker methods ---
+
+func TestIsNetworkEventMarkers(t *testing.T) {
+	// Ensure all Event implementations satisfy the interface.
+	// Calling isNetworkEvent() directly covers the marker bodies.
+	events := []Event{
+		RouteChange{},
+		AddrChange{},
+		IfChange{},
+		DNSInfoChange{},
+		PNACEvent{},
+		BondActiveMemberChange{},
+	}
+	for _, e := range events {
+		e.isNetworkEvent()
+	}
+}

--- a/pkg/pillar/netmonitor/netmonitor_test.go
+++ b/pkg/pillar/netmonitor/netmonitor_test.go
@@ -5,7 +5,11 @@ package netmonitor
 
 import (
 	"net"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
 // --- Route.IsDefaultRoute ---
@@ -129,5 +133,217 @@ func TestIsNetworkEventMarkers(t *testing.T) {
 	}
 	for _, e := range events {
 		e.isNetworkEvent()
+	}
+}
+
+// --- parseChurnState ---
+
+func TestParseChurnState(t *testing.T) {
+	tests := []struct {
+		input string
+		want  types.BondLACPChurnState
+	}{
+		{"none", types.BondLACPChurnNone},
+		{"monitoring", types.BondLACPChurnMonitoring},
+		{"churned", types.BondLACPChurnChurned},
+		{"", types.BondLACPChurnNone},
+		{"unknown", types.BondLACPChurnNone},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			if got := parseChurnState(tc.input); got != tc.want {
+				t.Errorf("parseChurnState(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- isDhcpcdNotRunningErr ---
+
+func TestIsDhcpcdNotRunningErr(t *testing.T) {
+	m := &LinuxNetworkMonitor{}
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"dhcpcd is not running", true},
+		{"prefix dhcpcd is not running suffix", true},
+		{"dhcp_dump: No such file or directory", true},
+		{"some other error message", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			if got := m.isDhcpcdNotRunningErr(tc.input); got != tc.want {
+				t.Errorf("isDhcpcdNotRunningErr(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- parseProcBondInfo ---
+
+const testProcBondInfoContent = `Ethernet Channel Bonding Driver: v3.7.1 (April 27, 2011)
+
+Bonding Mode: IEEE 802.3ad Dynamic link aggregation
+MII Status: up
+Peer Notification Delay (ms): 100
+ARP Missed Max: 5
+
+802.3ad info
+Active Aggregator Info:
+	Aggregator ID: 2
+	Actor Key: 9
+	Partner Key: 9
+	Partner Mac Address: 00:aa:bb:cc:dd:ee
+
+Slave Interface: eth0
+MII Status: up
+Aggregator ID: 2
+Actor Churn State: none
+Partner Churn State: monitoring
+
+Slave Interface: eth1
+MII Status: down
+Aggregator ID: 3
+Actor Churn State: churned
+Partner Churn State: churned
+`
+
+func writeTempBondFile(t *testing.T, content string) (dir, name string) {
+	t.Helper()
+	dir = t.TempDir()
+	name = "bond0"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write temp bond file: %v", err)
+	}
+	return dir, name
+}
+
+func TestParseProcBondInfo(t *testing.T) {
+	dir, name := writeTempBondFile(t, testProcBondInfoContent)
+
+	info, err := parseProcBondInfo(dir, name)
+	if err != nil {
+		t.Fatalf("parseProcBondInfo: unexpected error: %v", err)
+	}
+
+	if info.peerNotificationDelay != 100 {
+		t.Errorf("peerNotificationDelay: got %d, want 100", info.peerNotificationDelay)
+	}
+	if info.arpMissedMax != 5 {
+		t.Errorf("arpMissedMax: got %d, want 5", info.arpMissedMax)
+	}
+	if info.lacpInfo == nil {
+		t.Fatal("lacpInfo is nil")
+	}
+	if info.lacpInfo.AggregatorID != 2 {
+		t.Errorf("lacpInfo.AggregatorID: got %d, want 2", info.lacpInfo.AggregatorID)
+	}
+	if info.lacpInfo.ActorKey != 9 {
+		t.Errorf("lacpInfo.ActorKey: got %d, want 9", info.lacpInfo.ActorKey)
+	}
+	if info.lacpInfo.PartnerKey != 9 {
+		t.Errorf("lacpInfo.PartnerKey: got %d, want 9", info.lacpInfo.PartnerKey)
+	}
+	wantMAC, _ := net.ParseMAC("00:aa:bb:cc:dd:ee")
+	if info.lacpInfo.PartnerMAC.String() != wantMAC.String() {
+		t.Errorf("lacpInfo.PartnerMAC: got %v, want %v", info.lacpInfo.PartnerMAC, wantMAC)
+	}
+	if len(info.members) != 2 {
+		t.Fatalf("members: got %d, want 2", len(info.members))
+	}
+	m0 := info.members[0]
+	if m0.ifName != "eth0" {
+		t.Errorf("members[0].ifName: got %q, want %q", m0.ifName, "eth0")
+	}
+	if !m0.miiUp {
+		t.Error("members[0].miiUp: want true")
+	}
+	if m0.aggregatorID != 2 {
+		t.Errorf("members[0].aggregatorID: got %d, want 2", m0.aggregatorID)
+	}
+	if m0.actorChurnState != types.BondLACPChurnNone {
+		t.Errorf("members[0].actorChurnState: got %v, want None", m0.actorChurnState)
+	}
+	if m0.partnerChurnState != types.BondLACPChurnMonitoring {
+		t.Errorf("members[0].partnerChurnState: got %v, want Monitoring", m0.partnerChurnState)
+	}
+	m1 := info.members[1]
+	if m1.ifName != "eth1" {
+		t.Errorf("members[1].ifName: got %q, want %q", m1.ifName, "eth1")
+	}
+	if m1.miiUp {
+		t.Error("members[1].miiUp: want false")
+	}
+	if m1.aggregatorID != 3 {
+		t.Errorf("members[1].aggregatorID: got %d, want 3", m1.aggregatorID)
+	}
+	if m1.actorChurnState != types.BondLACPChurnChurned {
+		t.Errorf("members[1].actorChurnState: got %v, want Churned", m1.actorChurnState)
+	}
+	if m1.partnerChurnState != types.BondLACPChurnChurned {
+		t.Errorf("members[1].partnerChurnState: got %v, want Churned", m1.partnerChurnState)
+	}
+}
+
+func TestParseProcBondInfoNotFound(t *testing.T) {
+	_, err := parseProcBondInfo(t.TempDir(), "nonexistent")
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+// --- parseProcBondMemberMetrics ---
+
+const testProcBondMemberMetricsContent = `Ethernet Channel Bonding Driver: v3.7.1 (April 27, 2011)
+
+Bonding Mode: IEEE 802.3ad Dynamic link aggregation
+
+Slave Interface: eth0
+Actor Churned Count: 3
+Partner Churned Count: 7
+
+Slave Interface: eth1
+Actor Churned Count: 0
+Partner Churned Count: 2
+`
+
+func TestParseProcBondMemberMetrics(t *testing.T) {
+	dir, name := writeTempBondFile(t, testProcBondMemberMetricsContent)
+
+	metrics, err := parseProcBondMemberMetrics(dir, name)
+	if err != nil {
+		t.Fatalf("parseProcBondMemberMetrics: unexpected error: %v", err)
+	}
+	if len(metrics) != 2 {
+		t.Fatalf("metrics: got %d entries, want 2", len(metrics))
+	}
+	if m := metrics["eth0"]; m.actorChurnedCount != 3 || m.partnerChurnedCount != 7 {
+		t.Errorf("eth0: got actor=%d partner=%d, want 3/7",
+			m.actorChurnedCount, m.partnerChurnedCount)
+	}
+	if m := metrics["eth1"]; m.actorChurnedCount != 0 || m.partnerChurnedCount != 2 {
+		t.Errorf("eth1: got actor=%d partner=%d, want 0/2",
+			m.actorChurnedCount, m.partnerChurnedCount)
+	}
+}
+
+func TestParseProcBondMemberMetricsEmpty(t *testing.T) {
+	dir, name := writeTempBondFile(t, "")
+
+	metrics, err := parseProcBondMemberMetrics(dir, name)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(metrics) != 0 {
+		t.Errorf("expected empty map, got %d entries", len(metrics))
+	}
+}
+
+func TestParseProcBondMemberMetricsNotFound(t *testing.T) {
+	_, err := parseProcBondMemberMetrics(t.TempDir(), "nonexistent")
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
 	}
 }

--- a/pkg/pillar/nireconciler/genericitems/items_test.go
+++ b/pkg/pillar/nireconciler/genericitems/items_test.go
@@ -1,0 +1,430 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package genericitems
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+
+	dg "github.com/lf-edge/eve-libs/depgraph"
+	uuid "github.com/satori/go.uuid"
+)
+
+func mustParseCIDRGen(s string) *net.IPNet {
+	_, ipnet, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return ipnet
+}
+
+// --- Pure helper functions ---
+
+func TestEqualUpstreamDNSServer(t *testing.T) {
+	a := UpstreamDNSServer{IPAddress: net.IP{1, 1, 1, 1}, Port: NetworkIf{IfName: "eth0"}}
+	b := UpstreamDNSServer{IPAddress: net.IP{1, 1, 1, 1}, Port: NetworkIf{IfName: "eth0"}}
+	diffIP := UpstreamDNSServer{IPAddress: net.IP{8, 8, 8, 8}, Port: NetworkIf{IfName: "eth0"}}
+	diffPort := UpstreamDNSServer{IPAddress: net.IP{1, 1, 1, 1}, Port: NetworkIf{IfName: "eth1"}}
+	if !equalUpstreamDNSServer(a, b) {
+		t.Error("identical servers should be equal")
+	}
+	if equalUpstreamDNSServer(a, diffIP) {
+		t.Error("different IP should be unequal")
+	}
+	if equalUpstreamDNSServer(a, diffPort) {
+		t.Error("different Port should be unequal")
+	}
+}
+
+func TestEqualMACToIP(t *testing.T) {
+	a := MACToIP{MAC: net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x01}, IP: net.IP{10, 0, 0, 5}, Hostname: "app1"}
+	b := MACToIP{MAC: net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x01}, IP: net.IP{10, 0, 0, 5}, Hostname: "app1"}
+	diffMAC := MACToIP{MAC: net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x02}, IP: net.IP{10, 0, 0, 5}, Hostname: "app1"}
+	diffHostname := MACToIP{MAC: net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x01}, IP: net.IP{10, 0, 0, 5}, Hostname: "app2"}
+	if !equalMACToIP(a, b) {
+		t.Error("identical entries should be equal")
+	}
+	if equalMACToIP(a, diffMAC) {
+		t.Error("different MAC should be unequal")
+	}
+	if equalMACToIP(a, diffHostname) {
+		t.Error("different Hostname should be unequal")
+	}
+}
+
+func TestEqualIPRoutes(t *testing.T) {
+	r1 := IPRoute{DstNetwork: mustParseCIDRGen("192.168.1.0/24"), Gateway: net.IP{10, 0, 0, 1}}
+	r2 := IPRoute{DstNetwork: mustParseCIDRGen("192.168.1.0/24"), Gateway: net.IP{10, 0, 0, 1}}
+	r3 := IPRoute{DstNetwork: mustParseCIDRGen("10.0.0.0/8"), Gateway: net.IP{10, 0, 0, 1}}
+	r4 := IPRoute{DstNetwork: mustParseCIDRGen("192.168.1.0/24"), Gateway: net.IP{10, 0, 1, 1}}
+	if !EqualIPRoutes(r1, r2) {
+		t.Error("identical routes should be equal")
+	}
+	if EqualIPRoutes(r1, r3) {
+		t.Error("different dst should be unequal")
+	}
+	if EqualIPRoutes(r1, r4) {
+		t.Error("different gw should be unequal")
+	}
+}
+
+func TestEqualHostnameToIP(t *testing.T) {
+	a := HostnameToIPs{Hostname: "host", IPs: []net.IP{{10, 0, 0, 1}}}
+	b := HostnameToIPs{Hostname: "host", IPs: []net.IP{{10, 0, 0, 1}}}
+	diffHost := HostnameToIPs{Hostname: "other", IPs: []net.IP{{10, 0, 0, 1}}}
+	diffIP := HostnameToIPs{Hostname: "host", IPs: []net.IP{{10, 0, 0, 2}}}
+	if !equalHostnameToIP(a, b) {
+		t.Error("identical entries should be equal")
+	}
+	if equalHostnameToIP(a, diffHost) {
+		t.Error("different hostname should be unequal")
+	}
+	if equalHostnameToIP(a, diffIP) {
+		t.Error("different IP should be unequal")
+	}
+}
+
+func TestEqualLinuxIPSet(t *testing.T) {
+	a := LinuxIPSet{Domains: []string{"a.com"}, Sets: []string{"s1", "s2"}}
+	b := LinuxIPSet{Domains: []string{"a.com"}, Sets: []string{"s2", "s1"}} // order-independent
+	c := LinuxIPSet{Domains: []string{"b.com"}, Sets: []string{"s1", "s2"}}
+	d := LinuxIPSet{Domains: []string{"a.com"}, Sets: []string{"s1"}}
+	if !equalLinuxIPSet(a, b) {
+		t.Error("set equality should be order-independent")
+	}
+	if equalLinuxIPSet(a, c) {
+		t.Error("different domains should be unequal")
+	}
+	if equalLinuxIPSet(a, d) {
+		t.Error("different set count should be unequal")
+	}
+}
+
+func TestIsECONNREFUSED(t *testing.T) {
+	if isECONNREFUSED(fmt.Errorf("plain error")) {
+		t.Error("plain error should not be ECONNREFUSED")
+	}
+	opErr := &net.OpError{
+		Op:  "dial",
+		Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED},
+	}
+	if !isECONNREFUSED(opErr) {
+		t.Error("ECONNREFUSED error should be detected")
+	}
+	opErrOther := &net.OpError{
+		Op:  "dial",
+		Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNRESET},
+	}
+	if isECONNREFUSED(opErrOther) {
+		t.Error("ECONNRESET should not be ECONNREFUSED")
+	}
+}
+
+// --- DnsmasqConfigurator path helpers ---
+
+func TestDnsmasqConfiguratorPaths(t *testing.T) {
+	c := &DnsmasqConfigurator{}
+	tests := []struct {
+		fn   func(string) string
+		arg  string
+		want string
+	}{
+		{c.dnsmasqConfigPath, "br0", "/run/zedrouter/dnsmasq.br0.conf"},
+		{c.dnsmasqPidFile, "br0", "/run/zedrouter/dnsmasq.br0.pid"},
+		{c.dnsmasqDHCPHostsDir, "br0", "/run/zedrouter/dhcp-hosts.br0"},
+		{c.dnsmasqDNSHostsDir, "br0", "/run/zedrouter/hosts.br0"},
+	}
+	for _, tc := range tests {
+		if got := tc.fn(tc.arg); got != tc.want {
+			t.Errorf("got %q, want %q", got, tc.want)
+		}
+	}
+}
+
+func TestDhcpTagForHost(t *testing.T) {
+	c := &DnsmasqConfigurator{}
+	gwIP := net.IP{10, 0, 0, 100}
+	dhcpSrv := DHCPServer{
+		PropagateRoutes: []IPRoute{
+			{DstNetwork: mustParseCIDRGen("192.168.1.0/24"), Gateway: gwIP},
+		},
+	}
+	if got := c.dhcpTagForHost(dhcpSrv, gwIP); got != "gateway-10-0-0-100" {
+		t.Errorf("gateway host tag: got %q, want %q", got, "gateway-10-0-0-100")
+	}
+	endpointIP := net.IP{10, 0, 0, 5}
+	if got := c.dhcpTagForHost(dhcpSrv, endpointIP); got != endpointTag {
+		t.Errorf("endpoint host tag: got %q, want %q", got, endpointTag)
+	}
+}
+
+func TestGetAppGatewayTag(t *testing.T) {
+	c := &DnsmasqConfigurator{}
+	tests := []struct {
+		ip   net.IP
+		want string
+	}{
+		{net.IP{10, 0, 0, 100}, "gateway-10-0-0-100"},
+		{net.IP{10, 0, 1, 1}, "gateway-10-0-1-1"},
+	}
+	for _, tc := range tests {
+		if got := c.getAppGatewayTag(tc.ip); got != tc.want {
+			t.Errorf("getAppGatewayTag(%v): got %q, want %q", tc.ip, got, tc.want)
+		}
+	}
+}
+
+// --- RadvdConfigurator path helpers ---
+
+func TestRadvdConfiguratorPaths(t *testing.T) {
+	c := &RadvdConfigurator{}
+	if got := c.radvdConfigPath("br0"); got != "/run/zedrouter/radvd.br0.conf" {
+		t.Errorf("radvdConfigPath: got %q", got)
+	}
+	if got := c.radvdPidFile("br0"); got != "/run/zedrouter/radvd.br0.pid" {
+		t.Errorf("radvdPidFile: got %q", got)
+	}
+}
+
+// --- Dnsmasq item ---
+
+func TestDnsmasqEqual(t *testing.T) {
+	ni1 := uuid.Must(uuid.NewV4())
+	ni2 := uuid.Must(uuid.NewV4())
+	d1 := Dnsmasq{ForNI: ni1, ListenIf: NetworkIf{IfName: "br0"}}
+	d2Same := Dnsmasq{ForNI: ni1, ListenIf: NetworkIf{IfName: "br0"}}
+	d3DiffNI := Dnsmasq{ForNI: ni2, ListenIf: NetworkIf{IfName: "br0"}}
+	d4DiffIf := Dnsmasq{ForNI: ni1, ListenIf: NetworkIf{IfName: "br1"}}
+	if !d1.Equal(d2Same) {
+		t.Error("identical Dnsmasq instances should be equal")
+	}
+	if d1.Equal(d3DiffNI) {
+		t.Error("different ForNI should be unequal")
+	}
+	if d1.Equal(d4DiffIf) {
+		t.Error("different ListenIf should be unequal")
+	}
+}
+
+func TestDnsmasqDependencies(t *testing.T) {
+	listenIP := net.IP{10, 0, 0, 1}
+	listenRef := dg.ItemRef{ItemType: "Bridge", ItemName: "br0"}
+	portRef := dg.ItemRef{ItemType: PortTypename, ItemName: "eth0"}
+	d := Dnsmasq{
+		ListenIf: NetworkIf{IfName: "br0", ItemRef: listenRef},
+		DNSServer: DNSServer{
+			ListenIP: listenIP,
+			UpstreamServers: []UpstreamDNSServer{
+				{IPAddress: net.IP{1, 1, 1, 1}, Port: NetworkIf{IfName: "eth0", ItemRef: portRef}},
+			},
+			LinuxIPSets: []LinuxIPSet{
+				{Sets: []string{"ipv4.test.com"}},
+			},
+		},
+	}
+	deps := d.Dependencies()
+	if len(deps) < 3 {
+		t.Fatalf("expected at least 3 deps (listenIf + port + ipset), got %d", len(deps))
+	}
+	// First dep: ListenIf
+	if deps[0].RequiredItem != listenRef {
+		t.Errorf("first dep should be ListenIf")
+	}
+	if deps[0].MustSatisfy == nil {
+		t.Error("ListenIf dep should have MustSatisfy")
+	}
+	// MustSatisfy: Port with matching IP → true
+	matchingPort := Port{IPAddresses: []*net.IPNet{{IP: listenIP, Mask: net.CIDRMask(24, 32)}}}
+	if !deps[0].MustSatisfy(matchingPort) {
+		t.Error("MustSatisfy should return true when listenIP matches")
+	}
+	// MustSatisfy: Port without matching IP → false
+	noMatchPort := Port{IPAddresses: []*net.IPNet{{IP: net.IP{10, 0, 1, 1}, Mask: net.CIDRMask(24, 32)}}}
+	if deps[0].MustSatisfy(noMatchPort) {
+		t.Error("MustSatisfy should return false when IP does not match")
+	}
+	// MustSatisfy: non-NetworkIfWithIP item → false
+	if deps[0].MustSatisfy(Radvd{}) {
+		t.Error("MustSatisfy should return false for non-NetworkIfWithIP item")
+	}
+	// Last dep: IPSet
+	lastDep := deps[len(deps)-1]
+	if lastDep.RequiredItem.ItemType != IPSetTypename {
+		t.Errorf("last dep should be IPSet, got %q", lastDep.RequiredItem.ItemType)
+	}
+}
+
+// --- HTTPServer item ---
+
+func TestHTTPServerEqual(t *testing.T) {
+	ni1 := uuid.Must(uuid.NewV4())
+	ni2 := uuid.Must(uuid.NewV4())
+	ref := dg.ItemRef{ItemType: "Bridge", ItemName: "br0"}
+	s1 := HTTPServer{ForNI: ni1, ListenIf: NetworkIf{IfName: "br0", ItemRef: ref},
+		ListenIP: net.IP{10, 0, 0, 1}, Port: 8080}
+	s2Same := HTTPServer{ForNI: ni1, ListenIf: NetworkIf{IfName: "br0", ItemRef: ref},
+		ListenIP: net.IP{10, 0, 0, 1}, Port: 8080}
+	s3DiffNI := HTTPServer{ForNI: ni2, ListenIf: NetworkIf{IfName: "br0", ItemRef: ref},
+		ListenIP: net.IP{10, 0, 0, 1}, Port: 8080}
+	s4DiffPort := HTTPServer{ForNI: ni1, ListenIf: NetworkIf{IfName: "br0", ItemRef: ref},
+		ListenIP: net.IP{10, 0, 0, 1}, Port: 9090}
+	if !s1.Equal(s2Same) {
+		t.Error("identical HTTPServer instances should be equal")
+	}
+	if s1.Equal(s3DiffNI) {
+		t.Error("different ForNI should be unequal")
+	}
+	if s1.Equal(s4DiffPort) {
+		t.Error("different Port should be unequal")
+	}
+}
+
+func TestHTTPServerDependencies(t *testing.T) {
+	listenIP := net.IP{10, 0, 0, 1}
+	listenRef := dg.ItemRef{ItemType: "Bridge", ItemName: "br0"}
+	s := HTTPServer{
+		ListenIf: NetworkIf{IfName: "br0", ItemRef: listenRef},
+		ListenIP: listenIP,
+		Port:     8080,
+	}
+	deps := s.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dep, got %d", len(deps))
+	}
+	if deps[0].RequiredItem != listenRef {
+		t.Errorf("dep should be ListenIf")
+	}
+	if deps[0].MustSatisfy == nil {
+		t.Error("dep should have MustSatisfy")
+	}
+	matchingPort := Port{IPAddresses: []*net.IPNet{{IP: listenIP, Mask: net.CIDRMask(24, 32)}}}
+	if !deps[0].MustSatisfy(matchingPort) {
+		t.Error("MustSatisfy should return true when listenIP matches")
+	}
+	noMatchPort := Port{IPAddresses: []*net.IPNet{{IP: net.IP{10, 0, 1, 1}, Mask: net.CIDRMask(24, 32)}}}
+	if deps[0].MustSatisfy(noMatchPort) {
+		t.Error("MustSatisfy should return false when IP does not match")
+	}
+}
+
+// --- IPReserve item ---
+
+func TestIPReserveDependencies(t *testing.T) {
+	r := IPReserve{AddrWithMask: &net.IPNet{IP: net.IP{10, 0, 0, 1}, Mask: net.CIDRMask(24, 32)}}
+	if deps := r.Dependencies(); deps != nil {
+		t.Errorf("expected nil deps, got %v", deps)
+	}
+}
+
+func TestIPReserveEqual(t *testing.T) {
+	ip1 := &net.IPNet{IP: net.IP{10, 0, 0, 1}, Mask: net.CIDRMask(24, 32)}
+	ip2 := &net.IPNet{IP: net.IP{10, 0, 1, 1}, Mask: net.CIDRMask(24, 32)}
+	ref := dg.ItemRef{ItemType: "Bridge", ItemName: "br0"}
+	r1 := IPReserve{AddrWithMask: ip1, NetIf: NetworkIf{IfName: "br0", ItemRef: ref}}
+	r2Same := IPReserve{AddrWithMask: ip1, NetIf: NetworkIf{IfName: "br0", ItemRef: ref}}
+	r3DiffIP := IPReserve{AddrWithMask: ip2, NetIf: NetworkIf{IfName: "br0", ItemRef: ref}}
+	r4DiffIf := IPReserve{AddrWithMask: ip1, NetIf: NetworkIf{IfName: "br1"}}
+	r5WrongType := Port{}
+	tests := []struct {
+		name  string
+		other dg.Item
+		want  bool
+	}{
+		{"identical", r2Same, true},
+		{"different IP", r3DiffIP, false},
+		{"different NetIf", r4DiffIf, false},
+		{"wrong type", r5WrongType, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := r1.Equal(tc.other); got != tc.want {
+				t.Errorf("Equal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// --- Port item ---
+
+func TestPortDependencies(t *testing.T) {
+	p := Port{}
+	if deps := p.Dependencies(); deps != nil {
+		t.Errorf("expected nil deps, got %v", deps)
+	}
+}
+
+func TestPortGetAssignedIPs(t *testing.T) {
+	ip1 := &net.IPNet{IP: net.IP{10, 0, 0, 1}, Mask: net.CIDRMask(24, 32)}
+	ip2 := &net.IPNet{IP: net.IP{192, 168, 1, 1}, Mask: net.CIDRMask(24, 32)}
+	p := Port{IPAddresses: []*net.IPNet{ip1, ip2}}
+	ips := p.GetAssignedIPs()
+	if len(ips) != 2 {
+		t.Errorf("GetAssignedIPs: got %d IPs, want 2", len(ips))
+	}
+}
+
+func TestPortEqual(t *testing.T) {
+	ip1 := &net.IPNet{IP: net.IP{10, 0, 0, 1}, Mask: net.CIDRMask(24, 32)}
+	ip2 := &net.IPNet{IP: net.IP{10, 0, 1, 1}, Mask: net.CIDRMask(24, 32)}
+	p1 := Port{IfName: "eth0", LogicalLabel: "uplink", AdminUp: true, IPAddresses: []*net.IPNet{ip1}}
+	p2Same := Port{IfName: "eth0", LogicalLabel: "uplink", AdminUp: true, IPAddresses: []*net.IPNet{ip1}}
+	p3DiffName := Port{IfName: "eth1", LogicalLabel: "uplink", AdminUp: true, IPAddresses: []*net.IPNet{ip1}}
+	p4DiffIPs := Port{IfName: "eth0", LogicalLabel: "uplink", AdminUp: true, IPAddresses: []*net.IPNet{ip2}}
+	p5WrongType := IPReserve{AddrWithMask: ip1}
+	tests := []struct {
+		name  string
+		other dg.Item
+		want  bool
+	}{
+		{"identical", p2Same, true},
+		{"different IfName", p3DiffName, false},
+		{"different IPs", p4DiffIPs, false},
+		{"wrong type", p5WrongType, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := p1.Equal(tc.other); got != tc.want {
+				t.Errorf("Equal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// --- Radvd item ---
+
+func TestRadvdEqual(t *testing.T) {
+	ni1 := uuid.Must(uuid.NewV4())
+	ni2 := uuid.Must(uuid.NewV4())
+	r1 := Radvd{ForNI: ni1, ListenIf: NetworkIf{IfName: "br0"}, MTU: 1500}
+	r2Same := Radvd{ForNI: ni1, ListenIf: NetworkIf{IfName: "br0"}, MTU: 1500}
+	r3DiffNI := Radvd{ForNI: ni2, ListenIf: NetworkIf{IfName: "br0"}, MTU: 1500}
+	r4DiffMTU := Radvd{ForNI: ni1, ListenIf: NetworkIf{IfName: "br0"}, MTU: 9000}
+	if !r1.Equal(r2Same) {
+		t.Error("identical Radvd instances should be equal")
+	}
+	if r1.Equal(r3DiffNI) {
+		t.Error("different ForNI should be unequal")
+	}
+	if r1.Equal(r4DiffMTU) {
+		t.Error("different MTU should be unequal")
+	}
+}
+
+func TestRadvdDependencies(t *testing.T) {
+	listenRef := dg.ItemRef{ItemType: "Bridge", ItemName: "br0"}
+	r := Radvd{ListenIf: NetworkIf{IfName: "br0", ItemRef: listenRef}}
+	deps := r.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dep, got %d", len(deps))
+	}
+	if deps[0].RequiredItem != listenRef {
+		t.Errorf("dep should be ListenIf")
+	}
+	if deps[0].MustSatisfy != nil {
+		t.Error("Radvd dep should not have MustSatisfy")
+	}
+}

--- a/pkg/pillar/nireconciler/linuxitems/items_test.go
+++ b/pkg/pillar/nireconciler/linuxitems/items_test.go
@@ -1,0 +1,864 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package linuxitems
+
+import (
+	"net"
+	"testing"
+
+	dg "github.com/lf-edge/eve-libs/depgraph"
+	generic "github.com/lf-edge/eve/pkg/pillar/nireconciler/genericitems"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/vishvananda/netlink"
+)
+
+func mustParseCIDRLI(s string) *net.IPNet {
+	_, ipnet, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return ipnet
+}
+
+func uint32Ptr(v uint32) *uint32 { return &v }
+
+// depByType returns the first dependency on the given item type. Tests use this
+// instead of positional indexing so that reordering dependencies (which is
+// semantically irrelevant to the reconciler) does not break them.
+func depByType(t *testing.T, deps []dg.Dependency, itemType string) dg.Dependency {
+	t.Helper()
+	for _, d := range deps {
+		if d.RequiredItem.ItemType == itemType {
+			return d
+		}
+	}
+	t.Fatalf("no dependency on item type %q; got %v", itemType, deps)
+	return dg.Dependency{}
+}
+
+// --- equalBoolPtr ---
+
+func TestEqualBoolPtr(t *testing.T) {
+	tr := true
+	fa := false
+	if !equalBoolPtr(nil, nil) {
+		t.Error("(nil, nil) should be equal")
+	}
+	if equalBoolPtr(nil, &tr) {
+		t.Error("(nil, true) should be unequal")
+	}
+	if equalBoolPtr(&tr, nil) {
+		t.Error("(true, nil) should be unequal")
+	}
+	if !equalBoolPtr(&tr, &tr) {
+		t.Error("(true, true) should be equal")
+	}
+	if equalBoolPtr(&tr, &fa) {
+		t.Error("(true, false) should be unequal")
+	}
+}
+
+func TestEqualUint8Ptr(t *testing.T) {
+	v6 := uint8(6)
+	v17 := uint8(17)
+	if !equalUint8Ptr(nil, nil) {
+		t.Error("(nil, nil) should be equal")
+	}
+	if equalUint8Ptr(nil, &v6) {
+		t.Error("(nil, 6) should be unequal")
+	}
+	if !equalUint8Ptr(&v6, &v6) {
+		t.Error("(6, 6) should be equal")
+	}
+	if equalUint8Ptr(&v6, &v17) {
+		t.Error("(6, 17) should be unequal")
+	}
+}
+
+// --- BPDUGuard ---
+
+func TestBPDUGuardEqual(t *testing.T) {
+	g1 := BPDUGuard{BridgeIfName: "br0", PortIfName: "eth0", ForVIF: false}
+	g2Same := BPDUGuard{BridgeIfName: "br0", PortIfName: "vif0", ForVIF: false} // PortIfName not compared
+	g3DiffBridge := BPDUGuard{BridgeIfName: "br1", PortIfName: "eth0", ForVIF: false}
+	g4DiffForVIF := BPDUGuard{BridgeIfName: "br0", PortIfName: "eth0", ForVIF: true}
+	if !g1.Equal(g2Same) {
+		t.Error("same BridgeIfName+ForVIF should be equal (PortIfName not compared)")
+	}
+	if g1.Equal(g3DiffBridge) {
+		t.Error("different BridgeIfName should be unequal")
+	}
+	if g1.Equal(g4DiffForVIF) {
+		t.Error("different ForVIF should be unequal")
+	}
+	if g1.Equal(DummyIf{}) {
+		t.Error("wrong type should be unequal")
+	}
+}
+
+func TestBPDUGuardDependencies(t *testing.T) {
+	g := BPDUGuard{BridgeIfName: "br0", PortIfName: "eth0"}
+	deps := g.Dependencies()
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 deps, got %d", len(deps))
+	}
+	depByType(t, deps, BridgeTypename)
+	bpDep := depByType(t, deps, BridgePortTypename)
+	wantBPName := BridgePortName("br0", "eth0")
+	if bpDep.RequiredItem.ItemName != wantBPName {
+		t.Errorf("BridgePort dep name: got %q, want %q", bpDep.RequiredItem.ItemName, wantBPName)
+	}
+}
+
+// --- BridgeFwdMask ---
+
+func TestBridgeFwdMaskEqual(t *testing.T) {
+	m1 := BridgeFwdMask{BridgeIfName: "br0", ForwardLLDP: true}
+	m2Same := BridgeFwdMask{BridgeIfName: "br0", ForwardLLDP: true}
+	m3Diff := BridgeFwdMask{BridgeIfName: "br0", ForwardLLDP: false}
+	if !m1.Equal(m2Same) {
+		t.Error("identical masks should be equal")
+	}
+	if m1.Equal(m3Diff) {
+		t.Error("different ForwardLLDP should be unequal")
+	}
+	if m1.Equal(DummyIf{}) {
+		t.Error("wrong type should be unequal")
+	}
+}
+
+func TestBridgeFwdMaskDependencies(t *testing.T) {
+	m := BridgeFwdMask{BridgeIfName: "br0"}
+	deps := m.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dep, got %d", len(deps))
+	}
+	if deps[0].RequiredItem.ItemType != BridgeTypename || deps[0].RequiredItem.ItemName != "br0" {
+		t.Errorf("dep should be Bridge br0, got %+v", deps[0].RequiredItem)
+	}
+}
+
+func TestToMaskValue(t *testing.T) {
+	tests := []struct {
+		m    BridgeFwdMask
+		want string
+	}{
+		{BridgeFwdMask{}, "0x0"},
+		{BridgeFwdMask{ForwardLLDP: true}, "0x4000"},
+		{BridgeFwdMask{ForwardEAPOL: true}, "0x8"},
+		{BridgeFwdMask{ForwardMVRP: true}, "0x2000"},
+		{BridgeFwdMask{ForwardLLDP: true, ForwardEAPOL: true}, "0x4008"},
+	}
+	for _, tc := range tests {
+		if got := tc.m.toMaskValue(); got != tc.want {
+			t.Errorf("toMaskValue(%+v): got %q, want %q", tc.m, got, tc.want)
+		}
+	}
+}
+
+// --- Bridge ---
+
+func TestBridgeExternalCreatedByNIM(t *testing.T) {
+	b1 := Bridge{CreatedByNIM: true}
+	b2 := Bridge{CreatedByNIM: false}
+	if !b1.External() {
+		t.Error("CreatedByNIM=true should be external")
+	}
+	if b2.External() {
+		t.Error("CreatedByNIM=false should not be external")
+	}
+}
+
+func TestBridgeEqual(t *testing.T) {
+	mac1 := net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x01}
+	mac2 := net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x02}
+	b1 := Bridge{IfName: "br0", MACAddress: mac1, MTU: 1500}
+	b2Same := Bridge{IfName: "br0", MACAddress: mac1, MTU: 1500}
+	b3DiffMAC := Bridge{IfName: "br0", MACAddress: mac2, MTU: 1500}
+	b4DiffMTU := Bridge{IfName: "br0", MACAddress: mac1, MTU: 9000}
+	if !b1.Equal(b2Same) {
+		t.Error("identical bridges should be equal")
+	}
+	if b1.Equal(b3DiffMAC) {
+		t.Error("different MAC should be unequal")
+	}
+	if b1.Equal(b4DiffMTU) {
+		t.Error("different MTU should be unequal")
+	}
+	if b1.Equal(DummyIf{}) {
+		t.Error("wrong type should be unequal")
+	}
+}
+
+func TestBridgeGetAssignedIPs(t *testing.T) {
+	ip := &net.IPNet{IP: net.IP{10, 0, 0, 1}, Mask: net.CIDRMask(24, 32)}
+	b := Bridge{IPAddresses: []*net.IPNet{ip}}
+	if got := b.GetAssignedIPs(); len(got) != 1 {
+		t.Errorf("expected 1 IP, got %d", len(got))
+	}
+}
+
+func TestBridgeGetMTU(t *testing.T) {
+	b0 := Bridge{MTU: 0}
+	if got := b0.GetMTU(); got != types.DefaultMTU {
+		t.Errorf("zero MTU: got %d, want DefaultMTU (%d)", got, types.DefaultMTU)
+	}
+	b9000 := Bridge{MTU: 9000}
+	if got := b9000.GetMTU(); got != 9000 {
+		t.Errorf("explicit MTU: got %d, want 9000", got)
+	}
+}
+
+func TestBridgeDependenciesExternal(t *testing.T) {
+	b := Bridge{CreatedByNIM: true}
+	if deps := b.Dependencies(); deps != nil {
+		t.Errorf("external bridge should have no deps, got %v", deps)
+	}
+}
+
+func TestBridgeDependenciesNonExternal(t *testing.T) {
+	ip1 := &net.IPNet{IP: net.IP{10, 0, 0, 1}, Mask: net.CIDRMask(24, 32)}
+	ip2 := &net.IPNet{IP: net.IP{10, 0, 1, 1}, Mask: net.CIDRMask(24, 32)}
+	b := Bridge{IfName: "br0", IPAddresses: []*net.IPNet{ip1, ip2}}
+	deps := b.Dependencies()
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 deps (one per IP), got %d", len(deps))
+	}
+	for _, dep := range deps {
+		if dep.MustSatisfy == nil {
+			t.Fatalf("every IP dependency should have MustSatisfy, got %+v", dep)
+		}
+	}
+	// Each configured IP must be satisfied by some dependency, without assuming
+	// which dependency corresponds to which address.
+	for _, ip := range b.IPAddresses {
+		matchingReserve := generic.IPReserve{
+			AddrWithMask: ip,
+			NetIf:        generic.NetworkIf{ItemRef: dg.Reference(b)},
+		}
+		satisfied := false
+		for _, dep := range deps {
+			if dep.MustSatisfy(matchingReserve) {
+				satisfied = true
+				break
+			}
+		}
+		if !satisfied {
+			t.Errorf("no dependency satisfied by IPReserve for %v", ip)
+		}
+	}
+	// An IPReserve for a different NetIf must satisfy none of the dependencies.
+	nonMatchingReserve := generic.IPReserve{
+		AddrWithMask: b.IPAddresses[0],
+		NetIf:        generic.NetworkIf{ItemRef: dg.ItemRef{ItemType: "Bridge", ItemName: "other"}},
+	}
+	for _, dep := range deps {
+		if dep.MustSatisfy(nonMatchingReserve) {
+			t.Error("MustSatisfy should return false for non-matching NetIf")
+		}
+	}
+}
+
+// --- BridgePort ---
+
+func TestBridgePortEqual(t *testing.T) {
+	p1 := BridgePort{BridgeIfName: "br0", Variant: BridgePortVariant{PortIfName: "eth0"}, MTU: 1500}
+	p2Same := BridgePort{BridgeIfName: "br0", Variant: BridgePortVariant{PortIfName: "eth0"}, MTU: 1500}
+	p3DiffBridge := BridgePort{BridgeIfName: "br1", Variant: BridgePortVariant{PortIfName: "eth0"}, MTU: 1500}
+	if !p1.Equal(p2Same) {
+		t.Error("identical BridgePorts should be equal")
+	}
+	if p1.Equal(p3DiffBridge) {
+		t.Error("different BridgeIfName should be unequal")
+	}
+	if p1.Equal(DummyIf{}) {
+		t.Error("wrong type should be unequal")
+	}
+}
+
+func TestBridgePortGetMTU(t *testing.T) {
+	p0 := BridgePort{MTU: 0}
+	if got := p0.GetMTU(); got != types.DefaultMTU {
+		t.Errorf("zero MTU: got %d", got)
+	}
+	p9000 := BridgePort{MTU: 9000}
+	if got := p9000.GetMTU(); got != 9000 {
+		t.Errorf("explicit MTU: got %d", got)
+	}
+}
+
+func TestBridgePortDependenciesVIF(t *testing.T) {
+	p := BridgePort{BridgeIfName: "br0", Variant: BridgePortVariant{VIFIfName: "vif0"}}
+	deps := p.Dependencies()
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 deps, got %d", len(deps))
+	}
+	depByType(t, deps, BridgeTypename)
+	vifDep := depByType(t, deps, VIFTypename)
+	if vifDep.RequiredItem.ItemName != "vif0" {
+		t.Errorf("VIF dep name: got %q, want %q", vifDep.RequiredItem.ItemName, "vif0")
+	}
+}
+
+func TestBridgePortDependenciesPort(t *testing.T) {
+	// ExternallyBridged=false: no MustSatisfy
+	p := BridgePort{BridgeIfName: "br0", Variant: BridgePortVariant{PortIfName: "eth0"}}
+	deps := p.Dependencies()
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 deps, got %d", len(deps))
+	}
+	portDep := depByType(t, deps, generic.PortTypename)
+	if portDep.MustSatisfy != nil {
+		t.Error("non-externally bridged port dep should not have MustSatisfy")
+	}
+}
+
+func TestBridgePortDependenciesPortExternallyBridged(t *testing.T) {
+	p := BridgePort{BridgeIfName: "br0", Variant: BridgePortVariant{PortIfName: "eth0"}, ExternallyBridged: true}
+	deps := p.Dependencies()
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 deps, got %d", len(deps))
+	}
+	portDep := depByType(t, deps, generic.PortTypename)
+	if portDep.MustSatisfy == nil {
+		t.Fatal("externally bridged port dep should have MustSatisfy")
+	}
+	// Port with matching MasterIfName → true
+	portMatch := generic.Port{MasterIfName: "br0"}
+	if !portDep.MustSatisfy(portMatch) {
+		t.Error("MustSatisfy should be true for matching MasterIfName")
+	}
+	portNoMatch := generic.Port{MasterIfName: "br1"}
+	if portDep.MustSatisfy(portNoMatch) {
+		t.Error("MustSatisfy should be false for non-matching MasterIfName")
+	}
+}
+
+func TestBridgePortDependenciesVLANSubinterface(t *testing.T) {
+	subIf := &VLANSubinterface{IfName: "eth0.100", VID: 100}
+	p := BridgePort{BridgeIfName: "br0", Variant: BridgePortVariant{VLANSubinterface: subIf}, ExternallyBridged: true}
+	deps := p.Dependencies()
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 deps, got %d", len(deps))
+	}
+	subIfDep := depByType(t, deps, VLANSubIntfTypename)
+	if subIfDep.MustSatisfy == nil {
+		t.Fatal("VLANSubinterface dep should have MustSatisfy")
+	}
+	// VLANSubIf with matching ParentIfName and ID → true
+	match := VLANSubIf{ParentIfName: "br0", ID: 100}
+	if !subIfDep.MustSatisfy(match) {
+		t.Error("MustSatisfy should be true for matching VLANSubIf")
+	}
+	noMatch := VLANSubIf{ParentIfName: "br0", ID: 200}
+	if subIfDep.MustSatisfy(noMatch) {
+		t.Error("MustSatisfy should be false for wrong VID")
+	}
+}
+
+// --- DummyIf ---
+
+func TestDummyIfEqual(t *testing.T) {
+	d1 := DummyIf{IfName: "dummy0", ARPOff: true}
+	d2Same := DummyIf{IfName: "dummy0", ARPOff: true}
+	d3Diff := DummyIf{IfName: "dummy0", ARPOff: false}
+	if !d1.Equal(d2Same) {
+		t.Error("identical DummyIf instances should be equal")
+	}
+	if d1.Equal(d3Diff) {
+		t.Error("different ARPOff should be unequal")
+	}
+	if d1.Equal(Bridge{}) {
+		t.Error("wrong type should be unequal")
+	}
+}
+
+func TestDummyIfDependencies(t *testing.T) {
+	d := DummyIf{}
+	if deps := d.Dependencies(); deps != nil {
+		t.Errorf("expected nil deps, got %v", deps)
+	}
+}
+
+// --- IPRule (nireconciler version) ---
+
+func TestIPRuleDependencies(t *testing.T) {
+	r := IPRule{}
+	if deps := r.Dependencies(); deps != nil {
+		t.Errorf("expected nil deps, got %v", deps)
+	}
+}
+
+func TestIPRuleEqual(t *testing.T) {
+	mask := uint32(0xff)
+	r1 := IPRule{Priority: 100, Table: 254, Mark: 0xab, Mask: &mask}
+	r2Same := IPRule{Priority: 100, Table: 254, Mark: 0xab, Mask: &mask}
+	r3DiffMask := IPRule{Priority: 100, Table: 254, Mark: 0xab, Mask: uint32Ptr(0xfe)}
+	r4OneMaskNil := IPRule{Priority: 100, Table: 254, Mark: 0xab}
+	r5BothNil := IPRule{Priority: 100, Table: 254}
+	r6BothNil := IPRule{Priority: 100, Table: 254}
+	if !r1.Equal(r2Same) {
+		t.Error("identical rules should be equal")
+	}
+	if r1.Equal(r3DiffMask) {
+		t.Error("different Mask value should be unequal")
+	}
+	if r1.Equal(r4OneMaskNil) {
+		t.Error("one nil Mask should be unequal")
+	}
+	if !r5BothNil.Equal(r6BothNil) {
+		t.Error("both nil Mask should be equal")
+	}
+	if r1.Equal(Bridge{}) {
+		t.Error("wrong type should be unequal")
+	}
+}
+
+// --- IPSet ---
+
+func TestIPSetDependencies(t *testing.T) {
+	s := IPSet{}
+	if deps := s.Dependencies(); deps != nil {
+		t.Errorf("expected nil deps, got %v", deps)
+	}
+}
+
+func TestIPSetEqual(t *testing.T) {
+	s1 := IPSet{SetName: "s", TypeName: "hash:ip", Entries: []string{"10.0.0.1", "10.0.0.2"}}
+	s2Same := IPSet{SetName: "s", TypeName: "hash:ip", Entries: []string{"10.0.0.2", "10.0.0.1"}} // order-independent
+	s3DiffEntry := IPSet{SetName: "s", TypeName: "hash:ip", Entries: []string{"10.0.0.1"}}
+	if !s1.Equal(s2Same) {
+		t.Error("set equality should be order-independent")
+	}
+	if s1.Equal(s3DiffEntry) {
+		t.Error("different entries should be unequal")
+	}
+	if s1.Equal(DummyIf{}) {
+		t.Error("wrong type should be unequal")
+	}
+}
+
+// --- Sysctl ---
+
+func TestSysctlEqual(t *testing.T) {
+	tr := true
+	fa := false
+	s1 := Sysctl{EnableDAD: &tr, EnableARPNotify: &fa}
+	s2Same := Sysctl{EnableDAD: &tr, EnableARPNotify: &fa}
+	s3Diff := Sysctl{EnableDAD: &fa, EnableARPNotify: &fa}
+	if !s1.Equal(s2Same) {
+		t.Error("identical Sysctl instances should be equal")
+	}
+	if s1.Equal(s3Diff) {
+		t.Error("different EnableDAD should be unequal")
+	}
+	if s1.Equal(DummyIf{}) {
+		t.Error("wrong type should be unequal")
+	}
+}
+
+func TestSysctlDependencies(t *testing.T) {
+	// No interface → no deps
+	s1 := Sysctl{}
+	if deps := s1.Dependencies(); len(deps) != 0 {
+		t.Errorf("no interface: expected 0 deps, got %d", len(deps))
+	}
+	// With interface → 1 dep
+	ref := dg.ItemRef{ItemType: "Bridge", ItemName: "br0"}
+	s2 := Sysctl{NetIf: generic.NetworkIf{IfName: "br0", ItemRef: ref}}
+	deps := s2.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("with interface: expected 1 dep, got %d", len(deps))
+	}
+	if deps[0].RequiredItem != ref {
+		t.Errorf("dep should reference NetIf")
+	}
+}
+
+// --- TCIngress ---
+
+func TestTCIngressEqual(t *testing.T) {
+	ref := dg.ItemRef{ItemType: "Port", ItemName: "eth0"}
+	tc1 := TCIngress{NetIf: generic.NetworkIf{IfName: "eth0", ItemRef: ref}}
+	tc2Same := TCIngress{NetIf: generic.NetworkIf{IfName: "eth0", ItemRef: ref}}
+	tc3Diff := TCIngress{NetIf: generic.NetworkIf{IfName: "eth1"}}
+	if !tc1.Equal(tc2Same) {
+		t.Error("identical TCIngress should be equal")
+	}
+	if tc1.Equal(tc3Diff) {
+		t.Error("different NetIf should be unequal")
+	}
+	if tc1.Equal(DummyIf{}) {
+		t.Error("wrong type should be unequal")
+	}
+}
+
+func TestTCIngressDependencies(t *testing.T) {
+	ref := dg.ItemRef{ItemType: "Port", ItemName: "eth0"}
+	tc := TCIngress{NetIf: generic.NetworkIf{IfName: "eth0", ItemRef: ref}}
+	deps := tc.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dep, got %d", len(deps))
+	}
+	if deps[0].RequiredItem != ref {
+		t.Errorf("dep should be NetIf")
+	}
+	if !deps[0].Attributes.AutoDeletedByExternal {
+		t.Error("dep should be AutoDeletedByExternal")
+	}
+}
+
+// --- TCMirror ---
+
+func TestTCMirrorEqual(t *testing.T) {
+	toRef := dg.ItemRef{ItemType: "Bridge", ItemName: "br0"}
+	tc1 := TCMirror{
+		FromNetIf: generic.NetworkIf{IfName: "eth0"},
+		ToNetIf:   generic.NetworkIf{IfName: "br0", ItemRef: toRef},
+		Protocol:  TCMatchProtoIPv4,
+	}
+	tc2Same := TCMirror{
+		FromNetIf: generic.NetworkIf{IfName: "eth1"}, // FromNetIf not compared by Equal
+		ToNetIf:   generic.NetworkIf{IfName: "br0", ItemRef: toRef},
+		Protocol:  TCMatchProtoIPv4,
+	}
+	tc3DiffProto := TCMirror{
+		FromNetIf: generic.NetworkIf{IfName: "eth0"},
+		ToNetIf:   generic.NetworkIf{IfName: "br0", ItemRef: toRef},
+		Protocol:  TCMatchProtoIPv6,
+	}
+	if !tc1.Equal(tc2Same) {
+		t.Error("same ToNetIf+Protocol should be equal")
+	}
+	if tc1.Equal(tc3DiffProto) {
+		t.Error("different Protocol should be unequal")
+	}
+	if tc1.Equal(DummyIf{}) {
+		t.Error("wrong type should be unequal")
+	}
+}
+
+func TestTCMirrorDependencies(t *testing.T) {
+	fromRef := dg.ItemRef{ItemType: "Port", ItemName: "eth0"}
+	toRef := dg.ItemRef{ItemType: "Bridge", ItemName: "br0"}
+	tc := TCMirror{
+		FromNetIf: generic.NetworkIf{IfName: "eth0", ItemRef: fromRef},
+		ToNetIf:   generic.NetworkIf{IfName: "br0", ItemRef: toRef},
+	}
+	deps := tc.Dependencies()
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 deps, got %d", len(deps))
+	}
+	// One dep is a TCIngress for FromNetIf.
+	depByType(t, deps, TCIngressTypename)
+	// The other references ToNetIf.
+	foundTo := false
+	for _, d := range deps {
+		if d.RequiredItem == toRef {
+			foundTo = true
+		}
+	}
+	if !foundTo {
+		t.Errorf("expected a dependency on ToNetIf %v, got %v", toRef, deps)
+	}
+}
+
+// --- VIF ---
+
+func TestVIFGetAssignedIPs(t *testing.T) {
+	ip := &net.IPNet{IP: net.IP{10, 0, 0, 2}, Mask: net.CIDRMask(24, 32)}
+	vExt := VIF{Variant: VIFVariant{External: true}}
+	vVeth := VIF{Variant: VIFVariant{Veth: Veth{AppIPs: []*net.IPNet{ip}}}}
+	if ips := vExt.GetAssignedIPs(); ips != nil {
+		t.Errorf("external VIF: expected nil IPs, got %v", ips)
+	}
+	if ips := vVeth.GetAssignedIPs(); len(ips) != 1 {
+		t.Errorf("veth VIF: expected 1 IP, got %d", len(ips))
+	}
+}
+
+func TestVIFGetMTU(t *testing.T) {
+	vExt := VIF{Variant: VIFVariant{External: true}}
+	if got := vExt.GetMTU(); got != 0 {
+		t.Errorf("external VIF MTU: got %d, want 0", got)
+	}
+	vVeth0 := VIF{Variant: VIFVariant{Veth: Veth{MTU: 0}}}
+	if got := vVeth0.GetMTU(); got != types.DefaultMTU {
+		t.Errorf("veth zero MTU: got %d, want DefaultMTU", got)
+	}
+	vVeth9000 := VIF{Variant: VIFVariant{Veth: Veth{MTU: 9000}}}
+	if got := vVeth9000.GetMTU(); got != 9000 {
+		t.Errorf("veth MTU: got %d, want 9000", got)
+	}
+}
+
+func TestVIFEqual(t *testing.T) {
+	v1 := VIF{HostIfName: "vif0", NetAdapterName: "a", Variant: VIFVariant{External: true}}
+	v2Same := VIF{HostIfName: "vif0", NetAdapterName: "a", Variant: VIFVariant{External: true}}
+	v3DiffName := VIF{HostIfName: "vif1", NetAdapterName: "a", Variant: VIFVariant{External: true}}
+	if !v1.Equal(v2Same) {
+		t.Error("identical VIFs should be equal")
+	}
+	if v1.Equal(v3DiffName) {
+		t.Error("different HostIfName should be unequal")
+	}
+	if v1.Equal(DummyIf{}) {
+		t.Error("wrong type should be unequal")
+	}
+}
+
+func TestVIFDependencies(t *testing.T) {
+	v := VIF{}
+	if deps := v.Dependencies(); deps != nil {
+		t.Errorf("expected nil deps, got %v", deps)
+	}
+}
+
+// --- VLANBridge ---
+
+func TestVLANBridgeEqual(t *testing.T) {
+	v1 := VLANBridge{BridgeIfName: "br0", EnableVLANFiltering: true}
+	v2Same := VLANBridge{BridgeIfName: "br0", EnableVLANFiltering: true}
+	v3Diff := VLANBridge{BridgeIfName: "br0", EnableVLANFiltering: false}
+	if !v1.Equal(v2Same) {
+		t.Error("identical VLANBridges should be equal")
+	}
+	if v1.Equal(v3Diff) {
+		t.Error("different EnableVLANFiltering should be unequal")
+	}
+	if v1.Equal(DummyIf{}) {
+		t.Error("wrong type should be unequal")
+	}
+}
+
+func TestVLANBridgeDependencies(t *testing.T) {
+	v := VLANBridge{BridgeIfName: "br0"}
+	deps := v.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dep, got %d", len(deps))
+	}
+	if deps[0].RequiredItem.ItemType != BridgeTypename || deps[0].RequiredItem.ItemName != "br0" {
+		t.Errorf("dep should be Bridge br0, got %+v", deps[0].RequiredItem)
+	}
+}
+
+// --- VLANPort ---
+
+func TestVLANPortEqual(t *testing.T) {
+	v1 := VLANPort{
+		BridgeIfName: "br0", PortIfName: "eth0",
+		VLANConfig: VLANConfig{AccessPort: &AccessPort{VID: 100}},
+	}
+	v2Same := VLANPort{
+		BridgeIfName: "br0", PortIfName: "eth0",
+		VLANConfig: VLANConfig{AccessPort: &AccessPort{VID: 100}},
+	}
+	v3DiffVID := VLANPort{
+		BridgeIfName: "br0", PortIfName: "eth0",
+		VLANConfig: VLANConfig{AccessPort: &AccessPort{VID: 200}},
+	}
+	v4Trunk := VLANPort{
+		BridgeIfName: "br0", PortIfName: "eth0",
+		VLANConfig: VLANConfig{TrunkPort: &TrunkPort{AllVIDs: true}},
+	}
+	if !v1.Equal(v2Same) {
+		t.Error("identical VLANPorts should be equal")
+	}
+	if v1.Equal(v3DiffVID) {
+		t.Error("different VID should be unequal")
+	}
+	if v1.Equal(v4Trunk) {
+		t.Error("access vs trunk should be unequal")
+	}
+	if v1.Equal(DummyIf{}) {
+		t.Error("wrong type should be unequal")
+	}
+}
+
+func TestVLANPortEqualTrunk(t *testing.T) {
+	v1 := VLANPort{
+		VLANConfig: VLANConfig{TrunkPort: &TrunkPort{VIDs: []uint16{10, 20}}},
+	}
+	v2OrderDiff := VLANPort{
+		VLANConfig: VLANConfig{TrunkPort: &TrunkPort{VIDs: []uint16{20, 10}}},
+	}
+	v3AllVIDs := VLANPort{
+		VLANConfig: VLANConfig{TrunkPort: &TrunkPort{AllVIDs: true}},
+	}
+	if !v1.Equal(v2OrderDiff) {
+		t.Error("trunk VIDs equality should be order-independent")
+	}
+	if v1.Equal(v3AllVIDs) {
+		t.Error("AllVIDs=false vs true should be unequal")
+	}
+}
+
+func TestVLANPortDependencies(t *testing.T) {
+	v := VLANPort{
+		BridgeIfName: "br0", PortIfName: "eth0",
+		VLANConfig: VLANConfig{AccessPort: &AccessPort{VID: 100}},
+	}
+	deps := v.Dependencies()
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 deps, got %d", len(deps))
+	}
+	depByType(t, deps, VLANBridgeTypename)
+	depByType(t, deps, BridgePortTypename)
+}
+
+// --- VLANSubIf ---
+
+func TestVLANSubIfEqual(t *testing.T) {
+	v1 := VLANSubIf{IfName: "eth0.100", ParentIfName: "eth0", ID: 100}
+	v2Same := VLANSubIf{IfName: "eth0.100", ParentIfName: "eth0", ID: 100}
+	v3DiffID := VLANSubIf{IfName: "eth0.100", ParentIfName: "eth0", ID: 200}
+	v4DiffParent := VLANSubIf{IfName: "eth0.100", ParentIfName: "eth1", ID: 100}
+	if !v1.Equal(v2Same) {
+		t.Error("identical VLANSubIf instances should be equal")
+	}
+	if v1.Equal(v3DiffID) {
+		t.Error("different ID should be unequal")
+	}
+	if v1.Equal(v4DiffParent) {
+		t.Error("different ParentIfName should be unequal")
+	}
+}
+
+func TestVLANSubIfDependencies(t *testing.T) {
+	v := VLANSubIf{}
+	if deps := v.Dependencies(); deps != nil {
+		t.Errorf("expected nil deps, got %v", deps)
+	}
+}
+
+// --- Route ---
+
+func TestRouteHasDefaultDst(t *testing.T) {
+	tests := []struct {
+		name string
+		dst  *net.IPNet
+		want bool
+	}{
+		{"nil", nil, true},
+		{"0.0.0.0/0", mustParseCIDRLI("0.0.0.0/0"), true},
+		{"::/0", mustParseCIDRLI("::/0"), true},
+		{"10.0.0.0/8", mustParseCIDRLI("10.0.0.0/8"), false},
+		{"192.168.1.0/24", mustParseCIDRLI("192.168.1.0/24"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := Route{Route: netlink.Route{Dst: tc.dst}}
+			if got := r.hasDefaultDst(); got != tc.want {
+				t.Errorf("hasDefaultDst() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRouteNormalizedNetlinkRoute(t *testing.T) {
+	// nil Dst for IPv4 should become 0.0.0.0/0
+	r := Route{Route: netlink.Route{Family: netlink.FAMILY_V4, Dst: nil}}
+	norm := r.normalizedNetlinkRoute()
+	if norm.Dst == nil {
+		t.Error("normalized route should have non-nil Dst")
+	}
+	ones, _ := norm.Dst.Mask.Size()
+	if ones != 0 || !norm.Dst.IP.IsUnspecified() {
+		t.Errorf("normalized Dst should be 0.0.0.0/0, got %s", norm.Dst)
+	}
+	// Flags should be cleared
+	r2 := Route{Route: netlink.Route{Family: netlink.FAMILY_V4, Flags: 0x10, Dst: mustParseCIDRLI("10.0.0.0/8")}}
+	norm2 := r2.normalizedNetlinkRoute()
+	if norm2.Flags != 0 {
+		t.Errorf("flags should be cleared, got %d", norm2.Flags)
+	}
+}
+
+func TestRouteEqual(t *testing.T) {
+	r1 := Route{
+		Route:    netlink.Route{Family: netlink.FAMILY_V4, Table: 254, Dst: mustParseCIDRLI("10.0.0.0/8")},
+		OutputIf: generic.NetworkIf{IfName: "eth0"},
+	}
+	r2Same := Route{
+		Route:    netlink.Route{Family: netlink.FAMILY_V4, Table: 254, Dst: mustParseCIDRLI("10.0.0.0/8")},
+		OutputIf: generic.NetworkIf{IfName: "eth0"},
+	}
+	r3DiffDst := Route{
+		Route:    netlink.Route{Family: netlink.FAMILY_V4, Table: 254, Dst: mustParseCIDRLI("192.168.0.0/16")},
+		OutputIf: generic.NetworkIf{IfName: "eth0"},
+	}
+	r4DiffIf := Route{
+		Route:    netlink.Route{Family: netlink.FAMILY_V4, Table: 254, Dst: mustParseCIDRLI("10.0.0.0/8")},
+		OutputIf: generic.NetworkIf{IfName: "eth1"},
+	}
+	if !r1.Equal(r2Same) {
+		t.Error("identical routes should be equal")
+	}
+	if r1.Equal(r3DiffDst) {
+		t.Error("different Dst should be unequal")
+	}
+	if r1.Equal(r4DiffIf) {
+		t.Error("different OutputIf should be unequal")
+	}
+	if r1.Equal(DummyIf{}) {
+		t.Error("wrong type should be unequal")
+	}
+}
+
+func TestRouteDependenciesWithGw(t *testing.T) {
+	ifRef := dg.ItemRef{ItemType: "Bridge", ItemName: "br0"}
+	gw := net.IP{10, 0, 0, 254}
+	r := Route{
+		Route: netlink.Route{
+			Family: netlink.FAMILY_V4,
+			Table:  254,
+			Dst:    mustParseCIDRLI("0.0.0.0/0"),
+			Gw:     gw,
+		},
+		OutputIf: generic.NetworkIf{IfName: "br0", ItemRef: ifRef},
+	}
+	deps := r.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dep, got %d", len(deps))
+	}
+	if deps[0].RequiredItem != ifRef {
+		t.Errorf("dep should be OutputIf")
+	}
+	if deps[0].MustSatisfy == nil {
+		t.Error("dep should have MustSatisfy")
+	}
+	// Port with subnet containing gw → true
+	portMatch := generic.Port{
+		IPAddresses: []*net.IPNet{{IP: net.IP{10, 0, 0, 1}, Mask: net.CIDRMask(24, 32)}},
+	}
+	if !deps[0].MustSatisfy(portMatch) {
+		t.Error("MustSatisfy should be true when gw is in assigned subnet")
+	}
+	// Port with subnet not containing gw → false
+	portNoMatch := generic.Port{
+		IPAddresses: []*net.IPNet{{IP: net.IP{192, 168, 0, 1}, Mask: net.CIDRMask(24, 32)}},
+	}
+	if deps[0].MustSatisfy(portNoMatch) {
+		t.Error("MustSatisfy should be false when gw not in assigned subnet")
+	}
+}
+
+func TestRouteDependenciesNoOutputIf(t *testing.T) {
+	r := Route{Route: netlink.Route{Family: netlink.FAMILY_V4, Table: 254}}
+	deps := r.Dependencies()
+	if len(deps) != 0 {
+		t.Errorf("route without output interface should have no deps, got %d", len(deps))
+	}
+}
+
+func TestRouteDependenciesLoopback(t *testing.T) {
+	r := Route{
+		Route:    netlink.Route{Family: netlink.FAMILY_V4, Table: 254},
+		OutputIf: generic.NetworkIf{IfName: "lo"},
+	}
+	deps := r.Dependencies()
+	if len(deps) != 0 {
+		t.Errorf("loopback route should have no deps, got %d", len(deps))
+	}
+}


### PR DESCRIPTION
# Description

Commits 1–3 and 5 are test-only. The only production code change is commit 4
(c1dd0c99f), which is a mechanical refactor to enable testing.

Add Go unit tests for NIM-related packages in `pkg/pillar` that previously
had no or minimal test coverage. Five commits, covering five packages:

**Commit 1 (487661e2a)** — `dpcreconciler` wpa/bond/vlan items:
- `genericitems/wpa_supplicant_test.go`: `WpaSupplicant` metadata, `renderWifiConfig`, `renderPNACConfig`, path helpers, `WifiConfig`/`PNAC8021XConfig` helpers
- `linuxitems/bond_vlan_test.go`: `Bond`, `Vlan`, `isFailoverBondMode`, `GetMTU`, `NeedsRecreate`, `Dependencies`

**Commit 2 (70a6a51c1)** — remaining `dpcreconciler` and `netmonitor` items:
- `genericitems/items_test.go`: `AdapterAddrs`, `Dhcpcd`, `NetIO`, `ResolvConf`, `SSHAuthKeys`, `Wwan`
- `linuxitems/items_test.go`: `Adapter`, `Arp`, `IPRule`, `PhysIf`, `RFKill`, `Route`
- `netmonitor/netmonitor_test.go`: `IsDefaultRoute`, `IfAttrs.Equal`, `IfChange.Equal`, event marker methods

**Commit 3 (573e688b5)** — `nireconciler` item types:
- `nireconciler/genericitems/items_test.go`: `Dnsmasq`, `HTTPServer`, `IPReserve`, `Port`, `Radvd` plus helpers (`equalUpstreamDNSServer`, `equalMACToIP`, `EqualIPRoutes`, `isECONNREFUSED`, path helpers, `dhcpTagForHost`)
- `nireconciler/linuxitems/items_test.go`: `BPDUGuard`, `BridgeFwdMask`, `Bridge`, `BridgePort`, `DummyIf`, `IPRule`, `IPSet`, `Sysctl`, `TCIngress`, `TCMirror`, `VIF`, `VLANBridge`, `VLANPort`, `VLANSubIf`, `Route` plus helpers (`toMaskValue`, `equalBoolPtr`, `boolPtrToString`, `ipVersionStr`, `hasDefaultDst`)

**Commit 4 (c1dd0c99f)** — `netmonitor` proc parser refactor (minimal production change):
- Extract hardcoded `/proc/net/bonding` path into a `procNetBondingDir` constant and add it as a parameter to `parseProcBondInfo` and `parseProcBondMemberMetrics`, making them unit-testable without `/proc`.

**Commit 5 (075f5f509)** — `netmonitor` proc bond parser tests:
- `netmonitor/netmonitor_test.go`: `parseChurnState`, `isDhcpcdNotRunningErr`, `parseProcBondInfo`, `parseProcBondMemberMetrics` using synthetic temp-dir bond files.

Statement coverage improvements:
- `dpcreconciler/genericitems`: 7.1% → ~30%
- `dpcreconciler/linuxitems`: 0.0% → ~20%
- `netmonitor`: 0% → ~15%
- `nireconciler/genericitems`: 16.7% → 32.9%
- `nireconciler/linuxitems`: 0.0% → 26.6%

All new unit tests have no OS or hardware dependencies.

## PR dependencies

None.

## How to test and validate this PR

```
cd pkg/pillar
go test ./dpcreconciler/genericitems/
go test ./dpcreconciler/linuxitems/
go test ./netmonitor/
go test ./nireconciler/genericitems/
go test ./nireconciler/linuxitems/
```

All packages pass all tests.

## Changelog notes

No user-facing changes.

## PR Backports

- 16.0-stable: No, test-only change.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
