### PR TITLE
client: add seamed unit tests for onboarding loop

### DIFF
--- a/pkg/pillar/cmd/client/dogetuuid_test.go
+++ b/pkg/pillar/cmd/client/dogetuuid_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	eveuuid "github.com/lf-edge/eve-api/go/eveuuid"
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"google.golang.org/protobuf/proto"
+)
+
+func mustMarshalUUIDResponse(t *testing.T, msg *eveuuid.UuidResponse) []byte {
+	t.Helper()
+	b, err := proto.Marshal(msg)
+	if err != nil {
+		t.Fatalf("proto.Marshal: %v", err)
+	}
+	return b
+}
+
+func newDoGetUUIDCtx(sender *fakeControllerSender, led ledNotifier) *clientContext {
+	ctx := &clientContext{
+		sender:            sender,
+		led:               led,
+		serverNameAndPort: "test.example:8080",
+		getCertsTimer:     time.NewTimer(time.Hour),
+	}
+	ctx.getCertsTimer.Stop()
+	return ctx
+}
+
+func TestDoGetUUID_SuccessExtractsUUIDAndLEDs(t *testing.T) {
+	const goodUUID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	body := mustMarshalUUIDResponse(t, &eveuuid.UuidResponse{
+		Uuid:         goodUUID,
+		Manufacturer: "Dell",
+		ProductName:  "PowerEdge R740",
+	})
+	sender := &fakeControllerSender{sends: []sendResponse{
+		{rv: controllerconn.SendRetval{
+			HTTPResp:     httpResp(http.StatusOK, "application/x-proto-binary"),
+			RespContents: body,
+		}},
+	}}
+	led := &recordingLedNotifier{}
+	ctx := newDoGetUUIDCtx(sender, led)
+
+	done, devUUID, model := ctx.doGetUUID(&testTLSCfg, 0)
+	if !done {
+		t.Fatal("done = false, want true")
+	}
+	if devUUID.String() != goodUUID {
+		t.Errorf("devUUID = %s, want %s", devUUID, goodUUID)
+	}
+	if model != "Dell.PowerEdge R740" {
+		t.Errorf("model = %q, want %q", model, "Dell.PowerEdge R740")
+	}
+	// myPost emits Onboarded for 200; doGetUUID emits Onboarded again on parse success.
+	wantLed := []types.LedBlinkCount{types.LedBlinkOnboarded, types.LedBlinkOnboarded}
+	if !ledEqual(led.patterns, wantLed) {
+		t.Errorf("led = %v, want %v", led.patterns, wantLed)
+	}
+}
+
+func TestDoGetUUID_CertMissSchedulesTimer(t *testing.T) {
+	sender := &fakeControllerSender{sends: []sendResponse{
+		{rv: controllerconn.SendRetval{Status: types.SenderStatusCertMiss}, err: errors.New("cert miss")},
+	}}
+	led := &recordingLedNotifier{}
+	ctx := newDoGetUUIDCtx(sender, led)
+
+	done, _, _ := ctx.doGetUUID(&testTLSCfg, 0)
+	if done {
+		t.Error("done = true, want false on cert miss")
+	}
+	if ctx.getCertsTimer == nil {
+		t.Fatal("getCertsTimer = nil, want a re-armed timer")
+	}
+	select {
+	case <-ctx.getCertsTimer.C:
+	case <-time.After(2 * time.Second):
+		t.Fatal("getCertsTimer did not fire within 2s; was not re-armed by doGetUUID")
+	}
+}
+
+func TestDoGetUUID_ParseFailureReturnsFalse(t *testing.T) {
+	sender := &fakeControllerSender{sends: []sendResponse{
+		{rv: controllerconn.SendRetval{
+			HTTPResp:     httpResp(http.StatusOK, "application/x-proto-binary"),
+			RespContents: []byte("not a valid uuid response proto"),
+		}},
+	}}
+	led := &recordingLedNotifier{}
+	ctx := newDoGetUUIDCtx(sender, led)
+
+	done, _, _ := ctx.doGetUUID(&testTLSCfg, 0)
+	if done {
+		t.Error("done = true, want false on parse failure")
+	}
+}
+
+func TestDoGetUUID_NetworkErrorNoTimer(t *testing.T) {
+	sender := &fakeControllerSender{sends: []sendResponse{
+		{rv: controllerconn.SendRetval{Status: types.SenderStatusRefused}, err: errors.New("refused")},
+	}}
+	led := &recordingLedNotifier{}
+	ctx := newDoGetUUIDCtx(sender, led)
+
+	// Drain any pre-set timer to ensure the test observes a fresh state.
+	select {
+	case <-ctx.getCertsTimer.C:
+	default:
+	}
+	done, _, _ := ctx.doGetUUID(&testTLSCfg, 0)
+	if done {
+		t.Error("done = true, want false on network error")
+	}
+	// Timer must remain quiescent (no fresh re-arm on this code path).
+	select {
+	case <-ctx.getCertsTimer.C:
+		t.Error("getCertsTimer fired on non-CertMiss network error; should not have re-armed")
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/pkg/pillar/cmd/client/fakes_test.go
+++ b/pkg/pillar/cmd/client/fakes_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// fakeControllerSender satisfies controllerSender for unit tests. Each call
+// to SendOnAllIntf consumes the next queued response; queue exhaustion fails
+// the call so tests reliably catch unexpected requests.
+type fakeControllerSender struct {
+	// queued sends; first one consumed per SendOnAllIntf call.
+	sends []sendResponse
+	// canned verify outputs.
+	verifyChain     []byte
+	verifyChainErr  error
+	storeSigningErr error
+	updateProxyCert bool
+	// When updateProxyCert is true and proxyCertPool is non-nil, the fake
+	// installs the pool onto tlsConfig.RootCAs on UpdateTLSProxyCerts to
+	// mirror what the real *controllerconn.Client does.
+	proxyCertPool *x509.CertPool
+	// canned auth-container verify result.
+	authVerifyErr error
+
+	// recorded state
+	tlsConfig          *tls.Config
+	dns                *types.DeviceNetworkStatus
+	ledManagerDisabled bool
+	sentURLs           []string
+	sentBodies         [][]byte
+	storedSigningCert  []byte
+	authVerifyCalls    int
+}
+
+type sendResponse struct {
+	rv  controllerconn.SendRetval
+	err error
+}
+
+func (f *fakeControllerSender) GetContextForAllIntfFunctions() (context.Context, context.CancelFunc) {
+	return context.WithCancel(context.Background())
+}
+
+func (f *fakeControllerSender) SendOnAllIntf(_ context.Context, url string,
+	body *bytes.Buffer, _ controllerconn.RequestOptions) (controllerconn.SendRetval, error) {
+	f.sentURLs = append(f.sentURLs, url)
+	if body != nil {
+		f.sentBodies = append(f.sentBodies, append([]byte(nil), body.Bytes()...))
+	} else {
+		f.sentBodies = append(f.sentBodies, nil)
+	}
+	if len(f.sends) == 0 {
+		return controllerconn.SendRetval{}, fmt.Errorf("fakeControllerSender: no canned response for %s", url)
+	}
+	r := f.sends[0]
+	f.sends = f.sends[1:]
+	return r.rv, r.err
+}
+
+func (f *fakeControllerSender) RemoveAndVerifyAuthContainer(_ *controllerconn.SendRetval, _ bool) error {
+	f.authVerifyCalls++
+	return f.authVerifyErr
+}
+
+func (f *fakeControllerSender) VerifyProtoSigningCertChain(_ []byte) ([]byte, error) {
+	return f.verifyChain, f.verifyChainErr
+}
+
+func (f *fakeControllerSender) StoreServerSigningCert(b []byte) error {
+	f.storedSigningCert = append([]byte(nil), b...)
+	return f.storeSigningErr
+}
+
+func (f *fakeControllerSender) UpdateTLSProxyCerts() bool {
+	if f.updateProxyCert && f.tlsConfig != nil && f.proxyCertPool != nil {
+		f.tlsConfig.RootCAs = f.proxyCertPool
+	}
+	return f.updateProxyCert
+}
+
+func (f *fakeControllerSender) GetTLSConfig(_ *tls.Certificate) (*tls.Config, error) {
+	return &tls.Config{}, nil
+}
+
+func (f *fakeControllerSender) TLSConfig() *tls.Config                              { return f.tlsConfig }
+func (f *fakeControllerSender) SetTLSConfig(tc *tls.Config)                         { f.tlsConfig = tc }
+func (f *fakeControllerSender) SetDeviceNetworkStatus(d *types.DeviceNetworkStatus) { f.dns = d }
+func (f *fakeControllerSender) LedManagerDisabled() bool                            { return f.ledManagerDisabled }
+func (f *fakeControllerSender) SetLedManagerDisabled(b bool)                        { f.ledManagerDisabled = b }
+
+// fakeCertStore is an in-memory certStore.
+type fakeCertStore struct {
+	primary, backup []byte
+	saved           [][]byte
+}
+
+func (f *fakeCertStore) Read(useBackup bool) ([]byte, error) {
+	if useBackup {
+		return f.backup, nil
+	}
+	return f.primary, nil
+}
+
+func (f *fakeCertStore) MaybeSave(b []byte) {
+	f.saved = append(f.saved, append([]byte(nil), b...))
+}
+
+// recordingLedNotifier captures every Update call.
+type recordingLedNotifier struct {
+	patterns []types.LedBlinkCount
+}
+
+func (r *recordingLedNotifier) Update(p types.LedBlinkCount) {
+	r.patterns = append(r.patterns, p)
+}
+
+// fakeHostnameSetter records each Set call and returns an optional error.
+type fakeHostnameSetter struct {
+	calls []string
+	err   error
+}
+
+func (f *fakeHostnameSetter) Set(hostname string) error {
+	f.calls = append(f.calls, hostname)
+	return f.err
+}

--- a/pkg/pillar/cmd/client/fetchcertchain_test.go
+++ b/pkg/pillar/cmd/client/fetchcertchain_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func newFetchCtx(sender *fakeControllerSender, store *fakeCertStore) *clientContext {
+	return &clientContext{
+		sender:            sender,
+		certStore:         store,
+		led:               &recordingLedNotifier{},
+		serverNameAndPort: "test.example:8080",
+	}
+}
+
+// A valid (empty) cert chain proto marshals to zero bytes, which compares
+// equal to itself across calls — the only thing parseKeys cares about is
+// that proto.Unmarshal succeeds.
+var validCertBytes = []byte{}
+
+func TestFetchCertChain_ServerReturnsV1NotSupportedStatuses(t *testing.T) {
+	statuses := []int{
+		http.StatusNotFound,
+		http.StatusUnauthorized,
+		http.StatusNotImplemented,
+		http.StatusBadRequest,
+	}
+	for _, status := range statuses {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			sender := &fakeControllerSender{sends: []sendResponse{
+				{rv: controllerconn.SendRetval{HTTPResp: httpResp(status, "application/x-proto-binary")}},
+			}}
+			store := &fakeCertStore{}
+			ctx := newFetchCtx(sender, store)
+
+			ok := ctx.fetchCertChain(&testTLSCfg, 0)
+			if ok {
+				t.Errorf("fetchCertChain ok = true, want false on %s", http.StatusText(status))
+			}
+			if len(store.saved) != 0 {
+				t.Errorf("certStore.saved = %d entries, want 0", len(store.saved))
+			}
+		})
+	}
+}
+
+func TestFetchCertChain_VerifyChainFailureReturnsFalse(t *testing.T) {
+	sender := &fakeControllerSender{
+		sends: []sendResponse{
+			{rv: controllerconn.SendRetval{
+				HTTPResp:     httpResp(http.StatusOK, "application/x-proto-binary"),
+				RespContents: validCertBytes,
+			}},
+		},
+		verifyChainErr: errors.New("bad signature"),
+	}
+	store := &fakeCertStore{}
+	ctx := newFetchCtx(sender, store)
+
+	ok := ctx.fetchCertChain(&testTLSCfg, 0)
+	if ok {
+		t.Error("fetchCertChain ok = true, want false on verify failure")
+	}
+	if len(store.saved) != 0 {
+		t.Errorf("certStore.saved = %d, want 0", len(store.saved))
+	}
+}
+
+func TestFetchCertChain_StoreSigningFailureReturnsFalse(t *testing.T) {
+	sender := &fakeControllerSender{
+		sends: []sendResponse{
+			{rv: controllerconn.SendRetval{
+				HTTPResp:     httpResp(http.StatusOK, "application/x-proto-binary"),
+				RespContents: validCertBytes,
+			}},
+		},
+		verifyChain:     []byte("signer"),
+		storeSigningErr: errors.New("disk full"),
+	}
+	store := &fakeCertStore{}
+	ctx := newFetchCtx(sender, store)
+
+	if ok := ctx.fetchCertChain(&testTLSCfg, 0); ok {
+		t.Error("fetchCertChain ok = true, want false on StoreServerSigningCert failure")
+	}
+}
+
+func TestFetchCertChain_HappyPath_NoPreviousCheckpoint(t *testing.T) {
+	sender := &fakeControllerSender{
+		sends: []sendResponse{
+			{rv: controllerconn.SendRetval{
+				HTTPResp:     httpResp(http.StatusOK, "application/x-proto-binary"),
+				RespContents: validCertBytes,
+			}},
+		},
+		verifyChain: []byte("signer-cert"),
+	}
+	store := &fakeCertStore{}
+	ctx := newFetchCtx(sender, store)
+
+	if ok := ctx.fetchCertChain(&testTLSCfg, 0); !ok {
+		t.Fatal("fetchCertChain ok = false, want true on happy path")
+	}
+	if len(store.saved) != 1 {
+		t.Errorf("certStore.saved = %d, want 1 entry", len(store.saved))
+	}
+	if string(sender.storedSigningCert) != "signer-cert" {
+		t.Errorf("stored signing cert = %q, want %q", sender.storedSigningCert, "signer-cert")
+	}
+}
+
+func TestFetchCertChain_NoSaveWhenCheckpointMatches(t *testing.T) {
+	sender := &fakeControllerSender{
+		sends: []sendResponse{
+			{rv: controllerconn.SendRetval{
+				HTTPResp:     httpResp(http.StatusOK, "application/x-proto-binary"),
+				RespContents: validCertBytes,
+			}},
+		},
+		verifyChain: []byte("signer"),
+	}
+	store := &fakeCertStore{primary: validCertBytes}
+	ctx := newFetchCtx(sender, store)
+
+	if ok := ctx.fetchCertChain(&testTLSCfg, 0); !ok {
+		t.Fatal("fetchCertChain ok = false, want true when checkpoint matches")
+	}
+	if len(store.saved) != 0 {
+		t.Errorf("certStore.saved = %d, want no save when checkpoint matches", len(store.saved))
+	}
+}
+
+func TestFetchCertChain_LedSuppressionRestoredAfter(t *testing.T) {
+	sender := &fakeControllerSender{
+		sends: []sendResponse{
+			{rv: controllerconn.SendRetval{HTTPResp: httpResp(http.StatusNotFound, "application/x-proto-binary")}},
+		},
+	}
+	store := &fakeCertStore{}
+	ctx := newFetchCtx(sender, store)
+
+	// Caller starts with LED-manager enabled.
+	sender.SetLedManagerDisabled(false)
+	_ = ctx.fetchCertChain(&testTLSCfg, 0)
+	if sender.LedManagerDisabled() {
+		t.Error("LED-manager left disabled after fetchCertChain; should be restored")
+	}
+}
+
+func TestFetchCertChain_NetworkErrorReturnsFalse(t *testing.T) {
+	sender := &fakeControllerSender{sends: []sendResponse{
+		{rv: controllerconn.SendRetval{Status: types.SenderStatusRefused}, err: errors.New("net err")},
+	}}
+	store := &fakeCertStore{}
+	ctx := newFetchCtx(sender, store)
+
+	if ok := ctx.fetchCertChain(&testTLSCfg, 0); ok {
+		t.Error("fetchCertChain ok = true, want false on network error")
+	}
+}
+
+func TestHaveControllerCertsCheckpoint(t *testing.T) {
+	ctx := &clientContext{certStore: &fakeCertStore{}}
+	if ctx.haveControllerCertsCheckpoint() {
+		t.Error("want false on empty store")
+	}
+	ctx.certStore = &fakeCertStore{primary: []byte("x")}
+	if !ctx.haveControllerCertsCheckpoint() {
+		t.Error("want true when primary present")
+	}
+	ctx.certStore = &fakeCertStore{backup: []byte("x")}
+	if !ctx.haveControllerCertsCheckpoint() {
+		t.Error("want true when backup present")
+	}
+}

--- a/pkg/pillar/cmd/client/finalizeonboarding_test.go
+++ b/pkg/pillar/cmd/client/finalizeonboarding_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+)
+
+func newOnboardPublication(t *testing.T) pubsub.Publication {
+	t.Helper()
+	ps := pubsub.New(pubsub.NewMemoryDriver(), logrus.StandardLogger(), log)
+	pub, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: "client_test",
+		TopicType: types.OnboardingStatus{},
+	})
+	if err != nil {
+		t.Fatalf("NewPublication: %v", err)
+	}
+	return pub
+}
+
+func newFinalizeCtx(t *testing.T) (*clientContext, *fakeHostnameSetter, string) {
+	t.Helper()
+	dir := t.TempDir()
+	hs := &fakeHostnameSetter{}
+	ctx := &clientContext{
+		hostnameSetter:        hs,
+		uuidFileName:          filepath.Join(dir, "uuid"),
+		hardwaremodelFileName: filepath.Join(dir, "hardwaremodel"),
+	}
+	return ctx, hs, dir
+}
+
+func mustUUID(t *testing.T, s string) uuid.UUID {
+	t.Helper()
+	u, err := uuid.FromString(s)
+	if err != nil {
+		t.Fatalf("uuid.FromString(%s): %v", s, err)
+	}
+	return u
+}
+
+func TestFinalizeOnboarding_NilUUIDIsNoop(t *testing.T) {
+	ctx, hs, dir := newFinalizeCtx(t)
+	pub := newOnboardPublication(t)
+
+	ctx.finalizeOnboarding(nilUUID, nilUUID, "", "", pub)
+
+	if len(hs.calls) != 0 {
+		t.Errorf("hostname calls = %v, want 0 for nil UUID", hs.calls)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "uuid")); err == nil {
+		t.Error("uuid file written for nil UUID")
+	}
+}
+
+func TestFinalizeOnboarding_FirstOnboardWritesAllArtefacts(t *testing.T) {
+	const newUUID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	ctx, hs, dir := newFinalizeCtx(t)
+	pub := newOnboardPublication(t)
+
+	devUUID := mustUUID(t, newUUID)
+	ctx.finalizeOnboarding(devUUID, nilUUID, "Dell.PowerEdge R740", "", pub)
+
+	if len(hs.calls) != 1 || hs.calls[0] != newUUID {
+		t.Errorf("hostname calls = %v, want [%s]", hs.calls, newUUID)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "uuid"))
+	if err != nil {
+		t.Fatalf("read uuid file: %v", err)
+	}
+	if string(got) != newUUID+"\n" {
+		t.Errorf("uuid file = %q, want %q", got, newUUID+"\n")
+	}
+	gotModel, err := os.ReadFile(filepath.Join(dir, "hardwaremodel"))
+	if err != nil {
+		t.Fatalf("read hardwaremodel file: %v", err)
+	}
+	if string(gotModel) != "Dell.PowerEdge R740" {
+		t.Errorf("hardwaremodel file = %q", gotModel)
+	}
+	itm, err := pub.Get("global")
+	if err != nil {
+		t.Fatalf("pub.Get global: %v", err)
+	}
+	status := itm.(types.OnboardingStatus)
+	if status.DeviceUUID != devUUID {
+		t.Errorf("published UUID = %s, want %s", status.DeviceUUID, devUUID)
+	}
+	if status.HardwareModel != "Dell.PowerEdge R740" {
+		t.Errorf("published model = %q", status.HardwareModel)
+	}
+}
+
+func TestFinalizeOnboarding_UnchangedUUIDSkipsFileWriteWhenFileExists(t *testing.T) {
+	const goodUUID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	ctx, _, dir := newFinalizeCtx(t)
+	pub := newOnboardPublication(t)
+
+	// Pre-create the uuid file with stale contents to detect overwrite.
+	preExisting := []byte("stale\n")
+	if err := os.WriteFile(filepath.Join(dir, "uuid"), preExisting, 0644); err != nil {
+		t.Fatalf("seed uuid: %v", err)
+	}
+	// Allow filesystem timestamp granularity to register.
+	time.Sleep(20 * time.Millisecond)
+
+	devUUID := mustUUID(t, goodUUID)
+	ctx.finalizeOnboarding(devUUID, devUUID /* unchanged */, "", "", pub)
+
+	got, _ := os.ReadFile(filepath.Join(dir, "uuid"))
+	if string(got) != string(preExisting) {
+		t.Errorf("uuid file was overwritten: got %q, want unchanged %q", got, preExisting)
+	}
+}
+
+func TestFinalizeOnboarding_HardwaremodelUnchangedSkipsWrite(t *testing.T) {
+	const goodUUID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	ctx, _, dir := newFinalizeCtx(t)
+	pub := newOnboardPublication(t)
+
+	devUUID := mustUUID(t, goodUUID)
+	ctx.finalizeOnboarding(devUUID, devUUID, "Dell.X", "Dell.X" /* unchanged */, pub)
+
+	if _, err := os.Stat(filepath.Join(dir, "hardwaremodel")); err == nil {
+		t.Error("hardwaremodel file written when model unchanged")
+	}
+}
+
+func TestFinalizeOnboarding_HostnameSetterFailureDoesNotPanic(t *testing.T) {
+	const goodUUID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	ctx, hs, _ := newFinalizeCtx(t)
+	pub := newOnboardPublication(t)
+	hs.err = os.ErrPermission
+
+	devUUID := mustUUID(t, goodUUID)
+	ctx.finalizeOnboarding(devUUID, nilUUID, "Dell.X", "", pub)
+
+	// Despite the setter failing, OnboardingStatus must still be published.
+	if _, err := pub.Get("global"); err != nil {
+		t.Errorf("OnboardingStatus not published after hostname failure: %v", err)
+	}
+}

--- a/pkg/pillar/cmd/client/handlers_test.go
+++ b/pkg/pillar/cmd/client/handlers_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func newHandlerCtx(sender *fakeControllerSender) *clientContext {
+	return &clientContext{
+		sender:              sender,
+		deviceNetworkStatus: &types.DeviceNetworkStatus{},
+	}
+}
+
+func TestHandleDNSDelete_ResetsState(t *testing.T) {
+	ctx := newHandlerCtx(&fakeControllerSender{})
+	ctx.deviceNetworkStatus = &types.DeviceNetworkStatus{
+		State: types.DPCStateSuccess,
+	}
+	ctx.usableAddressCount = 5
+	ctx.networkState = types.DPCStateSuccess
+
+	handleDNSDelete(ctx, "global", types.DeviceNetworkStatus{})
+
+	if ctx.deviceNetworkStatus.State != types.DPCStateNone {
+		t.Errorf("state = %v, want zero (DPCStateNone)", ctx.deviceNetworkStatus.State)
+	}
+	if ctx.usableAddressCount != 0 {
+		t.Errorf("usableAddressCount = %d, want 0", ctx.usableAddressCount)
+	}
+}
+
+func TestHandleDNSDelete_IgnoresNonGlobalKey(t *testing.T) {
+	ctx := newHandlerCtx(&fakeControllerSender{})
+	ctx.deviceNetworkStatus = &types.DeviceNetworkStatus{State: types.DPCStateSuccess}
+	ctx.usableAddressCount = 5
+
+	handleDNSDelete(ctx, "other-key", types.DeviceNetworkStatus{})
+
+	if ctx.deviceNetworkStatus.State != types.DPCStateSuccess {
+		t.Error("state was reset for a non-global key")
+	}
+	if ctx.usableAddressCount != 5 {
+		t.Error("usableAddressCount was reset for a non-global key")
+	}
+}
+
+// dnsStatusWithAddrs builds a minimal DeviceNetworkStatus with the given
+// state and a single port carrying the provided non-link-local IPv4 addrs.
+// Each addr counts as one usable address.
+func dnsStatusWithAddrs(state types.DPCState, addrs ...string) types.DeviceNetworkStatus {
+	addrInfos := make([]types.AddrInfo, 0, len(addrs))
+	for _, a := range addrs {
+		addrInfos = append(addrInfos, types.AddrInfo{Addr: net.ParseIP(a)})
+	}
+	return types.DeviceNetworkStatus{
+		State: state,
+		Ports: []types.NetworkPortStatus{
+			{IfName: "eth0", IsMgmt: true, IsL3Port: true, AddrInfoList: addrInfos},
+		},
+	}
+}
+
+func TestHandleDNSImpl_StateAndAddressTransitions(t *testing.T) {
+	ctx := newHandlerCtx(&fakeControllerSender{})
+
+	// First update: no addresses, state PCIWait.
+	first := dnsStatusWithAddrs(types.DPCStatePCIWait)
+	handleDNSImpl(ctx, "global", first)
+	if ctx.networkState != types.DPCStatePCIWait {
+		t.Errorf("networkState = %v, want PCIWait", ctx.networkState)
+	}
+	if ctx.usableAddressCount != 0 {
+		t.Errorf("usableAddressCount = %d, want 0", ctx.usableAddressCount)
+	}
+
+	// Second update: same state, gain one address.
+	second := dnsStatusWithAddrs(types.DPCStatePCIWait, "10.0.0.1")
+	handleDNSImpl(ctx, "global", second)
+	if ctx.usableAddressCount != 1 {
+		t.Errorf("usableAddressCount = %d, want 1", ctx.usableAddressCount)
+	}
+
+	// Third update: state advances to Success, same one address.
+	third := dnsStatusWithAddrs(types.DPCStateSuccess, "10.0.0.1")
+	handleDNSImpl(ctx, "global", third)
+	if ctx.networkState != types.DPCStateSuccess {
+		t.Errorf("networkState = %v, want Success", ctx.networkState)
+	}
+	if ctx.usableAddressCount != 1 {
+		t.Errorf("usableAddressCount = %d, want 1 unchanged", ctx.usableAddressCount)
+	}
+
+	// Identical update returns early via MostlyEqual.
+	handleDNSImpl(ctx, "global", third)
+	if ctx.networkState != types.DPCStateSuccess {
+		t.Errorf("identical update changed state")
+	}
+}
+
+func TestHandleDNSImpl_IgnoresNonGlobalKey(t *testing.T) {
+	ctx := newHandlerCtx(&fakeControllerSender{})
+	original := *ctx.deviceNetworkStatus
+	handleDNSImpl(ctx, "other-key", dnsStatusWithAddrs(types.DPCStateSuccess, "10.0.0.1"))
+	if ctx.deviceNetworkStatus.State != original.State {
+		t.Error("non-global key altered state")
+	}
+}
+
+func TestHandleDNSImpl_ProxyCertsPropagatedToTLSConfigs(t *testing.T) {
+	pool := x509.NewCertPool()
+	sender := &fakeControllerSender{
+		updateProxyCert: true,
+		proxyCertPool:   pool,
+	}
+	ctx := newHandlerCtx(sender)
+	ctx.onboardTLSConfig = &tls.Config{}
+	ctx.devtlsConfig = &tls.Config{}
+
+	handleDNSImpl(ctx, "global", dnsStatusWithAddrs(types.DPCStateSuccess, "10.0.0.1"))
+
+	if ctx.onboardTLSConfig.RootCAs != pool {
+		t.Error("onboardTLSConfig.RootCAs not updated from sender")
+	}
+	if ctx.devtlsConfig.RootCAs != pool {
+		t.Error("devtlsConfig.RootCAs not updated from sender")
+	}
+	if sender.dns == nil {
+		t.Error("sender.SetDeviceNetworkStatus not called")
+	}
+}
+
+func TestHandleDNSCreateAndModify_DelegateToImpl(t *testing.T) {
+	ctx := newHandlerCtx(&fakeControllerSender{})
+	handleDNSCreate(ctx, "global", dnsStatusWithAddrs(types.DPCStateSuccess, "10.0.0.1"))
+	if ctx.networkState != types.DPCStateSuccess {
+		t.Errorf("after Create networkState = %v, want Success", ctx.networkState)
+	}
+	handleDNSModify(ctx, "global", dnsStatusWithAddrs(types.DPCStateFailWithIPAndDNS, "10.0.0.1"), nil)
+	if ctx.networkState != types.DPCStateFailWithIPAndDNS {
+		t.Errorf("after Modify networkState = %v, want FailWithIPAndDNS", ctx.networkState)
+	}
+}

--- a/pkg/pillar/cmd/client/mypost_test.go
+++ b/pkg/pillar/cmd/client/mypost_test.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"bytes"
+	"crypto/tls"
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+var testTLSCfg = tls.Config{} //nolint:gochecknoglobals
+
+func httpResp(status int, contentType string) *http.Response {
+	r := &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     http.Header{},
+	}
+	if contentType != "" {
+		r.Header.Set("Content-Type", contentType)
+	}
+	return r
+}
+
+func newMyPostCtx(sender *fakeControllerSender) *clientContext {
+	return &clientContext{
+		sender:            sender,
+		serverNameAndPort: "test.example:8080",
+	}
+}
+
+func ledEqual(got, want []types.LedBlinkCount) bool {
+	if len(want) == 0 && len(got) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(got, want)
+}
+
+func TestMyPost_SendErrorClassification(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  types.SenderStatus
+		wantLed []types.LedBlinkCount
+	}{
+		{name: "upgrade", status: types.SenderStatusUpgrade},
+		{name: "refused", status: types.SenderStatusRefused},
+		{name: "cert invalid", status: types.SenderStatusCertInvalid},
+		{name: "cert miss", status: types.SenderStatusCertMiss},
+		{name: "not found emits connected", status: types.SenderStatusNotFound,
+			wantLed: []types.LedBlinkCount{types.LedBlinkConnectedToController}},
+		{name: "unknown sender status (default branch)", status: types.SenderStatusNone},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sender := &fakeControllerSender{sends: []sendResponse{
+				{rv: controllerconn.SendRetval{Status: tc.status}, err: errors.New("send failed")},
+			}}
+			led := &recordingLedNotifier{}
+			ctx := newMyPostCtx(sender)
+
+			done, _ := ctx.myPost(led, &testTLSCfg, "http://x/y", false, 0, bytes.NewBufferString(""))
+			if done {
+				t.Errorf("done = true, want false on send error")
+			}
+			if !ledEqual(led.patterns, tc.wantLed) {
+				t.Errorf("led = %v, want %v", led.patterns, tc.wantLed)
+			}
+		})
+	}
+}
+
+func TestMyPost_HTTPStatusBranches(t *testing.T) {
+	tests := []struct {
+		name      string
+		resp      *http.Response
+		body      []byte
+		wantDone  bool
+		wantLed   []types.LedBlinkCount
+		authError error
+	}{
+		{
+			name:     "200 with empty body",
+			resp:     httpResp(http.StatusOK, "application/x-proto-binary"),
+			wantDone: true,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkOnboarded},
+		},
+		{
+			name:     "201 Created with empty body",
+			resp:     httpResp(http.StatusCreated, "application/x-proto-binary"),
+			wantDone: true,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkOnboarded},
+		},
+		{
+			name:     "409 Conflict",
+			resp:     httpResp(http.StatusConflict, "application/x-proto-binary"),
+			wantDone: false,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkOnboardingFailure},
+		},
+		{
+			name:     "404 Not Found",
+			resp:     httpResp(http.StatusNotFound, "application/x-proto-binary"),
+			wantDone: false,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkConnectedToController},
+		},
+		{
+			name:     "401 Unauthorized",
+			resp:     httpResp(http.StatusUnauthorized, "application/x-proto-binary"),
+			wantDone: false,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkConnectedToController},
+		},
+		{
+			name:     "304 Not Modified",
+			resp:     httpResp(http.StatusNotModified, "application/x-proto-binary"),
+			wantDone: false,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkConnectedToController},
+		},
+		{
+			name:     "500 default branch",
+			resp:     httpResp(http.StatusInternalServerError, "application/x-proto-binary"),
+			wantDone: false,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkConnectedToController},
+		},
+		{
+			name:     "200 missing content-type",
+			resp:     httpResp(http.StatusOK, ""),
+			wantDone: false,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkOnboarded},
+		},
+		{
+			name:     "200 unparsable content-type",
+			resp:     httpResp(http.StatusOK, "garbage; ; ;"),
+			wantDone: false,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkOnboarded},
+		},
+		{
+			name:     "200 unsupported MIME",
+			resp:     httpResp(http.StatusOK, "text/html"),
+			wantDone: false,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkOnboarded},
+		},
+		{
+			name:     "200 with body and auth verify ok",
+			resp:     httpResp(http.StatusOK, "application/x-proto-binary"),
+			body:     []byte("payload"),
+			wantDone: true,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkOnboarded},
+		},
+		{
+			name:      "200 with body and auth verify fails",
+			resp:      httpResp(http.StatusOK, "application/x-proto-binary"),
+			body:      []byte("payload"),
+			authError: errors.New("bad container"),
+			wantDone:  false,
+			wantLed:   []types.LedBlinkCount{types.LedBlinkOnboarded, types.LedBlinkInvalidAuthContainer},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sender := &fakeControllerSender{
+				sends: []sendResponse{
+					{rv: controllerconn.SendRetval{HTTPResp: tc.resp, RespContents: tc.body}},
+				},
+				authVerifyErr: tc.authError,
+			}
+			led := &recordingLedNotifier{}
+			ctx := newMyPostCtx(sender)
+
+			done, _ := ctx.myPost(led, &testTLSCfg, "http://x/y", false, 0, bytes.NewBufferString(""))
+			if done != tc.wantDone {
+				t.Errorf("done = %v, want %v", done, tc.wantDone)
+			}
+			if !ledEqual(led.patterns, tc.wantLed) {
+				t.Errorf("led = %v, want %v", led.patterns, tc.wantLed)
+			}
+			if tc.body != nil && tc.authError == nil && sender.authVerifyCalls != 1 {
+				t.Errorf("authVerifyCalls = %d, want 1", sender.authVerifyCalls)
+			}
+		})
+	}
+}

--- a/pkg/pillar/cmd/client/selfregister_test.go
+++ b/pkg/pillar/cmd/client/selfregister_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func newSelfRegisterCtx(sender *fakeControllerSender, led ledNotifier) *clientContext {
+	return &clientContext{
+		sender:            sender,
+		led:               led,
+		serverNameAndPort: "test.example:8080",
+	}
+}
+
+// Note: selfRegister currently always returns done=false when myPost
+// produced any HTTP response (the `done = false` override at the end of
+// the HTTPResp != nil block). Success is declared later by doGetUUID.
+// These tests assert the LED pattern emitted for each status code; the
+// done value is exercised only on the no-response path.
+
+func TestSelfRegister_StatusCodeLEDPatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		wantLed []types.LedBlinkCount
+	}{
+		{
+			name:    "200 - onboarded only (no override branch)",
+			status:  http.StatusOK,
+			wantLed: []types.LedBlinkCount{types.LedBlinkOnboarded},
+		},
+		{
+			name:    "201 - onboarded only (no override branch)",
+			status:  http.StatusCreated,
+			wantLed: []types.LedBlinkCount{types.LedBlinkOnboarded},
+		},
+		{
+			name:    "400 - connected then onboarding failure",
+			status:  http.StatusBadRequest,
+			wantLed: []types.LedBlinkCount{types.LedBlinkConnectedToController, types.LedBlinkOnboardingFailure},
+		},
+		{
+			name:    "504 - connected then onboarding failure",
+			status:  http.StatusGatewayTimeout,
+			wantLed: []types.LedBlinkCount{types.LedBlinkConnectedToController, types.LedBlinkOnboardingFailure},
+		},
+		{
+			name:    "500 - connected then onboarding failure",
+			status:  http.StatusInternalServerError,
+			wantLed: []types.LedBlinkCount{types.LedBlinkConnectedToController, types.LedBlinkOnboardingFailure},
+		},
+		{
+			name:    "403 - connected then onboarding failure not found",
+			status:  http.StatusForbidden,
+			wantLed: []types.LedBlinkCount{types.LedBlinkConnectedToController, types.LedBlinkOnboardingFailureNotFound},
+		},
+		{
+			name:    "409 - onboarding failure then conflict",
+			status:  http.StatusConflict,
+			wantLed: []types.LedBlinkCount{types.LedBlinkOnboardingFailure, types.LedBlinkOnboardingFailureConflict},
+		},
+		{
+			name:    "304 - connected then conflict",
+			status:  http.StatusNotModified,
+			wantLed: []types.LedBlinkCount{types.LedBlinkConnectedToController, types.LedBlinkOnboardingFailureConflict},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sender := &fakeControllerSender{sends: []sendResponse{
+				{rv: controllerconn.SendRetval{HTTPResp: httpResp(tc.status, "application/x-proto-binary")}},
+			}}
+			led := &recordingLedNotifier{}
+			ctx := newSelfRegisterCtx(sender, led)
+
+			done := ctx.selfRegister(&testTLSCfg, []byte("device-cert-pem"), 0)
+			if done {
+				t.Errorf("done = true; selfRegister always returns false when an HTTP response is received")
+			}
+			if !ledEqual(led.patterns, tc.wantLed) {
+				t.Errorf("led = %v, want %v", led.patterns, tc.wantLed)
+			}
+		})
+	}
+}
+
+func TestSelfRegister_NetworkErrorNoLED(t *testing.T) {
+	sender := &fakeControllerSender{sends: []sendResponse{
+		{rv: controllerconn.SendRetval{Status: types.SenderStatusUpgrade}, err: errors.New("net err")},
+	}}
+	led := &recordingLedNotifier{}
+	ctx := newSelfRegisterCtx(sender, led)
+
+	done := ctx.selfRegister(&testTLSCfg, []byte("device-cert-pem"), 0)
+	if done {
+		t.Errorf("done = true, want false on network error")
+	}
+	if len(led.patterns) != 0 {
+		t.Errorf("led = %v, want no emissions when HTTPResp is nil", led.patterns)
+	}
+}
+
+func TestSelfRegister_LedManagerDisabled(t *testing.T) {
+	sender := &fakeControllerSender{
+		ledManagerDisabled: true,
+		sends: []sendResponse{
+			{rv: controllerconn.SendRetval{HTTPResp: httpResp(http.StatusBadRequest, "application/x-proto-binary")}},
+		},
+	}
+	led := &recordingLedNotifier{}
+	ctx := newSelfRegisterCtx(sender, led)
+
+	_ = ctx.selfRegister(&testTLSCfg, []byte("device-cert-pem"), 0)
+	if len(led.patterns) != 0 {
+		t.Errorf("led = %v, want no emissions when LED manager disabled", led.patterns)
+	}
+}


### PR DESCRIPTION
## Description

Cover the network-facing and side-effect-bearing parts of the
onboarding loop using the seams introduced earlier: HTTP request
classification and LED transitions, the register/UUID-fetch outcomes,
controller-cert prefetch with checkpoint comparison, the post-loop
hostname/UUID/hardwaremodel publishing, and the DNS-status handler's
state-transition + proxy-cert propagation paths.

Package statement coverage rises from 0 % to **53.66 %** (242/451)
across the Phase-1 (#5957) and Phase-2 sets combined. Each function the
new tests target reaches 80-100%; the remaining dark code is the
top-level event loop and adapter wiring, reached by Eden e2e tests in
lf-edge/eden#1178.

With the Eden e2e suite included, `pkg/pillar/cmd/client` combined
block coverage reaches **85.59 %** (386/451, dedup'd across unit and
e2e profiles).

Depends on #5957.

## How to test and validate this PR

`go test -count=1 -cover ./pkg/pillar/cmd/client/...` from the pillar module.

## Changelog notes

No user-facing changes.

## PR Backports

- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [x] I've written the test verification instructions
