### PR TITLE
[16.0-stable] Force bonds/vlans re-parsing when lower layer changes

### DIFF
--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -154,8 +154,8 @@ func parseConfig(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig,
 		// used by systemAdapters
 		physioChanged := parseDeviceIoListConfig(getconfigCtx, config)
 		// It is important to parse Bonds before VLANs.
-		bondsChanged := parseBonds(getconfigCtx, config)
-		vlansChanged := parseVlans(getconfigCtx, config)
+		bondsChanged := parseBonds(getconfigCtx, config, physioChanged)
+		vlansChanged := parseVlans(getconfigCtx, config, physioChanged || bondsChanged)
 		// Network objects are used for systemAdapters
 		networksChanged := parseNetworkXObjectConfig(getconfigCtx, config)
 		sourceChanged := getconfigCtx.lastConfigSource != source
@@ -1685,7 +1685,8 @@ func parseDeviceIoListConfig(getconfigCtx *getconfigContext,
 
 var bondsPrevConfigHash []byte
 
-func parseBonds(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig) bool {
+func parseBonds(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig,
+	forceParse bool) bool {
 	bonds := config.GetBonds()
 	h := sha256.New()
 	for _, bond := range bonds {
@@ -1693,7 +1694,7 @@ func parseBonds(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig) b
 	}
 	configHash := h.Sum(nil)
 	same := bytes.Equal(configHash, bondsPrevConfigHash)
-	if same {
+	if same && !forceParse {
 		return false
 	}
 	bondsPrevConfigHash = configHash
@@ -1801,7 +1802,8 @@ func parseBonds(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig) b
 
 var vlansPrevConfigHash []byte
 
-func parseVlans(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig) bool {
+func parseVlans(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig,
+	forceParse bool) bool {
 	vlans := config.GetVlans()
 	h := sha256.New()
 	for _, vlan := range vlans {
@@ -1809,7 +1811,7 @@ func parseVlans(getconfigCtx *getconfigContext, config *zconfig.EdgeDevConfig) b
 	}
 	configHash := h.Sum(nil)
 	same := bytes.Equal(configHash, vlansPrevConfigHash)
-	if same {
+	if same && !forceParse {
 		return false
 	}
 	vlansPrevConfigHash = configHash

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -314,7 +314,7 @@ func TestParseVlans(t *testing.T) {
 	}
 
 	parseDeviceIoListConfig(getconfigCtx, config)
-	parseVlans(getconfigCtx, config)
+	parseVlans(getconfigCtx, config, false)
 	parseNetworkXObjectConfig(getconfigCtx, config)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 
@@ -513,7 +513,7 @@ func TestParseBonds(t *testing.T) {
 	}
 
 	parseDeviceIoListConfig(getconfigCtx, config)
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseNetworkXObjectConfig(getconfigCtx, config)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 
@@ -684,8 +684,8 @@ func TestParseVlansOverBonds(t *testing.T) {
 	}
 
 	parseDeviceIoListConfig(getconfigCtx, config)
-	parseBonds(getconfigCtx, config)
-	parseVlans(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
+	parseVlans(getconfigCtx, config, false)
 	parseNetworkXObjectConfig(getconfigCtx, config)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 
@@ -953,7 +953,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -965,7 +965,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 	// fix:
 	config.Bonds[0].Logicallabel = "bond-shopfloor"
 	config.SystemAdapterList[0].LowerLayerName = "bond-shopfloor"
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -984,7 +984,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1002,7 +1002,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			BondMode:        zcommon.BondMode_BOND_MODE_ACTIVE_BACKUP,
 		},
 	}
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1035,7 +1035,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1047,7 +1047,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 
 	// fix:
 	config.Bonds[0].LowerLayerNames = []string{"shopfloor"}
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1086,8 +1086,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(getconfigCtx, config)
-	parseVlans(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
+	parseVlans(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1101,8 +1101,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 
 	// fix:
 	config.Vlans[1].VlanId = 200
-	parseBonds(getconfigCtx, config)
-	parseVlans(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
+	parseVlans(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1143,8 +1143,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(getconfigCtx, config)
-	parseVlans(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
+	parseVlans(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1158,8 +1158,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 
 	// fix:
 	config.Bonds[0].LowerLayerNames = []string{"shopfloor"} // remove warehouse from the LAG
-	parseBonds(getconfigCtx, config)
-	parseVlans(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
+	parseVlans(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1198,7 +1198,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1213,7 +1213,7 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 	// fix
 	config.Bonds[0].LowerLayerNames = []string{"shopfloor"}
 	config.Bonds[1].LowerLayerNames = []string{"warehouse"}
-	parseBonds(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1240,8 +1240,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 			},
 		},
 	}
-	parseBonds(getconfigCtx, config)
-	parseVlans(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
+	parseVlans(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1253,8 +1253,8 @@ func TestInvalidLowerLayerReferences(t *testing.T) {
 
 	// fix:
 	config.Vlans[0].VlanId = 1000
-	parseBonds(getconfigCtx, config)
-	parseVlans(getconfigCtx, config)
+	parseBonds(getconfigCtx, config, false)
+	parseVlans(getconfigCtx, config, false)
 	parseSystemAdapterConfig(getconfigCtx, config, fromController, true)
 	portConfig, err = getconfigCtx.pubDevicePortConfig.Get("zedagent")
 	g.Expect(err).To(BeNil())
@@ -1840,4 +1840,160 @@ func TestParseIpspec_GatewayVersionMismatch(t *testing.T) {
 
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("IP version mismatch"))
+}
+
+// TestBondMemberSwap verifies that swapping physical adapters between two bonds
+// produces a correct DPC with no "aggregated by multiple bonds" error.
+//
+// The key scenario: bond2 has no direct system adapter (it is only reachable via
+// VLANs). When bond membership changes but the VLAN config is identical, the VLAN
+// hash is unchanged. Without forceParse, parseVlans would skip its re-parsing and
+// keep stale lowerL2Ports pointers to the old bond2, causing the old bond2
+// (with its old members) to appear in the DPC alongside the updated bond1,
+// making one adapter appear in both bonds.
+func TestBondMemberSwap(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctx := initGetConfigCtx(g)
+
+	const networkUUID = "572cd3bc-ade6-42ad-97a0-22cd24fed1a0"
+
+	config := &zconfig.EdgeDevConfig{
+		Networks: []*zconfig.NetworkConfig{
+			{
+				Id:   networkUUID,
+				Type: zcommon.NetworkType_V4,
+				Ip:   &zcommon.Ipspec{Dhcp: zcommon.DHCPType_Client},
+			},
+		},
+		DeviceIoList: []*zconfig.PhysicalIO{
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "eth0",
+				Logicallabel: "eth0",
+				Assigngrp:    "eth-grp-1",
+				Phyaddrs:     map[string]string{"ifname": "eth0", "pcilong": "0000:01:00.0"},
+				Usage:        zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "eth1",
+				Logicallabel: "eth1",
+				Assigngrp:    "eth-grp-2",
+				Phyaddrs:     map[string]string{"ifname": "eth1", "pcilong": "0000:02:00.0"},
+				Usage:        zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "eth2",
+				Logicallabel: "eth2",
+				Assigngrp:    "eth-grp-3",
+				Phyaddrs:     map[string]string{"ifname": "eth2", "pcilong": "0000:03:00.0"},
+				Usage:        zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+			{
+				Ptype:        zcommon.PhyIoType_PhyIoNetEth,
+				Phylabel:     "eth3",
+				Logicallabel: "eth3",
+				Assigngrp:    "eth-grp-4",
+				Phyaddrs:     map[string]string{"ifname": "eth3", "pcilong": "0000:04:00.0"},
+				Usage:        zcommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+			},
+		},
+		Bonds: []*zconfig.BondAdapter{
+			{
+				Logicallabel:    "bond1",
+				InterfaceName:   "bond1",
+				LowerLayerNames: []string{"eth0", "eth1"},
+				BondMode:        zcommon.BondMode_BOND_MODE_ACTIVE_BACKUP,
+				Monitoring:      &zconfig.BondAdapter_Mii{Mii: &zconfig.MIIMonitor{Interval: 100}},
+			},
+			{
+				Logicallabel:    "bond2",
+				InterfaceName:   "bond2",
+				LowerLayerNames: []string{"eth2", "eth3"},
+				BondMode:        zcommon.BondMode_BOND_MODE_ACTIVE_BACKUP,
+				Monitoring:      &zconfig.BondAdapter_Mii{Mii: &zconfig.MIIMonitor{Interval: 100}},
+			},
+		},
+		// bond2 has no direct system adapter — it is only accessible via VLANs.
+		// This is the configuration that exercises the stale-pointer path.
+		Vlans: []*zconfig.VlanAdapter{
+			{
+				Logicallabel:   "vlan20",
+				InterfaceName:  "bond2.20",
+				LowerLayerName: "bond2",
+				VlanId:         20,
+			},
+			{
+				Logicallabel:   "vlan21",
+				InterfaceName:  "bond2.21",
+				LowerLayerName: "bond2",
+				VlanId:         21,
+			},
+		},
+		SystemAdapterList: []*zconfig.SystemAdapter{
+			{
+				Name:           "adapter-bond1",
+				Uplink:         true,
+				NetworkUUID:    networkUUID,
+				LowerLayerName: "bond1",
+			},
+			{
+				Name:           "adapter-vlan20",
+				Uplink:         true,
+				NetworkUUID:    networkUUID,
+				LowerLayerName: "vlan20",
+			},
+			{
+				Name:           "adapter-vlan21",
+				Uplink:         true,
+				NetworkUUID:    networkUUID,
+				LowerLayerName: "vlan21",
+			},
+		},
+	}
+
+	// parseAll runs the parse functions in the same dependency order as parseConfig.
+	parseAll := func(cfg *zconfig.EdgeDevConfig) {
+		physioChanged := parseDeviceIoListConfig(ctx, cfg)
+		bondsChanged := parseBonds(ctx, cfg, physioChanged)
+		vlansChanged := parseVlans(ctx, cfg, physioChanged || bondsChanged)
+		parseNetworkXObjectConfig(ctx, cfg)
+		parseSystemAdapterConfig(ctx, cfg, fromController,
+			physioChanged || bondsChanged || vlansChanged)
+	}
+
+	// Round 1: initial config — bond1=[eth0,eth1], bond2=[eth2,eth3]
+	parseAll(config)
+	portConfig, err := ctx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc := portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeFalse())
+	bond1Port := dpc.LookupPortByLogicallabel("adapter-bond1")
+	g.Expect(bond1Port).ToNot(BeNil())
+	g.Expect(bond1Port.L2LinkConfig.Bond.AggregatedPorts).To(ConsistOf("eth0", "eth1"))
+	bond2Port := dpc.LookupPortByLogicallabel("bond2")
+	g.Expect(bond2Port).ToNot(BeNil())
+	g.Expect(bond2Port.L2LinkConfig.Bond.AggregatedPorts).To(ConsistOf("eth2", "eth3"))
+
+	// Round 2: swap eth1↔eth2 — bond1=[eth0,eth2], bond2=[eth1,eth3].
+	// The VLAN config is identical so parseVlans detects no hash change.
+	// Without forceParse the stale vlan→old-bond2 pointer would leave
+	// old bond2 (carrying eth2) in the DPC alongside new bond1 (also carrying
+	// eth2), triggering "Port eth2 is aggregated by multiple bond interfaces".
+	config.Bonds[0].LowerLayerNames = []string{"eth0", "eth2"}
+	config.Bonds[1].LowerLayerNames = []string{"eth1", "eth3"}
+	parseAll(config)
+	portConfig, err = ctx.pubDevicePortConfig.Get("zedagent")
+	g.Expect(err).To(BeNil())
+	dpc = portConfig.(types.DevicePortConfig)
+	g.Expect(dpc.HasError()).To(BeFalse())
+	g.Expect(getPortError(&dpc, "eth1")).To(BeEmpty())
+	g.Expect(getPortError(&dpc, "eth2")).To(BeEmpty())
+	bond1Port = dpc.LookupPortByLogicallabel("adapter-bond1")
+	g.Expect(bond1Port).ToNot(BeNil())
+	g.Expect(bond1Port.L2LinkConfig.Bond.AggregatedPorts).To(ConsistOf("eth0", "eth2"))
+	bond2Port = dpc.LookupPortByLogicallabel("bond2")
+	g.Expect(bond2Port).ToNot(BeNil())
+	g.Expect(bond2Port.L2LinkConfig.Bond.AggregatedPorts).To(ConsistOf("eth1", "eth3"))
 }


### PR DESCRIPTION
# Description

Backport of https://github.com/lf-edge/eve/pull/5902

## How to test and validate this PR

See https://github.com/lf-edge/eve/pull/5902 for detailed testing instructions.

## Changelog notes

Fixed a bug where re-configuring bond membership (e.g. swapping physical interfaces between two bonds) could leave the device with a broken network configuration and a port aggregated by multiple bonds error, requiring a reboot to recover.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.