### PR TITLE
[16.0-stable] kernel: update kernel commits to patch CVE-2026-31431

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,7 +421,7 @@ endif
 # The rootfs partition size is set to 512MB after 10.2.0 release (see commit 719b4d516)
 # Before 10.2.0 it was 300MB. We must maintain compatibility with older versions so rootfs size cannot exceed 300MB.
 # 'k' and nvidia are not affected by this limitation because there no installation of kubevirt/k3s prior to 10.2.0
-# Nevertheless lets check for ROOTFS_MAXSIZE_MB not exceeding 4GB for 'k', 450MB for NVIDIA based platforms (arm64) and 285MB for x86_64 and other arm64 platforms
+# Nevertheless lets check for ROOTFS_MAXSIZE_MB not exceeding 4GB for 'k', 450MB for NVIDIA based platforms (arm64) and 295MB for x86_64 and other arm64 platforms
 # That helps in catching image size increases earlier than at later stage.
 # We are currently filtering out a few packages from bulk builds since they are not getting published in Docker HUB
 ifeq ($(HV),k)
@@ -435,7 +435,7 @@ else
             ROOTFS_MAXSIZE_MB=9999
         # nvidia platform requires more space
         else ifeq (, $(findstring nvidia,$(PLATFORM)))
-            ROOTFS_MAXSIZE_MB=290
+            ROOTFS_MAXSIZE_MB=295
         else
             ROOTFS_MAXSIZE_MB=450
         endif

--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,6 +1,6 @@
-KERNEL_COMMIT_amd64_next_generic = 3152b8fe36ea
-KERNEL_COMMIT_amd64_v6.12.49_generic = ef7ccc4d151c
-KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = b4464b03583e
-KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 2154a157c3f4
-KERNEL_COMMIT_arm64_v6.1.155_generic = ece043d8b403
-KERNEL_COMMIT_riscv64_v6.1.112_generic = 18e1d313b90b
+KERNEL_COMMIT_amd64_next_generic = a65e45508b45
+KERNEL_COMMIT_amd64_v6.12.49_generic = 465d242734dc
+KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = 2e0dcfd3260d
+KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 4929f15eda41
+KERNEL_COMMIT_arm64_v6.1.155_generic = da7d6950689c
+KERNEL_COMMIT_riscv64_v6.1.112_generic = 30aa75d58cdd


### PR DESCRIPTION

# Description

- Update kernel-commits.mk with the latest commits across all branches to include the fix for CVE-2026-31431.
- The kernel update for https://github.com/advisories/GHSA-2274-3hgr-wxv6 increased the rootfs size to ~291MB, exceeding the previous 290MB limit. Bump the limit to 295MB to accommodate the larger kernel.

## PR dependencies

List all dependencies of this PR (when applicable, otherwise remove this
section).

## How to test and validate this PR

Please describe how the changes in this PR can be validated or verified. For
example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.

This will be used

1. to provide test scenarios for the QA team
1. by a reviewer to validate the changes in this PR.

The first is especially important, so, please make sure to provide as much
detail as possible.

If it's covered by an automated test, please mention it here.

## Changelog notes

Text in this section will be used to generate the changelog entry for
release notes. The consumers of this are end users, not developers.
So, provide a clear and short description of what is changed in the PR from
the end user perspective. If it changes only tooling or some internal
implementation, put a note like "No user-facing changes" or "None".

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 16.0-stable
- 14.5-stable
- 13.4-stable

For example, if this PR fixes a bug in a feature that was introduced in 14.5,
you can write:

```text
- 16.0-stable: To be backported.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
