### PR TITLE
assets.yml: improve compression for EVE evaluation artifacts

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -148,7 +148,7 @@ jobs:
         run: |
           for file in assets/*.raw assets/collected_sources.tar; do
             [ -e "$file" ] || continue
-            zstd -T0 --rm -q "$file"
+            zstd -T0 --rm -q --long=30 "$file"
           done
       - name: Rename, create SHA256 checksums and upload files
         env:


### PR DESCRIPTION
# Description

The evaluation `installer.raw` can exceed 2 GB after default zstd compression, which violates the GitHub release-asset 2 GB hard limit and forces manual workarounds at release time. https://github.com/lf-edge/eve/actions/runs/26231503039/job/77269170246

Enable zstd long-range mode with `--long=30` (1 GB window) on the asset-compression step. Raw disk images contain widely separated repeated regions (filesystem metadata, vendor blobs, zeroed areas) that sit beyond the default 128 MB window; opening the window to 1 GB lets zstd back-reference those duplicates and shrinks a ~10 GB image to under 1 GB.

The default compression level is kept on purpose: in `--long` mode the long-distance matcher is tuned less aggressively at higher levels (`-19+`), on the assumption that the inner compressor will pick up the rest — but the inner compressor's ~8 MB window can't see these long-range duplicates. Default level pairs with a more aggressive LDM and produces a smaller artifact for less CPU/RAM.

`--long=30` requires ~1 GB of RAM on decompression; modern zstd (>=1.3.2) reads the window size from the frame header and allocates automatically, so consumers running `zstd -d` just work.

### Measurements

Tested against a ~10 GB evaluation raw image produced by eve 17.0.0-rc1. Target: under the 2 GB GitHub release-asset limit.

| zstd parameters                  | output |
|----------------------------------|--------|
| (default, no `--long`)           | 2.2 GB |
| `--long` (= `--long=27`, 128 MB) | 2.2 GB |
| `-19 --long`                     | 2.2 GB |
| `--ultra -22 --long=31` (2 GB)   | 798 MB |
| `-19 --long=30` (1 GB window)    | 840 MB |
| `--long=30` (1 GB window)        | 824 MB |

## How to test and validate this PR

1. Trigger the `assets.yml` workflow against a release tag that produces an oversized evaluation `installer.raw` (the workflow ran prior to this PR was producing a ~2.2 GB compressed artifact for the evaluation platform).
2. Confirm the `*.installer.raw.zst` asset is published successfully and is well under the 2 GB GitHub release-asset limit (expected ~0.8 GB for evaluation builds).
3. Decompress with a modern `zstd -d` (>=1.3.2) and confirm the resulting raw image is byte-identical to the uncompressed source (e.g. `sha256sum` matches a pre-compression checksum on the same raw input).

Local verification was performed against a representative ~10 GB evaluation raw image; results in the table above.

## Changelog notes

No user-facing changes.

## PR Backports

- 16.0-stable: No, master-only release-tooling change.
- 14.5-stable: No, master-only release-tooling change.
- 13.4-stable: No, master-only release-tooling change.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.