### PR TITLE
baseosmgr: cancel install on BaseOsConfig delete

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -245,6 +245,14 @@ func handleBaseOsConfigDeleteByStatus(ctx *baseOsMgrContext, key string,
 	status *types.BaseOsStatus) {
 
 	log.Functionf("handleBaseOsConfigDeleteByStatus for %s", status.BaseOsVersion)
+	// Best-effort: clear the in-progress flag for any install job tied to
+	// this baseos so a queued WriteToPartition can be skipped. processWork
+	// itself is not interruptible, so a write that has already started
+	// will still complete; the partition-state rollback in doBaseOsUninstall
+	// is what prevents that completion from taking effect on the next boot.
+	if status.ContentTreeUUID != "" {
+		ctx.worker.Cancel(status.ContentTreeUUID)
+	}
 	removeBaseOsConfig(ctx, status.Key())
 }
 

--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -596,6 +596,12 @@ func doBaseOsUninstall(ctx *baseOsMgrContext, uuidStr string,
 	// In case this was a failed update we make sure we mark
 	// that !active partition as unused (in case it is inprogress),
 	// so that we can retry the same update.
+	// We also fire this when the other partition is "updating": the
+	// image was written and SetOtherPartitionStateUpdating() was called,
+	// but the BaseOsConfig was deleted before we rebooted into it. Without
+	// the rollback the next reboot would still pick up the now-stale
+	// image. ShortVersion is not yet refreshed in that window so we
+	// detect this case via the partition state directly.
 	if status.PartitionLabel != "" {
 		partName := status.PartitionLabel
 		partStatus := getZbootStatus(ctx, partName)
@@ -604,10 +610,13 @@ func doBaseOsUninstall(ctx *baseOsMgrContext, uuidStr string,
 				status.BaseOsVersion, uuidStr)
 			return changed, del
 		}
-		if status.BaseOsVersion == partStatus.ShortVersion &&
-			!partStatus.CurrentPartition {
-			log.Functionf("doBaseOsUninstall(%s) for %s, currently on other %s",
-				status.BaseOsVersion, uuidStr, partName)
+		versionMatchOnOther := status.BaseOsVersion == partStatus.ShortVersion &&
+			!partStatus.CurrentPartition
+		updatingOnOther := partStatus.PartitionState == "updating" &&
+			!partStatus.CurrentPartition
+		if versionMatchOnOther || updatingOnOther {
+			log.Functionf("doBaseOsUninstall(%s) for %s, currently on other %s (state %s)",
+				status.BaseOsVersion, uuidStr, partName, partStatus.PartitionState)
 			curPartState := getPartitionState(ctx,
 				zboot.GetCurrentPartition())
 			if curPartState == "active" {


### PR DESCRIPTION
# Description

I ran into this when creating new eden tests to cover the various aspects of baseosmgr. This isn't likely to hit in normal use - it was triggered by the draft tests pushing a new baseosconfig and then "changing their mind" by deleting it. But it makes sense removing this odd behavior from the code; if baseosmgr is not going to cause the reboot into the new version to take place (due to the delete) then it shouldn't live that latent IMGx=updating state in place since it will cause surprises at the next device reboot.

When the controller stops requesting a baseos update mid-flight, the
BaseOsConfig is unpublished but the install path can still complete:
the install worker is not interruptible and
`SetOtherPartitionStateUpdating()` may have already run, so the next
reboot picks up the abandoned image even though no controller config
ever asked for it.

This PR closes the gap on `BaseOsConfig` delete:

1. **Best-effort-cancel the pending install Work.** In
   `handleBaseOsConfigDeleteByStatus`, call
   `ctx.worker.Cancel(status.ContentTreeUUID)` so a queued
   `WriteToPartition` is dropped. The processWork loop itself is not
   interruptible, so a write that has already started will still
   complete; the next step is what prevents that completion from
   taking effect on the next boot.

2. **Roll the partition back to `unused` when the BaseOsConfig is
   deleted before reboot.** In `doBaseOsUninstall`, widen the
   existing partition-rollback branch so it also fires when the
   other partition is in state `updating`. The existing condition
   keyed on `status.BaseOsVersion == partStatus.ShortVersion`, which
   is unreliable in this window — `ShortVersion` is only refreshed
   when EVE actually boots into that partition, so during the race
   it still reflects the previously-installed version. Adding the
   `partStatus.PartitionState == "updating"` check catches the case
   directly.

Effect: a `BaseOsConfig` deletion while a baseos install is in flight
no longer leaves EVE booting into the abandoned image. The condition
that triggers this is the controller deciding to retract a baseos
update after EVE has started the install — a scenario `tests/baseosmgr`
exercises in the `force_fallback` and `retry_update` scenarios.

## How to test and validate this PR

Existing baseosmgr Eden scenarios already exercise the delete-during-
install path:

```sh
make eden-cover TEST_ALL=1
# or specifically:
eden test ./tests/baseosmgr -s eden.baseosmgr.tests.txt
```

Functional check that the fix doesn't regress steady-state behaviour:
the `smoke` workflow + `baseosmgr` scenarios both pass on the
patched build (verified locally on coverage-allprs G3 run today,
~92 min, both suites rc=0).

To exercise the specific code path the fix covers, drive an
`eden controller edge-node eveimage-update` followed by an
`eveimage-remove` while EVE is mid-download:

```sh
# Start an update:
eden controller edge-node eveimage-update <rootfs-blob> --os-version=Y
# As soon as EVE starts the install (observe in eve console), retract:
eden controller edge-node eveimage-remove <rootfs-blob> --os-version=Y
# Before this patch: EVE reboots into Y on next reboot.
# After this patch:  EVE stays on the original baseos.
```

`go test ./pkg/pillar/cmd/baseosmgr/` reports no test files on
master (unit tests for baseosmgr land via separate ongoing PRs);
`make pkg/pillar` builds clean.

## Changelog notes

Bug fix: a controller-initiated retraction of an in-flight baseos
update no longer risks EVE booting into the abandoned image on the
next reboot.

## PR Backports

This this is an odd minor case it doesn't make sense to backport.

- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation — N/A (internal fix, no
      operator-facing surface change beyond the bug going away)
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device — N/A, architecture-
      independent baseosmgr logic
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR