### PR TITLE
eve-k: kube/longhorn: tune replica rebuild, add snapshot management, fix replica/PVC size reporting

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -42,6 +42,7 @@
 | storage.dom0.disk.minusage.percent | integer percent | 20 | 20 | 80 | min. percent of persist partition reserved for dom0 |
 | storage.zfs.reserved.percent | integer percent | 20 | 1 | 99 | min. percent of persist partition reserved for zfs performance |
 | storage.longhorn.disk.reserved.gigabytes | integer GB | 2 | 0 | 1048576 | per-disk storage reserved by Longhorn on the local node; overrides Longhorn's default 25% reservation. 0 sets storageReserved to 0 bytes (no reservation). 1048576 disables EVE's override, leaving Longhorn's current value in place |
+| storage.longhorn.snapshot.cron | cron string | `0 0 * * *` | - | - | cron schedule for Longhorn recurring snapshots; empty string disables. Snapshots bound delta rebuilds after node power loss to writes since the last snapshot. Default daily at midnight UTC. Standard 5-field cron syntax. EVE-k only. |
 | storage.apps.ignore.disk.check | boolean | false | - | - | Ignore disk usage check for Apps. Allows apps to create images bigger than available disk |
 | timer.appcontainer.stats.interval | integer in seconds | 300 (5 minutes) | 1 | 4294967295 (max uint32) | collect application container stats |
 | timer.vault.ready.cutoff | integer in seconds | 300 (5 minutes) | 60 (1 minute) | 4294967295 (max uint32) | reboot after inaccessible vault |

--- a/docs/EVE-K.md
+++ b/docs/EVE-K.md
@@ -120,3 +120,102 @@ running as.  All storage classes installed by EVE will place volumes in /persist
 - Default single node 'First-Boot' Mode (No EdgeNodeCluster eve-api config): Longhorn and Local-Path
 - EdgeNodeCluster with Replicated Storage (CLUSTER_TYPE_REPLICATED_STORAGE): Longhorn and Local-Path
 - EdgeNodeCluster with Base Mode (CLUSTER_TYPE_K3S_BASE): Local-Path
+
+## Longhorn Recurring Snapshots and Rebuild Performance
+
+### How snapshots improve rebuild performance
+
+When a Longhorn replica fails and later recovers with its on-disk data intact (e.g. after
+a node power cycle), Longhorn can perform a **delta rebuild** — transferring only the blocks
+that changed since the last common snapshot rather than copying the entire volume. For a
+100 GiB volume with modest write rates, the difference between a delta rebuild and a full
+rebuild is typically hours vs. minutes.
+
+The delta rebuild path (`CheckAndReuseFailedReplica`) requires a shared snapshot baseline
+between the failed replica and the currently-healthy ones. Without any snapshot, the baseline
+falls back to volume creation time, which is equivalent to a full rebuild for any
+long-running volume.
+
+EVE-k automatically creates a Longhorn
+[`RecurringJob`](https://longhorn.io/docs/1.9.1/snapshots-and-backups/scheduling-backups-and-snapshots/)
+that snapshots all enrolled volumes on a configurable interval (default: daily). This caps
+the maximum delta rebuild data at approximately one interval's worth of writes regardless
+of volume age or size.
+
+### Configuration
+
+The snapshot interval is controlled by the EVE global config property:
+
+| Property | Default | Range | Description |
+| -------- | ------- | ----- | ----------- |
+| `storage.longhorn.snapshot.cron` | `0 0 * * *` | - | Cron schedule for recurring snapshots. Empty string disables. Standard 5-field cron syntax. |
+
+Changes take effect without a reboot: zedkube applies the update to the Longhorn
+`RecurringJob` CRD within one `kubeCfgTimer` cycle.
+
+### Volume enrollment
+
+All EVE storage classes (`lh-sc-rep1`, `lh-sc-rep2`, `lh-sc-rep3`) include
+`recurringJobSelector: '[{"name":"default","isGroup":true}]'`, so any PVC provisioned from
+an EVE storage class is automatically enrolled in the default snapshot group. No manual
+labeling is required for volumes created after cluster initialization.
+
+To enroll an existing PVC that was provisioned before recurring jobs were configured, label
+it directly:
+
+```bash
+kubectl patch pvc <pvc-name> -n eve-kube-app --type=merge \
+  -p '{"metadata":{"labels":{"recurring-job-group.longhorn.io/default":"enabled"}}}'
+```
+
+### Custom recurring jobs (development / testing)
+
+For testing or higher-frequency snapshots on specific volumes, create a custom RecurringJob
+manually. The following example runs an hourly snapshot, retaining 24:
+
+```yaml
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: hourly-dev-snapshots
+  namespace: longhorn-system
+spec:
+  cron: "0 * * * *"
+  task: snapshot
+  groups:
+    - hourly-dev
+  retain: 24
+  concurrency: 2
+```
+
+Apply it:
+
+```bash
+kubectl apply -f hourly-dev-snapshot-job.yaml
+```
+
+Then enroll a specific PVC by adding the job label directly (bypassing the group):
+
+```bash
+kubectl patch pvc <pvc-name> -n eve-kube-app --type=merge \
+  -p '{"metadata":{"labels":{"recurring-job.longhorn.io/hourly-dev-snapshots":"enabled"}}}'
+```
+
+Or enroll by group label if you want any PVC to pick it up:
+
+```bash
+kubectl patch pvc <pvc-name> -n eve-kube-app --type=merge \
+  -p '{"metadata":{"labels":{"recurring-job-group.longhorn.io/hourly-dev":"enabled"}}}'
+```
+
+Verify snapshot activity:
+
+```bash
+# List snapshots for a volume
+kubectl -n longhorn-system get snapshots.longhorn.io \
+  -l longhornvolume=<volume-name> \
+  --sort-by='.metadata.creationTimestamp'
+
+# Check RecurringJob execution history
+kubectl -n longhorn-system get recurringjob -o wide
+```

--- a/pkg/debug/scripts/collect-info.sh
+++ b/pkg/debug/scripts/collect-info.sh
@@ -6,7 +6,7 @@
 
 # Script version, don't forget to bump up once something is changed
 
-VERSION=43
+VERSION=44
 # Add required packages here, it will be passed to "apk add".
 # Once something added here don't forget to add the same package
 # to the Dockerfile ('ENV PKGS' line) of the debug container,
@@ -593,6 +593,10 @@ collect_longhorn_info()
         # when nodes are down.
         # Give up after 5min, and allow remaining system data to be collected.
         timeout 300s eve exec kube /usr/bin/longhorn-generate-support-bundle.sh
+        echo "============"
+        echo "longhorn-snapshot-overhead.sh -v"
+        echo "============"
+        eve exec kube /usr/bin/longhorn-snapshot-overhead.sh -v
     } > "$DIR/longhorn-info" 2>&1
 }
 

--- a/pkg/installer/Dockerfile
+++ b/pkg/installer/Dockerfile
@@ -28,7 +28,7 @@ RUN cargo sbom > sbom.spdx.json
 
 RUN cp "/usr/local/my-installer/target/$CARGO_BUILD_TARGET/release/installer" /usr/local/my-installer/target/installer
 
-FROM lfedge/eve-debug:fc1d616983ba734db1f4923ad3ea76199a567ee4 AS debug
+FROM lfedge/eve-debug:fd937fa82a11106e1c2fadee5f1cca338b5e0421 AS debug
 
 # Dockerfile to build installer img initrd
 FROM lfedge/eve-alpine:325b12087b386811fdb9d3c0adffa5fb94a34b95 AS build

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -82,6 +82,7 @@ COPY longhorn-utils.sh /usr/bin/
 COPY lh-cfg-v1.9.1.yaml /etc/
 COPY iscsid.conf /etc/iscsi/
 COPY longhorn-generate-support-bundle.sh /usr/bin/
+COPY longhorn-snapshot-overhead.sh /usr/bin/
 COPY nsmounter /usr/bin/
 COPY longhorn_uninstall_settings.yaml /etc/
 COPY failover-events.sh /usr/bin/

--- a/pkg/kube/cfg-manifests/longhorn-cfg.yaml
+++ b/pkg/kube/cfg-manifests/longhorn-cfg.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 ---
+# Ensure pods are rescheduled promptly when a node goes down rather than waiting for the node eviction timeout.
 apiVersion: longhorn.io/v1beta2
 kind: Setting
 metadata:
@@ -8,9 +9,56 @@ metadata:
   namespace: longhorn-system
 value: "delete-both-statefulset-and-deployment-pod"
 ---
+# Disable Longhorn's call-home version check; EVE manages Longhorn upgrades independently.
 apiVersion: longhorn.io/v1beta2
 kind: Setting
 metadata:
   name: upgrade-checker
   namespace: longhorn-system
 value: "false"
+---
+# replica-replenishment-wait-interval: how long Longhorn waits after a replica fails before
+# creating a replacement replica object (R-new). This must be long enough to cover the
+# worst-case boot time of the slowest cluster node after a simultaneous power reset.
+#
+# Why this matters: once R-new is created, Longhorn counts it as a "usable" slot
+# (FailedAt=="", Active==true) and getReplenishReplicasCount returns 0. This prevents
+# CheckAndReuseFailedReplica from ever being called, so when the original node returns with
+# its on-disk data, Longhorn schedules R-new there and forces a full rebuild instead of a
+# cheap delta sync. Keeping R-new from being created at all is the only way to preserve
+# the delta reuse path.
+#
+# In EVE's 3-node topology there are no spare nodes for R-new to schedule onto prematurely
+# (rep3 has no free node; rep2's tie-breaker node has Longhorn scheduling disabled), so the
+# wait interval cannot prevent bad placement — its sole purpose is to delay R-new creation
+# until the original nodes are back.
+#
+# Sizing: rank-0 (fastest node, 0 s stagger delay) takes ~2 min to reach Longhorn-ready.
+# rank-2 (50 s stagger delay + Longhorn pod startup) takes ~3:50 from power-on. The interval
+# clock starts when rank-0 sets lastDegradedAt (~T=2 min), so the minimum safe value is
+# ~110 s. The Longhorn default of 600 s provides ample margin and is explicitly set here
+# to make the intent visible in the manifest.
+apiVersion: longhorn.io/v1beta2
+kind: Setting
+metadata:
+  name: replica-replenishment-wait-interval
+  namespace: longhorn-system
+value: "600"
+---
+# Limit concurrent rebuilds per node to avoid saturating disk I/O on edge hardware when all
+# volumes need resync simultaneously after a cluster-wide power reset.
+apiVersion: longhorn.io/v1beta2
+kind: Setting
+metadata:
+  name: concurrent-replica-rebuild-per-node-limit
+  namespace: longhorn-system
+value: "2"
+---
+# Allow Longhorn to self-recover faulted volumes by salvaging the best available replica,
+# critical for unattended edge devices with no operator present to perform manual salvage.
+apiVersion: longhorn.io/v1beta2
+kind: Setting
+metadata:
+  name: auto-salvage
+  namespace: longhorn-system
+value: "true"

--- a/pkg/kube/longhorn-snapshot-overhead.sh
+++ b/pkg/kube/longhorn-snapshot-overhead.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Reports per-volume snapshot filesystem overhead for Longhorn volumes.
+#
+# Each Longhorn snapshot is copy-on-write: status.size is the number of bytes
+# exclusively owned by that snapshot (written since the previous snapshot).
+# Summing these across a volume gives the total space the snapshot chain
+# consumes beyond the live data (status.actualSize).
+#
+# The "volume-head" pseudo-snapshot (named <vol>-volume-head) represents the
+# live data pointer and is excluded from overhead calculations.
+#
+# Usage: longhorn-snapshot-overhead.sh [-v] [-n namespace]
+#   -v              show individual snapshot details per volume
+#   -n namespace    Longhorn namespace (default: longhorn-system)
+
+NAMESPACE=longhorn-system
+VERBOSE=0
+
+while getopts "vn:" opt; do
+    case $opt in
+        v) VERBOSE=1 ;;
+        n) NAMESPACE="$OPTARG" ;;
+        *) printf "Usage: %s [-v] [-n namespace]\n" "$0" >&2; exit 1 ;;
+    esac
+done
+
+for cmd in kubectl jq awk; do
+    if ! command -v "$cmd" > /dev/null 2>&1; then
+        printf "ERROR: %s is required but not found\n" "$cmd" >&2
+        exit 1
+    fi
+done
+
+human_bytes() {
+    b=$1
+    awk -v b="$b" 'BEGIN {
+        if      (b <= 0)           printf "0B"
+        else if (b >= 1073741824)  printf "%.1fGi", b/1073741824
+        else if (b >= 1048576)     printf "%.1fMi", b/1048576
+        else if (b >= 1024)        printf "%.1fKi", b/1024
+        else                       printf "%dB", b
+    }'
+}
+
+vol_json=$(kubectl -n "$NAMESPACE" get volumes.longhorn.io -o json 2>/dev/null)
+if [ -z "$vol_json" ]; then
+    printf "ERROR: could not query Longhorn volumes in namespace %s\n" "$NAMESPACE" >&2
+    exit 1
+fi
+
+vol_count=$(printf '%s' "$vol_json" | jq '.items | length')
+if [ "$vol_count" = "0" ]; then
+    printf "No Longhorn volumes found in namespace %s\n" "$NAMESPACE"
+    exit 0
+fi
+
+snap_tmp=$(mktemp)
+snap_json=$(kubectl -n "$NAMESPACE" get snapshots.longhorn.io -o json 2>"$snap_tmp")
+snap_rc=$?
+if [ "$snap_rc" -ne 0 ]; then
+    printf "warn: kubectl get snapshots.longhorn.io failed: %s\n" "$(cat "$snap_tmp")" >&2
+    snap_json='{"items":[]}'
+elif [ -z "$snap_json" ]; then
+    snap_json='{"items":[]}'
+fi
+rm -f "$snap_tmp"
+
+printf "%-44s %11s %11s %6s %11s %9s  STATE\n" \
+    "VOLUME" "PROVISIONED" "ACTUAL" "SNAPS" "SNAP-USED" "OVERHEAD"
+printf "%-44s %11s %11s %6s %11s %9s  -----\n" \
+    "--------------------------------------------" "-----------" "-----------" "------" "-----------" "---------"
+
+printf '%s' "$vol_json" | jq -r '.items[] | [
+    .metadata.name,
+    ((.spec.size // "0") | tostring),
+    (.status.actualSize // 0 | tostring),
+    (.status.state // "unknown")
+] | @tsv' | while IFS="$(printf '\t')" read -r vol_name spec_size actual_size vol_state; do
+
+    snap_agg=$(printf '%s' "$snap_json" | jq --arg vol "$vol_name" '
+        [ .items[] |
+          select(
+            .spec.volume == $vol and
+            (.metadata.name | endswith("-volume-head") | not)
+          )
+        ] | {
+            count: length,
+            bytes: ([ .[].status.size ] | map(if type == "number" then . else (. // 0 | tonumber) end) | add // 0),
+            list:  [ .[] | {
+                n: .metadata.name,
+                b: .status.size,
+                t: (.status.creationTime // ""),
+                u: .status.userCreated
+            }]
+        }
+    ')
+
+    snap_count=$(printf '%s' "$snap_agg" | jq -r '.count')
+    snap_bytes=$(printf '%s' "$snap_agg" | jq -r '.bytes')
+
+    overhead="0%"
+    if [ "$actual_size" -gt 0 ] 2>/dev/null && [ "$snap_bytes" -gt 0 ] 2>/dev/null; then
+        overhead=$(awk -v s="$snap_bytes" -v a="$actual_size" 'BEGIN { printf "%.1f%%", (s/a)*100 }')
+    elif [ "$snap_bytes" -gt 0 ] 2>/dev/null; then
+        overhead="n/a"
+    fi
+
+    printf "%-44s %11s %11s %6s %11s %9s  %s\n" \
+        "$vol_name" \
+        "$(human_bytes "$spec_size")" \
+        "$(human_bytes "$actual_size")" \
+        "$snap_count" \
+        "$(human_bytes "$snap_bytes")" \
+        "$overhead" \
+        "$vol_state"
+
+    if [ "$VERBOSE" = "1" ] && [ "$snap_count" -gt 0 ]; then
+        printf '%s' "$snap_agg" | jq -r '
+            .list | sort_by(.t) | .[] |
+            [.n, (.b | tostring), (.t // "unknown"), (if .u then "user" else "system" end)] | @tsv
+        ' | while IFS="$(printf '\t')" read -r sname sbytes screated stype; do
+            printf "  %-42s %11s  %-30s [%s]\n" \
+                "$sname" "$(human_bytes "$sbytes")" "$screated" "$stype"
+        done
+        printf "\n"
+    fi
+done
+
+# Totals calculated independently from jq (avoids subshell accumulation issues)
+tot_snap=$(printf '%s' "$snap_json" | jq '
+    [ .items[] |
+      select(.metadata.name | endswith("-volume-head") | not) |
+      .status.size | if type == "number" then . else (. // 0 | tonumber) end
+    ] | add // 0
+')
+tot_actual=$(printf '%s' "$vol_json" | jq '[.items[].status.actualSize // 0] | add // 0')
+
+printf "\n"
+printf "Volumes: %d\n" "$vol_count"
+printf "Total snapshot space:  %s\n" "$(human_bytes "$tot_snap")"
+printf "Total volume actual:   %s\n" "$(human_bytes "$tot_actual")"
+if [ "$tot_actual" -gt 0 ] 2>/dev/null && [ "$tot_snap" -gt 0 ] 2>/dev/null; then
+    awk -v s="$tot_snap" -v a="$tot_actual" 'BEGIN { printf "Overall overhead:      %.1f%%\n", (s/a)*100 }'
+fi

--- a/pkg/kube/manifests/storage-classes.yaml
+++ b/pkg/kube/manifests/storage-classes.yaml
@@ -11,6 +11,7 @@ reclaimPolicy: Delete
 volumeBindingMode: Immediate
 parameters:
   numberOfReplicas: "1"
+  recurringJobSelector: '[{"name":"default","isGroup":true}]'
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -22,6 +23,7 @@ reclaimPolicy: Delete
 volumeBindingMode: Immediate
 parameters:
   numberOfReplicas: "2"
+  recurringJobSelector: '[{"name":"default","isGroup":true}]'
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -33,3 +35,4 @@ reclaimPolicy: Delete
 volumeBindingMode: Immediate
 parameters:
   numberOfReplicas: "3"
+  recurringJobSelector: '[{"name":"default","isGroup":true}]'

--- a/pkg/kube/test/README.md
+++ b/pkg/kube/test/README.md
@@ -1,0 +1,33 @@
+# pkg/kube/test
+
+Scripts in this directory are **not installed** into the kube container image via the
+Dockerfile. They are development and verification tools intended to be bind-mounted into
+a running kube container on demand:
+
+```sh
+eve exec kube sh -c "mount --bind /host/path/to/test/<script>.sh /usr/bin/<script>.sh && <script>.sh"
+```
+
+or copied in for a one-shot run during cluster debugging.
+
+## Tools
+
+| Script | Purpose |
+| ------ | ------- |
+| `kube-test-longhorn-pvc-size.sh` | Compares Longhorn ground-truth PVC sizes (live data + snapshot chain) against EVE's pubsub-reported values in `VolumeStatus.CurrentSize` and `KubeClusterInfo.AllocatedBytes`. Exits 0 if all volumes are within the configurable drift tolerance, 1 otherwise. |
+
+## Usage
+
+```sh
+# Basic — 10% drift tolerance (default)
+kube-test-longhorn-pvc-size.sh
+
+# Stricter tolerance with per-snapshot detail
+kube-test-longhorn-pvc-size.sh -t 5 -v
+
+# Custom Longhorn namespace
+kube-test-longhorn-pvc-size.sh -n longhorn-system
+```
+
+Requires `kubectl`, `jq`, and `awk` in the container (`kubectl` and `jq` are present in
+the kube image; `awk` is provided by busybox).

--- a/pkg/kube/test/kube-test-longhorn-pvc-size.sh
+++ b/pkg/kube/test/kube-test-longhorn-pvc-size.sh
@@ -1,0 +1,263 @@
+#!/bin/sh
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verifies that EVE's pubsub-reported PVC sizes agree with Longhorn ground truth.
+#
+# Ground truth (LH-TOTAL) = status.actualSize (live data) + snapshot chain bytes.
+# Snapshot bytes are the CoW deltas exclusively owned by each snapshot; the
+# volume-head pseudo-snapshot is excluded.
+#
+# EVE reports this in two pubsub paths, both checked here:
+#   VolumeStatus.CurrentSize     /run/volumemgr/VolumeStatus/<key>.json
+#   KubeClusterInfo.AllocatedBytes  /run/zedkube/KubeClusterInfo/global.json
+#
+# Run on a cluster node:
+#   eve exec kube /usr/bin/kube-test-longhorn-pvc-size.sh [-t pct] [-n ns] [-v]
+#
+# Exit: 0 if all volumes within tolerance, 1 if any DRIFT or missing entry.
+#
+# Usage: kube-test-longhorn-pvc-size.sh [-t pct] [-n namespace] [-v]
+#   -t pct        acceptable drift percentage (default: 10)
+#   -n namespace  Longhorn namespace (default: longhorn-system)
+#   -v            verbose: show per-snapshot breakdown per volume
+
+NAMESPACE=longhorn-system
+TOLERANCE_PCT=10
+VERBOSE=0
+VS_DIR=/run/volumemgr/VolumeStatus
+KCI_FILE=/run/zedkube/KubeClusterInfo/global.json
+
+while getopts "t:vn:" opt; do
+    case $opt in
+        t) TOLERANCE_PCT="$OPTARG" ;;
+        v) VERBOSE=1 ;;
+        n) NAMESPACE="$OPTARG" ;;
+        *) printf "Usage: %s [-t pct] [-n namespace] [-v]\n" "$0" >&2; exit 1 ;;
+    esac
+done
+
+for cmd in kubectl jq awk; do
+    if ! command -v "$cmd" > /dev/null 2>&1; then
+        printf "ERROR: %s is required but not found\n" "$cmd" >&2
+        exit 1
+    fi
+done
+
+human_bytes() {
+    b=$1
+    awk -v b="$b" 'BEGIN {
+        if      (b <= 0)           printf "0B"
+        else if (b >= 1073741824)  printf "%.1fGi", b/1073741824
+        else if (b >= 1048576)     printf "%.1fMi", b/1048576
+        else if (b >= 1024)        printf "%.1fKi", b/1024
+        else                       printf "%dB", b
+    }'
+}
+
+# delta_pct actual reported → "X.X%" absolute percentage difference
+delta_pct() {
+    awk -v a="$1" -v r="$2" 'BEGIN {
+        if (a <= 0) { printf "n/a"; exit }
+        d = a - r; if (d < 0) d = -d
+        printf "%.1f%%", (d / a) * 100
+    }'
+}
+
+# within_tol actual reported tol → exits 0 (in tolerance) or 1 (out of tolerance)
+within_tol() {
+    awk -v a="$1" -v r="$2" -v t="$3" 'BEGIN {
+        if (a <= 0) { exit 0 }
+        d = a - r; if (d < 0) d = -d
+        exit ((d / a) * 100 > t) ? 1 : 0
+    }'
+}
+
+# --- collect Longhorn volumes ---
+vol_json=$(kubectl -n "$NAMESPACE" get volumes.longhorn.io -o json 2>/dev/null)
+if [ -z "$vol_json" ]; then
+    printf "ERROR: could not query Longhorn volumes in namespace %s\n" "$NAMESPACE" >&2
+    exit 1
+fi
+
+vol_count=$(printf '%s' "$vol_json" | jq '.items | length')
+if [ "$vol_count" = "0" ]; then
+    printf "No Longhorn volumes found in namespace %s\n" "$NAMESPACE"
+    exit 0
+fi
+
+# --- collect Longhorn snapshots ---
+snap_tmp=$(mktemp)
+snap_json=$(kubectl -n "$NAMESPACE" get snapshots.longhorn.io -o json 2>"$snap_tmp")
+snap_rc=$?
+if [ "$snap_rc" -ne 0 ]; then
+    printf "warn: kubectl get snapshots.longhorn.io failed: %s\n" "$(cat "$snap_tmp")" >&2
+    snap_json='{"items":[]}'
+elif [ -z "$snap_json" ]; then
+    snap_json='{"items":[]}'
+fi
+rm -f "$snap_tmp"
+
+# --- pre-fetch K8s PVCs once ---
+# VolumeStatus.FileLocation and KubeClusterInfo.Volumes[].Name both hold the K8s PVC
+# name (<EVE-VolumeID>-pvc-<gen>), NOT the Longhorn volume name (pvc-<k8s-uid>).
+# The K8s PVC object is the bridge: its spec.volumeName equals the Longhorn volume name.
+pvc_list=$(kubectl get pvc -A -o json 2>/dev/null || echo '{"items":[]}')
+
+# --- check pubsub paths ---
+kci_available=0
+[ -f "$KCI_FILE" ] && kci_available=1
+
+vs_available=0
+for _f in "$VS_DIR"/*.json; do
+    [ -f "$_f" ] && vs_available=1 && break
+done
+
+if [ "$kci_available" = "0" ]; then
+    printf "warn: %s not found — KCI columns will show NO-KCI\n" "$KCI_FILE" >&2
+fi
+if [ "$vs_available" = "0" ]; then
+    printf "warn: no VolumeStatus files in %s — VS columns will show NO-VS\n" "$VS_DIR" >&2
+fi
+
+# --- print header ---
+printf "%-44s %10s %10s %10s  %-10s %-8s %-6s  %-10s %-8s %-6s\n" \
+    "VOLUME" "LH-LIVE" "LH-SNAP" "LH-TOTAL" "VS-CURR" "VS-DELTA" "VS-ST" "KCI-ALLOC" "KCI-DELTA" "KCI-ST"
+printf "%-44s %10s %10s %10s  %-10s %-8s %-6s  %-10s %-8s %-6s\n" \
+    "--------------------------------------------" "----------" "----------" "----------" \
+    "----------" "--------" "------" "----------" "--------" "------"
+
+# --- per-volume comparison ---
+fail_tmp=$(mktemp)
+
+printf '%s' "$vol_json" | jq -r '.items[] | [
+    .metadata.name,
+    (.status.actualSize // 0 | tostring)
+] | @tsv' | while IFS="$(printf '\t')" read -r vol_name actual_size; do
+
+    # sum snapshot bytes for this volume, excluding the volume-head pseudo-snapshot
+    snap_agg=$(printf '%s' "$snap_json" | jq --arg vol "$vol_name" '
+        [ .items[] |
+          select(
+            .spec.volume == $vol and
+            (.metadata.name | endswith("-volume-head") | not)
+          )
+        ] | {
+            count: length,
+            bytes: ([ .[].status.size ] | map(if type == "number" then . else (. // 0 | tonumber) end) | add // 0),
+            list:  [ .[] | { n: .metadata.name, b: .status.size, t: (.status.creationTime // ""), u: .status.userCreated } ]
+        }
+    ')
+    snap_bytes=$(printf '%s' "$snap_agg" | jq -r '.bytes')
+    snap_count=$(printf '%s' "$snap_agg" | jq -r '.count')
+    # Use jq for addition — busybox awk printf "%d" truncates to 32-bit on large values.
+    lh_total=$(jq -n --argjson a "$actual_size" --argjson s "$snap_bytes" '$a + $s')
+
+    # --- resolve K8s PVC name from Longhorn volume name ---
+    # FileLocation and KubeVolumeInfo.Name hold the K8s PVC name, not the LH volume name.
+    k8s_pvc=$(printf '%s' "$pvc_list" | jq -r --arg lh "$vol_name" \
+        '.items[] | select(.spec.volumeName == $lh) | .metadata.name')
+
+    # --- VolumeStatus lookup: match FileLocation == K8s PVC name ---
+    vs_current="NO-VS"
+    if [ -n "$k8s_pvc" ]; then
+        for vs_file in "$VS_DIR"/*.json; do
+            [ -f "$vs_file" ] || continue
+            fl=$(jq -r '.FileLocation // ""' "$vs_file" 2>/dev/null)
+            if [ "$fl" = "$k8s_pvc" ]; then
+                vs_current=$(jq -r '.CurrentSize // 0' "$vs_file" 2>/dev/null)
+                break
+            fi
+        done
+    fi
+
+    # --- KubeClusterInfo lookup ---
+    # Storage field is serialised as "pubsub-large-Storage" in the on-disk JSON.
+    kci_alloc="NO-KCI"
+    if [ "$kci_available" = "1" ] && [ -n "$k8s_pvc" ]; then
+        val=$(jq -r --arg pvc "$k8s_pvc" \
+            '.["pubsub-large-Storage"].Volumes[] | select(.Name == $pvc) | .AllocatedBytes' \
+            "$KCI_FILE" 2>/dev/null)
+        if [ -n "$val" ] && [ "$val" != "null" ]; then
+            kci_alloc="$val"
+        fi
+    fi
+
+    # --- compute VS status ---
+    if [ "$vs_current" = "NO-VS" ]; then
+        vs_delta="n/a"
+        vs_st="NO-VS"
+    else
+        vs_delta=$(delta_pct "$lh_total" "$vs_current")
+        if within_tol "$lh_total" "$vs_current" "$TOLERANCE_PCT"; then
+            vs_st="MATCH"
+        else
+            vs_st="DRIFT"
+        fi
+    fi
+
+    # --- compute KCI status ---
+    if [ "$kci_alloc" = "NO-KCI" ]; then
+        kci_delta="n/a"
+        kci_st="NO-KCI"
+    else
+        kci_delta=$(delta_pct "$lh_total" "$kci_alloc")
+        if within_tol "$lh_total" "$kci_alloc" "$TOLERANCE_PCT"; then
+            kci_st="MATCH"
+        else
+            kci_st="DRIFT"
+        fi
+    fi
+
+    # record failure if either column is non-MATCH
+    if [ "$vs_st" != "MATCH" ] || [ "$kci_st" != "MATCH" ]; then
+        printf "%s\n" "$vol_name" >> "$fail_tmp"
+    fi
+
+    # --- print row ---
+    if [ "$vs_current" = "NO-VS" ]; then
+        vs_human="NO-VS"
+    else
+        vs_human=$(human_bytes "$vs_current")
+    fi
+    if [ "$kci_alloc" = "NO-KCI" ]; then
+        kci_human="NO-KCI"
+    else
+        kci_human=$(human_bytes "$kci_alloc")
+    fi
+
+    printf "%-44s %10s %10s %10s  %-10s %-8s %-6s  %-10s %-8s %-6s\n" \
+        "$vol_name" \
+        "$(human_bytes "$actual_size")" \
+        "$(human_bytes "$snap_bytes")" \
+        "$(human_bytes "$lh_total")" \
+        "$vs_human" "$vs_delta" "$vs_st" \
+        "$kci_human" "$kci_delta" "$kci_st"
+
+    if [ "$VERBOSE" = "1" ]; then
+        printf "  k8s-pvc: %s\n" "${k8s_pvc:-<not found>}"
+    fi
+    if [ "$VERBOSE" = "1" ] && [ "$snap_count" -gt 0 ]; then
+        printf '%s' "$snap_agg" | jq -r '
+            .list | sort_by(.t) | .[] |
+            [.n, (.b | tostring), (.t // "unknown"), (if .u then "user" else "system" end)] | @tsv
+        ' | while IFS="$(printf '\t')" read -r sname sbytes screated stype; do
+            printf "  snap %-40s %10s  %-30s [%s]\n" \
+                "$sname" "$(human_bytes "$sbytes")" "$screated" "$stype"
+        done
+    fi
+done
+
+printf "\n"
+
+# --- summary ---
+if [ -s "$fail_tmp" ]; then
+    fail_count=$(wc -l < "$fail_tmp" | tr -d ' ')
+    printf "FAIL: %d/%d volume(s) outside %d%% tolerance or missing pubsub entry\n" \
+        "$fail_count" "$vol_count" "$TOLERANCE_PCT"
+    rm -f "$fail_tmp"
+    exit 1
+fi
+rm -f "$fail_tmp"
+printf "PASS: all %d volume(s) within %d%% tolerance\n" "$vol_count" "$TOLERANCE_PCT"
+exit 0

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -131,6 +131,8 @@ type zedkube struct {
 
 	// longhornDiskReservedSet is true once the desired reservation has been applied to the Longhorn node
 	longhornDiskReservedSet bool
+	// longhornSnapshotSet is true once the desired recurring snapshot interval has been applied
+	longhornSnapshotSet bool
 
 	// Stuck-Pending-VMI detector state (keyed by app UUID string).
 	// vmiPendingSince: first time we observed a Pending VMI with a Running
@@ -721,6 +723,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		// Timer 4: cluster-wide component config application
 		case <-kubeCfgTimer.C:
 			zedkubeCtx.applyLonghornDiskReserved()
+			zedkubeCtx.applyLonghornRecurringSnapshot()
 			kubeCfgTimer = time.NewTimer(kubeCfgInterval * time.Second)
 
 		// Timer 5: leader-only safety-net re-evaluation of the stale-master
@@ -900,11 +903,20 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 			z.longhornDiskReservedSet = false
 		}
 
+		newSnapshotCron := newConfigItemValueMap.GlobalValueString(types.LonghornSnapshotCron)
+		existingSnapshotCron := currentConfigItemValueMap.GlobalValueString(types.LonghornSnapshotCron)
+		if newSnapshotCron != existingSnapshotCron {
+			log.Functionf("handleGlobalConfigImpl: LonghornSnapshotCron changed %q -> %q",
+				existingSnapshotCron, newSnapshotCron)
+			z.longhornSnapshotSet = false
+		}
+
 		z.globalConfig = newConfigItemValueMap
 		z.applyLonghornDiskReserved()
 
 		z.handleVmiDescheduleEventsOverride(newConfigItemValueMap)
 
+		z.applyLonghornRecurringSnapshot()
 	}
 	log.Functionf("handleGlobalConfigImpl(%s): done", key)
 }
@@ -929,6 +941,22 @@ func (z *zedkube) applyLonghornDiskReserved() {
 		return
 	}
 	z.longhornDiskReservedSet = applied
+}
+
+// applyLonghornRecurringSnapshot creates or updates the Longhorn recurring snapshot job
+// to match the configured interval. It is a no-op if the value has already been applied.
+// Callers should retry periodically until longhornSnapshotSet is true.
+func (z *zedkube) applyLonghornRecurringSnapshot() {
+	if z.longhornSnapshotSet {
+		return
+	}
+	cron := z.globalConfig.GlobalValueString(types.LonghornSnapshotCron)
+	applied, err := kubeapi.SetLonghornRecurringSnapshot(cron)
+	if err != nil {
+		log.Errorf("applyLonghornRecurringSnapshot: %v", err)
+		return
+	}
+	z.longhornSnapshotSet = applied
 }
 
 func handleK3sConfigOverrideChanged(currentGcp *types.ConfigItemValueMap, newGcp *types.ConfigItemValueMap) {

--- a/pkg/pillar/kubeapi/longhorninfo.go
+++ b/pkg/pillar/kubeapi/longhorninfo.go
@@ -58,6 +58,45 @@ func LonghornVolumeSizeDetails(longhornVolumeName string) (provisionedBytes uint
 	return uint64(lhVol.Spec.Size), uint64(lhVol.Status.ActualSize), nil
 }
 
+// LonghornVolumeSnapshotBytes returns the total bytes consumed by all snapshots
+// for the given Longhorn volume, excluding the live-data volume-head entry.
+// Returns 0 with no error when the Longhorn API is unavailable or no snapshots exist.
+func LonghornVolumeSnapshotBytes(longhornVolumeName string) (int64, error) {
+	apiExists, err := longhornAPIExists()
+	if err != nil || !apiExists {
+		return 0, err
+	}
+	config, err := GetKubeConfig()
+	if err != nil {
+		return 0, fmt.Errorf("LonghornVolumeSnapshotBytes: kubeconfig: %v", err)
+	}
+	lhClient, err := versioned.NewForConfig(config)
+	if err != nil {
+		return 0, fmt.Errorf("LonghornVolumeSnapshotBytes: client: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	snaps, err := lhClient.LonghornV1beta2().Snapshots(longhornNamespace).List(
+		ctx, metav1.ListOptions{LabelSelector: "longhornvolume=" + longhornVolumeName})
+	if err != nil {
+		return 0, fmt.Errorf("LonghornVolumeSnapshotBytes: list: %v", err)
+	}
+	return sumSnapshotBytes(snaps.Items), nil
+}
+
+// sumSnapshotBytes sums Status.Size for all non-head snapshots in the list.
+// MarkRemoved snapshots are intentionally included: they remain on disk until GC
+// completes, and omitting them would silently under-report disk usage if GC stalls.
+func sumSnapshotBytes(snaps []lhv1beta2.Snapshot) int64 {
+	var total int64
+	for _, s := range snaps {
+		if !strings.HasSuffix(s.Name, "-volume-head") {
+			total += s.Status.Size
+		}
+	}
+	return total
+}
+
 func min(a, b types.ServiceStatus) types.ServiceStatus {
 	if a < b {
 		return a
@@ -74,6 +113,70 @@ func replicaHasNoFsBacking(lhReplica lhv1beta2.Replica) bool {
 	return (lhReplica.Status.OwnerID == "") &&
 		(lhReplica.Status.InstanceManagerName == "") &&
 		(lhReplica.Status.CurrentImage == "")
+}
+
+// replicaModeProgress maps the engine's ReplicaModeMap entry for a single replica
+// to the three KubeVolumeReplicaInfo fields that populateKVIFromPVCName needs to set.
+// It always returns a definitive repStatus (Online for modes that do not change it).
+// isConsistent is true only for RW replicas that should be counted toward consistentReps.
+func replicaModeProgress(
+	inModeMap bool,
+	mode lhv1beta2.ReplicaMode,
+	hasRebuildEntry bool,
+	rebuildProgress int,
+) (percentage uint8, repStatus types.StorageVolumeReplicaStatus, isConsistent bool) {
+	repStatus = types.StorageVolumeReplicaStatusOnline
+	switch {
+	case !inModeMap:
+		// Running but not yet registered in the engine — not yet consistent.
+	case mode == lhv1beta2.ReplicaModeRW:
+		// Fully synced read-write: the only state that genuinely means 100%.
+		percentage = 100
+		isConsistent = true
+	case mode == lhv1beta2.ReplicaModeWO:
+		// Write-only: rebuild queued or in progress.
+		repStatus = types.StorageVolumeReplicaStatusRebuilding
+		if hasRebuildEntry {
+			// rebuildProgress is the Longhorn engine's Progress field, always 0-100.
+			percentage = uint8(rebuildProgress)
+		}
+	case mode == lhv1beta2.ReplicaModeERR:
+		repStatus = types.StorageVolumeReplicaStatusFailed
+	}
+	return
+}
+
+// robustnessSubstate maps (robustness, onlineReps, consistentReps) → the fine-grained
+// health substate reported to the controller. All inputs come from Longhorn API data;
+// the function is pure so it can be unit-tested without a live cluster.
+func robustnessSubstate(robustness types.StorageVolumeRobustness, onlineReps, consistentReps int) types.StorageHealthStatus {
+	switch robustness {
+	case types.StorageVolumeRobustnessHealthy:
+		return types.StorageHealthStatusHealthy
+	case types.StorageVolumeRobustnessFaulted:
+		return types.StorageHealthStatusFailed
+	case types.StorageVolumeRobustnessDegraded:
+		if onlineReps == 1 {
+			return types.StorageHealthStatusDegraded1ReplicaAvailableNotReplicating
+		}
+		if onlineReps == 2 {
+			if consistentReps == 1 {
+				return types.StorageHealthStatusDegraded1ReplicaAvailableReplicating
+			}
+			if consistentReps == 2 {
+				return types.StorageHealthStatusDegraded2ReplicaAvailableNotReplicating
+			}
+		}
+		if onlineReps == 3 {
+			if consistentReps == 1 {
+				return types.StorageHealthStatusDegraded1ReplicaAvailableReplicating
+			}
+			if consistentReps == 2 {
+				return types.StorageHealthStatusDegraded2ReplicaAvailableReplicating
+			}
+		}
+	}
+	return types.StorageHealthStatusUnknown
 }
 
 // PopulateKVIFromPVCName uses the longhorn api to retrieve volume and replica health
@@ -116,6 +219,9 @@ func populateKVIFromPVCName(kvi *types.KubeVolumeInfo) (*types.KubeVolumeInfo, e
 		return kvi, fmt.Errorf("PopulateKVIFromPVCName can't get lh vol err:%v", err)
 	}
 	kvi.AllocatedBytes = uint64(lhVol.Status.ActualSize)
+	if snapBytes, snapErr := LonghornVolumeSnapshotBytes(lhVolName); snapErr == nil && snapBytes > 0 {
+		kvi.AllocatedBytes += uint64(snapBytes)
+	}
 
 	switch lhVol.Status.Robustness {
 	case lhv1beta2.VolumeRobustnessHealthy:
@@ -126,13 +232,6 @@ func populateKVIFromPVCName(kvi *types.KubeVolumeInfo) (*types.KubeVolumeInfo, e
 		kvi.Robustness = types.StorageVolumeRobustnessFaulted
 	case lhv1beta2.VolumeRobustnessUnknown:
 		kvi.Robustness = types.StorageVolumeRobustnessUnknown
-	}
-
-	if kvi.Robustness == types.StorageVolumeRobustnessHealthy {
-		kvi.RobustnessSubstate = types.StorageHealthStatusHealthy
-	}
-	if kvi.Robustness == types.StorageVolumeRobustnessFaulted {
-		kvi.RobustnessSubstate = types.StorageHealthStatusFailed
 	}
 
 	switch lhVol.Status.State {
@@ -184,14 +283,33 @@ func populateKVIFromPVCName(kvi *types.KubeVolumeInfo) (*types.KubeVolumeInfo, e
 			if err != nil {
 				return kvi, fmt.Errorf("PopulateKVIFromPVCName can't get replica engine: %v", err)
 			}
-			replicaAddress := "tcp://" + net.JoinHostPort(replicaEngineIP, strconv.Itoa(replicaEnginePort))
-			rebuildStatus, ok := engine.Status.RebuildStatus[replicaAddress]
-			if !ok {
-				kviRep.RebuildProgressPercentage = 100
+
+			// Use the canonical address from the engine's own CurrentReplicaAddressMap
+			// rather than constructing tcp://IP:PORT from replica status.  The engine's
+			// ReplicaModeMap and RebuildStatus are both keyed by the address the engine
+			// process itself uses; constructing from replica.Status.IP/Port can diverge
+			// after a pod restart or IP reassignment, causing the lookup to silently miss.
+			replicaAddr, inEngineMap := engine.Status.CurrentReplicaAddressMap[lhReplica.Name]
+			if !inEngineMap {
+				replicaAddr = "tcp://" + net.JoinHostPort(replicaEngineIP, strconv.Itoa(replicaEnginePort))
+			}
+
+			// ReplicaModeMap is the authoritative oracle for replica sync state.
+			// RebuildStatus is ephemeral: it is absent before the rebuild transfer
+			// starts and cleared when the engine restarts, so "absent from RebuildStatus"
+			// does NOT mean the replica is consistent — it only means consistent when the
+			// replica is in RW mode.
+			replicaMode, inModeMap := engine.Status.ReplicaModeMap[replicaAddr]
+			rebuildEntry, hasRebuildEntry := engine.Status.RebuildStatus[replicaAddr]
+			rebuildProgress := 0
+			if hasRebuildEntry {
+				rebuildProgress = rebuildEntry.Progress
+			}
+			pct, repStatus, consistent := replicaModeProgress(inModeMap, replicaMode, hasRebuildEntry, rebuildProgress)
+			kviRep.RebuildProgressPercentage = pct
+			kviRep.Status = repStatus
+			if consistent {
 				consistentReps++
-			} else {
-				kviRep.RebuildProgressPercentage = uint8(rebuildStatus.Progress)
-				kviRep.Status = types.StorageVolumeReplicaStatusRebuilding
 			}
 
 			onlineReps++
@@ -210,37 +328,7 @@ func populateKVIFromPVCName(kvi *types.KubeVolumeInfo) (*types.KubeVolumeInfo, e
 		kvi.Replicas = append(kvi.Replicas, kviRep)
 	}
 
-	//RobustnessSubstate
-	//Take care of the simple cases, healthy and failed
-	if kvi.Robustness == types.StorageVolumeRobustnessHealthy {
-		kvi.RobustnessSubstate = types.StorageHealthStatusHealthy
-	}
-	if kvi.Robustness == types.StorageVolumeRobustnessFaulted {
-		kvi.RobustnessSubstate = types.StorageHealthStatusFailed
-	}
-	if kvi.Robustness == types.StorageVolumeRobustnessDegraded {
-		// Not rebuilding
-		if onlineReps == 1 {
-			kvi.RobustnessSubstate = types.StorageHealthStatusDegraded1ReplicaAvailableNotReplicating
-		}
-		// Rebuilding one or zero replicas
-		if onlineReps == 2 {
-			if consistentReps == 1 {
-				kvi.RobustnessSubstate = types.StorageHealthStatusDegraded1ReplicaAvailableReplicating
-			}
-			if consistentReps == 2 {
-				kvi.RobustnessSubstate = types.StorageHealthStatusDegraded2ReplicaAvailableNotReplicating
-			}
-		}
-		if onlineReps == 3 {
-			if consistentReps == 1 {
-				kvi.RobustnessSubstate = types.StorageHealthStatusDegraded1ReplicaAvailableReplicating
-			}
-			if consistentReps == 2 {
-				kvi.RobustnessSubstate = types.StorageHealthStatusDegraded2ReplicaAvailableReplicating
-			}
-		}
-	}
+	kvi.RobustnessSubstate = robustnessSubstate(kvi.Robustness, onlineReps, consistentReps)
 	return kvi, nil
 }
 

--- a/pkg/pillar/kubeapi/longhorninfo_test.go
+++ b/pkg/pillar/kubeapi/longhorninfo_test.go
@@ -1,0 +1,249 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package kubeapi
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func snap(name string, size int64, markRemoved bool) lhv1beta2.Snapshot {
+	return lhv1beta2.Snapshot{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     lhv1beta2.SnapshotStatus{Size: size, MarkRemoved: markRemoved},
+	}
+}
+
+func TestSumSnapshotBytes(t *testing.T) {
+	vol := "pvc-abc"
+	tests := []struct {
+		name  string
+		snaps []lhv1beta2.Snapshot
+		want  int64
+	}{
+		{
+			name:  "empty list",
+			snaps: nil,
+			want:  0,
+		},
+		{
+			name:  "volume-head excluded",
+			snaps: []lhv1beta2.Snapshot{snap(vol+"-volume-head", 1000, false)},
+			want:  0,
+		},
+		{
+			name:  "single real snapshot",
+			snaps: []lhv1beta2.Snapshot{snap("snap-1", 500, false)},
+			want:  500,
+		},
+		{
+			name: "MarkRemoved snapshot included",
+			snaps: []lhv1beta2.Snapshot{
+				snap("snap-old", 4096, true), // queued for GC but still on disk
+				snap("snap-new", 256, false),
+			},
+			want: 4352,
+		},
+		{
+			name: "head excluded, reals summed",
+			snaps: []lhv1beta2.Snapshot{
+				snap(vol+"-volume-head", 9999, false),
+				snap("snap-1", 100, false),
+				snap("snap-2", 200, false),
+			},
+			want: 300,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sumSnapshotBytes(tc.snaps); got != tc.want {
+				t.Errorf("sumSnapshotBytes: got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReplicaModeProgress(t *testing.T) {
+	tests := []struct {
+		name            string
+		inModeMap       bool
+		mode            lhv1beta2.ReplicaMode
+		hasRebuildEntry bool
+		rebuildProgress int
+		wantPct         uint8
+		wantStatus      types.StorageVolumeReplicaStatus
+		wantConsistent  bool
+	}{
+		{
+			name:           "not in mode map: not yet registered with engine",
+			inModeMap:      false,
+			wantPct:        0,
+			wantStatus:     types.StorageVolumeReplicaStatusOnline,
+			wantConsistent: false,
+		},
+		{
+			name:           "RW: fully synced — only state that means 100%",
+			inModeMap:      true,
+			mode:           lhv1beta2.ReplicaModeRW,
+			wantPct:        100,
+			wantStatus:     types.StorageVolumeReplicaStatusOnline,
+			wantConsistent: true,
+		},
+		{
+			// This is the false-100% bug case: WO with no RebuildStatus entry yet.
+			// Old code returned 100% here; correct behavior is 0% (queued, not started).
+			name:            "WO without rebuild entry: transfer queued, not started",
+			inModeMap:       true,
+			mode:            lhv1beta2.ReplicaModeWO,
+			hasRebuildEntry: false,
+			wantPct:         0,
+			wantStatus:      types.StorageVolumeReplicaStatusRebuilding,
+			wantConsistent:  false,
+		},
+		{
+			name:            "WO with rebuild entry 0%: transfer just started",
+			inModeMap:       true,
+			mode:            lhv1beta2.ReplicaModeWO,
+			hasRebuildEntry: true,
+			rebuildProgress: 0,
+			wantPct:         0,
+			wantStatus:      types.StorageVolumeReplicaStatusRebuilding,
+			wantConsistent:  false,
+		},
+		{
+			name:            "WO with rebuild entry 47%: transfer in progress",
+			inModeMap:       true,
+			mode:            lhv1beta2.ReplicaModeWO,
+			hasRebuildEntry: true,
+			rebuildProgress: 47,
+			wantPct:         47,
+			wantStatus:      types.StorageVolumeReplicaStatusRebuilding,
+			wantConsistent:  false,
+		},
+		{
+			// WO at 100% means the transfer completed but the engine has not yet
+			// promoted the replica to RW. It is still not consistent.
+			name:            "WO with rebuild entry 100%: transfer done, not yet promoted",
+			inModeMap:       true,
+			mode:            lhv1beta2.ReplicaModeWO,
+			hasRebuildEntry: true,
+			rebuildProgress: 100,
+			wantPct:         100,
+			wantStatus:      types.StorageVolumeReplicaStatusRebuilding,
+			wantConsistent:  false,
+		},
+		{
+			name:           "ERR: failed replica",
+			inModeMap:      true,
+			mode:           lhv1beta2.ReplicaModeERR,
+			wantPct:        0,
+			wantStatus:     types.StorageVolumeReplicaStatusFailed,
+			wantConsistent: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPct, gotStatus, gotConsistent := replicaModeProgress(
+				tc.inModeMap, tc.mode, tc.hasRebuildEntry, tc.rebuildProgress,
+			)
+			if gotPct != tc.wantPct {
+				t.Errorf("percentage: got %d, want %d", gotPct, tc.wantPct)
+			}
+			if gotStatus != tc.wantStatus {
+				t.Errorf("status: got %v, want %v", gotStatus, tc.wantStatus)
+			}
+			if gotConsistent != tc.wantConsistent {
+				t.Errorf("isConsistent: got %v, want %v", gotConsistent, tc.wantConsistent)
+			}
+		})
+	}
+}
+
+func TestRobustnessSubstate(t *testing.T) {
+	H := types.StorageVolumeRobustnessHealthy
+	D := types.StorageVolumeRobustnessDegraded
+	F := types.StorageVolumeRobustnessFaulted
+	U := types.StorageVolumeRobustnessUnknown
+
+	tests := []struct {
+		name         string
+		robustness   types.StorageVolumeRobustness
+		online       int
+		consistent   int
+		wantSubstate types.StorageHealthStatus
+	}{
+		{
+			name:         "healthy",
+			robustness:   H,
+			wantSubstate: types.StorageHealthStatusHealthy,
+		},
+		{
+			name:         "faulted",
+			robustness:   F,
+			wantSubstate: types.StorageHealthStatusFailed,
+		},
+		{
+			name:         "unknown robustness",
+			robustness:   U,
+			wantSubstate: types.StorageHealthStatusUnknown,
+		},
+		{
+			name:         "degraded online=1 (not replicating)",
+			robustness:   D,
+			online:       1,
+			consistent:   0,
+			wantSubstate: types.StorageHealthStatusDegraded1ReplicaAvailableNotReplicating,
+		},
+		{
+			name:         "degraded online=2 consistent=1 (replicating)",
+			robustness:   D,
+			online:       2,
+			consistent:   1,
+			wantSubstate: types.StorageHealthStatusDegraded1ReplicaAvailableReplicating,
+		},
+		{
+			name:         "degraded online=2 consistent=2 (2 up, not replicating)",
+			robustness:   D,
+			online:       2,
+			consistent:   2,
+			wantSubstate: types.StorageHealthStatusDegraded2ReplicaAvailableNotReplicating,
+		},
+		{
+			name:         "degraded online=3 consistent=1 (replicating)",
+			robustness:   D,
+			online:       3,
+			consistent:   1,
+			wantSubstate: types.StorageHealthStatusDegraded1ReplicaAvailableReplicating,
+		},
+		{
+			name:         "degraded online=3 consistent=2 (2 up, replicating)",
+			robustness:   D,
+			online:       3,
+			consistent:   2,
+			wantSubstate: types.StorageHealthStatusDegraded2ReplicaAvailableReplicating,
+		},
+		{
+			name:         "degraded unhandled combo (online=2 consistent=0) → unknown",
+			robustness:   D,
+			online:       2,
+			consistent:   0,
+			wantSubstate: types.StorageHealthStatusUnknown,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := robustnessSubstate(tc.robustness, tc.online, tc.consistent)
+			if got != tc.wantSubstate {
+				t.Errorf("robustnessSubstate: got %v, want %v", got, tc.wantSubstate)
+			}
+		})
+	}
+}

--- a/pkg/pillar/kubeapi/longhornsnap.go
+++ b/pkg/pillar/kubeapi/longhornsnap.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package kubeapi
+
+import (
+	"context"
+	"fmt"
+
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// eveRecurringJobName is the cluster-scoped name of the Longhorn RecurringJob EVE manages.
+// This name appears in kubectl diagnostics: kubectl -n longhorn-system get recurringjob default-eve-kube-app-snapshot
+const eveRecurringJobName = "default-eve-kube-app-snapshot"
+
+// SetLonghornRecurringSnapshot creates or updates the EVE recurring snapshot RecurringJob
+// using the provided cron expression. An empty cron string deletes the job if it exists.
+// Returns (true, nil) when the desired state has been successfully applied.
+// Returns (false, nil) when Longhorn is not yet available; callers should retry.
+func SetLonghornRecurringSnapshot(cron string) (bool, error) {
+	apiExists, err := longhornAPIExists()
+	if !apiExists && err == nil {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	config, err := GetKubeConfig()
+	if err != nil {
+		return false, fmt.Errorf("SetLonghornRecurringSnapshot: kubeconfig: %v", err)
+	}
+	lhClient, err := versioned.NewForConfig(config)
+	if err != nil {
+		return false, fmt.Errorf("SetLonghornRecurringSnapshot: versioned client: %v", err)
+	}
+
+	lhCtx, lhCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer lhCancel()
+
+	jobs := lhClient.LonghornV1beta2().RecurringJobs(longhornNamespace)
+	existing, err := jobs.Get(lhCtx, eveRecurringJobName, metav1.GetOptions{})
+	notFound := k8serrors.IsNotFound(err)
+	if err != nil && !notFound {
+		return false, fmt.Errorf("SetLonghornRecurringSnapshot: get: %v", err)
+	}
+
+	if cron == "" {
+		if notFound {
+			return true, nil
+		}
+		if err := jobs.Delete(lhCtx, eveRecurringJobName, metav1.DeleteOptions{}); err != nil {
+			return false, fmt.Errorf("SetLonghornRecurringSnapshot: delete: %v", err)
+		}
+		return true, nil
+	}
+
+	if notFound {
+		job := &lhv1beta2.RecurringJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      eveRecurringJobName,
+				Namespace: longhornNamespace,
+			},
+			Spec: lhv1beta2.RecurringJobSpec{
+				Task:        lhv1beta2.RecurringJobTypeSnapshot,
+				Groups:      []string{"default"},
+				Cron:        cron,
+				Retain:      3,
+				Concurrency: 1,
+			},
+		}
+		if _, err := jobs.Create(lhCtx, job, metav1.CreateOptions{}); err != nil {
+			return false, fmt.Errorf("SetLonghornRecurringSnapshot: create: %v", err)
+		}
+		return true, nil
+	}
+
+	if existing.Spec.Cron == cron {
+		return true, nil
+	}
+	// Only Cron is patched; Retain, Concurrency, Groups, and Task are left as-is.
+	// EVE does not re-assert those fields on update: the cron schedule is the only
+	// operator-controlled variable, and preserving other fields avoids overwriting
+	// any manual tuning an operator may have applied directly to the job.
+	existing.Spec.Cron = cron
+	if _, err := jobs.Update(lhCtx, existing, metav1.UpdateOptions{}); err != nil {
+		return false, fmt.Errorf("SetLonghornRecurringSnapshot: update: %v", err)
+	}
+	return true, nil
+}

--- a/pkg/pillar/kubeapi/longhornsnap_test.go
+++ b/pkg/pillar/kubeapi/longhornsnap_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package kubeapi
+
+import (
+	"testing"
+)
+
+// TestSetLonghornRecurringSnapshotIntegration exercises the create/update/delete
+// state machine against a live cluster. Skipped when no cluster is available.
+func TestSetLonghornRecurringSnapshotIntegration(t *testing.T) {
+	if _, err := GetClientSet(); err != nil {
+		t.Skipf("no local kube cluster: %v", err)
+	}
+
+	testCron := "0 3 * * *"
+
+	// Create
+	applied, err := SetLonghornRecurringSnapshot(testCron)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if !applied {
+		t.Fatal("create: expected applied=true")
+	}
+
+	// No-op (same cron)
+	applied, err = SetLonghornRecurringSnapshot(testCron)
+	if err != nil {
+		t.Fatalf("no-op: %v", err)
+	}
+	if !applied {
+		t.Fatal("no-op: expected applied=true")
+	}
+
+	// Update (different cron)
+	newCron := "0 4 * * *"
+	applied, err = SetLonghornRecurringSnapshot(newCron)
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !applied {
+		t.Fatal("update: expected applied=true")
+	}
+
+	// Delete
+	applied, err = SetLonghornRecurringSnapshot("")
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if !applied {
+		t.Fatal("delete: expected applied=true")
+	}
+
+	// Delete when already gone (no-op)
+	applied, err = SetLonghornRecurringSnapshot("")
+	if err != nil {
+		t.Fatalf("delete no-op: %v", err)
+	}
+	if !applied {
+		t.Fatal("delete no-op: expected applied=true")
+	}
+}

--- a/pkg/pillar/kubeapi/vitoapiserver.go
+++ b/pkg/pillar/kubeapi/vitoapiserver.go
@@ -147,6 +147,13 @@ func GetPVCInfo(pvcName string, log *base.LogObject) (*types.ImgInfo, error) {
 		log.Error(err)
 		return &imgInfo, err
 	}
+	// Add snapshot overhead so ActualSize reflects true on-disk consumption.
+	snapBytes, snapErr := LonghornVolumeSnapshotBytes(pvc.Spec.VolumeName)
+	if snapErr != nil {
+		log.Warningf("GetPVCInfo: snapshot bytes unavailable for %s: %v", pvcName, snapErr)
+	} else if snapBytes > 0 {
+		imgInfo.ActualSize += uint64(snapBytes)
+	}
 	return &imgInfo, nil
 }
 

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -470,6 +470,11 @@ const (
 	// over any EVE-OS baseos version defined k3s version (pkg/kube/cluster-update.sh)
 	K3sVersionOverride GlobalSettingKey = "k3s.version"
 
+	// LonghornSnapshotCron is the cron expression for the Longhorn recurring snapshot job
+	// used as delta-rebuild baselines after node power loss. Empty string disables recurring
+	// snapshots. Default "0 0 * * *" (daily at midnight UTC). Standard 5-field cron syntax.
+	LonghornSnapshotCron GlobalSettingKey = "storage.longhorn.snapshot.cron"
+
 	// SCEPRetryInterval defines the time interval between retry attempts
 	// for certificates that previously failed to enroll or returned PENDING
 	// from the SCEP server.
@@ -1227,6 +1232,8 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddStringItem(K3sConfigOverride, "", base64Validator)
 	configItemSpecMap.AddStringItem(K3sVersionOverride, "", k3sVersionValidator)
 	configItemSpecMap.AddStringItem(KubernetesVmiDescheduleEvents, "", blankValidator)
+	// LonghornSnapshotCron - Default daily at midnight. Empty string = disable recurring snapshots.
+	configItemSpecMap.AddStringItem(LonghornSnapshotCron, "0 0 * * *", cronValidator)
 
 	// SCEP settings
 	configItemSpecMap.AddIntItem(SCEPRetryInterval, 5*MinuteInSec, MinuteInSec, HourInSec)
@@ -1359,6 +1366,49 @@ func GetDiagRemoteEndpointURLs(log *base.LogObject, gcp *ConfigItemValueMap) []*
 
 // blankValidator - A validator that accepts any string
 func blankValidator(s string) error {
+	return nil
+}
+
+// cronValidator accepts empty (feature disabled) or standard 5-field cron expressions.
+// It rejects non-5-field forms (@hourly, 6-field, etc.), fields with invalid characters,
+// and field values that fall outside each position's valid numeric range.
+func cronValidator(s string) error {
+	if s == "" {
+		return nil
+	}
+	fields := strings.Fields(s)
+	if len(fields) != 5 {
+		return fmt.Errorf("cronValidator: %q must be empty or a 5-field cron expression (got %d fields)", s, len(fields))
+	}
+	// [lo, hi] inclusive range for minute, hour, day-of-month, month, day-of-week.
+	fieldRanges := [5][2]int{{0, 59}, {0, 23}, {1, 31}, {1, 12}, {0, 7}}
+	for i, f := range fields {
+		for _, c := range f {
+			if !strings.ContainsRune("0123456789*/-,", c) {
+				return fmt.Errorf("cronValidator: %q contains invalid character %q in field %q", s, c, f)
+			}
+		}
+		lo, hi := fieldRanges[i][0], fieldRanges[i][1]
+		for _, atom := range strings.Split(f, ",") {
+			// Strip step suffix: "*/5" → "*", "1-31/7" → "1-31".
+			valuePart := strings.SplitN(atom, "/", 2)[0]
+			if valuePart == "*" {
+				continue
+			}
+			for _, token := range strings.Split(valuePart, "-") {
+				if token == "" || token == "*" {
+					continue
+				}
+				n, err := strconv.Atoi(token)
+				if err != nil {
+					return fmt.Errorf("cronValidator: %q contains non-numeric token %q in field %q", s, token, f)
+				}
+				if n < lo || n > hi {
+					return fmt.Errorf("cronValidator: %q field %d value %d out of range [%d, %d]", s, i+1, n, lo, hi)
+				}
+			}
+		}
+	}
 	return nil
 }
 

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -131,6 +131,46 @@ func TestAddStringItem(t *testing.T) {
 	}
 }
 
+func TestCronValidator(t *testing.T) {
+	valid := []string{
+		"",                        // empty disables the feature
+		"0 0 * * *",               // daily midnight
+		"0 */6 * * *",             // every 6 hours
+		"*/5 * * * *",             // every 5 minutes
+		"0 0 1 1 *",               // once a year
+		"0 0 * * 0",               // every Sunday
+		"59 23 31 12 7",           // max valid value per field
+		"0-59 0-23 1-31 1-12 0-7", // full ranges
+	}
+	invalid := []string{
+		"@daily",         // named form
+		"@hourly",        // named form
+		"*/5 * * * * *",  // 6 fields
+		"* *",            // too few fields
+		"0 0 * * ?",      // Quartz wildcard
+		"0 0 * * L",      // Quartz last-day modifier
+		"not a cron",     // free text
+		"60 * * * *",     // minute out of range
+		"* 24 * * *",     // hour out of range
+		"* * 0 * *",      // day-of-month below minimum
+		"* * 32 * *",     // day-of-month above maximum
+		"* * * 0 *",      // month below minimum
+		"* * * 13 *",     // month above maximum
+		"* * * * 8",      // day-of-week out of range
+		"99 99 99 99 99", // all fields out of range
+	}
+	for _, s := range valid {
+		if err := cronValidator(s); err != nil {
+			t.Errorf("cronValidator(%q) returned unexpected error: %v", s, err)
+		}
+	}
+	for _, s := range invalid {
+		if err := cronValidator(s); err == nil {
+			t.Errorf("cronValidator(%q) expected error but got nil", s)
+		}
+	}
+}
+
 func TestNewConfigItemSpecMap(t *testing.T) {
 	// logrus.SetLevel(logrus.TraceLevel)
 	specMap := NewConfigItemSpecMap()
@@ -266,6 +306,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		IGPUGOPFile,
 		EnableEFIDebug,
 		KubernetesVmiDescheduleEvents,
+		LonghornSnapshotCron,
 	}
 	if len(specMap.GlobalSettings) != len(gsKeys) {
 		t.Errorf("GlobalSettings has more (%d) than expected keys (%d)",


### PR DESCRIPTION
## Description

Longhorn settings (pkg/kube/cfg-manifests/longhorn-cfg.yaml):
- Set replica-replenishment-wait-interval=600: prevents Longhorn from creating a
  replacement replica object while original nodes are recovering from a simultaneous
  power reset. Once a replacement is created Longhorn marks the slot as usable, blocking
  CheckAndReuseFailedReplica and forcing a full rebuild instead of a cheap delta sync.
  The 600 s default is sized against EVE's 3-node boot stagger: the last node is
  Longhorn-ready at ~T=3:50 from power-on; the interval clock starts at ~T=2:00.
- Set concurrent-replica-rebuild-per-node-limit=2: caps parallel rebuilds to avoid
  saturating disk I/O on edge hardware when all volumes need resync simultaneously.
- Set auto-salvage=true: enables self-recovery for faulted volumes on unattended devices.
  upgrade-checker settings.

Storage classes (pkg/kube/manifests/storage-classes.yaml):
- Add recurringJobSelector to all three storage classes so that volumes pick up the
  recurring snapshot job automatically via the default group.

Recurring snapshot management:
- Add kubeapi.SetLonghornRecurringSnapshot() (longhornsnap.go): creates, updates, or
  deletes a cluster-scoped Longhorn RecurringJob CR matching the LonghornSnapshotCron
  GlobalConfig value. Empty string disables the feature.
- Add cronValidator in types/global.go: validates LonghornSnapshotCron accepts only a
  5-field cron expression or empty string; rejects @daily/@hourly shorthands and
  6-field Quartz syntax.
- Wire applyLonghornRecurringSnapshot() into zedkube's main loop and GlobalConfig change
  handler (zedkube.go); idempotent via longhornSnapshotSet flag.
- Add LonghornSnapshotCron to CONFIG-PROPERTIES.md and EVE-K.md.

Replica progress reporting fix (longhorninfo.go):
- Fix false-100% progress for WO replicas that have no RebuildStatus entry yet.
  Previously replicaModeProgress returned 100% for WO mode when the rebuild entry was
  absent (transfer queued but not yet started). Now returns 0% / Rebuilding status.

Snapshot bytes in PVC size reporting (longhorninfo.go, vitoapiserver.go):
- Add LonghornVolumeSnapshotBytes(): queries Longhorn snapshot CRDs via the
  longhornvolume= label selector and sums Status.Size for all non-head snapshots.
  MarkRemoved snapshots are included intentionally — they consume disk until GC completes.
- Add snapshot bytes to VolumeStatus.CurrentSize via GetPVCInfo() (vitoapiserver.go).
- Add snapshot bytes to KubeClusterInfo.AllocatedBytes via populateKVIFromPVCName()
  (longhorninfo.go). Both paths previously reported live data only (status.actualSize),
  understating real on-disk usage when snapshot chains accumulate.

Observability:
- Add longhorn-snapshot-overhead.sh: shell tool reporting per-volume snapshot CoW
  overhead; installed into the kube container image via Dockerfile.
- Add longhorn-snapshot-overhead.sh -v to collect-info.sh longhorn_info section
  (VERSION 43→44).

Tests:
- TestSumSnapshotBytes: unit test for the pure sumSnapshotBytes helper covering empty
  list, volume-head exclusion, MarkRemoved inclusion, and mixed cases.
- TestReplicaModeProgress: unit tests for replicaModeProgress covering all mode
  combinations including the WO-without-rebuild-entry false-100% bug case.
- TestCronValidator: unit tests for cronValidator covering valid and invalid inputs.
- TestSetLonghornRecurringSnapshotIntegration: integration test for the
  create/update/delete state machine; skips when no cluster is reachable.

Verification tooling (pkg/kube/test/):
- Add kube-test-longhorn-pvc-size.sh: audit script comparing Longhorn ground-truth PVC
  sizes (actualSize + snapshot chain) against EVE's pubsub-reported CurrentSize and
  AllocatedBytes, with configurable drift tolerance for EVE's ~60 s polling cycle.
- Add README explaining pkg/kube/test/ as a home for ad-hoc test tools not installed
  via the Dockerfile, intended for bind-mount use during cluster debugging.

## PR dependencies

None

## How to test and validate this PR

TODO

## Changelog notes

TODO

## PR Backports

- 16.0-stable: No
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
