### PR TITLE
kube: clean up stale etcd masterleases after single-to-cluster transition

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -1,10 +1,19 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
 FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+ARG TARGETARCH
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables curl openrc \
          open-iscsi libvirt libvirt-client util-linux grep findutils jq \
          cni-plugins nfs-utils inotify-tools
 RUN eve-alpine-deploy.sh
+
+ENV ETCDCTL_VERSION=v3.5.5
+ADD https://github.com/etcd-io/etcd/releases/download/${ETCDCTL_VERSION}/etcd-${ETCDCTL_VERSION}-linux-${TARGETARCH}.tar.gz /tmp/etcd.tar.gz
+RUN mkdir -p /out/usr/bin /tmp/etcdtmp && \
+    tar -xzf /tmp/etcd.tar.gz -C /tmp/etcdtmp && \
+    cp "/tmp/etcdtmp/etcd-${ETCDCTL_VERSION}-linux-${TARGETARCH}/etcdctl" /out/usr/bin/etcdctl && \
+    chmod +x /out/usr/bin/etcdctl && \
+    rm -rf /tmp/etcd.tar.gz /tmp/etcdtmp
 
 COPY eve-bridge /plugins/eve-bridge
 WORKDIR /plugins/eve-bridge
@@ -41,7 +50,6 @@ COPY update-component/expected_versions.yaml /etc/
 COPY update-component/settings_longhorn.yaml /etc/
 
 # k3s
-COPY install-etcdctl.sh /usr/bin/
 RUN mkdir -p /etc/rancher/k3s
 COPY config.yaml /etc/rancher/k3s
 COPY debuguser-role-binding.yaml /etc/
@@ -98,7 +106,7 @@ COPY nvidia-container-runtime/nvidia-device-plugin-18.0.yml /etc/k3s-manifests/
 
 ARG TARGETARCH
 
-# Actual k3s install and config happens when this container starts during EVE bootup, look at cluster-init.sh
+# Actual k3s install and config happens when this container starts during EVE boot up, look at cluster-init.sh
 ### NOTE: the version of virtctl should match the version of kubevirt in cluster_init.sh, else PVC creation might fail due to incompatibility
 COPY k3s-control.sh /usr/bin/k3s-control
 RUN chmod +x /usr/bin/k3s-control && \

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -19,6 +19,7 @@ All_PODS_READY=true
 install_kubevirt=1
 TRANSITION_PIPE="/tmp/cluster_transition_pipe$$"
 TRANSITION_FLAG_FILE="/tmp/cluster_transition_flag"
+MASTERLEASE_CLEANUP_FLAG="/var/lib/masterlease-cleanup-needed"
 RebootReasonFile="/persist/reboot-reason"
 BootReasonFile="/persist/boot-reason"
 BootReasonKubeTransition="BootReasonKubeTransition" # Must match string in types package
@@ -340,6 +341,63 @@ check_start_k3s() {
         current_wait_time=$INITIAL_WAIT_TIME
   fi
   return 0
+}
+
+# cleanup_stale_masterleases removes etcd masterlease entries whose IP does not
+# match cluster_node_ip.  k3s's HA endpoint reconciler reads every key under
+# /registry/masterleases/ and writes each IP into the kubernetes service
+# EndpointSlice; a stale entry causes 30-second TCP timeouts on every third
+# connection (kubectl, Multus SetNetworkStatus, CDI importer).
+# Called in the main loop once k3s is running in cluster mode with embedded
+# etcd; guarded by MASTERLEASE_CLEANUP_FLAG (set during single-to-cluster
+# conversion) so it is a no-op unless a conversion just occurred.
+# If etcd is not ready yet (empty lease list) the flag is kept and the
+# function retries on the next main-loop iteration.
+cleanup_stale_masterleases() {
+    [ -f "$MASTERLEASE_CLEANUP_FLAG" ] || return 0
+    # Re-read enc_status: is_bootstrap and cluster_node_ip may be stale in the main
+    # shell after a single-to-cluster transition done in a background subshell.
+    get_enc_status || return 0
+    [ "$is_bootstrap" = "true" ] || return 0
+
+    ETCD_CA="/var/lib/rancher/k3s/server/tls/etcd/server-ca.crt"
+    ETCD_CERT="/var/lib/rancher/k3s/server/tls/etcd/client.crt"
+    ETCD_KEY="/var/lib/rancher/k3s/server/tls/etcd/client.key"
+    if [ ! -f "$ETCD_CA" ]; then
+        logmsg "cleanup_stale_masterleases: etcd certs not found, skipping"
+        return 0
+    fi
+
+    ETCDCTL_CMD="etcdctl --endpoints https://127.0.0.1:2379 --cacert $ETCD_CA --cert $ETCD_CERT --key $ETCD_KEY"
+
+    if ! leases=$($ETCDCTL_CMD get /registry/masterleases/ --prefix --keys-only 2>&1); then
+        logmsg "cleanup_stale_masterleases: etcdctl failed: $leases"
+        return 0
+    fi
+    leases=$(echo "$leases" | grep -v '^$')
+    if [ -z "$leases" ]; then
+        logmsg "cleanup_stale_masterleases: no masterleases yet, will retry"
+        return 0
+    fi
+    logmsg "cleanup_stale_masterleases: masterleases: $(echo "$leases" | tr '\n' ' ')"
+
+    cluster_prefix_mask=$(get_cluster_prefix_len)
+    cluster_net=$(ipcalc -n "$cluster_node_ip$cluster_prefix_mask" | cut -d= -f2)
+    if [ -z "$cluster_net" ]; then
+        logmsg "cleanup_stale_masterleases: could not determine cluster network, skipping"
+        return 0
+    fi
+
+    for lease in $leases; do
+        ip=$(echo "$lease" | sed 's|/registry/masterleases/||')
+        lease_net=$(ipcalc -n "$ip$cluster_prefix_mask" 2>/dev/null | cut -d= -f2)
+        if [ "$lease_net" != "$cluster_net" ]; then
+            logmsg "cleanup_stale_masterleases: removing stale lease for $ip (outside cluster subnet $cluster_node_ip$cluster_prefix_mask)"
+            $ETCDCTL_CMD del "$lease"
+        fi
+    done
+    rm -f "$MASTERLEASE_CLEANUP_FLAG"
+    logmsg "cleanup_stale_masterleases: done"
 }
 
 external_boot_image_import() {
@@ -790,6 +848,7 @@ check_cluster_config_change() {
 
             # rotate the token with the new token
             if [ "$is_bootstrap" = "true" ]; then
+                touch "$MASTERLEASE_CLEANUP_FLAG"
                 change_to_new_token
             fi
 
@@ -1283,7 +1342,6 @@ if [ ! -f /var/lib/all_components_initialized ]; then
                 sleep 5  # Ensure minimum sleep time before retrying
                 continue
         fi
-
         if ! external_boot_image_import; then
                 sleep 5
                 continue
@@ -1553,6 +1611,7 @@ else
                 fi
         fi
 fi
+        cleanup_stale_masterleases
         save_cluster_startup_rank
         check_log_file_size "k3s.log"
         check_log_file_size "multus.log"


### PR DESCRIPTION

# Description

  After a node converts from single-node to cluster mode, the old
  single-node IP remains as a /registry/masterleases/ entry in etcd. The
  HA endpoint reconciler in k3s reads every key under that prefix and
  writes all IPs — including the stale one — into the kubernetes service
  EndpointSlice. Connection load-balancing then distributes API server
  traffic across those endpoints; every third connection that lands on
  the dead IP times out after 30 seconds. This manifests on
  non-bootstrap nodes as repeated dial tcp 10.43.0.1:443: i/o timeout
  errors during pod bring-up, causing kubelet to stall and pods to take
  minutes to reach Running.

  cleanup_stale_masterleases uses etcdctl to delete any masterlease
  entry whose IP does not match the current node's cluster IP. It is
  gated by the flag /var/lib/masterlease-cleanup-needed, which is set
  during the single-to-cluster transition on the bootstrap node, so it
  is a no-op on every other boot.

  The function is called unconditionally in the main loop so it retries
  each iteration until etcd is ready and the stale lease is removed, at
  which point the flag is cleared.

## PR dependencies

## How to test and validate this PR

Load 3 nodes into eve-k image, and w/ this patch, configure the edge-node clustering
on the 3 nodes.
Check the kuberntes endpoints using 'kubectl get endpoints kubernetes', and verify all the entries display
belong to the cluster IP prefix, there is no other IP addresses in the list.
Also check the bootstrap node of the cluster, should see after the cluster conversion those lines in k3s-install.log:
```
2026-05-08 22:20:24 : cleanup_stale_masterleases: masterleases: /registry/masterleases/192.168.1.89 
2026-05-08 22:20:24 : cleanup_stale_masterleases: removing stale lease for 192.168.1.89 (cluster IP: 10.244.244.2)
2026-05-08 22:20:24 : cleanup_stale_masterleases: done
```

## Changelog notes

kube: clean up stale etcd masterleases after single-to-cluster transition

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
