### PR TITLE
[16.0-stable] bond: Enable active ARP validation to prevent cross-node interference

### DIFF
--- a/pkg/pillar/dpcreconciler/linuxitems/bond.go
+++ b/pkg/pillar/dpcreconciler/linuxitems/bond.go
@@ -145,6 +145,30 @@ func (c *BondConfigurator) Create(ctx context.Context, item depgraph.Item) error
 	} else if bondCfg.ARPMonitor.Enabled {
 		bond.ArpInterval = int(bondCfg.ARPMonitor.Interval)
 		bond.ArpIpTargets = bondCfg.ARPMonitor.IPTargets
+		// With arp_validate=none (default 0), the kernel considers the active
+		// slave healthy if it recently received *any* traffic, not just ARP
+		// replies from the configured target.  In EVE clustering mode, multiple
+		// EVE nodes share the same L2 segment, each running a bond with ARP
+		// monitoring directed at the same gateway.  Each bond periodically
+		// broadcasts ARP requests to the gateway; the switch delivers those
+		// broadcasts to all hosts on the segment, including the bond slaves of
+		// neighbouring nodes.  Should the link between the switch and the
+		// gateway fail, the gateway can no longer reply -- yet the cross-node
+		// ARP broadcasts continue to arrive on the local slave and refresh its
+		// last_rx timestamp, causing the ARP monitor to consider the path
+		// healthy and suppressing failover.
+		//
+		// arp_validate=active requires an ARP reply addressed to *this* device
+		// from the configured target to be received on the active slave, so
+		// cross-node traffic cannot falsely keep the slave alive.
+		//
+		// Note: this also fixes a bond failure when running EVE inside our test
+		// framework, where the bridge connecting the EVE VM to the SDN VM keeps
+		// forwarding STP BPDUs to the EVE bond slave even after the SDN-side interface
+		// is administratively brought down (to imitate link failure).
+		// With arp_validate=none those BPDUs refresh last_rx and mask the failure;
+		// with arp_validate=active they are correctly ignored.
+		bond.ArpValidate = netlink.BOND_ARP_VALIDATE_ACTIVE
 	} else if isFailoverBondMode(bondCfg.Mode) {
 		// Enable MII monitoring with a default interval for failover-type bonds
 		// when no monitoring method is explicitly configured. Without link monitoring,


### PR DESCRIPTION
# Description

Bonds with ARP monitoring now correctly detect gateway failures in multi-node cluster setups where cross-node ARP traffic could previously mask a broken path and suppress failover.

Backport of https://github.com/lf-edge/eve/pull/5939 (see the original PR for more detailed description)

## How to test and validate this PR

For test instructions, see: https://github.com/lf-edge/eve/pull/5939

## Changelog notes

Bonds with ARP monitoring now correctly detect gateway failures in multi-node cluster setups where cross-node ARP traffic could previously mask a broken path and suppress failover.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.