### PR TITLE
Force bonds/vlans re-parsing when lower layer changes

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -159,8 +159,8 @@ func parseConfig(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig,
 		forcePNACParse := physioChanged || scepChanged
 		pnacChanged := parsePNACConfig(getconfigCtx, config, forcePNACParse)
 		// It is important to parse Bonds before VLANs.
-		bondsChanged := parseBonds(getconfigCtx, config)
-		vlansChanged := parseVlans(getconfigCtx, config)
+		bondsChanged := parseBonds(getconfigCtx, config, physioChanged)
+		vlansChanged := parseVlans(getconfigCtx, config, physioChanged || bondsChanged)
 		// Network objects are used for systemAdapters
 		networksChanged := parseNetworkXObjectConfig(getconfigCtx, config)
 		sourceChanged := getconfigCtx.lastConfigSource != source
@@ -1980,7 +1980,8 @@ func parsePNACConfig(getconfigCtx *getconfigContext,
 
 var bondsPrevConfigHash []byte
 
-func parseBonds(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig) bool {
+func parseBonds(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig,
+	forceParse bool) bool {
 	bonds := config.GetBonds()
 	h := sha256.New()
 	for _, bond := range bonds {
@@ -1988,7 +1989,7 @@ func parseBonds(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig) b
 	}
 	configHash := h.Sum(nil)
 	same := bytes.Equal(configHash, bondsPrevConfigHash)
-	if same {
+	if same && !forceParse {
 		return false
 	}
 	bondsPrevConfigHash = configHash
@@ -2096,7 +2097,8 @@ func parseBonds(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig) b
 
 var vlansPrevConfigHash []byte
 
-func parseVlans(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig) bool {
+func parseVlans(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig,
+	forceParse bool) bool {
 	vlans := config.GetVlans()
 	h := sha256.New()
 	for _, vlan := range vlans {
@@ -2104,7 +2106,7 @@ func parseVlans(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig) b
 	}
 	configHash := h.Sum(nil)
 	same := bytes.Equal(configHash, vlansPrevConfigHash)
-	if same {
+	if same && !forceParse {
 		return false
 	}
 	vlansPrevConfigHash = configHash

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -320,7 +320,7 @@ func TestParseVlans(t *testing.T) {
 	}
 
 	parseDeviceIoListConfig(getconfigCtx, config)
-	parseVlans(getconfigCtx, config)
+	parseVlans(getconfigCtx, config, false)
 	parseNetworkXObjectConfig(getconfigCtx, config)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 
@@ -519,7 +519,7 @@ func TestParseBonds(t *testing.T) {
 	}
 
 	parseDeviceIoListConfig(getconfigCtx, config)
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseNetworkXObjectConfig(getconfigCtx, config)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 
@@ -690,8 +690,8 @@ func TestParseVlansOverBonds(t *testing.T) {
 	}
 
 	parseDeviceIoListConfig(getconfigCtx, config)
-	parseBonds(getconfigCtx, config)
-	parseVlans(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
+	parseVlans(getconfigCtx, config, false)
 	parseNetworkXObjectConfig(getconfigCtx, config)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 
@@ -959,7 +959,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -971,7 +971,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 	// fix:
 	config.Bonds[0].Logicallabel = "bond-shopfloor"
 	config.SystemAdapterList[0].LowerLayerName = "bond-shopfloor"
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -990,7 +990,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1008,7 +1008,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			BondMode:        zcommon.BondMode_BOND_MODE_ACTIVE_BACKUP,
 		},
 	}
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1041,7 +1041,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1053,7 +1053,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 
 	// fix:
 	config.Bonds[0].LowerLayerNames = []string{"shopfloor"}
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1092,8 +1092,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(getconfigCtx, config)
-	parseVlans(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
+	parseVlans(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1107,8 +1107,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 
 	// fix:
 	config.Vlans[1].VlanId = 200
-	parseBonds(getconfigCtx, config)
-	parseVlans(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
+	parseVlans(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1149,8 +1149,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(getconfigCtx, config)
-	parseVlans(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
+	parseVlans(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1164,8 +1164,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 
 	// fix:
 	config.Bonds[0].LowerLayerNames = []string{"shopfloor"} // remove warehouse from the LAG
-	parseBonds(getconfigCtx, config)
-	parseVlans(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
+	parseVlans(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1204,7 +1204,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1219,7 +1219,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 	// fix
 	config.Bonds[0].LowerLayerNames = []string{"shopfloor"}
 	config.Bonds[1].LowerLayerNames = []string{"warehouse"}
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1246,8 +1246,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(getconfigCtx, config)
-	parseVlans(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
+	parseVlans(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1259,8 +1259,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 
 	// fix:
 	config.Vlans[0].VlanId = 1000
-	parseBonds(getconfigCtx, config)
-	parseVlans(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
+	parseVlans(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -2150,7 +2150,7 @@ func TestParseInvalidPNAC(t *testing.T) {
 	parseDeviceIoListConfig(getconfigCtx, config)
 	parseSCEPProfiles(getconfigCtx, config)
 	parsePNACConfig(getconfigCtx, config, true)
-	parseVlans(getconfigCtx, config)
+	parseVlans(getconfigCtx, config, false)
 	parseNetworkXObjectConfig(getconfigCtx, config)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 
@@ -2223,4 +2223,160 @@ func TestParseInvalidPNAC(t *testing.T) {
 	g.Expect(scepProfile2.ParsingError.Error).ToNot(BeEmpty())
 	g.Expect(scepProfile2.ParsingError.Error).To(ContainSubstring(
 		"Invalid SCEP URL \"invalid-URL\""))
+}
+
+// TestBondMemberSwap verifies that swapping physical adapters between two bonds
+// produces a correct DPC with no "aggregated by multiple bonds" error.
+//
+// The key scenario: bond2 has no direct system adapter (it is only reachable via
+// VLANs). When bond membership changes but the VLAN config is identical, the VLAN
+// hash is unchanged. Without forceParse, parseVlans would skip its re-parsing and
+// keep stale lowerL2Ports pointers to the old bond2, causing the old bond2
+// (with its old members) to appear in the DPC alongside the updated bond1,
+// making one adapter appear in both bonds.
+func TestBondMemberSwap(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := initGetConfigCtx(g)
+
+	const networkUUID = "572cd3bc-ade6-42ad-97a0-22cd24fed1a0"
+
+	config := &zconfig.EdgeDevConfig{
+		Networks: []*zconfig.NetworkConfig{
+			{
+				Id:   networkUUID,
+				Type: zcommon.NetworkType_V4,
+				Ip:   &zcommon.Ipspec{Dhcp: zcommon.DHCPType_Client},
+			},
+		},
+		DeviceIoList: []*zconfig.PhysicalIO{
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "eth0",
+				Logicallabel: "eth0",
+				Assigngrp:    "eth-grp-1",
+				Phyaddrs:     map[string]string{"ifname": "eth0", "pcilong": "0000:01:00.0"},
+				Usage:        zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "eth1",
+				Logicallabel: "eth1",
+				Assigngrp:    "eth-grp-2",
+				Phyaddrs:     map[string]string{"ifname": "eth1", "pcilong": "0000:02:00.0"},
+				Usage:        zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "eth2",
+				Logicallabel: "eth2",
+				Assigngrp:    "eth-grp-3",
+				Phyaddrs:     map[string]string{"ifname": "eth2", "pcilong": "0000:03:00.0"},
+				Usage:        zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "eth3",
+				Logicallabel: "eth3",
+				Assigngrp:    "eth-grp-4",
+				Phyaddrs:     map[string]string{"ifname": "eth3", "pcilong": "0000:04:00.0"},
+				Usage:        zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+		},
+		Bonds: []*zconfig.BondAdapter{
+			{
+				Logicallabel:    "bond1",
+				InterfaceName:   "bond1",
+				LowerLayerNames: []string{"eth0", "eth1"},
+				BondMode:        zcommon.BondMode_BOND_MODE_ACTIVE_BACKUP,
+				Monitoring:      &zconfig.BondAdapter_Mii{Mii: &zconfig.MIIMonitor{Interval: 100}},
+			},
+			{
+				Logicallabel:    "bond2",
+				InterfaceName:   "bond2",
+				LowerLayerNames: []string{"eth2", "eth3"},
+				BondMode:        zcommon.BondMode_BOND_MODE_ACTIVE_BACKUP,
+				Monitoring:      &zconfig.BondAdapter_Mii{Mii: &zconfig.MIIMonitor{Interval: 100}},
+			},
+		},
+		// bond2 has no direct system adapter — it is only accessible via VLANs.
+		// This is the configuration that exercises the stale-pointer path.
+		Vlans: []*zconfig.VlanAdapter{
+			{
+				Logicallabel:   "vlan20",
+				InterfaceName:  "bond2.20",
+				LowerLayerName: "bond2",
+				VlanId:         20,
+			},
+			{
+				Logicallabel:   "vlan21",
+				InterfaceName:  "bond2.21",
+				LowerLayerName: "bond2",
+				VlanId:         21,
+			},
+		},
+		SystemAdapterList: []*zconfig.SystemAdapter{
+			{
+				Name:           "adapter-bond1",
+				Uplink:         true,
+				NetworkUUID:    networkUUID,
+				LowerLayerName: "bond1",
+			},
+			{
+				Name:           "adapter-vlan20",
+				Uplink:         true,
+				NetworkUUID:    networkUUID,
+				LowerLayerName: "vlan20",
+			},
+			{
+				Name:           "adapter-vlan21",
+				Uplink:         true,
+				NetworkUUID:    networkUUID,
+				LowerLayerName: "vlan21",
+			},
+		},
+	}
+
+	// parseAll runs the parse functions in the same dependency order as parseConfig.
+	parseAll := func(cfg *zconfig.EdgeDevConfig) {
+		physioChanged := parseDeviceIoListConfig(ctx, cfg)
+		bondsChanged := parseBonds(ctx, cfg, physioChanged)
+		vlansChanged := parseVlans(ctx, cfg, physioChanged || bondsChanged)
+		parseNetworkXObjectConfig(ctx, cfg)
+		parseSystemAdapterConfig(ctx, cfg, fromController,
+			physioChanged || bondsChanged || vlansChanged)
+	}
+
+	// Round 1: initial config — bond1=[eth0,eth1], bond2=[eth2,eth3]
+	parseAll(config)
+	portConfig, err := ctx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc := portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeFalse())
+	bond1Port := dpc.LookupPortByLogicallabel("adapter-bond1")
+	g.Expect(bond1Port).ToNot(BeNil())
+	g.Expect(bond1Port.L2LinkConfig.Bond.AggregatedPorts).To(ConsistOf("eth0", "eth1"))
+	bond2Port := dpc.LookupPortByLogicallabel("bond2")
+	g.Expect(bond2Port).ToNot(BeNil())
+	g.Expect(bond2Port.L2LinkConfig.Bond.AggregatedPorts).To(ConsistOf("eth2", "eth3"))
+
+	// Round 2: swap eth1↔eth2 — bond1=[eth0,eth2], bond2=[eth1,eth3].
+	// The VLAN config is identical so parseVlans detects no hash change.
+	// Without forceParse the stale vlan→old-bond2 pointer would leave
+	// old bond2 (carrying eth2) in the DPC alongside new bond1 (also carrying
+	// eth2), triggering "Port eth2 is aggregated by multiple bond interfaces".
+	config.Bonds[0].LowerLayerNames = []string{"eth0", "eth2"}
+	config.Bonds[1].LowerLayerNames = []string{"eth1", "eth3"}
+	parseAll(config)
+	portConfig, err = ctx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeFalse())
+	g.Expect(getPortError(&dpc, "eth1")).To(BeEmpty())
+	g.Expect(getPortError(&dpc, "eth2")).To(BeEmpty())
+	bond1Port = dpc.LookupPortByLogicallabel("adapter-bond1")
+	g.Expect(bond1Port).ToNot(BeNil())
+	g.Expect(bond1Port.L2LinkConfig.Bond.AggregatedPorts).To(ConsistOf("eth0", "eth2"))
+	bond2Port = dpc.LookupPortByLogicallabel("bond2")
+	g.Expect(bond2Port).ToNot(BeNil())
+	g.Expect(bond2Port.L2LinkConfig.Bond.AggregatedPorts).To(ConsistOf("eth1", "eth3"))
 }


### PR DESCRIPTION
# Description

`parseBonds` and `parseVlans` each use a content hash to skip parsing when their own config is unchanged. However, both store pointers to lower-layer objects (physio pointers in `bond.lowerPhysPorts`, bond pointers in `vlan.lowerL2Ports`) obtained at parse time. If a lower layer is parsed without the dependent layer being parsed, those pointers become stale (pointing at parsed old config).

Fix by propagating force-parse down the dependency chain:
- `parseBonds` is forced to parse when physio changes
- `parseVlans` is forced to parse when physio or bonds change

## How to test and validate this PR

Set up a device with four network adapters (e.g. `eth0`–`eth3`) and configure two bonds with VLAN sub-interfaces on top:

**Initial config**
- `bond1`: aggregates `eth0`, `eth1` — management uplink (DHCP)
- `bond2`: aggregates `eth2`, `eth3`
- `vlan20`, `vlan21`: parent port `bond2`

Apply this config and confirm the device connects and reports no port errors.

**Config change — swap `eth1` and `eth2` between the bonds**
- `bond1`: aggregates `eth0`, `eth2`
- `bond2`: aggregates `eth1`, `eth3`
- VLANs unchanged

**Expected (correct) result**
`/run/zedagent/DevicePortConfig/zedagent.json` should show:
- `bond1.Bond.AggregatedPorts = ["eth0", "eth2"]`
- `bond2.Bond.AggregatedPorts = ["eth1", "eth3"]`
- No `LastError` on any port

**Regression (what the bug produced)**
Without the fix, parsed VLAN config would remain stale from a prior parse and `zedagent.json` could show `eth2` under both `bond1` and `bond2`, resulting in:
```
LastError: "Port eth2 is aggregated by multiple bond interfaces (bond1, bond2, ...)"
```

## Changelog notes

Fixed a bug where re-configuring bond membership (e.g. swapping physical interfaces between two bonds) could leave the device with a broken network configuration and a `port aggregated by multiple bonds` error, requiring a reboot to recover.

## PR Backports

- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.