### PR TITLE
[16.0-stable] pkg/fw: Add .pnvm firmware file for Intel AX210

### DIFF
--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -152,6 +152,7 @@ COPY --from=build /lib/firmware/iwlwifi-9260* /lib/firmware/
 # AX210 160MHZ
 COPY --from=build /lib/firmware/iwlwifi-ty-a0-gf-a0-72.ucode /lib/firmware/
 COPY --from=build /lib/firmware/iwlwifi-ty-a0-gf-a0-89.ucode /lib/firmware/
+COPY --from=build /lib/firmware/iwlwifi-ty-a0-gf-a0.pnvm /lib/firmware/
 COPY --from=build /lib/firmware/intel/ibt-0041-0041* /lib/firmware/intel/
 # Intel AX211NGW
 COPY --from=build /lib/firmware/iwlwifi-so-a0-gf-a0* /lib/firmware/


### PR DESCRIPTION
# Description

Backport of #5945

This commit adds the file iwlwifi-ty-a0-gf-a0.pnvm, needed by the Intel AC210 WiFi devide, and which was missing from the firmware package.

## How to test and validate this PR

Boot the device, see `wlan0` interface is recognized and it works.

## Changelog notes

Add missing firmware file for Intel AX210 WiFi adapter.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.