### PR TITLE
grub: disable PCIe ACS override for EVE-K boot

### DIFF
--- a/docs/EVE-K.md
+++ b/docs/EVE-K.md
@@ -18,6 +18,14 @@ To use a zfs vault specify the config grub parameter `eve_install_zfs_with_raid_
 with the requested raid level or use multiple persist disk with `eve_persist_disk`
 which will use zfs automatically.
 
+## PCIe ACS / IOMMU groups
+
+Unlike the default EVE boot path, EVE-K boots without the `pcie_acs_override`
+kernel option. IOMMU groups therefore reflect the platform's actual ACS
+topology, and PCI passthrough configurations cannot rely on the override to
+split a shared group. See [HYPERVISORS.md](./HYPERVISORS.md#acs-override-on-the-kernel-command-line)
+for the full discussion.
+
 ## Modes
 
 EVE-API controller config will define a mode

--- a/docs/HYPERVISORS.md
+++ b/docs/HYPERVISORS.md
@@ -91,6 +91,12 @@ EVE relies on modern [IOMMU support](https://vfio.blogspot.com/2014/08/iommu-gro
 
 It must be noted, that given dual nature of IOMMU support in the Linux kernel itself (it can be used to optimized device drivers in addition to providing virtualization and user-space capabilities) they have an extra incentive to focus on properly enabling access controls via PCIe ACS (Access Control Services). Sadly, a lot of PCIe hardware is still [very](https://www.redhat.com/archives/vfio-users/2016-July/msg00043.html), [very](https://bugzilla.redhat.com/show_bug.cgi?id=1037684) badly broken and has to be worked around. For now, EVE takes a blunt approach of punting on fine-grained ACS controls with both [Xen](https://lists.gt.net/xen/devel/345180) and [KVM](https://lkml.org/lkml/2013/5/30/513) hypervisors.
 
+### ACS override on the kernel command line
+
+Historically EVE booted with `pcie_acs_override=downstream,multifunction` on the kernel command line. This option comes from the out-of-tree "ACS override" patch and forces the kernel to treat PCIe downstream and multifunction ports as if they implemented ACS, artificially splitting IOMMU groups so that devices which actually share isolation can still be assigned independently. It is useful for passthrough on consumer hardware where the platform does not implement ACS correctly, but it weakens the isolation guarantees that IOMMU groups are meant to express.
+
+EVE-K (the Kubernetes flavor) boots without `pcie_acs_override` — see `set_k_boot` in [`pkg/grub/rootfs.cfg`](../pkg/grub/rootfs.cfg). IOMMU groups on EVE-K therefore reflect the platform's actual ACS topology: devices that genuinely share a group remain grouped, and passthrough on such hardware must be configured deliberately rather than relying on the override to split a shared group.
+
 Further details of Xen vs. KVM IOMMU handling are [documented here](https://docs.google.com/document/d/12-z6JD41J_oNrCg_c0yAxGWg5ADBQ8_bSiP_NH6Hqwo/edit#).
 
 Hardware quirks aside, EVE uses the following hypervisor capabilities to manage IOMMU-based device assignments to domains:

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -432,7 +432,6 @@ function set_k_boot {
    set_global load_hv_cmd true
    set_global load_dom0_cmd linux
    set_global load_initrd_cmd initrd
-   set_global dom0_flavor_tweaks "pcie_acs_override=downstream,multifunction"
    if [ "$arch" = "x86_64" ]; then
       set_global dom0_flavor_tweaks "$dom0_flavor_tweaks crashkernel=2G-16G:128M,16G-128G:256M,128G-:512M"
    fi


### PR DESCRIPTION
# Description

EVE-K's grub config has been booting the kernel with `pcie_acs_override=downstream,multifunction` on the `dom0_flavor_tweaks` command line. The ACS override patch forces the kernel to treat PCIe downstream ports as if they implement Access Control Services, artificially splitting IOMMU groups. While useful for some passthrough scenarios on consumer hardware, it weakens isolation guarantees between devices and is not appropriate as a default for EVE-K nodes — IOMMU groups should reflect the platform's actual ACS topology.

This change removes that flag from `pkg/grub/rootfs.cfg` so EVE-K boots with upstream kernel behavior. Devices that genuinely share an IOMMU group continue to do so, and passthrough on such hardware must be configured deliberately rather than implicitly enabled by the ACS override.

**NOTE:** device model must be regenerated and update to EVE-k after this commit will break current installations but eve-k is not in production yet so this is not a problem

## How to test and validate this PR

1. Build an EVE-K image from this branch and install on a test node.
2. Inspect `/proc/cmdline` on the running node — the `pcie_acs_override=…` token must be absent.
3. Inspect `/sys/kernel/iommu_groups/` — IOMMU group membership should match the platform's actual ACS topology (groups with multiple devices that lack ACS should no longer be artificially split).
4. Sanity-check that EVE-K still boots and applications launch on platforms that previously relied on default isolation (i.e. weren't depending on the override to split a group).

## Changelog notes

EVE-K nodes no longer boot with the `pcie_acs_override` kernel option. IOMMU groups now reflect the platform's real ACS topology; PCI passthrough configurations that implicitly relied on the override to split a shared IOMMU group will need to be revisited.

## PR Backports

- 16.0-stable: No
- 14.5-stable: No
- 13.4-stable: No

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.