### PR TITLE
PNAC: fix DHCP reacquire being lost on concurrent DPC update

### DIFF
--- a/pkg/pillar/dpcmanager/dpc.go
+++ b/pkg/pillar/dpcmanager/dpc.go
@@ -235,10 +235,6 @@ func (m *DpcManager) doAddDPC(ctx context.Context, dpc types.DevicePortConfig) {
 		return
 	}
 
-	// Cancel any active DHCP reacquire trackers — the new DPC may change
-	// port configuration, making the previous subnet baseline invalid.
-	m.cancelAllDHCPReacquireTrackers()
-
 	// Restart verification.
 	m.dpcVerify.inProgress = false
 	m.restartVerify(ctx, fmt.Sprintf("new DPC (%s/%v)", dpc.Key, dpc.TimePriority))

--- a/pkg/pillar/dpcmanager/dpcmanager.go
+++ b/pkg/pillar/dpcmanager/dpcmanager.go
@@ -615,19 +615,28 @@ func (m *DpcManager) cancelDHCPReacquireTracker(portLL string) {
 	}
 }
 
-// cancelAllDHCPReacquireTrackers cancels all active DHCP reacquire trackers.
-func (m *DpcManager) cancelAllDHCPReacquireTrackers() {
-	for portLL := range m.dhcpReacquireState {
-		m.cancelDHCPReacquireTracker(portLL)
-	}
-}
-
 // processDHCPReacquireSignal handles a DHCP reacquire timer firing for a port.
 // It increments the reacquire counter to trigger DHCP client restart via the reconciler.
 func (m *DpcManager) processDHCPReacquireSignal(ctx context.Context, portLL string) {
 	tracker, ok := m.dhcpReacquireState[portLL]
 	if !ok {
-		// Tracker was cancelled (e.g. new DPC arrived); ignore stale signal.
+		// Tracker was already cancelled (e.g. subnet change completed);
+		// ignore stale signal.
+		return
+	}
+	// If the current DPC no longer has PNAC+DHCP client for this port,
+	// the reacquire is no longer needed.
+	dpc, haveDPC := m.getCurrentDPC()
+	if !haveDPC {
+		m.cancelDHCPReacquireTracker(portLL)
+		return
+	}
+	portConfig := dpc.LookupPortByLogicallabel(portLL)
+	if portConfig == nil ||
+		!portConfig.PNAC.Enabled || portConfig.Dhcp != types.DhcpTypeClient {
+		m.Log.Noticef("PNAC: Canceling DHCP reacquire for port %q: "+
+			"no longer has PNAC+DHCP client configured", portLL)
+		m.cancelDHCPReacquireTracker(portLL)
 		return
 	}
 	tracker.retriesDone++

--- a/pkg/pillar/dpcmanager/dpcmanager_test.go
+++ b/pkg/pillar/dpcmanager/dpcmanager_test.go
@@ -3485,6 +3485,7 @@ func TestPNACDHCPReacquire(test *testing.T) {
 	aa := makeAA(selectedIntfs{eth0: true})
 	timePrio1 := time.Now()
 	dpc := makeDPC("zedagent", timePrio1, selectedIntfs{eth0: true})
+	dpc.Ports[0].PNAC = types.PNACConfig{Enabled: true}
 	dpcManager.UpdateAA(aa)
 	dpcManager.AddDPC(dpc)
 
@@ -3562,6 +3563,7 @@ func TestPNACDHCPReacquireMaxRetries(test *testing.T) {
 	// Apply DPC.
 	aa := makeAA(selectedIntfs{eth0: true})
 	dpc := makeDPC("zedagent", time.Now(), selectedIntfs{eth0: true})
+	dpc.Ports[0].PNAC = types.PNACConfig{Enabled: true}
 	dpcManager.UpdateAA(aa)
 	dpcManager.AddDPC(dpc)
 
@@ -3617,6 +3619,7 @@ func TestPNACDHCPReacquireDisabled(test *testing.T) {
 	// Apply DPC.
 	aa := makeAA(selectedIntfs{eth0: true})
 	dpc := makeDPC("zedagent", time.Now(), selectedIntfs{eth0: true})
+	dpc.Ports[0].PNAC = types.PNACConfig{Enabled: true}
 	dpcManager.UpdateAA(aa)
 	dpcManager.AddDPC(dpc)
 
@@ -3636,26 +3639,26 @@ func TestPNACDHCPReacquireDisabled(test *testing.T) {
 		Should(Equal(0))
 }
 
-// TestPNACDHCPReacquireCancelledByNewDPC verifies that active DHCP reacquire
-// trackers are cancelled when a new DPC is applied.
-func TestPNACDHCPReacquireCancelledByNewDPC(test *testing.T) {
+// TestPNACDHCPReacquireNoPNACInNewDPC verifies that if a DPC update removes
+// PNAC from a port while a DHCP reacquire timer is pending, the timer
+// self-cancels without incrementing the reacquire counter.
+func TestPNACDHCPReacquireNoPNACInNewDPC(test *testing.T) {
 	t := initTest(test)
 
 	// Prepare simulated network stack.
 	eth0 := mockEth0()
-	eth1 := mockEth1()
 	networkMonitor.AddOrUpdateInterface(eth0)
-	networkMonitor.AddOrUpdateInterface(eth1)
 
-	// Apply global config.
+	// Apply global config with PNAC DHCP reacquire enabled.
 	gcp := globalConfig()
 	gcp.SetGlobalValueInt(types.PnacDHCPReacquireMaxRetries, 5)
 	dpcManager.UpdateGCP(gcp)
 
-	// Apply DPC with only eth0.
-	aa := makeAA(selectedIntfs{eth0: true, eth1: true})
+	// Apply DPC with eth0 configured for PNAC + DHCP client.
+	aa := makeAA(selectedIntfs{eth0: true})
 	timePrio1 := time.Now()
 	dpc := makeDPC("zedagent", timePrio1, selectedIntfs{eth0: true})
+	dpc.Ports[0].PNAC = types.PNACConfig{Enabled: true}
 	dpcManager.UpdateAA(aa)
 	dpcManager.AddDPC(dpc)
 
@@ -3664,30 +3667,25 @@ func TestPNACDHCPReacquireCancelledByNewDPC(test *testing.T) {
 	t.Eventually(testingInProgressCb()).Should(BeFalse())
 	t.Eventually(dpcStateCb(0)).Should(Equal(types.DPCStateSuccess))
 
-	// Simulate PNAC event.
+	// Simulate PNAC authentication — schedules a DHCP reacquire timer (2s delay).
 	networkMonitor.PublishPNACEvent(netmonitor.PNACEvent{
 		IfName:          "eth0",
 		IsAuthenticated: true,
 	})
 
-	// Wait for first retry.
+	// Apply a new DPC where eth0 no longer has PNAC enabled. The pending
+	// reacquire tracker survives the DPC transition but self-cancels when
+	// the timer fires because the new port config does not have PNAC.
+	timePrio2 := time.Now()
+	dpc2 := makeDPC("zedagent", timePrio2, selectedIntfs{eth0: true})
+	// dpc2.Ports[0].PNAC.Enabled is false (zero value) — PNAC removed.
+	dpcManager.AddDPC(dpc2)
+
+	// The reacquire counter must remain 0. Wait long enough for the pending
+	// 2s timer (and any scheduler jitter) to have fired and self-cancelled.
 	// The reacquire goroutine fires after 2s (backoff: 2^1), but the periodic
 	// dpcTestTimer (NetworkTestInterval=2s) can fire concurrently and block the
-	// main select loop for another ~2s running testConnectivityToController.
-	// Allow 10s total to cover this worst-case blocking plus scheduler jitter.
-	t.Eventually(dhcpReacquireCounterCb("eth0"), 10*time.Second, 200*time.Millisecond).
-		Should(Equal(1))
-
-	// Apply a new DPC that adds eth1 — the config change should cancel
-	// the active reacquire tracker and trigger re-verification.
-	timePrio2 := time.Now()
-	dpc2 := makeDPC("zedagent", timePrio2, selectedIntfs{eth0: true, eth1: true})
-	dpcManager.AddDPC(dpc2)
-	t.Eventually(testingInProgressCb()).Should(BeTrue())
-	t.Eventually(testingInProgressCb()).Should(BeFalse())
-	t.Eventually(dpcStateCb(0)).Should(Equal(types.DPCStateSuccess))
-
-	// The reacquire counter should not increase further.
+	// main select loop for another ~2s. Allow 10s total.
 	t.Consistently(dhcpReacquireCounterCb("eth0"), 10*time.Second, 500*time.Millisecond).
-		Should(Equal(1))
+		Should(Equal(0))
 }

--- a/pkg/pillar/dpcmanager/verify.go
+++ b/pkg/pillar/dpcmanager/verify.go
@@ -67,11 +67,6 @@ func (m *DpcManager) restartVerify(ctx context.Context, reason string) {
 func (m *DpcManager) setupVerify(index int, reason string) {
 	m.Log.Noticef("DPC verify: Setting up verification for DPC at index %d, reason: %s",
 		index, reason)
-	// Cancel any active DHCP reacquire trackers if switching to a different DPC,
-	// because the previous subnet baseline is no longer valid.
-	if m.dpcList.CurrentIndex != index {
-		m.cancelAllDHCPReacquireTrackers()
-	}
 	m.dpcList.CurrentIndex = index
 	m.dpcVerify.inProgress = true
 	m.dpcVerify.startedAt = time.Now()


### PR DESCRIPTION
# Description

When PNAC authenticates, `processPNACEvent` schedules a DHCP reacquire (2s delay, with exponential backoff) to pick up the authenticated VLAN's IP. If a new DPC arrives before that timer fires, `doAddDPC` used to call `cancelAllDHCPReacquireTrackers`, silently dropping any pending reacquire. If the port's PNAC and DHCP config did not change, `wpa_supplicant` stays authenticated without firing a new PNAC event, so the reacquire never happens and the device stays on the onboarding VLAN.

Fix: stop canceling trackers on DPC changes (both `doAddDPC` and `setupVerify`). Trackers now survive any DPC transition. When the timer fires, `processDHCPReacquireSignal` validates that the current DPC still has PNAC+DHCP client configured for the port; if not, it self-cancels. This keeps the guard against stale trackers without losing legitimate reacquires mid-flight.

## How to test and validate this PR

This is a race condition that sporadically occurs after reboot. NIM loads a persisted DPC and starts `wpa_supplicant` immediately; zedagent publishes the controller-provided DPC shortly after. If PNAC authentication completes in the window between the two, the resulting DHCP reacquire timer was canceled when the zedagent DPC arrived, and since the port config is unchanged `wpa_supplicant` does not re-authenticate, so no new PNAC event is fired to reschedule it.

Therefore I recommend to try to reboot edge-node with PNAC-enabled port couple times and check that every time the port eventually obtains authenticated-VLAN IP address.

## Changelog notes

802.1X: Fixed device sporadically staying on the onboarding VLAN after reboot despite successful authentication.

## PR Backports

```text
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```
## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
