### PR TITLE
[14.5-stable] device-steps: disable mdev hotplug

### DIFF
--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -491,6 +491,10 @@ if [ -f $CONFIGDIR/onboard.cert.pem ] && [ -f $CONFIGDIR/onboard.key.pem ]; then
    echo "$(date -Ins -u) Self-registering our device certificate"
    CLIENT_COMMANDS="selfRegister $CLIENT_COMMANDS"
 fi
+
+# disable mdev
+echo "" > /proc/sys/kernel/hotplug
+
 echo "$(date -Ins -u) Starting client $CLIENT_COMMANDS"
 # shellcheck disable=SC2086
 if ! $BINDIR/client $CLIENT_COMMANDS; then


### PR DESCRIPTION
# Description

Backport of https://github.com/lf-edge/eve/pull/5924

## How to test and validate this PR

Boot eve, check that `/proc/sys/kernel/hotplug` gets cleared.

## Changelog notes

Disable mdev

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
