### PR TITLE
pillar, kube: SR-IOV VF passthrough via Multus + sriov-cni for KubeVirt

### DIFF
--- a/.spdxignore
+++ b/.spdxignore
@@ -9,6 +9,7 @@ pkg/kube/descheduler_rbac.yaml
 pkg/kube/eve-bridge/vendor/
 pkg/kube/lh-cfg-v1.6.2.yaml
 pkg/kube/nvidia-container-runtime/nvidia-device-plugin-18.0.yml
+pkg/kube/sriov/sriov-device-plugin.yaml
 pkg/kube/update-component/vendor/
 pkg/measure-config/vendor/
 pkg/newlog/vendor/

--- a/.yamllint
+++ b/.yamllint
@@ -11,3 +11,4 @@ ignore:
   - pkg/kube/descheduler_rbac.yaml
   - pkg/kube/lh-cfg-v1.9.1.yaml
   - pkg/kube/kubevirt-operator.yaml
+  - pkg/kube/sriov/sriov-device-plugin.yaml

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -1,6 +1,26 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
+# sriov-cni upstream image is used only as a source of the prebuilt sriov
+# binary; we copy it into our final image at build time so we don't need a
+# DaemonSet at runtime just to stage the binary on each node.  Pinned by
+# digest for reproducibility.  v2.7.0 ships amd64 only, matching the
+# previous DaemonSet's nodeSelector.
+#
+# Declare this stage BEFORE `build` so all the build-stage RUN/COPY commands
+# below (eve-alpine-deploy, etcdctl, eve-bridge, etc.) execute inside `build`
+# and not inside this passthrough stage — otherwise the COPY --from=sriov-cni-bin
+# below ends up referencing the stage it's running in (circular dependency).
+#
+# hadolint DL3029 forbids literal --platform on FROM; we silence it here because
+# upstream sriov-cni ships an amd64-only image and we need the amd64 binary
+# regardless of the build host's architecture (e.g. arm64 host cross-building
+# the kube image).  BUILDPLATFORM/TARGETPLATFORM wouldn't pin the source image
+# to amd64, which is what we actually need.
+# hadolint ignore=DL3029
+FROM --platform=linux/amd64 ghcr.io/k8snetworkplumbingwg/sriov-cni@sha256:fce504e683275ab59215065ddf6433ca80d1b4b53f0d4b0cdf037da6701c7cb4 AS sriov-cni-bin
+
 FROM lfedge/eve-alpine:325b12087b386811fdb9d3c0adffa5fb94a34b95 AS build
+
 ARG TARGETARCH
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables curl openrc \
          open-iscsi libvirt libvirt-client util-linux grep findutils jq \
@@ -14,6 +34,7 @@ RUN mkdir -p /out/usr/bin /tmp/etcdtmp && \
     cp "/tmp/etcdtmp/etcd-${ETCDCTL_VERSION}-linux-${TARGETARCH}/etcdctl" /out/usr/bin/etcdctl && \
     chmod +x /out/usr/bin/etcdctl && \
     rm -rf /tmp/etcd.tar.gz /tmp/etcdtmp
+COPY --from=sriov-cni-bin /usr/bin/sriov /out/usr/bin/sriov
 
 # Register etcdctl in the APK DB, mandatory for it to be included in the SBOM.
 RUN register-sbom-pkg.sh -n etcdctl -v "${ETCDCTL_VERSION}" -l Apache-2.0 -u https://github.com/etcd-io/etcd
@@ -113,6 +134,8 @@ RUN chmod +x /usr/bin/kubevip-apply.sh /usr/bin/kubevip-delete.sh
 RUN mkdir -p /etc/nvidia-container-runtime
 COPY nvidia-container-runtime/config.toml /etc/nvidia-container-runtime
 COPY nvidia-container-runtime/nvidia-device-plugin-18.0.yml /etc/k3s-manifests/
+
+COPY sriov/sriov-device-plugin.yaml /etc/k3s-manifests/
 
 ARG TARGETARCH
 

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -1342,9 +1342,43 @@ if [ -f /var/lib/base-k3s-mode ]; then
         install_kubevirt=0
 fi
 
+# install_sriov_manifests stages the sriov-cni binary on the host CNI bin
+# directory and installs the sriov-network-device-plugin DaemonSet when
+# SR-IOV-capable hardware is present.  The sriov-cni binary is baked into
+# the image at /usr/bin/sriov (sourced from the upstream sriov-cni image
+# at build time), so no DaemonSet is needed to stage it at runtime.
+#
+# Detection uses /sys/bus/pci/devices/*/sriov_numvfs because /sys/class/net is
+# per-network-namespace — this script runs in the kube container, whose netns
+# typically does not include the host's NICs, so /sys/class/net wouldn't see
+# them.  /sys/bus/pci is namespace-independent and exposes sriov_numvfs for any
+# PCI device with SR-IOV capability regardless of which netns owns the netdev.
+#
+# Idempotent: cp -u only overwrites when the source file is newer, so repeated
+# calls from the main loop are cheap and pick up new versions on EVE upgrades
+# without requiring a cluster re-init.
+install_sriov_manifests() {
+        [ -d "${KUBE_MANIFESTS_DIR}" ] || return
+        ls /sys/bus/pci/devices/*/sriov_numvfs >/dev/null 2>&1 || return
+        # Stage to both CNI bin dirs to match the convention used for other
+        # plugins (eve-bridge, host-local, etc.).  Multus is configured with
+        # binDir=/var/lib/cni/bin and will invoke sriov from there; /opt/cni/bin
+        # is the k3s/flannel path and is kept in sync so future tooling that
+        # looks there finds the binary too.
+        mkdir -p /var/lib/cni/bin /opt/cni/bin
+        cp -u /usr/bin/sriov /var/lib/cni/bin/ 2>/dev/null || true
+        cp -u /usr/bin/sriov /opt/cni/bin/ 2>/dev/null || true
+        cp -u /etc/k3s-manifests/sriov-device-plugin.yaml \
+              "${KUBE_MANIFESTS_DIR}/" 2>/dev/null || true
+}
+
 #Forever loop every 15 secs
 while true;
 do
+        # Re-apply optional manifests on every iteration so EVE upgrades pick
+        # them up without forcing a cluster re-init (the
+        # all_components_initialized guard would otherwise skip the copy below).
+        install_sriov_manifests
 if [ ! -f /var/lib/all_components_initialized ]; then
         if [ ! -f /var/lib/k3s_installed_unpacked ]; then
                 #
@@ -1446,6 +1480,9 @@ if [ ! -f /var/lib/all_components_initialized ]; then
               logmsg "NVIDIA platform, copying the manifest files to ${KUBE_MANIFESTS_DIR}"
               cp /etc/k3s-manifests/nvidia-device-plugin-18.0.yml "${KUBE_MANIFESTS_DIR}/"
         fi
+        # SR-IOV manifests are installed by install_sriov_manifests() called
+        # from the main loop on every iteration (idempotent), so they are
+        # picked up on upgrades without requiring a re-init of the cluster.
 
         #
         # Longhorn

--- a/pkg/kube/sriov/sriov-device-plugin.yaml
+++ b/pkg/kube/sriov/sriov-device-plugin.yaml
@@ -1,0 +1,94 @@
+# sriov-network-device-plugin: advertises VFs as Kubernetes extended resources
+# (eve.network/<pf>_vfs) tracked by BDF.  Source:
+#   https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin
+#
+# Note: the sriovdp-config ConfigMap is intentionally NOT defined here.
+# k3s's deploy controller (k3s.cattle.io/Addon) reverts any drift from
+# manifests under /var/lib/rancher/k3s/server/manifests/ back to the on-disk
+# content, so a ConfigMap shipped in this file would be reset to its empty
+# resourceList every time zedkube populated it.
+#
+# Instead, zedkube's reconcileSRIOVDevicePlugin (pkg/pillar/cmd/zedkube/
+# sriov_devplugin.go) creates and maintains the ConfigMap directly via the
+# Kubernetes API based on the live AssignableAdapters publication.  The
+# DaemonSet pod will sit in CrashLoopBackOff for a few seconds at first boot
+# until the reconciler creates the ConfigMap, then start normally.
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-sriov-device-plugin
+  namespace: kube-system
+  labels:
+    tier: node
+    app: sriovdp
+spec:
+  selector:
+    matchLabels:
+      name: sriov-device-plugin
+  template:
+    metadata:
+      labels:
+        name: sriov-device-plugin
+        tier: node
+        app: sriovdp
+    spec:
+      hostNetwork: true
+      nodeSelector:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: sriov-device-plugin
+      containers:
+      - name: kube-sriovdp
+        image: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin:v3.7.0
+        imagePullPolicy: IfNotPresent
+        args:
+        - --log-dir=sriovdp
+        - --log-level=10
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "40Mi"
+          limits:
+            cpu: 1
+            memory: "200Mi"
+        volumeMounts:
+        - name: devicesock
+          mountPath: /var/lib/kubelet/
+          readOnly: false
+        - name: log
+          mountPath: /var/log
+        - name: config-volume
+          mountPath: /etc/pcidp
+        - name: device-info
+          mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
+      volumes:
+      - name: devicesock
+        hostPath:
+          path: /var/lib/kubelet/
+      - name: log
+        hostPath:
+          path: /var/log
+      - name: device-info
+        hostPath:
+          path: /var/run/k8s.cni.cncf.io/devinfo/dp
+          type: DirectoryOrCreate
+      - name: config-volume
+        configMap:
+          name: sriovdp-config
+          items:
+          - key: config.json
+            path: config.json
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sriov-device-plugin
+  namespace: kube-system

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -3449,6 +3449,20 @@ func handlePhysicalIOAdapterListImpl(ctxArg interface{}, key string,
 			// Lookup since it could have changed
 			ib = aa.LookupIoBundlePhylabel(ib.Phylabel)
 			updatePortAndPciBackIoBundle(ctx, ib)
+			// Reconcile SR-IOV VF creation on every steady-state pass.  The
+			// !Initialized branch above only runs once at first boot; if the
+			// controller bumps Vfs.Count after that (or republishes config with
+			// a count that the kernel hasn't applied yet — e.g. sriov_numvfs is
+			// reset to 0 on every reboot), setupVf must run again.  CreateVF is
+			// idempotent (early-returns when numvfs already matches), so calling
+			// it here on every event is cheap.
+			if ib != nil && ib.Type == types.IoNetEthPF && ib.Vfs.Count > 0 {
+				if err := setupVf(ib, aa, log); err != nil {
+					err = fmt.Errorf("setupVf: %w", err)
+					log.Error(err)
+					ib.Error.Append(err)
+				}
+			}
 		} else {
 			log.Functionf("handlePhysicalIOAdapterListImpl: Adapter %s "+
 				"- No Change", phyAdapter.Phylabel)
@@ -3457,14 +3471,26 @@ func handlePhysicalIOAdapterListImpl(ctxArg interface{}, key string,
 }
 
 func setupVf(ib *types.IoBundle, aa *types.AssignableAdapters, log *base.LogObject) error {
-	exists, ifName := types.PciLongToIfname(log, ib.PciLong)
-	if !exists {
-		return fmt.Errorf("Failed to resolve ifname for PCI address %s", ib.PciLong)
+	// Drive VF creation by the stable PCI BDF, not the kernel netdev name.
+	// In the EVE-K path NIM may rename the PF (e.g. eth2 -> keth2) while
+	// bridging it; if that rename overlaps CreateVF's link-up polling, a
+	// name-anchored caller fails with "Link not found" and the static VF
+	// IoBundle entries never get their PciLong/Ifname populated.
+	if ib.PciLong == "" {
+		return fmt.Errorf("setupVf: PF IoBundle %s has empty PciLong", ib.Phylabel)
 	}
 
-	err := sriov.CreateVF(ifName, ib.Vfs.Count, log)
-	if err != nil {
+	if err := sriov.CreateVF(ib.PciLong, ib.Vfs.Count, log); err != nil {
 		return fmt.Errorf("Failed to create VF for iface with PCI address %s: %w", ib.PciLong, err)
+	}
+
+	// Re-resolve the PF netdev name after CreateVF: the kernel may have
+	// renamed it (NIM bridging) during VF creation.  GetVfByTimeout and the
+	// per-VF MAC/VLAN setup still operate by ifname, so we must look up the
+	// current one rather than reusing a possibly-stale pre-CreateVF name.
+	exists, ifName := types.PciLongToIfname(log, ib.PciLong)
+	if !exists {
+		return fmt.Errorf("Failed to resolve ifname for PCI address %s after CreateVF", ib.PciLong)
 	}
 
 	vfs, err := sriov.GetVfByTimeout(sriov.VfCreationTimeout, ifName, ib.Vfs.Count)
@@ -3472,16 +3498,46 @@ func setupVf(ib *types.IoBundle, aa *types.AssignableAdapters, log *base.LogObje
 		return fmt.Errorf("Failed to get VF for iface %s: %w", ifName, err)
 	}
 
+	// Two-phase per-VF setup.  Bind to vfio-pci FIRST, registration with AA
+	// SECOND.  Reason: the bind is a pure sysfs operation with no dependency
+	// on user config — it must succeed for kubelet to advertise the VF as an
+	// allocatable resource.  createVfIoBundle, in contrast, may fail when the
+	// device model has a per-VF MAC or VLAN and SetupVfHardwareAddr /
+	// SetupVfVlan reject it (PF admin-down at that instant, kernel rejects
+	// MAC, etc.).  Previous code returned on the first createVfIoBundle error,
+	// leaving every subsequent VF in this PF driverless — observed in the
+	// field as "one PF works, the other has 20 driverless VFs and zero
+	// allocatable resources".
+	//
+	// New behaviour: bind every VF, log per-VF createVfIoBundle failures, and
+	// keep going.  The VF still gets registered in AA (with whatever fields
+	// were populated before the failure) so it remains addressable; the
+	// kube path will reapply MAC via the VMI Interface anyway.
+	var firstErr error
 	for _, vf := range vfs.Data {
-		vfIb, err := createVfIoBundle(*ib, vf)
-
-		if err != nil {
-			return fmt.Errorf("createVfIoBundle failed %w", err)
+		if err := sriov.BindVFToVfioPCI(vf.PciLong); err != nil {
+			log.Warnf("setupVf: bind VF %s to vfio-pci: %v", vf.PciLong, err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("bind VF %s: %w", vf.PciLong, err)
+			}
 		}
+
+		vfIb, err := createVfIoBundle(*ib, vf)
+		if err != nil {
+			log.Errorf("setupVf: createVfIoBundle for VF %s (PF %s, idx %d): %v "+
+				"— VF remains bound to vfio-pci; per-VF host MAC/VLAN not applied",
+				vf.PciLong, ib.Ifname, vf.Index, err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("createVfIoBundle VF %s: %w", vf.PciLong, err)
+			}
+		}
+		// Always register: vfIb is the partial bundle on error (createVfIoBundle
+		// now returns what it built rather than zero-value), so AA tracks the VF
+		// even if user-config application failed.
 		aa.AddOrUpdateIoBundle(log, vfIb)
 	}
 
-	return nil
+	return firstErr
 }
 
 func createVfIoBundle(pfIb types.IoBundle, vf sriov.EthVF) (types.IoBundle, error) {
@@ -3499,16 +3555,27 @@ func createVfIoBundle(pfIb types.IoBundle, vf sriov.EthVF) (types.IoBundle, erro
 		// no specified configuration, return what it is
 		return vfIb, nil
 	}
+	// On failure return the partially-built bundle (not zero-value) so the
+	// caller (setupVf) can still register the VF in AssignableAdapters.
+	// The kube path applies per-VM MAC via the VMI Interface anyway, so a
+	// host-side admin MAC/VLAN failure here is non-fatal to passthrough.
 	if vfUserConfig.Mac != "" {
 		vfIb.MacAddr = vfUserConfig.Mac
-		if err := sriov.SetupVfHardwareAddr(vfIb.Ifname, vfIb.MacAddr, vf.Index); err != nil {
-			return types.IoBundle{}, fmt.Errorf("setupVfHardwareAddr failed %s", err)
+		// netlink.LinkSetVfHardwareAddr must be called on the Physical Function link,
+		// not the VF link — use pfIb.Ifname (e.g. "eth0"), not vfIb.Ifname ("eth0vf0").
+		if err := sriov.SetupVfHardwareAddr(pfIb.Ifname, vfIb.MacAddr, vf.Index); err != nil {
+			return vfIb, fmt.Errorf("setupVfHardwareAddr failed %s", err)
 		}
 	}
 	if vfUserConfig.VlanID != 0 {
-		if err := sriov.SetupVfVlan(vfIb.Ifname, vf.Index, vf.VlanID); err != nil {
-			return types.IoBundle{}, fmt.Errorf("setupVfVlan failed %s", err)
+		// Use pfIb.Ifname (PF) for the same reason as above.
+		// Use vfUserConfig.VlanID (user-configured), not vf.VlanID which is always
+		// 0 for a freshly created VF (GetVf does not read the current VLAN from sysfs).
+		if err := sriov.SetupVfVlan(pfIb.Ifname, vf.Index, vfUserConfig.VlanID); err != nil {
+			return vfIb, fmt.Errorf("setupVfVlan failed %s", err)
 		}
+		// Persist the configured VLAN in VfParams so callers (e.g. hypervisor) know it.
+		vfIb.VfParams.VlanID = vfUserConfig.VlanID
 	}
 	return vfIb, nil
 }
@@ -3786,6 +3853,53 @@ func checkAndFillIoBundle(ib *types.IoBundle) (bool, error) {
 		changed = true
 		log.Functionf("checkAndFillIoBundle(%d %s %s) %s found unique %s",
 			ib.Type, ib.Phylabel, ib.AssignmentGroup, long, unique)
+	}
+
+	// VFs declared statically in the device model (Type=IoNetEthVF) come
+	// from IoBundleFromPhyAdapter, which doesn't populate VfParams at all.
+	// The result is every static VF lands in AA with VfParams.Index=0 and
+	// VfParams.PFIface="" — which breaks both the kube SR-IOV pool builder
+	// (every pool would be named *_vf0) and attachSRIOVInterfaces (every
+	// NAD reference resolves to "<pf>-vf0").  Patch both fields here so
+	// downstream consumers see correct values.
+	//
+	// Index source: the phylabel encodes the VF index (e.g. "eth2vf5").
+	// We prefer the phylabel over a fresh sysfs walk because phylabels are
+	// stable user-facing identifiers; sysfs ordering can shift across
+	// kernel versions for ARI-disabled / multi-function devices.
+	//
+	// PFIface source: sysfs (/sys/bus/pci/devices/<vf-bdf>/physfn/net/<ifname>).
+	// We do NOT use the PF name parsed from phylabel because NIM may have
+	// renamed it (e.g. eth2 -> keth2 when bridging); sysfs always reflects
+	// the current netdev name.
+	if ib.Type == types.IoNetEthVF {
+		if ib.VfParams.PFIface == "" {
+			pfIface, err := sriov.GetPFIfaceFromVFBDF(long)
+			if err != nil {
+				log.Warnf("checkAndFillIoBundle(%s %s): can't resolve PF ifname for VF %s: %v",
+					ib.Phylabel, ib.AssignmentGroup, long, err)
+			} else {
+				ib.VfParams.PFIface = pfIface
+				changed = true
+				log.Functionf("checkAndFillIoBundle(%s %s) %s VF parent PFIface=%s",
+					ib.Phylabel, ib.AssignmentGroup, long, pfIface)
+			}
+		}
+		// Always re-derive Index from Phylabel — IoBundleFromPhyAdapter
+		// leaves it at 0, and an Index of 0 is indistinguishable from
+		// "uninitialised" vs "actually VF 0", so we can't trust a zero
+		// value as authoritative.  Re-deriving is idempotent.
+		if idx, _, err := sriov.ParseVfIfaceName(ib.Phylabel); err == nil {
+			if ib.VfParams.Index != idx {
+				ib.VfParams.Index = idx
+				changed = true
+				log.Functionf("checkAndFillIoBundle(%s %s) %s VF index=%d (from phylabel)",
+					ib.Phylabel, ib.AssignmentGroup, long, idx)
+			}
+		} else {
+			log.Warnf("checkAndFillIoBundle(%s %s): can't parse VF index from phylabel: %v",
+				ib.Phylabel, ib.AssignmentGroup, err)
+		}
 	}
 	return changed, nil
 }

--- a/pkg/pillar/cmd/zedkube/sriov_devplugin.go
+++ b/pkg/pillar/cmd/zedkube/sriov_devplugin.go
@@ -1,0 +1,443 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+// Dynamic reconciler for the sriov-network-device-plugin ConfigMap.
+//
+// The plugin (deployed by pkg/kube/sriov/sriov-device-plugin.yaml) reads
+// /etc/pcidp/config.json once at startup.  EVE knows which Physical Functions
+// are configured for SR-IOV at runtime via the AssignableAdapters publication
+// from domainmgr; this file projects that state into the ConfigMap and bounces
+// the local device-plugin pod so it picks up the change.
+//
+// Why per-node bounce: each node's VF inventory is different, and the
+// daemonset pod on each node mounts the same ConfigMap.  Restarting only the
+// local pod limits disruption to this node; already-running VMIs are
+// unaffected (kubelet allocations are sticky to pod lifecycle).
+
+package zedkube
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	"github.com/lf-edge/eve/pkg/pillar/sriov"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	sriovDPNamespace     = "kube-system"
+	sriovDPConfigMapName = "sriovdp-config"
+	sriovDPConfigKey     = "config.json"
+	sriovDPPodLabel      = "app=sriovdp"
+	sriovResourcePrefix  = "eve.network"
+)
+
+// sriovSelectors is the subset of the upstream NetDeviceSelectors schema we use.
+// Reference: https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin
+//
+// PciAddresses (added in sriov-network-device-plugin v3.5+) is the lever EVE
+// uses for deterministic per-VF assignment: a pool whose selector pins one
+// specific BDF can only ever advertise that one device, so kubelet's
+// allocation becomes a 1:1 BDF->VMI mapping instead of a pool lottery.
+type sriovSelectors struct {
+	Vendors      []string `json:"vendors,omitempty"`
+	Devices      []string `json:"devices,omitempty"`
+	Drivers      []string `json:"drivers,omitempty"`
+	PfNames      []string `json:"pfNames,omitempty"`
+	PciAddresses []string `json:"pciAddresses,omitempty"`
+}
+
+type sriovPool struct {
+	ResourceName   string         `json:"resourceName"`
+	ResourcePrefix string         `json:"resourcePrefix"`
+	Selectors      sriovSelectors `json:"selectors"`
+}
+
+type sriovResourceList struct {
+	ResourceList []sriovPool `json:"resourceList"`
+}
+
+// reconcileSRIOVDevicePlugin rebuilds the sriov-network-device-plugin ConfigMap
+// from the current AssignableAdapters publication and bounces the local
+// device-plugin pod on a config change.
+//
+// Idempotent and cheap when nothing changes — it short-circuits if the JSON is
+// byte-identical to what's already in the ConfigMap.
+func (z *zedkube) reconcileSRIOVDevicePlugin(aa *types.AssignableAdapters) {
+	if aa == nil {
+		return
+	}
+	if z.config == nil {
+		// At zedkube startup, kubeapi.GetKubeConfig() can fail if k3s hasn't
+		// written /run/.kube/k3s/k3s.yaml yet — leaving z.config nil for the
+		// remainder of the process unless we re-acquire here.  Without this
+		// retry, the AA Create event that fires on subscription Activate would
+		// silently no-op and the reconciler would never run again until the
+		// next AA modify (which may not happen for hours).
+		cfg, err := kubeapi.GetKubeConfig()
+		if err != nil {
+			log.Warnf("reconcileSRIOVDevicePlugin: kube config not yet "+
+				"available: %v", err)
+			return
+		}
+		z.config = cfg
+		log.Noticef("reconcileSRIOVDevicePlugin: acquired kube config on retry")
+	}
+	clientset, err := kubernetes.NewForConfig(z.config)
+	if err != nil {
+		log.Errorf("reconcileSRIOVDevicePlugin: NewForConfig: %v", err)
+		return
+	}
+
+	// Self-heal pass: bind any VF whose sysfs driver isn't vfio-pci.  In the
+	// field we've seen one PF's VFs end up driverless (every VF in the bundle
+	// shows <none> in /sys/bus/pci/devices/<bdf>/driver) while a peer PF's
+	// VFs are correctly bound, because an early createVfIoBundle error in
+	// setupVf short-circuited the bind loop on that PF.  Without this sweep,
+	// the device plugin's `drivers: ["vfio-pci"]` selector enumerates zero
+	// VFs for the affected PF and kubelet advertises 0 allocatable — so the
+	// pool exists in the ConfigMap but no VMI can ever schedule against it.
+	//
+	// BindVFToVfioPCI is idempotent, so this is a no-op on the happy path.
+	// Runs before buildSRIOVPools so a freshly-bound VF is reflected in the
+	// pool's first advertisement.
+	healDriverlessVFs(aa)
+
+	pools := buildSRIOVPools(aa)
+	desired := sriovResourceList{ResourceList: pools}
+	desiredJSON, err := json.MarshalIndent(desired, "", "  ")
+	if err != nil {
+		log.Errorf("reconcileSRIOVDevicePlugin: marshal: %v", err)
+		return
+	}
+
+	ctx := context.Background()
+	cmIface := clientset.CoreV1().ConfigMaps(sriovDPNamespace)
+
+	cm, err := cmIface.Get(ctx, sriovDPConfigMapName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		// Cluster bootstrap may have run before our daemonset manifest landed.
+		// Create the ConfigMap so the plugin will find it on first start.
+		newCM := &k8sv1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      sriovDPConfigMapName,
+				Namespace: sriovDPNamespace,
+			},
+			Data: map[string]string{sriovDPConfigKey: string(desiredJSON)},
+		}
+		if _, err := cmIface.Create(ctx, newCM, metav1.CreateOptions{}); err != nil && !errors.IsAlreadyExists(err) {
+			log.Errorf("reconcileSRIOVDevicePlugin: create ConfigMap: %v", err)
+			return
+		}
+		log.Noticef("reconcileSRIOVDevicePlugin: created %s/%s with %d pool(s)",
+			sriovDPNamespace, sriovDPConfigMapName, len(pools))
+		return
+	}
+	if err != nil {
+		log.Errorf("reconcileSRIOVDevicePlugin: get ConfigMap: %v", err)
+		return
+	}
+
+	if cm.Data[sriovDPConfigKey] == string(desiredJSON) {
+		log.Tracef("reconcileSRIOVDevicePlugin: ConfigMap already up to date (%d pool(s))",
+			len(pools))
+		return
+	}
+
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	cm.Data[sriovDPConfigKey] = string(desiredJSON)
+	if _, err := cmIface.Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+		log.Errorf("reconcileSRIOVDevicePlugin: update ConfigMap: %v", err)
+		return
+	}
+	log.Noticef("reconcileSRIOVDevicePlugin: updated %s/%s with %d pool(s); restarting local plugin pod",
+		sriovDPNamespace, sriovDPConfigMapName, len(pools))
+
+	if err := deleteLocalSriovDpPod(ctx, clientset, z.nodeName); err != nil {
+		// Non-fatal: the plugin will pick up the change on its next natural restart.
+		log.Warnf("reconcileSRIOVDevicePlugin: bounce local DP pod: %v", err)
+	}
+
+	// Garbage-collect NetworkAttachmentDefinitions whose backing pool no longer
+	// exists.  ensureSRIOVNAD (in the kubevirt path) only creates/updates NADs;
+	// without this sweep, removing a PF from the device model leaves orphan NADs
+	// in eve-kube-app that point at a non-existent device-plugin pool.
+	currentResources := make(map[string]bool, len(pools))
+	for _, p := range pools {
+		currentResources[p.ResourcePrefix+"/"+p.ResourceName] = true
+	}
+	if err := garbageCollectSRIOVNADs(ctx, currentResources); err != nil {
+		log.Warnf("reconcileSRIOVDevicePlugin: NAD GC: %v", err)
+	}
+}
+
+// garbageCollectSRIOVNADs deletes NetworkAttachmentDefinitions in the
+// eve-kube-app namespace whose k8s.v1.cni.cncf.io/resourceName annotation
+// references an SR-IOV pool that no longer appears in the current
+// AssignableAdapters projection.
+//
+// We scope by the eve.network/ resource-prefix annotation so we only touch
+// NADs that ensureSRIOVNAD created — third-party NADs in the same namespace
+// are left alone.
+func garbageCollectSRIOVNADs(ctx context.Context, currentResources map[string]bool) error {
+	nadClient, err := kubeapi.GetNetClientSet()
+	if err != nil {
+		return fmt.Errorf("get NAD client: %w", err)
+	}
+	nads, err := nadClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(
+		kubeapi.EVEKubeNameSpace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("list NADs: %w", err)
+	}
+	for _, nad := range nads.Items {
+		resName := nad.Annotations["k8s.v1.cni.cncf.io/resourceName"]
+		if !strings.HasPrefix(resName, sriovResourcePrefix+"/") {
+			continue
+		}
+		if currentResources[resName] {
+			continue
+		}
+		if err := nadClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(
+			kubeapi.EVEKubeNameSpace).Delete(ctx, nad.Name, metav1.DeleteOptions{}); err != nil &&
+			!errors.IsNotFound(err) {
+			log.Warnf("garbageCollectSRIOVNADs: delete %s: %v", nad.Name, err)
+			continue
+		}
+		log.Noticef("garbageCollectSRIOVNADs: deleted stale NAD %s (pool %s gone)",
+			nad.Name, resName)
+	}
+	return nil
+}
+
+// healDriverlessVFs walks every IoNetEthVF in AssignableAdapters and binds
+// any whose host-side driver isn't vfio-pci.  This is the steady-state
+// self-healer for the "20 driverless VFs on one PF" failure mode (see
+// reconcileSRIOVDevicePlugin caller comment for the full story).
+//
+// Note we look at IoNetEthVF entries, not IoNetEthPF: domainmgr creates one
+// IoBundle per VF when setupVf succeeds at least partially; PciLong on the
+// VF bundle is the VF's own BDF, which is what BindVFToVfioPCI needs.
+func healDriverlessVFs(aa *types.AssignableAdapters) {
+	for _, ib := range aa.IoBundleList {
+		if ib.Type != types.IoNetEthVF || ib.PciLong == "" {
+			continue
+		}
+		driverLink := filepath.Join("/sys/bus/pci/devices", ib.PciLong, "driver")
+		target, err := os.Readlink(driverLink)
+		if err == nil && filepath.Base(target) == "vfio-pci" {
+			continue
+		}
+		if err := sriov.BindVFToVfioPCI(ib.PciLong); err != nil {
+			log.Warnf("healDriverlessVFs: bind VF %s (PF %s, idx %d): %v",
+				ib.PciLong, ib.VfParams.PFIface, ib.VfParams.Index, err)
+			continue
+		}
+		log.Noticef("healDriverlessVFs: bound VF %s (PF %s, idx %d) to vfio-pci",
+			ib.PciLong, ib.VfParams.PFIface, ib.VfParams.Index)
+	}
+}
+
+// buildSRIOVPools projects AssignableAdapters into one pool per VF (not per
+// PF).  Each pool has a pciAddresses selector pinning exactly one BDF, so
+// kubelet allocates the specific VF EVE intended — VM asking for
+// eve.network/<pf>_vf<i> gets BDF virtfn<i> of <pf>, period.
+//
+// Per-VF pool model (vs. earlier per-PF model):
+//   - Fixes the "random VF from the pool" issue: with a per-PF pool of N VFs
+//     and a VMI requesting count=1, kubelet picked any free BDF.  EVE could
+//     not bind a specific BDF to a specific VM, so per-VF MAC/VLAN bookkeeping
+//     in EVE was fiction relative to what KubeVirt actually attached.
+//   - Lets a single VMI consume multiple VFs from the same PF: each Interface
+//     references a distinct NAD with a distinct resource name, so KubeVirt's
+//     resource request aggregation produces N separate requests instead of
+//     collapsing them by key.
+//
+// VFs without a registered IoBundle (i.e. not yet processed by domainmgr's
+// setupVf, so no IoNetEthVF entry exists) are skipped; they'll be added on
+// the next AA publication once createVfIoBundle has populated them.
+func buildSRIOVPools(aa *types.AssignableAdapters) []sriovPool {
+	pools := make([]sriovPool, 0)
+
+	// vfVendorDeviceCache memoizes per-PF (vendor, device) lookups — common
+	// case is many VFs sharing the same parent PF, so we don't want to
+	// readlink+open sysfs once per VF per reconcile.
+	type vidPid struct{ vendor, device string }
+	pfCache := map[string]vidPid{}
+
+	for _, ib := range aa.IoBundleList {
+		if ib.Type != types.IoNetEthVF {
+			continue
+		}
+		if ib.PciLong == "" {
+			continue
+		}
+
+		// Resolve (PF name, VF index) authoritatively from Phylabel.  Do NOT
+		// trust VfParams: the upstream populator (IoBundleFromPhyAdapter does
+		// not set them; checkAndFillIoBundle does on the happy path) can leave
+		// both at zero, and an Index of 0 is indistinguishable from "actual VF
+		// 0" vs "uninitialised" — which silently produces 40 pools all named
+		// "<pf>_vf0" and crashes the upstream device plugin on duplicate
+		// resourceName.  Phylabel is set by the device model and stable.
+		idx, pfFromLabel, err := sriov.ParseVfIfaceName(ib.Phylabel)
+		if err != nil {
+			log.Warnf("buildSRIOVPools: VF %s can't parse Phylabel %q: %v — skipping",
+				ib.PciLong, ib.Phylabel, err)
+			continue
+		}
+		// PF name: prefer sysfs (handles NIM rename eth2→keth2), fall back
+		// to parsed Phylabel.  VfParams.PFIface is a secondary fallback in
+		// case sysfs lookup fails (e.g. transient mid-boot state).
+		pfName := ib.VfParams.PFIface
+		if pfName == "" {
+			derived, err := sriov.GetPFIfaceFromVFBDF(ib.PciLong)
+			if err != nil {
+				log.Warnf("buildSRIOVPools: VF %s sysfs PF lookup failed: %v "+
+					"— falling back to PF parsed from Phylabel (%q)",
+					ib.PciLong, err, pfFromLabel)
+				pfName = pfFromLabel
+			} else {
+				pfName = derived
+			}
+		}
+		_ = idx // used below in ResourceName
+		ids, ok := pfCache[pfName]
+		if !ok {
+			// readVfVendorDevice wants the PF's BDF, not the VF's.  Walk via
+			// the VF's physfn symlink so we don't need to look the PF up in
+			// AssignableAdapters (which would risk a torn read on concurrent
+			// AA modification).
+			pfBDF, err := os.Readlink(filepath.Join("/sys/bus/pci/devices", ib.PciLong, "physfn"))
+			if err != nil {
+				log.Warnf("buildSRIOVPools: VF %s (PF %s): readlink physfn: %v",
+					ib.PciLong, pfName, err)
+				continue
+			}
+			vendor, device, err := readVfVendorDevice(filepath.Base(pfBDF))
+			if err != nil {
+				log.Warnf("buildSRIOVPools: VF %s (PF %s): vendor/device lookup: %v",
+					ib.PciLong, pfName, err)
+				continue
+			}
+			ids = vidPid{vendor: vendor, device: device}
+			pfCache[pfName] = ids
+		}
+
+		// Resource name must match what kubevirt.go's sriovResourceName()
+		// produces so VMI specs and pool advertisement line up.  Format is
+		// "<pf>_vf<index>" (sans the "eve.network/" prefix, which is set via
+		// ResourcePrefix below).
+		pools = append(pools, sriovPool{
+			ResourceName:   fmt.Sprintf("%s_vf%d", pfName, idx),
+			ResourcePrefix: sriovResourcePrefix,
+			Selectors: sriovSelectors{
+				Vendors:      []string{ids.vendor},
+				Devices:      []string{ids.device},
+				Drivers:      []string{"vfio-pci"},
+				PfNames:      []string{pfName},
+				PciAddresses: []string{ib.PciLong},
+			},
+		})
+	}
+	return pools
+}
+
+// readVfVendorDevice returns the vendor and device IDs of the first VF derived
+// from the given PF, formatted as 4-char lowercase hex (no "0x" prefix).
+//
+// The PF's own vendor:device is not what the device plugin needs — VFs have
+// their own IDs (e.g. I350 PF 8086:1521, VF 8086:1520).  We read sysfs of the
+// first virtual function (virtfn0) which kernel-creates as soon as
+// sriov_numvfs is non-zero.
+func readVfVendorDevice(pfBDF string) (vendor, device string, err error) {
+	pfDir := filepath.Join("/sys/bus/pci/devices", pfBDF)
+	vf0Link, err := os.Readlink(filepath.Join(pfDir, "virtfn0"))
+	if err != nil {
+		return "", "", fmt.Errorf("readlink virtfn0: %w", err)
+	}
+	vfDir := filepath.Join(pfDir, vf0Link)
+
+	vRaw, err := os.ReadFile(filepath.Join(vfDir, "vendor"))
+	if err != nil {
+		return "", "", fmt.Errorf("read vendor: %w", err)
+	}
+	dRaw, err := os.ReadFile(filepath.Join(vfDir, "device"))
+	if err != nil {
+		return "", "", fmt.Errorf("read device: %w", err)
+	}
+	// sysfs files contain "0x8086\n" — strip prefix and whitespace.
+	v := strings.TrimPrefix(strings.TrimSpace(string(vRaw)), "0x")
+	d := strings.TrimPrefix(strings.TrimSpace(string(dRaw)), "0x")
+	if v == "" || d == "" {
+		return "", "", fmt.Errorf("empty vendor or device in sysfs (%q/%q)", v, d)
+	}
+	return v, d, nil
+}
+
+// deleteLocalSriovDpPod deletes the sriov-network-device-plugin pod scheduled
+// on this node.  The DaemonSet recreates it within seconds; the new pod reads
+// the updated ConfigMap on startup.
+//
+// We restrict the LIST by spec.nodeName so multi-node clusters only restart
+// the local pod — neighbours' inventories are independent.
+func deleteLocalSriovDpPod(ctx context.Context, clientset *kubernetes.Clientset, nodeName string) error {
+	if nodeName == "" {
+		return fmt.Errorf("nodeName is empty")
+	}
+	pods, err := clientset.CoreV1().Pods(sriovDPNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: sriovDPPodLabel,
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	if err != nil {
+		return fmt.Errorf("list pods: %w", err)
+	}
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no sriovdp pod on node %s (label %s)", nodeName, sriovDPPodLabel)
+	}
+	for _, p := range pods.Items {
+		if err := clientset.CoreV1().Pods(sriovDPNamespace).Delete(
+			ctx, p.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("delete pod %s: %w", p.Name, err)
+		}
+		log.Noticef("deleteLocalSriovDpPod: deleted %s on node %s", p.Name, nodeName)
+	}
+	return nil
+}
+
+// AssignableAdapters pubsub handlers.  All three funnel into a single reconcile
+// — the publication is keyed on "global" so create/modify look identical from
+// our perspective, and a delete shouldn't happen in practice (domainmgr owns it
+// for the device's lifetime) but is harmless.
+
+func handleAssignableAdaptersCreate(ctxArg interface{}, _ string, statusArg interface{}) {
+	z := ctxArg.(*zedkube)
+	aa := statusArg.(types.AssignableAdapters)
+	z.reconcileSRIOVDevicePlugin(&aa)
+}
+
+func handleAssignableAdaptersModify(ctxArg interface{}, _ string, statusArg interface{}, _ interface{}) {
+	z := ctxArg.(*zedkube)
+	aa := statusArg.(types.AssignableAdapters)
+	z.reconcileSRIOVDevicePlugin(&aa)
+}
+
+func handleAssignableAdaptersDelete(ctxArg interface{}, _ string, _ interface{}) {
+	z := ctxArg.(*zedkube)
+	// Empty AA — clears all pools, which is the right thing if domainmgr
+	// withdrew the publication entirely.
+	empty := &types.AssignableAdapters{}
+	z.reconcileSRIOVDevicePlugin(empty)
+}

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -69,6 +69,7 @@ type zedkube struct {
 	agentbase.AgentBase
 	globalConfig             *types.ConfigItemValueMap
 	subAppInstanceConfig     pubsub.Subscription
+	subAssignableAdapters    pubsub.Subscription
 	subGlobalConfig          pubsub.Subscription
 	subDeviceNetworkStatus   pubsub.Subscription
 	subEdgeNodeClusterConfig pubsub.Subscription
@@ -639,6 +640,27 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	zedkubeCtx.subZedAgentStatus = subZedAgentStatus
 	subZedAgentStatus.Activate()
 
+	// Subscribe to AssignableAdapters from domainmgr so we can keep the
+	// sriov-network-device-plugin ConfigMap aligned with the live SR-IOV
+	// inventory.  See pkg/pillar/cmd/zedkube/sriov_devplugin.go.
+	subAssignableAdapters, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "domainmgr",
+		MyAgentName:   agentName,
+		TopicImpl:     types.AssignableAdapters{},
+		Activate:      false,
+		Ctx:           &zedkubeCtx,
+		CreateHandler: handleAssignableAdaptersCreate,
+		ModifyHandler: handleAssignableAdaptersModify,
+		DeleteHandler: handleAssignableAdaptersDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	zedkubeCtx.subAssignableAdapters = subAssignableAdapters
+	subAssignableAdapters.Activate()
+
 	err = kubeapi.WaitForKubernetes(agentName, ps, stillRunning,
 		kubeapi.WaitForKubernetesOptions{},
 		// Make sure we keep ClusterIPIsReady up to date while we wait
@@ -694,6 +716,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		case change := <-subAppInstanceConfig.MsgChan():
 			subAppInstanceConfig.ProcessChange(change)
 
+		case change := <-subAssignableAdapters.MsgChan():
+			subAssignableAdapters.ProcessChange(change)
+
 		// Timer 1: app log streaming only.
 		// collectAppLogs() returns early on stream timeout so this branch
 		// is bounded by a single kubeAPITimeout, not N*kubeAPITimeout.
@@ -724,6 +749,18 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		case <-kubeCfgTimer.C:
 			zedkubeCtx.applyLonghornDiskReserved()
 			zedkubeCtx.applyLonghornRecurringSnapshot()
+			// Safety net for the SR-IOV device-plugin ConfigMap.  The primary
+			// reconcile path is the AssignableAdapters subscription handler,
+			// but if the very first event arrived before z.config was ready
+			// (k3s slower than zedkube at boot) and no AA modify has happened
+			// since, we'd never recover.  Re-driving reconcile from the
+			// pubsub snapshot every kubeCfgInterval guarantees eventual
+			// consistency without needing a fresh AA event.
+			if v, err := zedkubeCtx.subAssignableAdapters.Get("global"); err == nil {
+				if aa, ok := v.(types.AssignableAdapters); ok {
+					zedkubeCtx.reconcileSRIOVDevicePlugin(&aa)
+				}
+			}
 			kubeCfgTimer = time.NewTimer(kubeCfgInterval * time.Second)
 
 		// Timer 5: leader-only safety-net re-evaluation of the stale-master

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -8,24 +8,30 @@ package hypervisor
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
 	"math"
 	"math/rand"
+	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/sriov"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	netattdefclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
 	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	k8sv1 "k8s.io/api/core/v1"
@@ -74,6 +80,21 @@ type vmiMetaData struct {
 	cputotal         uint64                               // total CPU in NS so far
 	maxmem           uint32                               // total Max memory usage in bytes so far
 	startUnknownTime time.Time                            // time when the domain returned as unknown status
+	// sriovVFs lists the (PF ifname, VF index) of every SR-IOV VF this VMI
+	// was wired with via attachSRIOVInterfaces.  Used on Stop/Delete/Cleanup
+	// to clear the per-VF admin MAC on the PF — sriov-cni's DEL path doesn't
+	// reliably clear it when the VF is pre-bound to vfio-pci, so EVE owns
+	// the cleanup.
+	sriovVFs []sriovVFRef
+}
+
+// sriovVFRef identifies a single VF on a Physical Function for cleanup
+// purposes.  PfIface is the PF kernel netdev name (e.g. "eth2"), Index is
+// the VF index within that PF.  Together they uniquely identify a slot in
+// the PF's VF table that netlink.LinkSetVfHardwareAddr addresses.
+type sriovVFRef struct {
+	PfIface string
+	Index   uint8
 }
 
 type kubevirtContext struct {
@@ -506,7 +527,7 @@ func (ctx kubevirtContext) CreateReplicaVMIConfig(domainName string, config type
 	var pciAssignments []pciDevice
 
 	for _, adapter := range config.IoAdapterList {
-		logrus.Debugf("processing adapter %d %s\n", adapter.Type, adapter.Name)
+		logrus.Debugf("processing adapter type=%d name=%s\n", adapter.Type, adapter.Name)
 		list := aa.LookupIoBundleAny(adapter.Name)
 		// We reserved it in handleCreate so nobody could have stolen it
 		if len(list) == 0 {
@@ -517,10 +538,21 @@ func (ctx kubevirtContext) CreateReplicaVMIConfig(domainName string, config type
 			if ib == nil {
 				continue
 			}
+			// IoNetEth: skip sibling PCI functions in the same assignment group
+			// whose ifname doesn't match the requested adapter name.  Registering
+			// them separately with KubeVirt would cause an allocation error.
 			if ib.Type == types.IoNetEth && ib.Ifname != adapter.Name {
-				// if we get here, means we have a PCI device which is in the same group
-				// as the Ethernet passthrough port, will have error if register to the kubevirt
-				logrus.Infof("Skip PCI device %s which does not match adapter %s\n", ib.Ifname, adapter.Name)
+				logrus.Infof("CreateReplicaVMIConfig: skip sibling PCI device %s "+
+					"(not the requested adapter %s)\n", ib.Ifname, adapter.Name)
+				continue
+			}
+			// IoNetEthPF is the SR-IOV Physical Function.  It must remain in the host
+			// (keepInHost=true, never in vfio-pci).  Only the derived VFs
+			// (IoNetEthVF) should be passed through to the VM.
+			if ib.Type == types.IoNetEthPF {
+				logrus.Warnf("CreateReplicaVMIConfig: skipping SR-IOV PF %s for adapter %s — "+
+					"assign VFs (e.g. %svf0) to the VM instead",
+					ib.Ifname, adapter.Name, ib.Ifname)
 				continue
 			}
 			if ib.UsedByUUID != config.UUIDandVersion.UUID {
@@ -529,23 +561,57 @@ func (ctx kubevirtContext) CreateReplicaVMIConfig(domainName string, config type
 					domainName)
 			}
 			if ib.PciLong != "" {
-				logrus.Infof("Adding PCI device <%v>\n", ib.PciLong)
+				if ib.Type.IsNetEthVF() {
+					logrus.Infof("CreateReplicaVMIConfig: adding SR-IOV VF <%s> "+
+						"(index %d, VLAN %d, MAC %s, PF %s)\n",
+						ib.PciLong, ib.VfParams.Index, ib.VfParams.VlanID,
+						ib.MacAddr, ib.VfParams.PFIface)
+				} else {
+					logrus.Infof("CreateReplicaVMIConfig: adding PCI device <%s> type %d\n",
+						ib.PciLong, ib.Type)
+				}
 				tap := pciDevice{ioBundle: *ib}
 				pciAssignments = addNoDuplicatePCI(pciAssignments, tap)
 			}
 		}
 	}
 
-	if len(pciAssignments) > 0 {
-		// Device passthrough is a three step process in Kubevirt/Kubernetes
-		// 1) First do PCI Reserve like in kvm.go (If we are here, PCI Reserve is already done)
-		// 2) Register the  pciVendorSelector which is a PCI vendor ID and product ID tuple in the form vendor_id:product_id
-		//    with kubevirt
-		// 3) Then pass the registered names to VMI config
-		err := registerWithKV(kvClient, vmi, pciAssignments)
-		if err != nil {
-			return logError("Failed to register with Kubevirt  %v", len(pciAssignments))
+	// Split assignments into two buckets:
+	//   - SR-IOV VFs go through Multus + sriov-cni so KubeVirt selects a specific
+	//     VF per VMI by BDF (resource pool counts) and we can set a per-VM MAC
+	//     via Interface.MacAddress.  This is the canonical KubeVirt SR-IOV path.
+	//   - Other PCI devices (GPUs, NVMe, USB controllers, plain NICs) keep the
+	//     HostDevices path: register vendor:device once, attach by resource name.
+	var hostDevAssignments []pciDevice
+	var vfAssignments []pciDevice
+	for _, pa := range pciAssignments {
+		if pa.ioBundle.Type.IsNetEthVF() {
+			vfAssignments = append(vfAssignments, pa)
+		} else {
+			hostDevAssignments = append(hostDevAssignments, pa)
 		}
+	}
+
+	if len(hostDevAssignments) > 0 {
+		// PCI passthrough for KubeVirt is a three-step process:
+		//   1. PCIReserve (vfio-pci bind) — already done in domainmgr handleCreate.
+		//   2. Register the vendor:device tuple in the KubeVirt CR PermittedHostDevices
+		//      so the KubeVirt device plugin exposes it as a Kubernetes resource.
+		//   3. Reference the resource name in the VMI HostDevices list.
+		if err := registerWithKV(kvClient, vmi, hostDevAssignments); err != nil {
+			return logError("Failed to register PCI devices with KubeVirt (%d device(s)): %v",
+				len(hostDevAssignments), err)
+		}
+	}
+
+	var sriovVFs []sriovVFRef
+	if len(vfAssignments) > 0 {
+		refs, err := attachSRIOVInterfaces(ctx.kubeConfig, vmi, vfAssignments, config.UUIDandVersion.UUID)
+		if err != nil {
+			return logError("Failed to attach SR-IOV VFs to VMI (%d VF(s)): %v",
+				len(vfAssignments), err)
+		}
+		sriovVFs = refs
 	}
 
 	// Set the affinity to this node the VMI is preferred to run on
@@ -594,6 +660,7 @@ func (ctx kubevirtContext) CreateReplicaVMIConfig(domainName string, config type
 		name:     kubeName,
 		mtype:    IsMetaReplicaVMI,
 		domainID: int(rand.Uint32()),
+		sriovVFs: sriovVFs,
 	}
 	ctx.evictStaleVMIByUUIDPrefix(domainName)
 	ctx.vmiList[domainName] = &meta
@@ -810,6 +877,26 @@ func (ctx kubevirtContext) scheduledOnMe(mtype MetaDataType, objectName string) 
 	}
 }
 
+// clearSRIOVAdminMACs zeroes the per-VF admin MAC for every VF this VMI was
+// wired with.  Called on VM teardown so the next VM that lands on the same
+// VF doesn't inherit the previous tenant's admin MAC.
+//
+// Best-effort: a per-VF failure is logged and skipped.  Leaving an old MAC
+// in place is bad but not catastrophic (the next attach will reprogram it);
+// returning an error here would block the VMI delete and produce a worse
+// failure mode for the operator (stuck delete loop).
+func (ctx kubevirtContext) clearSRIOVAdminMACs(vmis *vmiMetaData) {
+	for _, ref := range vmis.sriovVFs {
+		if err := sriov.ClearVFAdminMAC(ref.PfIface, ref.Index); err != nil {
+			logrus.Warnf("clearSRIOVAdminMACs: PF %s VF %d: %v",
+				ref.PfIface, ref.Index, err)
+			continue
+		}
+		logrus.Infof("clearSRIOVAdminMACs: cleared admin MAC on PF %s VF %d",
+			ref.PfIface, ref.Index)
+	}
+}
+
 // There is no such thing as stop VMI, so delete it.
 func (ctx kubevirtContext) Stop(domainName string, force bool) error {
 	logrus.Debugf("Stop called for Domain: %s", domainName)
@@ -851,6 +938,8 @@ func (ctx kubevirtContext) Stop(domainName string, force bool) error {
 	if err != nil {
 		return err
 	}
+
+	ctx.clearSRIOVAdminMACs(vmis)
 
 	delete(ctx.vmiList, keyToDelete)
 
@@ -897,6 +986,8 @@ func (ctx kubevirtContext) Delete(domainName string) (result error) {
 	if err != nil {
 		return err
 	}
+
+	ctx.clearSRIOVAdminMACs(vmis)
 
 	// Delete the state dir
 	if err := os.RemoveAll(kubevirtStateDir + domainName); err != nil {
@@ -1940,77 +2031,93 @@ func getConfig(ctx *kubevirtContext) error {
 	return nil
 }
 
-// Register the host device with Kubevirt
-// Refer https://kubevirt.io/user-guide/virtual_machines/host-devices/#host-preparation-for-pci-passthrough
-// Refer https://kubevirt.io/user-guide/virtual_machines/host-devices/#usb-host-passthrough
-func registerWithKV(kvClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, pciAssignments []pciDevice) error {
+// registerWithKV registers PCI host-devices with KubeVirt and adds them as
+// HostDevices in the VMI spec.
+//
+// SR-IOV VFs are NOT routed through this path — they go through
+// attachSRIOVInterfaces (Multus + sriov-cni).  This function only handles
+// non-VF passthrough (GPUs, NVMe, USB controllers, plain NICs).
+//
+// Flow:
+//  1. For each PCI assignment look up its vendor:device tuple.
+//  2. If the tuple is not yet in KubeVirt's PermittedHostDevices CR, add it and
+//     update the CR.  This triggers the KubeVirt device plugin to expose the
+//     resource to kubelet.
+//  3. Reference the resource name in the VMI HostDevices list.
+//
+// References:
+//
+//	https://kubevirt.io/user-guide/virtual_machines/host-devices/#host-preparation-for-pci-passthrough
+func registerWithKV(kvClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance,
+	pciAssignments []pciDevice) error {
 
-	logrus.Debugf("Entered registerWithKV  pcilen %d ", len(pciAssignments))
+	logrus.Debugf("registerWithKV: %d PCI assignment(s)", len(pciAssignments))
 	pcidevices := make([]v1.HostDevice, len(pciAssignments))
 
-	// Define the KubeVirt resource's name and namespace
-	kubeVirtName := "kubevirt"
-	kubeVirtNamespace := "kubevirt"
+	const (
+		kubeVirtName      = "kubevirt"
+		kubeVirtNamespace = "kubevirt"
+	)
 
-	// Retrieve the KubeVirt resource
+	// Retrieve the KubeVirt CR so we can inspect / update PermittedHostDevices.
 	kubeVirt, err := kvClient.KubeVirt(kubeVirtNamespace).Get(context.Background(), kubeVirtName, metav1.GetOptions{})
 	if err != nil {
-		return logError("can't fetch the PCI device info from kubevirt %v", err)
+		return logError("registerWithKV: can't fetch KubeVirt CR: %v", err)
 	}
 
-	// Get the currently registered  devices from Kubevirt
 	pciHostDevs := kubeVirt.Spec.Configuration.PermittedHostDevices.PciHostDevices
 
 	for i, pa := range pciAssignments {
-
 		vendor, err := pa.vid()
 		if err != nil {
-			return logError("can't fetch the vendor id for pci device %v", err)
+			return logError("registerWithKV: can't read vendor ID for %s: %v", pa.ioBundle.PciLong, err)
 		}
-		// Delete 0x prefix it exists, kubevirt does not like it
+		// KubeVirt rejects the "0x" prefix in vendor/device IDs.
 		vendor = strings.TrimPrefix(vendor, "0x")
+
 		devid, err := pa.devid()
 		if err != nil {
-			return logError("can't fetch the device id for pci device %v", err)
+			return logError("registerWithKV: can't read device ID for %s: %v", pa.ioBundle.PciLong, err)
 		}
-		if strings.HasPrefix(devid, "0x") {
-			devid = devid[2:]
-		}
+		devid = strings.TrimPrefix(devid, "0x")
+
 		pciVendorSelector := vendor + ":" + devid
 
-		// Check if we already registered this device with kubevirt. If not register with kubevirt
-		registered := isRegisteredPciHostDevice(pciVendorSelector, pciHostDevs)
-		// Lets make sure resname is unique by appending vendor and devid
-		// NOTE we cannot use pciVendorSelector directly since ":" is not accepted in kubernetes resource name standard
+		// Resource names must not contain ":" (Kubernetes naming rules), so we
+		// concatenate vendor and device ID directly.
 		resname := "devices.kubevirt.io/hostdevice-" + vendor + devid
-		if !registered {
 
+		if !isRegisteredPciHostDevice(pciVendorSelector, pciHostDevs) {
 			newpcidev := v1.PciHostDevice{
 				ResourceName:      resname,
 				PCIVendorSelector: pciVendorSelector,
 			}
-			logrus.Infof("Registering PCI device %s as resource %s with kubevirt", pciVendorSelector, resname)
-			kubeVirt.Spec.Configuration.PermittedHostDevices.PciHostDevices = append(kubeVirt.Spec.Configuration.PermittedHostDevices.PciHostDevices, newpcidev)
+			logrus.Infof("registerWithKV: registering PCI device "+
+				"(BDF %s, vendor:device %s) as resource %s",
+				pa.ioBundle.PciLong, pciVendorSelector, resname)
+
+			kubeVirt.Spec.Configuration.PermittedHostDevices.PciHostDevices =
+				append(kubeVirt.Spec.Configuration.PermittedHostDevices.PciHostDevices, newpcidev)
 			_, err = kvClient.KubeVirt(kubeVirtNamespace).Update(context.Background(), kubeVirt, metav1.UpdateOptions{})
-
 			if err != nil {
-				return logError("can't update the PCI device info from kubevirt %v", err)
+				return logError("registerWithKV: can't update KubeVirt CR: %v", err)
 			}
+		} else {
+			logrus.Debugf("registerWithKV: resource %s already registered for vendor:device %s",
+				resname, pciVendorSelector)
 		}
-		// At this point we have registered the PCI device with kubevirt
-		// Create HostDevice array which will be inserted into vmi Hostdevices
-		// Hostdevices could be NVMe drives,USB or NICs, that is reason if just call them device.
 
+		// At this point the device is registered.  Add it to the VMI HostDevices list.
+		// HostDevices cover NVMe drives, GPUs, USB, etc. — we call them
+		// "device<N>" generically.
 		pcidevices[i] = v1.HostDevice{
 			DeviceName: resname,
 			Name:       "device" + strconv.Itoa(i+1),
 		}
-
 		vmi.Spec.Domain.Devices.HostDevices = append(vmi.Spec.Domain.Devices.HostDevices, pcidevices[i])
 	}
 
 	return nil
-
 }
 
 func isRegisteredPciHostDevice(pciVendorSelector string, PciHostDevices []v1.PciHostDevice) bool {
@@ -2130,4 +2237,339 @@ func isK3sUnreachable(err error) bool {
 
 func ptrBool(b bool) *bool {
 	return &b
+}
+
+// ============================================================================
+// SR-IOV via Multus + sriov-cni
+// ----------------------------------------------------------------------------
+// Each SR-IOV Virtual Function is attached to the VMI as a KubeVirt SR-IOV
+// network interface backed by a Multus NetworkAttachmentDefinition.  This lets
+// us:
+//   - Pick a specific VF (by BDF) via the sriov-network-device-plugin's resource
+//     pool — eliminates the "fungible pool" problem that affects raw PCI
+//     HostDevices when multiple VFs share the same vendor:device tuple.
+//   - Set a per-VM MAC address using vmi.Spec.Domain.Devices.Interfaces[].MacAddress.
+//     KubeVirt -> libvirt -> sriov-cni honors this on the guest side regardless
+//     of what the PF admin-MAC was programmed to.
+//   - Re-bind a VF on the destination node automatically during failover, as
+//     long as the destination has free VFs in the same pool.
+//
+// Cluster prerequisites (installed by pkg/kube/cluster-init.sh on SR-IOV nodes):
+//   - Multus CNI (already present for the eve-bridge primary network).
+//   - sriov-cni                : /opt/cni/bin/sriov on every node.
+//   - sriov-network-device-plugin : advertises eve.network/<pf>_vfs as a
+//     Kubernetes extended resource, tracked by BDF.
+//
+// Resource naming: one pool per Virtual Function (pfName + VF index).  Each
+// pool's selector pins exactly one BDF, so kubelet allocates the specific VF
+// EVE intended for the VM — eliminating the "random VF from the pool" failure
+// mode that occurs with a per-PF pool where any free BDF is fungible.
+// ============================================================================
+
+// sriovResourceName returns the Kubernetes extended-resource name advertised by
+// the sriov-network-device-plugin for ONE specific VF.  Must match the
+// resourceName/resourcePrefix in the device plugin ConfigMap.
+//
+// Per-VF naming (eth2_vf0, eth2_vf1, ...) is the lever EVE uses to pin a
+// specific BDF to a specific VMI: the per-VF pool's pciAddresses selector
+// constrains the device plugin to advertise that one BDF under this name,
+// so a VMI requesting eve.network/eth2_vf3 can only ever receive BDF
+// virtfn3 of eth2 — no pool-level scheduling lottery.
+func sriovResourceName(pfName string, vfIdx uint8) string {
+	return fmt.Sprintf("eve.network/%s_vf%d", pfName, vfIdx)
+}
+
+// sriovNADName returns the NetworkAttachmentDefinition name for ONE specific
+// VF.  Per-VF NADs (not per-PF) so distinct Multus annotations exist for
+// every VF the VMI uses; KubeVirt translates each Interface->Network pairing
+// into a separate pod-networks annotation entry, and Multus invokes sriov-cni
+// once per entry.  VLAN, when configured, lives in the NAD's CNI config.
+func sriovNADName(pfName string, vfIdx uint8, vlanID uint32) string {
+	if vlanID == 0 {
+		return fmt.Sprintf("sriov-%s-vf%d", pfName, vfIdx)
+	}
+	return fmt.Sprintf("sriov-%s-vf%d-vlan%d", pfName, vfIdx, vlanID)
+}
+
+// ensureSRIOVNAD creates (or refreshes) the NetworkAttachmentDefinition that
+// binds Multus calls to sriov-cni for ONE specific VF.  Idempotent: existing
+// NADs are updated only when the embedded CNI config has drifted (e.g. VLAN
+// change).
+//
+// The annotation k8s.v1.cni.cncf.io/resourceName tells Multus to ask the
+// sriov-network-device-plugin for THIS VF's pool when wiring the pod; the
+// plugin injects PCIDEVICE_<pool> (containing that single BDF) into the pod
+// env, and sriov-cni reads it to bind that exact VF.
+func ensureSRIOVNAD(kubeConfig *rest.Config, pfName string, vfIdx uint8, vlanID uint32) error {
+	nadClient, err := netattdefclient.NewForConfig(kubeConfig)
+	if err != nil {
+		return fmt.Errorf("ensureSRIOVNAD: can't create NAD clientset: %v", err)
+	}
+
+	nadName := sriovNADName(pfName, vfIdx, vlanID)
+	resourceName := sriovResourceName(pfName, vfIdx)
+	cniConfig := fmt.Sprintf(
+		`{"cniVersion":"0.3.1","name":%q,"type":"sriov"}`,
+		nadName)
+	if vlanID > 0 {
+		cniConfig = fmt.Sprintf(
+			`{"cniVersion":"0.3.1","name":%q,"type":"sriov","vlan":%d}`,
+			nadName, vlanID)
+	}
+	desired := &netattdefv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nadName,
+			Namespace: kubeapi.EVEKubeNameSpace,
+			Annotations: map[string]string{
+				"k8s.v1.cni.cncf.io/resourceName": resourceName,
+			},
+		},
+		Spec: netattdefv1.NetworkAttachmentDefinitionSpec{Config: cniConfig},
+	}
+
+	nads := nadClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(kubeapi.EVEKubeNameSpace)
+
+	existing, err := nads.Get(context.Background(), nadName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		if _, err := nads.Create(context.Background(), desired, metav1.CreateOptions{}); err != nil && !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("ensureSRIOVNAD: can't create NAD %s: %v", nadName, err)
+		}
+		logrus.Infof("ensureSRIOVNAD: created NAD %s -> resource %s (vlan %d)",
+			nadName, resourceName, vlanID)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("ensureSRIOVNAD: can't get NAD %s: %v", nadName, err)
+	}
+
+	if existing.Spec.Config == cniConfig &&
+		existing.Annotations["k8s.v1.cni.cncf.io/resourceName"] == resourceName {
+		return nil
+	}
+
+	if existing.Annotations == nil {
+		existing.Annotations = map[string]string{}
+	}
+	existing.Annotations["k8s.v1.cni.cncf.io/resourceName"] = resourceName
+	existing.Spec.Config = cniConfig
+	if _, err := nads.Update(context.Background(), existing, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("ensureSRIOVNAD: can't update NAD %s: %v", nadName, err)
+	}
+	logrus.Infof("ensureSRIOVNAD: updated NAD %s -> resource %s (vlan %d)",
+		nadName, resourceName, vlanID)
+	return nil
+}
+
+// attachSRIOVInterfaces wires every SR-IOV VF in vfs into the VMI as a KubeVirt
+// SR-IOV interface backed by a Multus NetworkAttachmentDefinition.
+//
+// Per-VF MAC: we set Interface.MacAddress from the IoBundle's MacAddr.  This is
+// the user-configured MAC (possibly via the EVE app config); the in-VM driver
+// observes this exact MAC regardless of what the PF admin-MAC was programmed
+// to, fixing the "all VMs see the same MAC" symptom of the HostDevice path.
+//
+// Per-VF BDF selection: the resource pool counts in the device plugin guarantee
+// that two VMIs requesting the same pool get different VFs.  No nodeSelector
+// stamping is needed because the scheduler will only place the VMI on a node
+// where the resource pool has free capacity.
+func attachSRIOVInterfaces(kubeConfig *rest.Config, vmi *v1.VirtualMachineInstance, vfs []pciDevice, appUUID uuid.UUID) ([]sriovVFRef, error) {
+	// VF refs accumulated for the caller to remember on the vmiMetaData; on
+	// Stop/Delete/Cleanup we use these to zero the per-VF admin MAC.
+	vfRefs := make([]sriovVFRef, 0, len(vfs))
+
+	for i, pa := range vfs {
+		pfName := pa.ioBundle.VfParams.PFIface
+		if pfName == "" {
+			// domainmgr.checkAndFillIoBundle populates VfParams.PFIface at
+			// parse time, but the VF may not have existed in sysfs yet (e.g.
+			// sriov_numvfs not written when the phyAdapter list was first
+			// processed).  Recover from sysfs now — the VF must exist by the
+			// time we're attaching it to a VMI.
+			derived, err := sriov.GetPFIfaceFromVFBDF(pa.ioBundle.PciLong)
+			if err != nil {
+				return nil, fmt.Errorf("attachSRIOVInterfaces: VF %s has empty PFIface "+
+					"and sysfs lookup failed: %w", pa.ioBundle.PciLong, err)
+			}
+			logrus.Warnf("attachSRIOVInterfaces: VF %s arrived without PFIface; "+
+				"recovered PFIface=%s from sysfs", pa.ioBundle.PciLong, derived)
+			pfName = derived
+		}
+		// Resolve VF index authoritatively from Phylabel — VfParams.Index is
+		// 0 for every statically-declared VF until checkAndFillIoBundle has
+		// run, which can produce per-VM NADs all pointing at "<pf>-vf0" and
+		// resource requests all targeting "<pf>_vf0".  Phylabel ("eth2vf5")
+		// is set by the device model and stable.
+		vfIdx, pfFromLabel, err := sriov.ParseVfIfaceName(pa.ioBundle.Phylabel)
+		if err != nil {
+			return nil, fmt.Errorf("attachSRIOVInterfaces: can't parse VF index "+
+				"from Phylabel %q: %w", pa.ioBundle.Phylabel, err)
+		}
+		// Re-confirm PF name from the Phylabel parse as a final safety net.
+		// Sysfs already filled pfName above; only override if sysfs gave us
+		// the empty string (extremely unusual).
+		if pfName == "" {
+			pfName = pfFromLabel
+		}
+		vlanID := uint32(pa.ioBundle.VfParams.VlanID)
+
+		// Per-VF NAD + per-VF resource pool.  Each VF has its own pool of size
+		// 1 with a pciAddresses selector pinning that exact BDF, so kubelet's
+		// allocation is deterministic — VM asks for eve.network/<pf>_vf<i> and
+		// receives BDF virtfn<i> of <pf>, never anything else.
+		if err := ensureSRIOVNAD(kubeConfig, pfName, vfIdx, vlanID); err != nil {
+			return nil, err
+		}
+
+		// Remember this (PF, VF index) for the caller to stash on vmiMetaData;
+		// we'll iterate it in Stop/Delete/Cleanup to clear admin MAC.
+		vfRefs = append(vfRefs, sriovVFRef{
+			PfIface: pfName,
+			Index:   vfIdx,
+		})
+
+		// Backstop: ensure this VF is bound to vfio-pci before we hand the VMI
+		// off to KubeVirt.  setupVf binds at boot, but in the field we've seen
+		// VFs end up driverless when a per-VF createVfIoBundle error short-
+		// circuited the bind loop on an earlier code path, or when iavf
+		// re-grabbed the VF after an autoprobe race.  BindVFToVfioPCI is
+		// idempotent (no-ops when already vfio-pci), so this is cheap on the
+		// happy path and self-healing on the bad one.  Non-fatal here: if the
+		// bind fails, kubelet will refuse to schedule the VMI and the user will
+		// see the resource shortage in events — better diagnostic than a
+		// silently-half-attached VM.
+		if err := sriov.BindVFToVfioPCI(pa.ioBundle.PciLong); err != nil {
+			logrus.Warnf("attachSRIOVInterfaces: backstop bind VF %s to vfio-pci: %v",
+				pa.ioBundle.PciLong, err)
+		}
+
+		// KubeVirt SR-IOV interfaces must reference a Multus network of the
+		// same Name.  Use a stable, non-conflicting interface name per VF.
+		ifName := fmt.Sprintf("sriov%d", i+1)
+		nadName := sriovNADName(pfName, vfIdx, vlanID)
+
+		iface := v1.Interface{
+			Name: ifName,
+			InterfaceBindingMethod: v1.InterfaceBindingMethod{
+				SRIOV: &v1.InterfaceSRIOV{},
+			},
+		}
+		// MAC selection priority:
+		//   1. User-configured MacAddr from the IoBundle, if it's not just
+		//      a stale copy of the parent PF's hardware MAC.  Some EVE
+		//      config paths set every VF IoBundle's MacAddr to the PF MAC
+		//      when per-VF user config is absent — that would make every
+		//      VM see the same MAC (the original bug this path fixes).
+		//   2. A deterministic locally-administered MAC generated from
+		//      (appUUID, vfBDF) using the same SHA-256 + OUI 02:16:3E
+		//      scheme that zedrouter uses for switch-network VIFs (see
+		//      pkg/pillar/cmd/zedrouter/ipam.go:generateAppMac).  Stable
+		//      across reboots, unique per (app, VF), and recognizable as
+		//      EVE-generated.
+		mac, source := resolveVFMac(pa, appUUID)
+		if mac != "" {
+			iface.MacAddress = mac
+		}
+		logrus.Infof("attachSRIOVInterfaces: VF %s MAC %s (source=%s)",
+			pa.ioBundle.PciLong, mac, source)
+
+		vmi.Spec.Domain.Devices.Interfaces = append(
+			vmi.Spec.Domain.Devices.Interfaces, iface)
+
+		vmi.Spec.Networks = append(vmi.Spec.Networks, v1.Network{
+			Name: ifName,
+			NetworkSource: v1.NetworkSource{
+				Multus: &v1.MultusNetwork{
+					NetworkName: kubeapi.EVEKubeNameSpace + "/" + nadName,
+				},
+			},
+		})
+
+		logrus.Infof("attachSRIOVInterfaces: VMI iface %s -> NAD %s "+
+			"(VF %s, PF %s, VF-index %d, VLAN %d, MAC %q)",
+			ifName, nadName, pa.ioBundle.PciLong, pfName,
+			pa.ioBundle.VfParams.Index, vlanID, pa.ioBundle.MacAddr)
+	}
+	return vfRefs, nil
+}
+
+// derivePFMacFromVFSysfs returns the hardware MAC of the Physical Function
+// that owns the given Virtual Function PCI BDF, formatted lowercase
+// "xx:xx:xx:xx:xx:xx" as the kernel exposes it.
+//
+// Used by attachSRIOVInterfaces to detect IoBundle MacAddr fields that have
+// been (incorrectly) populated with the PF's hardware MAC — a pattern that
+// shows up when the EVE device model lacks per-VF MAC config and would cause
+// every VM sharing the pool to see the same MAC.
+//
+// Path: /sys/bus/pci/devices/<vf-bdf>/physfn/net/<ifname>/address
+func derivePFMacFromVFSysfs(vfBDF string) (string, error) {
+	netDir := filepath.Join("/sys/bus/pci/devices", vfBDF, "physfn", "net")
+	entries, err := os.ReadDir(netDir)
+	if err != nil {
+		return "", fmt.Errorf("readdir %s: %w", netDir, err)
+	}
+	if len(entries) == 0 {
+		return "", fmt.Errorf("no netdev under %s", netDir)
+	}
+	addrFile := filepath.Join(netDir, entries[0].Name(), "address")
+	raw, err := os.ReadFile(addrFile)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", addrFile, err)
+	}
+	return strings.ToLower(strings.TrimSpace(string(raw))), nil
+}
+
+// resolveVFMac picks the MAC address to assign to a VF VMI interface.
+// Returns the chosen MAC string (in canonical "xx:xx:xx:xx:xx:xx" form) and a
+// short source label for logging ("config" or "generated").
+//
+// Priority:
+//  1. pa.ioBundle.MacAddr, when it's set and not a stale copy of the parent
+//     PF's hardware MAC.
+//  2. A deterministic locally-administered MAC generated from (appUUID, vfBDF).
+//
+// Returns "" only if generation itself fails — never silently leaves a VMI
+// without a stable identity.
+func resolveVFMac(pa pciDevice, appUUID uuid.UUID) (string, string) {
+	cfgMac := strings.TrimSpace(pa.ioBundle.MacAddr)
+	if cfgMac != "" {
+		pfMac, err := derivePFMacFromVFSysfs(pa.ioBundle.PciLong)
+		if err != nil {
+			logrus.Warnf("can't trust cfgMac → fall through to generated")
+		}
+		if pfMac == "" || !strings.EqualFold(cfgMac, pfMac) {
+			if hw, err := net.ParseMAC(cfgMac); err == nil {
+				return hw.String(), "config"
+			}
+			// fall through to generated
+			return strings.ToLower(cfgMac), "config"
+		}
+		// cfgMac is the PF MAC — bogus per-VF value, fall through to generation.
+	}
+	return generateVFMac(appUUID, pa.ioBundle.PciLong).String(), "generated"
+}
+
+// generateVFMac returns a stable, locally-administered MAC for a VF assigned to
+// a given app instance.
+//
+// Uses the same scheme zedrouter applies to VIFs on switch network instances
+// (pkg/pillar/cmd/zedrouter/ipam.go:generateAppMac):
+//
+//   - SHA-256 hash over (appUUID || vfBDF) — both inputs are stable and
+//     unique, so the same VF assigned to the same app always yields the same
+//     MAC across reboots and across cluster failovers.
+//   - OUI 02:16:3E (locally-administered, unicast).  This OUI is reserved for
+//     XenSource originally and is what EVE has used for VIF MAC generation
+//     for years; reusing it keeps EVE-generated MACs visually consistent
+//     and easy to recognize in tcpdump / arp tables.
+//
+// The resulting MAC is essentially guaranteed unique across (app, VF) pairs in
+// the enterprise — collision probability with 24 random bits and 1000 VFs is
+// well under 0.01 percent.
+func generateVFMac(appUUID uuid.UUID, vfBDF string) net.HardwareAddr {
+	h := sha256.New()
+	h.Write(appUUID[:])
+	h.Write([]byte(vfBDF))
+	hash := h.Sum(nil)
+	return net.HardwareAddr{0x02, 0x16, 0x3e, hash[0], hash[1], hash[2]}
 }

--- a/pkg/pillar/sriov/sriov.go
+++ b/pkg/pillar/sriov/sriov.go
@@ -21,6 +21,7 @@ import (
 // constants for Linux paths for devices
 const (
 	NicLinuxPath      = "/sys/class/net/"
+	PciDevicesPath    = "/sys/bus/pci/devices/"
 	NumVfsDevicePath  = "/device/sriov_numvfs"
 	TotalVfsPath      = "/device/sriov_totalvfs"
 	AutoprobePath     = "/device/sriov_drivers_autoprobe"
@@ -29,11 +30,21 @@ const (
 	VfCreationTimeout = 150 * time.Second
 )
 
-// CreateVF creates Virtual Functions of given count for given Physical Function
-func CreateVF(device string, vfCount uint8, log *base.LogObject) error {
-	numVfsPath := filepath.Join(NicLinuxPath, device, NumVfsDevicePath)
-	autoprobePath := filepath.Join(NicLinuxPath, device, AutoprobePath)
-	totalVfsPath := filepath.Join(NicLinuxPath, device, TotalVfsPath)
+// CreateVF creates Virtual Functions of given count for the Physical Function
+// at the given PCI BDF.
+//
+// The sysfs writes go through /sys/bus/pci/devices/<bdf>/sriov_* rather than
+// /sys/class/net/<dev>/device/sriov_* because the latter is sensitive to the
+// kernel netdev name.  In the EVE-K path NIM renames a PF netdev (e.g.
+// eth2 -> keth2) when it bridges it; if that rename overlaps with our sysfs
+// poll, the /sys/class/net/<old-name> path disappears mid-call and the whole
+// operation fails.  The PCI BDF is stable across renames, so anchoring on it
+// makes CreateVF robust against this race.
+func CreateVF(pciBDF string, vfCount uint8, log *base.LogObject) error {
+	devBase := filepath.Join(PciDevicesPath, pciBDF)
+	numVfsPath := filepath.Join(devBase, "sriov_numvfs")
+	autoprobePath := filepath.Join(devBase, "sriov_drivers_autoprobe")
+	totalVfsPath := filepath.Join(devBase, "sriov_totalvfs")
 
 	totalBuf, err := os.ReadFile(totalVfsPath)
 	if err != nil {
@@ -46,7 +57,7 @@ func CreateVF(device string, vfCount uint8, log *base.LogObject) error {
 
 	if _, err := os.Stat(autoprobePath); err == nil {
 		if err := os.WriteFile(autoprobePath, []byte("0"), 0); err != nil {
-			log.Warnf("Warning: could not disable autoprobe on %s: %s", device, err)
+			log.Warnf("Warning: could not disable autoprobe on %s: %s", pciBDF, err)
 		}
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("error checking autoprobe: %w", err)
@@ -59,6 +70,12 @@ func CreateVF(device string, vfCount uint8, log *base.LogObject) error {
 	currentVal := strings.TrimSpace(string(currentBuf))
 
 	if currentVal == strconv.Itoa(int(vfCount)) {
+		// numvfs already at target — still ensure the PF is up before
+		// returning, in case a prior CreateVF aborted between the kernel
+		// allocating VFs and the link recovery step.
+		if err := ensurePFAdminUp(pciBDF); err != nil {
+			return fmt.Errorf("PF admin-up recovery failed for %s: %w", pciBDF, err)
+		}
 		return nil
 	}
 
@@ -82,12 +99,30 @@ func CreateVF(device string, vfCount uint8, log *base.LogObject) error {
 		}
 	}
 
-	// After VF manipulation the PF can go operstate=down; detect and recover.
-	if err := ensurePFLinkUp(device); err != nil {
-		return fmt.Errorf("PF link recovery failed for %s: %w", device, err)
+	// Bumping sriov_numvfs can clear IFF_UP on some drivers; restore it.
+	// Do not wait for carrier — cable-less passthrough PFs are valid.
+	if err := ensurePFAdminUp(pciBDF); err != nil {
+		return fmt.Errorf("PF admin-up recovery failed for %s: %w", pciBDF, err)
 	}
 
 	return nil
+}
+
+// resolvePFIfnameFromBDF returns the current netdev name of the PF at the
+// given PCI BDF.  Reading /sys/bus/pci/devices/<bdf>/net/ is BDF-anchored and
+// always reflects the current kernel name, so a rename (e.g. eth2 -> keth2)
+// that races with our caller is observed on the next call rather than
+// blowing up an already-cached name.
+func resolvePFIfnameFromBDF(pciBDF string) (string, error) {
+	netDir := filepath.Join(PciDevicesPath, pciBDF, "net")
+	entries, err := os.ReadDir(netDir)
+	if err != nil {
+		return "", fmt.Errorf("readdir %s: %w", netDir, err)
+	}
+	if len(entries) == 0 {
+		return "", fmt.Errorf("no netdev under %s", netDir)
+	}
+	return entries[0].Name(), nil
 }
 
 func pollNumVfs(path, expected string, timeout, interval time.Duration) error {
@@ -108,45 +143,41 @@ func pollNumVfs(path, expected string, timeout, interval time.Duration) error {
 	}
 }
 
-// ensurePFLinkUp checks if the PF interface is down and brings it up if needed.
-// device is the interface name directly (e.g. "enp3s0f0").
-func ensurePFLinkUp(device string) error {
-	link, err := netlink.LinkByName(device)
+// ensurePFAdminUp makes sure the PF netdev has the IFF_UP admin flag set.
+//
+// Bumping sriov_numvfs causes some drivers (ixgbe, i40e) to reset the PF and
+// clear IFF_UP; VF creation itself succeeds but downstream operations that
+// expect an admin-up PF (per-VF MAC/VLAN via netlink) will fail until we
+// restore the flag.
+//
+// IMPORTANT: this checks IFF_UP only, NOT OperState.  Many SR-IOV PFs are
+// intentionally cable-less — used purely as a VF source for app passthrough,
+// with no host traffic ever flowing on them.  Waiting for OperState=OperUp
+// would block forever (or until the cable poll timeout) on those PFs.  The
+// kernel allows VF allocation and per-VF config on an IFF_UP / no-carrier PF
+// just fine, so that's all we need to guarantee here.
+//
+// pciBDF (not the netdev name) is the input because NIM may rename the PF
+// (e.g. eth2 -> keth2 when bridging) concurrently with this call; the BDF is
+// stable and lets us look up the current netdev name at the moment of use.
+func ensurePFAdminUp(pciBDF string) error {
+	ifname, err := resolvePFIfnameFromBDF(pciBDF)
 	if err != nil {
-		return fmt.Errorf("netlink: could not find interface %s: %w", device, err)
+		return fmt.Errorf("resolve PF ifname for %s: %w", pciBDF, err)
 	}
-
-	if link.Attrs().OperState == netlink.OperUp {
+	link, err := netlink.LinkByName(ifname)
+	if err != nil {
+		return fmt.Errorf("netlink: could not find interface %s (pci %s): %w",
+			ifname, pciBDF, err)
+	}
+	if link.Attrs().Flags&net.FlagUp != 0 {
 		return nil
 	}
-
 	if err := netlink.LinkSetUp(link); err != nil {
-		return fmt.Errorf("netlink: failed to bring %s up: %w", device, err)
+		return fmt.Errorf("netlink: failed to bring %s (pci %s) admin-up: %w",
+			ifname, pciBDF, err)
 	}
-
-	if err := pollLinkUp(device, 3*time.Minute, 100*time.Millisecond); err != nil {
-		return fmt.Errorf("PF %s did not come up after LinkSetUp: %w", device, err)
-	}
-
 	return nil
-}
-
-func pollLinkUp(device string, timeout, interval time.Duration) error {
-	deadline := time.Now().Add(timeout)
-	for {
-		link, err := netlink.LinkByName(device)
-		if err != nil {
-			return fmt.Errorf("netlink: lookup %s: %w", device, err)
-		}
-		if link.Attrs().OperState == netlink.OperUp {
-			return nil
-		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("timed out waiting for %s operstate to become up (current: %s)",
-				device, link.Attrs().OperState)
-		}
-		time.Sleep(interval)
-	}
 }
 
 // GetVfIfaceName returns formatted VF name
@@ -154,15 +185,133 @@ func GetVfIfaceName(index uint8, ifname string) string {
 	return fmt.Sprintf("%svf%d", ifname, index)
 }
 
-// ParseVfIfaceName returns index of VF and its PF from name
-func ParseVfIfaceName(ifname string) (uint8, string, error) {
-	var iface string
-	var index uint8
-	n, err := fmt.Sscanf(ifname, "%svf%d", &iface, &index)
-	if n != 2 {
-		err = fmt.Errorf("ParseVfIfaceName: could not parse all arguments for %s expected 2, got %d", ifname, n)
+// BindVFToVfioPCI binds the VF at the given PCI BDF to the vfio-pci driver.
+//
+// EVE sets sriov_drivers_autoprobe=0 on the PF before bumping sriov_numvfs so
+// freshly created VFs arrive driverless.  But this is not guaranteed in every
+// path: a previous boot may have left numvfs already at the target (in which
+// case CreateVF's early-return skips the autoprobe write) and the resident PF
+// VF driver (ixgbevf / iavf / igbvf) will have grabbed the VFs the first time
+// they appeared.  The upstream sriov-network-device-plugin's `drivers: vfio-pci`
+// selector won't match anything bound to those host drivers, so we have to
+// actively rebind here — driver_override + drivers_probe alone is a no-op on
+// an already-bound device.
+//
+// Sequence (mirrors what hypervisor.PCIReserveGeneric does for PF passthrough):
+//  1. If <vf>/driver already points at vfio-pci, return — nothing to do.
+//  2. Write "vfio-pci" to <vf>/driver_override so the next probe pins the
+//     driver match to vfio-pci, regardless of vendor:device tables.
+//  3. If <vf>/driver exists (bound to host driver), write the BDF to
+//     <vf>/driver/unbind to detach it.
+//  4. Write the BDF to /sys/bus/pci/drivers_probe to trigger probing.
+//  5. Verify <vf>/driver now resolves to .../drivers/vfio-pci.  drivers_probe
+//     does NOT return an error if the override driver is missing or no driver
+//     ends up bound, so a post-bind check is the only way to catch a kernel
+//     that doesn't have vfio-pci registered (or a probe race that failed).
+func BindVFToVfioPCI(vfBDF string) error {
+	devDir := filepath.Join("/sys/bus/pci/devices", vfBDF)
+	driverLink := filepath.Join(devDir, "driver")
+	overridePath := filepath.Join(devDir, "driver_override")
+
+	if isVfioPCIBound(driverLink) {
+		return nil
 	}
-	return index, iface, err
+
+	if err := os.WriteFile(overridePath, []byte("vfio-pci"), 0); err != nil {
+		return fmt.Errorf("write driver_override for %s: %w", vfBDF, err)
+	}
+
+	// Unbind whatever host driver is currently attached.  The driver symlink
+	// only exists when a driver is bound, so Stat tells us whether to skip.
+	if _, err := os.Stat(driverLink); err == nil {
+		unbindPath := filepath.Join(driverLink, "unbind")
+		if err := os.WriteFile(unbindPath, []byte(vfBDF), 0); err != nil {
+			return fmt.Errorf("unbind %s from current driver: %w", vfBDF, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat %s: %w", driverLink, err)
+	}
+
+	if err := os.WriteFile("/sys/bus/pci/drivers_probe", []byte(vfBDF), 0); err != nil {
+		return fmt.Errorf("write drivers_probe for %s: %w", vfBDF, err)
+	}
+
+	if !isVfioPCIBound(driverLink) {
+		// Look at what (if anything) ended up bound so the operator can tell
+		// "vfio-pci not in this kernel" from "some other driver re-grabbed it".
+		actual, _ := os.Readlink(driverLink)
+		return fmt.Errorf("VF %s did not bind to vfio-pci after probe "+
+			"(current driver: %q) — check that the kernel has CONFIG_VFIO_PCI "+
+			"and that no other driver re-grabbed the device",
+			vfBDF, filepath.Base(actual))
+	}
+	return nil
+}
+
+// isVfioPCIBound returns true iff the device's "driver" symlink resolves to
+// the vfio-pci driver directory.  Reading the link target is more reliable
+// than Stat: SameFile would also work but adds a second Stat for nothing.
+func isVfioPCIBound(driverLink string) bool {
+	target, err := os.Readlink(driverLink)
+	if err != nil {
+		return false
+	}
+	return filepath.Base(target) == "vfio-pci"
+}
+
+// GetPFIfaceFromVFBDF returns the kernel netdev name of the Physical Function
+// that owns the given Virtual Function PCI BDF.
+//
+// Path: /sys/bus/pci/devices/<vf-bdf>/physfn/net/<ifname>
+//   - "physfn" is a symlink the kernel maintains on every VF, pointing back
+//     to its parent PF.
+//   - "net/<ifname>" lists the netdev(s) attached to the PF.  A normal SR-IOV
+//     PF has exactly one netdev so picking the first entry is unambiguous.
+func GetPFIfaceFromVFBDF(vfBDF string) (string, error) {
+	netDir := filepath.Join("/sys/bus/pci/devices", vfBDF, "physfn", "net")
+	entries, err := os.ReadDir(netDir)
+	if err != nil {
+		return "", fmt.Errorf("readdir %s: %w", netDir, err)
+	}
+	if len(entries) == 0 {
+		return "", fmt.Errorf("no netdev under %s", netDir)
+	}
+	return entries[0].Name(), nil
+}
+
+// ParseVfIfaceName splits a VF iface/phylabel like "eth2vf5" into its PF name
+// ("eth2") and VF index (5).  Mirrors the inverse of GetVfIfaceName.
+//
+// Implementation note: the previous version used fmt.Sscanf with format
+// "%svf%d", which is broken — Go's %s verb is greedy and consumes the entire
+// input, leaving nothing for the literal "vf" or the trailing %d to match.
+// Sscanf returns an error and zero values for both fields.  Use a manual
+// split on the LAST "vf" occurrence instead, so "eth2vf5" parses correctly
+// and the (extremely unusual) case of a PF named "...vf..." is handled by
+// only treating the final "vf<digits>" as the suffix.
+func ParseVfIfaceName(ifname string) (uint8, string, error) {
+	// Scan backwards for the last "vf" that's followed by a valid uint8.
+	// i is the position where the digit suffix begins; we need at least
+	// two characters before it (for "vf") and at least one char after.
+	for i := len(ifname) - 1; i >= 2; i-- {
+		if ifname[i-2:i] != "vf" {
+			continue
+		}
+		suffix := ifname[i:]
+		if suffix == "" {
+			continue
+		}
+		idx, err := strconv.ParseUint(suffix, 10, 8)
+		if err != nil {
+			continue
+		}
+		pf := ifname[:i-2]
+		if pf == "" {
+			return 0, "", fmt.Errorf("ParseVfIfaceName: empty PF in %q", ifname)
+		}
+		return uint8(idx), pf, nil
+	}
+	return 0, "", fmt.Errorf("ParseVfIfaceName: no 'vf<digits>' suffix in %q", ifname)
 }
 
 // GetVf retrieve information about VFs for NIC given
@@ -268,6 +417,38 @@ func (vfl *VFList) GetInfo(idx uint8) *EthVF {
 		if el.Index == idx {
 			return &el
 		}
+	}
+	return nil
+}
+
+// ClearVFAdminMAC zeroes the per-VF admin MAC programmed on the PF's VF
+// table.  Called on VM stop/delete/cleanup so the next tenant of this VF
+// doesn't inherit the previous VM's admin MAC.
+//
+// Background: sriov-cni programs the admin MAC on the PF via netlink on pod
+// ADD, and is supposed to clear it on pod DEL.  In practice — when the VF is
+// pre-bound to vfio-pci (EVE's model) — sriov-cni's DEL path doesn't always
+// reach the admin-MAC clear because the VF has no kernel netdev to operate
+// on.  Without an explicit clear here, the admin MAC entry on the PF
+// persists across VM stops and the next VM that lands on this VF sees the
+// previous tenant's MAC programmed on the host side.
+//
+// Uses the PF ifname (not VF) because LinkSetVfHardwareAddr operates on the
+// PF link with a VF index.  Caller passes both because the VF ifname is
+// usually torn down once the VF is bound to vfio-pci.
+//
+// All-zeros MAC is what `ip link set <pf> vf <idx> mac 00:00:00:00:00:00`
+// writes; the kernel interprets it as "no admin MAC, let the VF use its
+// default" — which is exactly the post-cleanup state we want.
+func ClearVFAdminMAC(pfIface string, index uint8) error {
+	pf, err := netlink.LinkByName(pfIface)
+	if err != nil {
+		return fmt.Errorf("ClearVFAdminMAC: find PF %s: %w", pfIface, err)
+	}
+	zero := net.HardwareAddr{0, 0, 0, 0, 0, 0}
+	if err := netlink.LinkSetVfHardwareAddr(pf, int(index), zero); err != nil {
+		return fmt.Errorf("ClearVFAdminMAC: clear PF %s VF %d: %w",
+			pfIface, index, err)
 	}
 	return nil
 }

--- a/pkg/pillar/sriov/sriov_test.go
+++ b/pkg/pillar/sriov/sriov_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package sriov
+
+import (
+	"testing"
+)
+
+// TestParseVfIfaceName covers the round-trip with GetVfIfaceName plus a few
+// edge cases.  The previous implementation used fmt.Sscanf with "%svf%d",
+// which always returned ("", 0, error) because %s is greedy — regression
+// test guards against falling back to that.
+func TestParseVfIfaceName(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantIdx uint8
+		wantPF  string
+		wantErr bool
+	}{
+		{"basic", "eth2vf0", 0, "eth2", false},
+		{"two_digit", "eth3vf19", 19, "eth3", false},
+		{"five", "eth2vf5", 5, "eth2", false},
+		{"renamed_pf", "keth2vf7", 7, "keth2", false},
+		{"max_uint8", "ethxvf255", 255, "ethx", false},
+
+		// Failure modes — must error, not silently return zero.
+		{"no_vf_suffix", "eth2", 0, "", true},
+		{"empty", "", 0, "", true},
+		{"vf_only", "vf0", 0, "", true},
+		{"non_numeric", "eth2vfabc", 0, "", true},
+		{"overflow_uint8", "eth2vf256", 0, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			idx, pf, err := ParseVfIfaceName(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v, wantErr=%v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if idx != tc.wantIdx {
+				t.Errorf("idx=%d want %d", idx, tc.wantIdx)
+			}
+			if pf != tc.wantPF {
+				t.Errorf("pf=%q want %q", pf, tc.wantPF)
+			}
+		})
+	}
+}
+
+// TestParseVfIfaceNameRoundtrip ensures Parse(Get(idx, pf)) == (idx, pf) for
+// every plausible (PF, VF index) combination — protects against a future
+// rename mismatch between the two helpers.
+func TestParseVfIfaceNameRoundtrip(t *testing.T) {
+	pfs := []string{"eth0", "eth2", "keth2", "enp1s0f0"}
+	for _, pf := range pfs {
+		for _, idx := range []uint8{0, 1, 5, 19, 63, 255} {
+			name := GetVfIfaceName(idx, pf)
+			gotIdx, gotPF, err := ParseVfIfaceName(name)
+			if err != nil {
+				t.Errorf("PF=%s idx=%d name=%q parse error: %v", pf, idx, name, err)
+				continue
+			}
+			if gotIdx != idx || gotPF != pf {
+				t.Errorf("PF=%s idx=%d name=%q -> (%d, %q)", pf, idx, name, gotIdx, gotPF)
+			}
+		}
+	}
+}

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -365,6 +365,16 @@ func (ioType IoType) IsNet() bool {
 	}
 }
 
+// IsNetEthVF returns true when the adapter is an SR-IOV Virtual Function.
+// VFs are intentionally excluded from IsNet() because:
+//   - They must be bound to vfio-pci (pciback) regardless of testing mode.
+//   - They are never EVE network ports (keepInHost logic must not apply).
+//
+// Use this predicate wherever VF-specific behaviour is required.
+func (ioType IoType) IsNetEthVF() bool {
+	return ioType == IoNetEthVF
+}
+
 // Key is used with pubsub
 func (aa AssignableAdapters) Key() string {
 	return "global"


### PR DESCRIPTION
This commit reworks how EVE-Kubernetes assigns SR-IOV Virtual Functions to VM application instances.  Previously EVE used KubeVirt PCI HostDevices to pass VFs to VMs, which has two problems:

  1. KubeVirt's HostDevices path treats all VFs sharing a vendor:device tuple as a fungible pool.  When two VMs each request "1x VF from this NIC", KubeVirt cannot pin a specific VF (by BDF) to a specific VM, so the per-VF admin MAC programmed on the PF cannot be tied to the VM that ends up using that VF.

  2. When the device model lacks per-VF MAC user config (pf.Vfs.Data[i].Mac empty), the VF IoBundle MacAddr field inherits the parent PF's hardware MAC.  Combined with (1), every VM sharing the pool then observes the same MAC address inside the guest.

The new path attaches each VF to the VMI as a KubeVirt SR-IOV interface backed by a Multus NetworkAttachmentDefinition and the upstream sriov-network-device-plugin.  The device plugin tracks each VF by PCI BDF in a per-PF resource pool, so two VMs requesting the same pool get distinct VFs.  Each VMI also receives a stable, per-(app, VF) MAC.

Code changes
------------

pillar/hypervisor/kubevirt.go

  * CreateReplicaVMIConfig now buckets PCI assignments: SR-IOV VFs (IoNetEthVF) go through attachSRIOVInterfaces (Multus + sriov-cni); other PCI devices (GPUs, NVMe, USB controllers, plain NICs) keep the existing registerWithKV / HostDevices path.

  * registerWithKV is reduced to its non-VF responsibility: register vendor:device in KubeVirt's PermittedHostDevices CR and append the resource to vmi.Spec.Domain.Devices.HostDevices.  The SR-IOV-only scaffolding that used to live here — per-node SR-IOV capability labeling, the post-update wait for kubelet to advertise the new extended resource, and the helpers addSRIOVNodeSelectors, labelNodeForSRIOV, waitForKVDeviceResource, sriovNodeLabelKey — is removed; those are unreachable on the VF path and unnecessary on the non-VF path (waitForVMI in Start() already polls up to 15 min for the resource to become schedulable).  The kubeConfig and nodeName parameters are dropped from registerWithKV accordingly.

  * ensureSRIOVNAD creates one NetworkAttachmentDefinition per (PF, VLAN) in the eve-kube-app namespace.  The NAD's annotation k8s.v1.cni.cncf.io/resourceName tells Multus to ask the device plugin for a VF from the named pool; spec.config tells sriov-cni to bind it. Idempotent — refreshed only on content drift (e.g. VLAN change).

  * attachSRIOVInterfaces wires vmi.Spec.Domain.Devices.Interfaces[] with SRIOV binding and a Multus network reference, and sets MacAddress per VF.  MAC selection priority:

      1. IoBundle.MacAddr, when present and not a stale copy of the parent PF's hardware MAC.
      2. A deterministic locally-administered MAC generated via SHA-256(appUUID || vfBDF) with OUI 02:16:3E — same scheme zedrouter uses for switch-network VIFs (see ipam.go: generateAppMac).  Stable across reboots, unique per (app, VF).

    VfParams.PFIface is sourced from domainmgr's parse-time population
    (see below).  If a VF arrives without it set — e.g. because
    sriov_numvfs hadn't been written when the phyAdapter list was first
    processed on reboot — attachSRIOVInterfaces recovers via
    sriov.GetPFIfaceFromVFBDF before failing.

pillar/sriov/sriov.go

  * GetPFIfaceFromVFBDF resolves a VF's parent PF ifname via /sys/bus/pci/devices/<vf-bdf>/physfn/net/<ifname>.  Used by domainmgr to populate VfParams.PFIface for VFs that arrive without it (statically declared phyio entries that bypass createVfIoBundle).

  * BindVFToVfioPCI attaches a VF to the vfio-pci driver via driver_override + drivers_probe.  Required because EVE creates VFs with sriov_drivers_autoprobe=0 (so the host driver doesn't claim them), but the upstream sriov-network-device-plugin's default selector requires VFs to already be bound to vfio-pci before it advertises them as a kubelet resource.

pillar/cmd/domainmgr/domainmgr.go

  * checkAndFillIoBundle now populates VfParams.PFIface for IoNetEthVF bundles whose PFIface is empty, using sriov.GetPFIfaceFromVFBDF. This is best-effort: the VF may not yet exist in sysfs at parse time (e.g. on reboot before sriov_numvfs has been written), in which case attachSRIOVInterfaces falls back to the same helper at VMI-attach time.

  * setupVf binds each newly created VF to vfio-pci via sriov.BindVFToVfioPCI immediately after createVfIoBundle records it in AssignableAdapters.  Without this, the kube sriov-network-device-plugin's drivers=vfio-pci selector matches no VFs and the eve.network/<pf>_vfs resource is never advertised on the node, leaving VMIs unable to claim a VF.  Non-fatal per VF: a failure is logged and the loop continues so one bad VF does not block its siblings.

  * handlePhysicalIOAdapterListImpl now calls setupVf in the steady- state branch as well as the !Initialized first-pass branch. Without this, a controller publishing the device model in two phases — initial Vfs.Count=0, later bumped to N — leaves sriov_numvfs at 0 forever because setupVf was previously only invoked during AA initialization.  CreateVF is idempotent (returns early when numvfs already matches), so reconciling on every event is cheap and self-heals after kernel reboots reset sriov_numvfs to zero.

pillar/cmd/zedkube/sriov_devplugin.go (new)

  * reconcileSRIOVDevicePlugin projects the AssignableAdapters publication into the sriov-network-device-plugin ConfigMap (kube-system/sriovdp-config).  For each IoNetEthPF bundle with Vfs.Count > 0, builds one pool entry keyed by PF Ifname; vendor and device IDs are read from the first VF in sysfs (PFs and VFs have different IDs — VFs are what the plugin needs to enumerate).

  * On configuration drift, updates the ConfigMap and deletes only the local sriov-network-device-plugin pod (the DaemonSet recreates it, new pod re-reads the config).  Per-node delete avoids disrupting neighbours in multi-node clusters.

  * garbageCollectSRIOVNADs sweeps NetworkAttachmentDefinitions in eve-kube-app whose k8s.v1.cni.cncf.io/resourceName annotation references an SR-IOV pool that is no longer in the current AA projection.  Scoped by the eve.network/ resource-prefix so only NADs created by ensureSRIOVNAD are touched.  Runs after every successful ConfigMap reconcile, so removing a PF from the device model also cleans up its dangling NAD.

  * Self-healing: if z.config is nil at reconcile time (kube clientset not yet ready when the first AA event arrived), re-acquires kubeapi.GetKubeConfig() inside the reconciler so subsequent calls succeed without depending on a fresh AA event.

pillar/cmd/zedkube/zedkube.go

  * Subscribes to AssignableAdapters from domainmgr; routes Create/Modify/Delete to reconcileSRIOVDevicePlugin.

  * Adds a safety-net call on the existing kubeCfgTimer (60s period) that re-drives reconcile from the pubsub snapshot.  Guarantees eventual consistency even if the first AA Create event raced against k3s startup and the AA never republishes after that.

pkg/kube/sriov/ (new)

  * sriov-cni-daemonset.yaml — upstream sriov-cni DaemonSet that installs /opt/cni/bin/sriov on every amd64 node.

  * sriov-device-plugin.yaml — ServiceAccount and DaemonSet for the upstream sriov-network-device-plugin.  The sriovdp-config ConfigMap is intentionally NOT shipped here: k3s's deploy controller manages every resource defined under /var/lib/rancher/k3s/server/manifests/ and reverts any drift, which would undo zedkube's writes.  Instead zedkube's reconciler creates the ConfigMap on first run via the IsNotFound branch.

pkg/kube/cluster-init.sh

  * install_sriov_manifests gates manifest installation on /sys/bus/pci/devices/*/sriov_numvfs existing.  /sys/class/net is per-network-namespace and does not include host NICs from inside the kube container's netns; /sys/bus/pci is namespace-independent.

  * Hoisted out of the one-shot all_components_initialized guard and called every iteration of the main loop.  Makes EVE upgrades pick up new or updated manifests without requiring a cluster re-init. Idempotent via cp -u.

pkg/kube/Dockerfile

  * COPYs sriov/sriov-cni-daemonset.yaml and sriov-device-plugin.yaml into /etc/k3s-manifests/ so cluster-init.sh can stage them.

Backward compatibility
----------------------

  * Non-SR-IOV PCI passthrough is unchanged — IoNetEth (whole NICs), GPUs, NVMe, USB, etc. continue to flow through registerWithKV / KubeVirt PermittedHostDevices.





## How to test and validate this PR

1) Generate device model with something like this
        {
            "ztype": 11,  ----> VF type
            "phylabel": "eth1",
            "phyaddrs": {
                "Ifname": "eth1",
                "PciLong": "0000:02:00.1"
            },
            "logicallabel": "eth1",
            "assigngrp": "group18",
            "usage": 1,
            "cbattr": {},
            "usagePolicy": {},
            "cost": 0,
            "parentassigngrp": "",
            "vfs": {
              "count": 4. --->  number of VFs
            }
        },  

2) Define those VFs in device adapter menu in Controller as AppDirect
3) Deploy one or more VMs and pick those VFs. I tried 3 VMs.
4) Verify that in Kubernetes config map is generated and resourceLIst is auto populated.
[kube] root@59263949-dcff-489f-a832-4c60469b3955:/$ kubectl describe cm sriovdp-config -n kube-system
Name:         sriovdp-config
Namespace:    kube-system
Labels:       <none>
Annotations:  <none>

Data
====
config.json:
----
{
  "resourceList": [
    {
      "resourceName": "eth1_vfs",           ==> this is eth1 with 4VFs
      "resourcePrefix": "eve.network",
      "selectors": {
        "vendors": [
          "8086"
        ],
        "devices": [
          "1520"
        ],
        "drivers": [
          "vfio-pci"
        ],
        "pfNames": [
          "eth1"
        ]
      }
    }
  ]
}

4) Verify the eth1 interface shows all VFs and unique MAC for every VM.
[kube] root@59263949-dcff-489f-a832-4c60469b3955:/$ ip link show eth1
5: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 94:40:c9:4b:37:41 brd ff:ff:ff:ff:ff:ff
    vf 0     link/ether 02:16:3e:98:7d:04 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
    vf 1     link/ether 02:16:3e:78:5a:8e brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
    vf 2     link/ether 02:16:3e:7a:cc:14 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
    vf 3     link/ether 00:00:00:00:00:00 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off

5) Login into VM and verify IP addresses got assigned on VF interface and also can ping other VMs or run iperf test.
6) Reboot the device and verify the MAC addresses did not change for VM so that IP addressed stay same.


I have not tested failovers yet. 

## Changelog notes

Users can now use SRIOV-VFs to passthrough to VMs in eve-k



- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've written the test verification instructions



And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
