### PR TITLE
docs(config-properties): correct debug.enable.{usb,vga,console} defaults

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -34,10 +34,10 @@
 | network.fallback.any.eth | "enabled" or "disabled" | disabled (enabled forcefully during onboarding if no network config) | - | - | if no connectivity try any Ethernet, WiFi, or LTE with DHCP client |
 | network.download.max.cost | 0-255 | 0 | 0 | 255 | [max port cost for download](DEVICE-CONNECTIVITY.md) to avoid e.g., LTE ports |
 | blob.download.max.retries | 1-10 | 5 | 1 | 10 | max download retries when image verification fails. |
-| debug.enable.usb | boolean | false | - | - | allow USB e.g. keyboards on device |
-| debug.enable.vga | boolean | false | - | - | allow VGA console on device |
+| debug.enable.usb | boolean | true | - | - | allow USB e.g. keyboards on device (controller by default overrides to false) |
+| debug.enable.vga | boolean | true | - | - | allow VGA console on device (controller by default overrides to false) |
 | debug.enable.ssh | authorized ssh key | empty string(ssh disabled) | - | - | allow ssh to EVE |
-| debug.enable.console | boolean | false | - | - | allow console access to EVE (reboot required to disable) |
+| debug.enable.console | boolean | true | - | - | allow console access to EVE, reboot required to disable (controller by default overrides to false) |
 | debug.enable.vnc.shim.vm | boolean | false | - | - | allow VNC access to the container application shim VM (reboot required to disable) |
 | storage.dom0.disk.minusage.percent | integer percent | 20 | 20 | 80 | min. percent of persist partition reserved for dom0 |
 | storage.zfs.reserved.percent | integer percent | 20 | 1 | 99 | min. percent of persist partition reserved for zfs performance |


### PR DESCRIPTION
Refs #5298 — fixing the most clearly verifiable subset of the documented vs code-default drift in `CONFIG-PROPERTIES.md`.

Three boolean defaults in the doc were `false`, but EVE's own defaults in `pkg/pillar/types/global.go` are `true`:

```go
configItemSpecMap.AddBoolItem(UsbAccess, true)     // global.go:1121, key "debug.enable.usb"
configItemSpecMap.AddBoolItem(VgaAccess, true)     // global.go:1122, key "debug.enable.vga"
configItemSpecMap.AddBoolItem(ConsoleAccess, true) // global.go:1129, key "debug.enable.console"
```

The code has a `// Controller likely default to false` comment next to each, which explains where the doc's prior value came from. Treating EVE's default and the controller's default as the same thing is the bit that confuses someone running EVE without a controller. The doc now reflects EVE's default and notes the controller-side override so the reader can match either path.

Scope kept narrow on purpose. The full sync requested in #5298 is a bigger pass, and one item raised in the issue thread (`kubernetes.drain.timeout` vs `kubevirt.drain.timeout`) didn't reproduce against `master` — code uses `kubernetes.drain.timeout` at `pkg/pillar/types/global.go:402`. Easier to land the verifiable defaults first; happy to follow up with the missing-keys pass if the direction here is right.

DCO: `Signed-off-by: Matt Van Horn <mvanhorn@gmail.com>`