### PR TITLE
nodeagent: Phase 2 — Zboot/RebootStore/path seams + tests

### DIFF
--- a/pkg/pillar/cmd/nodeagent/handlelastreboot_test.go
+++ b/pkg/pillar/cmd/nodeagent/handlelastreboot_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// TestHandleLastRebootReason_StoredReason exercises the happy path
+// where a reason was persisted from the previous boot.
+func TestHandleLastRebootReason_StoredReason(t *testing.T) {
+	tc := newTestCtx()
+	tc.rebootStore.rebootReason = "user requested reboot"
+	tc.rebootStore.rebootStack = "stack contents"
+	tc.rebootStore.bootReason = types.BootReasonRebootCmd
+	tc.rebootStore.bootTime = time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	tc.rebootStore.rebootImage = "lfedge/eve:foo"
+	tc.ctx.paths.firstbootFile = filepath.Join(t.TempDir(), "no-such-firstboot")
+
+	handleLastRebootReason(tc.ctx)
+
+	if !tc.rebootStore.discardedRebootReason {
+		t.Errorf("expected stored reboot reason to be discarded")
+	}
+	if !tc.rebootStore.discardedBootReason {
+		t.Errorf("expected stored boot reason to be discarded")
+	}
+	if !tc.rebootStore.discardedRebootImage {
+		t.Errorf("expected stored reboot image to be discarded")
+	}
+	if tc.ctx.rebootReason != "user requested reboot" {
+		t.Errorf("expected stored reason to be preserved, got %q",
+			tc.ctx.rebootReason)
+	}
+	if tc.ctx.bootReason != types.BootReasonRebootCmd {
+		t.Errorf("expected stored bootReason, got %v", tc.ctx.bootReason)
+	}
+	// The wrapper should NOT overwrite the stored time when bootReason
+	// is non-None.
+	if !tc.ctx.rebootTime.Equal(tc.rebootStore.bootTime) {
+		t.Errorf("expected stored bootTime to be used")
+	}
+	if tc.ctx.rebootImage != "lfedge/eve:foo" {
+		t.Errorf("expected stored image, got %q", tc.ctx.rebootImage)
+	}
+}
+
+// TestHandleLastRebootReason_FirstBoot exercises the first-boot
+// synthesis path: no stored reason, but the firstboot marker exists.
+// Verifies that the marker file is removed afterwards.
+func TestHandleLastRebootReason_FirstBoot(t *testing.T) {
+	tc := newTestCtx()
+	dir := t.TempDir()
+	tc.ctx.paths.firstbootFile = filepath.Join(dir, "first-boot")
+	mustWrite(t, tc.ctx.paths.firstbootFile, "")
+
+	handleLastRebootReason(tc.ctx)
+
+	if tc.ctx.bootReason != types.BootReasonFirst {
+		t.Errorf("expected BootReasonFirst, got %v", tc.ctx.bootReason)
+	}
+	if !strings.HasPrefix(tc.ctx.rebootReason, "NORMAL: First boot") {
+		t.Errorf("unexpected synthesized reason: %q", tc.ctx.rebootReason)
+	}
+	// firstboot marker must be removed.
+	if _, err := os.Stat(tc.ctx.paths.firstbootFile); err == nil {
+		t.Errorf("first-boot marker should have been removed")
+	}
+}
+
+// TestHandleLastRebootReason_StackTagging covers the dmesg/stack
+// log-tagging branch when a stored stack is present alongside a
+// kernel-panic boot reason.
+func TestHandleLastRebootReason_StackTagging(t *testing.T) {
+	tc := newTestCtx()
+	tc.rebootStore.rebootReason = "kernel panic"
+	tc.rebootStore.rebootStack = "frame1\nframe2\nframe3"
+	tc.rebootStore.bootReason = types.BootReasonKernel
+	tc.rebootStore.bootTime = time.Now()
+	tc.ctx.paths.firstbootFile = filepath.Join(t.TempDir(), "absent")
+
+	handleLastRebootReason(tc.ctx)
+
+	if tc.ctx.bootReason != types.BootReasonKernel {
+		t.Errorf("expected BootReasonKernel, got %v", tc.ctx.bootReason)
+	}
+	if tc.ctx.rebootStack != "frame1\nframe2\nframe3" {
+		t.Errorf("short stack should pass through truncateRebootStack unchanged")
+	}
+}
+
+// TestHandleLastRebootReason_RestartCounterIncremented confirms the
+// wrapper updates ctx.restartCounter via incrementRestartCounter.
+func TestHandleLastRebootReason_RestartCounterIncremented(t *testing.T) {
+	tc := newTestCtx()
+	tc.rebootStore.rebootReason = "x"
+	tc.rebootStore.bootTime = time.Now()
+	tc.ctx.paths.firstbootFile = filepath.Join(t.TempDir(), "absent")
+	tc.ctx.paths.restartCounterFile = filepath.Join(t.TempDir(), "rc")
+	mustWrite(t, tc.ctx.paths.restartCounterFile, "5")
+
+	handleLastRebootReason(tc.ctx)
+
+	if tc.ctx.restartCounter != 5 {
+		t.Errorf("expected restartCounter=5 (pre-increment), got %d",
+			tc.ctx.restartCounter)
+	}
+}

--- a/pkg/pillar/cmd/nodeagent/handletimers.go
+++ b/pkg/pillar/cmd/nodeagent/handletimers.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/zboot"
 )
 
 // node health timer functions
@@ -346,7 +345,7 @@ func waitForAllDomainsHalted(ctxPtr *nodeagentContext) {
 
 func handleNodeOperation(ctxPtr *nodeagentContext, op types.DeviceOperation) {
 	// Wait for MinRebootDelay time
-	duration := time.Second * time.Duration(minRebootDelay)
+	duration := time.Second * time.Duration(ctxPtr.minRebootDelay)
 	rebootTimer := time.NewTimer(duration)
 	log.Functionf("handleNodeOperation: minRebootDelay timer %d seconds",
 		duration/time.Second)
@@ -354,7 +353,7 @@ func handleNodeOperation(ctxPtr *nodeagentContext, op types.DeviceOperation) {
 
 	if op != types.DeviceOperationShutdown {
 		// set the reboot reason
-		agentlog.RebootReason(ctxPtr.requestedRebootReason,
+		ctxPtr.rebootStore.WriteRebootReason(ctxPtr.requestedRebootReason,
 			ctxPtr.requestedBootReason, agentName, os.Getpid(), true)
 	}
 	// Wait for All Domains Halted
@@ -397,8 +396,8 @@ func handleNodeOperation(ctxPtr *nodeagentContext, op types.DeviceOperation) {
 	}()
 	agentlog.FlushCoverage(log)
 	if op == types.DeviceOperationPoweroff {
-		zboot.Poweroff(log)
+		ctxPtr.zboot.Poweroff()
 	} else {
-		zboot.Reset(log)
+		ctxPtr.zboot.Reset()
 	}
 }

--- a/pkg/pillar/cmd/nodeagent/handlezboot.go
+++ b/pkg/pillar/cmd/nodeagent/handlezboot.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/zboot"
 )
 
 func lookupZbootStatus(ctx *nodeagentContext, key string) *types.ZbootStatus {
@@ -68,7 +67,7 @@ func getZbootConfigAll(ctx *nodeagentContext) []types.ZbootConfig {
 }
 
 func publishZbootConfig(ctx *nodeagentContext, config types.ZbootConfig) {
-	if !zboot.IsValidPartitionLabel(config.PartitionLabel) {
+	if !ctx.zboot.IsValidPartitionLabel(config.PartitionLabel) {
 		return
 	}
 	pub := ctx.pubZbootConfig
@@ -79,7 +78,7 @@ func publishZbootConfig(ctx *nodeagentContext, config types.ZbootConfig) {
 
 func publishZbootConfigAll(ctx *nodeagentContext) {
 	log.Tracef("publishZbootConfigAll")
-	partitionNames := zboot.GetValidPartitionLabels()
+	partitionNames := ctx.zboot.GetValidPartitionLabels()
 	for _, partName := range partitionNames {
 		config := types.ZbootConfig{}
 		partName = strings.TrimSpace(partName)
@@ -97,7 +96,7 @@ func getZbootOtherPartition(ctx *nodeagentContext) string {
 			return status.PartitionLabel
 		}
 	}
-	return zboot.GetOtherPartition()
+	return ctx.zboot.GetOtherPartition()
 }
 
 func isZbootOtherPartitionStateUpdating(ctx *nodeagentContext) bool {
@@ -108,5 +107,5 @@ func isZbootOtherPartitionStateUpdating(ctx *nodeagentContext) bool {
 		}
 		return false
 	}
-	return zboot.IsOtherPartitionStateUpdating()
+	return ctx.zboot.IsOtherPartitionStateUpdating()
 }

--- a/pkg/pillar/cmd/nodeagent/installlog_test.go
+++ b/pkg/pillar/cmd/nodeagent/installlog_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lf-edge/eve/pkg/pillar/agentbase"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+)
+
+// installLogTestCtx wraps a real-ish nodeagentContext with a minimal
+// agentbase.AgentBase so handleInstallationLog can call ctx.Logger().
+func installLogTestCtx(t *testing.T) *testCtx {
+	t.Helper()
+	tc := newTestCtx()
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+	logObj := base.NewSourceLogObject(logger, "test", 1)
+	agentbase.Init(tc.ctx, logger, logObj, "test")
+	return tc
+}
+
+// TestHandleInstallationLog_NoSendReq verifies the early-return when
+// /persist/installer/send-require is absent.
+func TestHandleInstallationLog_NoSendReq(t *testing.T) {
+	tc := installLogTestCtx(t)
+	dir := t.TempDir()
+	tc.ctx.paths.installLogSendReq = filepath.Join(dir, "send-require")
+	tc.ctx.paths.installLog = filepath.Join(dir, "installer.log")
+
+	handleInstallationLog(tc.ctx)
+	// No assertion: returning without panicking is the goal.
+}
+
+// TestHandleInstallationLog_SendReqPresent verifies that when
+// send-require exists, the installer log is read and the marker is
+// scheduled for removal. The removal fires after warningTime
+// (40 seconds), which is too long for a unit test, so we only verify
+// that the read happened (no panic, no error from the early-return
+// branch) and that the send-require marker still exists immediately
+// after the call.
+func TestHandleInstallationLog_SendReqPresent(t *testing.T) {
+	tc := installLogTestCtx(t)
+	dir := t.TempDir()
+	tc.ctx.paths.installLogSendReq = filepath.Join(dir, "send-require")
+	tc.ctx.paths.installLog = filepath.Join(dir, "installer.log")
+	mustWrite(t, tc.ctx.paths.installLogSendReq, "")
+	mustWrite(t, tc.ctx.paths.installLog, "line one\nline two\n")
+
+	handleInstallationLog(tc.ctx)
+
+	// Marker is removed by a time.AfterFunc; immediately after the call
+	// the file still exists.
+	if _, err := os.Stat(tc.ctx.paths.installLogSendReq); err != nil {
+		t.Errorf("send-require marker should still exist immediately after, got %v", err)
+	}
+}

--- a/pkg/pillar/cmd/nodeagent/interfaces.go
+++ b/pkg/pillar/cmd/nodeagent/interfaces.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagent
+
+import (
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/zboot"
+)
+
+// Zboot is the subset of the pillar/zboot package that nodeagent uses.
+// Wrapping it as an interface lets tests substitute a stub so they don't
+// actually call /sbin/zboot or reset the host.
+type Zboot interface {
+	EveCurrentPartition() string
+	IsCurrentPartitionStateInProgress() bool
+	IsValidPartitionLabel(string) bool
+	GetValidPartitionLabels() []string
+	GetOtherPartition() string
+	IsOtherPartitionStateUpdating() bool
+	Reset()
+	Poweroff()
+}
+
+// RebootStore is the subset of pillar/agentlog that nodeagent uses to
+// read and write the reboot/boot reason files in /persist. Wrapping it
+// lets tests work against in-memory state.
+type RebootStore interface {
+	GetRebootReason() (reason string, ts time.Time, stack string)
+	GetBootReason() (br types.BootReason, ts time.Time)
+	GetRebootImage() string
+	DiscardRebootReason()
+	DiscardBootReason()
+	DiscardRebootImage()
+	WriteRebootReason(reason string, br types.BootReason,
+		agent string, pid int, last bool)
+}
+
+// pathConfig holds the on-disk paths nodeagent reads or writes.
+// Centralising them makes the agent unit-testable against a t.TempDir().
+type pathConfig struct {
+	firstbootFile      string
+	installLog         string
+	installLogSendReq  string
+	restartCounterFile string
+	faultInjectionFile string
+	smartCurrent       string
+	smartPrevious      string
+}
+
+func defaultPathConfig() pathConfig {
+	return pathConfig{
+		firstbootFile:      firstbootFile,
+		installLog:         installLog,
+		installLogSendReq:  installLogSendReq,
+		restartCounterFile: restartCounterFile,
+		faultInjectionFile: "/persist/fault-injection/readfile",
+		smartCurrent:       "/persist/SMART_details.json",
+		smartPrevious:      "/persist/SMART_details_previous.json",
+	}
+}
+
+// realZboot adapts the pillar/zboot package to the Zboot interface.
+type realZboot struct{}
+
+func (realZboot) EveCurrentPartition() string { return agentlog.EveCurrentPartition() }
+func (realZboot) IsCurrentPartitionStateInProgress() bool {
+	return zboot.IsCurrentPartitionStateInProgress()
+}
+func (realZboot) IsValidPartitionLabel(s string) bool { return zboot.IsValidPartitionLabel(s) }
+func (realZboot) GetValidPartitionLabels() []string   { return zboot.GetValidPartitionLabels() }
+func (realZboot) GetOtherPartition() string           { return zboot.GetOtherPartition() }
+func (realZboot) IsOtherPartitionStateUpdating() bool { return zboot.IsOtherPartitionStateUpdating() }
+func (z realZboot) Reset()                            { zboot.Reset(log) }
+func (z realZboot) Poweroff()                         { zboot.Poweroff(log) }
+
+// realRebootStore adapts pillar/agentlog to the RebootStore interface.
+type realRebootStore struct {
+	log *base.LogObject
+}
+
+func (r realRebootStore) GetRebootReason() (string, time.Time, string) {
+	return agentlog.GetRebootReason(r.log)
+}
+func (r realRebootStore) GetBootReason() (types.BootReason, time.Time) {
+	return agentlog.GetBootReason(r.log)
+}
+func (r realRebootStore) GetRebootImage() string { return agentlog.GetRebootImage(r.log) }
+func (r realRebootStore) DiscardRebootReason()   { agentlog.DiscardRebootReason(r.log) }
+func (r realRebootStore) DiscardBootReason()     { agentlog.DiscardBootReason(r.log) }
+func (r realRebootStore) DiscardRebootImage()    { agentlog.DiscardRebootImage(r.log) }
+func (r realRebootStore) WriteRebootReason(reason string, br types.BootReason,
+	agent string, pid int, last bool) {
+	agentlog.RebootReason(reason, br, agent, pid, last)
+}

--- a/pkg/pillar/cmd/nodeagent/mocks_test.go
+++ b/pkg/pillar/cmd/nodeagent/mocks_test.go
@@ -5,6 +5,7 @@ package nodeagent
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
@@ -67,6 +68,80 @@ func (m *mockPubSub) ProcessChange(_ pubsub.Change) {}
 func (m *mockPubSub) MsgChan() <-chan pubsub.Change { return nil }
 func (m *mockPubSub) Activate() error               { return nil }
 
+// --- mockZboot ------------------------------------------------------
+
+// mockZboot is a recording stub of the Zboot interface. By default
+// every partition label is valid, the partition list is IMGA/IMGB,
+// and the device is on IMGA with no upgrade in progress.
+type mockZboot struct {
+	currentPart       string
+	otherPart         string
+	currentInProgress bool
+	otherUpdating     bool
+	resetCalled       int
+	poweroffCalled    int
+	validLabels       map[string]bool
+}
+
+func newMockZboot() *mockZboot {
+	return &mockZboot{
+		currentPart: "IMGA",
+		otherPart:   "IMGB",
+		validLabels: map[string]bool{"IMGA": true, "IMGB": true},
+	}
+}
+
+func (m *mockZboot) EveCurrentPartition() string             { return m.currentPart }
+func (m *mockZboot) IsCurrentPartitionStateInProgress() bool { return m.currentInProgress }
+func (m *mockZboot) IsValidPartitionLabel(s string) bool     { return m.validLabels[s] }
+func (m *mockZboot) GetValidPartitionLabels() []string       { return []string{"IMGA", "IMGB"} }
+func (m *mockZboot) GetOtherPartition() string               { return m.otherPart }
+func (m *mockZboot) IsOtherPartitionStateUpdating() bool     { return m.otherUpdating }
+func (m *mockZboot) Reset()                                  { m.resetCalled++ }
+func (m *mockZboot) Poweroff()                               { m.poweroffCalled++ }
+
+// --- mockRebootStore -------------------------------------------------
+
+// mockRebootStore records writes and serves reads from in-memory state.
+type mockRebootStore struct {
+	rebootReason string
+	rebootTime   time.Time
+	rebootStack  string
+	bootReason   types.BootReason
+	bootTime     time.Time
+	rebootImage  string
+
+	discardedRebootReason bool
+	discardedBootReason   bool
+	discardedRebootImage  bool
+	written               []rebootWrite
+}
+
+type rebootWrite struct {
+	reason string
+	br     types.BootReason
+	agent  string
+	pid    int
+	last   bool
+}
+
+func (m *mockRebootStore) GetRebootReason() (string, time.Time, string) {
+	return m.rebootReason, m.rebootTime, m.rebootStack
+}
+func (m *mockRebootStore) GetBootReason() (types.BootReason, time.Time) {
+	return m.bootReason, m.bootTime
+}
+func (m *mockRebootStore) GetRebootImage() string { return m.rebootImage }
+func (m *mockRebootStore) DiscardRebootReason()   { m.discardedRebootReason = true }
+func (m *mockRebootStore) DiscardBootReason()     { m.discardedBootReason = true }
+func (m *mockRebootStore) DiscardRebootImage()    { m.discardedRebootImage = true }
+func (m *mockRebootStore) WriteRebootReason(reason string, br types.BootReason,
+	agent string, pid int, last bool) {
+	m.written = append(m.written, rebootWrite{reason, br, agent, pid, last})
+}
+
+// --- testCtx --------------------------------------------------------
+
 // newTestNodeagentContext builds a nodeagentContext suitable for
 // handler tests: mock publications/subscriptions, default global
 // config, and a recording stub for startNodeOperation. The returned
@@ -78,6 +153,8 @@ type testCtx struct {
 	pubZbootConfig     *mockPubSub
 	subZbootStatus     *mockPubSub
 	subDomainStatus    *mockPubSub
+	zboot              *mockZboot
+	rebootStore        *mockRebootStore
 	scheduledOps       []scheduledOp
 }
 
@@ -94,6 +171,8 @@ func newTestCtx() *testCtx {
 		pubZbootConfig:     newMockPubSub(),
 		subZbootStatus:     newMockPubSub(),
 		subDomainStatus:    newMockPubSub(),
+		zboot:              newMockZboot(),
+		rebootStore:        &mockRebootStore{},
 	}
 	ctx := &nodeagentContext{}
 	ctx.globalConfig = types.DefaultConfigItemValueMap()
@@ -101,6 +180,9 @@ func newTestCtx() *testCtx {
 	ctx.pubZbootConfig = tc.pubZbootConfig
 	ctx.subZbootStatus = tc.subZbootStatus
 	ctx.subDomainStatus = tc.subDomainStatus
+	ctx.zboot = tc.zboot
+	ctx.rebootStore = tc.rebootStore
+	ctx.paths = defaultPathConfig()
 	ctx.minRebootDelay = 0
 	ctx.maxDomainHaltTime = 0
 	ctx.domainHaltWaitIncrement = 1

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -34,7 +34,6 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/lf-edge/eve/pkg/pillar/utils/wait"
-	"github.com/lf-edge/eve/pkg/pillar/zboot"
 	"github.com/sirupsen/logrus"
 )
 
@@ -129,9 +128,15 @@ type nodeagentContext struct {
 	// Defaulted in newNodeagentContext to handleNodeOperation; overridden
 	// by tests so they don't actually call zboot.Reset / zboot.Poweroff.
 	startNodeOperation func(types.DeviceOperation)
+
+	// Test seams. Defaulted to real implementations in
+	// newNodeagentContext; overridden by tests.
+	zboot       Zboot
+	rebootStore RebootStore
+	paths       pathConfig
 }
 
-func newNodeagentContext(ps *pubsub.PubSub, _ *logrus.Logger, _ *base.LogObject) *nodeagentContext {
+func newNodeagentContext(ps *pubsub.PubSub, _ *logrus.Logger, logArg *base.LogObject) *nodeagentContext {
 	nodeagentCtx := nodeagentContext{}
 	nodeagentCtx.minRebootDelay = minRebootDelay
 	nodeagentCtx.maxDomainHaltTime = maxDomainHaltTime
@@ -149,7 +154,11 @@ func newNodeagentContext(ps *pubsub.PubSub, _ *logrus.Logger, _ *base.LogObject)
 	nodeagentCtx.tickerTimer = time.NewTicker(duration)
 	nodeagentCtx.configGetStatus = types.ConfigGetFail
 
-	curpart := agentlog.EveCurrentPartition()
+	nodeagentCtx.zboot = realZboot{}
+	nodeagentCtx.rebootStore = realRebootStore{log: logArg}
+	nodeagentCtx.paths = defaultPathConfig()
+
+	curpart := nodeagentCtx.zboot.EveCurrentPartition()
 	nodeagentCtx.curPart = strings.TrimSpace(curpart)
 	nodeagentCtx.vaultOperational = types.TS_NONE
 	nodeagentCtx.hvTypeKube = base.IsHVTypeKube()
@@ -211,7 +220,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	log.Functionf("processed GlobalConfig")
 
 	//Parse SMART data
-	parseSMARTData()
+	parseSMARTData(ctxPtr)
 	// get the last reboot reason
 	handleLastRebootReason(ctxPtr)
 	// send Installation log and remove first-boot from installation
@@ -219,7 +228,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	// Fault injection; if /persist/fault-injection/readfile exists we read it
 	// which will use memory
-	fileToRead := "/persist/fault-injection/readfile"
+	fileToRead := ctxPtr.paths.faultInjectionFile
 	if _, err := os.Stat(fileToRead); err == nil {
 		log.Warnf("Reading %s", fileToRead)
 		content, err := os.ReadFile(fileToRead)
@@ -313,7 +322,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	publishZbootConfigAll(ctxPtr)
 
 	// access the zboot APIs directly, baseosmgr is still not ready
-	ctxPtr.updateInprogress = zboot.IsCurrentPartitionStateInProgress()
+	ctxPtr.updateInprogress = ctxPtr.zboot.IsCurrentPartitionStateInProgress()
 	log.Functionf("Current partition: %s, inProgress: %v", ctxPtr.curPart,
 		ctxPtr.updateInprogress)
 	publishNodeAgentStatus(ctxPtr)
@@ -580,21 +589,21 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 	// Wait to update ctx until the end since the timer publishes these
 	// values and don't want partial or changing data.
 	// until after truncation.
-	rebootReason, rebootTime, rebootStack := agentlog.GetRebootReason(log)
+	rebootReason, rebootTime, rebootStack := ctx.rebootStore.GetRebootReason()
 	if rebootReason != "" {
 		log.Warnf("Current partition RebootReason: %s",
 			rebootReason)
-		agentlog.DiscardRebootReason(log)
+		ctx.rebootStore.DiscardRebootReason()
 	}
 	// We override the above rebootTime since if bootReason is known this is when things
 	// started going down
-	bootReason, ts := agentlog.GetBootReason(log)
+	bootReason, ts := ctx.rebootStore.GetBootReason()
 	if bootReason != types.BootReasonNone {
 		rebootTime = ts
 		log.Noticef("found bootReason %s", bootReason)
 	}
 
-	agentlog.DiscardBootReason(log)
+	ctx.rebootStore.DiscardBootReason()
 	// Make sure we log the reboot stack or dmesg
 	if len(rebootStack) > 0 {
 		lines := strings.Split(rebootStack, "\n")
@@ -616,21 +625,21 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 	if rebootReason == "" {
 		rebootTime = time.Now()
 		rebootReason, bootReason = synthesizeRebootReason(
-			fileutils.FileExists(log, firstbootFile),
+			fileutils.FileExists(log, ctx.paths.firstbootFile),
 			bootReason, previousSmartData, smartData,
 			hwWatchdogCardReset(), rebootTime)
 		log.Warnf("Default RebootReason: %s", rebootReason)
 		rebootStack = ""
 	}
 	// remove the first boot file, if it is present
-	if fileutils.FileExists(log, firstbootFile) {
-		os.Remove(firstbootFile)
+	if fileutils.FileExists(log, ctx.paths.firstbootFile) {
+		os.Remove(ctx.paths.firstbootFile)
 	}
 
 	rebootStack = truncateRebootStack(rebootStack)
-	rebootImage := agentlog.GetRebootImage(log)
+	rebootImage := ctx.rebootStore.GetRebootImage()
 	if rebootImage != "" {
-		agentlog.DiscardRebootImage(log)
+		ctx.rebootStore.DiscardRebootImage()
 	}
 	// Update context
 	ctx.lastLock.Lock()
@@ -640,7 +649,7 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 	ctx.rebootTime = rebootTime
 	ctx.rebootStack = rebootStack
 	// Read and increment restartCounter
-	ctx.restartCounter = incrementRestartCounter()
+	ctx.restartCounter = incrementRestartCounter(ctx)
 	ctx.lastLock.Unlock()
 }
 
@@ -725,8 +734,8 @@ func truncateRebootStack(stack string) string {
 // send log from installation to the controller
 // and remove file after small timeout to not send them after reboot
 func handleInstallationLog(ctx *nodeagentContext) {
-	if fileutils.FileExists(log, installLogSendReq) {
-		f, err := os.Open(installLog)
+	if fileutils.FileExists(log, ctx.paths.installLogSendReq) {
+		f, err := os.Open(ctx.paths.installLog)
 		if err != nil {
 			log.Errorf("cannot open installation log: %s", err)
 			return
@@ -745,8 +754,9 @@ func handleInstallationLog(ctx *nodeagentContext) {
 		_ = f.Close()
 		// schedule remove of installLogSendReq file after small timeout
 		// to not re-send log after reboot
+		removePath := ctx.paths.installLogSendReq
 		time.AfterFunc(warningTime, func() {
-			err := os.Remove(installLogSendReq)
+			err := os.Remove(removePath)
 			if err != nil {
 				log.Errorf("cannot remove installation log sending request file: %s", err)
 			}
@@ -756,8 +766,8 @@ func handleInstallationLog(ctx *nodeagentContext) {
 
 // If the file doesn't exist we pick zero.
 // Return value before increment; write new value to file
-func incrementRestartCounter() uint32 {
-	return incrementRestartCounterIn(restartCounterFile)
+func incrementRestartCounter(ctx *nodeagentContext) uint32 {
+	return incrementRestartCounterIn(ctx.paths.restartCounterFile)
 }
 
 // incrementRestartCounterIn is the path-parameterised core of
@@ -895,10 +905,10 @@ func handleVolumeMgrStatusImpl(ctxArg interface{}, key string,
 	}
 }
 
-func parseSMARTData() {
+func parseSMARTData(ctx *nodeagentContext) {
 	parseSMARTDataFiles(
-		"/persist/SMART_details.json",
-		"/persist/SMART_details_previous.json",
+		ctx.paths.smartCurrent,
+		ctx.paths.smartPrevious,
 		smartData, previousSmartData)
 }
 

--- a/pkg/pillar/cmd/nodeagent/nodeoperation_test.go
+++ b/pkg/pillar/cmd/nodeagent/nodeoperation_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagent
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// TestHandleNodeOperation_Reboot ensures a reboot op writes the reboot
+// reason, marks all domains halted, and dispatches to zboot.Reset.
+func TestHandleNodeOperation_Reboot(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.requestedRebootReason = "test-reboot"
+	tc.ctx.requestedBootReason = types.BootReasonRebootCmd
+
+	handleNodeOperation(tc.ctx, types.DeviceOperationReboot)
+
+	if !tc.ctx.allDomainsHalted {
+		t.Errorf("allDomainsHalted should be set to true")
+	}
+	if got := tc.zboot.resetCalled; got != 1 {
+		t.Errorf("zboot.Reset call count: want 1, got %d", got)
+	}
+	if got := tc.zboot.poweroffCalled; got != 0 {
+		t.Errorf("zboot.Poweroff call count: want 0, got %d", got)
+	}
+	if got := len(tc.rebootStore.written); got != 1 {
+		t.Fatalf("WriteRebootReason call count: want 1, got %d", got)
+	}
+	w := tc.rebootStore.written[0]
+	if w.reason != "test-reboot" || w.br != types.BootReasonRebootCmd ||
+		w.agent != agentName || !w.last {
+		t.Errorf("WriteRebootReason called with %+v", w)
+	}
+	pub, _ := tc.pubNodeAgentStatus.items["nodeagent"].(types.NodeAgentStatus)
+	if !pub.AllDomainsHalted {
+		t.Errorf("expected AllDomainsHalted=true in published status")
+	}
+}
+
+func TestHandleNodeOperation_Poweroff(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.requestedRebootReason = "test-poweroff"
+	tc.ctx.requestedBootReason = types.BootReasonPoweroffCmd
+
+	handleNodeOperation(tc.ctx, types.DeviceOperationPoweroff)
+
+	if got := tc.zboot.poweroffCalled; got != 1 {
+		t.Errorf("zboot.Poweroff call count: want 1, got %d", got)
+	}
+	if got := tc.zboot.resetCalled; got != 0 {
+		t.Errorf("zboot.Reset call count: want 0, got %d", got)
+	}
+	if got := len(tc.rebootStore.written); got != 1 {
+		t.Errorf("WriteRebootReason call count: want 1, got %d", got)
+	}
+}
+
+// TestHandleNodeOperation_Shutdown verifies that shutdown does NOT write
+// the reboot reason and does NOT call zboot — it just halts domains and
+// returns so the caller can leave the device powered.
+func TestHandleNodeOperation_Shutdown(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.requestedRebootReason = "test-shutdown"
+
+	handleNodeOperation(tc.ctx, types.DeviceOperationShutdown)
+
+	if !tc.ctx.allDomainsHalted {
+		t.Errorf("allDomainsHalted should be set to true")
+	}
+	if got := tc.zboot.resetCalled + tc.zboot.poweroffCalled; got != 0 {
+		t.Errorf("zboot should not be called for shutdown, got %d calls", got)
+	}
+	if got := len(tc.rebootStore.written); got != 0 {
+		t.Errorf("WriteRebootReason should not be called for shutdown, got %d", got)
+	}
+}
+
+// TestWaitForAllDomainsHalted_ImmediateReturn ensures that when the
+// subscription reports all domains deactivated, the wait loop returns
+// without iterating.
+func TestWaitForAllDomainsHalted_ImmediateReturn(t *testing.T) {
+	tc := newTestCtx()
+	tc.subDomainStatus.items["app1"] = types.DomainStatus{Activated: false}
+
+	// If this hangs the test will time out — that's the point.
+	waitForAllDomainsHalted(tc.ctx)
+}
+
+// TestWaitForAllDomainsHalted_BoundedWait ensures that even if domains
+// stay activated, the loop terminates after maxDomainHaltTime ticks.
+func TestWaitForAllDomainsHalted_BoundedWait(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.maxDomainHaltTime = 1
+	tc.ctx.domainHaltWaitIncrement = 1
+	tc.subDomainStatus.items["app1"] = types.DomainStatus{Activated: true}
+
+	waitForAllDomainsHalted(tc.ctx)
+	// no assertion: arrival at this line == bounded wait honoured
+}

--- a/pkg/pillar/cmd/nodeagent/restartcounter_test.go
+++ b/pkg/pillar/cmd/nodeagent/restartcounter_test.go
@@ -58,6 +58,25 @@ func TestIncrementRestartCounterIn_GarbageContent(t *testing.T) {
 	}
 }
 
+// TestIncrementRestartCounter_Wrapper verifies the production wrapper
+// reads ctx.paths.restartCounterFile.
+func TestIncrementRestartCounter_Wrapper(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.paths.restartCounterFile = filepath.Join(t.TempDir(), "rc")
+	if err := os.WriteFile(tc.ctx.paths.restartCounterFile,
+		[]byte("99"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := incrementRestartCounter(tc.ctx)
+	if got != 99 {
+		t.Errorf("expected 99, got %d", got)
+	}
+	if got = readCounter(t, tc.ctx.paths.restartCounterFile); got != 100 {
+		t.Errorf("expected file=100, got %d", got)
+	}
+}
+
 // readCounter reads the file and parses it as a decimal uint32. The test
 // asserts equality on the in-memory value rather than going through
 // strconv to avoid duplicating the production parse logic.

--- a/pkg/pillar/cmd/nodeagent/smart_test.go
+++ b/pkg/pillar/cmd/nodeagent/smart_test.go
@@ -71,6 +71,37 @@ func TestParseSMARTDataFiles_MalformedJSON(t *testing.T) {
 	}
 }
 
+// TestParseSMARTData_Wrapper verifies the production wrapper reads
+// from ctx.paths.smartCurrent / smartPrevious into the package-level
+// globals.
+func TestParseSMARTData_Wrapper(t *testing.T) {
+	tc := newTestCtx()
+	dir := t.TempDir()
+	tc.ctx.paths.smartCurrent = filepath.Join(dir, "curr.json")
+	tc.ctx.paths.smartPrevious = filepath.Join(dir, "prev.json")
+	mustWrite(t, tc.ctx.paths.smartCurrent,
+		`{"power_on_time":{"hours":7},"power_cycle_count":11}`)
+	mustWrite(t, tc.ctx.paths.smartPrevious,
+		`{"power_on_time":{"hours":3},"power_cycle_count":7}`)
+
+	// The wrapper writes into package globals; reset them first so
+	// the assertion is meaningful regardless of test ordering.
+	*smartData = types.DeviceSmartInfo{PowerCycleCount: -1,
+		PowerOnTime: types.PowerOnTime{Hours: -1}}
+	*previousSmartData = types.DeviceSmartInfo{PowerCycleCount: -1,
+		PowerOnTime: types.PowerOnTime{Hours: -1}}
+
+	parseSMARTData(tc.ctx)
+
+	if smartData.PowerCycleCount != 11 || smartData.PowerOnTime.Hours != 7 {
+		t.Errorf("smartData not populated: %+v", smartData)
+	}
+	if previousSmartData.PowerCycleCount != 7 ||
+		previousSmartData.PowerOnTime.Hours != 3 {
+		t.Errorf("previousSmartData not populated: %+v", previousSmartData)
+	}
+}
+
 func mustWrite(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {

--- a/pkg/pillar/cmd/nodeagent/wrappers_test.go
+++ b/pkg/pillar/cmd/nodeagent/wrappers_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeagent
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve-api/go/info"
+
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// The Create/Modify/Delete dispatch wrappers are trivial — they unpack
+// the pubsub callback args, look up the relevant *Impl, and call it.
+// These tests verify each wrapper dispatches without panicking.
+
+// --- ZedAgentStatus -------------------------------------------------
+
+func TestZedAgentStatus_CreateModifyDelete(t *testing.T) {
+	tc := newTestCtx()
+	st := types.ZedAgentStatus{
+		ConfigGetStatus: types.ConfigGetSuccess,
+	}
+	handleZedAgentStatusCreate(tc.ctx, "global", st)
+	handleZedAgentStatusModify(tc.ctx, "global", st, st)
+	handleZedAgentStatusDelete(tc.ctx, "global", st)
+}
+
+// --- ZbootStatus ----------------------------------------------------
+
+func TestZbootStatus_CreateModifyDelete(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.curPart = "IMGA"
+	tc.subZbootStatus.items["IMGA"] = types.ZbootStatus{
+		PartitionLabel: "IMGA", PartitionState: "active", CurrentPartition: true,
+	}
+	st := tc.subZbootStatus.items["IMGA"].(types.ZbootStatus)
+	handleZbootStatusCreate(tc.ctx, "IMGA", st)
+	handleZbootStatusModify(tc.ctx, "IMGA", st, st)
+	handleZbootStatusDelete(tc.ctx, "IMGA", st)
+	// Delete on an unknown key takes a different branch.
+	handleZbootStatusDelete(tc.ctx, "no-such-part", types.ZbootStatus{})
+}
+
+// --- VaultStatus ----------------------------------------------------
+
+func TestVaultStatus_CreateModify(t *testing.T) {
+	tc := newTestCtx()
+	st := types.VaultStatus{
+		Name:               types.DefaultVaultName,
+		Status:             info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED,
+		ConversionComplete: true,
+	}
+	handleVaultStatusCreate(tc.ctx, "global", st)
+	handleVaultStatusModify(tc.ctx, "global", st, st)
+	if tc.ctx.vaultOperational != types.TS_ENABLED {
+		t.Errorf("Create+Modify should drive vault to ENABLED, got %v",
+			tc.ctx.vaultOperational)
+	}
+}
+
+// --- VolumeMgrStatus ------------------------------------------------
+
+func TestVolumeMgrStatus_CreateModify(t *testing.T) {
+	tc := newTestCtx()
+	st := types.VolumeMgrStatus{RemainingSpace: 0}
+	handleVolumeMgrStatusCreate(tc.ctx, "global", st)
+	handleVolumeMgrStatusModify(tc.ctx, "global", st, st)
+	if !tc.ctx.maintMode {
+		t.Errorf("Create+Modify with no space should set maintMode")
+	}
+}
+
+// --- TpmStatus ------------------------------------------------------
+
+func TestTpmStatus_CreateModify(t *testing.T) {
+	tc := newTestCtx()
+	st := types.TpmSanityStatus{
+		Status: types.MaintenanceModeReasonTpmEncFailure,
+	}
+	handleTpmStatusCreate(tc.ctx, "global", st)
+	handleTpmStatusModify(tc.ctx, "global", st, st)
+	if !tc.ctx.maintMode {
+		t.Errorf("Create+Modify with TPM failure should set maintMode")
+	}
+}
+
+// --- NodeDrainStatus ------------------------------------------------
+
+func TestNodeDrainStatus_CreateModifyDelete(t *testing.T) {
+	tc := newTestCtx()
+	st := kubeapi.NodeDrainStatus{
+		Status:      kubeapi.STARTING,
+		RequestedBy: kubeapi.DEVICEOP,
+	}
+	handleNodeDrainStatusCreate(tc.ctx, "global", st)
+	handleNodeDrainStatusModify(tc.ctx, "global", st, st)
+	handleNodeDrainStatusDelete(tc.ctx, "global", st)
+	if !tc.ctx.waitDrainInProgress {
+		t.Errorf("Create+Modify with STARTING should set waitDrainInProgress")
+	}
+}
+
+// --- GlobalConfig ---------------------------------------------------
+
+func TestGlobalConfig_DeleteIgnoresNonGlobalKey(t *testing.T) {
+	tc := newTestCtx()
+	tc.ctx.subGlobalConfig = newMockPubSub()
+
+	// "non-global" key is a fast no-op path.
+	handleGlobalConfigDelete(tc.ctx, "not-global", nil)
+}

--- a/pkg/pillar/cmd/nodeagent/zbootstatus_test.go
+++ b/pkg/pillar/cmd/nodeagent/zbootstatus_test.go
@@ -134,6 +134,64 @@ func TestInitiateBaseOsControllerTestComplete(t *testing.T) {
 	}
 }
 
+func TestPublishZbootConfigAll(t *testing.T) {
+	tc := newTestCtx()
+	publishZbootConfigAll(tc.ctx)
+
+	for _, label := range []string{"IMGA", "IMGB"} {
+		got, err := tc.pubZbootConfig.Get(label)
+		if err != nil {
+			t.Errorf("expected ZbootConfig for %s, got err %v", label, err)
+			continue
+		}
+		cfg := got.(types.ZbootConfig)
+		if cfg.PartitionLabel != label {
+			t.Errorf("partition label mismatch: got %q want %q",
+				cfg.PartitionLabel, label)
+		}
+	}
+}
+
+func TestPublishZbootConfig_InvalidLabelRejected(t *testing.T) {
+	tc := newTestCtx()
+	tc.zboot.validLabels = map[string]bool{} // nothing is valid
+
+	publishZbootConfig(tc.ctx, types.ZbootConfig{PartitionLabel: "IMGA"})
+
+	if _, err := tc.pubZbootConfig.Get("IMGA"); err == nil {
+		t.Errorf("expected publish to be rejected for invalid label")
+	}
+}
+
+func TestGetZbootConfigAll(t *testing.T) {
+	tc := newTestCtx()
+	publishZbootConfigAll(tc.ctx)
+
+	cfgs := getZbootConfigAll(tc.ctx)
+	if len(cfgs) != 2 {
+		t.Errorf("expected 2 configs, got %d", len(cfgs))
+	}
+}
+
+func TestGetZbootConfigAll_Empty(t *testing.T) {
+	tc := newTestCtx()
+	cfgs := getZbootConfigAll(tc.ctx)
+	if len(cfgs) != 0 {
+		t.Errorf("expected empty config list, got %d", len(cfgs))
+	}
+}
+
+func TestHandleDeviceTimers_NoOpBaseline(t *testing.T) {
+	// handleDeviceTimers calls all four health-timer handlers in
+	// sequence. With a fresh context, all four should be no-ops.
+	tc := newTestCtx()
+	handleDeviceTimers(tc.ctx)
+	if len(tc.scheduledOps) != 0 {
+		t.Errorf("baseline ctx should not schedule any ops, got %d",
+			len(tc.scheduledOps))
+	}
+}
+
 func TestInitiateBaseOsControllerTestComplete_AlreadySet(t *testing.T) {
 	tc := newTestCtx()
 	tc.ctx.curPart = "IMGA"


### PR DESCRIPTION
# Description

Phase 2 of the nodeagent unit-test work. Stacks on #5914 (Phase 1) and is best reviewed after it. Brings package coverage from 48.7% (end of Phase 1) to **70.3%** of statements.

The PR is split into two commits so the refactor can be reviewed independently from the tests:

1. **`nodeagent: add Zboot/RebootStore/path seams`** — refactor only, no behaviour change. Three small interfaces let the goroutine-spawned reboot path, the boot-reason reconstruction, and the file-touching helpers be driven from unit tests without invoking `/sbin/zboot`, persisting under `/persist`, or calling `os.Exit` from the test binary.
   - `Zboot` — wraps the subset of `pkg/pillar/zboot` (current/other partition, valid labels, Reset, Poweroff). `realZboot` adapts the package; `nodeagentContext.zboot` defaults to it.
   - `RebootStore` — wraps `pkg/pillar/agentlog` reboot/boot-reason persistence.
   - `pathConfig` — centralises the on-disk paths nodeagent reads or writes (firstboot file, installer log + send-require, restart counter, fault-injection file, SMART current/previous). Reuses existing package constants where they exist.
   - Plus two adjacent fixes:
     - `handleNodeOperation` now uses `ctxPtr.minRebootDelay` rather than the package constant — finally honours the existing comment "Some constants.. Declared here as variables to enable unit tests".
     - `newNodeagentContext` now uses its `logArg` parameter (was `_`).
   - `mocks_test.go` is extended with `mockZboot` and `mockRebootStore` so existing Phase-1 tests keep building.

2. **`nodeagent: add Phase-2 unit tests`** — uses the seams. No production change.
   - `nodeoperation_test.go` — `handleNodeOperation` reboot/poweroff/shutdown plus `waitForAllDomainsHalted`'s empty and bounded-wait branches.
   - `handlelastreboot_test.go` — `handleLastRebootReason` wrapper (stored-reason, first-boot, stack-tagging, restart-counter).
   - `installlog_test.go` — `handleInstallationLog` with/without the send-require marker.
   - `wrappers_test.go` — smoke tests for the trivial Create/Modify/Delete dispatch wrappers across all six pubsub topics + the GlobalConfig non-global-key fast path.
   - Folded into existing files: `incrementRestartCounter` and `parseSMARTData` wrapper tests, `publishZbootConfigAll`, `publishZbootConfig` invalid-label rejection, `getZbootConfigAll` empty/populated, `handleDeviceTimers` no-op baseline.

## Coverage delta

| Source | Before this PR | After |
|---|---|---|
| `go test -count=1 -cover ./cmd/nodeagent/...` | 48.7% | **70.3%** |

Remaining 0% targets are now exclusively things best covered end-to-end by Eden (Phase 3 of the plan):
- `Run()` lifecycle / pubsub wiring, `newNodeagentContext`, `initNodeDrainPubSub` — agent boot.
- The real adapter methods (`realZboot.X`, `realRebootStore.X`) — already covered by `pkg/pillar/zboot` and `pkg/pillar/agentlog` tests, plus Eden e2e.

## How to test and validate this PR

```sh
cd pkg/pillar
go test -count=1 -race -cover ./cmd/nodeagent/...
go test -count=1 -coverprofile=/tmp/n.cov ./cmd/nodeagent/...
go tool cover -func=/tmp/n.cov | grep total
```

Expected: all tests pass, coverage ≈ 70.3%.

## Changelog notes

No user-facing changes.

## PR Backports

- 16.0-stable: No, test-only addition.
- 14.5-stable: No, test-only addition.
- 13.4-stable: No, test-only addition.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device — N/A, host-side unit tests
- [ ] I've tested my PR on arm64 device — N/A, host-side unit tests
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR