### PR TITLE
docs(tpmmgr,evetpm): architecture documentation

### DIFF
--- a/pkg/pillar/docs/tpmmgr.md
+++ b/pkg/pillar/docs/tpmmgr.md
@@ -1,30 +1,443 @@
+# TPM Manager
 
-# TPM Manager(tpmmgr) microservice
+## Overview
 
-This service is responsible for managing the Trusted Platform Module on EVE systems
+`tpmmgr` is the EVE microservice responsible for managing the
+[Trusted Platform Module](https://trustedcomputinggroup.org) (TPM)
+on EVE systems. The TPM is a
+[Trusted Computing Group](https://trustedcomputinggroup.org) standard
+for a discrete hardware chip or platform firmware component that
+creates crypto keys, seals secrets, measures system components, and
+stores those measurements in a tamper-evident way. EVE targets the
+**TPM 2.0** revision of the standard; a TPM 1.0 device, or a TPM 2.0
+that fails the runtime checks in `etpm.IsTpmEnabled()`, is treated
+as "no usable TPM" and `tpmmgr` switches to the soft fallback paths.
+`tpmmgr` is the userspace interface between EVE and that hardware (or
+firmware).
 
-## What is Trusted Platform Module
+`tpmmgr` runs in two modes:
 
-Trusted Platform Module is a purpose-build hardware module, for providing tools to
-build a secure and trusted endpoint. It can securely create crypto keys, seal secrets,
-and help measure various components of the system and store the measurements in a
-tamper-proof manner. For more details, refer to <https://trustedcomputinggroup.org> which is
-the govering body for defining specifications for TPM implementations.
+* **Single-shot CLI**, invoked from `onboot.sh` / `device-steps.sh`
+  during boot to provision the device identity key/cert and the
+  EK / SRK / AK / quote / ECDH keys, generate the matching X.509
+  certs, and save TPM vendor info. Each subcommand is a one-shot
+  process.
+* **Long-running service**, started under `zedbox` after onboarding.
+  It publishes the device's edge-node certificates to `zedagent`,
+  services controller-initiated attestation quotes via
+  `AttestNonce` → `AttestQuote`, and runs an hourly `tpmSanityCheck`
+  whose `TpmSanityStatus` publication drives `nodeagent`'s
+  `MaintenanceModeReasonTpm{Enc,Quote}Failure` paths. The
+  `EdgeNodeCert` publication carries the EK's `TPM2B_PUBLIC` as
+  metadata so the controller can verify the key chain back to the
+  TPM manufacturer.
 
-## Role of tpmmgr
+Without a usable TPM (no TPM at all, TPM 1.x, or a TPM 2.0 that fails
+`etpm.IsTpmEnabled()`) the device identity key and ECDH / quote certs
+are generated as soft keys on disk so the device can still onboard.
+The EK cert is not published, attestation quotes are not produced,
+and the sanity check is skipped.
 
-Role of tpmmgr is to help interface with Trusted Platform Modules from Edge Virtualization Engine,
-to make the edge device secure. To begin with, one of the goals is to secure the device identity
-certificate by generating its ECDSA private key in TPM. More details at the LF Edge Wiki page here:
-<https://wiki.lfedge.org/display/EVE/Device+Identity%2C+Onboarding%2C+Security+Foundation>
-<https://wiki.lfedge.org/display/EVE/Device+Identity+rooted+at+TPM>
+The on-TPM data layout — well-known handles, NV indices for the
+device cert and credentials, the sealed disk-key blob, PCR selections
+— is owned by the `pkg/pillar/evetpm` package; see
+[`pkg/pillar/evetpm/evetpm.md`](../evetpm/evetpm.md) for the canonical
+table. `tpmmgr` is the microservice that drives it; `vaultmgr` and
+`zedagent` use the same package directly for vault key sealing/unsealing
+and for cert hashing.
 
-## The TSS2.0 support
+### Where edge-node certificates live on disk
 
-tpmmgr uses go-tpm package from Google, to interface with the TPM device, which implements TSS2.0.
-Go-tpm package is hosted at <https://github.com/google/go-tpm/>. Go-tpm is licensed under Apache License 2.0.
+| Cert / key | Path | TPM-backed? | Survives EVE re-install? |
+|---|---|---|---|
+| Device cert PEM | `/config/device.cert.pem` | Yes (private key in TPM) | Yes — the cert PEM is also mirrored into TPM NV index `0x1500000`, so a fresh `/config` is restored from NV on first boot |
+| Device key PEM | `/config/device.key.pem` | No (soft path only) | Yes if present (only exists on no-TPM platforms) |
+| ECDH cert / key | `/persist/certs/ecdh.{cert,key}.pem` | Cert yes; soft key only when TPM path failed | **No** — regenerated on first boot after re-install |
+| Quote ("attest") cert / key | `/persist/certs/attest.{cert,key}.pem` | Cert yes; soft key only when TPM path failed | **No** — regenerated on first boot after re-install |
+| EK cert | `/persist/certs/ek.cert.pem` | Yes (no soft variant) | **No** — regenerated on first boot after re-install |
+
+The asymmetry matters: re-installing EVE preserves the **device
+identity** (because it lives in TPM NVRAM), but the EK / ECDH / quote
+certs are regenerated. The controller therefore sees fresh
+`EdgeNodeCert` publications after every re-install even though the
+device's identity hasn't changed.
+
+## Key Input/Output
+
+**tpmmgr consumes** (via pubsub unless noted):
+
+* global configuration
+  * `ConfigItemValueMap` from `zedagent` — only used for log levels.
+* attestation requests
+  * `AttestNonce` from `zedagent` — published with a fresh nonce
+    each time the controller wants a quote; carries `Requester` for
+    log traceability and `Nonce` (12–32 bytes).
+* TPM device
+  * `/dev/tpmrm0` (`etpm.TpmDevicePath`) — the resource-managed TPM
+    device file. All TPM2 commands go through this.
+  * Persistent handles (EK / SRK / AK / quote / ECDH at
+    `0x8100000{1..5}`, device key at `0x817FFFFF`) and NV indices
+    (device-cert backup `0x1500000`, credentials `0x1600000`, sealed
+    disk-key pair `0x1800000` / `0x1900000`) — see
+    [evetpm.md](../evetpm/evetpm.md#on-tpm-data-layout) for the
+    canonical table. `tpmmgr` itself touches the device key (for cert
+    signing via `etpm.TpmPrivateKey`), the quote key (attestation),
+    NV `0x1500000` (device-cert backup), and NV `0x1600000` (the
+    credential used as the device-key `userAuth`); the sealed
+    disk-key NV pair is owned by `vaultmgr`.
+* on-disk
+  * `/config/tpm_credential` — TPM credentials cache, mirrored from
+    NV index `0x1600000`. Created on first boot; used as the
+    device-key `userAuth` — see
+    [`TpmPasswdHdl` in evetpm.md](../evetpm/evetpm.md#nv-indices).
+  * `/config/device.cert.pem`, `/config/device.key.pem` — device
+    identity cert and (for non-TPM platforms) its private key.
+  * `/persist/certs/ecdh.cert.pem`, `attest.cert.pem`, `ek.cert.pem`
+    — published edge-node certs.
+  * `/persist/certs/ecdh.key.pem`, `attest.key.pem` — soft private
+    keys, written when the TPM path is unavailable or the per-cert
+    TPM path fails and the dispatcher falls back to soft.
+
+**tpmmgr publishes**:
+
+* `EdgeNodeCert` (persistent) — one entry per cert type
+  (`CertTypeEcdhXchange`, `CertTypeRestrictSigning`, `CertTypeEk`).
+  Carries the cert PEM, a sha256-first-16 hash as `CertID`, an
+  `IsTpm` flag indicating whether the corresponding key actually
+  lives in the TPM, and (for the EK only) a `MetaDataItems` slice
+  containing the EK's `TPM2B_PUBLIC` blob. Consumed by `zedagent`,
+  forwarded to the controller.
+* `AttestQuote` — one entry per nonce, keyed on the nonce itself.
+  Carries the signed quote (ECDSA-SHA256), the signature, and the
+  raw PCR values (SHA256 bank) read separately for the controller's
+  use. Only produced when a usable TPM is present. The read range
+  and the in-quote range are separately defined — see
+  [Attestation quote](#attestation-quote-getquote--handleattestnonceimpl).
+  Consumed by `zedagent`'s attestation FSM, then unpublished after the
+  controller confirms receipt.
+* `TpmSanityStatus` — keyed on the TPM device path. `Status` is one
+  of `MaintenanceModeReasonNone` (TPM healthy),
+  `MaintenanceModeReasonTpmEncFailure` (encrypt/decrypt round-trip
+  failed), or `MaintenanceModeReasonTpmQuoteFailure` (`Quote` cmd
+  failed). Consumed by `nodeagent` to drive Maintenance Mode.
+
+## Components
+
+`tpmmgr` lives in a single source file (`cmd/tpmmgr/tpmmgr.go`) with
+no internal sub-packages. The logical responsibilities are partitioned
+across function groups as follows.
+
+### Lifecycle / pubsub wiring (long-running service)
+
+`Run()` blocks on `wait.WaitForOnboarded()`, subscribes
+`ConfigItemValueMap` and `AttestNonce`, creates the publications,
+and immediately publishes the three edge-node certificates that
+must reach the controller for attestation to work:
+
+* `ecdh.cert.pem` as `CertTypeEcdhXchange`
+* `attest.cert.pem` as `CertTypeRestrictSigning`
+* `ek.cert.pem` as `CertTypeEk` with the EK's `TPM2B_PUBLIC` attached
+  via `getEkCertMetaData()`
+
+`IsTpm` is set per-cert: true only if the TPM is enabled and no soft
+fallback key file is present (`etpm.EcdhKeyFile` for ECDH,
+`quoteKeyFile` for the quote cert). The EK is always TPM-backed and
+is not published when there is no usable TPM.
+
+After `GCInitialized`, `Run()` enters its event loop driving an
+hourly `tpmSanityCheckTicker`.
+
+### Single-shot CLI (`runCommand`)
+
+Subcommands and the boot script that invokes each:
+
+| Subcommand | Caller | What it does |
+|---|---|---|
+| `createDeviceCert` | `device-steps.sh` (TPM present, no soft key file) | TPM-rooted device-identity provisioning — see [Key + cert creation](#key--cert-creation-tpm-rooted-vs-soft). |
+| `createSoftDeviceCert` | `device-steps.sh` (no TPM, or `createDeviceCert` failed) | Soft device-identity provisioning. |
+| `createCerts` | `device-steps.sh` (TPM present) | TPM-rooted ECDH / quote / EK certs; per-cert soft fallback. |
+| `createSoftCerts` | `device-steps.sh` (no TPM) | Soft ECDH and quote certs (no EK). |
+| `genCredentials` / `readCredentials` | startup | Generate/read the UUID at `/config/tpm_credential` ↔ NV `0x1600000`. Used as the device-key `userAuth` (see [Key Input/Output](#key-inputoutput)). |
+| `saveTpmInfo <file>` | `device-steps.sh` | Dump TPM vendor / firmware description (`etpm.FetchTpmHwInfoDescription`) for diagnostic bundles. |
+| `printCapability` / `printPCRs` | manual (debugging) | Print vendor info; read all PCRs (SHA256) and a sample quote. |
+| `testTpmEcdhSupport` / `testEcdhAES` / `testEncryptDecrypt` | manual / CI (debugging) | Exercise the ECDH, ECDH-AES, and EncryptDecryptUsingTpm round trips (the same primitives `vaultmgr` and the controller cipher path use). |
+
+### Key + cert creation (TPM-rooted vs soft)
+
+For each non-EK cert (device, quote, ECDH), `tpmmgr` has paired
+`create*OnTpm` / `create*Soft` implementations. The TPM-rooted variant
+signs via `etpm.TpmPrivateKey` (which routes through the device key
+at `0x817FFFFF`); the soft variant generates an in-memory ECDSA P-256
+key with `ecdsa.GenerateKey` and writes the matching `.key.pem` next
+to the cert. The dispatchers `createQuoteCert` / `createEcdhCert`
+prefer TPM and fall back to soft on failure. `createDeviceCert` does
+not fall back internally — `device-steps.sh` catches the non-zero
+exit and invokes `createSoftDeviceCert`.
+
+`createOtherKeys(override bool)` bulk-creates the EK / SRK / AK /
+quote / ECDH keys at their well-known handles. `override=true`
+(`createDeviceCert`) wipes and recreates from a fresh owner;
+`override=false` (`createCerts`) only fills empty slots. The EK has
+no soft variant and is therefore not published when there is no
+usable TPM.
+
+### Attestation quote (`getQuote` / `handleAttestNonceImpl`)
+
+`getQuote(nonce)` validates nonce length (12–32 bytes), reads every
+PCR 0..23 in the SHA256 bank, and signs PCRs 0..15
+(`etpm.PcrListForQuote`) via `tpm2.Quote(TpmQuoteKeyHdl, …)`. The raw
+0..23 values ride along in `AttestQuote.PCRs` (unsigned), letting the
+controller inspect the dynamic-PCR range without re-deriving the
+quote; PCRs 16–23 are deliberately excluded from the signed range.
+The signed selection itself is fixed — disk-key sealing in `vaultmgr`
+is a separate path with its own controller-configurable selection
+(see [PCR selections in evetpm.md](../evetpm/evetpm.md#pcr-selections)).
+
+`handleAttestNonceImpl` calls `getQuote` and publishes
+`AttestQuote{Nonce, SigType:EcdsaSha256, Signature, Quote, PCRs}`
+keyed on the nonce; `handleAttestNonceDelete` unpublishes on delete.
+
+### TPM sanity check
+
+`tpmSanityCheck()` runs every hour from the long-running service.
+It exists because some TPM failures only surface when the device
+needs an upgrade or the controller needs a quote — i.e. far too
+late. The check verifies the two operations whose failure modes are
+not caught by ordinary device traffic:
+
+1. `etpm.EncryptDecryptUsingTpm` round-trip — this is what
+   `vaultmgr` uses to wrap/unwrap vault keys; failure means a
+   PCR-changing upgrade can no longer be rescued by the controller,
+   which would maroon the device on the old image.
+2. `tpm2.Quote` with a random nonce — this is what attestation uses;
+   failure means the controller cannot verify integrity even if
+   `tpmmgr` is otherwise running.
+
+The result is published as `TpmSanityStatus` keyed on the TPM device
+path. `nodeagent` watches this publication and lifts the corresponding
+maintenance reason when the status flips back to
+`MaintenanceModeReasonNone`.
+
+The other TPM-failure paths are caught implicitly: vault seal/unseal
+failure sets `VaultStatus=ERROR` (which `nodeagent` handles), and
+device-key signing is exercised on every onboarding handshake.
+
+### TSS 2.0 backend
+
+TPM2 commands go through Google's
+[`go-tpm`](https://github.com/google/go-tpm) (Apache 2.0). EVE pulls in
+both the `legacy/tpm2` API (used by `tpmmgr` and most of `evetpm`) and
+the newer top-level `tpm2` (used by `pkg/pillar/evetpm/enc_seal.go` for
+encrypted disk-key seal/unseal, where parameter encryption is only
+exposed on the v2 API). The full file-by-file split and the v1→v2
+migration status are documented in
+[`pkg/pillar/evetpm/evetpm.md`](../evetpm/evetpm.md#tss-20-backend).
+
+## Control-flow
+
+There are four largely independent paths through `tpmmgr`.
+
+### 1. First-boot provisioning (single-shot CLI)
+
+```text
+device-steps.sh: device.cert.pem missing
+  if /dev/tpmrm0 present and /config/device.key.pem absent:
+    tpmmgr createDeviceCert
+      ├─ initializeDirs()
+      ├─ genCredentials()                  /config/tpm_credential + NV 0x1600000
+      ├─ readDeviceCert()                  re-read previous cert from NV (idempotent)
+      └─ on miss:
+         ├─ createDeviceKey()              CreatePrimary at owner hierarchy,
+         │                                 EvictControl into TpmDeviceKeyHdl
+         ├─ createDeviceCertOnTpm()        x509 cert signed via TpmPrivateKey
+         ├─ writeDeviceCert()              /config/device.cert.pem + NV 0x1500000
+         └─ createOtherKeys(override=true) EK/SRK/AK/quote/ECDH
+    on failure:
+      tpmmgr createSoftDeviceCert         soft ECDSA, /config/device.{key,cert}.pem
+  else:
+    tpmmgr createSoftDeviceCert
+```
+
+Then, once `/config/server` and `/config/root-certificate.pem` are
+present:
+
+```text
+device-steps.sh: provision additional certs
+  if /dev/tpmrm0 present and /config/device.key.pem absent:
+    tpmmgr createCerts
+      ├─ createOtherKeys(override=false)   create only what's missing
+      ├─ createEcdhCert()                  TPM-rooted, fall back to soft
+      ├─ createQuoteCert()                 TPM-rooted, fall back to soft
+      └─ createEkCert()                    TPM-rooted, no soft fallback
+  else:
+    tpmmgr createSoftCerts                 ECDH + quote, soft only
+```
+
+### 2. Boot-time long-running service (`Run()`)
+
+```text
+Run()
+  └─ wait.WaitForOnboarded()
+  └─ subscribe ConfigItemValueMap, AttestNonce
+  └─ create publications: AttestQuote, EdgeNodeCert (persistent), TpmSanityStatus
+  └─ publishEdgeNodeCertToController(ecdh.cert.pem,    CertTypeEcdhXchange,  IsTpm=…)
+  └─ publishEdgeNodeCertToController(attest.cert.pem,  CertTypeRestrictSigning, IsTpm=…)
+  └─ publishEdgeNodeCertToController(ek.cert.pem,      CertTypeEk, IsTpm=true,
+                                     metaData=getEkCertMetaData())   TPM2B_PUBLIC
+  └─ wait for GCInitialized
+  └─ if /config/tpm_credential missing: readCredentials()             recover from NV
+  └─ start tpmSanityCheckTicker (1h)
+  └─ event loop:
+       AttestNonce arrives → handleAttestNonceImpl
+                           → getQuote() → publish AttestQuote
+       AttestNonce deleted → handleAttestNonceDelete → unpublish
+       tpmSanityCheckTicker fires → periodicTpmSanityCheck
+                                  → publish TpmSanityStatus
+```
+
+### 3. Attestation quote
+
+```text
+zedagent.AttestNonce{Nonce, Requester} arrives
+  → handleAttestNonceImpl
+    → getQuote(Nonce)
+      ├─ validate len(Nonce) ∈ [12,32]
+      ├─ for i in 0..23: tpm2.ReadPCR(i, AlgSHA256)
+      └─ tpm2.Quote(TpmQuoteKeyHdl, Nonce, PcrListForQuote=[0..15])
+    → asn1.Marshal({R,S})
+    → publish AttestQuote{Nonce, SigType:EcdsaSha256, Signature, Quote, PCRs}
+zedagent picks up AttestQuote and forwards it to controller.
+After controller acks: zedagent removes AttestNonce
+  → handleAttestNonceDelete → unpublish AttestQuote
+```
+
+### 4. Periodic TPM sanity check
+
+```text
+tpmSanityCheckTicker fires (every 1h)
+  → periodicTpmSanityCheck
+    if !etpm.IsTpmEnabled(): return
+    → tpmSanityCheck()
+      ├─ EncryptDecryptUsingTpm(msg, true)  encrypt
+      ├─ EncryptDecryptUsingTpm(enc,  false) decrypt
+      ├─ bytes.Equal(msg, decrypted)?
+      └─ getQuote(random nonce)
+    on failure:
+      → publish TpmSanityStatus{Status:TpmEncFailure | TpmQuoteFailure,
+                                ErrorAndTime{...}}
+    on success:
+      → publish TpmSanityStatus{Status:None}
+```
+
+`nodeagent` watches `TpmSanityStatus` and adds/removes the matching
+maintenance reason. A device whose TPM has degraded — but is still
+running — therefore goes into Maintenance Mode within an hour, well
+before the next baseos upgrade attempt.
 
 ## Debugging
 
-To print TPM vendor information, use `/opt/zededa/bin/tpmmgr printCapability`
-To see logs from tpmmgr, one can find recent ones with source being tpmmgr it under `/persist/newlog/devUpload` using zcat or on the controller.
+### PubSub
+
+```sh
+ls /persist/status/tpmmgr/EdgeNodeCert/    # one file per cert type
+cat /run/tpmmgr/AttestQuote/*.json | jq    # only present during attestation
+cat /run/tpmmgr/TpmSanityStatus/*.json | jq
+```
+
+`EdgeNodeCert` is the canonical "what does this device claim to be?"
+output. `TpmSanityStatus.Status==MaintenanceModeReasonNone` and a
+recent `ErrorAndTime` cleared is the "TPM healthy" indicator.
+
+### Files of interest
+
+* `/dev/tpmrm0` — resource-managed TPM device
+* `/config/device.cert.pem`, `/config/device.key.pem` — identity cert
+  (key file only present on no-TPM platforms)
+* `/config/tpm_credential` — TPM credentials cache, mirror of NV
+  `0x1600000`
+* `/persist/certs/{ecdh,attest,ek}.cert.pem` — published certs
+* `/persist/certs/{ecdh,attest}.key.pem` — soft private keys, if any
+* `/persist/status/tpm_measurement_seal_success`,
+  `/persist/status/tpm_measurement_unseal_fail` — written by
+  `pkg/pillar/evetpm` (not by `tpmmgr` itself); used by
+  `FindMismatchingPCRs` to diagnose why a vault unseal failed
+
+### Useful CLIs (from a pillar shell)
+
+```sh
+/opt/zededa/bin/tpmmgr printCapability       # vendor / firmware info
+/opt/zededa/bin/tpmmgr printPCRs             # PCR 0..23 SHA256 + sample quote
+/opt/zededa/bin/tpmmgr testTpmEcdhSupport    # ECDHKeyGen + ECDHZGen round trip
+/opt/zededa/bin/tpmmgr testEncryptDecrypt    # what vaultmgr's wrap/unwrap relies on
+/opt/zededa/bin/tpmmgr testEcdhAES           # full ECDH-AES exchange against ecdh.cert.pem
+/opt/zededa/bin/tpmmgr saveTpmInfo /tmp/tpm.txt
+```
+
+### Logs
+
+`tpmmgr`'s log records ship through `newlogd` like every other
+agent. On a running device, recent (not-yet-uploaded) batches land
+under `/persist/newlog/devUpload/` as gzipped JSON; filter on
+`source=tpmmgr`:
+
+```sh
+zcat /persist/newlog/devUpload/*.gz | jq -c 'select(.source=="tpmmgr")'
+```
+
+Once uploaded, the same records are available in the controller's
+log store.
+
+### Useful grep patterns
+
+These are literal substrings from log calls in
+`pkg/pillar/cmd/tpmmgr/tpmmgr.go`; they have no `printf` directives
+and can be fed directly to `grep` (or `jq 'select(.msg | contains(...))'`).
+
+```text
+"TPM Quote Nonce"                                       – attestation quote requested by zedagent
+"Received quote request from"                           – same line, includes the Requester string
+"publishing quote for nonce"                            – AttestQuote being published
+"Unpublishing quote for nonce"                          – AttestQuote being removed after controller ack
+"TPM sanity check failed"                               – periodic 1h check failed (errored detail follows)
+"failed to encrypt key using TPM"                       – TpmEncFailure path (wrapped into TpmSanityStatus.ErrorAndTime)
+"failed to get quote using TPM"                         – TpmQuoteFailure path (wrapped into TpmSanityStatus.ErrorAndTime)
+"readDeviceCert success"                                – first-boot path found cert in NV index 0x1500000
+"readDeviceCert failed"                                 – first-boot path actually creating the device key (subsequent log line: "generating new key and cert")
+"CreatePrimary failed"                                  – TPM owner-hierarchy refusal; usually means BIOS reset needed
+"Error in creating Endorsement Key Certificate"         – EK cert creation failed (no soft fallback; cert simply not published)
+"publishEdgeNodeCertToController failed: no cert file"  – cert PEM missing on disk
+```
+
+### Forcing transitions for development
+
+* **Trigger the sanity-check failure path**: replace `/dev/tpmrm0`
+  with a `swtpm` instance whose state has been damaged (e.g. force
+  a key handle to be evicted). The next `tpmSanityCheckTicker` tick
+  will publish `TpmSanityStatus{Status:TpmEncFailure}`, and within
+  10s `nodeagent` will add `MaintenanceModeReasonTpmEncFailure` to
+  `NodeAgentStatus.LocalMaintenanceModeReasons`.
+* **Force soft fallback on an already-onboarded device**: drop a
+  (dummy) `/config/device.key.pem` file. `etpm.IsTpmEnabled()` is
+  defined as `device.cert.pem exists AND device.key.pem does NOT
+  exist`, so the soft key file makes it return `false`; subsequent
+  `EdgeNodeCert` publications carry `IsTpm=false`. This does not
+  retro-actively unwind earlier TPM state — keys at the well-known
+  handles remain, and an EK cert that was already published stays in
+  `/persist/certs/`. To exercise the no-TPM provisioning paths from
+  scratch, omit `/dev/tpmrm0` before the first `device-steps.sh` run
+  on a fresh install.
+* **Re-issue device cert without re-onboarding**: delete
+  `/config/device.cert.pem` and reboot. `device-steps.sh` will
+  re-invoke `tpmmgr createDeviceCert`, which finds the previous cert
+  in NV `0x1500000` via `readDeviceCert()` and restores it — no
+  re-onboarding required.
+
+## Further reading
+
+* [EVE Security Architecture](../../../docs/SECURITY-ARCHITECTURE.md) —
+  device identity, onboarding, attestation, and the broader EVE
+  security foundation that `tpmmgr` plugs into.
+* [Trusted Computing Group](https://trustedcomputinggroup.org) — the
+  governing body for TPM specifications.
+* [`go-tpm`](https://github.com/google/go-tpm) — the Go library
+  `tpmmgr` and `pkg/pillar/evetpm` use to drive the TPM (Apache 2.0).

--- a/pkg/pillar/evetpm/evetpm.md
+++ b/pkg/pillar/evetpm/evetpm.md
@@ -1,0 +1,338 @@
+# evetpm: Shared TPM 2.0 Primitive Layer
+
+## Overview
+
+`pkg/pillar/evetpm` is the Go library that every pillar component
+which touches the TPM goes through. It owns the
+on-TPM data layout for EVE (well-known persistent handles, NV
+indices, PCR selections, disk-key seal blobs, policy-PCR bookkeeping)
+and exposes the primitives — probe, sign, encrypt/decrypt, seal/unseal,
+PCR policy — that the microservices above it compose into product
+behaviour. It is not itself a microservice; it has no `Run()`, no
+pubsub, and no long-lived state of its own beyond what it stores in
+the TPM or on disk on behalf of its callers.
+
+The boundary against the microservices is intentionally narrow:
+
+* **`evetpm`** decides *what* the on-TPM layout looks like (which
+  handles, which NV indices, which PCRs go into a disk-key policy,
+  how the policy digest is computed) and provides the operations
+  (`SealDiskKey`, `UnsealDiskKey`, `EncryptDecryptUsingTpm`,
+  `TpmSign`, …) that mutate or read it. It opens `/dev/tpmrm0` on
+  every call and closes it again; it holds no TPM session across
+  calls.
+* **`tpmmgr`** drives provisioning and attestation against that
+  layout — see [`pkg/pillar/docs/tpmmgr.md`](../docs/tpmmgr.md).
+* **`vaultmgr`** drives disk-key seal/unseal on top of
+  `SealDiskKey` / `UnsealDiskKey` / `FetchSealedVaultKey`.
+* **`zedagent`** and **`controllerconn`** use the encrypt/decrypt
+  and signing primitives for cert hashing, the attestation FSM, and
+  the device-key-signed authentication to the controller.
+
+EVE targets the TPM 2.0 revision. A TPM 1.0 device or a TPM 2.0 that
+fails the runtime check in `IsTpmEnabled` is treated as "no usable
+TPM"; callers branch into their soft (on-disk key) paths and the
+TPM-rooted operations in this package are skipped.
+
+## On-TPM Data Layout
+
+The package owns the global EVE convention for what lives where on
+the TPM. Other pillar code references these constants rather than
+hard-coding handle values. The microservice doc
+[`pkg/pillar/docs/tpmmgr.md`](../docs/tpmmgr.md#key-inputoutput)
+summarises the same table from the operator's perspective; this
+section is the canonical statement.
+
+### Persistent key handles
+
+| Constant | Handle | Purpose |
+|---|---|---|
+| `TpmEKHdl` | `0x81000001` | Endorsement Key (RSA-2048, restricted decrypt). Created from the TCG standard EK template (`DefaultEkTemplate`). |
+| `TpmSRKHdl` | `0x81000002` | Storage Root Key (RSA-2048, restricted decrypt). Parent for sealed objects. |
+| `TpmAIKHdl` | `0x81000003` | Attestation Key (AK; RSA-2048, restricted signing). Used in the vTPM credential-activation flow. The constant identifier retains the TPM 1.2 "AIK" name; the TPM 2.0 spec calls it AK. |
+| `TpmQuoteKeyHdl` | `0x81000004` | PCR Quote signing key (ECC P-256, restricted signing). |
+| `TpmEcdhKeyHdl` | `0x81000005` | ECDH key (ECC P-256). Used both for ECDH key derivation in `EncryptDecryptUsingTpm` / `DecryptSecretWithEcdhKey` and by `vaultmgr` for vault-key wrap/unwrap. |
+| `TpmDeviceKeyHdl` | `0x817FFFFF` | Long-lived ECDSA device-identity key. The certificate at `/config/device.cert.pem` chains to this. |
+
+### NV indices
+
+| Constant | Handle | Contents |
+|---|---|---|
+| `TpmDeviceCertHdl` | `0x1500000` | Backup copy of `/config/device.cert.pem`. `tpmmgr` mirrors the device cert into NV at first boot so the cert survives a wipe of `/config`. |
+| `TpmPasswdHdl` | `0x1600000` | TPM credentials (a UUID generated on first boot, truncated to `MaxPasswdLength` = 7 bytes by `ReadOwnerCrdl`). Mirrored at `/config/tpm_credential`. **Not** the owner-hierarchy password — every owner-hierarchy operation in `evetpm`/`tpmmgr` passes `EmptyPassword`. The credential is instead bound as the `userAuth` of the **device key** at creation time (`CreatePrimary`'s `inSensitive.userAuth` in `createDeviceKey`), and must subsequently be supplied to authorize that key in `TpmSign` and `ECDHZGen`. `vcomlink` also passes it as the auth value for caller-supplied NV / signing / certify operations. |
+| `TpmDiskKeyHdl` | `0x1700000` | Legacy (un-sealed) disk key — random 32-byte raw key written via `writeDiskKey`. Pre-dates PCR-sealed vaults; carried forward for upgrade compatibility (see `FetchSealedVaultKey`). |
+| `TpmSealedDiskPubHdl` | `0x1900000` | TPM2B_PUBLIC of the sealed disk-key object. Both the encrypted (`enc_seal.go`) and legacy (`tpm.go`) seal paths write here. |
+| `TpmSealedDiskPrivHdl` | `0x1800000` | TPM2B_PRIVATE of the sealed disk-key object. |
+
+The legacy disk key at `TpmDiskKeyHdl` and the sealed pair at
+`TpmSealedDiskPubHdl` / `TpmSealedDiskPrivHdl` can coexist on the
+same device — see [Disk-key seal / unseal](#disk-key-seal--unseal) for
+the migration logic.
+
+### PCR selections
+
+All PCR operations are in the SHA256 bank. The package exposes three
+distinct selections, used for different things; conflating them is a
+common source of bugs.
+
+| Variable | PCRs | Used for |
+|---|---|---|
+| `PcrSelection` | `{7}` | "Entropy" PCR selection passed to `CreatePrimary` when generating non-policy keys. The contents don't matter for the resulting key, but PCR 7 is stable across boots. |
+| `PcrListForQuote` | `{0..15}` | Selection signed in `tpm2.Quote` for attestation. PCRs 16–23 are deliberately excluded. |
+| `DefaultDiskKeySealingPCRs` | `{0,1,2,3,4,6,7,8,9,10,11,12,13,14}` | Default selection sealing the vault key. PCR 5 is excluded (`PCRIndexGPT`, which measures the GPT partition table — volatile across A/B image updates because EVE flips the IMGA/IMGB "active" vs "updating" attribute bits in the GPT header on every base-OS upgrade); PCR 15 is excluded (`PCRIndexOS`, reserved for OS / user use). |
+
+`ValidatePolicyPcr` enforces the constraints on any controller-supplied
+selection: PCR 0 (`PCRIndexSRTM`) must be present, PCR 5 must not be
+present, no duplicates, all indexes in `[0..15]`, total count ≤ 15
+(`PCRIndexMaxCount`).
+
+### Disk-key policy persistence
+
+The PCR selection actually used to seal the on-disk vault key is
+persisted at `types.PolicyPcrFile` (`/persist/status/policy-pcr.json`),
+serialised as `types.VaultKeyPolicyPCR{PolicyPresent, Indexes, ID}`.
+The file is owned by this package — `GetDiskKeyPolicyPcrOrDefault`,
+`SaveDiskKeyPolicyPcr`, `RecoverDiskKeyPolicyPcr`, and
+`ValidatePolicyPcr` all read or write it under a file lock.
+
+The `ID` field distinguishes how the policy got there:
+
+* `> 0` — controller-supplied (the integer is the controller's policy
+  ID).
+* `0` (`PolicyPCRRecoveredDefault`) — recovery succeeded with the
+  default PCR set.
+* `-1` (`PolicyPCRRecovered`) — recovery searched the candidate space
+  and found a non-default subset that produces the digest baked into
+  the sealed object's `AuthPolicy`.
+
+`RecoverDiskKeyPolicyPcr` is the read-back path used when unseal
+fails with the saved selection. It reads the `AuthPolicy` digest out
+of the sealed object's public area
+(`tpm2.NVReadEx(TpmSealedDiskPubHdl)` →
+`tpm2.DecodePublic` → `pubData.AuthPolicy`) and brute-forces all
+subsets of `PcrListForQuote.PCRs` against the current PCR values,
+computing each candidate digest with `computePolicyPCRAuthDigest`.
+With 16 candidate PCRs that is at most 2^16 trials — sub-millisecond
+in practice. The recovered selection is persisted back to
+`policy-pcr.json` so subsequent unseals can skip the search.
+
+`computePolicyPCRAuthDigest` reproduces the TPM's policy-digest
+formula in software:
+
+```text
+newPolicyDigest = SHA256(
+        oldPolicyDigest         // 32 bytes of zero, since PolicyPCR
+                                // is the first and only policy
+     || TPM_CC_PolicyPCR        // 0x0000017F, big-endian
+     || TPML_PCR_SELECTION      // Count | HashAlg | SizeOfSelect | bitmap
+     || SHA256(PCR_i ‖ PCR_j ‖ …)  // digestTPM, PCRs concatenated in
+                                   // ascending index order
+)
+```
+
+The bitmap is 3 bytes wide (sufficient for PCRs 0–23, matching the
+`PcrListForQuote` range), MSB-first within each byte.
+
+### Other persistent state on disk
+
+| Path | Written by | Purpose |
+|---|---|---|
+| `/persist/status/sealingpcrs` (`savedSealingPcrsFile`) | `saveDiskKeySealingPCRs` after a successful seal | gob-encoded `map[int][]byte` of PCR values at seal time. Read by `FindMismatchingPCRs` to diagnose unseal failure. |
+| `/persist/status/tpm_measurement_seal_success` (`measurementLogSealSuccess`) | `SealDiskKey` (and `-backup` rotation on re-seal) | Concatenation of `types.TpmMeasurementLogFile` + `types.TpmMeasurefsEventLog` at seal time. |
+| `/persist/status/tpm_measurement_unseal_fail` (`measurementLogUnsealFail`) | `UnsealDiskKey` on failure | Same shape, captured at the failing unseal. Diffing this against `…_seal_success` is the operator's tool for "why did unseal fail?" |
+| `/persist/status/boot_vars/success`, `…/fail` | `saveBootVariables` from the same call sites | EFI BootOrder + BootXXXX variables copied from `/hostfs/sys/firmware/efi/efivars/`, with the GUID suffix stripped. |
+
+`GetTpmLogFileNames`, `GetTpmLogBackupFileNames`, and
+`GetBootVariablesDirNames` are the public accessors `monitor` and
+similar tools use to reach the log paths without hard-coding them.
+
+## Public API Surface
+
+### Capability / probe
+
+| Function | What it returns |
+|---|---|
+| `IsTpmEnabled() bool` | `true` iff `/config/device.cert.pem` exists and `/config/device.key.pem` does not. The presence of the soft key file is the canonical "TPM path failed at provisioning time" marker. Before `tpmmgr createDeviceCert` has run (no cert file yet) it returns `false`, which is correct: a not-yet-provisioned device has no TPM-rooted identity. |
+| `PCRBankSHA256Enabled() bool` | Cached probe: reads PCR 0 in the SHA256 bank once and remembers the result in `pcrBank256Status`. False on no-TPM platforms or TPMs without a SHA256 bank. |
+| `FetchTpmSwStatus() info.HwSecurityModuleStatus` | `NOTFOUND` / `DISABLED` / `ENABLED` for the controller report. |
+| `FetchTpmHwInfo() / FetchTpmHwInfoDescription() (string, error)` | "`<vendor>-<model>, FW Version <v>`" string for the controller report. Returns `ErrNoTPM` on no-TPM platforms (or `""` from `…Description`). Cached after the first call. |
+| `GetSpecVersion() (string, error)` | TPM family indicator (e.g. `"2.0"`). |
+| `GetTpmProperty(tpm2.TPMProp) (uint32, error)` | Raw `GetCapability` wrapper used by the helpers above. |
+| `GetModelName(v1, v2 uint32) string` / `GetFirmwareVersion(v1, v2 uint32) string` | Decode the four-byte ASCII vendor strings and packed firmware-version words returned by the TPM. |
+| `GetRandom(uint16) ([]byte, error)` | `tpm2.GetRandom` wrapper. Used as the entropy source for vault-key seed generation (`FetchVaultKey`, `FetchSealedVaultKey`) — TPM RNG is preferred over `/dev/urandom` to match the recommendation in the TPM 2.0 architecture spec. |
+
+### Key + cert primitives
+
+| Function | Purpose |
+|---|---|
+| `TpmPrivateKey` | `crypto.Signer` whose `Sign` routes through the TPM device key. Used as the private-key argument to `x509.CreateCertificate` so that certs are signed by the in-TPM device key without ever materialising the private value. `Public()` returns either the cached value set by `SetDevicePublicKey` (used during the bootstrap before `device.cert.pem` is on disk) or the public key parsed from the cert file. |
+| `SetDevicePublicKey(crypto.PublicKey)` | Seed the cached public key for `TpmPrivateKey.Public()` during the self-signed bootstrap. |
+| `TpmSign(digest []byte) (*big.Int, *big.Int, error)` | Low-level: sign a 32-byte SHA-256 digest with the device key (`TpmDeviceKeyHdl`), returning the raw ECDSA `R, S`. `controllerconn/authen.go` calls this for the device-authenticated handshake. `TpmPrivateKey.Sign` wraps it with `asn1.Marshal`. |
+| `CreateKey(log, tpmPath, keyHandle, ownerHandle, template, overwrite)` | Generate a primary key under the owner hierarchy and `EvictControl` it into a persistent slot. The `overwrite=false` path is idempotent: an existing key with matching attributes is left in place; only attribute mismatches trigger a recreate. Called by `tpmmgr` for EK / SRK / AK / quote / ECDH and for the device key itself. |
+| `ReadOwnerCrdl() (string, error)` | Read `/config/tpm_credential` and truncate to `MaxPasswdLength` (7 bytes). This is the auth value bound to the device key on creation (see `TpmPasswdHdl` row above); device-key operations (`TpmSign`, `ECDHZGen`, and vcomlink's `tpmSign` / `tpmReadNV` / `tpmCertifyKeyWithAik`) must pass it. |
+| `GetDevicePrivateKey()` / `GetPrivateKeyFromFile(path)` / `GetPublicKeyFromCert(path)` | PEM helpers in `keys.go` for the soft-key path. `GetDevicePrivateKey` reads `/config/device.key.pem` and returns an `*ecdsa.PrivateKey`; `GetPublicKeyFromCert` parses any X.509 cert PEM. |
+| `EccIntToBytes(curve, *big.Int) []byte` | Left-pad an ECC scalar to the curve's byte width. Works around the "missing leading zero" issue in pre-v1.38 TPMs that reject ECPoints whose `XRaw`/`YRaw` are shorter than the curve size. |
+
+`DefaultKeyParams`, `DefaultEkTemplate`, `DefaultSrkTemplate`,
+`DefaultAikTemplate`, `DefaultQuoteKeyTemplate`,
+`DefaultEcdhKeyTemplate` are the `tpm2.Public` templates used with
+`CreateKey`. The EK template is the TCG standard EK template
+(verbatim AuthPolicy from
+[Credential_Profile_EK_V2.0](https://trustedcomputinggroup.org/wp-content/uploads/Credential_Profile_EK_V2.0_R14_published.pdf));
+the others are bespoke to EVE.
+
+### Encrypt / decrypt
+
+`encryptdecypt.go` implements the two operations that funnel almost
+every "secret crossing the TPM boundary" path in pillar:
+
+| Function | Used by |
+|---|---|
+| `EncryptDecryptUsingTpm(in []byte, encrypt bool) ([]byte, error)` | `vaultmgr` for vault-key wrap/unwrap; `tpmmgr testEncryptDecrypt` and the periodic TPM sanity check; `cipher` for `EdgeNodeCert` body roundtrips. Derives an AES-256 key from the ECDH shared secret between the device's own ECDH key (`TpmEcdhKeyHdl`) and the device cert public key, then AES-CFB encrypts or decrypts with an all-zero IV. Same call on both sides → reversible. |
+| `DecryptSecretWithEcdhKey(log, X, Y, edgeNodeCert, iv, ciphertext, plaintext)` | `cipher` for controller-to-device secret exchange. The controller has performed the other half of an ECDH against the published `ecdh.cert.pem`; this function reconstructs the shared secret (`tpm2.ECDHZGen(TpmEcdhKeyHdl, …)` if TPM, scalar mult if soft), KDFs it (SHA256 over the X/Y points padded to curve width), and AES-CFB-decrypts. |
+| `AESEncrypt` / `AESDecrypt` | The AES-CFB primitive used by both of the above. Also exported for direct use by `cipher`. |
+| `Sha256FromECPoint(X, Y, pubKey)` | KDF: pad X and Y to curve width, concatenate, SHA-256. |
+
+The soft-fallback path inside `getDecryptKey` triggers when either
+`IsTpmEnabled()` is false or `edgeNodeCert.IsTpm` is false — the
+latter handles the case where the device has a TPM in general but
+the ECDH cert was created via the soft path. In that case the
+private key is read from `EcdhKeyFile` (`/persist/certs/ecdh.key.pem`)
+and the scalar multiplication happens in Go rather than in hardware.
+
+### Disk-key seal / unseal
+
+`SealDiskKey` and `UnsealDiskKey` are the public entry points. Both
+branch on `tpmSupportsAES128CFB()`:
+
+* If the TPM supports AES-128-CFB as a symmetric cipher (queried via
+  `tpm2.TestParms`), the encrypted variants in `enc_seal.go` are used.
+  These wrap the seal/unseal in a salted HMAC session
+  (`tpm2.Salted(TpmEKHdl, ekPub)`) with `tpm2.AESEncryption(128,
+  Encrypt{In,Out})` parameter encryption. The session salt is
+  encrypted to the EK public key by the kernel-side
+  `transport.TPM`; the plaintext disk key is therefore encrypted on
+  the CPU↔TPM bus and protected from a passive bus snooper.
+* Otherwise, the legacy variants `sealDiskKeyLegacy` /
+  `unsealDiskKeyLegacy` are used. These use the older `legacy/tpm2`
+  API with a plain `PolicyPCR` session — correct, but the key value
+  is in cleartext on the bus.
+
+Both paths store the sealed object in the same two NV indices
+(`TpmSealedDiskPubHdl` / `TpmSealedDiskPrivHdl`) in the same wire
+format. The encrypted variant strips the leading 2-byte size prefix
+from the v2 `tpm2.Marshal(TPMTPublic)` output before storing, so an
+encrypted-path seal can be unsealed by the legacy path on a
+subsequent boot (and vice versa) — both paths read the same on-TPM
+bytes.
+
+The two reasons `enc_seal.go` uses the newer `tpm2` package while
+the rest of the file uses `legacy/tpm2`:
+
+1. Parameter encryption (`AESEncryption(128, Encrypt{In,Out})`) on
+   salted HMAC sessions is only available on the v2 API.
+2. `TPMLPCRSelection` / `TPMSPCRSelection` carry the
+   PC-Client-compatible bitmap helpers (`PCClientCompatible.PCRs(...)`)
+   needed to build the policy session correctly for the v2 ABI.
+
+Migrating the rest of the package to v2 is tracked separately — see
+[TSS 2.0 Backend](#tss-20-backend) below.
+
+#### Wrapper / high-level entry points
+
+| Function | What it does |
+|---|---|
+| `FetchVaultKey(log)` | Legacy (un-sealed) path. Reads `TpmDiskKeyHdl` from NV; on miss generates 32 random bytes via `GetRandom` and writes them. Used on TPMs without a usable SHA256 PCR bank. |
+| `FetchSealedVaultKey(log)` | Modern path. Branches on `(sealedKeyPresent, legacyKeyPresent)`: fresh install → generate + seal; legacy only → "clone-then-seal" migration so a failed upgrade can still fall back; sealed present → unseal. Falls back to `FetchVaultKey` if the SHA256 PCR bank is absent. |
+| `SealDiskKey(log, key, pcrSel)` | Seal + write success-side measurement log + boot variables + sealing-PCR snapshot. |
+| `UnsealDiskKey(pcrSel)` | Unseal; on failure also copy the current measurement log and boot variables into the `…_unseal_fail` slots, and call `FindMismatchingPCRs` to enrich the returned error with the list of PCR indexes whose values have changed since seal time. |
+| `UnsealDiskKeyWithRecovery(log, pcrSel)` | Try `UnsealDiskKey(pcrSel)`; on failure call `RecoverDiskKeyPolicyPcr` and try again with the recovered selection. Called from inside `FetchSealedVaultKey`. |
+| `WipeOutStaleSealedKeyIfAny()` | NV-undefine both seal handles. Used by `vaultmgr` before re-sealing with a new policy. |
+| `PolicyPCRSession(rw, pcrSel)` | Build a `tpm2.SessionPolicy` with a single `PolicyPCR` step and return the session handle + computed policy digest. Used by the legacy seal/unseal path. |
+| `CompareLegacyandSealedKey(log)` | Returns a `SealedKeyType` (`Unknown` / `Reused` / `New` / `Unprotected`) describing the relationship between the legacy and sealed keys for the controller report. |
+
+`SealedKeyType` is the user-facing label set published in
+`EncryptedVaultKeyFromDevice`; its `String()` is what the controller
+sees.
+
+### PCR policy bookkeeping
+
+| Function | What it does |
+|---|---|
+| `GetDiskKeyPolicyPcrOrDefault(path) tpm2.PCRSelection` | Read `policy-pcr.json` under a file lock, validate, return the selection. Fall back to `DefaultDiskKeySealingPCRs` on missing / corrupt / invalid file. |
+| `SaveDiskKeyPolicyPcr(sp, path) (changed, err)` | Sort indexes, compare to existing file under lock, write atomically only if different. **Crashes the service via `log.Fatalf` on write failure** — the rationale is to let the boot loop retry rather than continue with a stale policy. |
+| `ValidatePolicyPcr(sp) error` | Constraint check (see [PCR selections](#pcr-selections)). |
+| `RecoverDiskKeyPolicyPcr() (tpm2.PCRSelection, error)` | Read the sealed object's `AuthPolicy` digest, try the default selection first, then brute-force subsets of `PcrListForQuote.PCRs`. Saves the recovered selection back to `policy-pcr.json` with `ID = PolicyPCRRecoveredDefault` or `PolicyPCRRecovered`. |
+| `FindMismatchingPCRs() ([]int, error)` | Read the saved sealing-time PCR map (`sealingpcrs`) and compare against current PCR values; return the indexes that differ. Used to enrich unseal-failure errors with operator-actionable detail (e.g. "PCR 7 changed → secure-boot policy update"). |
+
+## Callers
+
+`evetpm` has no main package; the dependency arrows all point inward.
+Major callers in pillar:
+
+| Caller | What it uses `evetpm` for |
+|---|---|
+| `pkg/pillar/cmd/tpmmgr` | Everything provisioning-related: `CreateKey` against every template, `IsTpmEnabled`, `TpmPrivateKey`, `FetchTpmHwInfoDescription`, `EncryptDecryptUsingTpm` (sanity check), `GetTpmLogFileNames` / `GetBootVariablesDirNames` (debug bundles). See [`pkg/pillar/docs/tpmmgr.md`](../docs/tpmmgr.md). |
+| `pkg/pillar/cmd/vaultmgr` | `FetchSealedVaultKey`, `SealDiskKey`, `EncryptDecryptUsingTpm` (wrap/unwrap of the controller-supplied vault key), `CompareLegacyandSealedKey`, `ValidatePolicyPcr` / `SaveDiskKeyPolicyPcr`. The vault key seal/unseal flow is the principal consumer of this package; `UnsealDiskKeyWithRecovery`, `WipeOutStaleSealedKeyIfAny`, and `FindMismatchingPCRs` are reached transitively through `FetchSealedVaultKey` and the `pkg/pillar/vault` handlers. |
+| `pkg/pillar/vault/{handler_ext4,handler_zfs,key}.go` | Wrappers that pick `FetchSealedVaultKey` vs. `FetchVaultKey` based on `PCRBankSHA256Enabled()`. |
+| `pkg/pillar/cipher/handlecipher.go` | `DecryptSecretWithEcdhKey`, `EncryptDecryptUsingTpm` for the controller-to-device secret exchange (`EdgeNodeCert`-keyed cipher blocks). |
+| `pkg/pillar/controllerconn/{authen,tls}.go` | `TpmPrivateKey`, `TpmSign` for the device-key-signed authentication handshake; `IsTpmEnabled` to pick the soft vs. TPM-rooted code path. |
+| `pkg/pillar/cmd/zedagent/reportinfo.go` | `FetchTpmSwStatus`, `FetchTpmHwInfoDescription`, `GetSpecVersion`, `CompareLegacyandSealedKey` for the controller info report (`HSMStatus`, `HSMInfo`). |
+| `pkg/pillar/cmd/vcomlink` | `TpmEKHdl`, `TpmAIKHdl` and the read primitives — the guest-VM TPM service exposed over vsock proxies a subset of TPM ops back into this package. |
+| `pkg/pillar/cmd/msrv` | Credential-activation flow (`ActivateCredentialReq`) goes through the same handles. |
+| `pkg/pillar/cmd/monitor/messages.go` | `GetTpmLogFileNames`, `GetTpmLogBackupFileNames`, `GetBootVariablesDirNames` to ship the latest seal/unseal artefacts off the device for diagnostics. |
+| `pkg/pillar/hardware/inventory.go` | `FetchTpmHwInfo` for the hardware inventory. |
+
+`nodeagent` is an indirect consumer: it watches `TpmSanityStatus`
+published by `tpmmgr`, which `tpmmgr` derives from the result of
+`EncryptDecryptUsingTpm` + `tpm2.Quote` here.
+
+## TSS 2.0 Backend
+
+TPM2 commands go through Google's
+[`go-tpm`](https://github.com/google/go-tpm) (Apache 2.0). The
+package pulls in **both** the `legacy/tpm2` package and the newer
+top-level `tpm2` (plus `tpm2/transport`). The split is by file:
+
+| File | API | Why |
+|---|---|---|
+| `tpm.go`, `encryptdecypt.go` | `legacy/tpm2` | These predate the v2 package upstream. The legacy API is still supported and the migration cost has not justified the rewrite. |
+| `enc_seal.go` | `tpm2` + `tpm2/transport` | Salted HMAC sessions with AES-128-CFB parameter encryption are only exposed on the v2 API. The bitmap helpers (`PCClientCompatible.PCRs(...)`) and `TPMLPCRSelection` types also live there. |
+| `keys.go` | none (pure Go `crypto/*` / PEM) | Soft-key helpers. |
+
+Most of `tpmmgr` and `evetpm` predate the v2 package and the legacy
+API has remained adequate; `enc_seal.go` was written against the v2
+package because parameter encryption and `TPMLPCRSelection` are only
+exposed there. A full v2 migration is **TBD** — a tracking issue will
+be filed separately.
+
+## Test Hooks
+
+`testhelper.go` exposes two helpers (`SimTpmWaitForTpmReadyState`,
+`SimTpmAvailable`) for unit tests that run against a `swtpm`
+simulator. Several package globals are deliberately `var` rather
+than `const` so tests can redirect them:
+
+* `TpmDevicePath` (`/dev/tpmrm0`) — set to the swtpm socket.
+* `EcdhKeyFile` (`/persist/certs/ecdh.key.pem`) — set to a tempdir
+  path; `SetECDHPrivateKeyFile` is the public setter.
+* `savedSealingPcrsFile`, `measurementLogSealSuccess`,
+  `measurementLogUnsealFail` — redirected so a test seal/unseal does
+  not stomp the on-device persistent state.
+
+These are not part of the runtime API surface — production callers
+should treat them as constants.
+
+## Further Reading
+
+* [`pkg/pillar/docs/tpmmgr.md`](../docs/tpmmgr.md) — the microservice
+  that drives provisioning and attestation through this package.
+* [`docs/SECURITY-ARCHITECTURE.md`](../../../docs/SECURITY-ARCHITECTURE.md)
+  — EVE's top-level security design: device identity, onboarding,
+  vault-key sealing, attestation.
+* [Trusted Computing Group](https://trustedcomputinggroup.org/) —
+  TPM 2.0 specifications. The policy-digest formula reproduced in
+  `computePolicyPCRAuthDigest` is in Part 1 ("Architecture"), the
+  EK template is from the EK Credential Profile.
+* [`go-tpm`](https://github.com/google/go-tpm) — both `legacy/tpm2`
+  and the top-level `tpm2` packages used here.


### PR DESCRIPTION
Replace the 30-line stub at `pkg/pillar/docs/tpmmgr.md` with a full
microservice architecture doc, and add `pkg/pillar/evetpm/evetpm.md`
as the canonical reference for the on-TPM data layout, public API
surface, and disk-key seal/unseal owned by `pkg/pillar/evetpm`.
`tpmmgr.md` is operator-facing and cross-links into `evetpm.md` for
package-level detail.

Docs-only — review by rendering both files and spot-checking the
technical claims against `pkg/pillar/cmd/tpmmgr/tpmmgr.go` and
`pkg/pillar/evetpm/*.go`. No backport.