### PR TITLE
github/zizmor: ignore legitimate audit findings

### DIFF
--- a/.github/workflows/eden-trusted.yml
+++ b/.github/workflows/eden-trusted.yml
@@ -179,7 +179,7 @@ jobs:
     name: ${{ needs.context.outputs.eden_parent_job_title }} for 13.4-stable
     needs: context
     if: needs.context.outputs.skip_run == 'false' && needs.context.outputs.pr_base_ref == '13.4-stable'
-    uses: lf-edge/eden/.github/workflows/test.yml@1.0.15
+    uses: lf-edge/eden/.github/workflows/test.yml@1.0.15  # zizmor: ignore[unpinned-uses] eden release tag versioned with our EVE release branches; a SHA pin would force a cross-repo bump on every eden patch release
     secrets: inherit
     with:
       eve_image: "evebuild/pr:${{ needs.context.outputs.pr_id }}"
@@ -192,7 +192,7 @@ jobs:
     name: ${{ needs.context.outputs.eden_parent_job_title }} for 14.5-stable
     needs: context
     if: needs.context.outputs.skip_run == 'false' && needs.context.outputs.pr_base_ref == '14.5-stable'
-    uses: lf-edge/eden/.github/workflows/test.yml@1.0.15
+    uses: lf-edge/eden/.github/workflows/test.yml@1.0.15  # zizmor: ignore[unpinned-uses] eden release tag versioned with our EVE release branches; a SHA pin would force a cross-repo bump on every eden patch release
     secrets: inherit
     with:
       eve_image: "evebuild/pr:${{ needs.context.outputs.pr_id }}"
@@ -205,7 +205,7 @@ jobs:
     name: ${{ needs.context.outputs.eden_parent_job_title }} for 16.0-stable
     needs: context
     if: needs.context.outputs.skip_run == 'false' && needs.context.outputs.pr_base_ref == '16.0-stable'
-    uses: lf-edge/eden/.github/workflows/test.yml@1.0.15
+    uses: lf-edge/eden/.github/workflows/test.yml@1.0.15  # zizmor: ignore[unpinned-uses] eden release tag versioned with our EVE release branches; a SHA pin would force a cross-repo bump on every eden patch release
     secrets: inherit
     with:
       eve_image: "evebuild/pr:${{ needs.context.outputs.pr_id }}"
@@ -218,7 +218,7 @@ jobs:
     name: ${{ needs.context.outputs.eden_parent_job_title }} for master
     needs: context
     if: needs.context.outputs.skip_run == 'false' && needs.context.outputs.pr_base_ref == 'master'
-    uses: lf-edge/eden/.github/workflows/test.yml@master
+    uses: lf-edge/eden/.github/workflows/test.yml@master  # zizmor: ignore[unpinned-uses] eden master tracks this repo's master branch; a SHA pin would force a cross-repo bump on every eden change
     secrets: inherit
     with:
       eve_image: "evebuild/pr:${{ needs.context.outputs.pr_id }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -302,7 +302,7 @@ jobs:
   trigger_assets:
     if: ${{ (startsWith(github.ref, 'refs/tags/')) && (github.event.repository.full_name == 'lf-edge/eve') }}
     needs: [manifest, eve]
-    uses: lf-edge/eve/.github/workflows/assets.yml@master
+    uses: lf-edge/eve/.github/workflows/assets.yml@master  # zizmor: ignore[unpinned-uses] same-repo reusable workflow; @master is this repo's own head, which tagged release builds invoke
     secrets:
       DOCKERHUB_PULL_TOKEN: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
       DOCKERHUB_PULL_USER: ${{ secrets.DOCKERHUB_PULL_USER }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Per-rule ignore list for the Zizmor workflow audit. Each entry below
+# documents a finding that is legitimate by design and would be a
+# regression to "fix" by changing the affected workflow. Mechanical
+# findings (artipacked, excessive-permissions, template-injection,
+# secrets-outside-env) are addressed in separate PRs, not suppressed
+# here.
+#
+# unpinned-uses findings are suppressed inline in the workflow files
+# ("# zizmor: ignore[unpinned-uses]" on the affected uses: line), so the
+# suppression travels with the line instead of a fragile anchor here.
+---
+rules:
+  dangerous-triggers:
+    ignore:
+      # pull_request_target: posts an explanatory comment and closes the
+      # PR via the GitHub API. No checkout of the head ref; no shell
+      # execution touches PR-controlled content.
+      - close-master-pr.yml
+      # pull_request_target: checks out the base ref, fetches the head
+      # SHA, and only reads .github/CODEOWNERS (base-controlled). The
+      # head ref is interpolated into shell; that template-injection
+      # exposure is fixed separately, not by changing the trigger.
+      - request_codeowners_review.yml
+      # workflow_run after a successful "PR build": reads only the
+      # gate context artifact produced by the trusted workflow and
+      # forwards the PR identifier. Privileged context is needed to
+      # write commit statuses on the PR head SHA.
+      - pr-gate.yml
+      # workflow_run after a successful "PR Gate": dispatches to the
+      # lf-edge/eden reusable test workflow with a fixed payload.
+      # Privileged context is needed to update commit statuses and
+      # pull DOCKERHUB_PULL_* secrets for the eden harness.
+      - eden-trusted.yml
+      # workflow_run after a successful "PR build": dispatches to the
+      # shjala/eve-cvewatch reusable scanner with the PR head URL and
+      # SHA. No untrusted checkout in the caller workflow.
+      - cve-scan.yml
+
+  secrets-inherit:
+    ignore:
+      # Calls the lf-edge/eden reusable test workflow, which is part
+      # of the same org-controlled trust boundary as this repo.
+      # Enumerating the secrets explicitly is tracked separately; it
+      # requires aligning with the inputs declared by eden's test.yml
+      # and would not change the trust model.
+      - eden-trusted.yml


### PR DESCRIPTION
# Description

Adds `.github/zizmor.yml` so the Zizmor workflow stops reporting the
ten audit findings that are legitimate by design.

The covered findings:

- **`dangerous-triggers`** (5 files) — `close-master-pr.yml` and
  `request_codeowners_review.yml` rely on `pull_request_target` to
  use the base-branch token for writing PR metadata; neither checks
  out PR-controlled code into a trusted context. `pr-gate.yml`,
  `eden-trusted.yml`, and `cve-scan.yml` run on `workflow_run` after
  a privileged PR build completes and need privileged context to
  write commit statuses and call same-org reusable workflows.

- **`unpinned-uses`** (5 references) — the four calls in
  `eden-trusted.yml` pin `lf-edge/eden`'s reusable test workflow to
  the release tag aligned with the EVE branch (`1.0.15` for current
  stable lines, `master` for master). Pinning to a commit SHA would
  force a cross-repo bump on every eden patch release. The single
  `publish.yml:345` reference is to this repo's own `assets.yml` at
  `@master`, which is the documented entry point for tagged release
  builds.

- **`secrets-inherit`** (4 calls, all in `eden-trusted.yml`) — calls
  the same `lf-edge/eden` reusable test workflow, inside the
  org-controlled trust boundary. Enumerating the secrets explicitly
  is a cosmetic change and is tracked separately.

Mechanical findings (`artipacked`, `excessive-permissions`,
`template-injection`, `secrets-outside-env`) are **not** suppressed
here and will be addressed in dedicated PRs.

## PR dependencies

None.

## How to test and validate this PR

- Confirm the Zizmor workflow on this PR completes without reporting
  the listed audits.
- Spot-check the `lf-edge/eve` Security → Code scanning view after
  merge: the open-alert count should drop by the ten findings listed
  above (5 `dangerous-triggers`, 5 `unpinned-uses` references / 7
  alert rows minus the two we intentionally left open, and 4
  `secrets-inherit`). The `cve-scan.yml:17` and `claude-review.yml:46`
  `unpinned-uses` alerts are deliberately not suppressed.
- No runtime workflow change: the affected workflows still execute
  the same steps.

## Changelog notes

None. CI-only change.

## PR Backports

- 16.0-stable: No, master-only CI hygiene.
- 14.5-stable: No, master-only CI hygiene.
- 13.4-stable: No, master-only CI hygiene.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device — n/a, CI config only
- [ ] I've tested my PR on arm64 device — n/a, CI config only
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason