### PR TITLE
client: drop unused /config fallback

### DIFF
--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -806,13 +806,6 @@ func compareControllerCertBytes(newCertChainBytes, prevCertChainBytes []byte) bo
 
 func doGetUUID(ctx *clientContext, tlsConfig *tls.Config,
 	retryCount int) (bool, uuid.UUID, string) {
-	//First try the new /uuid api, if fails, fall back to /config API
-	done, devUUID, hardwaremodel := doGetUUIDNew(ctx, tlsConfig, retryCount)
-	return done, devUUID, hardwaremodel
-}
-
-func doGetUUIDNew(ctx *clientContext, tlsConfig *tls.Config,
-	retryCount int) (bool, uuid.UUID, string) {
 	ctrlClient := ctx.ctrlClient
 
 	// get UUID does not have UUID string

--- a/pkg/pillar/cmd/client/parseuuid.go
+++ b/pkg/pillar/cmd/client/parseuuid.go
@@ -1,22 +1,20 @@
-// Copyright (c) 2017-2018 Zededa, Inc.
+// Copyright (c) 2017-2026 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package client
 
 import (
-	"fmt"
-	"mime"
 	"net/http"
 	"strings"
 
-	zconfig "github.com/lf-edge/eve-api/go/config"
 	eveuuid "github.com/lf-edge/eve-api/go/eveuuid"
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"google.golang.org/protobuf/proto"
 )
 
-// Return UUID, hardwaremodel, enterprise, and devicename
+// parseUUIDResponse extracts the device UUID and the controller-provided
+// hardwaremodel override (if any) from a /uuid response body.
 func parseUUIDResponse(resp *http.Response, contents []byte) (uuid.UUID, string, error) {
 	var hardwaremodel string
 	var devUUID uuid.UUID
@@ -39,92 +37,6 @@ func parseUUIDResponse(resp *http.Response, contents []byte) (uuid.UUID, string,
 	}
 	return devUUID, hardwaremodel, err
 }
-
-// Return UUID, hardwaremodel, enterprise, and devicename
-func parseConfig(configUrl string, resp *http.Response, contents []byte) (uuid.UUID, string, error) {
-	var devUUID uuid.UUID
-	var hardwaremodel string
-
-	if resp.StatusCode == http.StatusNotModified {
-		log.Tracef("StatusNotModified len %d", len(contents))
-		// Return as error since we are not returning any useful values.
-		return devUUID, hardwaremodel,
-			fmt.Errorf("Unchanged StatusNotModified")
-	}
-
-	if err := validateConfigMessage(configUrl, resp); err != nil {
-		log.Errorln("validateConfigMessage: ", err)
-		return devUUID, hardwaremodel, err
-	}
-
-	configResponse, err := readConfigResponseProtoMessage(contents)
-	if err != nil {
-		log.Errorln("readConfigResponseProtoMessage: ", err)
-		return devUUID, hardwaremodel, err
-	}
-	hash := configResponse.GetConfigHash()
-	if hash == prevConfigHash {
-		log.Tracef("Same ConfigHash %s len %d", hash, len(contents))
-		// Return as error since we are not returning any useful values.
-		return devUUID, hardwaremodel,
-			fmt.Errorf("Unchanged config hash")
-	}
-	log.Functionf("Change in ConfigHash from %s to %s", prevConfigHash, hash)
-	prevConfigHash = hash
-	config := configResponse.GetConfig()
-
-	// Check if we have an override from the device config
-	manufacturer := config.GetManufacturer()
-	productName := config.GetProductName()
-	if manufacturer != "" && productName != "" {
-		hardwaremodel = hardware.FormatModel(manufacturer, productName,
-			"")
-	}
-	uuidStr := strings.TrimSpace(config.GetId().Uuid)
-	devUUID, err = uuid.FromString(uuidStr)
-	if err != nil {
-		log.Errorf("uuid.FromString(%s): %s", uuidStr, err)
-		return devUUID, hardwaremodel, err
-	}
-	return devUUID, hardwaremodel, nil
-}
-
-// From zedagent/handleconfig.go
-func validateConfigMessage(configUrl string, r *http.Response) error {
-
-	var ctTypeStr = "Content-Type"
-	var ctTypeProtoStr = "application/x-proto-binary"
-
-	ct := r.Header.Get(ctTypeStr)
-	if ct == "" {
-		return fmt.Errorf("No content-type")
-	}
-	mimeType, _, err := mime.ParseMediaType(ct)
-	if err != nil {
-		return fmt.Errorf("Get Content-type error")
-	}
-	switch mimeType {
-	case ctTypeProtoStr:
-		return nil
-	default:
-		return fmt.Errorf("Content-type %s not supported",
-			mimeType)
-	}
-}
-
-func readConfigResponseProtoMessage(contents []byte) (*zconfig.ConfigResponse, error) {
-	var configResponse = &zconfig.ConfigResponse{}
-
-	err := proto.Unmarshal(contents, configResponse)
-	if err != nil {
-		log.Errorf("Unmarshalling failed: %v", err)
-		return nil, err
-	}
-	return configResponse, nil
-}
-
-// The most recent config hash we received
-var prevConfigHash string
 
 func generateUUIDRequest() ([]byte, error) {
 	uuidRequest := &eveuuid.UuidRequest{}


### PR DESCRIPTION
## Description

Found some dead comment and dead code from a long time ago when we introduced the /uuid API endoint in the controllers.

zedclient's `doGetUUID` carried a comment promising a fall-back to the
legacy `/config` endpoint when `/uuid` fails. The fallback was never
wired up — only the `/uuid` path is reachable. This PR removes the
unreachable code and the misleading comment. No behavior change.

## How to test and validate this PR

Onboard a device against any controller and confirm the device UUID is
fetched and written as before. Existing onboarding e2e in Eden covers
this path; no new test added in this PR.

## Changelog notes

No user-facing changes.

## PR Backports

- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [x] I've written the test verification instructions