### PR TITLE
client: add pure-Go unit tests for onboarding helpers

### DIFF
--- a/pkg/pillar/cmd/client/certchain_test.go
+++ b/pkg/pillar/cmd/client/certchain_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"encoding/hex"
+	"testing"
+
+	zcert "github.com/lf-edge/eve-api/go/certs"
+	"google.golang.org/protobuf/proto"
+)
+
+func marshalCerts(t *testing.T, hashes ...[]byte) []byte {
+	t.Helper()
+	msg := &zcert.ZControllerCert{}
+	for _, h := range hashes {
+		msg.Certs = append(msg.Certs, &zcert.ZCert{CertHash: h})
+	}
+	b, err := proto.Marshal(msg)
+	if err != nil {
+		t.Fatalf("proto.Marshal: %v", err)
+	}
+	return b
+}
+
+func TestParseKeysFromControllerCerts(t *testing.T) {
+	h1 := []byte{0xab, 0xcd}
+	h2 := []byte{0xde, 0xad, 0xbe, 0xef}
+
+	t.Run("empty cert set", func(t *testing.T) {
+		keys, err := parseKeysFromControllerCerts(marshalCerts(t))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(keys) != 0 {
+			t.Errorf("keys = %v, want empty", keys)
+		}
+	})
+
+	t.Run("single cert", func(t *testing.T) {
+		keys, err := parseKeysFromControllerCerts(marshalCerts(t, h1))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(keys) != 1 || keys[0] != hex.EncodeToString(h1) {
+			t.Errorf("keys = %v, want [%s]", keys, hex.EncodeToString(h1))
+		}
+	})
+
+	t.Run("two certs preserve insertion order", func(t *testing.T) {
+		keys, err := parseKeysFromControllerCerts(marshalCerts(t, h1, h2))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []string{hex.EncodeToString(h1), hex.EncodeToString(h2)}
+		if len(keys) != 2 || keys[0] != want[0] || keys[1] != want[1] {
+			t.Errorf("keys = %v, want %v", keys, want)
+		}
+	})
+
+	t.Run("garbage bytes fail unmarshal", func(t *testing.T) {
+		_, err := parseKeysFromControllerCerts([]byte("not a protobuf"))
+		if err == nil {
+			t.Fatal("want error, got nil")
+		}
+	})
+}
+
+func TestCompareControllerCertBytes(t *testing.T) {
+	h1 := []byte{0xab, 0xcd}
+	h2 := []byte{0xde, 0xad}
+	h3 := []byte{0xbe, 0xef}
+
+	tests := []struct {
+		name        string
+		newBytes    []byte
+		prevBytes   []byte
+		wantChanged bool
+	}{
+		{
+			name:        "identical bytes",
+			newBytes:    marshalCerts(t, h1, h2),
+			prevBytes:   marshalCerts(t, h1, h2),
+			wantChanged: false,
+		},
+		{
+			name:        "same certs different order",
+			newBytes:    marshalCerts(t, h1, h2),
+			prevBytes:   marshalCerts(t, h2, h1),
+			wantChanged: false,
+		},
+		{
+			name:        "cert added",
+			newBytes:    marshalCerts(t, h1, h2, h3),
+			prevBytes:   marshalCerts(t, h1, h2),
+			wantChanged: true,
+		},
+		{
+			name:        "cert removed",
+			newBytes:    marshalCerts(t, h1),
+			prevBytes:   marshalCerts(t, h1, h2),
+			wantChanged: true,
+		},
+		{
+			name:        "cert swapped",
+			newBytes:    marshalCerts(t, h1, h3),
+			prevBytes:   marshalCerts(t, h1, h2),
+			wantChanged: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := compareControllerCertBytes(tc.newBytes, tc.prevBytes)
+			if got != tc.wantChanged {
+				t.Errorf("compareControllerCertBytes = %v, want %v", got, tc.wantChanged)
+			}
+		})
+	}
+}

--- a/pkg/pillar/cmd/client/cliflags_test.go
+++ b/pkg/pillar/cmd/client/cliflags_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"flag"
+	"testing"
+)
+
+// withFatalPanic installs a logger ExitFunc that panics rather than exiting,
+// so a test can drive log.Fatal paths and recover. Restored on test cleanup.
+func withFatalPanic(t *testing.T) {
+	t.Helper()
+	prev := logger.ExitFunc
+	logger.ExitFunc = func(int) { panic("log.Fatal called") }
+	t.Cleanup(func() { logger.ExitFunc = prev })
+}
+
+func newClientContextForFlags(ops map[string]bool) *clientContext {
+	return &clientContext{operations: ops}
+}
+
+func TestProcessAgentSpecificCLIFlags_KnownOps(t *testing.T) {
+	ctx := newClientContextForFlags(map[string]bool{
+		"selfRegister": false,
+		"getUuid":      false,
+	})
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	ctx.AddAgentSpecificCLIFlags(fs)
+	if err := fs.Parse([]string{"selfRegister", "getUuid"}); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	ctx.ProcessAgentSpecificCLIFlags(fs)
+
+	if !ctx.operations["selfRegister"] || !ctx.operations["getUuid"] {
+		t.Errorf("operations = %v, want both true", ctx.operations)
+	}
+}
+
+func TestProcessAgentSpecificCLIFlags_UnknownOpFatals(t *testing.T) {
+	withFatalPanic(t)
+	ctx := newClientContextForFlags(map[string]bool{
+		"selfRegister": false,
+	})
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	ctx.AddAgentSpecificCLIFlags(fs)
+	if err := fs.Parse([]string{"bogus"}); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected log.Fatal to be reached for unknown arg")
+		}
+	}()
+	ctx.ProcessAgentSpecificCLIFlags(fs)
+}

--- a/pkg/pillar/cmd/client/parseuuid_test.go
+++ b/pkg/pillar/cmd/client/parseuuid_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"testing"
+
+	eveuuid "github.com/lf-edge/eve-api/go/eveuuid"
+	uuid "github.com/satori/go.uuid"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestGenerateUUIDRequest_RoundTrip(t *testing.T) {
+	b, err := generateUUIDRequest()
+	if err != nil {
+		t.Fatalf("generateUUIDRequest: %v", err)
+	}
+	if b == nil {
+		t.Fatal("generateUUIDRequest returned nil bytes")
+	}
+	var req eveuuid.UuidRequest
+	if err := proto.Unmarshal(b, &req); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+}
+
+func TestParseUUIDResponse(t *testing.T) {
+	const goodUUID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+
+	marshal := func(t *testing.T, msg *eveuuid.UuidResponse) []byte {
+		t.Helper()
+		b, err := proto.Marshal(msg)
+		if err != nil {
+			t.Fatalf("proto.Marshal: %v", err)
+		}
+		return b
+	}
+
+	tests := []struct {
+		name         string
+		body         []byte
+		wantUUID     string
+		wantModel    string
+		wantParseErr bool
+		emptyModelOK bool // for cases where empty hardwaremodel is the expected result
+	}{
+		{
+			name: "valid with manufacturer and product",
+			body: marshal(t, &eveuuid.UuidResponse{
+				Uuid:         goodUUID,
+				Manufacturer: "Dell",
+				ProductName:  "PowerEdge R740",
+			}),
+			wantUUID:  goodUUID,
+			wantModel: "Dell.PowerEdge R740",
+		},
+		{
+			name: "valid without manufacturer/product gives empty model",
+			body: marshal(t, &eveuuid.UuidResponse{
+				Uuid: goodUUID,
+			}),
+			wantUUID:     goodUUID,
+			emptyModelOK: true,
+		},
+		{
+			name: "manufacturer only is not enough for a model",
+			body: marshal(t, &eveuuid.UuidResponse{
+				Uuid:         goodUUID,
+				Manufacturer: "Dell",
+			}),
+			wantUUID:     goodUUID,
+			emptyModelOK: true,
+		},
+		{
+			name: "uuid with surrounding whitespace is trimmed",
+			body: marshal(t, &eveuuid.UuidResponse{
+				Uuid: "  " + goodUUID + "\n",
+			}),
+			wantUUID:     goodUUID,
+			emptyModelOK: true,
+		},
+		{
+			name:         "invalid uuid string returns error",
+			body:         marshal(t, &eveuuid.UuidResponse{Uuid: "not-a-uuid"}),
+			wantParseErr: true,
+		},
+		{
+			name:         "garbage bytes fail proto unmarshal",
+			body:         []byte("not a protobuf"),
+			wantParseErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotUUID, gotModel, err := parseUUIDResponse(nil, tc.body)
+			if tc.wantParseErr {
+				if err == nil {
+					t.Fatalf("want error, got UUID=%s model=%q", gotUUID, gotModel)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			wantUUID, _ := uuid.FromString(tc.wantUUID)
+			if gotUUID != wantUUID {
+				t.Errorf("UUID = %s, want %s", gotUUID, wantUUID)
+			}
+			if tc.emptyModelOK {
+				if gotModel != "" {
+					t.Errorf("hardwaremodel = %q, want empty", gotModel)
+				}
+				return
+			}
+			if gotModel != tc.wantModel {
+				t.Errorf("hardwaremodel = %q, want %q", gotModel, tc.wantModel)
+			}
+		})
+	}
+}

--- a/pkg/pillar/cmd/client/setup_test.go
+++ b/pkg/pillar/cmd/client/setup_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"os"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
+)
+
+func TestMain(m *testing.M) {
+	logger = logrus.StandardLogger()
+	logger.SetLevel(logrus.PanicLevel)
+	log = base.NewSourceLogObject(logger, "client_test", 0)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Description

Cover the pure helpers in cmd/client with table-driven tests: UUID
response parsing, /uuid request generation, the controller-cert key
extraction and set-comparison used to decide whether to rewrite the
on-disk checkpoint, and the CLI argument validator.

Each targeted function reaches 100% statement coverage. Package
statement coverage from unit tests alone goes from 0 to ~10%; the
remaining gap is the onboarding loop itself, which is covered in a
follow-up that drives the seamed paths.

Combined with the Phase-2 follow-up (#5958) and the Eden e2e suite in
lf-edge/eden#1178, `pkg/pillar/cmd/client` block coverage reaches
**85.59 %** (242/451 from unit tests + further blocks from eden, dedup'd).

Depends on #5956.

## How to test and validate this PR

`go test -count=1 ./pkg/pillar/cmd/client/...` from the pillar module.

## Changelog notes

No user-facing changes.

## PR Backports

- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [x] I've written the test verification instructions
