### PR TITLE
pillar: emit coverage for short-lived agents

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -29,6 +29,16 @@ TPMINFOTEMPFILE=/var/tmp/tpminfo.txt
 echo "$(date -Ins -u) Starting device-steps.sh"
 echo "$(date -Ins -u) EVE version: $(cat /run/eve-release)"
 
+# Set GOCOVERDIR for coverage-instrumented pillar binaries (built with
+# COVER=y).  This MUST be in the environment before any pillar binary
+# is exec'd: Go's -cover runtime caches GOCOVERDIR at main-package init
+# time, so setting it later via os.Setenv would only help the explicit
+# WriteMetaDir/WriteCountersDir paths and leave the auto-on-exit path
+# poisoned (no covcounters for short-lived agents like client).
+# Harmless on non-coverage builds.
+mkdir -p $PERSISTDIR/coverage
+export GOCOVERDIR=$PERSISTDIR/coverage
+
 if [ -f "$FIRSTBOOTFILE" ]; then
   FIRSTBOOT=1
 fi

--- a/pkg/pillar/scripts/onboot.sh
+++ b/pkg/pillar/scripts/onboot.sh
@@ -25,6 +25,16 @@ MIN_DISKSPACE=4096 # MBytes
 
 echo "$(date -Ins -u) Starting onboot.sh"
 
+# Set GOCOVERDIR for coverage-instrumented pillar binaries (built with
+# COVER=y).  This MUST be in the environment before any pillar binary
+# is exec'd: Go's -cover runtime caches GOCOVERDIR at main-package init
+# time, so setting it later via os.Setenv would only help the explicit
+# WriteMetaDir/WriteCountersDir paths and leave the auto-on-exit path
+# poisoned (no covcounters for short-lived agents like client).
+# Harmless on non-coverage builds.
+mkdir -p $PERSISTDIR/coverage
+export GOCOVERDIR=$PERSISTDIR/coverage
+
 # Copy pre-defined fscrypt.conf
 cp fscrypt.conf /etc/fscrypt.conf
 

--- a/pkg/pillar/zedbox/zedbox.go
+++ b/pkg/pillar/zedbox/zedbox.go
@@ -134,6 +134,7 @@ func main() {
 			}
 		}
 		retval := runService(basename, sep, inline)
+		agentlog.FlushCoverage(log)
 		os.Exit(retval)
 	}
 	// If this zedbox?
@@ -146,9 +147,11 @@ func main() {
 		}
 		retval := runService(basename, sep, inline)
 		// Not likely to ever return, but for uniformity ...
+		agentlog.FlushCoverage(log)
 		os.Exit(retval)
 	}
 	fmt.Printf("zedbox: Unknown package: %s\n", basename)
+	agentlog.FlushCoverage(log)
 	os.Exit(1)
 }
 


### PR DESCRIPTION
# Description

I realized the cover output had nothing for pkg/pillar/cmd/client. This is the fix for that.

Go's `-cover` runtime caches `GOCOVERDIR` (via `os.Getenv`) at main-package
init time, from `internal/coverage/cfile.InitHook` → `emitMetaData`. If
the env var is empty at that point, the auto-on-exit hook silently drops
counters forever — `goCoverDir == ""` short-circuits `emitCounterData`.
Setting `GOCOVERDIR` afterwards from `zedbox/coverage.go`'s `init()` via
`os.Setenv` arrives **after** that capture; it only helps the explicit
`coverage.WriteMetaDir`/`WriteCountersDir` paths (which take a directory
argument and don't consult the cached value).

That is why every inline entrypoint invoked as a separate process —
`client`, `hardwaremodel`, `waitforaddr`, `conntrack`, `upgradeconverter`,
`ipcmonitor`, and `tpmmgr`/`vaultmgr`/`zedkube` when called with args —
shows 0% in the collected coverage profile, while daemons running inside
the long-lived `zedbox` process average ~58%.

This PR fixes it two ways (belt-and-suspenders, so either alone is
enough but together they cover every code path):

1. **Set `GOCOVERDIR` in the environment** before any pillar binary is
   exec'd. `pkg/pillar/scripts/onboot.sh` and
   `pkg/pillar/scripts/device-steps.sh` each `mkdir -p
   /persist/coverage` and `export GOCOVERDIR=/persist/coverage` near the
   top. Both scripts run as separate linuxkit containers (`pillar-onboot`
   and the pillar service via `rootfs.yml.in`), so each needs its own
   export. Harmless on non-coverage builds (the env var is unused).
2. **Explicit flush before `os.Exit`** in `pkg/pillar/zedbox/zedbox.go`.
   `agentlog.FlushCoverage(log)` is called immediately before each of
   the three `os.Exit` paths in `main`. It routes through the public
   `WriteMetaDir`/`WriteCountersDir` API which takes the directory as an
   argument, so it works even if a wrapper script forgets to export
   `GOCOVERDIR`. `FlushCoverage` is already a no-op on non-coverage
   builds via the existing build-tag stub in `agentlog/coverage_stub.go`.

The existing `FlushCoverage` calls before `zboot.Reset`/`zboot.Poweroff`
in `nodeagent/handletimers.go:394` and `evalmgr/system_reset.go:22`
already work for the same architectural reason — they use the public
API with an explicit directory, gated only on `finalHashComputed` and
`cmode == CtrModeAtomic`, both set unconditionally in
`prepareForMetaEmit` before the GOCOVERDIR check. No change needed
there.

## How to test and validate this PR

1. Build EVE with `COVER=y` (instrumented binary).
2. Boot and let Eden run an e2e test against the device.
3. Run `eden eve collect-coverage --output-dir /tmp/eve-coverage/`.
4. Convert and inspect:
   `go tool covdata textfmt -i=… -o=/tmp/cov.txt && grep cmd/client/ /tmp/cov.txt`.
5. Expected: non-zero coverage on `cmd/client/`, `cmd/waitforaddr/`,
   `cmd/hardwaremodel/`, `cmd/conntrack/`, `cmd/upgradeconverter/`,
   `cmd/ipcmonitor/`, and any other inline-spawned agent that actually
   ran during the test. Daemon agents (`zedagent`, `nim`, `nodeagent`,
   …) should be unchanged.
6. On a non-coverage (`COVER` unset) build, EVE should boot and run
   normally — no behavioral change.

Diagnostic: on the device before the fix, console/stderr from inline
binaries showed `warning: GOCOVERDIR not set, no coverage data emitted`
from the Go cover runtime. That message should no longer appear.

## Changelog notes

No user-facing changes. Improves test coverage reporting for short-lived
pillar agents on EVE builds compiled with `COVER=y`.

## PR Backports

- 16.0-stable: No, this only affects test instrumentation in `COVER=y`
  builds (not shipped to users).
- 14.5-stable: No, same reason.
- 13.4-stable: No, same reason.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (commit message + PR body)
- [ ] I've tested my PR on amd64 device — pending Eden run with `COVER=y` build
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR