### PR TITLE
ci: COVER=y build/test path via coverage label

### DIFF
--- a/.github/actions/build-eve/action.yml
+++ b/.github/actions/build-eve/action.yml
@@ -14,6 +14,10 @@ inputs:
   cache-artifact:
     required: true
     description: "Name of the linuxkit cache artifact to download"
+  cover:
+    required: false
+    default: 'false'
+    description: "Build pillar with COVER=y so zedbox is coverage-instrumented"
 
 runs:
   using: composite
@@ -40,14 +44,30 @@ runs:
       shell: bash
       env:
         PR_ID: ${{ github.event.pull_request.number }}
+        COVER: ${{ inputs.cover }}
       run: |
         COMMIT_ID=$(git describe --abbrev=8 --always)
-        echo "VERSION=0.0.0-pr$PR_ID-$COMMIT_ID" >> $GITHUB_ENV
-        echo "TAG=evebuild/pr:$PR_ID" >> $GITHUB_ENV
-    - name: Build EVE ${{ inputs.hv }}-${{ inputs.arch }}-${{ inputs.platform }}
+        if [ "$COVER" = "true" ]; then
+          echo "VERSION=0.0.0-pr$PR_ID-$COMMIT_ID-cover" >> "$GITHUB_ENV"
+          echo "TAG=evebuild/pr-cover:$PR_ID" >> "$GITHUB_ENV"
+          echo "ARTIFACT_BASE=eve-cover-${{ inputs.hv }}-${{ inputs.arch }}-${{ inputs.platform }}" >> "$GITHUB_ENV"
+        else
+          echo "VERSION=0.0.0-pr$PR_ID-$COMMIT_ID" >> "$GITHUB_ENV"
+          echo "TAG=evebuild/pr:$PR_ID" >> "$GITHUB_ENV"
+          echo "ARTIFACT_BASE=eve-${{ inputs.hv }}-${{ inputs.arch }}-${{ inputs.platform }}" >> "$GITHUB_ENV"
+        fi
+    - name: Rebuild pillar with coverage instrumentation
+      if: ${{ inputs.cover == 'true' }}
       shell: bash
       run: |
-        make V=1 ROOTFS_VERSION="$VERSION" PLATFORM=${{ inputs.platform }} \
+        make V=1 ROOTFS_VERSION="$VERSION" COVER=y PLATFORM=${{ inputs.platform }} \
+          HV=${{ inputs.hv }} ZARCH=${{ inputs.arch }} eve-pillar
+    - name: Build EVE ${{ inputs.hv }}-${{ inputs.arch }}-${{ inputs.platform }}
+      shell: bash
+      env:
+        COVER_FLAG: ${{ inputs.cover == 'true' && 'COVER=y' || '' }}
+      run: |
+        make V=1 ROOTFS_VERSION="$VERSION" $COVER_FLAG PLATFORM=${{ inputs.platform }} \
           HV=${{ inputs.hv }} ZARCH=${{ inputs.arch }} eve
     - name: Post build report
       shell: bash
@@ -59,13 +79,13 @@ runs:
       run: |
         make cache-export ZARCH=${{ inputs.arch }} \
           IMAGE=lfedge/eve:$VERSION-${{ inputs.hv }} \
-          OUTFILE=eve-${{ inputs.hv }}-${{ inputs.arch }}-${{ inputs.platform }}.tar \
+          OUTFILE=$ARTIFACT_BASE.tar \
           IMAGE_NAME=$TAG-${{ inputs.hv }}-${{ inputs.arch }}
     - name: Upload EVE image
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
       with:
-        name: eve-${{ inputs.hv }}-${{ inputs.arch }}-${{ inputs.platform }}
-        path: eve-${{ inputs.hv }}-${{ inputs.arch }}-${{ inputs.platform }}.tar
+        name: ${{ env.ARTIFACT_BASE }}
+        path: ${{ env.ARTIFACT_BASE }}.tar
     - name: Clean
       if: always()
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,36 @@ jobs:
           hv: kvm
           cache-artifact: linuxkit-cache-amd64-generic
 
+  # Coverage-instrumented build. Opt-in via the `coverage` PR label so the
+  # extra ~1× build cost only lands on PRs that want a coverage signal from
+  # the Eden test matrix. The Eden trusted workflow's tests-master-cover job
+  # consumes the eve-cover-* artifact this produces.
+  eve-amd64-kvm-generic-cover:
+    name: "eve (amd64, kvm, generic, cover)"
+    needs: pkgs-amd64-generic
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'coverage') }}
+    runs-on: zededa-ubuntu-2204
+    timeout-minutes: 1440
+    steps:
+      - name: Clear repository
+        shell: bash
+        run: |
+          sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
+          rm -fr ~/.linuxkit
+          docker system prune --all --force --volumes
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+      - uses: ./.github/actions/build-eve
+        with:
+          arch: amd64
+          platform: generic
+          hv: kvm
+          cache-artifact: linuxkit-cache-amd64-generic
+          cover: 'true'
+
   # ── amd64 rt ──
 
   eve-amd64-kvm-rt:

--- a/.github/workflows/eden-trusted.yml
+++ b/.github/workflows/eden-trusted.yml
@@ -37,6 +37,7 @@ jobs:
       gate_run_id: ${{ steps.extract.outputs.gate_run_id }}
       gate_status_name: ${{ steps.extract.outputs.gate_status_name }}
       skip_run: ${{ steps.check_gate.outputs.skip_run }}
+      has_coverage: ${{ steps.labels.outputs.has_coverage }}
     steps:
       - name: Download
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -107,6 +108,22 @@ jobs:
             fi
             echo "$field=$value" >> "$GITHUB_OUTPUT"
           done
+
+      - name: Detect coverage label
+        if: ${{ steps.check_gate.outputs.skip_run == 'false' }}
+        id: labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_ID: ${{ steps.extract.outputs.pr_id }}
+        run: |
+          # gh api bypasses the classic-Projects GraphQL deprecation error that
+          # affects `gh pr view` on lf-edge repos.
+          has=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_ID}" --jq '.labels[].name' | grep -Fx coverage || true)
+          if [ -n "$has" ]; then
+            echo "has_coverage=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_coverage=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Define Titles
         if: ${{ steps.check_gate.outputs.skip_run == 'false' }}
@@ -227,16 +244,36 @@ jobs:
       artifact_run_id: ${{ needs.context.outputs.original_run_id }}
       eden_version: "master"
 
+  # Coverage-instrumented run, opt-in via the `coverage` PR label. Consumes
+  # the eve-cover-* artifact produced by build.yml's *-cover job and emits
+  # the covdata-merged artifact via eden's coverage-merge job.
+  tests-master-cover:
+    name: ${{ needs.context.outputs.eden_parent_job_title }} for master (cover)
+    needs: context
+    if: >-
+      needs.context.outputs.skip_run == 'false'
+      && needs.context.outputs.pr_base_ref == 'master'
+      && needs.context.outputs.has_coverage == 'true'
+    uses: lf-edge/eden/.github/workflows/test.yml@master
+    secrets: inherit
+    with:
+      eve_image: "evebuild/pr-cover:${{ needs.context.outputs.pr_id }}"
+      eve_log_level: "debug"
+      eve_artifact_name: "eve-cover-${{ needs.context.outputs.hv }}-${{ needs.context.outputs.arch }}-${{ needs.context.outputs.platform }}"
+      artifact_run_id: ${{ needs.context.outputs.original_run_id }}
+      eden_version: "master"
+
   finalize:
     name: Eden Tests Complete
-    needs: [context, tests-13-4-stable, tests-14-5-stable, tests-16-0-stable, tests-master]
+    needs: [context, tests-13-4-stable, tests-14-5-stable, tests-16-0-stable, tests-master, tests-master-cover]
     if: always() && needs.context.outputs.skip_run == 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Check test results
         id: check
         run: |
-          # Determine which job ran
+          # Determine which job ran. The cover variant runs alongside
+          # tests-master on coverage-labeled PRs; require both to succeed.
           if [[ "${{ needs.tests-13-4-stable.result }}" != "skipped" ]]; then
             result="${{ needs.tests-13-4-stable.result }}"
           elif [[ "${{ needs.tests-14-5-stable.result }}" != "skipped" ]]; then
@@ -245,6 +282,10 @@ jobs:
             result="${{ needs.tests-16-0-stable.result }}"
           else
             result="${{ needs.tests-master.result }}"
+            cover_result="${{ needs.tests-master-cover.result }}"
+            if [[ "$cover_result" != "skipped" && "$cover_result" != "success" ]]; then
+              result="$cover_result"
+            fi
           fi
 
           echo "Eden tests result: $result"

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -89,18 +89,34 @@ jobs:
           RUN_ID: ${{ steps.meta.outputs.original_run_id }}
           GH_REPO: ${{ github.repository }}
           BUILD_JOB_NAME: "eve (${{ matrix.arch }}, ${{ matrix.hv }}, ${{ matrix.platform }})"
+          COVER_BUILD_JOB_NAME: "eve (${{ matrix.arch }}, ${{ matrix.hv }}, ${{ matrix.platform }}, cover)"
         run: |
-          build_conclusion=$(gh api \
-            /repos/$GH_REPO/actions/runs/$RUN_ID/jobs \
-            -X GET \
-            -q ".jobs[] | select(.name == \"$BUILD_JOB_NAME\") | .conclusion" ) || api_status=$?
+          jobs_json=$(gh api "/repos/$GH_REPO/actions/runs/$RUN_ID/jobs") || api_status=$?
 
           if [[ "${api_status:-0}" -ne 0 ]]; then
             echo "::error::Failed to fetch build job status for run $RUN_ID"
             echo "build_ok=false" >>"$GITHUB_OUTPUT"
-          else
-            echo "build_ok=$([[ "$build_conclusion" == 'success' ]] && echo true || echo false)" >>"$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          # On the pull_request_review trigger this step may run while the
+          # coverage-instrumented build is still in flight. If the cover job
+          # exists (label present) and is not yet in a terminal state, hold
+          # the gate -- otherwise eden-trusted's tests-master-cover would
+          # start before the eve-cover-* artifact is ready. When the label
+          # is absent the cover job is marked "skipped" at workflow start,
+          # which is already a terminal state.
+          cover_status=$(echo "$jobs_json" | \
+            jq -r ".jobs[] | select(.name == \"$COVER_BUILD_JOB_NAME\") | .status")
+          if [[ -n "$cover_status" && "$cover_status" != "completed" ]]; then
+            echo "Cover build status=$cover_status; gate waits for completion"
+            echo "build_ok=false" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          build_conclusion=$(echo "$jobs_json" | \
+            jq -r ".jobs[] | select(.name == \"$BUILD_JOB_NAME\") | .conclusion")
+          echo "build_ok=$([[ "$build_conclusion" == 'success' ]] && echo true || echo false)" >>"$GITHUB_OUTPUT"
 
       - name: Check Gate Condition
         id: check


### PR DESCRIPTION
# Description

Wire end-to-end opt-in coverage collection for Eden runs against EVE.
Adding the `coverage` PR label causes a parallel `COVER=y` EVE image
build threaded through PR Gate and the Eden trusted workflow into a
second Eden run, which consumes the instrumented artifact and emits
the `covdata-merged` artifact via eden's `coverage-merge` job.

Four pieces:

- **`.github/actions/build-eve/action.yml`** — new `cover` input
  rebuilds pillar with `COVER=y` then builds the eve rootfs with the
  instrumented pillar package. The cover artifact is tagged
  `evebuild/pr-cover:<pr_id>` and uploaded as
  `eve-cover-<hv>-<arch>-<platform>` so it does not collide with the
  non-cover artifact on the runner or in docker.
- **`.github/workflows/build.yml`** — `eve-amd64-kvm-generic-cover`
  runs in parallel with the existing `amd64-kvm-generic` build,
  gated on `contains(labels, 'coverage')`. Non-coverage PRs see this
  job as skipped at workflow start.
- **`.github/workflows/pr-gate.yml`** — Check Build Result fetches
  all jobs from the PR build run once and holds the gate while the
  cover job is in a non-terminal status. The `pull_request_review`
  trigger fires on review submission regardless of PR build progress,
  so on a coverage-labeled PR the cover build can still be in flight
  at that moment; without the wait, the non-cover build's success
  would let the gate pass and eden-trusted would start
  `tests-master-cover` before the `eve-cover-*` artifact was ready.
  Cover-build failure is a soft signal: `build_ok` is decided by the
  non-cover conclusion, so a failed cover build does not block the
  PR — `tests-master-cover` will surface the failure loudly by
  failing to download the artifact.
- **`.github/workflows/eden-trusted.yml`** — detect the `coverage`
  label via `gh api`, thread it through `has_coverage` on the context
  job's outputs, and add a `tests-master-cover` job that runs
  alongside `tests-master` and consumes the `eve-cover-*` artifact
  plus the `evebuild/pr-cover` tag.

The cover path is master-only for now: stable-branch eden tags
(`1.0.15`) predate eden's `eden eve collect-coverage` command, so
adding `tests-<rel>-cover` jobs would have no effect until that eden
change is backported to a new tag.

## PR dependencies

Depends on lf-edge/eden#1173 (`ci-coverage-collection` branch on
`eriknordmark/eden`):

- `collect-coverage: preserve raw covdata in output` — exposes the
  raw `covmeta.*` / `covcounters.*` files in `<output-dir>/covdata/`
  alongside the existing text profile, so `go tool covdata merge` can
  be used across runs.
- `ci: collect eden e2e coverage per matrix job` — adds a
  best-effort `Collect coverage` / `Upload coverage artifact` pair
  to `run-eden-test`, and a `coverage-merge` fan-in job to
  `test.yml` that produces the `covdata-merged` artifact this PR
  expects at the end of each Eden run.

This PR's `tests-master-cover` job calls into
`lf-edge/eden/.github/workflows/test.yml@master`, so the eden change
must be merged first; otherwise the cover job will succeed at running
tests but emit no covdata artifact.

## How to test and validate this PR

1. Land the eden dependency PR first.
2. Open a draft PR against `lf-edge/eve` with the `coverage` label
   set, against `master`.
3. Confirm in the **PR build** workflow that both
   `eve (amd64, kvm, generic)` and `eve (amd64, kvm, generic, cover)`
   jobs run and upload `eve-kvm-amd64-generic` and
   `eve-cover-kvm-amd64-generic` artifacts respectively.
4. Confirm in the **PR Gate** workflow that the gate passes only
   after both build jobs have reached a terminal state, even if a
   review is submitted while the cover build is still in flight.
5. Confirm in the **Run Eden** workflow that both `tests-master` and
   `tests-master-cover` run, and that the cover variant's
   `coverage-merge` job produces a `covdata-merged` artifact
   containing `combined_coverage.txt` and `coverage-summary.txt`.
6. Repeat (2)–(5) on a PR **without** the `coverage` label and
   confirm:
   - The `eve-amd64-kvm-generic-cover` job is skipped at workflow
     start (no extra build cost).
   - PR Gate's Check Build Result reads `cover_status == "completed"`
     (skipped is a terminal state) and falls through to the existing
     non-cover gate logic with no behavior change.
   - `tests-master-cover` is gated off by `has_coverage == 'false'`
     and does not run.

## Changelog notes

No user-facing changes. Internal CI only.

## PR Backports

- 16.0-stable: No — depends on an eden change that is not in the
  eden tag pinned by `eden-trusted.yml` for 16.0-stable.
- 14.5-stable: No — same reason.
- 13.4-stable: No — same reason.

Coverage on stable branches can be enabled later by backporting the
eden change to a new `1.0.x` tag and then mirroring this PR with
`tests-<rel>-cover` jobs pinned at the new tag.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device — not applicable (amd64 only
      for the initial cover matrix entry)
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
