### PR TITLE
Fix SBOM: Add missing packages

### DIFF
--- a/.github/workflows/sbom-coverage-check.yml
+++ b/.github/workflows/sbom-coverage-check.yml
@@ -1,0 +1,29 @@
+# Copyright (c) 2026, Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+name: SBOM Coverage Check
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - "master"
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-stable"
+      - "feature/*"
+    paths:
+      - "pkg/**/Dockerfile"
+      - "pkg/alpine/register-sbom-pkg.sh"
+      - "tools/check-sbom-coverage.sh"
+      - "tools/sbom-coverage-allowlist.txt"
+      - ".github/workflows/sbom-coverage-check.yml"
+
+jobs:
+  check-sbom-coverage:
+    name: Every source-built pkg must call register-sbom-pkg.sh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Run SBOM coverage check
+        run: ./tools/check-sbom-coverage.sh

--- a/eve-tools/bpftrace-compiler/root/Dockerfile
+++ b/eve-tools/bpftrace-compiler/root/Dockerfile
@@ -5,7 +5,7 @@ ARG EVE_KERNEL
 # hadolint ignore=DL3006
 FROM ${EVE_KERNEL} AS kernel
 
-FROM lfedge/eve-bpftrace:03c26b968615b09b491f71e61e35d3f2675835ef AS eve-bpftrace
+FROM lfedge/eve-bpftrace:1702f469e947203d6d6f37cb784c463e465f2de1 AS eve-bpftrace
 
 FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS bpftrace
 

--- a/eve-tools/bpftrace-compiler/root/Dockerfile
+++ b/eve-tools/bpftrace-compiler/root/Dockerfile
@@ -7,7 +7,7 @@ FROM ${EVE_KERNEL} AS kernel
 
 FROM lfedge/eve-bpftrace:03c26b968615b09b491f71e61e35d3f2675835ef AS eve-bpftrace
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS bpftrace
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS bpftrace
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache --initdb binutils make gcc g++ git perl musl-dev cmake zlib-dev bcc-dev libbpf-dev cereal flex bison llvm17-libs llvm17-dev llvm17-static clang17-dev clang17-static pahole gtest-dev bash

--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright (c) 2023-2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
 # DON'T FORGET TO UPDATE THE HASH WHEN SOMETHING CHANGES!
 # please see https://github.com/lf-edge/eve/blob/master/docs/BUILD.md#how-to-update-eve-alpine-package
 FROM lfedge/eve-alpine-base:77cc1495c875b7468dbf4123210abf86a1ffb852-07a6e7df6 AS cache-build
@@ -47,7 +50,7 @@ ARG GO_VERSION=1.24.6
 COPY --from=cache-build /etc/apk/repositories* /etc/apk/
 COPY --from=cache-build /etc/apk/keys /etc/apk/keys/
 COPY --from=cache-build /mirror /mirror/
-COPY eve-alpine-deploy.sh go-compile.sh /bin/
+COPY eve-alpine-deploy.sh go-compile.sh register-sbom-pkg.sh /bin/
 
 RUN apk update && apk upgrade -a
 

--- a/pkg/alpine/register-sbom-pkg.sh
+++ b/pkg/alpine/register-sbom-pkg.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# Copyright (c) 2023 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# shellcheck disable=SC2086
+#
+# register-sbom-pkg.sh - Register a source-built package in the APK DB so
+# syft includes it in the SBOM.
+#
+# Usage:
+#   register-sbom-pkg.sh -n <name> -v <version> -l <license> -u <url> [-d <description>] [-o <outdir>]
+#
+# Arguments:
+#   -n  package name       (required)
+#   -v  package version    (required)
+#   -l  SPDX license ID    (required, e.g. BSD-3-Clause, MIT, Apache-2.0)
+#   -u  upstream URL       (required)
+#   -d  description        (optional, defaults to "<name> (built from source)")
+#   -o  output root dir    (optional, defaults to /out)
+#
+# Example:
+#   register-sbom-pkg.sh -n libtpms -v 0.10.0 -l BSD-3-Clause -u https://github.com/stefanberger/libtpms
+#
+# The entry is appended to <outdir>/lib/apk/db/installed.
+#
+set -e
+
+usage() {
+    echo "Usage: $0 -n <name> -v <version> -l <license> -u <url> [-d <description>] [-o <outdir>]" >&2
+    exit 1
+}
+
+OUTDIR=/out
+
+while getopts "n:v:l:u:d:o:" opt; do
+    case "$opt" in
+        n) PKG_NAME="$OPTARG" ;;
+        v) PKG_VERSION="$OPTARG" ;;
+        l) PKG_LICENSE="$OPTARG" ;;
+        u) PKG_URL="$OPTARG" ;;
+        d) PKG_DESC="$OPTARG" ;;
+        o) OUTDIR="$OPTARG" ;;
+        *) usage ;;
+    esac
+done
+
+APK_DB="${OUTDIR}/lib/apk/db/installed"
+
+# Always make sure the apk DB directory and file exist so that callers can
+# rely on it being present even when this script is invoked only to
+# initialize the file (no -n/-v/-l/-u). This also lets later
+# COPY --from=<stage> /.../lib/apk/db/installed succeed unconditionally.
+mkdir -p "$(dirname "$APK_DB")"
+[ -e "$APK_DB" ] || touch "$APK_DB"
+
+# Init-only mode: if no package fields were supplied, we just ensured the
+# file exists and we're done.
+if [ -z "$PKG_NAME" ] && [ -z "$PKG_VERSION" ] && [ -z "$PKG_LICENSE" ] && [ -z "$PKG_URL" ]; then
+    echo "Initialized $APK_DB"
+    exit 0
+fi
+
+[ -n "$PKG_NAME" ]    || { echo "ERROR: -n (name) is required" >&2;    usage; }
+[ -n "$PKG_VERSION" ] || { echo "ERROR: -v (version) is required" >&2; usage; }
+[ -n "$PKG_LICENSE" ] || { echo "ERROR: -l (license) is required" >&2; usage; }
+[ -n "$PKG_URL" ]     || { echo "ERROR: -u (url) is required" >&2;     usage; }
+
+PKG_DESC="${PKG_DESC:-${PKG_NAME} (built from source)}"
+PKG_ARCH="$(apk --print-arch)"
+
+printf 'P:%s\nV:%s\nL:%s\nA:%s\nT:%s\nU:%s\n\n' \
+    "$PKG_NAME" "$PKG_VERSION" "$PKG_LICENSE" "$PKG_ARCH" "$PKG_DESC" "$PKG_URL" \
+    >> "$APK_DB"
+
+echo "Registered $PKG_NAME-$PKG_VERSION in $APK_DB"

--- a/pkg/apparmor/Dockerfile
+++ b/pkg/apparmor/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ENV BUILD_PKGS linux-headers musl-dev musl-utils musl-libintl git gcc g++ \
                autoconf autoconf-archive automake libtool make flex bison \
                bash sed gettext
@@ -19,6 +19,9 @@ RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 WORKDIR /apparmor/parser
 RUN ../common/list_af_names.sh > base_af_names.h
 RUN make CFLAGS="-Os"
+
+# Register apparmor in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n apparmor -v 4.1.3 -l GPL-2.0-only -u https://gitlab.com/apparmor/apparmor.git
 
 #Pull a selected set of artifacts into the final stage.
 FROM scratch

--- a/pkg/bpftrace/Dockerfile
+++ b/pkg/bpftrace/Dockerfile
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 
 ENV BUILD_PKGS libbpf-dev make gcc g++ git perl linux-headers musl-dev cmake elfutils-dev llvm17-libs llvm17-dev llvm17-gtest llvm17-static cereal flex bison clang17-extra-tools clang17-dev clang17-static pahole gtest-dev bash py3-setuptools zip zlib-dev
 
@@ -23,6 +23,8 @@ RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_COMPILER=clang++-17 -DCMA
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN make install
 
+# Register bcc in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n bcc -v 0.27.0 -l Apache-2.0 -u https://github.com/iovisor/bcc.git
 
 RUN mkdir -p /usr/src
 ADD https://github.com/bpftrace/bpftrace.git#v0.20.3 /usr/src/bpftrace
@@ -34,6 +36,9 @@ WORKDIR /usr/src/bpftrace/build
 RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_COMPILER=clang++-17 -DCMAKE_C_COMPILER=clang-17 ..
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN make install
+
+# Register bpftrace in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n bpftrace -v 0.20.3 -l Apache-2.0 -u https://github.com/bpftrace/bpftrace.git
 
 # portability analyser is disabled, therefore skip those tests
 # skip file exist test - probably broken because of container
@@ -52,6 +57,7 @@ RUN if [ "$TARGETARCH" = "$BUILDARCH" ]; then \
     fi
 
 FROM scratch AS bin
+COPY --from=build /out/lib/apk/db/installed /lib/apk/db/installed
 COPY --from=build /usr/bin/bpftrace /bpftrace/usr/bin/bpftrace
 COPY --from=build /usr/bin/bpftrace-aotrt /bpftrace-aotrt/usr/bin/bpftrace-aotrt
 

--- a/pkg/bsp-imx/Dockerfile
+++ b/pkg/bsp-imx/Dockerfile
@@ -4,7 +4,7 @@
 ARG BUILD_PKGS_BASE="bash binutils-dev build-base bc bison flex openssl-dev util-linux-dev swig gnutls-dev perl python3 python3-dev py3-setuptools py3-pycryptodome py3-elftools"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1
 
 # OPTEE-OS images
 FROM lfedge/eve-optee-os:3c441f553d0037cbd49689e35b695632c2c8a9b4 AS optee-os
@@ -197,8 +197,16 @@ RUN for target in ${UBOOT_TARGETS}; do \
         [ -f "$udtb" ] && cp $udtb /bsp/ ;\
     done
 
+# Register imx-atf, firmware-imx and uboot-imx in the APK DB, mandatory for them to be included in the SBOM.
+RUN if [ "$EVE_TARGET_ARCH" = "aarch64" ]; then \
+        register-sbom-pkg.sh -n imx-atf -v "${ATF_COMMIT_imx8mp_pollux:0:8}" -l BSD-3-Clause -u https://github.com/nxp-imx/imx-atf && \
+        register-sbom-pkg.sh -n firmware-imx -v "${FIRMWARE_VER}" -l proprietary -u https://www.nxp.com && \
+        register-sbom-pkg.sh -n uboot-imx -v "${UBOOT_VERSION}" -l GPL-2.0-only -u https://github.com/nxp-imx/uboot-imx; \
+    fi
+
 FROM scratch
 ENTRYPOINT []
 CMD []
 COPY --from=build /bsp /bsp-imx
+COPY --from=build /out/lib/apk/db/installed /lib/apk/db/installed
 

--- a/pkg/bsp-imx/Dockerfile
+++ b/pkg/bsp-imx/Dockerfile
@@ -7,7 +7,7 @@ ARG BUILD_PKGS_BASE="bash binutils-dev build-base bc bison flex openssl-dev util
 ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1
 
 # OPTEE-OS images
-FROM lfedge/eve-optee-os:3c441f553d0037cbd49689e35b695632c2c8a9b4 AS optee-os
+FROM lfedge/eve-optee-os:db7952003e0c1b8efd08506167626c5b10de27e9 AS optee-os
 
 # hadolint ignore=DL3006
 FROM ${EVE_ALPINE_IMAGE} AS build-native

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -8,8 +8,8 @@
 # has a fast path for stack unwinding. This also happens
 # to be a perfect place to put any other kind of debug info
 # into the package: see abuild/etc/abuild.conf.
-FROM lfedge/eve-recovertpm:478513dfbf4681b19f11a9afdede6194cceea301 AS recovertpm
-FROM lfedge/eve-bpftrace:03c26b968615b09b491f71e61e35d3f2675835ef AS bpftrace
+FROM lfedge/eve-recovertpm:31a2e12f1e934db7835b34005328547b80c201f6 AS recovertpm
+FROM lfedge/eve-bpftrace:1702f469e947203d6d6f37cb784c463e465f2de1 AS bpftrace
 FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ENV BUILD_PKGS="abuild curl tar make linux-headers patch g++ git gcc gpg gettext gettext-static ncurses-dev jq autoconf openssl-dev zlib-dev zlib-static gpg-agent"
 # Feel free to add additional packages here, but be aware that

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -10,7 +10,7 @@
 # into the package: see abuild/etc/abuild.conf.
 FROM lfedge/eve-recovertpm:478513dfbf4681b19f11a9afdede6194cceea301 AS recovertpm
 FROM lfedge/eve-bpftrace:03c26b968615b09b491f71e61e35d3f2675835ef AS bpftrace
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ENV BUILD_PKGS="abuild curl tar make linux-headers patch g++ git gcc gpg gettext gettext-static ncurses-dev jq autoconf openssl-dev zlib-dev zlib-static gpg-agent"
 # Feel free to add additional packages here, but be aware that
 # EVE's rootfs image can be no larger than 300Mb (and don't
@@ -58,6 +58,9 @@ RUN for patch in *.patch; do \
     make -j$(nproc) -C src VERSION=B.${LSHW_VERSION} NO_VERSION_CHECK=1 RPM_OPT_FLAGS=-DNONLS ZLIB=1 GZIP="busybox gzip -n9" static && \
     cp src/lshw-static /out/usr/bin/lshw && strip /out/usr/bin/lshw
 
+# Register lshw in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n lshw -v "B.${LSHW_VERSION}" -l GPL-2.0-only -u https://www.ezix.org/software/files/lshw
+
 # building hexedit
 WORKDIR /tmp/hexedit/hexedit-1.5
 # hadolint ignore=DL4006
@@ -65,6 +68,9 @@ ADD https://github.com/pixel/hexedit/archive/refs/tags/1.5.tar.gz ../1.5.tar.gz
 RUN tar -C .. -xzvf ../1.5.tar.gz
 # hadolint ignore=SC2046
 RUN ./autogen.sh && ./configure && make -j$(nproc) && make DESTDIR=/out install
+
+# Register hexedit in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n hexedit -v 1.5 -l GPL-2.0-only -u https://github.com/pixel/hexedit
 
 # tweaking various bit
 WORKDIR /out

--- a/pkg/dnsmasq/Dockerfile
+++ b/pkg/dnsmasq/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ENV BUILD_PKGS gcc make patch libc-dev linux-headers tar xz coreutils
 RUN eve-alpine-deploy.sh
 
@@ -24,6 +24,9 @@ RUN set -e && for patch in ../patches/*.patch; do \
 RUN rm -rf /out
 RUN make  -j "$(getconf _NPROCESSORS_ONLN)"
 RUN make install DESTDIR=/out PREFIX=/usr
+
+# Register dnsmasq in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n dnsmasq -v "${DNSMASQ_VERSION}" -l GPL-2.0-only -u https://thekelleys.org.uk/dnsmasq
 
 FROM build AS test
 

--- a/pkg/dom0-ztools/Dockerfile
+++ b/pkg/dom0-ztools/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS zfs
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS zfs
 ENV BUILD_PKGS="git patch ca-certificates util-linux build-base gettext-dev libtirpc-dev automake autoconf \
     libtool linux-headers attr-dev e2fsprogs-dev glib-dev openssl-dev util-linux-dev coreutils"
 ENV PKGS="ca-certificates util-linux libintl libuuid libtirpc libblkid libcrypto3 zlib"
@@ -42,6 +42,9 @@ RUN rm -rf /tmp/zfs-out/usr/share && rm -rf /tmp/zfs-out/usr/src && \
 # hadolint ignore=DL4006
 RUN find /tmp/zfs-out -mindepth 1|sed 's@/tmp/zfs-out@@'>/out/etc/zfs-files
 RUN cp -r /tmp/zfs-out/* /out
+
+# Register zfs in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n zfs -v "${ZFS_VERSION}" -l CDDL-1.0 -u https://github.com/openzfs/zfs
 
 # Add directory for CDI files
 RUN mkdir -p /out/etc/cdi

--- a/pkg/edgeview/Dockerfile
+++ b/pkg/edgeview/Dockerfile
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # hadolint ignore=DL3006
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS runtime
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS runtime
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables
 RUN eve-alpine-deploy.sh
 
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ARG TARGETARCH
 
 COPY src/  /edge-view/.

--- a/pkg/eve/Dockerfile.in
+++ b/pkg/eve/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS tools
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS tools
 ENV PKGS="qemu-img tar u-boot-tools coreutils dosfstools"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/fscrypt/Dockerfile
+++ b/pkg/fscrypt/Dockerfile
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build-base
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build-base
 
 FROM build-base AS build-amd64
 FROM build-base AS build-arm64
@@ -28,5 +28,9 @@ RUN set -e && for patch in *.patch; do \
 
 RUN make -j "$(getconf _NPROCESSORS_ONLN)" && make DESTDIR="/out/opt/zededa" PREFIX="" install
 
+# Register fscrypt in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n fscrypt -v "${FSCRYPT_COMMIT}" -l Apache-2.0 -u https://github.com/google/fscrypt
+
 FROM scratch
 COPY --from=build /out/opt/zededa/bin /opt/zededa/bin
+COPY --from=build /out/lib/apk/db/installed /lib/apk/db/installed

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 ARG PLATFORM=generic
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build-base
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build-base
 
 ARG TARGETARCH
 
@@ -100,10 +100,24 @@ ADD ${RPI_BT_FIRMWARE_URL}/${RPI_BT_FIRMWARE_VERSION}/broadcom/BCM4345C5.hcd .
 ENV HAILO_FW_VERSION=4.21.0
 ADD https://hailo-hailort.s3.eu-west-2.amazonaws.com/Hailo8/${HAILO_FW_VERSION}/FW/hailo8_fw.${HAILO_FW_VERSION}.bin /lib/firmware/hailo/hailo8_fw.bin
 
+# Register firmware packages in the APK DB, mandatory for them to be included in the SBOM.
+RUN register-sbom-pkg.sh -n wireless-regdb -v "${WIRELESS_REGDB_VERSION}" -l ISC -u https://wireless.wiki.kernel.org/en/developers/regulatory/wireless-regdb -o /sbom-out
+RUN register-sbom-pkg.sh -n linux-firmware -v "${LINUX_FIRMWARE_VERSION}" -l GPL-2.0-only -u https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git -o /sbom-out
+RUN register-sbom-pkg.sh -n rtw88-firmware -v "${RTL8822_FW_VERSION:0:8}" -l GPL-2.0-only -u https://github.com/lwfinger/rtw88 -o /sbom-out
+RUN register-sbom-pkg.sh -n hailo8-firmware -v "${HAILO_FW_VERSION}" -l proprietary -u https://hailo.ai -o /sbom-out
+RUN register-sbom-pkg.sh -n nvidia-l4t-firmware -v "${NVIDIA_FW_TEGRA}" -l proprietary -u https://repo.download.nvidia.com/jetson -o /sbom-out
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+        register-sbom-pkg.sh -n rpi-firmware-nonfree -v "${RPI_FIRMWARE_VERSION:0:8}" -l proprietary -u https://github.com/RPi-Distro/firmware-nonfree -o /sbom-out && \
+        register-sbom-pkg.sh -n rpi-bluez-firmware -v "${RPI_BT_FIRMWARE_VERSION:0:8}" -l proprietary -u https://github.com/RPi-Distro/bluez-firmware -o /sbom-out; \
+    fi
+
 # generate initrd for Intel's and AMD's microcode
 # it makes sense only for x86_64 platform
-FROM --platform=${TARGETPLATFORM} lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS ucode-build-common
+FROM --platform=${TARGETPLATFORM} lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS ucode-build-common
 RUN mkdir -p /boot /tmp/ucode/intel /tmp/ucode/amd /usr/share/licenses/ucode
+# Ensure /sbom-out/lib/apk/db/installed exists for all archs so the COPY in
+# compactor-common works even when no ucode registrations run (arm64/riscv64).
+RUN register-sbom-pkg.sh -o /sbom-out
 
 FROM ucode-build-common AS ucode-build-amd64
 ENV BUILD_PKGS=iucode-tool
@@ -139,13 +153,22 @@ RUN cp /tmp/ucode/amd/linux-firmware/LICENSE.amd-ucode /usr/share/licenses/ucode
 # merge intel and amd microcode
 RUN cat /tmp/ucode/intel/intel-ucode.img /tmp/ucode/amd/amd-ucode.img >/boot/ucode.img
 
+# Register intel-ucode and amd-ucode in the APK DB, mandatory for them to be included in the SBOM.
+RUN register-sbom-pkg.sh -n intel-ucode -v "${INTEL_UCODE_VERSION}" -l proprietary -u https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files -o /sbom-out
+RUN register-sbom-pkg.sh -n amd-ucode -v "${AMD_UCODE_VERSION}" -l proprietary -u https://www.amd.com -o /sbom-out
+
 FROM ucode-build-common AS ucode-build-arm64
 FROM ucode-build-common AS ucode-build-riscv64
 FROM ucode-build-${TARGETARCH} AS ucode-build
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS compactor-common
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS compactor-common
 ENTRYPOINT []
 WORKDIR /
+# Reset the APK DB so the final image only reports source-built/firmware packages
+RUN rm -f /lib/apk/db/installed && register-sbom-pkg.sh -o /
+COPY --from=build /sbom-out/lib/apk/db/installed /tmp/sbom-fw
+COPY --from=ucode-build /sbom-out/lib/apk/db/installed /tmp/sbom-ucode
+RUN cat /tmp/sbom-fw /tmp/sbom-ucode >> /lib/apk/db/installed && rm -f /tmp/sbom-fw /tmp/sbom-ucode
 COPY --from=build /lib/firmware/regulatory* /lib/firmware/
 COPY --from=build /lib/firmware/bnx2x/* /lib/firmware/bnx2x/
 COPY --from=build /lib/firmware/mrvl/*.bin /lib/firmware/mrvl/
@@ -222,7 +245,12 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
     fi
 
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS compactor-full
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS compactor-full
+# Reset the APK DB so the final image only reports source-built/firmware packages
+RUN rm -f /lib/apk/db/installed && register-sbom-pkg.sh -o /
+COPY --from=build /sbom-out/lib/apk/db/installed /tmp/sbom-fw
+COPY --from=ucode-build /sbom-out/lib/apk/db/installed /tmp/sbom-ucode
+RUN cat /tmp/sbom-fw /tmp/sbom-ucode >> /lib/apk/db/installed && rm -f /tmp/sbom-fw /tmp/sbom-ucode
 # get all possible FW
 COPY --from=build /lib/firmware/ /lib/firmware/
 
@@ -239,5 +267,6 @@ ENTRYPOINT []
 WORKDIR /
 
 COPY --from=compactor /lib/firmware /lib/firmware
+COPY --from=compactor /lib/apk/db/installed /lib/apk/db/installed
 COPY --from=ucode-build /boot/ /boot/
 COPY --from=ucode-build /usr/share/licenses/ucode /usr/share/licenses/ucode

--- a/pkg/gpt-tools/Dockerfile
+++ b/pkg/gpt-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ENV BUILD_PKGS="gcc make file patch libc-dev linux-headers openssl-dev g++ tar coreutils"
 # util-linux-static on riscv64 is broken; we build libuuid from source instead (see below).
 ENV BUILD_PKGS_amd64="util-linux-static util-linux-dev"
@@ -21,6 +21,11 @@ RUN if [ "${TARGETARCH}" = "riscv64" ]; then \
       cp .libs/libuuid.a /usr/lib/libuuid.a && \
       mkdir -p /usr/include/uuid && \
       cp libuuid/src/uuid.h /usr/include/uuid/uuid.h; \
+    fi
+
+# Register util-linux in the APK DB, mandatory for it to be included in the SBOM.
+RUN if [ "${TARGETARCH}" = "riscv64" ]; then \
+      register-sbom-pkg.sh -n util-linux -v 2.41 -l GPL-2.0-only -u https://github.com/util-linux/util-linux; \
     fi
 
 #
@@ -55,6 +60,9 @@ RUN make -j "$(getconf _NPROCESSORS_ONLN)" CXXFLAGS="-Dfstat64=fstat -Dstat64=st
 RUN strip sgdisk
 RUN cp sgdisk /out/sgdisk
 
+# Register gptfdisk in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n gptfdisk -v "${GPTFDISK_VERSION}" -l GPL-2.0-only -u https://sourceforge.net/projects/gptfdisk
+
 
 #
 # Step 2: Fetch and compile CGPT
@@ -68,7 +76,11 @@ RUN [ -d host/arch/riscv64 ] || cp -r host/arch/arm host/arch/riscv64
 RUN make cgpt -j "$(getconf _NPROCESSORS_ONLN)" USE_FLASHROM=0 LDFLAGS=-static
 RUN cp build/cgpt/cgpt /out/cgpt
 
+# Register vboot in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n vboot -v "${VBOOT_COMMIT:0:8}" -l GPL-3.0-only -u https://github.com/coreboot/vboot
+
 FROM scratch
 COPY --from=build /out/sgdisk /usr/bin/sgdisk
 COPY --from=build /out/cgpt /usr/bin/cgpt
+COPY --from=build /out/lib/apk/db/installed /lib/apk/db/installed
 COPY files/zboot /usr/bin/zboot

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) 2025-2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS grub-build-base
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS grub-build-base
 ENV BUILD_PKGS="automake \
                make \
                bison \
@@ -97,9 +97,13 @@ RUN case "$(uname -m)" in \
     ./grub-mkimage -O riscv64-efi -d /grub-lib/grub/riscv64-efi -o /grub-lib/BOOTRISCV64.EFI -p /EFI/BOOT ${GRUB_MODULES_PORT} ${GRUB_MODULES} ;;\
   esac
 
+# Register grub in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n grub -v "${GRUB_COMMIT}" -l GPL-3.0-only -u https://www.gnu.org/software/grub
+
 FROM scratch
 ENTRYPOINT []
 CMD []
+COPY --from=grub-build /out/lib/apk/db/installed /lib/apk/db/installed
 WORKDIR /EFI/BOOT
 COPY --from=grub-build /grub-lib/BOOT* ./
 COPY rootfs.cfg grub.cfg

--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ENV BUILD_PKGS cairo-dev jpeg-dev libpng-dev gcc make libc-dev openssl-dev libvncserver-dev file patch
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs p11-kit cairo jpeg libpng libvncserver
 RUN eve-alpine-deploy.sh
@@ -13,6 +13,9 @@ COPY patches /patches
 
 RUN cd /uuid-1.6.2 ; ./configure --prefix=/usr/ && make -j "$(getconf _NPROCESSORS_ONLN)" && make install
 
+# Register ossp-uuid in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n ossp-uuid -v 1.6.2 -l MIT -u http://www.ossp.org/pkg/lib/uuid
+
 RUN tar xzvf ${GUACD_VERSION}.tar.gz ;\
     cd /guacamole-server-${GUACD_VERSION} ;\
     [ -d /patches/guacd-"${GUACD_VERSION}" ] && for patch in /patches/guacd-"${GUACD_VERSION}"/*.patch; do \
@@ -21,6 +24,9 @@ RUN tar xzvf ${GUACD_VERSION}.tar.gz ;\
         done;\
     ./configure --prefix=/usr/ --with-vnc --disable-guacenc --disable-dependency-tracking && \
      make -j "$(getconf _NPROCESSORS_ONLN)" && make install
+
+# Register guacamole-server in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n guacamole-server -v "${GUACD_VERSION}" -l Apache-2.0 -u https://guacamole.apache.org
 
 FROM scratch
 

--- a/pkg/installer/Dockerfile
+++ b/pkg/installer/Dockerfile
@@ -31,7 +31,7 @@ RUN cp "/usr/local/my-installer/target/$CARGO_BUILD_TARGET/release/installer" /u
 FROM lfedge/eve-debug:e06d7bcd9fb4d382bb5e94b39e8764d5c41c5f40 AS debug
 
 # Dockerfile to build installer img initrd
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 ENV BUILD_PKGS="mkinitfs grep patch make coreutils musl-dev gcc g++ perl \
     autoconf automake libtool file bsd-compat-headers libc-dev \
@@ -73,11 +73,19 @@ WORKDIR /out/edid-decode-188950472c19492547e298b27f9da0d72cf826df
 RUN make \
     && find . -type f | perl -lne "print if -B and -x" | xargs strip \
     && install -m 0755 edid-decode /out/usr/bin
+
+# Register edid-decode in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n edid-decode -v 18895047 -l MIT -u https://git.linuxtv.org/edid-decode.git
+
 WORKDIR /out/ddcutil-1.2.2
 RUN ./configure --prefix=/out/usr \
     && make \
     && find . -type f | perl -lne "print if -B and -x" | xargs strip \
     && make install
+
+# Register ddcutil in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n ddcutil -v 1.2.2 -l GPL-2.0-only -u https://www.ddcutil.com
+
 WORKDIR /out/hw-probe-1.6-AI
 RUN install -m 755 hw-probe.pl /out/usr/bin/hw-probe  \
     && sed -i "s/root\/HW_PROBE/tmp\/HW_PROBE/" /out/usr/bin/hw-probe
@@ -92,11 +100,18 @@ RUN ./bootstrap && \
 RUN cp /usr/local/lib/libtss2* /out/usr/lib/
 RUN strip --strip-unneeded /out/usr/lib/libtss2*.so*
 
+# Register tpm2-tss in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n tpm2-tss -v 4.0.1 -l BSD-2-Clause -u https://github.com/tpm2-software/tpm2-tss
+
 WORKDIR /out/tpm2-tools-5.5
 RUN ./bootstrap
 RUN ./configure --prefix=/out/usr CFLAGS="-Wno-error"
 RUN make -j"$(nproc)" CFLAGS="-Wno-error"
 RUN make install
+
+# Register tpm2-tools in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n tpm2-tools -v 5.5 -l BSD-3-Clause -u https://github.com/tpm2-software/tpm2-tools
+
 RUN rm -rf /out/edid-decode-188950472c19492547e298b27f9da0d72cf826df \
     /out/ddcutil-1.2.2 /out/hw-probe-1.6-AI /out/tpm2-tools-5.5
 

--- a/pkg/installer/Dockerfile
+++ b/pkg/installer/Dockerfile
@@ -28,7 +28,7 @@ RUN cargo sbom > sbom.spdx.json
 
 RUN cp "/usr/local/my-installer/target/$CARGO_BUILD_TARGET/release/installer" /usr/local/my-installer/target/installer
 
-FROM lfedge/eve-debug:e06d7bcd9fb4d382bb5e94b39e8764d5c41c5f40 AS debug
+FROM lfedge/eve-debug:71295e22685ade2ca6135aa527f070501656d987 AS debug
 
 # Dockerfile to build installer img initrd
 FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build

--- a/pkg/ipxe/Dockerfile
+++ b/pkg/ipxe/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 
 ENV BUILD_PKGS="patch make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev"
 RUN eve-alpine-deploy.sh
@@ -24,5 +24,9 @@ RUN mkdir -p /ws/src/bin-riscv64 && touch /ws/src/bin-riscv64/ipxe.riscv64 && to
 RUN mv /ws/src/bin/undionly.kpxe /ws/src/bin/ipxe.undionly 2>/dev/null || :
 RUN rm /ws/src/bin*/*.*.*
 
+# Register ipxe in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n ipxe -v "${IPXE_VERSION:0:8}" -l GPL-2.0-only -u https://ipxe.org
+
 FROM scratch
+COPY --from=build /out/lib/apk/db/installed /lib/apk/db/installed
 COPY --from=build /ws/src/bin*/ipxe.* /

--- a/pkg/kdump/Dockerfile
+++ b/pkg/kdump/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 
 ENV BUILD_PKGS patch curl make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev elfutils-dev libbz2
 ENV PKGS xz-libs elfutils-dev libbz2
@@ -14,6 +14,9 @@ RUN tar -C .. -xzvf 1.7.1.tar.gz
 RUN ln -s /usr/lib/libbz2.so.1 /usr/lib/libbz2.so && \
     make LINKTYPE=dynamic && \
     make DESTDIR=/out install
+
+# Register makedumpfile in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n makedumpfile -v 1.7.1 -l GPL-2.0-only -u https://github.com/makedumpfile/makedumpfile
 
 FROM scratch
 COPY --from=build /out /

--- a/pkg/kexec/Dockerfile
+++ b/pkg/kexec/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 
 ENV BUILD_PKGS patch curl make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev elfutils-dev libbz2
 ENV PKGS xz-libs util-linux elfutils-dev libbz2
@@ -13,6 +13,9 @@ RUN tar -C .. -xzvf ../kexec-tools.tgz && rm -f ../kexec-tools.tgz
 RUN ./configure --prefix /usr
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN make DESTDIR=/out install
+
+# Register kexec-tools in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n kexec-tools -v "${KEXEC_VERSION}" -l GPL-2.0-only -u https://kernel.org/pub/linux/utils/kernel/kexec
 
 FROM scratch
 COPY --from=build /out /

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ARG TARGETARCH
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables curl openrc \
          open-iscsi libvirt libvirt-client util-linux grep findutils jq \
@@ -14,6 +14,16 @@ RUN mkdir -p /out/usr/bin /tmp/etcdtmp && \
     cp "/tmp/etcdtmp/etcd-${ETCDCTL_VERSION}-linux-${TARGETARCH}/etcdctl" /out/usr/bin/etcdctl && \
     chmod +x /out/usr/bin/etcdctl && \
     rm -rf /tmp/etcd.tar.gz /tmp/etcdtmp
+
+# Register etcdctl in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n etcdctl -v "${ETCDCTL_VERSION}" -l Apache-2.0 -u https://github.com/etcd-io/etcd
+
+# Note: virtctl itself is downloaded and installed in the final scratch stage below;
+# the APK DB entry is added here in the build stage so it propagates via COPY /out/.
+# Keep this version aligned with VIRTCTL_VERSION in the final stage.
+ENV VIRTCTL_VERSION=v1.6.0
+# Register virtctl in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n virtctl -v "${VIRTCTL_VERSION}" -l Apache-2.0 -u https://github.com/kubevirt/kubevirt
 
 COPY eve-bridge /plugins/eve-bridge
 WORKDIR /plugins/eve-bridge

--- a/pkg/measure-config/Dockerfile
+++ b/pkg/measure-config/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ARG TARGETARCH
 
 COPY src/  /measure-config/.

--- a/pkg/memory-monitor/Dockerfile
+++ b/pkg/memory-monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS memory-monitor-build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS memory-monitor-build
 
 ENV BUILD_PKGS gcc musl-dev make linux-headers cmake build-base
 ENV PKGS alpine-baselayout curl strace

--- a/pkg/mkconf/Dockerfile
+++ b/pkg/mkconf/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 
 ENV PKGS mtools dosfstools
 RUN eve-alpine-deploy.sh

--- a/pkg/mkimage-iso-efi/Dockerfile
+++ b/pkg/mkimage-iso-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 
 ENV PKGS="dosfstools libarchive-tools binutils mtools xorriso mkinitfs squashfs-tools"
 RUN eve-alpine-deploy.sh

--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -5,7 +5,7 @@
 #   /EFI/BOOT/grub.cfg - Chainloads main bootloader
 #   /UsbInvocationScript.txt - Enables USB boot on Dell 3000 series
 #
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 ENV BUILD_PKGS="grep patch git make gcc linux-headers musl-dev autoconf automake pkgconfig kmod-dev util-linux-dev cryptsetup-dev lddtree libgcc mkinitfs"
 ENV PKGS="mtools dosfstools libarchive-tools sgdisk e2fsprogs util-linux squashfs-tools coreutils tar dmidecode \
@@ -20,6 +20,9 @@ ADD https://github.com/alpinelinux/mkinitfs.git#3.8.1 /tmp/mkinitfs
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 WORKDIR /
 RUN make -C /tmp/mkinitfs install
+
+# Register mkinitfs in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n mkinitfs -v 3.8.1 -l GPL-2.0-only -u https://github.com/alpinelinux/mkinitfs
 
 WORKDIR /out
 RUN echo "mtools_skip_check=1" >> etc/mtools.conf

--- a/pkg/mkrootfs-ext4/Dockerfile
+++ b/pkg/mkrootfs-ext4/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools sfdisk sgdisk xfsprogs \
          e2fsprogs util-linux coreutils multipath-tools squashfs-tools

--- a/pkg/mkrootfs-squash/Dockerfile
+++ b/pkg/mkrootfs-squash/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools sfdisk sgdisk \
     xfsprogs e2fsprogs util-linux coreutils multipath-tools squashfs-tools

--- a/pkg/monitor/Dockerfile
+++ b/pkg/monitor/Dockerfile
@@ -49,9 +49,13 @@ RUN cargo sbom > sbom.spdx.json
 RUN cp /app/target/$CARGO_BUILD_TARGET/release/monitor /app/target/
 
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS runtime
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS runtime
+ARG MONITOR_RS_VERSION
 ENV PKGS="kbd pciutils usbutils"
 RUN eve-alpine-deploy.sh
+
+# Register eve-monitor-rs in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n eve-monitor-rs -v "${MONITOR_RS_VERSION}" -l Apache-2.0 -u https://github.com/lf-edge/eve-monitor-rs
 
 FROM scratch
 COPY --from=runtime /out/usr/bin/openvt /usr/bin/openvt

--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # hadolint ignore=DL3006
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS runtime
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS runtime
 ENV PKGS coreutils
 RUN eve-alpine-deploy.sh
 
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ARG TARGETARCH
 
 COPY go.mod /newlog/

--- a/pkg/nvidia/Dockerfile
+++ b/pkg/nvidia/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG PLATFORM=generic
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build-base
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build-base
 ENV BUILD_PKGS="autoconf automake build-base coreutils gettext git glib-dev libtool libmd-dev ncurses-dev tar xz-dev yq zstd-dev dpkg"
 
 RUN eve-alpine-deploy.sh
@@ -91,6 +91,18 @@ RUN mkdir -p /ldconfig-bin && \
     dpkg -x /libc-bin_2.31-0ubuntu9_arm64.deb /ldconfig && \
     cp /ldconfig/sbin/ldconfig.real /ldconfig-bin/ldconfig-glibc
 
+# Register source-built / downloaded NVIDIA components in the APK DB, mandatory
+# for them to be included in the SBOM.
+RUN case "${JETPACK_VER}" in \
+        jp5) JL_VER=r35.5.0 ;; \
+        jp6) JL_VER=r36.3.0 ;; \
+        jp7) JL_VER=r38.4.0 ;; \
+        *)   JL_VER="${JETPACK_VER}" ;; \
+    esac && \
+    register-sbom-pkg.sh -n jetson-linux -v "${JL_VER}" -l proprietary -u https://developer.nvidia.com/embedded/jetson-linux -o /sbom-out && \
+    register-sbom-pkg.sh -n nvidia-container-toolkit -v "${NVIDIA_CONTAINER_TOOLKIT_REV}" -l Apache-2.0 -u https://github.com/NVIDIA/nvidia-container-toolkit -o /sbom-out && \
+    register-sbom-pkg.sh -n libc-bin -v 2.31-0ubuntu9 -l LGPL-2.1-or-later -u http://ports.ubuntu.com/ubuntu-ports/pool/main/g/glibc -o /sbom-out
+
 # Copy udev rules
 COPY udev/${JETPACK_VER}/rules.d/* /rules.d/
 
@@ -130,6 +142,7 @@ COPY --from=build /nvfanctrl/dist/* /opt/vendor/nvidia/bin/
 COPY --from=build /nvct/dist/* /opt/vendor/nvidia/bin/
 COPY --from=build /nv-init.sh /opt/vendor/nvidia/init.d/
 COPY --from=build /eve-platform /opt/vendor/nvidia/
+COPY --from=build /sbom-out/lib/apk/db/installed /lib/apk/db/installed
 
 ENTRYPOINT []
 CMD []

--- a/pkg/optee-client/Dockerfile
+++ b/pkg/optee-client/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build-arm64
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build-arm64
 
 ARG BUILD_PKGS="bash binutils-dev bsd-compat-headers build-base bc bison \
   cmake flex openssl-dev util-linux-dev linux-headers swig git gnutls-dev \
@@ -30,6 +30,9 @@ RUN git config --global user.name 'Project EVE' && \
 RUN cmake -DCMAKE_INSTALL_PREFIX=/out/usr && \
       make -j "$(getconf _NPROCESSORS_ONLN)" && \
       make install
+
+# Register optee_client in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n optee_client -v "${OPTEE_CLIENT_VERSION}" -l BSD-2-Clause -u https://github.com/OP-TEE/optee_client
 
 FROM scratch AS output-amd64
 FROM scratch AS output-riscv64

--- a/pkg/optee-os/Dockerfile
+++ b/pkg/optee-os/Dockerfile
@@ -4,7 +4,7 @@
 ARG BUILD_PKGS_BASE="autoconf automake bash binutils binutils-dev build-base bc bison curl dtc expat flex openssl-dev util-linux-dev swig gnutls-dev perl python3 python3-dev py3-setuptools py3-pycryptodome py3-elftools py3-cryptography"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1
 
 # hadolint ignore=DL3006
 FROM ${EVE_ALPINE_IMAGE} AS build-native

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -8,7 +8,7 @@ ARG BUILD_PKGS_BASE="git gcc linux-headers libc-dev make linux-pam-dev m4 findut
                      libintl libuuid libtirpc libblkid libcrypto3 zlib tar"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1
 
 FROM lfedge/eve-uefi:c5eb2951550c9cc112c54d49ee57fa2c858d8579 AS uefi-build
 FROM lfedge/eve-dom0-ztools:12f3be8183942a1134241414bc265f624dbaad51 AS zfs
@@ -157,6 +157,10 @@ ENV PKGS alpine-baselayout musl-utils libtasn1-progs pciutils yajl xz bash iptab
     libintl libtirpc libblkid zlib rsync chrony wireless-tools wpa_supplicant
 RUN eve-alpine-deploy.sh
 
+# Snapshot collector's own apk DB (alpine PKGS installed above) before the
+# cross-stage COPYs below would overwrite /out/lib/apk/db/installed.
+RUN cp /out/lib/apk/db/installed /tmp/apk-collector.installed
+
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 WORKDIR /
@@ -202,6 +206,23 @@ RUN if [ "$(uname -m)" = "aarch64" ] ; then                                     
        xargs strip                                                                     ;\
        apk del findutils binutils file                                                 ;\
     fi
+
+# Merge apk DBs from every source pkg into /out/lib/apk/db/installed so the
+# final SBOM reflects entries from every contributing pkg image.
+COPY --from=zfs /lib/apk/db/installed /tmp/apk-zfs.installed
+COPY --from=fscrypt /lib/apk/db/installed /tmp/apk-fscrypt.installed
+COPY --from=gpttools /lib/apk/db/installed /tmp/apk-gpttools.installed
+COPY --from=dnsmasq /lib/apk/db/installed /tmp/apk-dnsmasq.installed
+COPY --from=uefi-build /lib/apk/db/installed /tmp/apk-uefi.installed
+COPY --from=dhcpcd-bin /out/lib/apk/db/installed /tmp/apk-dhcpcd.installed
+RUN cat /tmp/apk-collector.installed \
+        /tmp/apk-zfs.installed \
+        /tmp/apk-fscrypt.installed \
+        /tmp/apk-gpttools.installed \
+        /tmp/apk-dnsmasq.installed \
+        /tmp/apk-uefi.installed \
+        /tmp/apk-dhcpcd.installed > /out/lib/apk/db/installed && \
+    rm -f /tmp/apk-*.installed
 
 FROM scratch
 

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -10,8 +10,8 @@ ARG BUILD_PKGS_BASE="git gcc linux-headers libc-dev make linux-pam-dev m4 findut
 # we use the same image in several places
 ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1
 
-FROM lfedge/eve-uefi:c5eb2951550c9cc112c54d49ee57fa2c858d8579 AS uefi-build
-FROM lfedge/eve-dom0-ztools:12f3be8183942a1134241414bc265f624dbaad51 AS zfs
+FROM lfedge/eve-uefi:af155c30b466aa52b8061b48e3824159a122411a AS uefi-build
+FROM lfedge/eve-dom0-ztools:30914d1e4993e8b1e4ddec17d02523cdeff02d3b AS zfs
 RUN mkdir /out
 # copy zfs-related files from dom0-ztools using prepared list of files
 RUN while read -r x; do \
@@ -135,9 +135,9 @@ RUN --mount=type=cache,target=/root/.cache/go-build if [ "${TEST_TOOLS}" = "y" ]
     GOBIN=/final/opt/ GOFLAGS="" go install gotest.tools/gotestsum@v1.7.0; \
 fi
 
-FROM lfedge/eve-fscrypt:e6a8b9da0aa85206bf84cbebd3a2c6e8df959216 AS fscrypt
-FROM lfedge/eve-dnsmasq:960948b6a5627ec1d3815d58235d6f2ca64642bc AS dnsmasq
-FROM lfedge/eve-gpt-tools:36b9660038be7724ef1a7d2e0458a33fe4489b45 AS gpttools
+FROM lfedge/eve-fscrypt:cf2d03f3fb3c646639076b1f96ee8d908dec4ff3 AS fscrypt
+FROM lfedge/eve-dnsmasq:a44436ae4fd5bfb0e72c312e6bf305cbf7673017 AS dnsmasq
+FROM lfedge/eve-gpt-tools:118f6058a3cfd3204456178da448f5e2bb2975e5 AS gpttools
 
 # dhcpcd: Alpine 3.21+ ships a sufficiently up-to-date version (10.x with required IPv6 fixes).
 # No --platform means Docker BuildKit uses the target platform, giving us the correct binary arch.

--- a/pkg/recovertpm/Dockerfile
+++ b/pkg/recovertpm/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ARG TARGETARCH
 
 # build the tpm-recovery tool

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ENV BUILD_PKGS gcc musl-dev linux-headers
 RUN eve-alpine-deploy.sh
 

--- a/pkg/sources/Dockerfile
+++ b/pkg/sources/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS tools
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS tools
 
 COPY collected_sources.tar.gz /var/collected_sources.tar.gz
 RUN mkdir -p /var/sources && tar -C /var/sources -xzf /var/collected_sources.tar.gz

--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ENV PKGS="alpine-baselayout musl-utils bash glib squashfs-tools util-linux e2fsprogs e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/u-boot/Dockerfile
+++ b/pkg/u-boot/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build-base
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build-base
 ENV BUILD_PKGS bash binutils-dev build-base bc bison flex openssl-dev python3 swig dtc
 ENV BUILD_PKGS_amd64 python3-dev py-pip
 RUN eve-alpine-deploy.sh
@@ -69,8 +69,18 @@ RUN if [ "$(uname -m)" = aarch64 ]; then \
           cp /u-boot/arch/arm/dts/bcm2711-rpi-4-b.dtb /boot          ;\
        fi
 
+# Register u-boot in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n u-boot -v "${VERSION}" -l GPL-2.0-only -u https://www.denx.de/wiki/U-Boot
+
+# Register raspberrypi-firmware in the APK DB, mandatory for it to be included in the SBOM.
+RUN if [ "$(uname -m)" = aarch64 ]; then \
+        register-sbom-pkg.sh -n raspberrypi-firmware -v "${RASPBERRY_FIRMWARE_BLOBS_VERSION}" -l proprietary -u https://github.com/raspberrypi/firmware && \
+        register-sbom-pkg.sh -n raspberrypi-firmware-rpi5 -v "${RASPBERRY_FIRMWARE_BLOBS_VERSION_RPI5}" -l proprietary -u https://github.com/raspberrypi/firmware; \
+    fi
+
 FROM scratch
 ENTRYPOINT []
 CMD []
 COPY --from=build /u-boot/u-boot* /u-boot/
 COPY --from=build /boot /boot
+COPY --from=build /out/lib/apk/db/installed /lib/apk/db/installed

--- a/pkg/udev/Dockerfile
+++ b/pkg/udev/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ENV PKGS="udev kmod"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/uefi/Dockerfile
+++ b/pkg/uefi/Dockerfile
@@ -10,7 +10,7 @@
 #   git clone https://git.linaro.org/uefi/uefi-tools.git
 #   ./uefi-tools/edk2-build.sh -b DEBUG -b RELEASE all
 #
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ENV BUILD_PKGS make gcc g++ python3 libuuid nasm util-linux-dev bash git util-linux patch
 ENV BUILD_PKGS_amd64 iasl
 ENV BUILD_PKGS_arm64 iasl
@@ -97,6 +97,15 @@ RUN case $(uname -m) in \
         ;; \
     esac
 
+# Register source-built UEFI components in the APK DB, mandatory for them to be included in the SBOM.
+RUN case "$(uname -m)" in \
+        x86_64)  register-sbom-pkg.sh -n edk2 -v "${EDK_VERSION}" -l BSD-2-Clause-Patent -u https://github.com/tianocore/edk2 -o /sbom-out && \
+                 register-sbom-pkg.sh -n VfioIgdPkg -v "${VFIOIGD_COMMIT:0:8}" -l BSD-2-Clause-Patent -u https://github.com/tomitamoeko/VfioIgdPkg -o /sbom-out ;; \
+        aarch64) register-sbom-pkg.sh -n edk2 -v "${EDK_VERSION}" -l BSD-2-Clause-Patent -u https://github.com/tianocore/edk2 -o /sbom-out ;; \
+        riscv64) register-sbom-pkg.sh -n opensbi -v "${SBI_COMMIT:0:8}" -l BSD-2-Clause -u https://github.com/riscv/opensbi -o /sbom-out ;; \
+    esac
+
 
 FROM scratch
+COPY --from=build-interim /sbom-out/lib/apk/db/installed /lib/apk/db/installed
 COPY --from=build-interim /out/* /

--- a/pkg/vector/Dockerfile
+++ b/pkg/vector/Dockerfile
@@ -62,9 +62,12 @@ RUN cargo build --release $VECTOR_FEATURES
 RUN cargo sbom > sbom.spdx.json
 RUN cp "/app/target/$CARGO_BUILD_TARGET/release/vector" /app/target/
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS runtime
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS runtime
 ENV PKGS="inotify-tools"
 RUN eve-alpine-deploy.sh
+
+# Register vector in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n vector -v 0.54.0 -l MPL-2.0 -u https://github.com/vectordotdev/vector
 
 # Assemble the final image
 FROM scratch

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -10,7 +10,7 @@ FROM lfedge/eve-dom0-ztools:12f3be8183942a1134241414bc265f624dbaad51 AS dom0
 # These use autoconf/automake with many -dev dependencies, so for now they
 # remain under QEMU emulation when cross-building.
 # ===========================================================================
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build-c
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build-c
 ENV BUILD_PKGS="gcc g++ autoconf automake libtool make openssl-dev libtasn1-dev \
     json-glib-dev gnutls bash expect gawk socat libseccomp-dev gmp-dev \
     musl-utils autoconf-archive git json-c json-c-dev libcurl curl-dev \
@@ -26,6 +26,10 @@ RUN make -j$(nproc)
 RUN make -j$(nproc) install
 RUN cp /usr/lib/libtpms.so.* /out/usr/lib/
 RUN strip --strip-unneeded /out/usr/lib/libtpms.so.*
+# Register libtpms in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n libtpms -v 0.10.0 -l BSD-3-Clause \
+    -u https://github.com/stefanberger/libtpms \
+    -d "TPM 2.0 emulation library (built from source)"
 
 # build swtpm
 WORKDIR /swtpm
@@ -38,6 +42,10 @@ RUN src/swtpm/swtpm socket --tpm2 --print-capabilities | grep "tpmstate-dir-back
 RUN make -j$(nproc) install
 RUN cp /out/usr/lib/swtpm/* /out/usr/lib/
 RUN strip --strip-unneeded /out/usr/lib/swtpm/*.so*
+# Register swtpm in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n swtpm -v 732bbd6a -l BSD-3-Clause \
+    -u https://github.com/stefanberger/swtpm \
+    -d "TPM emulator (built from source)"
 
 # build tpm2-tss, it is needed by tpm2-tools
 WORKDIR /tpm2-tss
@@ -48,6 +56,10 @@ RUN ./bootstrap && \
     make install
 RUN cp /usr/local/lib/libtss2* /out/usr/lib/
 RUN strip --strip-unneeded /out/usr/lib/libtss2*.so*
+# Register tpm2-tss in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n tpm2-tss -v 4.0.1 -l BSD-2-Clause \
+    -u https://github.com/tpm2-software/tpm2-tss \
+    -d "TPM2 Software Stack (built from source)"
 
 # build tpm2-tools, it is needed by ptpm
 WORKDIR /tpm2-tools
@@ -63,6 +75,10 @@ RUN make -j$(nproc)
 RUN cp lib/.libs/libcommon.so* /out/usr/lib/
 RUN cp tools/.libs/tpm2 /out/usr/bin/
 RUN strip --strip-unneeded /out/usr/lib/*.so*
+# Register tpm2-tools in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n tpm2-tools -v 5.5 -l BSD-3-Clause \
+    -u https://github.com/tpm2-software/tpm2-tools \
+    -d "TPM2 command line tools (built from source)"
 
 # Build ptpm (C++)
 WORKDIR /ptpm-build
@@ -83,7 +99,7 @@ RUN rm /out/usr/lib/libprotoc.so*
 # This avoids QEMU, which is known to deadlock on go vet / go build.
 # ===========================================================================
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build-go
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build-go
 ARG TARGETARCH
 
 WORKDIR /vtpm-build

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023-2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-dom0-ztools:12f3be8183942a1134241414bc265f624dbaad51 AS dom0
+FROM lfedge/eve-dom0-ztools:30914d1e4993e8b1e4ddec17d02523cdeff02d3b AS dom0
 
 # ===========================================================================
 # C builds (libtpms, swtpm, tpm2-tss, tpm2-tools, ptpm)

--- a/pkg/watchdog/Dockerfile
+++ b/pkg/watchdog/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS watchdog-build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS watchdog-build
 ENV BUILD_PKGS build-base file libtirpc-dev linux-headers tar util-linux
 ENV PKGS alpine-baselayout musl-utils libsmartcols
 RUN eve-alpine-deploy.sh
@@ -35,6 +35,9 @@ ENV CONFIGURE_OPTS "--disable-nfs"
 
 RUN \
     CPPFLAGS=-I/usr/include/tirpc ./configure ${CONFIGURE_OPTS} && make -j "$(getconf _NPROCESSORS_ONLN)" && make install DESTDIR=/out
+
+# Register watchdog in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n watchdog -v "${WATCHDOGD_VERSION}" -l GPL-2.0-only -u https://sourceforge.net/projects/watchdog
 
 FROM scratch
 WORKDIR /

--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023-2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ENV BUILD_PKGS meson ninja git libc-dev glib-dev make gcc udev dbus-dev libgudev-dev
 ENV PKGS alpine-baselayout dbus glib kmod-dev libgudev
 RUN eve-alpine-deploy.sh
@@ -22,6 +22,9 @@ RUN meson build --buildtype=release --prefix=/usr --sysconfdir=/etc --libdir=/us
     ninja -C build && \
     ninja -C build install
 
+# Register libqrtr-glib in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n libqrtr-glib -v "${LIBQRTR_VERSION}" -l LGPL-2.1-only -u https://github.com/linux-mobile-broadband/libqrtr-glib
+
 ADD --keep-git-dir=true https://github.com/linux-mobile-broadband/libmbim.git#${LIBMBIM_VERSION} /libmbim
 WORKDIR /libmbim
 RUN meson build --buildtype=release --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib \
@@ -29,12 +32,18 @@ RUN meson build --buildtype=release --prefix=/usr --sysconfdir=/etc --libdir=/us
     ninja -C build && \
     ninja -C build install
 
+# Register libmbim in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n libmbim -v "${LIBMBIM_VERSION}" -l LGPL-2.1-only -u https://github.com/linux-mobile-broadband/libmbim
+
 ADD --keep-git-dir=true https://github.com/linux-mobile-broadband/libqmi.git#${LIBQMI_VERSION} /libqmi
 WORKDIR /libqmi
 RUN meson build --buildtype=release --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib \
           -Dbash_completion=false -Dintrospection=false -Dman=false && \
     ninja -C build && \
     ninja -C build install
+
+# Register libqmi in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n libqmi -v "${LIBQMI_VERSION}" -l LGPL-2.1-only -u https://github.com/linux-mobile-broadband/libqmi
 
 ADD --keep-git-dir=true https://github.com/linux-mobile-broadband/ModemManager.git#${MM_VERSION} /mm
 WORKDIR /mm
@@ -44,10 +53,16 @@ RUN meson build --buildtype=release --prefix=/usr --sysconfdir=/etc --libdir=/us
     ninja -C build && \
     ninja -C build install
 
+# Register ModemManager in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n ModemManager -v "${MM_VERSION}" -l GPL-2.0-only -u https://gitlab.freedesktop.org/mobile-broadband/ModemManager
+
 ADD --keep-git-dir=true https://github.com/npat-efault/picocom.git#${PICOCOM_COMMIT} /picocom
 WORKDIR /picocom
 # Need this patch to build with musl: https://github.com/npat-efault/picocom/commit/1acf1ddabaf3576b4023c4f6f09c5a3e4b086fb8
 RUN make -j "$(getconf _NPROCESSORS_ONLN)" && strip picocom && cp picocom /usr/bin/
+
+# Register picocom in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n picocom -v "${PICOCOM_COMMIT:0:8}" -l GPL-2.0-only -u https://github.com/npat-efault/picocom
 
 # Install FCC-unlock scripts/tools provided by device vendors
 ADD --keep-git-dir=true https://github.com/lenovo/lenovo-wwan-unlock.git#${LENOVO_WWAN_UNLOCK_COMMIT} /lenovo-wwan-unlock
@@ -57,6 +72,9 @@ RUN cp libdpr.so.2.0.1 /out/usr/lib/ && chmod 444 /out/usr/lib/libdpr.so.2.0.1
 RUN mkdir -p /out/opt/lenovo/ && \
     cp DPR_Fcc_unlock_service /out/opt/lenovo/ && chmod 544 /out/opt/lenovo/DPR_Fcc_unlock_service
 COPY --chown=root:root --chmod=500 fcc-unlock /out/usr/lib/ModemManager/fcc-unlock.d
+
+# Register lenovo-wwan-unlock in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n lenovo-wwan-unlock -v "${LENOVO_WWAN_UNLOCK_COMMIT:0:8}" -l proprietary -u https://github.com/lenovo/lenovo-wwan-unlock
 
 RUN strip /usr/bin/*cli /usr/libexec/*proxy
 

--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM lfedge/eve-uefi:c5eb2951550c9cc112c54d49ee57fa2c858d8579 AS uefi-build
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS runx-build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS runx-build
 ENV BUILD_PKGS="mkinitfs gcc musl-dev e2fsprogs chrony agetty"
 RUN eve-alpine-deploy.sh
 
@@ -20,7 +20,7 @@ RUN gcc -s -o /chroot2 /tmp/chroot2.c -Wall -Werror
 RUN gcc -s -o /hacf /tmp/hacf.c -Wall -Werror
 RUN mkinitfs -n -F base -i /init-initrd -o /runx-initrd
 
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS build
 ENV BUILD_PKGS="\
     gcc make libc-dev dev86 xz-dev perl bash python3-dev \
     gettext iasl util-linux-dev ncurses-dev glib-dev \
@@ -57,6 +57,9 @@ RUN make src && make install DESTDIR=/out && make install
 # Filter out unneeded stuff
 RUN rm -rf /out/usr/man
 RUN strip /out/usr/lib/* || :
+
+# Register liburing in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n liburing -v "${LIBURING_VERSION}" -l LGPL-2.1-only -u https://github.com/axboe/liburing
 
 # When changing this version, also update SEABIOS_UPSTREAM_REVISION to whatever is in `Config.mk` in the xen source
 ENV XEN_VERSION=4.19.0
@@ -103,6 +106,12 @@ RUN ./configure --prefix=/usr --disable-xen --disable-golang --disable-qemu-trad
     --disable-storage-daemon
 RUN make -j "$(getconf _NPROCESSORS_ONLN)" && make dist
 RUN dist/install.sh /out
+
+# Register xen in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n xen -v "${XEN_VERSION}" -l GPL-2.0-only -u https://xenproject.org
+
+# Register seabios in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n seabios -v "${SEABIOS_UPSTREAM_REVISION}" -l LGPL-2.1-only -u https://www.seabios.org
 
 # Filter out a few things that we don't currently need
 RUN rm -rf /out/usr/share/qemu-xen/qemu/edk2-* /out/var/run /usr/include /usr/lib/*.a

--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023-2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-uefi:c5eb2951550c9cc112c54d49ee57fa2c858d8579 AS uefi-build
+FROM lfedge/eve-uefi:af155c30b466aa52b8061b48e3824159a122411a AS uefi-build
 FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS runx-build
 ENV BUILD_PKGS="mkinitfs gcc musl-dev e2fsprogs chrony agetty"
 RUN eve-alpine-deploy.sh

--- a/pkg/xen/Dockerfile
+++ b/pkg/xen/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:1f744180283ffb4eabcc3862531aeacf1de886b3 AS kernel-build
+FROM lfedge/eve-alpine:41f3648ded073c351d0dcd3432322f5816c9c7b1 AS kernel-build
 
 ENV BUILD_PKGS argp-standalone automake bash bc binutils-dev bison build-base \
                diffutils flex git gmp-dev gnupg installkernel kmod \
@@ -44,8 +44,12 @@ RUN make -j "$(getconf _NPROCESSORS_ONLN)" && \
         ;; \
     esac
 
+# Register xen in the APK DB, mandatory for it to be included in the SBOM.
+RUN register-sbom-pkg.sh -n xen -v "${XEN_VERSION}" -l GPL-2.0-only -u https://xenproject.org -o /sbom-out
+
 FROM scratch
 ENTRYPOINT []
 CMD []
+COPY --from=kernel-build /sbom-out/lib/apk/db/installed /lib/apk/db/installed
 WORKDIR /boot
 COPY --from=kernel-build /out/* .

--- a/tools/check-sbom-coverage.sh
+++ b/tools/check-sbom-coverage.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# check-sbom-coverage.sh
+#
+# CI check: every pkg/*/Dockerfile that pulls external source code MUST also
+# call register-sbom-pkg.sh so that syft picks up the resulting package in the
+# SBOM via the apk-db-cataloger.
+#
+# Heuristic:
+#   - Count ADD lines targeting an external URL (ADD https://..., including
+#     ADD --keep-git-dir=true https://... for git sources).
+#   - Count register-sbom-pkg.sh invocations.
+#   - If the Dockerfile fetches external sources but never calls the registry
+#     helper, fail — unless the Dockerfile path is explicitly listed in
+#     tools/sbom-coverage-allowlist.txt with a justification.
+#
+# Out of scope: Go modules (go.mod/go.sum) and Rust crates (Cargo.lock) are
+# resolved by syft's language-specific catalogers and do not need apk-db
+# entries. apk add ... is handled by Alpine's own apk database.
+
+set -eu
+
+ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+cd "$ROOT"
+
+ALLOWLIST_FILE="tools/sbom-coverage-allowlist.txt"
+
+is_allowed() {
+    [ -f "$ALLOWLIST_FILE" ] || return 1
+    # Lines beginning with # are comments; blank lines ignored.
+    grep -vE '^[[:space:]]*(#|$)' "$ALLOWLIST_FILE" | grep -qxF "$1"
+}
+
+failures=0
+FAILED_FILES=""
+
+for df in $(find pkg -type f -name Dockerfile | sort); do
+    ext_fetches=$(grep -cE '^[[:space:]]*ADD([[:space:]]+--[a-z-]+(=[^[:space:]]+)?)*[[:space:]]+https?://' "$df" 2>/dev/null || true)
+    [ "$ext_fetches" -gt 0 ] || continue
+
+    registers=$(grep -cE 'register-sbom-pkg\.sh' "$df" 2>/dev/null || true)
+    [ "$registers" -eq 0 ] || continue
+
+    is_allowed "$df" && continue
+
+    FAILED_FILES="$FAILED_FILES $df"
+    failures=$((failures + 1))
+done
+
+if [ "$failures" -gt 0 ]; then
+    echo ""
+    echo "===== SBOM coverage check FAILED ====="
+    echo ""
+    for f in $FAILED_FILES; do
+        # shellcheck disable=SC2086
+        echo "  $f  (pulls external source via ADD but never calls register-sbom-pkg.sh)"
+    done
+    cat >&2 <<EOF
+
+One or more Dockerfiles fetch external source code (ADD https:// or
+ADD --keep-git-dir=...) but do not register the resulting package in the
+APK DB via register-sbom-pkg.sh. Without that call, syft cannot include
+the package in the final SBOM.
+
+Either:
+
+  1. Add a register-sbom-pkg.sh call after the build step that produces the
+     binary/library, e.g.:
+
+       RUN register-sbom-pkg.sh \\
+           -n <name> -v <version> -l <SPDX-license> -u <upstream-url>
+
+     See pkg/alpine/register-sbom-pkg.sh for the full interface, and
+     pkg/dnsmasq/Dockerfile for a typical example.
+
+  2. If the Dockerfile legitimately does not need a registration (e.g., the
+     fetched artifact is a build-time toolchain that never reaches the final
+     image, or the resulting binary is repackaged into another pkg that
+     already covers the SBOM entry), add the Dockerfile path to
+     ${ALLOWLIST_FILE} with a one-line justification comment.
+
+EOF
+    exit 1
+fi
+
+echo "SBOM coverage check passed: every Dockerfile with external source fetches calls register-sbom-pkg.sh."

--- a/tools/sbom-coverage-allowlist.txt
+++ b/tools/sbom-coverage-allowlist.txt
@@ -1,0 +1,20 @@
+# Allowlist for tools/check-sbom-coverage.sh
+#
+# Dockerfiles listed here pull external source code via ADD but are exempt
+# from the register-sbom-pkg.sh requirement. Each entry MUST be accompanied
+# by a justification comment above it.
+#
+# Format: one Dockerfile path per line (relative to repo root). Blank lines
+# and lines starting with '#' are ignored.
+
+# Cross-compiler toolchains: build-time only. The fetched GCC/binutils/musl
+# tarballs produce APKs that get installed into other pkgs' build stages via
+# apk add; they never appear in the EVE rootfs as compiled artifacts, so no
+# apk-db entry is needed in the final SBOM.
+pkg/cross-compilers/Dockerfile
+
+# OP-TEE OS: cross-compiled by a non-eve-alpine toolchain image, so
+# register-sbom-pkg.sh is not available in that stage. The resulting
+# OP-TEE binary is consumed by pkg/bsp-imx which already registers it
+# under the imx-atf / firmware-imx / uboot-imx umbrella entries.
+pkg/optee-os/Dockerfile


### PR DESCRIPTION
# Description

EVE's SBOM was missing every package that was compiled from source rather than installed via `apk add`. Source-built artifacts (bpftrace, libtpms, swtpm, xen, grub, ipxe, etc.) leave no fingerprint that syft can detect, so the resulting SBOMs were silently incomplete.

This PR closes that gap in four stacked commits:

1. **`pkg/alpine`**: `register-sbom-pkg.sh` helper that appends a minimal APK DB record (P/V/L/A/T/U fields) to `<outdir>/lib/apk/db/installed` so syft picks the package up.

2. **`tools/check-sbom-coverage.sh` + CI workflow**: a pre-merge gate that scans every `pkg/*/Dockerfile`, counts external source fetches (`ADD https://...`, `ADD --keep-git-dir=...`) and `register-sbom-pkg.sh` calls, and fails the PR with a clear remediation message if a Dockerfile pulls external source but never registers it. A small allowlist (`tools/sbom-coverage-allowlist.txt`) covers legitimate exemptions (cross-compiler toolchain, optee-os cross build).

3. **All affected `pkg/*/Dockerfile`**: 30+ source-built packages registered.

4. **Hash bumps**: pinned updated pkg-image hashes.

## PR dependencies

None.

## How to test and validate this PR

**Build-time**:

1. Build EVE end-to-end on amd64 and arm64:
   ```sh
   make pkgs && make eve
   ```
   All pkg images that previously built should still build.
   
2. Confirm the CI check works:
   ```sh
   ./tools/check-sbom-coverage.sh   # passes on this branch
   ```
   Then temporarily inject a new `ADD https://example.com/foo.tar.gz /tmp/foo.tgz` into any `pkg/*/Dockerfile` without a `register-sbom-pkg.sh` call and re-run — the script should exit 1 with the remediation message. Revert after.

**SBOM verification** (the meat of the test):

1. Generate the SBOM for the freshly built EVE rootfs:
   ```sh
   make sbom
   ```
2. Confirm the following packages appear (they were absent before this PR):
   - `bcc`, `bpftrace`, `lshw`, `hexedit`, `dnsmasq`, `zfs`, `fscrypt`, `gptfdisk`, `vboot`, `grub`, `guacamole-server`, `ossp-uuid`, `edid-decode`, `ddcutil`, `tpm2-tss`, `tpm2-tools`, `ipxe`, `makedumpfile`, `kexec-tools`, `mkinitfs`, `optee_client`, `watchdog`, `libqrtr-glib`, `libmbim`, `libqmi`, `ModemManager`, `picocom`, `lenovo-wwan-unlock`, `xen`, `liburing`, `seabios`, `libtpms`, `swtpm`, `u-boot`, `raspberrypi-firmware`, `imx-atf`, `firmware-imx`, `uboot-imx`, `wireless-regdb`, `linux-firmware`, `rtw88-firmware`, `hailo8-firmware`, `nvidia-l4t-firmware`, `rpi-firmware-nonfree`, `rpi-bluez-firmware`, `intel-ucode`, `amd-ucode`, `edk2`, `VfioIgdPkg`, `opensbi`, `etcdctl`, `virtctl`, `eve-monitor-rs`, `jetson-linux`, `nvidia-container-toolkit`, `vector`.

## Changelog notes

N/A

## PR Backports

- 16.0-stable
- 14.5-stable
- 13.4-stable

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't check them.
