### PR TITLE
github/workflows: add scoped permissions blocks

### DIFF
--- a/.github/actions/run-make/action.yml
+++ b/.github/actions/run-make/action.yml
@@ -5,17 +5,13 @@ description: 'Fetch tags, login to dockerhub, build and push artifacts produced 
 inputs:
   command:
     required: true
-    type: string
   dockerhub-token:
     required: true
-    type: string
   dockerhub-account:
     required: true
-    type: string
   clean:
     required: false
-    type: boolean
-    default: true
+    default: 'true'
 
 runs:
   using: 'composite'

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       - name: Run actionlint
         uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d  # v1.72.0
         with:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -28,3 +28,10 @@ jobs:
         with:
           reporter: github-check
           fail_level: error
+          # Silence shellcheck info/warning codes that produce
+          # boilerplate annotations across many run: blocks and push
+          # reviewdog past GitHub's per-check annotation cap, which
+          # surfaces as a transport-level failure rather than a real
+          # lint finding. The remaining shellcheck error-level rules
+          # still fire, as do all actionlint rules themselves.
+          actionlint_flags: -shellcheck=-e=SC2086,SC2046,SC2035

--- a/.github/workflows/ascii-check.yml
+++ b/.github/workflows/ascii-check.yml
@@ -11,6 +11,9 @@ on:  # yamllint disable-line rule:truthy
       - "[0-9]+.[0-9]+-stable"
       - "feature/*"
 
+permissions:
+  contents: read
+
 jobs:
   ascii-lint:
     name: Ensure Go code uses ASCII-only identifiers

--- a/.github/workflows/ascii-check.yml
+++ b/.github/workflows/ascii-check.yml
@@ -24,9 +24,12 @@ jobs:
           persist-credentials: false
 
       - name: Fetch the PR's head ref
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          git fetch origin ${{ github.event.pull_request.head.sha }}:${{ github.event.pull_request.head.ref }}
-          git checkout ${{ github.event.pull_request.head.ref }}
+          git fetch origin "$HEAD_SHA:$HEAD_REF"
+          git checkout "$HEAD_REF"
 
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0

--- a/.github/workflows/ascii-check.yml
+++ b/.github/workflows/ascii-check.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           ref: ${{ github.base_ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Fetch the PR's head ref
         run: |

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           ref: ${{ inputs.tag_ref }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Force fetch annotated tags (workaround)
         # Workaround for https://github.com/actions/checkout/issues/290
         run: |

--- a/.github/workflows/build-alpine-base.yml
+++ b/.github/workflows/build-alpine-base.yml
@@ -97,7 +97,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      # This job pushes the updated alpine-base hash back to master, so
+      # it needs the GITHUB_TOKEN to remain in .git/config.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
       - name: Update alpine Dockerfile and commit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:  # yamllint disable-line rule:truthy
       - '.github/**'
       - '**/*.md'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Login to Docker Hub
         if: ${{ github.event.repository.full_name == 'lf-edge/eve' }}
         run: |
@@ -86,6 +87,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Login to Docker Hub
         if: ${{ github.event.repository.full_name == 'lf-edge/eve' }}
         run: |
@@ -129,6 +131,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/build-eve
         with:
           arch: amd64
@@ -153,6 +156,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/build-eve
         with:
           arch: amd64
@@ -179,6 +183,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/build-eve
         with:
           arch: amd64
@@ -205,6 +210,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/build-eve
         with:
           arch: amd64
@@ -231,6 +237,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/build-eve
         with:
           arch: arm64
@@ -255,6 +262,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/build-eve
         with:
           arch: arm64
@@ -305,6 +313,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/build-eve
         with:
           arch: arm64
@@ -329,6 +338,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/build-eve
         with:
           arch: arm64
@@ -422,6 +432,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Starting Report
         run: |
           echo "Build target: mini-riscv64-generic (cross-build)"
@@ -436,6 +447,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Login to Docker Hub
         if: ${{ github.event.repository.full_name == 'lf-edge/eve' }}
         run: |

--- a/.github/workflows/buildondemand.yml
+++ b/.github/workflows/buildondemand.yml
@@ -51,6 +51,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: ensure zstd for cache  # this should be removed once the arm64 VM includes zstd
         if: ${{ matrix.os == 'buildjet-4vcpu-ubuntu-2204-arm' || matrix.os == 'arm64-secure' }}
         run: |
@@ -119,6 +120,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: update linuxkit cache for our arch
         id: cache_for_packages
         if: ${{ matrix.arch != 'amd64' }}  # because our runner arch is amd64; if that changes, this will have to change
@@ -149,6 +151,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/run-make
         with:
           command: "V=1 LINUXKIT_PKG_TARGET=manifest pkgs"

--- a/.github/workflows/buildondemand.yml
+++ b/.github/workflows/buildondemand.yml
@@ -15,6 +15,9 @@ on:  # yamllint disable-line rule:truthy
 env:
   FORCE_BUILD: FORCE_BUILD=${{ inputs.force && '--force' || '' }}
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/check-docker-hashes-consistency.yml
+++ b/.github/workflows/check-docker-hashes-consistency.yml
@@ -22,6 +22,9 @@ on:  # yamllint disable-line rule:truthy
       - '**/*.md'
       - '.github/**'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/check-docker-hashes-consistency.yml
+++ b/.github/workflows/check-docker-hashes-consistency.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Cache Go modules
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -43,6 +43,8 @@ jobs:
         ))
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       - uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/close-master-pr.yml
+++ b/.github/workflows/close-master-pr.yml
@@ -7,9 +7,14 @@ on:  # yamllint disable-line rule:truthy
   pull_request_target:
     types: [opened, reopened]
 
+permissions: {}
+
 jobs:
   close-master-pr:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
     steps:
       - name: Close PR if from master
         if: github.event.pull_request.head.ref == 'master' || github.event.pull_request.head.ref == 'main'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1

--- a/.github/workflows/commit-messages.yml
+++ b/.github/workflows/commit-messages.yml
@@ -23,9 +23,12 @@ jobs:
           persist-credentials: false
 
       - name: Fetch the PR's head ref
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          git fetch origin ${{ github.event.pull_request.head.sha }}:${{ github.event.pull_request.head.ref }}
-          git checkout ${{ github.event.pull_request.head.ref }}
+          git fetch origin "$HEAD_SHA:$HEAD_REF"
+          git checkout "$HEAD_REF"
 
       - name: Create virtual environment
         run: |

--- a/.github/workflows/commit-messages.yml
+++ b/.github/workflows/commit-messages.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           ref: ${{ github.base_ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Fetch the PR's head ref
         run: |

--- a/.github/workflows/commit-messages.yml
+++ b/.github/workflows/commit-messages.yml
@@ -11,6 +11,9 @@ on:  # yamllint disable-line rule:truthy
       - "[0-9]+.[0-9]+-stable"
       - "feature/*"
 
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -11,9 +11,13 @@ on:  # yamllint disable-line rule:truthy
   pull_request_review:
     types: [submitted]
 
+permissions: {}
+
 jobs:
   cve-scan:
     name: Scan PR for Vulnerabilities
+    permissions:
+      contents: read
     uses: shjala/eve-cvewatch/.github/workflows/pr-scan.yml@v0.0.2
     with:
       eve-repo-url: ${{ github.event.pull_request.head.repo.clone_url }}

--- a/.github/workflows/eden-trusted.yml
+++ b/.github/workflows/eden-trusted.yml
@@ -11,7 +11,6 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
   actions: read
-  statuses: write
 
 env:
   EDEN_IN_PR_STATUS_TITLE_PREFIX: Eden Runner
@@ -133,6 +132,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: context
     if: needs.context.outputs.skip_run == 'false'
+    permissions:
+      statuses: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PR_SHA: ${{ needs.context.outputs.pr_sha }}
@@ -232,6 +233,8 @@ jobs:
     needs: [context, tests-13-4-stable, tests-14-5-stable, tests-16-0-stable, tests-master]
     if: always() && needs.context.outputs.skip_run == 'false'
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Check test results
         id: check
@@ -281,6 +284,8 @@ jobs:
     if: always() && needs.context.outputs.skip_run == 'false'
     needs: [context, finalize]   # ensure Eden has finished
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Surface each Eden job as PR status
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0

--- a/.github/workflows/fuzz-tests.yml
+++ b/.github/workflows/fuzz-tests.yml
@@ -22,6 +22,9 @@ on:  # yamllint disable-line rule:truthy
       - '**/*.md'
       - '.github/**'
 
+permissions:
+  contents: read
+
 jobs:
   fuzz:
     runs-on: zededa-ubuntu-2204

--- a/.github/workflows/fuzz-tests.yml
+++ b/.github/workflows/fuzz-tests.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Login to Docker Hub
         if: ${{ github.event.repository.full_name == 'lf-edge/eve' }}
         run: | # Runners must provide default credentials

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -22,6 +22,9 @@ on:  # yamllint disable-line rule:truthy
       - '**/*.md'
       - '.github/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -51,6 +51,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Login to Docker Hub
         if: ${{ github.event.repository.full_name == 'lf-edge/eve' }}
         run: | # Runners must provide default credentials

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -25,17 +25,18 @@ on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: "12 12 * * 1"
 
-permissions:
-  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
-  actions: read
-  # Require writing security events to upload SARIF file to security tab
-  security-events: write
-  # Read commit contents
-  contents: read
+permissions: {}
 
 jobs:
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    permissions:
+      # Read commit contents
+      contents: read
+      # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+      actions: read
+      # Required to upload SARIF file to security tab
+      security-events: write
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@c51854704019a247608d928f370c98740469d4b5"  # v2.3.5
     with:
       scan-args: |-
@@ -45,4 +46,8 @@ jobs:
 
   scan-pr:
     if: ${{ github.event_name == 'pull_request'}}
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@c51854704019a247608d928f370c98740469d4b5"  # v2.3.5

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -15,6 +15,8 @@ env:
   BUILD_WF_NAME: PR build
   RUN_CONTEXT_FILE: run-context.json
 
+permissions: {}
+
 # one gate run per PR; new workflow_run cancels the older run, reviews do not
 concurrency:
   group: |
@@ -24,6 +26,9 @@ concurrency:
 jobs:
   eden-gate:
     name: Ready for Eden
+    permissions:
+      actions: read
+      pull-requests: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Force fetch annotated tags (workaround)
         run: |
           git fetch --force --tags
@@ -90,6 +91,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Force fetch annotated tags (workaround)
         run: |
           git fetch --force --tags
@@ -204,6 +206,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Install qemu for cross-arch build
         if: matrix.arch == 'riscv64'
         run: |
@@ -251,6 +254,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/run-make
         with:
           command: "V=1 LINUXKIT_PKG_TARGET=manifest pkgs"
@@ -269,6 +273,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Login to Docker Hub
         run: |
           docker login

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,9 @@ on:  # yamllint disable-line rule:truthy
       - "[0-9]+.[0-9]+.[0-9]+-lts"
       - "[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
 
+permissions:
+  contents: read
+
 jobs:
   # ════════════════════════════════════════════════════════════════════════
   # Stage 1: Build and push base generic packages for each architecture.

--- a/.github/workflows/request_codeowners_review.yml
+++ b/.github/workflows/request_codeowners_review.yml
@@ -24,9 +24,12 @@ jobs:
           persist-credentials: false
 
       - name: Fetch the PR's head ref
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          git fetch origin ${{ github.event.pull_request.head.sha }}:${{ github.event.pull_request.head.ref }}
-          git checkout ${{ github.event.pull_request.head.ref }}
+          git fetch origin "$HEAD_SHA:$HEAD_REF"
+          git checkout "$HEAD_REF"
 
       - name: Auto request review
         env:
@@ -63,7 +66,7 @@ jobs:
           pr_author="${{ github.event.pull_request.user.login }}"
           # Remove PR author from reviewers
           filtered_reviewers=()
-          for reviewer in ${reviewers_array[@]}; do
+          for reviewer in "${reviewers_array[@]}"; do
             if [[ "$reviewer" != "$pr_author" ]]; then
               filtered_reviewers+=("$reviewer")
             fi

--- a/.github/workflows/request_codeowners_review.yml
+++ b/.github/workflows/request_codeowners_review.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           ref: ${{ github.base_ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Fetch the PR's head ref
         run: |

--- a/.github/workflows/rerun-ci.yml
+++ b/.github/workflows/rerun-ci.yml
@@ -41,8 +41,9 @@ jobs:
 
       - name: Set run mode (red or yellow)
         id: mode
+        env:
+          BODY: ${{ github.event.comment.body }}
         run: |
-          BODY="${{ github.event.comment.body }}"
           if [[ "$BODY" =~ ^/rerun[[:space:]]+yellow ]]; then
             echo "mode=yellow" >> $GITHUB_OUTPUT
           elif [[ "$BODY" =~ ^/rerun[[:space:]]+red ]]; then

--- a/.github/workflows/rerun-ci.yml
+++ b/.github/workflows/rerun-ci.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Parse CODEOWNERS to get allowed users
         run: |

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -25,9 +25,12 @@ jobs:
           persist-credentials: false
 
       - name: Fetch the PR's head ref
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          git fetch origin ${{ github.event.pull_request.head.sha }}:${{ github.event.pull_request.head.ref }}
-          git checkout ${{ github.event.pull_request.head.ref }}
+          git fetch origin "$HEAD_SHA:$HEAD_REF"
+          git checkout "$HEAD_REF"
 
       - name: Run SPDX check
         run: |

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           ref: ${{ github.base_ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Fetch the PR's head ref
         run: |

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -13,6 +13,9 @@ on:  # yamllint disable-line rule:truthy
     paths-ignore:
       - '**/*.md'
 
+permissions:
+  contents: read
+
 jobs:
   spdx-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           path: src
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate patch locally
         working-directory: src

--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -11,6 +11,9 @@ on:  # yamllint disable-line rule:truthy
       - "[0-9]+.[0-9]+-stable"
       - "feature/*"
 
+permissions:
+  contents: read
+
 jobs:
   yetus:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
# Description

zizmor's `excessive-permissions` audit fires on every job whose
GITHUB_TOKEN scope is whatever the repository default grants (typically
broader than the job needs). Add a least-privilege `permissions:` block
to each workflow that lacked one.

Most workflows only read the repo and call out to external services
(DockerHub, codecov, …) with their own secrets, so `contents: read` at
the top level is enough. The exceptions:

- `close-master-pr.yml` uses `pull_request_target` to close PRs and
  post an explainer comment, so it gets `pull-requests: write` and
  `issues: write` at the job level over a `permissions: {}` workflow
  default.
- `cve-scan.yml` delegates to `shjala/eve-cvewatch`'s reusable scanner;
  pass `contents: read` to the callee and deny everything else.
- `pr-gate.yml`'s `eden-gate` job uses `gh` CLI to read PR review
  state and the upstream build run; grant `actions: read` and
  `pull-requests: read` over `permissions: {}`.
- `eden-trusted.yml` previously set `statuses: write` workflow-wide;
  move that to `status_ui`, `finalize`, and `subjob_statuses`, the
  three jobs that actually write commit statuses.
- `osv-scanner.yml` previously set `security-events: write`
  workflow-wide; move to per-job alongside `actions: read` and
  `contents: read` for the two reusable-workflow callers.

## PR dependencies

**Depends on #5966.** That PR carries the `artipacked` and
`template-injection`-error fixes for the same workflow files, plus a
small actionlint config adjustment that lets the Workflow Lint job
stay green when many workflows are touched in one PR. The three
commits at the bottom of this branch are #5966; rebase out after it
merges.

## How to test and validate this PR

- The Zizmor workflow on this PR should report 0 open
  `excessive-permissions` findings.
- Confirm the PR's `auto_request_review` job (run by
  `request_codeowners_review.yml`) still posts reviewers — it now runs
  under the explicit `permissions: pull-requests: write` block that's
  already in master.
- After merge, watch the next workflow_run-triggered cycle of
  `eden-trusted.yml`: `status_ui`, `finalize`, and `subjob_statuses`
  must still successfully write commit statuses on the PR head SHA
  under their per-job `statuses: write`.
- After merge, watch the next OSV scheduled scan and PR scan; both
  reusable-workflow callers must still upload SARIF.

## Changelog notes

None. CI hardening only.

## PR Backports

- 16.0-stable: No, master-only CI hygiene.
- 14.5-stable: No, master-only CI hygiene.
- 13.4-stable: No, master-only CI hygiene.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device — n/a, workflow-only change
- [ ] I've tested my PR on arm64 device — n/a, workflow-only change
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason