### PR TITLE
baseosmgr: clean up orphan BaseOsStatus on ContentTreeStatus delete

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/handlevolumemgr.go
+++ b/pkg/pillar/cmd/baseosmgr/handlevolumemgr.go
@@ -34,6 +34,23 @@ func handleContentTreeStatusModify(ctxArg interface{}, key string,
 func handleContentTreeStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 	handleContentTreeStatusImpl(ctxArg, key, statusArg)
+
+	// If the BaseOsConfig for a BaseOsStatus referencing this content
+	// tree has already been deleted, doBaseOsUninstall ran at
+	// BaseOsConfig-delete time but returned del=false because
+	// ContentTreeStatus was still present. Retry the uninstall now so
+	// the orphan BaseOsStatus is unpublished instead of lingering until
+	// the next reboot.
+	status := statusArg.(types.ContentTreeStatus)
+	ctx := ctxArg.(*baseOsMgrContext)
+	for _, el := range lookupBaseOsStatusesByContentID(ctx, status.ContentID.String()) {
+		if lookupBaseOsConfig(ctx, el.Key()) != nil {
+			continue
+		}
+		log.Functionf("handleContentTreeStatusDelete: retrying removeBaseOsStatus for %s",
+			el.Key())
+		removeBaseOsStatus(ctx, el.Key())
+	}
 }
 
 func handleContentTreeStatusImpl(ctxArg interface{}, key string,


### PR DESCRIPTION
# Description

This race condition was detected when running new eden tests.

If the content-tree for a failed EVE image is deleted by volumemgr before the baseosconfig, then the baseosstatus is removed. But if the order is different the baseosconfig stays around. Thus depending on races inside EVE when the user does a eveimage-remove one can get different results.

Once the cleanup misses, nothing re-triggers it. The stale BaseOsStatus survives until the agent restarts, and continues to advertise a failed install for a ContentTree that no longer exists. If the controller later pushes the same image back, the install is silently skipped — the agent still remembers the prior failure.

The fix closes the gap by re-running the cleanup when the ContentTree goes away. If a ContentTree is deleted while a BaseOsStatus still references it — and there is no BaseOsConfig keeping that BaseOsStatus alive — the agent retries the cleanup at that moment. The retry succeeds because the ContentTree is now confirmed gone, so the BaseOsStatus is removed exactly as the original cleanup path would have done if the timing had been the other way around.

## How to test and validate this PR

End-to-end verified on qemu (HV=kvm, ZARCH=amd64):

1. Push an EVE image update to the device. The device receives the new BaseOsConfig and ContentTree and begins the install.
2. Remove the image via the controller (`eden eve reset`, or an explicit `eveimage-remove`).
3. **Before the fix:** the failed-install record stays on the device indefinitely. A subsequent attempt to push the same image is silently skipped.
4. **After the fix:** the record is cleared within seconds of the controller removing the image, regardless of which way the internal cleanup race resolved.

A focused unit test for this race would seed a BaseOsStatus whose BaseOsConfig has already been removed, signal the ContentTree delete, and assert that the BaseOsStatus is cleared. Not included in this PR; happy to add if reviewers want it before merge.

## Changelog notes

None (internal cleanup of a stale pubsub record).

## PR Backports

- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (n/a — internal cleanup)
- [x] I've tested my PR on amd64 device (qemu, see above)
- [ ] I've tested my PR on arm64 device (n/a — code path is arch-agnostic)
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

