### PR TITLE
zedmanager: fix ENC app reporting race and ActivateInprogress stuck failback

### DIFF
--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -948,6 +948,11 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 		status.Activated = true
 		status.ActivateInprogress = false
 		changed = true
+	} else if status.ActivateInprogress {
+		// Failback: domain is running but ActivateInprogress was re-set
+		// during a prior failover cycle where Activated was already true.
+		status.ActivateInprogress = false
+		changed = true
 	}
 	// Are we doing a restart?
 	if status.RestartInprogress == types.BringUp {
@@ -1041,7 +1046,7 @@ func doRemove(ctx *zedmanagerContext,
 	c, done := doInactivate(ctx, appInstID, status)
 	changed = changed || c
 	if !done {
-		log.Functionf("doRemove waiting for inactivate for %s", uuidStr)
+		log.Functionf("doRemove waiting for deactivate for %s", uuidStr)
 		return changed, done
 	}
 	if !status.Activated {

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -89,6 +89,7 @@ func (ctx *zedmanagerContext) AddAgentSpecificCLIFlags(flagSet *flag.FlagSet) {
 var logger *logrus.Logger
 var log *base.LogObject
 
+// Run - Main function - invoked from zedbox.go
 func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
 	log = logArg
@@ -796,10 +797,16 @@ func publishAppInstanceStatus(ctx *zedmanagerContext,
 				log.Functionf("publishAppInstanceStatus(%s) suppressed: IsDNidNode=%v ScheduledOnThisNode=%v AppKubeStatus=%v",
 					key, clusterStatus.IsDNidNode, clusterStatus.ScheduledOnThisNode, clusterStatus.AppKubeStatus)
 			}
+		} else if !status.IsDesignatedNodeID {
+			// No ENClusterAppStatus yet for this app, but the config says this node
+			// is not the designated node for this app. A peer owns reporting; suppress
+			// until our ENClusterAppStatus arrives and sets the correct policy.
+			// Single-device k8s and the DNID node both have IsDesignatedNodeID=true,
+			// so they are unaffected and continue to report.
+			status.NoUploadStatsToController = true
+			log.Functionf("publishAppInstanceStatus(%s) suppressed: no ENClusterAppStatus yet, not DNID node",
+				key)
 		}
-		// st == nil: leave flag at its prior value (defaults to false on a fresh
-		// AppInstanceStatus). Cold-start reporting goes through; a later ENClusterAppStatus
-		// update re-publishes AppInstanceStatus through handleENClusterAppStatusImpl.
 	}
 	pub.Publish(key, *status)
 }


### PR DESCRIPTION

# Description

 - After a node reboot, ENClusterAppStatus is unavailable until zedkube reconnects to k3s (~72 seconds). During this window, the non-DNID node created a fresh AppInstanceStatus with NoUploadStatsToController=false and uploaded State=INITIAL to the cloud, overriding the DNID node's RUNNING report.

   Fix: in publishAppInstanceStatus, when no ENClusterAppStatus exists yet for an app (st == nil), suppress uploads immediately if !status.IsDesignatedNodeID. This field is set from AppInstanceConfig (persistent across reboots) and is false only on cluster non-DNID nodes — single-device k8s and the DNID node both have it true and are unaffected.

 - doActivate sets ActivateInprogress=true unconditionally at line 755. The clearing logic at line 947 was guarded by !status.Activated, so if Activated was already true (from a prior activation cycle, as happens on failback), ActivateInprogress was never cleared.

   Fix: add else if status.ActivateInprogress branch to clear the flag when the domain reaches running state and Activated is already set.

## PR dependencies

## How to test and validate this PR

Need to config edge-node cluster, reboot the original node and failover an app to another node.
When the original node comes back, when the app is rescheduled back, it should not report in
the controller as 'init' state while the app is actually up running.

## Changelog notes

zedmanager: fix ENC app reporting race and ActivateInprogress stuck failback

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
