### PR TITLE
Make sure SenderStatusCertMiss is not overwritten

### DIFF
--- a/pkg/pillar/controllerconn/authen.go
+++ b/pkg/pillar/controllerconn/authen.go
@@ -110,15 +110,16 @@ func (c *Client) VerifyAuthContainerHeader(sm *zauth.AuthContainer) (
 	types.SenderStatus, error) {
 	status, err := c.tryVerifyAuthContainerHeader(sm, false)
 	if status == types.SenderStatusCertMiss {
-		// Try backup
+		// Try backup without clobbering status. SenderStatusCertMiss
+		// is needed to trigger a fetch of the certificates.
 		c.ClearServerCert()
-		status, err = c.tryVerifyAuthContainerHeader(sm, true)
-		if status == types.SenderStatusNone {
+		status2, err2 := c.tryVerifyAuthContainerHeader(sm, true)
+		if status2 == types.SenderStatusNone && err2 == nil {
 			c.log.Notice("controllercerts.bak worked")
-		} else {
-			c.log.Errorf("controllercerts and controllercerts.bak failed: %s, %s",
-				status, err)
+			return status2, err2
 		}
+		c.log.Errorf("controllercerts and controllercerts.bak failed: %s, %s: returning %s, %s",
+			status2, err2, status, err)
 	}
 	return status, err
 }


### PR DESCRIPTION
# Description

This is needed to fetch new controller certificates. Without it certificate rotation can fail to propagate to
EVE devices in a timely manner (the 24 h timer will do it as a fallback).

Fixes the failures we see in the ctrl_cert_change test.

This was introduced in #5584 but the manual testing of those fixes always had a .bak file, and the eden smoke tests have had several cases of flaky tests preceeding the crtl_cert_change test so it has not been getting to the point of trying crtl_cert_change until recently.

## How to test and validate this PR

Should be part of the normal regression testing, but in this case we need to run the manual 
test which updates the controller signing certificate in addition to the eden test.

## Changelog notes

None (part of the PR 5584)

## PR Backports

MUST be backported where #5584 is backported wich is:

- 16.0-stable - yes
- 14.5-stable - yes
- 13.4-stable - no

## Checklist

- [X] I've provided a proper description
- [X] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [X] I've written the test verification instructions
- [X] I've set the proper labels to this PR

- [X] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
