### PR TITLE
[16.0-stable] newlog: sanitize non-Latin-1 chars in gzip header

### DIFF
--- a/pkg/newlog/cmd/doMoveCompressFile.go
+++ b/pkg/newlog/cmd/doMoveCompressFile.go
@@ -274,11 +274,19 @@ func prepareGzipToOutTempFile(gzipDirName string, fHdr fileChanInfo, now time.Ti
 	gw, _ := gzip.NewWriterLevel(writer, gzip.BestCompression)
 
 	// for app upload, use gzip header 'Name' for appName string to simplify cloud side implementation
-	// for now, the gw.Comment has the metadata for device log, and gw.Name for appName for app log
+	// for now, the gw.Comment has the metadata for device log, and gw.Name for appName for app log.
+	// RFC 1952 restricts both fields to NUL-free Latin-1, so sanitize the
+	// operator-supplied app DisplayName first or gw.Close() will fatal with
+	// "gzip.Write: non-Latin-1 header string".
+	header := sanitizeGzipHeader(fHdr.header)
+	if header != fHdr.header {
+		log.Warnf("prepareGzipToOutTempFile: header %q contains non-Latin-1 characters; escaped to %q",
+			fHdr.header, header)
+	}
 	if fHdr.isApp {
-		gw.Name = fHdr.header
+		gw.Name = header
 	} else {
-		gw.Comment = fHdr.header
+		gw.Comment = header
 	}
 	gw.ModTime = now
 

--- a/pkg/newlog/cmd/util.go
+++ b/pkg/newlog/cmd/util.go
@@ -5,6 +5,8 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/lf-edge/eve-api/go/logs"
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -44,6 +46,42 @@ func parseSyslogLogLevel(loglevel string) uint32 {
 	}
 
 	return prio
+}
+
+// sanitizeGzipHeader rewrites s so it is safe to assign to gzip.Writer.Name
+// or gzip.Writer.Comment. RFC 1952 restricts those fields to ISO-8859-1
+// with no NUL byte; Go's gzip writer enforces this and returns
+// "gzip.Write: non-Latin-1 header string" from Close() otherwise, which
+// is fatal in newlogd's compression path. Each disallowed rune is
+// replaced with a Go-style \uXXXX / \UXXXXXXXX escape so the original
+// value is recoverable downstream. Latin-1 runes (including accented
+// characters in 0x80-0xFF) pass through unchanged.
+func sanitizeGzipHeader(s string) string {
+	safe := true
+	for _, r := range s {
+		if r == 0 || r > 0xff {
+			safe = false
+			break
+		}
+	}
+	if safe {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r == 0:
+			b.WriteString(`\u0000`)
+		case r > 0xffff:
+			fmt.Fprintf(&b, `\U%08x`, r)
+		case r > 0xff:
+			fmt.Fprintf(&b, `\u%04x`, r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 func parseAgentLogLevel(loglevel string) logrus.Level {

--- a/pkg/newlog/cmd/util_test.go
+++ b/pkg/newlog/cmd/util_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// nulEscape is the literal 6-char text sequence that sanitizeGzipHeader
+// writes for a NUL byte: backslash, lowercase u, four zeros. Written as a
+// double-quoted Go string with an escaped backslash so this file contains
+// no actual NUL bytes (which break editors and some tooling).
+const nulEscape = "\\u0000"
+
+// referenceSanitize is a second implementation of the sanitization rule that
+// the production sanitizeGzipHeader must match. Keeping a parallel, simpler
+// implementation here lets the table test assert the contract directly
+// without hand-transcribed expected strings.
+func referenceSanitize(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r == 0:
+			b.WriteString(nulEscape)
+		case r > 0xffff:
+			fmt.Fprintf(&b, "\\U%08x", r)
+		case r > 0xff:
+			fmt.Fprintf(&b, "\\u%04x", r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func TestSanitizeGzipHeader(t *testing.T) {
+	inputs := []string{
+		"",
+		"my-app",
+		"café-Ñandú",     // pure Latin-1 (é=0xE9, Ñ=0xD1, ú=0xFA)
+		"中文",             // CJK -- both > 0xFF
+		"“hi”",           // smart quotes U+201C / U+201D
+		"Łódź",           // mixed: Ł=U+0141, ó=0x00F3, d ASCII, ź=U+017A
+		"★",              // U+2605
+		"\U0001F600",     // supplementary-plane emoji
+		"a\x00b",         // NUL byte
+		"app-中-é-\x00-Ł", // mix of all categories
+	}
+	for _, in := range inputs {
+		t.Run(fmt.Sprintf("%q", in), func(t *testing.T) {
+			got := sanitizeGzipHeader(in)
+			want := referenceSanitize(in)
+			if got != want {
+				t.Fatalf("sanitizeGzipHeader(%q) = %q, want %q", in, got, want)
+			}
+			for _, r := range got {
+				if r == 0 || r > 0xff {
+					t.Fatalf("sanitizeGzipHeader(%q) = %q contains disallowed rune U+%04X",
+						in, got, r)
+				}
+			}
+		})
+	}
+}
+
+// TestSanitizeGzipHeaderRoundTripsThroughGzip is the regression test for the
+// "non-Latin-1 header string" crash in finalizeGzipToOutTempFile: a sanitized
+// header must be accepted by gzip.Writer.Close() and survive a read-back.
+func TestSanitizeGzipHeaderRoundTripsThroughGzip(t *testing.T) {
+	inputs := []string{
+		"ascii-name",
+		"café-Ñandú",
+		"中文-app",
+		"app\x00with\x00nul",
+		"\U0001F600-emoji",
+		"mix-中-é-\x00-Ł",
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			var buf bytes.Buffer
+			gw := gzip.NewWriter(&buf)
+			gw.Name = sanitizeGzipHeader(in)
+			if _, err := gw.Write([]byte("payload\n")); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+			if err := gw.Close(); err != nil {
+				t.Fatalf("Close on sanitized header %q (original %q): %v", gw.Name, in, err)
+			}
+			gr, err := gzip.NewReader(&buf)
+			if err != nil {
+				t.Fatalf("NewReader: %v", err)
+			}
+			if gr.Name != sanitizeGzipHeader(in) {
+				t.Fatalf("round-tripped Name = %q, want %q", gr.Name, sanitizeGzipHeader(in))
+			}
+		})
+	}
+}
+
+// TestUnsanitizedHeaderCrashesGzip pins the precondition: assigning a raw
+// non-Latin-1 string to gzip.Writer.Name causes Close() to fail. If Go ever
+// loosens this, the sanitizer becomes unnecessary and this test surfaces it.
+func TestUnsanitizedHeaderCrashesGzip(t *testing.T) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	gw.Name = "中文"
+	_, _ = gw.Write([]byte("payload\n"))
+	if err := gw.Close(); err == nil {
+		t.Fatalf("expected gzip Close to reject non-Latin-1 Name, got nil error")
+	}
+}


### PR DESCRIPTION
# Description

Backport of #5977.

newlogd assigns the per-batch metadata header to `gzip.Writer.Name` (app logs,
holds the app's `DisplayName`) or `Comment` (device logs). Go's gzip writer
enforces RFC 1952's NUL-free ISO-8859-1 restriction on those fields, so the
operator-supplied `DisplayName` can contain bytes the writer refuses to emit
(CJK, emoji, smart quotes, extended-Latin glyphs like `Łódź`). The error
surfaces from `gw.Write` or `gw.Close` as `log.Fatal`, taking newlogd down;
the watchdog then reboots the device. After reboot the same collect file is
still on `/persist`, so the crash repeats — a reboot loop attributed to
"agent newlogd" with the signature
`finalizeGzipToOutTempFile: cannot close filegzip.Write: non-Latin-1 header string`.

Sanitize the header at the assignment site. Runes outside `0x01–0xFF` are
rewritten to the literal text form of a Go Unicode escape (`\uXXXX` or
`\UXXXXXXXX`); valid Latin-1 (including `0x80–0xFF` accented characters)
passes through unchanged. The substitution is reversible — cloud-side parsing
can recover the original DisplayName if desired. A one-shot warning is logged
when sanitization fires.

## How to test and validate this PR

Deploy an app instance with a non-Latin-1 character in its DisplayName (e.g.
`test-中-app`). Watch newlogd in `logread`; with the fix it logs
`prepareGzipToOutTempFile: header "test-中-app" contains non-Latin-1 characters; escaped to "test-中-app"`
and rotates a gzip file under `/persist/newlog/keepSentQueue/app.<uuid>.log.<ts>.gz`
with `Name="test-中-app"`. Without the fix, newlogd dies on the rotation
and the device reboots within ~60s with the signature above.

Latin-1-only DisplayNames (e.g. `café-Ñandú`) must pass through unchanged —
no warning, no escape.

Unit coverage: `pkg/newlog/cmd/util_test.go` (added in this PR) covers the
sanitizer's identity behavior on Latin-1 input, the escape rules for runes
outside Latin-1 and NUL, the round-trip through `gzip.Writer.Close`, and pins
the underlying stdlib precondition.

End-to-end validation was performed on master before merge of #5977; this is
a direct cherry-pick (`-x`) with no functional differences.

## Changelog notes

Fixes a device reboot loop triggered when an app's DisplayName contains
non-Latin-1 characters.

## PR Backports

- 14.5-stable: separate PR.
- 13.4-stable: separate PR.

## Checklist

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
