### PR TITLE
scepclient: clean up obsolete enrolled certs on boot

### DIFF
--- a/pkg/pillar/cmd/scepclient/run.go
+++ b/pkg/pillar/cmd/scepclient/run.go
@@ -108,6 +108,7 @@ type SCEPClient struct {
 	subControllerCert      pubsub.Subscription
 	subEdgeNodeCert        pubsub.Subscription
 	subSCEPProfile         pubsub.Subscription
+	subZedAgentStatus      pubsub.Subscription
 	pubEnrolledCertStatus  pubsub.Publication
 
 	devUUID          uuid.UUID
@@ -331,6 +332,21 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject,
 	scepClient.subSCEPProfile = subSCEPProfile
 	subSCEPProfile.Activate()
 
+	// subscribe to zedagent status events
+	subZedAgentStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:   "zedagent",
+		MyAgentName: agentName,
+		TopicImpl:   types.ZedAgentStatus{},
+		Activate:    false,
+		WarningTime: warningTime,
+		ErrorTime:   errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	scepClient.subZedAgentStatus = subZedAgentStatus
+	subZedAgentStatus.Activate()
+
 	// Ticker used to periodically:
 	//   - Detect enrolled certificates or private keys that have been lost
 	//     (e.g. due to a disk error or vault re-creation) and trigger re-enrollment.
@@ -366,6 +382,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject,
 
 		case change := <-subSCEPProfile.MsgChan():
 			subSCEPProfile.ProcessChange(change)
+
+		case change := <-subZedAgentStatus.MsgChan():
+			subZedAgentStatus.ProcessChange(change)
 
 		case <-scepClient.retryTicker.C:
 			scepClient.retryAndStartRenew()

--- a/pkg/pillar/cmd/scepclient/scep.go
+++ b/pkg/pillar/cmd/scepclient/scep.go
@@ -52,24 +52,7 @@ func (c *SCEPClient) handleSCEPProfile(profile types.SCEPProfile, deleted bool) 
 	if deleted {
 		c.log.Noticef("Clearing EnrolledCertificateStatus for deleted SCEP profile %s",
 			profile.ProfileName)
-		if enrolledCert.CertFilepath != "" {
-			if err = os.Remove(enrolledCert.CertFilepath); err != nil {
-				c.log.Errorf(
-					"Failed to remove certificate file %q for deleted SCEP profile %q: %v",
-					enrolledCert.CertFilepath, profile.ProfileName, err)
-			}
-		}
-		if enrolledCert.PrivateKeyFilepath != "" {
-			if err = os.Remove(enrolledCert.PrivateKeyFilepath); err != nil {
-				c.log.Errorf(
-					"Failed to remove private key file %q for deleted SCEP profile %q: %v",
-					enrolledCert.PrivateKeyFilepath, profile.ProfileName, err)
-			}
-		}
-		if err = c.pubEnrolledCertStatus.Unpublish(profile.ProfileName); err != nil {
-			c.log.Errorf("Failed to un-publish EnrolledCertificateStatus for profile %s",
-				profile.ProfileName)
-		}
+		c.deleteEnrolledCert(profile.ProfileName, enrolledCert)
 		return
 	}
 
@@ -1513,6 +1496,8 @@ func (c *SCEPClient) retryAndStartRenew() {
 		enrolledCert.Error = types.ErrorDescription{}
 		c.publishEnrolledCertStatus(enrolledCert)
 	}
+
+	c.cleanupObsoleteEnrolledCerts()
 }
 
 // populateCertStatus copies certificate-derived fields from cert
@@ -1689,6 +1674,61 @@ func (c *SCEPClient) removeCACertBundle(enrolledCert *types.EnrolledCertificateS
 	if enrolledCert.CACertBundleFilepath != "" {
 		_ = os.Remove(enrolledCert.CACertBundleFilepath)
 		enrolledCert.CACertBundleFilepath = ""
+	}
+}
+
+// deleteEnrolledCert removes the cert, private key, and CA bundle files associated
+// with an EnrolledCertificateStatus and unpublishes the status.
+func (c *SCEPClient) deleteEnrolledCert(profileName string,
+	enrolledCert types.EnrolledCertificateStatus) {
+	if enrolledCert.CertFilepath != "" {
+		if err := os.Remove(enrolledCert.CertFilepath); err != nil {
+			c.log.Errorf(
+				"Failed to remove certificate file %q for deleted SCEP profile %q: %v",
+				enrolledCert.CertFilepath, profileName, err)
+		}
+	}
+	if enrolledCert.PrivateKeyFilepath != "" {
+		if err := os.Remove(enrolledCert.PrivateKeyFilepath); err != nil {
+			c.log.Errorf(
+				"Failed to remove private key file %q for deleted SCEP profile %q: %v",
+				enrolledCert.PrivateKeyFilepath, profileName, err)
+		}
+	}
+	c.removeCACertBundle(&enrolledCert)
+	if err := c.pubEnrolledCertStatus.Unpublish(profileName); err != nil {
+		c.log.Errorf("Failed to un-publish EnrolledCertificateStatus for profile %s",
+			profileName)
+	}
+}
+
+// cleanupObsoleteEnrolledCerts removes EnrolledCertificateStatus entries (and their
+// associated files) for SCEP profiles that zedagent no longer publishes. This covers
+// the case where a profile is deleted while the device is powered off: on next boot
+// scepclient receives no "delete" pubsub notification and must detect the orphan itself.
+//
+// The cleanup is skipped until zedagent reports ConfigGetSuccess or ConfigGetReadSaved,
+// to avoid removing certs before zedagent has had a chance to publish all current profiles.
+func (c *SCEPClient) cleanupObsoleteEnrolledCerts() {
+	zedAgentStatusObj, err := c.subZedAgentStatus.Get("zedagent")
+	if err != nil || zedAgentStatusObj == nil {
+		return
+	}
+	zedAgentStatus := zedAgentStatusObj.(types.ZedAgentStatus)
+	if zedAgentStatus.ConfigGetStatus != types.ConfigGetSuccess &&
+		zedAgentStatus.ConfigGetStatus != types.ConfigGetReadSaved {
+		return
+	}
+
+	for _, certStatusObj := range c.pubEnrolledCertStatus.GetAll() {
+		certStatus := certStatusObj.(types.EnrolledCertificateStatus)
+		profileName := certStatus.CertEnrollmentProfileName
+		if _, err := c.subSCEPProfile.Get(profileName); err == nil {
+			continue
+		}
+		c.log.Noticef("Removing EnrolledCertificateStatus for obsolete SCEP profile %s",
+			profileName)
+		c.deleteEnrolledCert(profileName, certStatus)
 	}
 }
 


### PR DESCRIPTION
# Description

When a SCEP profile is replaced while the device is powered off, scepclient receives no "profile deleted" pubsub notification on next boot and therefore leaves behind stale `EnrolledCertificateStatus` entries and their cert/key files.

Fix by scanning all published `EnrolledCertificateStatus` entries in `retryAndStartRenew()` and removing any that lack a matching `SCEPProfile` from zedagent. The scan is gated on zedagent reporting `ConfigGetSuccess` or `ConfigGetReadSaved` so we do not prematurely remove certs before zedagent has had a chance to fetch and publish all current profiles.

The deletion logic is extracted into `deleteEnrolledCert()` to avoid duplication with the existing `handleSCEPProfile` delete path.

## How to test and validate this PR

1. Deploy edge-node with a configured SCEP profile.
2. Wait until the device successfully enrolls a certificate for the configured SCEP profile.
3. Power off the device.
4. While the device is offline, replace the existing SCEP profile with a new one (at minimum, use a different profile name).
5. Power the device back on.
6. Within a few minutes (depending on `scep.retry.interval`), the device should report successful enrollment for the new profile and stop reporting `info.CertInfo` for the previous, now-obsolete profile.
7. You can also verify on the device that `/persist/status/scepclient/EnrolledCertificateStatus/` contains a JSON file only for the new profile.

## Changelog notes

Fixed stale certificates and keys not being removed when a SCEP profile is deleted while the device is powered off.

## PR Backports

```text
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.