### PR TITLE
tests/eden: pin coverage runs to eden master

### DIFF
--- a/docs/CODE-COVERAGE.md
+++ b/docs/CODE-COVERAGE.md
@@ -77,8 +77,8 @@ go tool cover -html=pkg/pillar/coverage.txt -o coverage_unit.html
    while running.
 
 2. Clones and builds Eden from EDEN_REPO (default: github.com/lf-edge/eden)
-   using EDEN_TAG (default: 1.0.16) which contains the coverage-collection
-   extensions.
+   using EDEN_TAG (default: master), which carries the coverage-collection
+   extensions and the current default EVE image size.
 
 3. Starts the EVE VM under QEMU, onboards it, and runs the selected test
    scenarios exactly as `make eden` would.
@@ -312,8 +312,9 @@ tools such as `gocovmerge` can be used on the text profiles directly.
 
 ### eden-cover vs eden
 
-Both `make eden` and `make eden-cover` use the upstream Eden release
-(`EDEN_TAG=1.0.16` from `github.com/lf-edge/eden`).  The difference is
+Both `make eden` and `make eden-cover` use eden from
+`github.com/lf-edge/eden` (default `EDEN_TAG=master`; override
+`EDEN_TAG=<sha-or-tag>` for reproducibility).  The difference is
 that `make eden-cover` sets `COVER=y`, which causes `run.sh` to pass
 `--coverage-dir` to each `eden test` invocation and to call
 `eden eve collect-coverage` after all scenarios complete.

--- a/tests/eden/run.sh
+++ b/tests/eden/run.sh
@@ -8,7 +8,7 @@ set -eo pipefail
 EVE_ROOT=$(pwd)
 EDEN_DEBUG_OPT=""
 PREFIX="[EDEN_TEST]"
-EDEN_TAG=${EDEN_TAG:-1.0.16}
+EDEN_TAG=${EDEN_TAG:-master}
 EDEN_REPO=${EDEN_REPO:-https://github.com/lf-edge/eden.git}
 COVER=${COVER:-}
 EVE_FLAVOR=${EVE_FLAVOR:-kvm}


### PR DESCRIPTION
## Description

The eden-cover entry point cloned eden at tag 1.0.16 by default. That
tag is now five months stale and predates the bump of the default
EVE live-image size from 8 GB to 16 GB (lf-edge/eden cd853ca4 in April).
On a fresh coverage bringup that 8 GB default leaves no room for the
IMGB partition, and the COVER=y zedbox fatals in a reboot loop within
seconds (\`zboot partdev IMGB: err exit status 1\`).

Tracking master keeps the coverage runs aligned with the eden
default-size bump and any subsequent eden fixes that land before a new
tag. Override with \`EDEN_TAG=<sha-or-tag>\` when reproducibility
against a specific eden revision matters.

## How to test and validate this PR

\`\`\`sh
make COVER=y eve-pillar
make COVER=y eve
make eden-cover    # or SETUP_ONLY=1 ./tests/eden/run.sh
\`\`\`

Verify \`dist/<arch>/current/eden_config/contexts/default.yml\` shows
\`disk: 16384\`, and the resulting QEMU live image has IMGB carved
(boot does not loop on \`zboot partdev IMGB\`).

## Changelog notes

No user-facing changes.

## PR Backports

- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [x] I've written the test verification instructions