### PR TITLE
tools: coverage tooling for block-level aggregation and multi-suite eden runs

### DIFF
--- a/docs/CODE-COVERAGE.md
+++ b/docs/CODE-COVERAGE.md
@@ -293,6 +293,13 @@ exercised across all coverage sources" questions. Use
 or `combined_coverage.txt`) for statement-weighted reporting and
 per-function detail.
 
+For driving multiple Eden suites in one Eden lifetime (the typical
+shape of a coverage run that wants more than just `smoke`), see
+[`../tools/README-coverage.md`](../tools/README-coverage.md) — the
+`run_eden_suites.sh` driver and the `eden_run_lib.sh` shell library it
+builds on handle pre-flight EVE-tag verification, between-suite state
+reset, and drift detection.
+
 ## Running all steps in sequence
 
 ```sh

--- a/docs/CODE-COVERAGE.md
+++ b/docs/CODE-COVERAGE.md
@@ -254,6 +254,45 @@ scp -r -P 2222 root@127.0.0.1:/persist/coverage/ /local/my-run-cov/
 
 Pass `/local/my-run-cov/` as `EXTRA_COVERAGE_DIR` to `coverage-merge`.
 
+## Step 5 — Correct aggregate block coverage
+
+`go tool cover -func=combined_coverage.txt` reports per-function and
+total percentages over the statement-weighted form of the merged
+profile. That's fine when you want statement coverage. For
+**block-level** aggregate coverage — counting each `(file, range)`
+basic block once and asking "did *any* test suite hit it?" — the
+combined file as produced by `make coverage-merge` requires
+deduplication first, since it concatenates the input profiles without
+collapsing identical blocks.
+
+`tools/compute_coverage.sh` does that deduplication and prints a
+single-line summary. It dedupes blocks by `(file, range)` key, treats
+a block as covered if any input profile reports a non-zero hit for it,
+and reports `<covered> / <total>` plus the percentage:
+
+```sh
+tools/compute_coverage.sh "unit"           pkg/pillar/coverage.txt
+tools/compute_coverage.sh "unit + eden"    pkg/pillar/coverage.txt \
+    dist/amd64/current/eden_coverage/eden_e2e_coverage.txt
+tools/compute_coverage.sh "all"            pkg/pillar/coverage.txt \
+    dist/amd64/current/eden_coverage/eden_e2e_coverage.txt \
+    /path/to/hw-test-coverage.txt
+```
+
+Worked example output:
+
+```text
+unit                                                 9259 /  34275 = 27.01 %
+unit + eden                                         16203 /  35269 = 45.94 %
+all                                                 23660 /  42066 = 56.24 %
+```
+
+This is the right number for "what fraction of basic blocks are
+exercised across all coverage sources" questions. Use
+`go tool cover -func` / `-html` (against either an individual profile
+or `combined_coverage.txt`) for statement-weighted reporting and
+per-function detail.
+
 ## Running all steps in sequence
 
 ```sh
@@ -305,6 +344,15 @@ header followed by all coverage lines from all source profiles.  Lines covering
 the same source statement from different runs are additive: `go tool cover`
 sums the hit counts when both report the same statement, giving a correct
 aggregate view of which lines were exercised by either test suite.
+
+A consequence of the simple-concatenation strategy is that a block hit
+by both unit tests and Eden e2e appears as **two lines** in the combined
+file. `go tool cover -func` aggregates these correctly for
+statement-weighted reporting, but ad-hoc `awk '$3>0{c++} END{print c}'`
+or `wc -l`-style counting over the raw file would double-count the
+blocks. For block-level aggregate coverage, use
+`tools/compute_coverage.sh` (Step 5) which dedupes by `(file, range)`
+before counting.
 
 For more sophisticated merging (e.g. deduplication or per-package
 breakdown) the `golang.org/x/tools/cmd/cover` package and third-party

--- a/tools/README-coverage.md
+++ b/tools/README-coverage.md
@@ -1,0 +1,170 @@
+# Coverage tooling
+
+This directory holds the scripts that support EVE's code-coverage workflow:
+
+| Script | Purpose |
+|---|---|
+| `filter_coverage_conflicts.py` | De-duplicate (file, range) blocks across merged profiles, dropping NumStmt mismatches. Used internally by `make coverage-merge`. |
+| `compute_coverage.sh` | Compute aggregate **block-level** coverage across one or more text profiles. Dedupes correctly so `go tool cover -func`'s statement-weighted view and this script's block view answer different questions correctly. |
+| `eden_run_lib.sh` | Sourceable Bash library of reusable helpers for driving multiple Eden suites in one Eden lifetime: SSH-based EVE-tag verification, between-suite state reset, single-suite execution with drift detection. |
+| `run_eden_suites.sh` | Driver that uses the library to run a user-supplied list of suites with pre-flight + per-suite verification + optional coverage collection at the end. |
+
+The data-flow concepts (unit / Eden e2e / extras → merge → analyze) are
+described in [`../docs/CODE-COVERAGE.md`](../docs/CODE-COVERAGE.md). This
+README is about the script interfaces and a worked example.
+
+---
+
+## When to use which script
+
+| Question | Tool |
+|---|---|
+| "Did this function get exercised?" | `go tool cover -func=<profile>` |
+| "What percentage of *blocks* did *any* test source hit?" | `compute_coverage.sh` |
+| "Run smoke + baseosmgr + nodeagent suites in one Eden run, abort if EVE drifts" | `run_eden_suites.sh` |
+| "I'm writing my own multi-suite driver" | Source `eden_run_lib.sh` |
+
+---
+
+## Worked example: coverage across a multi-PR integration branch
+
+This is the workflow we used to measure combined coverage of a topic
+branch (`coverage-allprs`) that merged six in-flight EVE PRs onto
+master. The same shape applies to any other multi-source coverage
+measurement.
+
+### Setup
+
+1. **Build a COVER=y EVE image** from the integration branch:
+
+   ```sh
+   cd ~/lf-edge/work/coverage-allprs/eve
+   make COVER=y HV=kvm ZARCH=amd64 eve-pillar
+   make COVER=y HV=kvm ZARCH=amd64 eve
+   make COVER=y HV=kvm ZARCH=amd64 live
+   ```
+
+2. **Set up Eden** pointing at the new image (per
+   [`../docs/CODE-COVERAGE.md`](../docs/CODE-COVERAGE.md) "Step 2"):
+
+   ```sh
+   eden setup --image-file dist/amd64/current/live.img
+   eden start
+   eden eve onboard
+   ```
+
+3. **Run unit tests** to produce `pkg/pillar/coverage.txt`:
+
+   ```sh
+   make test
+   ```
+
+### Multi-suite Eden run
+
+With Eden up and EVE onboarded, drive the suites:
+
+```sh
+EVE_TAG=$(basename "$(readlink -f dist/amd64/current)")
+export EVE_EXPECTED_TAG="${EVE_TAG}-kvm-amd64"
+export EDEN=$EDEN_SRC/dist/bin/eden-linux-amd64
+export EDEN_HOME=$PWD/dist/amd64/current/eden_config
+export EVE_SSH_KEY=$EDEN_SRC/dist/default-certs/id_rsa
+export EDEN_RUNLOGS=$PWD/dist/amd64/current/eden_runlogs
+
+tools/run_eden_suites.sh \
+    --coverage-dir "$PWD/dist/amd64/current/eden_coverage" \
+    --assert-no-baseos \
+    smoke:./tests/workflow:smoke.tests.txt \
+    baseosmgr:./tests/baseosmgr:eden.baseosmgr.tests.txt
+```
+
+What this does, in order:
+
+1. Verifies EVE is on `$EVE_EXPECTED_TAG` (catches "you forgot to update
+   `eve.tag` after rebuilding").
+2. Pre-flight resets adam state and re-verifies.
+3. `--assert-no-baseos` flag: aborts if adam still has a baseos config
+   from a prior run (useful for any suite that touches baseos —
+   `baseosmgr`, `nodeagent`, `update_eve_image`).
+4. For each `label:dir:scenario` spec:
+   - Runs `eden test <dir> -s <scenario> --coverage-dir <dir>`.
+   - Verifies EVE didn't swap to a different version mid-suite (the
+     `retry_update.txt` / `force_fallback.txt` / `baseos_fallback_*.txt`
+     tests all touch EVE's running version and don't always self-clean).
+   - Resets adam state between suites.
+5. After the last suite, `eden eve collect-coverage` rsyncs
+   `/persist/coverage/` back to `--coverage-dir`, producing
+   `eden_e2e_coverage.txt`.
+
+### Merge and analyze
+
+```sh
+make coverage-merge EXTRA_COVERAGE_DIR="/path/to/hw-test-coverage"
+# → dist/amd64/current/combined_coverage.txt
+
+# Statement-weighted, per-function: use go tool cover.
+go tool cover -func=dist/amd64/current/combined_coverage.txt | tail -1
+
+# Block-level aggregate across all sources:
+tools/compute_coverage.sh "all" \
+    pkg/pillar/coverage.txt \
+    dist/amd64/current/eden_coverage/eden_e2e_coverage.txt \
+    /path/to/hw-test-coverage.txt
+# → all   24239 / 42066 = 57.62 %
+```
+
+For incremental analysis (how much does each source add):
+
+```sh
+tools/compute_coverage.sh "unit"           pkg/pillar/coverage.txt
+tools/compute_coverage.sh "unit + eden"    pkg/pillar/coverage.txt \
+    dist/amd64/current/eden_coverage/eden_e2e_coverage.txt
+tools/compute_coverage.sh "all"            pkg/pillar/coverage.txt \
+    dist/amd64/current/eden_coverage/eden_e2e_coverage.txt \
+    /path/to/hw-test-coverage.txt
+```
+
+---
+
+## Suite-spec format
+
+`run_eden_suites.sh` takes one or more positional `label:dir:scenario`
+triples:
+
+- **`label`** — used as the log filename (`$EDEN_RUNLOGS/<label>.log`)
+  and in console output. Free-form, no spaces.
+- **`dir`** — passed to `eden test <dir>`. A path to an eden test
+  directory under `tests/`, typically `./tests/<area>`.
+- **`scenario`** — passed to `eden test -s <scenario>`. The scenario
+  file under `<dir>/`, e.g. `smoke.tests.txt`,
+  `eden.baseosmgr.tests.txt`.
+
+Examples:
+
+```sh
+smoke:./tests/workflow:smoke.tests.txt
+baseosmgr:./tests/baseosmgr:eden.baseosmgr.tests.txt
+nodeagent:./tests/nodeagent:eden.nodeagent.tests.txt
+networking:./tests/workflow:networking.tests.txt
+```
+
+---
+
+## Authoring your own driver
+
+If `run_eden_suites.sh`'s flags don't fit, source `eden_run_lib.sh`
+directly. The library exposes four functions; see the header comment in
+`eden_run_lib.sh` for the contract:
+
+```sh
+. tools/eden_run_lib.sh
+
+verify_eve_tag "before-anything" || exit 1
+eden_reset_state "warm-up"
+run_eden_suite "smoke" ./tests/workflow smoke.tests.txt || exit 1
+# … custom logic between suites …
+run_eden_suite "my-area" ./tests/my-area my-scenario.tests.txt || exit 1
+```
+
+Set the required env vars (`EDEN`, `EDEN_HOME`, `EVE_EXPECTED_TAG`,
+`EVE_SSH_KEY`, `EDEN_RUNLOGS`) before sourcing or before calling.

--- a/tools/compute_coverage.sh
+++ b/tools/compute_coverage.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Compute aggregate block coverage from one or more Go coverage text
+# profiles. Each (file, range) block is counted once and is considered
+# covered if ANY input profile recorded a non-zero hit for it.
+#
+# This matters because `make coverage-merge` concatenates profiles
+# without deduplicating — a block hit by both unit tests and Eden e2e
+# appears as two lines in the combined file. A naive
+# `awk '$3>0{c++} END{print c}'` over the combined file would
+# double-count. Using this script instead produces the correct union.
+#
+# Usage:
+#     tools/compute_coverage.sh <label> <file1.txt> [file2.txt ...]
+#
+# Output format (one line, label left-padded):
+#     <label>           <covered> / <total> = <pct> %
+#
+# Examples:
+#     tools/compute_coverage.sh "unit"                 pkg/pillar/coverage.txt
+#     tools/compute_coverage.sh "unit + eden"          \
+#         pkg/pillar/coverage.txt \
+#         dist/amd64/current/eden_coverage/eden_e2e_coverage.txt
+#     tools/compute_coverage.sh "unit + eden + extras" \
+#         pkg/pillar/coverage.txt \
+#         dist/amd64/current/eden_coverage/eden_e2e_coverage.txt \
+#         dist/amd64/current/combined_coverage.txt
+#
+# Filter co-located: tools/filter_coverage_conflicts.py is discovered
+# relative to this script, so the script is portable across workspaces.
+
+set -euo pipefail
+
+usage() {
+    sed -n '2,/^$/p; /^#/!q' "$0" | sed 's/^# \{0,1\}//'
+    exit "$1"
+}
+
+case "${1:-}" in
+    -h|--help) usage 0 ;;
+    "") echo "error: missing <label>" >&2; usage 1 ;;
+esac
+
+if [ "$#" -lt 2 ]; then
+    echo "error: at least one coverage file is required" >&2
+    usage 1
+fi
+
+LABEL=$1; shift
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+FILTER="$SCRIPT_DIR/filter_coverage_conflicts.py"
+if [ ! -f "$FILTER" ]; then
+    echo "error: filter_coverage_conflicts.py not found at $FILTER" >&2
+    exit 1
+fi
+
+for f in "$@"; do
+    if [ ! -f "$f" ]; then
+        echo "error: input not found: $f" >&2
+        exit 1
+    fi
+done
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+OUT=$WORK/merged.txt
+echo "mode: atomic" > "$OUT"
+for f in "$@"; do
+    # Drop the per-file "mode:" header (first line); concatenate the rest.
+    tail -n +2 "$f"
+done >> "$OUT"
+
+# Filter conflicting NumStmt entries (warnings go to stderr; let them through).
+FILTERED=$WORK/filtered.txt
+python3 "$FILTER" "$OUT" "$FILTERED"
+
+# Dedup blocks by (file, range). A block counts once toward "total"; it is
+# "covered" if any of its occurrences across the input profiles has a
+# non-zero hit count.
+awk -v LABEL="$LABEL" '
+NR == 1 { next }              # skip the merged "mode: atomic" header
+NF == 3 {
+    key = $1
+    count = $3
+    if (!(key in seen)) {
+        seen[key] = 1
+        max_count[key] = count
+        total++
+    } else if (count > 0) {
+        max_count[key] = count
+    }
+}
+END {
+    for (k in max_count) if (max_count[k] > 0) covered++
+    pct = (total > 0) ? (100.0 * covered / total) : 0.0
+    printf "%-50s %6d / %6d = %5.2f %%\n", LABEL, covered, total, pct
+}
+' "$FILTERED"

--- a/tools/eden_run_lib.sh
+++ b/tools/eden_run_lib.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Reusable shell functions for driving multiple Eden test suites against
+# a single Eden lifetime, with per-suite EVE-tag verification and
+# between-suite state reset.
+#
+# Source this file from a driver script:
+#     . "$(dirname "$0")/eden_run_lib.sh"
+#
+# Required environment (caller sets before sourcing or before calling):
+#     EDEN              path to eden binary
+#     EDEN_HOME         eden context dir (standard eden env var)
+#     EVE_EXPECTED_TAG  e.g. "0.0.0-mybranch-deadbeef-kvm-amd64"
+#     EVE_SSH_KEY       path to SSH key for the EVE qemu instance
+#     EDEN_RUNLOGS      directory for per-suite log files (created if absent)
+#
+# Optional environment:
+#     EVE_SSH_PORT      default 2222 (matches eden's default eve.hostfwd)
+#     EVE_SSH_HOST      default 127.0.0.1
+#     EVE_COVERAGE_DIR  if set, passed to `eden test --coverage-dir`
+#     EDEN_RESET_SETTLE default 30 (seconds to wait after eden eve reset)
+
+: "${EVE_SSH_PORT:=2222}"
+: "${EVE_SSH_HOST:=127.0.0.1}"
+: "${EDEN_RESET_SETTLE:=30}"
+
+# eve_ssh <command> — run a one-shot SSH command against EVE.
+# Removes stale known_hosts entries (qemu reboots shuffle host keys).
+# Returns SSH's exit status; caller decides whether to retry.
+eve_ssh() {
+    ssh-keygen -f "$HOME/.ssh/known_hosts" \
+        -R "[$EVE_SSH_HOST]:$EVE_SSH_PORT" >/dev/null 2>&1 || true
+    ssh -i "$EVE_SSH_KEY" -p "$EVE_SSH_PORT" \
+        -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+        -o ConnectTimeout=5 -o LogLevel=ERROR \
+        "root@$EVE_SSH_HOST" "$@"
+}
+
+# verify_eve_tag <label> [max_attempts] — SSH to EVE, check that
+# /run/eve-release matches $EVE_EXPECTED_TAG. Retries until SSH is up
+# or max_attempts is reached. Returns 0 if the tag matches, 1 otherwise.
+verify_eve_tag() {
+    local label="$1" max_attempts="${2:-30}" running raw
+    for i in $(seq 1 "$max_attempts"); do
+        raw=$(eve_ssh 'cat /run/eve-release' 2>&1)
+        running=$(printf '%s' "$raw" | tr -d '\r' | grep -v '^$' | tail -1)
+        # A well-formed tag looks like "<version>-<hv>-<arch>".
+        if printf '%s' "$running" | grep -qE '^[0-9A-Za-z._-]+-(kvm|xen)-(amd64|arm64)$'; then
+            break
+        fi
+        running=""
+        echo "[$label] SSH not ready (attempt $i/$max_attempts); retrying in 10s..." >&2
+        sleep 10
+    done
+    if [ -z "$running" ]; then
+        echo "[$label] ABORT — could not read /run/eve-release" >&2
+        return 1
+    fi
+    if [ "$running" != "$EVE_EXPECTED_TAG" ]; then
+        echo "[$label] ABORT — EVE is running '$running', expected '$EVE_EXPECTED_TAG'" >&2
+        return 1
+    fi
+    echo "[$label] EVE OK ($running)"
+    return 0
+}
+
+# eden_reset_state <label> — clear adam-side config + bump epoch + settle.
+# Logs to $EDEN_RUNLOGS/reset_<label>.log. Non-fatal on individual command
+# failures (we expect transient failures during EVE reboots).
+eden_reset_state() {
+    local label="$1"
+    local log="$EDEN_RUNLOGS/reset_${label}.log"
+    echo "[$label] eden reset"
+    "$EDEN" eve reset > "$log" 2>&1 \
+        || echo "[$label] WARNING: 'eden eve reset' failed (see $log)" >&2
+    "$EDEN" eve epoch >> "$log" 2>&1 || true
+    sleep "$EDEN_RESET_SETTLE"
+}
+
+# run_eden_suite <label> <suite-dir> <scenario> — run one suite, verify
+# EVE didn't drift, reset state. Returns 0 on success, 1 if EVE drifted.
+# The suite's own pass/fail rc is logged but doesn't gate this function —
+# the caller decides what to do with it (typically: abort on drift,
+# continue on suite failure).
+run_eden_suite() {
+    local label="$1" dir="$2" scenario="$3" rc
+    local extra=()
+    [ -n "${EVE_COVERAGE_DIR:-}" ] && extra+=(--coverage-dir "$EVE_COVERAGE_DIR")
+
+    echo "================================================================"
+    echo "[$label] Running (suite=$dir, scenario=$scenario) at $(date)"
+    "$EDEN" test "$dir" -s "$scenario" -v debug "${extra[@]}" \
+        > "$EDEN_RUNLOGS/${label}.log" 2>&1
+    rc=$?
+    echo "[$label] completed rc=$rc at $(date)"
+
+    if ! verify_eve_tag "after-$label"; then
+        echo "[$label] EVE drifted during this suite — aborting" >&2
+        return 1
+    fi
+    eden_reset_state "after-$label"
+    return 0
+}

--- a/tools/run_eden_suites.sh
+++ b/tools/run_eden_suites.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Drive multiple Eden test suites against a single Eden lifetime.
+# Per-suite EVE-tag verification + between-suite state reset.
+#
+# Usage:
+#     tools/run_eden_suites.sh [flags] \
+#         <label>:<suite-dir>:<scenario> [<label>:<suite-dir>:<scenario>...]
+#
+# Flags:
+#     --coverage-dir <path>     pass --coverage-dir to each `eden test`;
+#                               also runs `eden eve collect-coverage` at end
+#     --assert-no-baseos        in pre-flight, abort if adam still has a
+#                               baseos config (catches stale state from a
+#                               prior aborted run; useful for baseos /
+#                               nodeagent / update_eve_image suites)
+#
+# Required env (or set inline before invocation):
+#     EDEN, EDEN_HOME, EVE_EXPECTED_TAG, EVE_SSH_KEY, EDEN_RUNLOGS
+#
+# This driver assumes eden + EVE are already set up and onboarded. The
+# multi-suite phase is its only scope. For bring-up, see `make eden-cover`
+# or the `run-eden-test` skill.
+#
+# See tools/README-coverage.md for a worked end-to-end example.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# shellcheck source=tools/eden_run_lib.sh
+. "$SCRIPT_DIR/eden_run_lib.sh"
+
+usage() {
+    sed -n '2,/^$/p; /^#/!q' "$0" | sed 's/^# \{0,1\}//'
+    exit "$1"
+}
+
+assert_no_baseos=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --coverage-dir) EVE_COVERAGE_DIR="$2"; shift 2 ;;
+        --assert-no-baseos) assert_no_baseos=1; shift ;;
+        -h|--help) usage 0 ;;
+        --) shift; break ;;
+        -*) echo "error: unknown flag: $1" >&2; usage 1 ;;
+        *) break ;;
+    esac
+done
+
+if [ $# -eq 0 ]; then
+    echo "error: at least one suite spec required" >&2
+    usage 1
+fi
+
+# Caller env validation.
+for v in EDEN EDEN_HOME EVE_EXPECTED_TAG EVE_SSH_KEY EDEN_RUNLOGS; do
+    if [ -z "${!v:-}" ]; then
+        echo "error: required environment variable $v is not set" >&2
+        exit 1
+    fi
+done
+
+mkdir -p "$EDEN_RUNLOGS"
+[ -n "${EVE_COVERAGE_DIR:-}" ] && mkdir -p "$EVE_COVERAGE_DIR"
+
+# Pre-flight: verify EVE is on the expected image, clear adam state,
+# re-verify, optionally assert no leftover baseos config.
+verify_eve_tag "pre-flight" || exit 1
+eden_reset_state "pre-flight"
+verify_eve_tag "pre-flight-post-reset" || exit 1
+
+if [ "$assert_no_baseos" = "1" ]; then
+    cfg=$("$EDEN" controller edge-node get-config 2>&1)
+    if echo "$cfg" | grep -qE '"base_os_version"\s*:\s*"[^"]'; then
+        echo "ABORT — adam still has baseos config after reset:" >&2
+        echo "$cfg" | grep -E '"base_os_version"|"content_tree_uuid"' | head -5 >&2
+        exit 1
+    fi
+fi
+
+# Run each suite spec.
+for spec in "$@"; do
+    IFS=':' read -r label dir scenario <<<"$spec"
+    if [ -z "$label" ] || [ -z "$dir" ] || [ -z "$scenario" ]; then
+        echo "error: malformed spec '$spec' (want label:dir:scenario)" >&2
+        exit 1
+    fi
+    run_eden_suite "$label" "$dir" "$scenario" || exit 1
+done
+
+# Optional: final coverage collect.
+if [ -n "${EVE_COVERAGE_DIR:-}" ]; then
+    echo "[final] eden eve collect-coverage at $(date)"
+    "$EDEN" eve collect-coverage --output-dir "$EVE_COVERAGE_DIR" \
+        > "$EDEN_RUNLOGS/coverage_final.log" 2>&1 \
+        || echo "[final] coverage collect failed (see log)" >&2
+fi
+
+echo "[done] at $(date)"


### PR DESCRIPTION
# Description

Adds four tools to support EVE's code-coverage workflow, plus matching documentation.

## What's new

| File | Purpose |
|---|---|
| `tools/compute_coverage.sh` | Computes **block-level** aggregate coverage across one or more text profiles. Dedupes by `(file, range)`; treats a block as covered if any profile reports a non-zero hit. |
| `tools/eden_run_lib.sh` | Sourceable Bash library: `verify_eve_tag`, `eden_reset_state`, `run_eden_suite`. Codifies the recurring "SSH-check EVE tag → run suite → reset adam state" pattern. |
| `tools/run_eden_suites.sh` | Driver using the library. Takes a list of `label:dir:scenario` specs, runs each with per-suite EVE-tag verification + between-suite reset, optionally collects coverage at the end. |
| `tools/README-coverage.md` | Co-located README covering the script interfaces, a worked end-to-end example from a multi-PR integration branch (coverage-allprs), and notes for authoring your own driver. |
| `docs/CODE-COVERAGE.md` | Adds a "Step 5" walkthrough of `compute_coverage.sh`, a paragraph in "Merging profiles" calling out the double-counting pitfall, and a pointer to the new README. |

## Why

Three recurring issues in EVE's coverage workflow:

1. **Block-level coverage requires dedup.** `make coverage-merge` concatenates profiles without collapsing identical `(file, range)` blocks. `go tool cover -func` aggregates correctly for statement-weighted reporting, but ad-hoc shell counting over the raw file double-counts blocks present in more than one source profile. `compute_coverage.sh` produces the right block-level number.
2. **Multi-suite Eden runs need drift detection.** Several tests (`tests/baseosmgr/retry_update.txt`, `tests/baseosmgr/force_fallback.txt`, `tests/nodeagent/baseos_fallback_*.txt`, `tests/update_eve_image/*.txt`) deliberately swap EVE's running version and don't always self-clean. Running them back-to-back in one Eden lifetime risks running suite N+1 against a different EVE than expected, invalidating both functional results and coverage. `verify_eve_tag` after every suite catches this.
3. **Multi-suite drivers were one-off scripts.** Today each user building a coverage run hand-rolls the SSH retry loop, the adam reset between suites, and the pre-flight check. Factoring into `eden_run_lib.sh` makes the pattern reusable.

## How to test and validate this PR

### `compute_coverage.sh`

After `make test` and `make eden-cover` produce profiles:

```sh
tools/compute_coverage.sh "unit"           pkg/pillar/coverage.txt
tools/compute_coverage.sh "unit + eden"    pkg/pillar/coverage.txt \
    dist/amd64/current/eden_coverage/eden_e2e_coverage.txt
```

Each prints `<label> <covered>/<total> = <pct>%`. The "unit + eden" covered count should be ≥ "unit" alone (eden can only add coverage, not subtract). For comparison, `go tool cover -func=…` reports the statement-weighted view; block-level numbers from this script differ by a few percentage points and answer a different question.

### `run_eden_suites.sh`

With Eden up and an onboarded EVE on `$EVE_EXPECTED_TAG`:

```sh
export EDEN=…/eden-linux-amd64
export EDEN_HOME=…/eden_config
export EVE_EXPECTED_TAG=0.0.0-mybranch-deadbeef-kvm-amd64
export EVE_SSH_KEY=…/default-certs/id_rsa
export EDEN_RUNLOGS=…/eden_runlogs

tools/run_eden_suites.sh --assert-no-baseos \
    smoke:./tests/workflow:smoke.tests.txt \
    baseosmgr:./tests/baseosmgr:eden.baseosmgr.tests.txt
```

Expected behavior:

- Pre-flight aborts cleanly if `$EVE_EXPECTED_TAG` doesn't match what's running, or (with `--assert-no-baseos`) if adam has leftover baseos config.
- Each suite produces `$EDEN_RUNLOGS/<label>.log`.
- A suite that drifts EVE (e.g. `retry_update.txt` halfway through) triggers an "EVE drifted during this suite — aborting" message from the post-suite `verify_eve_tag` and exits non-zero.

### Help text

```sh
tools/compute_coverage.sh --help
tools/run_eden_suites.sh --help
```

Both print the in-file usage block.

## Changelog notes

No user-facing changes. Developer tooling for coverage analysis and multi-suite Eden runs.

## PR Backports

- 16.0-stable: No (developer tooling, not a fix).
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (`docs/CODE-COVERAGE.md` + `tools/README-coverage.md`)
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device — N/A, host-side shell/Python
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR — to be set
