### PR TITLE
Fix CSR attribute ordering for SCEP enrollment

### DIFF
--- a/pkg/pillar/cmd/scepclient/scep.go
+++ b/pkg/pillar/cmd/scepclient/scep.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
+	_ "crypto/sha512" // register SHA384 and SHA512 for CSR signing
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -38,7 +39,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
 	"github.com/smallstep/pkcs7"
 	"github.com/smallstep/scep"
-	"github.com/smallstep/scep/x509util"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -1065,23 +1065,122 @@ func (c *SCEPClient) decryptChallengePassword(
 	return decBlock.SCEPChallengePassword, nil
 }
 
+// ASN.1 structures mirroring the Go stdlib x509 package internals,
+// used to manipulate raw CSR bytes for attribute reordering.
+type csrPublicKeyInfo struct {
+	Raw       asn1.RawContent
+	Algorithm pkix.AlgorithmIdentifier
+	PublicKey asn1.BitString
+}
+
+type csrTBSCertificateRequest struct {
+	Raw           asn1.RawContent
+	Version       int
+	Subject       asn1.RawValue
+	PublicKey     csrPublicKeyInfo
+	RawAttributes []asn1.RawValue `asn1:"tag:0"`
+}
+
+type csrCertificateRequest struct {
+	Raw                asn1.RawContent
+	TBSCSR             csrTBSCertificateRequest
+	SignatureAlgorithm pkix.AlgorithmIdentifier
+	SignatureValue     asn1.BitString
+}
+
+type csrChallengePasswordAttribute struct {
+	Type  asn1.ObjectIdentifier
+	Value []string `asn1:"set"`
+}
+
+var oidChallengePassword = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 7}
+
+// PrependChallengePassword inserts the challengePassword attribute as the first
+// attribute in the CSR DER, before the Extension Request attribute. Some SCEP
+// servers require this ordering and reject CSRs where it appears after extensions.
+func PrependChallengePassword(derBytes []byte, challenge string,
+	sigAlgo x509.SignatureAlgorithm, key crypto.Signer) ([]byte, error) {
+	var req csrCertificateRequest
+	rest, err := asn1.Unmarshal(derBytes, &req)
+	if err != nil {
+		return nil, err
+	}
+	if len(rest) != 0 {
+		return nil, errors.New("trailing data after CSR")
+	}
+
+	attr := csrChallengePasswordAttribute{
+		Type:  oidChallengePassword,
+		Value: []string{challenge},
+	}
+	attrBytes, err := asn1.Marshal(attr)
+	if err != nil {
+		return nil, err
+	}
+	var rawAttr asn1.RawValue
+	if _, err = asn1.Unmarshal(attrBytes, &rawAttr); err != nil {
+		return nil, err
+	}
+
+	tbsCSR := csrTBSCertificateRequest{
+		Version:       0,
+		Subject:       req.TBSCSR.Subject,
+		PublicKey:     req.TBSCSR.PublicKey,
+		RawAttributes: append([]asn1.RawValue{rawAttr}, req.TBSCSR.RawAttributes...),
+	}
+	tbsBytes, err := asn1.Marshal(tbsCSR)
+	if err != nil {
+		return nil, err
+	}
+
+	hashFunc, err := hashFuncForSignatureAlgorithm(sigAlgo)
+	if err != nil {
+		return nil, err
+	}
+	h := hashFunc.New()
+	h.Write(tbsBytes)
+	sig, err := key.Sign(rand.Reader, h.Sum(nil), hashFunc)
+	if err != nil {
+		return nil, err
+	}
+
+	return asn1.Marshal(csrCertificateRequest{
+		TBSCSR:             tbsCSR,
+		SignatureAlgorithm: req.SignatureAlgorithm,
+		SignatureValue: asn1.BitString{
+			Bytes:     sig,
+			BitLength: len(sig) * 8,
+		},
+	})
+}
+
+func hashFuncForSignatureAlgorithm(sigAlgo x509.SignatureAlgorithm) (crypto.Hash, error) {
+	switch sigAlgo {
+	case x509.SHA256WithRSA, x509.ECDSAWithSHA256:
+		return crypto.SHA256, nil
+	case x509.SHA384WithRSA, x509.ECDSAWithSHA384:
+		return crypto.SHA384, nil
+	case x509.SHA512WithRSA, x509.ECDSAWithSHA512:
+		return crypto.SHA512, nil
+	default:
+		return 0, fmt.Errorf("unsupported signature algorithm: %v", sigAlgo)
+	}
+}
+
 func (c *SCEPClient) makeCSR(profile types.CSRProfile, privateKey SignerAndDecrypter,
 	challengePassword string) (*x509.CertificateRequest, error) {
-	template := &x509util.CertificateRequest{
-		CertificateRequest: x509.CertificateRequest{
-			Subject: pkix.Name{
-				CommonName:         profile.Subject.CommonName,
-				Organization:       profile.Subject.Organization,
-				OrganizationalUnit: profile.Subject.OrganizationalUnit,
-				Country:            profile.Subject.Country,
-				Province:           profile.Subject.State,
-				Locality:           profile.Subject.Locality,
-			},
-			DNSNames:       profile.SAN.DNSNames,
-			EmailAddresses: profile.SAN.EmailAddresses,
-			IPAddresses:    profile.SAN.IPAddresses,
+	template := &x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName:         profile.Subject.CommonName,
+			Organization:       profile.Subject.Organization,
+			OrganizationalUnit: profile.Subject.OrganizationalUnit,
+			Country:            profile.Subject.Country,
+			Province:           profile.Subject.State,
+			Locality:           profile.Subject.Locality,
 		},
-		ChallengePassword: challengePassword,
+		DNSNames:       profile.SAN.DNSNames,
+		EmailAddresses: profile.SAN.EmailAddresses,
+		IPAddresses:    profile.SAN.IPAddresses,
 	}
 	for _, uriStr := range profile.SAN.URIs {
 		// url.Parse implements a generic RFC 3986 URI parser (despite the name).
@@ -1108,9 +1207,15 @@ func (c *SCEPClient) makeCSR(profile types.CSRProfile, privateKey SignerAndDecry
 	template.SignatureAlgorithm = sigAlg
 
 	// Create CSR
-	csrDER, err := x509util.CreateCertificateRequest(rand.Reader, template, privateKey)
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, template, privateKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CSR: %w", err)
+	}
+	if challengePassword != "" {
+		csrDER, err = PrependChallengePassword(csrDER, challengePassword, sigAlg, privateKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to add challenge password to CSR: %w", err)
+		}
 	}
 	csr, err := x509.ParseCertificateRequest(csrDER)
 	if err != nil {

--- a/pkg/pillar/cmd/scepclient/scep_test.go
+++ b/pkg/pillar/cmd/scepclient/scep_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package scepclient_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"net/url"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/cmd/scepclient"
+)
+
+var (
+	oidChallengePassword = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 7}
+	oidExtensionRequest  = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 14}
+)
+
+// TestPrependChallengePassword verifies that PrependChallengePassword:
+//   - produces a CSR whose self-signature validates,
+//   - places challengePassword as the first attribute,
+//   - places Extension Request (SAN) as the second attribute,
+//   - preserves SAN entries from the original CSR.
+func TestPrependChallengePassword(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	sanURI, _ := url.Parse("urn:serial:TEST123")
+	template := &x509.CertificateRequest{
+		Subject:            pkix.Name{CommonName: "test-device"},
+		URIs:               []*url.URL{sanURI},
+		SignatureAlgorithm: x509.SHA256WithRSA,
+	}
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, template, key)
+	if err != nil {
+		t.Fatalf("create CSR: %v", err)
+	}
+
+	fixedDER, err := scepclient.PrependChallengePassword(csrDER, "s3cret", x509.SHA256WithRSA, key)
+	if err != nil {
+		t.Fatalf("PrependChallengePassword: %v", err)
+	}
+
+	// Signature must validate.
+	csr, err := x509.ParseCertificateRequest(fixedDER)
+	if err != nil {
+		t.Fatalf("parse fixed CSR: %v", err)
+	}
+	if err = csr.CheckSignature(); err != nil {
+		t.Fatalf("signature invalid: %v", err)
+	}
+
+	// Parse raw attributes to verify ordering.
+	type tbsCertReq struct {
+		Raw           asn1.RawContent
+		Version       int
+		Subject       asn1.RawValue
+		PublicKey     asn1.RawValue
+		RawAttributes []asn1.RawValue `asn1:"tag:0"`
+	}
+	type certReq struct {
+		Raw      asn1.RawContent
+		TBS      tbsCertReq
+		SigAlg   asn1.RawValue
+		SigValue asn1.BitString
+	}
+	var req certReq
+	if _, err = asn1.Unmarshal(fixedDER, &req); err != nil {
+		t.Fatalf("unmarshal fixed CSR: %v", err)
+	}
+	attrs := req.TBS.RawAttributes
+	if len(attrs) < 2 {
+		t.Fatalf("expected at least 2 attributes, got %d", len(attrs))
+	}
+
+	attrOID := func(raw asn1.RawValue) asn1.ObjectIdentifier {
+		var attr struct {
+			Type  asn1.ObjectIdentifier
+			Value asn1.RawValue `asn1:"set"`
+		}
+		if _, err := asn1.Unmarshal(raw.FullBytes, &attr); err != nil {
+			t.Fatalf("unmarshal attribute: %v", err)
+		}
+		return attr.Type
+	}
+
+	if !attrOID(attrs[0]).Equal(oidChallengePassword) {
+		t.Errorf("first attribute = %v, want challengePassword", attrOID(attrs[0]))
+	}
+	if !attrOID(attrs[1]).Equal(oidExtensionRequest) {
+		t.Errorf("second attribute = %v, want extensionRequest", attrOID(attrs[1]))
+	}
+
+	// SAN URI must be preserved.
+	if len(csr.URIs) != 1 || csr.URIs[0].String() != sanURI.String() {
+		t.Errorf("SAN URIs = %v, want [%s]", csr.URIs, sanURI)
+	}
+}


### PR DESCRIPTION
# Description

Some SCEP servers (e.g. [Sectigo/cert-manager](https://www.sectigo.com/)) require the `challengePassword` attribute to appear before all the Extension Request attributes (e.g. SAN attributes) in the CSR. The `smallstep/scep`'s `x509util.CreateCertificateRequest` appends `challengePassword` after Extension Requests, causing enrollment to fail.

Fix by calling `x509.CreateCertificateRequest` directly (dropping the `x509util` wrapper) and prepending `challengePassword` manually to the raw CSR DER before the Extension Request, then re-signing the certificate request.

## How to test and validate this PR

Not every SCEP server requires that the `challengePassword` precedes Extension Request attributes.
For example, https://github.com/micromdm/scep is fine with any order.
However, if you are for example using Certificate Manager from [sectigo](https://www.sectigo.com/), and configure SCEP profile with some SAN attributes, the enrollment would fail without this patch with an error `badRequest (2)`.

## Changelog notes

Fixed SCEP certificate enrollment failing due to incorrect CSR attribute ordering: the challenge password attribute is now placed before the certificate extensions, as required by some SCEP servers.

## PR Backports

```text
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.