### PR TITLE
device-steps: disable mdev hotplug

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -479,6 +479,10 @@ if [ -f $CONFIGDIR/onboard.cert.pem ] && [ -f $CONFIGDIR/onboard.key.pem ]; then
    echo "$(date -Ins -u) Self-registering our device certificate"
    CLIENT_COMMANDS="selfRegister $CLIENT_COMMANDS"
 fi
+
+# disable mdev
+echo "" > /proc/sys/kernel/hotplug
+
 echo "$(date -Ins -u) Starting client $CLIENT_COMMANDS"
 # shellcheck disable=SC2086
 if ! $BINDIR/client $CLIENT_COMMANDS; then


### PR DESCRIPTION
# Description

Linuxkit sets /proc/sys/kernel/hotplug to mdev in
linuxkit/pkg/init/cmd/rc.init/main.go. Clear it as we're using udev for this now.
It is unneeded and a source of confusion; there is also a user report with an
OOM that shows several mdev processes running and one getting killed.

See also https://github.com/lf-edge/eve/pull/4122

## How to test and validate this PR

Boot eve, check that `/proc/sys/kernel/hotplug` gets cleared.

## Changelog notes

Disable mdev

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 16.0-stable: yes
- 14.5-stable: yes
- 13.4-stable: yes



## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
