### PR TITLE
nodeagent: add Phase-1 unit tests + refactor

### DIFF
--- a/pkg/pillar/cmd/nodeagent/handlers_test.go
+++ b/pkg/pillar/cmd/nodeagent/handlers_test.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagent
+
+import (
+	"testing"
+
+	uuid "github.com/satori/go.uuid"
+
+	"github.com/lf-edge/eve-api/go/info"
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// --- handleVolumeMgrStatusImpl --------------------------------------
+
+func TestVolumeMgrStatus_NoSpaceAddsReason(t *testing.T) {
+	tc := newTestCtx()
+	handleVolumeMgrStatusImpl(tc.ctx, "global",
+		types.VolumeMgrStatus{RemainingSpace: 0})
+
+	if !tc.ctx.maintMode {
+		t.Fatalf("expected MaintenanceMode set when RemainingSpace=0")
+	}
+	if !hasReason(tc.ctx.maintModeReasons,
+		types.MaintenanceModeReasonNoDiskSpace) {
+		t.Errorf("expected NoDiskSpace reason, got %v",
+			tc.ctx.maintModeReasons)
+	}
+}
+
+func TestVolumeMgrStatus_SpaceClearsReason(t *testing.T) {
+	tc := newTestCtx()
+	addMaintenanceModeReason(tc.ctx,
+		types.MaintenanceModeReasonNoDiskSpace, "fixture")
+
+	handleVolumeMgrStatusImpl(tc.ctx, "global",
+		types.VolumeMgrStatus{RemainingSpace: 1 << 30})
+
+	if tc.ctx.maintMode {
+		t.Errorf("expected MaintenanceMode cleared once space returned")
+	}
+}
+
+// --- handleTpmStatusImpl --------------------------------------------
+
+func TestTpmStatus_EncFailureAddsReason(t *testing.T) {
+	tc := newTestCtx()
+	handleTpmStatusImpl(tc.ctx, "global", types.TpmSanityStatus{
+		Status: types.MaintenanceModeReasonTpmEncFailure,
+	})
+
+	if !hasReason(tc.ctx.maintModeReasons,
+		types.MaintenanceModeReasonTpmEncFailure) {
+		t.Errorf("expected TpmEncFailure reason, got %v",
+			tc.ctx.maintModeReasons)
+	}
+}
+
+func TestTpmStatus_OkClearsReason(t *testing.T) {
+	tc := newTestCtx()
+	addMaintenanceModeReason(tc.ctx,
+		types.MaintenanceModeReasonTpmEncFailure, "fixture")
+
+	handleTpmStatusImpl(tc.ctx, "global", types.TpmSanityStatus{
+		Status: types.MaintenanceModeReasonNone,
+	})
+
+	if hasReason(tc.ctx.maintModeReasons,
+		types.MaintenanceModeReasonTpmEncFailure) {
+		t.Errorf("TpmEncFailure should be cleared, got %v",
+			tc.ctx.maintModeReasons)
+	}
+}
+
+// --- handleVaultStatusImpl ------------------------------------------
+
+func TestVaultStatus_OtherVaultIgnored(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.vaultOperational = types.TS_DISABLED
+
+	handleVaultStatusImpl(tc.ctx, "global", types.VaultStatus{
+		Name:               "some-other-vault",
+		Status:             info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED,
+		ConversionComplete: true,
+	})
+
+	// Untouched because Name != DefaultVaultName.
+	if tc.ctx.vaultOperational != types.TS_DISABLED {
+		t.Errorf("expected vaultOperational unchanged for irrelevant vault")
+	}
+}
+
+func TestVaultStatus_DefaultVaultEnabled(t *testing.T) {
+	tc := newTestCtx()
+	addMaintenanceModeReason(tc.ctx,
+		types.MaintenanceModeReasonVaultLockedUp, "fixture")
+	tc.ctx.vaultOperational = types.TS_NONE
+
+	handleVaultStatusImpl(tc.ctx, "global", types.VaultStatus{
+		Name:               types.DefaultVaultName,
+		Status:             info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED,
+		ConversionComplete: true,
+	})
+
+	if tc.ctx.vaultOperational != types.TS_ENABLED {
+		t.Errorf("expected TS_ENABLED, got %v", tc.ctx.vaultOperational)
+	}
+	if hasReason(tc.ctx.maintModeReasons,
+		types.MaintenanceModeReasonVaultLockedUp) {
+		t.Errorf("VaultLockedUp should be cleared once vault is enabled")
+	}
+}
+
+func TestVaultStatus_DefaultVaultError(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.vaultOperational = types.TS_ENABLED
+
+	handleVaultStatusImpl(tc.ctx, "global", types.VaultStatus{
+		Name:   types.DefaultVaultName,
+		Status: info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR,
+	})
+
+	if tc.ctx.vaultOperational != types.TS_DISABLED {
+		t.Errorf("expected TS_DISABLED on error, got %v",
+			tc.ctx.vaultOperational)
+	}
+}
+
+func TestVaultStatus_RecordsTestStartOnFirstReport(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.timeTickCount = 42
+	tc.ctx.vaultmgrReported = false
+	tc.ctx.vaultTestStartTime = 0
+
+	handleVaultStatusImpl(tc.ctx, "global", types.VaultStatus{
+		Name:               "some-vault",
+		Status:             info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED,
+		ConversionComplete: true,
+	})
+
+	if !tc.ctx.vaultmgrReported {
+		t.Errorf("expected vaultmgrReported=true after first report")
+	}
+	if tc.ctx.vaultTestStartTime != 42 {
+		t.Errorf("expected vaultTestStartTime=42, got %d",
+			tc.ctx.vaultTestStartTime)
+	}
+}
+
+// --- handleNodeDrainStatusImpl --------------------------------------
+
+func TestNodeDrain_NonDeviceOpIgnored(t *testing.T) {
+	tc := newTestCtx()
+	handleNodeDrainStatusImpl(tc.ctx, "global", kubeapi.NodeDrainStatus{
+		Status:      kubeapi.REQUESTED,
+		RequestedBy: kubeapi.UPDATE,
+	}, nil)
+	if tc.ctx.waitDrainInProgress {
+		t.Errorf("non-DEVICEOP drain should be ignored")
+	}
+}
+
+func TestNodeDrain_DeviceOpInProgress(t *testing.T) {
+	tc := newTestCtx()
+	handleNodeDrainStatusImpl(tc.ctx, "global", kubeapi.NodeDrainStatus{
+		Status:      kubeapi.STARTING,
+		RequestedBy: kubeapi.DEVICEOP,
+	}, nil)
+	if !tc.ctx.waitDrainInProgress {
+		t.Errorf("expected waitDrainInProgress=true")
+	}
+}
+
+func TestNodeDrain_DeviceOpComplete(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.waitDrainInProgress = true
+
+	handleNodeDrainStatusImpl(tc.ctx, "global", kubeapi.NodeDrainStatus{
+		Status:      kubeapi.COMPLETE,
+		RequestedBy: kubeapi.DEVICEOP,
+	}, nil)
+	if tc.ctx.waitDrainInProgress {
+		t.Errorf("expected waitDrainInProgress=false after COMPLETE")
+	}
+}
+
+// --- allDomainsHalted -----------------------------------------------
+
+func TestAllDomainsHalted_Empty(t *testing.T) {
+	tc := newTestCtx()
+	if !allDomainsHalted(tc.ctx) {
+		t.Errorf("empty domain set should be considered halted")
+	}
+}
+
+func TestAllDomainsHalted_OneActivated(t *testing.T) {
+	tc := newTestCtx()
+	tc.subDomainStatus.items["app1"] = types.DomainStatus{
+		UUIDandVersion: types.UUIDandVersion{UUID: uuid.UUID{}},
+		DisplayName:    "app1",
+		Activated:      true,
+	}
+	if allDomainsHalted(tc.ctx) {
+		t.Errorf("activated domain should prevent halt")
+	}
+}
+
+func TestAllDomainsHalted_AllDeactivated(t *testing.T) {
+	tc := newTestCtx()
+	tc.subDomainStatus.items["app1"] = types.DomainStatus{
+		DisplayName: "app1", Activated: false,
+	}
+	tc.subDomainStatus.items["app2"] = types.DomainStatus{
+		DisplayName: "app2", Activated: false,
+	}
+	if !allDomainsHalted(tc.ctx) {
+		t.Errorf("all-deactivated domain set should be considered halted")
+	}
+}
+
+func hasReason(rs types.MaintenanceModeMultiReason,
+	want types.MaintenanceModeReason) bool {
+	for _, r := range rs {
+		if r == want {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/pillar/cmd/nodeagent/handletimers.go
+++ b/pkg/pillar/cmd/nodeagent/handletimers.go
@@ -299,7 +299,7 @@ func scheduleNodeOperation(ctxPtr *nodeagentContext, requestedReasonStr string, 
 	// in any case, execute the reboot procedure
 	// with a delayed timer
 	log.Functionf("Creating %s at %s", "scheduleNodeOperation", agentlog.GetMyStack())
-	go handleNodeOperation(ctxPtr, op)
+	ctxPtr.startNodeOperation(op)
 }
 
 func allDomainsHalted(ctxPtr *nodeagentContext) bool {

--- a/pkg/pillar/cmd/nodeagent/handletimers_test.go
+++ b/pkg/pillar/cmd/nodeagent/handletimers_test.go
@@ -1,0 +1,299 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagent
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// --- handleFallbackOnCloudDisconnect ---------------------------------
+
+func TestFallbackOnCloudDisconnect_NoUpgrade(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.updateInprogress = false
+
+	handleFallbackOnCloudDisconnect(tc.ctx)
+
+	if len(tc.scheduledOps) != 0 {
+		t.Fatalf("no upgrade in progress: should not schedule reboot")
+	}
+}
+
+func TestFallbackOnCloudDisconnect_WithinLimit(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.updateInprogress = true
+	limit := tc.ctx.globalConfig.GlobalValueInt(types.FallbackIfCloudGoneTime)
+	tc.ctx.timeTickCount = limit / 2
+	tc.ctx.lastControllerReachableTime = 0
+
+	handleFallbackOnCloudDisconnect(tc.ctx)
+
+	if len(tc.scheduledOps) != 0 {
+		t.Fatalf("within fallback window: should not schedule reboot")
+	}
+}
+
+func TestFallbackOnCloudDisconnect_Exceeded(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.updateInprogress = true
+	limit := tc.ctx.globalConfig.GlobalValueInt(types.FallbackIfCloudGoneTime)
+	tc.ctx.timeTickCount = limit + 100
+	tc.ctx.lastControllerReachableTime = 0
+
+	handleFallbackOnCloudDisconnect(tc.ctx)
+
+	if len(tc.scheduledOps) != 1 {
+		t.Fatalf("expected 1 reboot scheduled, got %d", len(tc.scheduledOps))
+	}
+	got := tc.scheduledOps[0]
+	if got.op != types.DeviceOperationReboot {
+		t.Errorf("expected reboot op, got %v", got.op)
+	}
+	if got.bootRsn != types.BootReasonFallback {
+		t.Errorf("expected BootReasonFallback, got %v", got.bootRsn)
+	}
+}
+
+// --- handleResetOnCloudDisconnect ------------------------------------
+
+func TestResetOnCloudDisconnect_WithinLimit(t *testing.T) {
+	tc := newTestCtx()
+	limit := tc.ctx.globalConfig.GlobalValueInt(types.ResetIfCloudGoneTime)
+	tc.ctx.timeTickCount = limit / 2
+
+	handleResetOnCloudDisconnect(tc.ctx)
+
+	if len(tc.scheduledOps) != 0 {
+		t.Fatalf("within reset window: should not schedule reboot")
+	}
+}
+
+func TestResetOnCloudDisconnect_Exceeded(t *testing.T) {
+	tc := newTestCtx()
+	limit := tc.ctx.globalConfig.GlobalValueInt(types.ResetIfCloudGoneTime)
+	tc.ctx.timeTickCount = limit + 1
+	tc.ctx.lastControllerReachableTime = 0
+
+	handleResetOnCloudDisconnect(tc.ctx)
+
+	if len(tc.scheduledOps) != 1 {
+		t.Fatalf("expected reboot scheduled, got %d", len(tc.scheduledOps))
+	}
+	if got := tc.scheduledOps[0]; got.bootRsn != types.BootReasonDisconnect {
+		t.Errorf("expected BootReasonDisconnect, got %v", got.bootRsn)
+	}
+}
+
+// --- handleRebootOnVaultLocked ---------------------------------------
+
+func TestRebootOnVaultLocked_VaultEnabled(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.vaultOperational = types.TS_ENABLED
+
+	handleRebootOnVaultLocked(tc.ctx)
+
+	if len(tc.scheduledOps) != 0 || tc.ctx.maintMode {
+		t.Fatalf("vault enabled: should be no-op")
+	}
+}
+
+func TestRebootOnVaultLocked_WithinCutoff(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.vaultOperational = types.TS_DISABLED
+	tc.ctx.vaultmgrReported = true
+	tc.ctx.configGetSuccess = true
+	cutoff := tc.ctx.globalConfig.GlobalValueInt(types.VaultReadyCutOffTime)
+	tc.ctx.vaultTestStartTime = 0
+	tc.ctx.timeTickCount = cutoff / 2
+
+	handleRebootOnVaultLocked(tc.ctx)
+
+	if len(tc.scheduledOps) != 0 || tc.ctx.maintMode {
+		t.Fatalf("within cutoff: should be no-op")
+	}
+}
+
+func TestRebootOnVaultLocked_ExceededWithUpgrade(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.vaultOperational = types.TS_DISABLED
+	tc.ctx.vaultmgrReported = true
+	tc.ctx.configGetSuccess = true
+	tc.ctx.updateInprogress = true
+	cutoff := tc.ctx.globalConfig.GlobalValueInt(types.VaultReadyCutOffTime)
+	tc.ctx.vaultTestStartTime = 0
+	tc.ctx.timeTickCount = cutoff + 1
+
+	handleRebootOnVaultLocked(tc.ctx)
+
+	if len(tc.scheduledOps) != 1 {
+		t.Fatalf("expected reboot, got %d ops", len(tc.scheduledOps))
+	}
+	if got := tc.scheduledOps[0]; got.bootRsn != types.BootReasonVaultFailure {
+		t.Errorf("expected BootReasonVaultFailure, got %v", got.bootRsn)
+	}
+	if tc.ctx.maintMode {
+		t.Errorf("maintMode should not be set when an upgrade is in flight")
+	}
+}
+
+func TestRebootOnVaultLocked_ExceededWithoutUpgrade(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.vaultOperational = types.TS_DISABLED
+	tc.ctx.vaultmgrReported = true
+	tc.ctx.configGetSuccess = true
+	tc.ctx.updateInprogress = false
+	cutoff := tc.ctx.globalConfig.GlobalValueInt(types.VaultReadyCutOffTime)
+	tc.ctx.vaultTestStartTime = 0
+	tc.ctx.timeTickCount = cutoff + 1
+
+	handleRebootOnVaultLocked(tc.ctx)
+
+	if len(tc.scheduledOps) != 0 {
+		t.Errorf("no upgrade: should enter maintenance, not reboot")
+	}
+	if !tc.ctx.maintMode {
+		t.Errorf("expected MaintenanceMode set")
+	}
+	found := false
+	for _, r := range tc.ctx.maintModeReasons {
+		if r == types.MaintenanceModeReasonVaultLockedUp {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected VaultLockedUp reason, got %v",
+			tc.ctx.maintModeReasons)
+	}
+}
+
+// --- handleUpgradeTestValidation -------------------------------------
+
+func TestUpgradeTestValidation_NotInProgress(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.testInprogress = false
+
+	handleUpgradeTestValidation(tc.ctx)
+
+	// Nothing to assert beyond no panic and no reboot scheduled.
+	if len(tc.scheduledOps) != 0 {
+		t.Fatalf("test not in progress: should not schedule reboot")
+	}
+}
+
+func TestUpgradeTestValidation_StillCounting(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.testInprogress = true
+	tc.ctx.updateInprogress = true
+	tc.ctx.curPart = "IMGA"
+	limit := tc.ctx.globalConfig.GlobalValueInt(types.MintimeUpdateSuccess)
+	tc.ctx.upgradeTestStartTime = 0
+	tc.ctx.timeTickCount = limit / 2
+
+	handleUpgradeTestValidation(tc.ctx)
+
+	if tc.ctx.testComplete {
+		t.Errorf("test should not be complete yet")
+	}
+	if tc.ctx.remainingTestTime <= 0 {
+		t.Errorf("remainingTestTime should be > 0, got %v",
+			tc.ctx.remainingTestTime)
+	}
+}
+
+func TestUpgradeTestValidation_Expires(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.testInprogress = true
+	tc.ctx.updateInprogress = true
+	tc.ctx.curPart = "IMGA"
+	// Pre-populate the ZbootConfig that initiateBaseOsControllerTestComplete
+	// will read+update.
+	tc.pubZbootConfig.items["IMGA"] = types.ZbootConfig{
+		PartitionLabel: "IMGA", TestComplete: false,
+	}
+	tc.subZbootStatus.items["IMGA"] = types.ZbootStatus{
+		PartitionLabel: "IMGA", CurrentPartition: true,
+		PartitionState: "inprogress", ShortVersion: "v2",
+	}
+	limit := tc.ctx.globalConfig.GlobalValueInt(types.MintimeUpdateSuccess)
+	tc.ctx.upgradeTestStartTime = 0
+	tc.ctx.timeTickCount = limit + 1
+
+	handleUpgradeTestValidation(tc.ctx)
+
+	if !tc.ctx.testComplete {
+		t.Errorf("expected testComplete=true after expiry")
+	}
+	got, _ := tc.pubZbootConfig.items["IMGA"].(types.ZbootConfig)
+	if !got.TestComplete {
+		t.Errorf("expected ZbootConfig.TestComplete=true, got %+v", got)
+	}
+}
+
+// --- updateTickerTime + handleDeviceTimers integration ---------------
+
+func TestUpdateTickerTime_Advances(t *testing.T) {
+	tc := newTestCtx()
+	before := tc.ctx.timeTickCount
+	updateTickerTime(tc.ctx)
+	if tc.ctx.timeTickCount != before+timeTickInterval {
+		t.Errorf("timeTickCount should advance by %d, got %d → %d",
+			timeTickInterval, before, tc.ctx.timeTickCount)
+	}
+}
+
+func TestUpdateTickerTime_ConfigGetSuccessRefreshes(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.timeTickCount = 100
+	tc.ctx.configGetStatus = types.ConfigGetSuccess
+
+	updateTickerTime(tc.ctx)
+
+	if tc.ctx.lastControllerReachableTime != tc.ctx.timeTickCount {
+		t.Errorf("lastControllerReachableTime should be refreshed to %d, got %d",
+			tc.ctx.timeTickCount, tc.ctx.lastControllerReachableTime)
+	}
+}
+
+// --- pubsub publish smoke check --------------------------------------
+//
+// Ensures the recorded reason on a scheduled op survives the
+// publishNodeAgentStatus call inside scheduleNodeOperation.
+func TestScheduleNodeOperation_PublishesStatus(t *testing.T) {
+	tc := newTestCtx()
+	scheduleNodeOperation(tc.ctx, "test-reason",
+		types.BootReasonRebootCmd, types.DeviceOperationReboot)
+
+	if len(tc.scheduledOps) != 1 {
+		t.Fatalf("expected exactly 1 scheduled op, got %d",
+			len(tc.scheduledOps))
+	}
+	pub, _ := tc.pubNodeAgentStatus.items["nodeagent"].(types.NodeAgentStatus)
+	if !pub.DeviceReboot {
+		t.Errorf("expected DeviceReboot=true in published status")
+	}
+	if !strings.Contains(tc.scheduledOps[0].reason, "test-reason") {
+		t.Errorf("expected scheduled reason to contain test-reason, got %q",
+			tc.scheduledOps[0].reason)
+	}
+}
+
+func TestScheduleNodeOperation_Idempotent(t *testing.T) {
+	tc := newTestCtx()
+	scheduleNodeOperation(tc.ctx, "r", types.BootReasonRebootCmd,
+		types.DeviceOperationReboot)
+	scheduleNodeOperation(tc.ctx, "r", types.BootReasonRebootCmd,
+		types.DeviceOperationReboot)
+
+	if len(tc.scheduledOps) != 1 {
+		t.Errorf("second reboot schedule should be a no-op, got %d ops",
+			len(tc.scheduledOps))
+	}
+}
+
+// silence "imported and not used" if a future edit drops time usage
+var _ = time.Second

--- a/pkg/pillar/cmd/nodeagent/helpers_test.go
+++ b/pkg/pillar/cmd/nodeagent/helpers_test.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagent
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
+)
+
+// initTestLog initialises the package-level log so tests can call
+// production helpers that log unconditionally. Idempotent.
+func initTestLog() {
+	if log != nil {
+		return
+	}
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+	log = base.NewSourceLogObject(logger, "nodeagent_test", 1)
+}

--- a/pkg/pillar/cmd/nodeagent/maintmode_test.go
+++ b/pkg/pillar/cmd/nodeagent/maintmode_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagent
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func TestMaintenanceMode_AddAndRemove(t *testing.T) {
+	initTestLog()
+	ctx := &nodeagentContext{}
+
+	addMaintenanceModeReason(ctx,
+		types.MaintenanceModeReasonNoDiskSpace, "test")
+	if !ctx.maintMode {
+		t.Fatal("maintMode should be true after add")
+	}
+	if got := len(ctx.maintModeReasons); got != 1 {
+		t.Fatalf("expected 1 reason, got %d", got)
+	}
+
+	// Adding the same reason a second time is a no-op.
+	addMaintenanceModeReason(ctx,
+		types.MaintenanceModeReasonNoDiskSpace, "test")
+	if got := len(ctx.maintModeReasons); got != 1 {
+		t.Fatalf("idempotent add expected 1 reason, got %d", got)
+	}
+
+	removeMaintenanceModeReason(ctx,
+		types.MaintenanceModeReasonNoDiskSpace, "test")
+	if ctx.maintMode {
+		t.Fatal("maintMode should be cleared after last reason removed")
+	}
+	if got := len(ctx.maintModeReasons); got != 0 {
+		t.Fatalf("expected 0 reasons, got %d", got)
+	}
+}
+
+func TestMaintenanceMode_MultipleReasons(t *testing.T) {
+	initTestLog()
+	ctx := &nodeagentContext{}
+
+	addMaintenanceModeReason(ctx,
+		types.MaintenanceModeReasonNoDiskSpace, "test")
+	addMaintenanceModeReason(ctx,
+		types.MaintenanceModeReasonVaultLockedUp, "test")
+
+	// Removing one keeps maintMode true while another remains.
+	removeMaintenanceModeReason(ctx,
+		types.MaintenanceModeReasonNoDiskSpace, "test")
+	if !ctx.maintMode {
+		t.Fatal("maintMode should remain true while another reason is set")
+	}
+	if got := len(ctx.maintModeReasons); got != 1 {
+		t.Fatalf("expected 1 remaining reason, got %d", got)
+	}
+	if ctx.maintModeReasons[0] != types.MaintenanceModeReasonVaultLockedUp {
+		t.Fatalf("expected VaultLockedUp to remain, got %v",
+			ctx.maintModeReasons[0])
+	}
+
+	removeMaintenanceModeReason(ctx,
+		types.MaintenanceModeReasonVaultLockedUp, "test")
+	if ctx.maintMode {
+		t.Fatal("maintMode should be cleared after last reason removed")
+	}
+}
+
+func TestMaintenanceMode_RemoveFromEmpty(t *testing.T) {
+	initTestLog()
+	ctx := &nodeagentContext{}
+
+	// No-op; in particular, must not flip maintMode true.
+	removeMaintenanceModeReason(ctx,
+		types.MaintenanceModeReasonNoDiskSpace, "test")
+	if ctx.maintMode {
+		t.Fatal("maintMode unexpectedly set after remove on empty ctx")
+	}
+}

--- a/pkg/pillar/cmd/nodeagent/mocks_test.go
+++ b/pkg/pillar/cmd/nodeagent/mocks_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagent
+
+import (
+	"fmt"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// mockPubSub satisfies pubsub.Publication and pubsub.Subscription enough
+// for nodeagent's handlers. Only Get/GetAll/Iterate/Publish/Unpublish are
+// meaningful; everything else is a stub.
+type mockPubSub struct {
+	items map[string]interface{}
+}
+
+func newMockPubSub() *mockPubSub {
+	return &mockPubSub{items: map[string]interface{}{}}
+}
+
+// pubsub.Publication
+
+func (m *mockPubSub) CheckMaxSize(string, interface{}) error { return nil }
+func (m *mockPubSub) Publish(key string, item interface{}) error {
+	m.items[key] = item
+	return nil
+}
+func (m *mockPubSub) Unpublish(key string) error {
+	delete(m.items, key)
+	return nil
+}
+func (m *mockPubSub) SignalRestarted() error { return nil }
+func (m *mockPubSub) ClearRestarted() error  { return nil }
+func (m *mockPubSub) Get(key string) (interface{}, error) {
+	v, ok := m.items[key]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+	return v, nil
+}
+func (m *mockPubSub) GetAll() map[string]interface{} {
+	out := make(map[string]interface{}, len(m.items))
+	for k, v := range m.items {
+		out[k] = v
+	}
+	return out
+}
+func (m *mockPubSub) Iterate(fn base.StrMapFunc) {
+	for k, v := range m.items {
+		if !fn(k, v) {
+			return
+		}
+	}
+}
+func (m *mockPubSub) Close() error { return nil }
+
+// pubsub.Subscription extras
+
+func (m *mockPubSub) Restarted() bool               { return false }
+func (m *mockPubSub) RestartCounter() int           { return 0 }
+func (m *mockPubSub) Synchronized() bool            { return true }
+func (m *mockPubSub) ProcessChange(_ pubsub.Change) {}
+func (m *mockPubSub) MsgChan() <-chan pubsub.Change { return nil }
+func (m *mockPubSub) Activate() error               { return nil }
+
+// newTestNodeagentContext builds a nodeagentContext suitable for
+// handler tests: mock publications/subscriptions, default global
+// config, and a recording stub for startNodeOperation. The returned
+// helpers expose the underlying maps so tests can pre-populate
+// subscriptions and inspect publications.
+type testCtx struct {
+	ctx                *nodeagentContext
+	pubNodeAgentStatus *mockPubSub
+	pubZbootConfig     *mockPubSub
+	subZbootStatus     *mockPubSub
+	subDomainStatus    *mockPubSub
+	scheduledOps       []scheduledOp
+}
+
+type scheduledOp struct {
+	op      types.DeviceOperation
+	reason  string
+	bootRsn types.BootReason
+}
+
+func newTestCtx() *testCtx {
+	initTestLog()
+	tc := &testCtx{
+		pubNodeAgentStatus: newMockPubSub(),
+		pubZbootConfig:     newMockPubSub(),
+		subZbootStatus:     newMockPubSub(),
+		subDomainStatus:    newMockPubSub(),
+	}
+	ctx := &nodeagentContext{}
+	ctx.globalConfig = types.DefaultConfigItemValueMap()
+	ctx.pubNodeAgentStatus = tc.pubNodeAgentStatus
+	ctx.pubZbootConfig = tc.pubZbootConfig
+	ctx.subZbootStatus = tc.subZbootStatus
+	ctx.subDomainStatus = tc.subDomainStatus
+	ctx.minRebootDelay = 0
+	ctx.maxDomainHaltTime = 0
+	ctx.domainHaltWaitIncrement = 1
+	ctx.startNodeOperation = func(op types.DeviceOperation) {
+		tc.scheduledOps = append(tc.scheduledOps, scheduledOp{
+			op:      op,
+			reason:  ctx.requestedRebootReason,
+			bootRsn: ctx.requestedBootReason,
+		})
+	}
+	tc.ctx = ctx
+	return tc
+}

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -124,6 +124,11 @@ type nodeagentContext struct {
 	minRebootDelay          uint32
 	maxDomainHaltTime       uint32
 	domainHaltWaitIncrement uint32
+
+	// startNodeOperation spawns the reboot/shutdown/poweroff goroutine.
+	// Defaulted in newNodeagentContext to handleNodeOperation; overridden
+	// by tests so they don't actually call zboot.Reset / zboot.Poweroff.
+	startNodeOperation func(types.DeviceOperation)
 }
 
 func newNodeagentContext(ps *pubsub.PubSub, _ *logrus.Logger, _ *base.LogObject) *nodeagentContext {
@@ -148,6 +153,9 @@ func newNodeagentContext(ps *pubsub.PubSub, _ *logrus.Logger, _ *base.LogObject)
 	nodeagentCtx.curPart = strings.TrimSpace(curpart)
 	nodeagentCtx.vaultOperational = types.TS_NONE
 	nodeagentCtx.hvTypeKube = base.IsHVTypeKube()
+	nodeagentCtx.startNodeOperation = func(op types.DeviceOperation) {
+		go handleNodeOperation(&nodeagentCtx, op)
+	}
 	return &nodeagentCtx
 }
 
@@ -604,53 +612,14 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 			log.Warnf("[%s #%d]: %s", tag, i, l)
 		}
 	}
-	// still no rebootReason? set the default
+	// still no rebootReason? set based on other info
 	if rebootReason == "" {
 		rebootTime = time.Now()
-		dateStr := rebootTime.Format(time.RFC3339Nano)
-		// The hardware watchdog latches WDIOF_CARDRESET when it reset the
-		// device. Recorded at boot by pkg/watchdog; used to disambiguate the
-		// reboots that SMART power-cycle counters and EVE's own bookkeeping
-		// cannot otherwise explain.
-		hwWatchdogReset := hwWatchdogCardReset()
-		var reason string
-		if fileutils.FileExists(log, firstbootFile) {
-			reason = fmt.Sprintf("NORMAL: First boot of device - at %s",
-				dateStr)
-			if bootReason == types.BootReasonNone {
-				bootReason = types.BootReasonFirst
-			}
-		} else if previousSmartData.PowerCycleCount > -1 && smartData.PowerCycleCount > -1 &&
-			bootReason == types.BootReasonNone {
-			log.Noticef("previous power cycle count %d current %d",
-				previousSmartData.PowerCycleCount,
-				smartData.PowerCycleCount)
-			if previousSmartData.PowerCycleCount < smartData.PowerCycleCount {
-				reason = fmt.Sprintf("Reboot reason - device powered off. Restarted at %s",
-					dateStr)
-				bootReason = types.BootReasonPowerFail
-			} else if hwWatchdogReset {
-				reason = fmt.Sprintf("Reboot reason - hardware watchdog reset the device - at %s",
-					dateStr)
-				bootReason = types.BootReasonHWWatchdog
-			} else {
-				reason = fmt.Sprintf("Reboot reason - system reset, reboot or kernel panic due to watchdog or kernel bug (no kdump) - at %s",
-					dateStr)
-				bootReason = types.BootReasonKernel
-			}
-		} else if hwWatchdogReset && bootReason == types.BootReasonNone {
-			reason = fmt.Sprintf("Reboot reason - hardware watchdog reset the device - at %s",
-				dateStr)
-			bootReason = types.BootReasonHWWatchdog
-		} else {
-			reason = fmt.Sprintf("Unknown reboot reason - power failure or crash - at %s",
-				dateStr)
-			if bootReason == types.BootReasonNone {
-				bootReason = types.BootReasonUnknown
-			}
-		}
-		log.Warnf("Default RebootReason: %s", reason)
-		rebootReason = reason
+		rebootReason, bootReason = synthesizeRebootReason(
+			fileutils.FileExists(log, firstbootFile),
+			bootReason, previousSmartData, smartData,
+			hwWatchdogCardReset(), rebootTime)
+		log.Warnf("Default RebootReason: %s", rebootReason)
 		rebootStack = ""
 	}
 	// remove the first boot file, if it is present
@@ -658,23 +627,7 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 		os.Remove(firstbootFile)
 	}
 
-	// if reboot stack size crosses max size, truncate
-	if len(rebootStack) > maxJSONAttributeSize {
-		runes := bytes.Runes([]byte(rebootStack))
-		sz := len(runes)
-		// Repeat the check for runes
-		if sz > maxJSONAttributeSize {
-			// Get the tail of the stack, because stack grows down and in
-			// case of truncation it is important to see the beginning of
-			// it (bottom) rather then the end (top).
-			runes = runes[sz-maxRebootStackSize : sz]
-			rebootStack = fmt.Sprintf("...\n%v", string(runes))
-		} else {
-			// It is quite possible bytes array size is beyond the max, but
-			// runes size is less. We ignore this and assume it is not so
-			// important.
-		}
-	}
+	rebootStack = truncateRebootStack(rebootStack)
 	rebootImage := agentlog.GetRebootImage(log)
 	if rebootImage != "" {
 		agentlog.DiscardRebootImage(log)
@@ -689,6 +642,83 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 	// Read and increment restartCounter
 	ctx.restartCounter = incrementRestartCounter()
 	ctx.lastLock.Unlock()
+}
+
+// synthesizeRebootReason produces a default RebootReason and BootReason for a
+// boot where nothing was persisted from the previous one. firstBoot says
+// whether the first-boot marker is present; storedBootReason is whatever EVE
+// already concluded (BootReasonNone when nothing did); prevSmart and currSmart
+// are the previous and current SMART snapshots, either of which may be nil;
+// hwWatchdogReset says whether the hardware watchdog latched WDIOF_CARDRESET,
+// which pkg/watchdog records at boot and which disambiguates the reboots that
+// SMART power-cycle counters and EVE's own bookkeeping cannot explain; now
+// stamps the returned string.
+//
+// A storedBootReason other than BootReasonNone is returned unchanged — only
+// the human-readable reason is synthesized in that case. Does no I/O, but
+// emits one diagnostic line through the package logger when it consults the
+// SMART counters.
+func synthesizeRebootReason(firstBoot bool, storedBootReason types.BootReason,
+	prevSmart, currSmart *types.DeviceSmartInfo, hwWatchdogReset bool,
+	now time.Time) (string, types.BootReason) {
+
+	bootReason := storedBootReason
+	smartUsable := prevSmart != nil && currSmart != nil &&
+		prevSmart.PowerCycleCount > -1 && currSmart.PowerCycleCount > -1
+	dateStr := now.Format(time.RFC3339Nano)
+	var reason string
+	switch {
+	case firstBoot:
+		reason = fmt.Sprintf("NORMAL: First boot of device - at %s",
+			dateStr)
+		if bootReason == types.BootReasonNone {
+			bootReason = types.BootReasonFirst
+		}
+	case smartUsable && bootReason == types.BootReasonNone:
+		log.Noticef("previous power cycle count %d current %d",
+			prevSmart.PowerCycleCount, currSmart.PowerCycleCount)
+		if prevSmart.PowerCycleCount < currSmart.PowerCycleCount {
+			reason = fmt.Sprintf("Reboot reason - device powered off. Restarted at %s",
+				dateStr)
+			bootReason = types.BootReasonPowerFail
+		} else if hwWatchdogReset {
+			reason = fmt.Sprintf("Reboot reason - hardware watchdog reset the device - at %s",
+				dateStr)
+			bootReason = types.BootReasonHWWatchdog
+		} else {
+			reason = fmt.Sprintf("Reboot reason - system reset, reboot or kernel panic due to watchdog or kernel bug (no kdump) - at %s",
+				dateStr)
+			bootReason = types.BootReasonKernel
+		}
+	case hwWatchdogReset && bootReason == types.BootReasonNone:
+		reason = fmt.Sprintf("Reboot reason - hardware watchdog reset the device - at %s",
+			dateStr)
+		bootReason = types.BootReasonHWWatchdog
+	default:
+		reason = fmt.Sprintf("Unknown reboot reason - power failure or crash - at %s",
+			dateStr)
+		if bootReason == types.BootReasonNone {
+			bootReason = types.BootReasonUnknown
+		}
+	}
+	return reason, bootReason
+}
+
+// truncateRebootStack tail-truncates the reboot stack to fit in pubsub.
+// The tail is preserved (rather than the head) because the stack grows
+// down and the bottom frames are more interesting after truncation.
+// Pure: no I/O.
+func truncateRebootStack(stack string) string {
+	if len(stack) <= maxJSONAttributeSize {
+		return stack
+	}
+	runes := bytes.Runes([]byte(stack))
+	sz := len(runes)
+	if sz <= maxJSONAttributeSize {
+		// Bytes too long but runes fit; not worth truncating.
+		return stack
+	}
+	return fmt.Sprintf("...\n%v", string(runes[sz-maxRebootStackSize:sz]))
 }
 
 // handleInstallationLog checks if we should send installer logs
@@ -727,10 +757,16 @@ func handleInstallationLog(ctx *nodeagentContext) {
 // If the file doesn't exist we pick zero.
 // Return value before increment; write new value to file
 func incrementRestartCounter() uint32 {
+	return incrementRestartCounterIn(restartCounterFile)
+}
+
+// incrementRestartCounterIn is the path-parameterised core of
+// incrementRestartCounter, used by unit tests.
+func incrementRestartCounterIn(path string) uint32 {
 	var restartCounter uint32
 
-	if _, err := os.Stat(restartCounterFile); err == nil {
-		b, err := fileutils.ReadWithMaxSize(log, restartCounterFile,
+	if _, err := os.Stat(path); err == nil {
+		b, err := fileutils.ReadWithMaxSize(log, path,
 			maxReadSize)
 		if err != nil {
 			log.Errorf("incrementRestartCounter: %s", err)
@@ -745,7 +781,7 @@ func incrementRestartCounter() uint32 {
 		}
 	}
 	b := []byte(fmt.Sprintf("%d", restartCounter+1))
-	err := os.WriteFile(restartCounterFile, b, 0644)
+	err := os.WriteFile(path, b, 0644)
 	if err != nil {
 		log.Errorf("incrementRestartCounter write: %s", err)
 	}
@@ -860,23 +896,31 @@ func handleVolumeMgrStatusImpl(ctxArg interface{}, key string,
 }
 
 func parseSMARTData() {
-	currentSMARTfilename := "/persist/SMART_details.json"
-	previousSMARTfilename := "/persist/SMART_details_previous.json"
-	parseData := func(filePath string, SMARTDataObj *types.DeviceSmartInfo) {
+	parseSMARTDataFiles(
+		"/persist/SMART_details.json",
+		"/persist/SMART_details_previous.json",
+		smartData, previousSmartData)
+}
+
+// parseSMARTDataFiles is the path-parameterised core of parseSMARTData,
+// used by unit tests. Missing or malformed files leave the destination
+// unchanged.
+func parseSMARTDataFiles(currPath, prevPath string,
+	curr, prev *types.DeviceSmartInfo) {
+	parseOne := func(filePath string, dst *types.DeviceSmartInfo) {
 		data, err := fileutils.ReadWithMaxSize(log, filePath,
 			maxSmartCtlSize)
 		if err != nil {
 			log.Errorf("parseSMARTData: exception while opening %s. %s", filePath, err.Error())
 			return
 		}
-		if err := json.Unmarshal(data, &SMARTDataObj); err != nil {
+		if err := json.Unmarshal(data, &dst); err != nil {
 			log.Errorf("parseSMARTData: exception while parsing SMART data. %s", err.Error())
 			return
 		}
 	}
-
-	parseData(currentSMARTfilename, smartData)
-	parseData(previousSMARTfilename, previousSmartData)
+	parseOne(currPath, curr)
+	parseOne(prevPath, prev)
 }
 
 // hwWatchdogCardReset reports whether the hardware watchdog reset the device

--- a/pkg/pillar/cmd/nodeagent/rebootreason_test.go
+++ b/pkg/pillar/cmd/nodeagent/rebootreason_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagent
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func TestSynthesizeRebootReason_FirstBoot(t *testing.T) {
+	initTestLog()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	prev := types.NewSmartDataWithDefaults()
+	curr := types.NewSmartDataWithDefaults()
+
+	reason, br := synthesizeRebootReason(true,
+		types.BootReasonNone, prev, curr, false, now)
+	if br != types.BootReasonFirst {
+		t.Errorf("expected BootReasonFirst, got %s", br)
+	}
+	if !strings.HasPrefix(reason, "NORMAL: First boot") {
+		t.Errorf("unexpected reason: %q", reason)
+	}
+}
+
+func TestSynthesizeRebootReason_PowerFail(t *testing.T) {
+	initTestLog()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	prev := &types.DeviceSmartInfo{PowerCycleCount: 5}
+	curr := &types.DeviceSmartInfo{PowerCycleCount: 6}
+
+	reason, br := synthesizeRebootReason(false,
+		types.BootReasonNone, prev, curr, false, now)
+	if br != types.BootReasonPowerFail {
+		t.Errorf("expected BootReasonPowerFail, got %s", br)
+	}
+	if !strings.Contains(reason, "device powered off") {
+		t.Errorf("unexpected reason: %q", reason)
+	}
+}
+
+func TestSynthesizeRebootReason_KernelPanic(t *testing.T) {
+	initTestLog()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Equal counters → no power cycle, presume kernel panic.
+	prev := &types.DeviceSmartInfo{PowerCycleCount: 5}
+	curr := &types.DeviceSmartInfo{PowerCycleCount: 5}
+
+	reason, br := synthesizeRebootReason(false,
+		types.BootReasonNone, prev, curr, false, now)
+	if br != types.BootReasonKernel {
+		t.Errorf("expected BootReasonKernel, got %s", br)
+	}
+	if !strings.Contains(reason, "kernel panic") {
+		t.Errorf("unexpected reason: %q", reason)
+	}
+}
+
+func TestSynthesizeRebootReason_Unknown_NoSmart(t *testing.T) {
+	initTestLog()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	prev := types.NewSmartDataWithDefaults() // PowerCycleCount = -1
+	curr := types.NewSmartDataWithDefaults() // PowerCycleCount = -1
+
+	reason, br := synthesizeRebootReason(false,
+		types.BootReasonNone, prev, curr, false, now)
+	if br != types.BootReasonUnknown {
+		t.Errorf("expected BootReasonUnknown, got %s", br)
+	}
+	if !strings.Contains(reason, "Unknown reboot reason") {
+		t.Errorf("unexpected reason: %q", reason)
+	}
+}
+
+func TestSynthesizeRebootReason_StoredBootReasonWins(t *testing.T) {
+	initTestLog()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	prev := &types.DeviceSmartInfo{PowerCycleCount: 5}
+	curr := &types.DeviceSmartInfo{PowerCycleCount: 6}
+
+	// A non-None stored boot reason must NOT be overwritten by the
+	// power-cycle heuristic.
+	_, br := synthesizeRebootReason(false,
+		types.BootReasonFatal, prev, curr, false, now)
+	if br != types.BootReasonFatal {
+		t.Errorf("stored bootReason should win, got %s", br)
+	}
+}
+
+func TestSynthesizeRebootReason_HWWatchdog_NoSmart(t *testing.T) {
+	initTestLog()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	prev := types.NewSmartDataWithDefaults() // PowerCycleCount = -1
+	curr := types.NewSmartDataWithDefaults() // PowerCycleCount = -1
+
+	// Without usable SMART counters the watchdog latch is the only signal.
+	reason, br := synthesizeRebootReason(false,
+		types.BootReasonNone, prev, curr, true, now)
+	if br != types.BootReasonHWWatchdog {
+		t.Errorf("expected BootReasonHWWatchdog, got %s", br)
+	}
+	if !strings.Contains(reason, "hardware watchdog reset the device") {
+		t.Errorf("unexpected reason: %q", reason)
+	}
+}
+
+func TestSynthesizeRebootReason_HWWatchdog_EqualPowerCycles(t *testing.T) {
+	initTestLog()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// No power cycle, so the watchdog latch beats the kernel-panic guess.
+	prev := &types.DeviceSmartInfo{PowerCycleCount: 5}
+	curr := &types.DeviceSmartInfo{PowerCycleCount: 5}
+
+	reason, br := synthesizeRebootReason(false,
+		types.BootReasonNone, prev, curr, true, now)
+	if br != types.BootReasonHWWatchdog {
+		t.Errorf("expected BootReasonHWWatchdog, got %s", br)
+	}
+	if !strings.Contains(reason, "hardware watchdog reset the device") {
+		t.Errorf("unexpected reason: %q", reason)
+	}
+}
+
+func TestSynthesizeRebootReason_PowerFailBeatsHWWatchdog(t *testing.T) {
+	initTestLog()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// A power cycle is the stronger signal: the watchdog latch survives a
+	// reset, so it can still be set on a boot that also lost power.
+	prev := &types.DeviceSmartInfo{PowerCycleCount: 5}
+	curr := &types.DeviceSmartInfo{PowerCycleCount: 6}
+
+	reason, br := synthesizeRebootReason(false,
+		types.BootReasonNone, prev, curr, true, now)
+	if br != types.BootReasonPowerFail {
+		t.Errorf("expected BootReasonPowerFail, got %s", br)
+	}
+	if !strings.Contains(reason, "device powered off") {
+		t.Errorf("unexpected reason: %q", reason)
+	}
+}
+
+func TestSynthesizeRebootReason_HWWatchdogDoesNotOverrideStored(t *testing.T) {
+	initTestLog()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	prev := types.NewSmartDataWithDefaults()
+	curr := types.NewSmartDataWithDefaults()
+
+	// EVE already knows why it rebooted; the watchdog latch must not
+	// relabel it.
+	reason, br := synthesizeRebootReason(false,
+		types.BootReasonRebootCmd, prev, curr, true, now)
+	if br != types.BootReasonRebootCmd {
+		t.Errorf("stored bootReason should win, got %s", br)
+	}
+	if !strings.Contains(reason, "Unknown reboot reason") {
+		t.Errorf("unexpected reason: %q", reason)
+	}
+}
+
+func TestTruncateRebootStack_ShortUnchanged(t *testing.T) {
+	in := strings.Repeat("a", 100)
+	if got := truncateRebootStack(in); got != in {
+		t.Errorf("short stack should not be truncated")
+	}
+}
+
+func TestTruncateRebootStack_LongTailKept(t *testing.T) {
+	// Build a stack much longer than maxJSONAttributeSize.
+	in := strings.Repeat("X", maxJSONAttributeSize) +
+		"BOTTOMOFSTACK"
+	got := truncateRebootStack(in)
+	if !strings.HasPrefix(got, "...\n") {
+		t.Errorf("truncated stack should start with marker, got %q",
+			got[:10])
+	}
+	if !strings.HasSuffix(got, "BOTTOMOFSTACK") {
+		t.Errorf("truncated stack should preserve tail, got tail %q",
+			got[len(got)-15:])
+	}
+	// Truncated payload (excluding the leading "...\n") must not exceed
+	// maxRebootStackSize runes.
+	body := strings.TrimPrefix(got, "...\n")
+	if len([]rune(body)) > maxRebootStackSize {
+		t.Errorf("truncated body exceeds maxRebootStackSize: %d",
+			len([]rune(body)))
+	}
+}

--- a/pkg/pillar/cmd/nodeagent/restartcounter_test.go
+++ b/pkg/pillar/cmd/nodeagent/restartcounter_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIncrementRestartCounterIn_FileAbsent(t *testing.T) {
+	initTestLog()
+	path := filepath.Join(t.TempDir(), "restartcounter")
+
+	got := incrementRestartCounterIn(path)
+	if got != 0 {
+		t.Fatalf("expected 0 on absent file, got %d", got)
+	}
+	got = readCounter(t, path)
+	if got != 1 {
+		t.Fatalf("expected file=1 after first call, got %d", got)
+	}
+}
+
+func TestIncrementRestartCounterIn_ExistingValue(t *testing.T) {
+	initTestLog()
+	path := filepath.Join(t.TempDir(), "restartcounter")
+	if err := os.WriteFile(path, []byte("42"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := incrementRestartCounterIn(path)
+	if got != 42 {
+		t.Fatalf("expected 42, got %d", got)
+	}
+	got = readCounter(t, path)
+	if got != 43 {
+		t.Fatalf("expected file=43, got %d", got)
+	}
+}
+
+func TestIncrementRestartCounterIn_GarbageContent(t *testing.T) {
+	initTestLog()
+	path := filepath.Join(t.TempDir(), "restartcounter")
+	if err := os.WriteFile(path, []byte("not-a-number"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := incrementRestartCounterIn(path)
+	if got != 0 {
+		t.Fatalf("expected 0 on garbage, got %d", got)
+	}
+	got = readCounter(t, path)
+	if got != 1 {
+		t.Fatalf("expected file=1 after garbage overwrite, got %d", got)
+	}
+}
+
+// readCounter reads the file and parses it as a decimal uint32. The test
+// asserts equality on the in-memory value rather than going through
+// strconv to avoid duplicating the production parse logic.
+func readCounter(t *testing.T, path string) uint32 {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read counter: %v", err)
+	}
+	s := strings.TrimSpace(string(b))
+	var v uint32
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			t.Fatalf("non-digit in counter file: %q", s)
+		}
+		v = v*10 + uint32(c-'0')
+	}
+	return v
+}

--- a/pkg/pillar/cmd/nodeagent/smart_test.go
+++ b/pkg/pillar/cmd/nodeagent/smart_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func TestParseSMARTDataFiles_BothPresent(t *testing.T) {
+	initTestLog()
+	dir := t.TempDir()
+	currPath := filepath.Join(dir, "curr.json")
+	prevPath := filepath.Join(dir, "prev.json")
+	mustWrite(t, currPath,
+		`{"power_on_time":{"hours":100},"power_cycle_count":7}`)
+	mustWrite(t, prevPath,
+		`{"power_on_time":{"hours":50},"power_cycle_count":5}`)
+
+	curr := types.NewSmartDataWithDefaults()
+	prev := types.NewSmartDataWithDefaults()
+	parseSMARTDataFiles(currPath, prevPath, curr, prev)
+
+	if curr.PowerCycleCount != 7 || curr.PowerOnTime.Hours != 100 {
+		t.Errorf("curr not populated: %+v", curr)
+	}
+	if prev.PowerCycleCount != 5 || prev.PowerOnTime.Hours != 50 {
+		t.Errorf("prev not populated: %+v", prev)
+	}
+}
+
+func TestParseSMARTDataFiles_PrevMissing(t *testing.T) {
+	initTestLog()
+	dir := t.TempDir()
+	currPath := filepath.Join(dir, "curr.json")
+	prevPath := filepath.Join(dir, "no-such-file.json")
+	mustWrite(t, currPath,
+		`{"power_on_time":{"hours":10},"power_cycle_count":3}`)
+
+	curr := types.NewSmartDataWithDefaults()
+	prev := types.NewSmartDataWithDefaults()
+	parseSMARTDataFiles(currPath, prevPath, curr, prev)
+
+	if curr.PowerCycleCount != 3 {
+		t.Errorf("curr not populated: %+v", curr)
+	}
+	if prev.PowerCycleCount != -1 {
+		t.Errorf("prev should retain default -1, got %d", prev.PowerCycleCount)
+	}
+}
+
+func TestParseSMARTDataFiles_MalformedJSON(t *testing.T) {
+	initTestLog()
+	dir := t.TempDir()
+	currPath := filepath.Join(dir, "curr.json")
+	prevPath := filepath.Join(dir, "prev.json")
+	mustWrite(t, currPath, "{not valid json")
+	mustWrite(t, prevPath, "")
+
+	curr := types.NewSmartDataWithDefaults()
+	prev := types.NewSmartDataWithDefaults()
+	parseSMARTDataFiles(currPath, prevPath, curr, prev)
+
+	if curr.PowerCycleCount != -1 || prev.PowerCycleCount != -1 {
+		t.Errorf("malformed JSON should leave defaults, got curr=%+v prev=%+v",
+			curr, prev)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/pillar/cmd/nodeagent/zbootstatus_test.go
+++ b/pkg/pillar/cmd/nodeagent/zbootstatus_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagent
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// seedZbootPartitions populates the test ctx with two-partition zboot
+// state. The current partition is always IMGA; otherState lets the test
+// pick the *other* partition's state ("inprogress", "active", "updating").
+func seedZbootPartitions(tc *testCtx, currentState, otherState string) {
+	tc.subZbootStatus.items["IMGA"] = types.ZbootStatus{
+		PartitionLabel:   "IMGA",
+		PartitionState:   currentState,
+		ShortVersion:     "v1",
+		CurrentPartition: true,
+	}
+	tc.subZbootStatus.items["IMGB"] = types.ZbootStatus{
+		PartitionLabel:   "IMGB",
+		PartitionState:   otherState,
+		ShortVersion:     "v2",
+		CurrentPartition: false,
+	}
+	tc.pubZbootConfig.items["IMGA"] = types.ZbootConfig{PartitionLabel: "IMGA"}
+	tc.pubZbootConfig.items["IMGB"] = types.ZbootConfig{PartitionLabel: "IMGB"}
+}
+
+func TestHandleZbootStatus_OtherUpdatingSchedulesReboot(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.curPart = "IMGA"
+	seedZbootPartitions(tc, "inprogress", "updating")
+
+	// IMGB is the one that just became updating; the handler is
+	// invoked for IMGB.
+	imgb := tc.subZbootStatus.items["IMGB"].(types.ZbootStatus)
+	handleZbootStatusImpl(tc.ctx, "IMGB", imgb)
+
+	if len(tc.scheduledOps) != 1 {
+		t.Fatalf("expected reboot scheduled, got %d", len(tc.scheduledOps))
+	}
+	got := tc.scheduledOps[0]
+	if got.bootRsn != types.BootReasonUpdate {
+		t.Errorf("expected BootReasonUpdate, got %v", got.bootRsn)
+	}
+	if got.op != types.DeviceOperationReboot {
+		t.Errorf("expected reboot op, got %v", got.op)
+	}
+}
+
+func TestHandleZbootStatus_CurrentBecomesActive(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.curPart = "IMGA"
+	tc.ctx.updateInprogress = true
+	tc.ctx.testComplete = true
+	tc.ctx.updateComplete = true
+	seedZbootPartitions(tc, "active", "unused")
+
+	// Mark current state in the in-memory map AS active.
+	imga := tc.subZbootStatus.items["IMGA"].(types.ZbootStatus)
+	handleZbootStatusImpl(tc.ctx, "IMGA", imga)
+
+	if tc.ctx.updateInprogress {
+		t.Errorf("updateInprogress should be cleared once curPart is active")
+	}
+	if tc.ctx.testComplete {
+		t.Errorf("testComplete should be cleared once curPart is active")
+	}
+	if tc.ctx.updateComplete {
+		t.Errorf("updateComplete should be cleared once curPart is active")
+	}
+}
+
+func TestDoZbootBaseOsTestValidationComplete_Acks(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.curPart = "IMGA"
+	tc.ctx.updateInprogress = true
+	tc.ctx.updateComplete = false
+	tc.pubZbootConfig.items["IMGA"] = types.ZbootConfig{
+		PartitionLabel: "IMGA",
+		TestComplete:   true, // we previously asked for it
+	}
+
+	doZbootBaseOsTestValidationComplete(tc.ctx, "IMGA",
+		types.ZbootStatus{
+			PartitionLabel: "IMGA",
+			TestComplete:   true,
+		})
+
+	if !tc.ctx.updateComplete {
+		t.Errorf("expected updateComplete=true")
+	}
+	got := tc.pubZbootConfig.items["IMGA"].(types.ZbootConfig)
+	if got.TestComplete {
+		t.Errorf("expected TestComplete=false after ack, got true")
+	}
+}
+
+func TestDoZbootBaseOsTestValidationComplete_NoUpgrade(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.updateInprogress = false
+
+	doZbootBaseOsTestValidationComplete(tc.ctx, "IMGA",
+		types.ZbootStatus{PartitionLabel: "IMGA", TestComplete: true})
+
+	if tc.ctx.updateComplete {
+		t.Errorf("no-op when no upgrade in progress")
+	}
+}
+
+func TestInitiateBaseOsControllerTestComplete(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.curPart = "IMGA"
+	tc.ctx.updateInprogress = true
+	tc.subZbootStatus.items["IMGA"] = types.ZbootStatus{
+		PartitionLabel: "IMGA", ShortVersion: "v2",
+		CurrentPartition: true, PartitionState: "inprogress",
+	}
+	tc.pubZbootConfig.items["IMGA"] = types.ZbootConfig{
+		PartitionLabel: "IMGA",
+	}
+
+	initiateBaseOsControllerTestComplete(tc.ctx)
+
+	if !tc.ctx.testComplete {
+		t.Errorf("expected testComplete=true")
+	}
+	got := tc.pubZbootConfig.items["IMGA"].(types.ZbootConfig)
+	if !got.TestComplete {
+		t.Errorf("expected ZbootConfig.TestComplete=true after initiate")
+	}
+}
+
+func TestInitiateBaseOsControllerTestComplete_AlreadySet(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.curPart = "IMGA"
+	tc.ctx.updateInprogress = true
+	tc.subZbootStatus.items["IMGA"] = types.ZbootStatus{
+		PartitionLabel: "IMGA", CurrentPartition: true,
+	}
+	tc.pubZbootConfig.items["IMGA"] = types.ZbootConfig{
+		PartitionLabel: "IMGA",
+		TestComplete:   true, // already set
+	}
+
+	initiateBaseOsControllerTestComplete(tc.ctx)
+
+	// The function logs an error and returns; ctx.testComplete stays
+	// false (it was never flipped on this path).
+	if tc.ctx.testComplete {
+		t.Errorf("testComplete should not be flipped when already set")
+	}
+}

--- a/pkg/pillar/cmd/nodeagent/zedagentstatus_test.go
+++ b/pkg/pillar/cmd/nodeagent/zedagentstatus_test.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagent
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// --- updateZedagentCloudConnectStatus -------------------------------
+
+func TestZedagentCloudConnect_FailToSuccess(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.timeTickCount = 100
+	tc.ctx.configGetStatus = types.ConfigGetFail
+
+	updateZedagentCloudConnectStatus(tc.ctx,
+		types.ZedAgentStatus{ConfigGetStatus: types.ConfigGetSuccess})
+
+	if !tc.ctx.configGetSuccess {
+		t.Errorf("expected configGetSuccess=true")
+	}
+	if tc.ctx.lastControllerReachableTime != 100 {
+		t.Errorf("expected lastControllerReachableTime=100, got %d",
+			tc.ctx.lastControllerReachableTime)
+	}
+}
+
+func TestZedagentCloudConnect_VaultTestStartReset(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.timeTickCount = 200
+	tc.ctx.vaultmgrReported = true  // vaultmgr already reported
+	tc.ctx.configGetSuccess = false // first ever success
+	tc.ctx.configGetStatus = types.ConfigGetFail
+	tc.ctx.vaultTestStartTime = 50
+
+	updateZedagentCloudConnectStatus(tc.ctx,
+		types.ZedAgentStatus{ConfigGetStatus: types.ConfigGetSuccess})
+
+	if tc.ctx.vaultTestStartTime != 200 {
+		t.Errorf("expected vaultTestStartTime reset to %d, got %d",
+			tc.ctx.timeTickCount, tc.ctx.vaultTestStartTime)
+	}
+}
+
+func TestZedagentCloudConnect_TemporaryFail(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.timeTickCount = 300
+	tc.ctx.configGetStatus = types.ConfigGetFail
+	tc.ctx.updateInprogress = true
+	tc.ctx.testInprogress = true
+
+	updateZedagentCloudConnectStatus(tc.ctx,
+		types.ZedAgentStatus{ConfigGetStatus: types.ConfigGetTemporaryFail})
+
+	if tc.ctx.lastControllerReachableTime != 300 {
+		t.Errorf("temp-fail should still bump reachable time, got %d",
+			tc.ctx.lastControllerReachableTime)
+	}
+	if !tc.ctx.testInprogress {
+		t.Errorf("test should be re-armed")
+	}
+}
+
+func TestZedagentCloudConnect_NoChangeIsFastPath(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.timeTickCount = 100
+	tc.ctx.configGetStatus = types.ConfigGetSuccess
+	tc.ctx.lastControllerReachableTime = 50
+
+	updateZedagentCloudConnectStatus(tc.ctx,
+		types.ZedAgentStatus{ConfigGetStatus: types.ConfigGetSuccess})
+
+	if tc.ctx.lastControllerReachableTime != 50 {
+		t.Errorf("no-change fast path should not refresh reachable time, got %d",
+			tc.ctx.lastControllerReachableTime)
+	}
+}
+
+// --- handleDeviceCmd / scheduleNodeOperation ------------------------
+
+func TestHandleDeviceCmd_Reboot(t *testing.T) {
+	tc := newTestCtx()
+	handleDeviceCmd(tc.ctx, types.ZedAgentStatus{
+		RebootCmd:             true,
+		RequestedRebootReason: "user-initiated",
+		RequestedBootReason:   types.BootReasonRebootCmd,
+	}, types.DeviceOperationReboot)
+
+	if !tc.ctx.rebootCmd {
+		t.Errorf("expected rebootCmd=true")
+	}
+	if len(tc.scheduledOps) != 1 {
+		t.Fatalf("expected 1 scheduled op, got %d", len(tc.scheduledOps))
+	}
+	if got := tc.scheduledOps[0]; got.bootRsn != types.BootReasonRebootCmd {
+		t.Errorf("expected BootReasonRebootCmd, got %v", got.bootRsn)
+	}
+}
+
+func TestHandleDeviceCmd_RebootIdempotent(t *testing.T) {
+	tc := newTestCtx()
+	for i := 0; i < 3; i++ {
+		handleDeviceCmd(tc.ctx, types.ZedAgentStatus{
+			RebootCmd:           true,
+			RequestedBootReason: types.BootReasonRebootCmd,
+		}, types.DeviceOperationReboot)
+	}
+	if len(tc.scheduledOps) != 1 {
+		t.Errorf("repeated RebootCmd should schedule only once, got %d",
+			len(tc.scheduledOps))
+	}
+}
+
+func TestHandleDeviceCmd_Shutdown(t *testing.T) {
+	tc := newTestCtx()
+	handleDeviceCmd(tc.ctx, types.ZedAgentStatus{
+		ShutdownCmd:         true,
+		RequestedBootReason: types.BootReasonRebootCmd,
+	}, types.DeviceOperationShutdown)
+
+	if !tc.ctx.shutdownCmd {
+		t.Errorf("expected shutdownCmd=true")
+	}
+	if got := tc.scheduledOps[0]; got.op != types.DeviceOperationShutdown {
+		t.Errorf("expected shutdown op, got %v", got.op)
+	}
+}
+
+func TestHandleDeviceCmd_Poweroff(t *testing.T) {
+	tc := newTestCtx()
+	handleDeviceCmd(tc.ctx, types.ZedAgentStatus{
+		PoweroffCmd:         true,
+		RequestedBootReason: types.BootReasonPoweroffCmd,
+	}, types.DeviceOperationPoweroff)
+
+	if !tc.ctx.poweroffCmd {
+		t.Errorf("expected poweroffCmd=true")
+	}
+	if got := tc.scheduledOps[0]; got.op != types.DeviceOperationPoweroff {
+		t.Errorf("expected poweroff op, got %v", got.op)
+	}
+}
+
+func TestHandleDeviceCmd_FlagFalseIsNoop(t *testing.T) {
+	tc := newTestCtx()
+	handleDeviceCmd(tc.ctx, types.ZedAgentStatus{RebootCmd: false},
+		types.DeviceOperationReboot)
+	if len(tc.scheduledOps) != 0 || tc.ctx.rebootCmd {
+		t.Errorf("RebootCmd=false should be no-op")
+	}
+}
+
+// --- handleZedAgentStatusImpl ---------------------------------------
+
+func TestHandleZedAgentStatus_RebootDispatch(t *testing.T) {
+	tc := newTestCtx()
+	handleZedAgentStatusImpl(tc.ctx, "global", types.ZedAgentStatus{
+		RebootCmd:           true,
+		RequestedBootReason: types.BootReasonRebootCmd,
+	})
+	if len(tc.scheduledOps) != 1 ||
+		tc.scheduledOps[0].op != types.DeviceOperationReboot {
+		t.Errorf("expected reboot dispatch, got %+v", tc.scheduledOps)
+	}
+}
+
+func TestHandleZedAgentStatus_CertsRefused(t *testing.T) {
+	tc := newTestCtx()
+	handleZedAgentStatusImpl(tc.ctx, "global", types.ZedAgentStatus{
+		EdgeNodeCertsRefused: true,
+	})
+
+	if !hasMaintReason(tc.ctx,
+		types.MaintenanceModeReasonEdgeNodeCertsRefused) {
+		t.Errorf("expected EdgeNodeCertsRefused reason added")
+	}
+
+	// Now clear it.
+	handleZedAgentStatusImpl(tc.ctx, "global", types.ZedAgentStatus{
+		EdgeNodeCertsRefused: false,
+	})
+	if hasMaintReason(tc.ctx,
+		types.MaintenanceModeReasonEdgeNodeCertsRefused) {
+		t.Errorf("expected EdgeNodeCertsRefused reason cleared")
+	}
+}
+
+func hasMaintReason(ctx *nodeagentContext,
+	want types.MaintenanceModeReason) bool {
+	for _, r := range ctx.maintModeReasons {
+		if r == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
# Description

Phase 1 of bringing `pkg/pillar/cmd/nodeagent/` from 0% to non-trivial unit-test coverage. Companion to #5913 (the architecture doc); the plan this PR realises is in `~/notes/nodeagent-coverage-plan.md` (kept locally — not part of this PR).

The PR is split into two commits so the refactor can be reviewed independently from the tests:

1. **`nodeagent: split out pure helpers for unit tests`** — refactor only; no behaviour change. Lifts four pieces of logic out so tests can drive them directly:
   - `incrementRestartCounterIn(path)` — file-path-parameterised core of `incrementRestartCounter`.
   - `parseSMARTDataFiles(currPath, prevPath, curr, prev)` — likewise for `parseSMARTData`.
   - `synthesizeRebootReason(...)` and `truncateRebootStack(...)` — pure functions extracted from `handleLastRebootReason`.
   - `nodeagentContext.startNodeOperation` — function-pointer seam defaulting to `go handleNodeOperation`; `scheduleNodeOperation` now calls it instead of inlining the goroutine spawn, so tests can observe the scheduled op without actually launching the reboot path that would call `zboot.Reset` / `zboot.Poweroff` and `os.Exit`.

2. **`nodeagent: add Phase-1 unit tests`** — 10 new test files. No production change.

## Coverage delta

| Source | Before | After |
|---|---|---|
| `go test -count=1 -cover ./cmd/nodeagent/...` | 0.0% | **48.7%** |

Per-function highlights (from `go tool cover -func`):

- `synthesizeRebootReason`, `addMaintenanceModeReason`, `removeMaintenanceModeReason`, `handleVolumeMgrStatusImpl`, `handleTpmStatusImpl`, `handleZbootStatusImpl`, `publishNodeAgentStatus`, `parseSMARTDataFiles` → 100%
- `handleVaultStatusImpl` → 93%, `incrementRestartCounterIn` → 87%, `truncateRebootStack` → 86%
- The four health-timer handlers, `updateZedagentCloudConnectStatus`, `handleDeviceCmd`, `scheduleNodeOperation`, `doZbootBaseOsTestValidationComplete`, `initiateBaseOsControllerTestComplete`, `handleNodeDrainStatusImpl`, `allDomainsHalted` are all exercised.

The remaining ~50% is intentional and split across:
- `Run()` lifecycle / pubsub wiring,
- the goroutine `handleNodeOperation` (the actual `zboot.Reset` / `Poweroff` / `os.Exit` path — Phase 2 territory: needs a Zboot interface),
- `handleInstallationLog`, the `fault-injection/readfile` knob,
- the thin Create/Modify/Delete pubsub-handler wrappers.

These are best covered end-to-end by Eden tests (Phase 3 of the plan).

## How to test and validate this PR

```sh
cd pkg/pillar
go test -count=1 -race -cover ./cmd/nodeagent/...
go test -count=1 -coverprofile=/tmp/n.cov ./cmd/nodeagent/...
go tool cover -func=/tmp/n.cov
```

Expected: all tests pass, coverage ≈ 48.7%.

For semantic-equivalence review of the refactor commit, all behaviour-changing concerns are documented in the analysis I sent in the working session — happy to paste it inline if useful. The summary is: every external entry point keeps its signature and call sites; the only new code paths exposed to production are the two `synthesizeRebootReason` defensive nil checks (unreachable in practice — the args are package globals never set to nil).

## Changelog notes

No user-facing changes.

## PR Backports

- 16.0-stable: No, test-only addition.
- 14.5-stable: No, test-only addition.
- 13.4-stable: No, test-only addition.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device — N/A, host-side unit tests
- [ ] I've tested my PR on arm64 device — N/A, host-side unit tests
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR