### PR TITLE
GHA: add arm64 kubevirt and nvidia-jp7 build/publish coverage

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -56,8 +56,23 @@ jobs:
           - arch: arm64
             platform: "nvidia-jp6"
             hv: "kvm"
+          - arch: arm64
+            platform: "nvidia-jp7"
+            hv: "kvm"
           - arch: amd64
             platform: "generic"
+            hv: "k"
+          - arch: arm64
+            platform: "generic"
+            hv: "k"
+          - arch: arm64
+            platform: "nvidia-jp5"
+            hv: "k"
+          - arch: arm64
+            platform: "nvidia-jp6"
+            hv: "k"
+          - arch: arm64
+            platform: "nvidia-jp7"
             hv: "k"
           - arch: amd64
             platform: "evaluation"

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -130,16 +130,26 @@ jobs:
              docker run "$EVE" installer_iso > assets/installer.iso
              docker run "$EVE" installer_net > assets/installer-net.tar
           fi
-      - name: Pull eve-sources and publish collected_sources.tar.gz to assets
+      - name: Export eve-sources to assets/collected_sources.tar
         run: |
           if [ "${{ matrix.platform }}" != "evaluation" ]; then
             HV=${{ matrix.hv }}
             EVE_SOURCES=lfedge/eve-sources:${TAG}-${{ env.PLATFORMVER }}${HV}-${{ env.ARCH }}
             docker pull "$EVE_SOURCES"
             docker create --name eve_sources "$EVE_SOURCES" bash
-            docker export --output assets/collected_sources.tar.gz eve_sources
+            docker export --output assets/collected_sources.tar eve_sources
             docker rm eve_sources
           fi
+      - name: Compress large assets with zstd
+        # installer.raw, live.raw, and collected_sources.tar can exceed the
+        # GitHub release asset size limit (2 GiB). These compress extremely
+        # well (raw disk images typically 5-20x for sparse regions), keeping
+        # them well under the limit and reducing transfer time.
+        run: |
+          for file in assets/*.raw assets/collected_sources.tar; do
+            [ -e "$file" ] || continue
+            zstd -T0 --rm -q "$file"
+          done
       - name: Rename, create SHA256 checksums and upload files
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -164,7 +174,9 @@ jobs:
           cd ../
           mv "$sha256_file" assets/
           mv "$sizes_file" assets/
-          # Upload files
+          # Upload files. Track failures and fail the job at the end so that
+          # all assets are attempted before the run is marked failed.
+          upload_failed=0
           for file in assets/*; do
             file_name=$(basename $file)
             echo "Uploading ${file_name}..."
@@ -176,6 +188,8 @@ jobs:
             if echo "$upload_response" | jq -e .id > /dev/null; then
               echo "$file_name uploaded successfully."
             else
-              echo "Error uploading $file_name: $upload_response"
+              echo "::error::Failed to upload $file_name: $upload_response"
+              upload_failed=1
             fi
           done
+          exit "$upload_failed"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,6 +288,30 @@ jobs:
           hv: kvm
           cache-artifact: linuxkit-cache-arm64-generic
 
+  eve-arm64-k-generic:
+    name: "eve (arm64, k, generic)"
+    needs: pkgs-arm64-generic
+    runs-on: zededa-ubuntu-2204-arm64
+    timeout-minutes: 1440
+    steps:
+      - name: Clear repository
+        shell: bash
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+      - uses: ./.github/actions/build-eve
+        with:
+          arch: arm64
+          platform: generic
+          hv: k
+          cache-artifact: linuxkit-cache-arm64-generic
+
   # ── arm64 nvidia ──
 
   eve-arm64-kvm-nvidia-jp5:
@@ -336,6 +360,78 @@ jobs:
           arch: arm64
           platform: nvidia-jp6
           hv: kvm
+          cache-artifact: linuxkit-cache-arm64-generic
+
+  eve-arm64-kvm-nvidia-jp7:
+    name: "eve (arm64, kvm, nvidia-jp7)"
+    needs: pkgs-arm64-generic
+    runs-on: zededa-ubuntu-2204-arm64
+    timeout-minutes: 1440
+    steps:
+      - name: Clear repository
+        shell: bash
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+      - uses: ./.github/actions/build-eve
+        with:
+          arch: arm64
+          platform: nvidia-jp7
+          hv: kvm
+          cache-artifact: linuxkit-cache-arm64-generic
+
+  eve-arm64-k-nvidia-jp6:
+    name: "eve (arm64, k, nvidia-jp6)"
+    needs: pkgs-arm64-generic
+    runs-on: zededa-ubuntu-2204-arm64
+    timeout-minutes: 1440
+    steps:
+      - name: Clear repository
+        shell: bash
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+      - uses: ./.github/actions/build-eve
+        with:
+          arch: arm64
+          platform: nvidia-jp6
+          hv: k
+          cache-artifact: linuxkit-cache-arm64-generic
+
+  eve-arm64-k-nvidia-jp7:
+    name: "eve (arm64, k, nvidia-jp7)"
+    needs: pkgs-arm64-generic
+    runs-on: zededa-ubuntu-2204-arm64
+    timeout-minutes: 1440
+    steps:
+      - name: Clear repository
+        shell: bash
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+      - uses: ./.github/actions/build-eve
+        with:
+          arch: arm64
+          platform: nvidia-jp7
+          hv: k
           cache-artifact: linuxkit-cache-arm64-generic
 
   # ════════════════════════════════════════════════════════════════════════

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,30 +17,15 @@ on:  # yamllint disable-line rule:truthy
       - "[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
 
 jobs:
-  # 1) non-ARM packages, fully parallel
-  packages-non-arm:
+  # ════════════════════════════════════════════════════════════════════════
+  # Stage 1: Build and push base generic packages for each architecture.
+  # Stage 2 EVE jobs pull these from the registry; `make pkgs` only
+  # rebuilds any extra HV/platform-specific packages on top.
+  # ════════════════════════════════════════════════════════════════════════
+
+  pkgs-amd64:
     if: github.event.repository.full_name == 'lf-edge/eve'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: zededa-ubuntu-2204
-            arch: amd64
-            platform: "generic"
-            hv: kvm
-          - os: zededa-ubuntu-2204
-            arch: amd64
-            platform: "generic"
-            hv: k
-          - os: zededa-ubuntu-2204
-            arch: amd64
-            platform: "evaluation"
-            hv: kvm
-          - os: zededa-ubuntu-2204
-            arch: riscv64
-            platform: "generic"
-            hv: mini
+    runs-on: zededa-ubuntu-2204
     steps:
       - name: Starting Report
         run: |
@@ -56,50 +41,24 @@ jobs:
       - name: Force fetch annotated tags (workaround)
         run: |
           git fetch --force --tags
-      - name: Determine architecture prefix and ref
-        env:
-          REF: ${{ github.ref }}
-        run: |
-          echo "ARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
-          echo "TAG=$(echo "$REF" | sed -e 's#^.*/##' -e 's#master#snapshot#' -e 's#main#snapshot#')" >> "$GITHUB_ENV"
-      - name: Login to Docker Hub (build)
+      - name: Login to Docker Hub
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
-        if: ${{ github.event.repository.full_name == 'lf-edge/eve' }}
-        with:
-          username: ${{ secrets.DOCKERHUB_PULL_USER }}
-          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
-      - name: Build packages
-        run: |
-          SUCCESS=
-          for i in 1 2 3; do
-            echo "Run attempt: $i"
-            if make -e V=1 HV="${{ matrix.hv }}" ZARCH="${{ matrix.arch }}" PLATFORM="${{ matrix.platform }}" LINUXKIT_PKG_TARGET=build pkgs; then
-              SUCCESS=true
-              break
-            else
-              docker system prune -f -a --volumes
-            fi
-          done
-          if [ -z "$SUCCESS" ]; then echo "::error::failed to build packages" && exit 1; fi
-      - name: Login to Docker Hub (push)
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
-        if: ${{ github.event.repository.full_name == 'lf-edge/eve' }}
         with:
           username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
           password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
-      - name: Push packages
+      - name: Build and push packages
         run: |
           SUCCESS=
           for i in 1 2 3; do
             echo "Run attempt: $i"
-            if make -e V=1 HV="${{ matrix.hv }}" ZARCH="${{ matrix.arch }}" PLATFORM="${{ matrix.platform }}" LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
+            if make -e V=1 HV=kvm ZARCH=amd64 PLATFORM=generic LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
               SUCCESS=true
               break
             else
               docker system prune -f -a --volumes
             fi
           done
-          if [ -z "$SUCCESS" ]; then echo "::error::failed to push packages" && exit 1; fi
+          if [ -z "$SUCCESS" ]; then echo "::error::failed to build and push packages" && exit 1; fi
       - name: Post package report
         run: |
           echo Disk usage
@@ -115,25 +74,10 @@ jobs:
           docker system prune -f -a --volumes
           rm -rf ~/.linuxkit
 
-  # 2) ARM packages, serialized
-  packages-arm:
+  pkgs-arm64:
     if: github.event.repository.full_name == 'lf-edge/eve'
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 1440  # It takes more time when building arm64 on an amd64 runner
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        include:
-          - os: zededa-ubuntu-2204-arm64
-            arch: arm64
-            platform: "generic"
-          - os: zededa-ubuntu-2204-arm64
-            arch: arm64
-            platform: "nvidia-jp5"
-          - os: zededa-ubuntu-2204-arm64
-            arch: arm64
-            platform: "nvidia-jp6"
+    runs-on: zededa-ubuntu-2204-arm64
+    timeout-minutes: 1440
     steps:
       - name: Starting Report
         run: |
@@ -147,68 +91,26 @@ jobs:
         with:
           fetch-depth: 0
       - name: Force fetch annotated tags (workaround)
-        # Workaround for https://github.com/actions/checkout/issues/290
         run: |
           git fetch --force --tags
-      - name: Determine architecture prefix and ref
-        env:
-          REF: ${{ github.ref }}
-        run: |
-          # some special installs when building for riscv64
-          if [ "${{ matrix.arch }}" = riscv64 ]; then
-             APT_INSTALL="sudo apt install -y binfmt-support qemu-user-static"
-             # the following weird statement is here to speed up the happy path
-             # if the default server is responding -- we can skip apt update
-             $APT_INSTALL || { sudo apt update && $APT_INSTALL ; }
-             # constraining environment for riscv64 builds
-             echo "ZARCH=riscv64" >> "$GITHUB_ENV"
-          fi
-          echo "ARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
-          echo "TAG=$(echo "$REF" | sed -e 's#^.*/##' -e 's#master#snapshot#' -e 's#main#snapshot#')" >> "$GITHUB_ENV"
-
-      - name: Login to Docker Hub (build)
-        if: ${{ github.event.repository.full_name == 'lf-edge/eve' }}
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
-        with:
-          username: ${{ secrets.DOCKERHUB_PULL_USER }}
-          password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
-
-      - name: Build packages
-        run: |
-          SUCCESS=
-          # sadly, our build sometimes times out on network access
-          # and running out of disk space: re-trying for 3 times
-          for i in 1 2 3; do
-             echo "Run attempt: $i"
-             if make -e V=1 ZARCH="${{ matrix.arch }}" PLATFORM="${{ matrix.platform }}" LINUXKIT_PKG_TARGET=build pkgs; then
-                SUCCESS=true
-                break
-             else
-                docker system prune -f -a --volumes
-             fi
-          done
-          if [ -z "$SUCCESS" ]; then echo "::error::failed to build packages" && exit 1; fi
-      - name: Login to Docker Hub (push)
-        if: ${{ github.event.repository.full_name == 'lf-edge/eve' }}
+      - name: Login to Docker Hub
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
         with:
           username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
           password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
-      - name: Push packages
+      - name: Build and push packages
         run: |
           SUCCESS=
-          # sadly, our build sometimes times out on network access
-          # and running out of disk space: re-trying for 3 times
           for i in 1 2 3; do
-             echo "Run attempt: $i"
-             if make -e V=1 ZARCH="${{ matrix.arch }}" PLATFORM="${{ matrix.platform }}" LINUXKIT_PKG_TARGET=push pkgs; then
-                SUCCESS=true
-                break
-             else
-                docker system prune -f -a --volumes
-             fi
+            echo "Run attempt: $i"
+            if make -e V=1 HV=kvm ZARCH=arm64 PLATFORM=generic LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs; then
+              SUCCESS=true
+              break
+            else
+              docker system prune -f -a --volumes
+            fi
           done
-          if [ -z "$SUCCESS" ]; then echo "::error::failed to push packages" && exit 1; fi
+          if [ -z "$SUCCESS" ]; then echo "::error::failed to build and push packages" && exit 1; fi
       - name: Post package report
         run: |
           echo Disk usage
@@ -224,51 +126,107 @@ jobs:
           docker system prune -f -a --volumes
           rm -rf ~/.linuxkit
 
-  # 3) downstream jobs depend on both package jobs
+  # ════════════════════════════════════════════════════════════════════════
+  # Stage 2: Build and push EVE images for every variant.
+  # Base generic packages are already in the registry from Stage 1.
+  # Each job builds any remaining HV/platform-specific packages (a fast
+  # delta), pushes them, then builds and pushes the EVE image.
+  # ════════════════════════════════════════════════════════════════════════
+
   eve:
     if: github.event.repository.full_name == 'lf-edge/eve'
-    needs: [packages-non-arm, packages-arm]
-    runs-on: zededa-ubuntu-2204
+    needs: [pkgs-amd64, pkgs-arm64]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 1440
     strategy:
       fail-fast: false
       matrix:
-        arch: [arm64, amd64]
-        hv: [kvm, xen]
-        platform: ["generic"]
         include:
+          # amd64
+          - arch: amd64
+            hv: kvm
+            platform: "generic"
+            os: zededa-ubuntu-2204
+          - arch: amd64
+            hv: xen
+            platform: "generic"
+            os: zededa-ubuntu-2204
+          - arch: amd64
+            hv: k
+            platform: "generic"
+            os: zededa-ubuntu-2204
+          - arch: amd64
+            hv: kvm
+            platform: "evaluation"
+            os: zededa-ubuntu-2204
+          # arm64 generic
+          - arch: arm64
+            hv: kvm
+            platform: "generic"
+            os: zededa-ubuntu-2204-arm64
+          - arch: arm64
+            hv: xen
+            platform: "generic"
+            os: zededa-ubuntu-2204-arm64
+          - arch: arm64
+            hv: k
+            platform: "generic"
+            os: zededa-ubuntu-2204-arm64
+          # arm64 nvidia
+          - arch: arm64
+            hv: kvm
+            platform: "nvidia-jp5"
+            os: zededa-ubuntu-2204-arm64
+          - arch: arm64
+            hv: kvm
+            platform: "nvidia-jp6"
+            os: zededa-ubuntu-2204-arm64
+          - arch: arm64
+            hv: kvm
+            platform: "nvidia-jp7"
+            os: zededa-ubuntu-2204-arm64
+          - arch: arm64
+            hv: k
+            platform: "nvidia-jp5"
+            os: zededa-ubuntu-2204-arm64
+          - arch: arm64
+            hv: k
+            platform: "nvidia-jp6"
+            os: zededa-ubuntu-2204-arm64
+          - arch: arm64
+            hv: k
+            platform: "nvidia-jp7"
+            os: zededa-ubuntu-2204-arm64
+          # riscv64 (cross-build on amd64 runner via qemu)
           - arch: riscv64
             hv: mini
             platform: "generic"
-          - arch: arm64
-            hv: kvm
-            platform: "nvidia-jp5"
-          - arch: arm64
-            hv: kvm
-            platform: "nvidia-jp6"
-          - arch: amd64
-            hv: k
-            platform: "generic"
-          - arch: amd64
-            hv: kvm
-            platform: "evaluation"
+            os: zededa-ubuntu-2204
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-      - name: Build EVE
+      - name: Install qemu for cross-arch build
+        if: matrix.arch == 'riscv64'
+        run: |
+          APT_INSTALL="sudo apt install -y binfmt-support qemu-user-static"
+          $APT_INSTALL || { sudo apt update && $APT_INSTALL ; }
+      - name: Build and push remaining packages
         uses: ./.github/actions/run-make
         with:
-          command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=build eve"
-          dockerhub-token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
-          dockerhub-account: ${{ secrets.DOCKERHUB_PULL_USER }}
+          command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push PRUNE=1 pkgs"
+          dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+          dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
           clean: false
-      - name: Push EVE
+      - name: Build and push EVE
         uses: ./.github/actions/run-make
         with:
           command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push eve"
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+          clean: false
       - name: Collect and push SBOM and sources
         uses: ./.github/actions/run-make
         if: matrix.arch != 'riscv64'
@@ -276,6 +234,7 @@ jobs:
           command: "V=1 HV=${{ matrix.hv }} ZARCH=${{ matrix.arch }} PLATFORM=${{ matrix.platform }} LINUXKIT_PKG_TARGET=push sbom collected_sources compare_sbom_collected_sources publish_sources"
           dockerhub-token: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
           dockerhub-account: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+          clean: false
       - name: Clean
         if: ${{ always() }}
         run: |
@@ -283,9 +242,14 @@ jobs:
           docker system prune -f -a --volumes
           rm -rf ~/.linuxkit
 
+  # ════════════════════════════════════════════════════════════════════════
+  # Stage 3: Multi-arch manifests and release assets.
+  # Runs after all EVE jobs so every package image has been pushed.
+  # ════════════════════════════════════════════════════════════════════════
+
   manifest:
     if: github.event.repository.full_name == 'lf-edge/eve'
-    needs: [packages-non-arm, packages-arm]
+    needs: eve
     runs-on: zededa-ubuntu-2204
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -136,7 +136,7 @@ create_efi_raw() {
   rm -rf /parts
   ln -s /bits /parts
   dd if=/dev/zero of="$OUTPUT_IMG" seek=$(( $1 * 1024 * 1024 - 1)) bs=1 count=1
-  /make-raw "$OUTPUT_IMG" "$2"
+  /make-raw "$OUTPUT_IMG" "$2" || bail "ERROR: make-raw failed to build a $1 MiB image with partitions: $2"
 }
 
 do_rootfs() {

--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -659,6 +659,15 @@ PERSIST_PART=$(( PART_OFFSET + PERSIST_PART_OFFSET ))
 INVENTORY_WIN_PART=$(( PART_OFFSET + INVENTORY_WIN_PART_OFFSET ))
 USB_CONF_PART=$(( PART_OFFSET + USB_CONF_PART_OFFSET ))
 
+# Verify the pre-sized image is big enough to hold all requested partitions.
+REQUIRED_SIZE=$(calc_image_size)
+ACTUAL_SIZE=$(stat -L -c %s "$IMGFILE")
+if [ "$REQUIRED_SIZE" -gt "$ACTUAL_SIZE" ]; then
+  echo "ERROR: partition layout requires $((REQUIRED_SIZE / 1024 / 1024)) MiB but disk image is only $((ACTUAL_SIZE / 1024 / 1024)) MiB." >&2
+  echo "Requested partitions: $PARTS" >&2
+  exit 1
+fi
+
 # override regular efi for efiinstaller if both efi and installer are here
 if echo "$PARTS" | grep -q "efi" && echo "$PARTS" | grep -q "installer"; then
   PARTS=$(echo "$PARTS" | sed -e 's/efi/efiinstaller/')


### PR DESCRIPTION
# Description

Expands CI coverage for the kubevirt (`HV=k`) hypervisor on arm64 and the new nvidia-jp7 (Jetson JetPack 7) platform across both the `build` and `publish` workflows.

The PR contains three commits, each described in its own commit message; a quick summary:

- **`publish.yml`** — restructure into staged jobs that mirror the shape of `build.yml`. Stage 1 (`pkgs-amd64`, `pkgs-arm64`) builds the generic package set once per architecture; stage 2 (`eve`) pulls these from the registry and only rebuilds the HV/platform-specific delta on top. Adds nvidia-jp7 to the matrix (`kvm` and `k`). Collapses `build`/`push` step pairs into single `LINUXKIT_PKG_TARGET=push` invocations so retries skip already-pushed images. Drops the pull-only Docker Hub login, since pulls now go through a pull-through mirror that handles authentication transparently.

- **`tools/parse-pkgs.sh`** — add `EXTERNAL_BOOT_IMAGE_TAG`. `pkg/external-boot-image` is required to build `HV=k`, so its tag needs to be tracked alongside the other package tags.

- **`build.yml`** — add four new arm64 eve build jobs: `eve-arm64-k-generic`, `eve-arm64-k-nvidia-jp6`, `eve-arm64-k-nvidia-jp7`, and `eve-arm64-kvm-nvidia-jp7` (the last one for parity with `publish.yml`).

## How to test and validate this PR

The publish workflow was already tested on rene/eve https://github.com/rene/eve/actions/runs/25392062779
All EVE variants got published to the local registy:
```
0.0.0-master-5c60faa1-evaluation-kvm
0.0.0-master-5c60faa1-evaluation-kvm-amd64
0.0.0-master-5c60faa1-k
0.0.0-master-5c60faa1-k-amd64
0.0.0-master-5c60faa1-k-arm64
0.0.0-master-5c60faa1-kvm
0.0.0-master-5c60faa1-kvm-amd64
0.0.0-master-5c60faa1-kvm-arm64
0.0.0-master-5c60faa1-mini
0.0.0-master-5c60faa1-mini-riscv64
0.0.0-master-5c60faa1-nvidia-jp5-k
0.0.0-master-5c60faa1-nvidia-jp5-k-arm64
0.0.0-master-5c60faa1-nvidia-jp5-kvm
0.0.0-master-5c60faa1-nvidia-jp5-kvm-arm64
0.0.0-master-5c60faa1-nvidia-jp6-k
0.0.0-master-5c60faa1-nvidia-jp6-k-arm64
0.0.0-master-5c60faa1-nvidia-jp6-kvm
0.0.0-master-5c60faa1-nvidia-jp6-kvm-arm64
0.0.0-master-5c60faa1-nvidia-jp7-k
0.0.0-master-5c60faa1-nvidia-jp7-k-arm64
0.0.0-master-5c60faa1-nvidia-jp7-kvm
0.0.0-master-5c60faa1-nvidia-jp7-kvm-arm64
0.0.0-master-5c60faa1-xen
0.0.0-master-5c60faa1-xen-amd64
0.0.0-master-5c60faa1-xen-arm64
```

## Changelog notes

Adds CI build and publish coverage for the nvidia-jp7 (Jetson JetPack 7) platform and for the kubevirt hypervisor variant on arm64. No runtime/user-facing behaviour change beyond the availability of additional published EVE image variants.

## PR Backports

- 16.0-stable: No — nvidia-jp7 platform support is not present in this branch.
- 14.5-stable: No — nvidia-jp7 platform support is not present in this branch.
- 13.4-stable: No — nvidia-jp7 platform support is not present in this branch.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.