### PR TITLE
bond: Enable active ARP validation to prevent cross-node interference

### DIFF
--- a/pkg/pillar/dpcreconciler/linuxitems/bond.go
+++ b/pkg/pillar/dpcreconciler/linuxitems/bond.go
@@ -145,6 +145,30 @@ func (c *BondConfigurator) Create(ctx context.Context, item depgraph.Item) error
 	} else if bondCfg.ARPMonitor.Enabled {
 		bond.ArpInterval = int(bondCfg.ARPMonitor.Interval)
 		bond.ArpIpTargets = bondCfg.ARPMonitor.IPTargets
+		// With arp_validate=none (default 0), the kernel considers the active
+		// slave healthy if it recently received *any* traffic, not just ARP
+		// replies from the configured target.  In EVE clustering mode, multiple
+		// EVE nodes share the same L2 segment, each running a bond with ARP
+		// monitoring directed at the same gateway.  Each bond periodically
+		// broadcasts ARP requests to the gateway; the switch delivers those
+		// broadcasts to all hosts on the segment, including the bond slaves of
+		// neighbouring nodes.  Should the link between the switch and the
+		// gateway fail, the gateway can no longer reply -- yet the cross-node
+		// ARP broadcasts continue to arrive on the local slave and refresh its
+		// last_rx timestamp, causing the ARP monitor to consider the path
+		// healthy and suppressing failover.
+		//
+		// arp_validate=active requires an ARP reply addressed to *this* device
+		// from the configured target to be received on the active slave, so
+		// cross-node traffic cannot falsely keep the slave alive.
+		//
+		// Note: this also fixes a bond failure when running EVE inside our test
+		// framework, where the bridge connecting the EVE VM to the SDN VM keeps
+		// forwarding STP BPDUs to the EVE bond slave even after the SDN-side interface
+		// is administratively brought down (to imitate link failure).
+		// With arp_validate=none those BPDUs refresh last_rx and mask the failure;
+		// with arp_validate=active they are correctly ignored.
+		bond.ArpValidate = netlink.BOND_ARP_VALIDATE_ACTIVE
 	} else if isFailoverBondMode(bondCfg.Mode) {
 		// Enable MII monitoring with a default interval for failover-type bonds
 		// when no monitoring method is explicitly configured. Without link monitoring,


### PR DESCRIPTION
# Description

With the default `arp_validate=none (0)`, the kernel considers the active slave healthy if it recently received *any* traffic on that slave, not just an ARP reply from the configured target.

In EVE clustering mode, multiple EVE nodes share the same L2 segment, each running a bond with ARP monitoring directed at the same gateway. Each bond periodically broadcasts ARP requests to the gateway; the switch delivers those broadcasts to all hosts on the segment, including the bond slaves of neighboring nodes.  Should the link between the switch and the gateway fail (while the switch itself remains up), the gateway can no longer reply -- yet the cross-node ARP broadcasts continue to arrive on the local slave and refresh its `last_rx` timestamp, causing the ARP monitor to consider the path healthy and suppressing failover.

Set `arp_validate=active` so that liveness requires an ARP reply addressed to *this* device from the configured target to be received on the active slave.  Cross-node traffic is therefore ignored, and a local path failure is detected after `arp_missed_max` intervals with no valid ARP replies.

Note: this also fixes a bond failure when running EVE inside our test framework, where the bridge connecting the EVE VM to the SDN VM keeps forwarding STP BPDUs to the EVE bond slave even after the SDN-side interface is administratively brought down (to imitate link failure). With `arp_validate=none` those BPDUs refresh `last_rx` and mask the failure; with `arp_validate=active` they are correctly ignored.

## How to test and validate this PR

**Network setup:**
- 3-node EVE cluster, each node connected to two switches (SW1 and SW2) via an active-backup bond -- one slave per switch.
- SW1 and SW2 are interconnected and both have uplinks to the gateway.
- All bonds use ARP monitoring directed at the gateway.

**Failure scenario:**
- Sever the uplink between SW1 and the gateway, leaving SW2's uplink intact.
- Nodes whose active slave is on SW1 lose the path to the gateway, but keep receiving each other's ARP probes.

**Expected behavior with `arp_validate=active`:**
- Each node only counts ARP replies from the gateway that are addressed to
  *itself*. Requests/Replies sourced/destined from/to a neighbouring node are ignored.
- Nodes with their active slave on SW1 detect the failure within
  `arp_missed_max × arp_interval` ms and failover to the slave on SW2,
  restoring gateway connectivity.

**Verification:**
- `cat /sys/class/net/<bond>/bonding/arp_validate` should read `active 1`.
- After injecting the failure, confirm the active slave switches from the
  SW1-facing interface to the SW2-facing one within the expected timeout.

## Changelog notes

Bonds with ARP monitoring now correctly detect gateway failures in multi-node cluster setups where cross-node ARP traffic could previously mask a broken path and suppress failover

## PR Backports

- 16.0-stable: to be backported
- 14.5-stable: not necessary (we announced bond support only since 16.0)
- 13.4-stable: not necessary (we announced bond support only since 16.0)

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.