### PR TITLE
msrv: fix OpenStack metadata routing

### DIFF
--- a/pkg/pillar/cmd/msrv/handlers.go
+++ b/pkg/pillar/cmd/msrv/handlers.go
@@ -219,8 +219,9 @@ func (msrv *Msrv) handleOpenStack() func(http.ResponseWriter, *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("{}"))
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
 		}
-		w.WriteHeader(http.StatusNotFound)
 	}
 }
 

--- a/pkg/pillar/cmd/msrv/msrv.go
+++ b/pkg/pillar/cmd/msrv/msrv.go
@@ -743,7 +743,7 @@ func (msrv *Msrv) MakeMetadataHandler() http.Handler {
 	r.Get("/eve/app-custom-blobs", msrv.handleAppCustomBlobs())
 
 	r.Get("/openstack", msrv.handleOpenStack())
-	r.Get("/openstack/", msrv.handleOpenStack())
+	r.Get("/openstack/*", msrv.handleOpenStack())
 
 	return r
 }


### PR DESCRIPTION
## Summary

I ran into this when trying to use the openstack metadata URLs to test that the controller can rotate the encryption cert without rotating the signing cert (hence re-encrypting the metadata). That failed because the openstack URLs don't get routed to the handler.


- The OpenStack metadata handler dispatches on the request path's last component (`meta_data.json`, `network_data.json`, `user_data`, `vendor_data.json`), but the chi router only registered the static paths `/openstack` and `/openstack/`. Sub-paths like `/openstack/latest/meta_data.json` — which is what cloud-init's OpenStack data source actually requests — returned 404 from the router, so every switch arm beyond the version listing was dead code.
- Register `/openstack/*` so sub-paths reach `handleOpenStack`, and replace the unconditional trailing `w.WriteHeader(http.StatusNotFound)` (which fired after every successful response and produced `http: superfluous response.WriteHeader` warnings) with a `default:` arm that returns 404 only when no case matched.

## Test plan

- [x] `go vet ./pkg/pillar/cmd/msrv/` passes
- [x] `go build ./pkg/pillar/cmd/msrv/` passes
- [x] `go test ./pkg/pillar/cmd/msrv/` passes
- [x] Confirmed against vendored chi v5: `GET /openstack/latest/meta_data.json` now reaches the handler with `filename="meta_data.json"`; previously it 404'd at the router.
- [ ] Manually verify a VM app deployed with `MetaDataType=MetaDataOpenStack` and cloud-init configured for the OpenStack data source receives `meta_data.json` / `user_data` from the metadata server (169.254.169.254).

🤖 Generated with [Claude Code](https://claude.com/claude-code)