### PR TITLE
mkimage-raw-efi: fix pre-flight size check on real block devices

### DIFF
--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -659,9 +659,16 @@ PERSIST_PART=$(( PART_OFFSET + PERSIST_PART_OFFSET ))
 INVENTORY_WIN_PART=$(( PART_OFFSET + INVENTORY_WIN_PART_OFFSET ))
 USB_CONF_PART=$(( PART_OFFSET + USB_CONF_PART_OFFSET ))
 
-# Verify the pre-sized image is big enough to hold all requested partitions.
+# Verify the target is big enough to hold all requested partitions.
+# IMGFILE may be either a regular file (build-time image creation) or a
+# real block device (installer writing to the target disk). `stat -c %s`
+# returns 0 for device nodes, so use `blockdev --getsize64` for those.
 REQUIRED_SIZE=$(calc_image_size)
-ACTUAL_SIZE=$(stat -L -c %s "$IMGFILE")
+if [ -b "$IMGFILE" ]; then
+  ACTUAL_SIZE=$(blockdev --getsize64 "$IMGFILE")
+else
+  ACTUAL_SIZE=$(stat -L -c %s "$IMGFILE")
+fi
 if [ "$REQUIRED_SIZE" -gt "$ACTUAL_SIZE" ]; then
   echo "ERROR: partition layout requires $((REQUIRED_SIZE / 1024 / 1024)) MiB but disk image is only $((ACTUAL_SIZE / 1024 / 1024)) MiB." >&2
   echo "Requested partitions: $PARTS" >&2


### PR DESCRIPTION
# Description

`make-raw`'s pre-flight image-size check uses `stat -L -c %s "$IMGFILE"` to determine how large the target is. That works for the build-time case where `IMGFILE` is a regular pre-sized disk image, but `make-raw` is also invoked
from the installer (`pkg/installer/install`) with a real block-device path like `/dev/sda`. `stat -c %s` returns 0 for block/character device nodes —it reports the size of the inode entry, not the device capacity — so the
check would always fail with:

```
[   30.624231][ T1789]  sda:
ERROR: partition layout requires 22544 MiB but disk image is only 0 MiB.
Requested partitions: efi imga imgb conf persist

```

and abort the install before any partitions were written, regardless of the actual disk size.

This change branches on `[ -b "$IMGFILE" ]` and uses `blockdev --getsize64` for block devices, keeping the existing `stat` path for regular files.

## How to test and validate this PR

- run make installer-raw without PR. confirm issues is reproduced
- run make installer-raw  then make run-target - confirm issue is gone
- run installer on real device to validate

## Changelog notes

Fixes a regression where installing EVE to a real disk would fail with a "disk image is only 0 MiB" error before any partitions were written.

## PR Backports

- 17.0: YES - needed for rc2
- 16.0-stable: No 
- 14.5-stable: No 
- 13.4-stable: No 

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.