### PR TITLE
kube: align virtctl version with KubeVirt v1.7.3

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -21,7 +21,7 @@ RUN register-sbom-pkg.sh -n etcdctl -v "${ETCDCTL_VERSION}" -l Apache-2.0 -u htt
 # Note: virtctl itself is downloaded and installed in the final scratch stage below;
 # the APK DB entry is added here in the build stage so it propagates via COPY /out/.
 # Keep this version aligned with VIRTCTL_VERSION in the final stage.
-ENV VIRTCTL_VERSION=v1.6.0
+ENV VIRTCTL_VERSION=v1.7.3
 # Register virtctl in the APK DB, mandatory for it to be included in the SBOM.
 RUN register-sbom-pkg.sh -n virtctl -v "${VIRTCTL_VERSION}" -l Apache-2.0 -u https://github.com/kubevirt/kubevirt
 
@@ -124,7 +124,7 @@ RUN chmod +x /usr/bin/k3s-control && \
     ln -s /usr/bin/k3s-control /usr/bin/k3s-start && \
     ln -s /usr/bin/k3s-control /usr/bin/k3s-status
 
-ENV VIRTCTL_VERSION v1.6.0
+ENV VIRTCTL_VERSION v1.7.3
 ADD https://github.com/kubevirt/kubevirt/releases/download/${VIRTCTL_VERSION}/virtctl-${VIRTCTL_VERSION}-linux-${TARGETARCH} .
 
 RUN install virtctl-${VIRTCTL_VERSION}-linux-${TARGETARCH} /usr/bin/virtctl


### PR DESCRIPTION
# Description

Commit 849b4cd7e1 (`Move to kubevirt 1.7.3`) bumped `KUBEVIRT_VERSION` in `kubevirt-utils.sh` and `kubevirt-operator.yaml` to `v1.7.3` but left `VIRTCTL_VERSION` in `pkg/kube/Dockerfile` at `v1.6.0`.

The version mismatch may break container app deployment on eve-k (the issue happens non-deterministically, it is unclear to me why). When volumemgr attempts to populate a newly-created PVC by running
```
  virtctl image-upload ... --no-create
```
virtctl performs a client/server version check before doing anything else. With the v1.6.0 client talking to a v1.7.3 KubeVirt server it immediately exits with:
```
  "You are using a client virtctl version that is different from the KubeVirt version running in the cluster"
```
Each of the 10 upload retries fails within ~40 ms, exhausting the retry loop in about 5 minutes. Because virtctl never got as far as creating a CDI `UploadTokenRequest`, the CDI controller never annotated the PVC with the upload-pod name, so the subsequent diagnostic check in `RolloutDiskToPVC` reports:
```
  "PVC Upload for pvc:<id> attempts to upload image failed, no upload pod annotation"
```
The volume stays in `CREATING_VOLUME / SEVERITY_ERROR` state and the app never starts.

Fix: bump both `VIRTCTL_VERSION` occurrences in the Dockerfile to v1.7.3 to match the KubeVirt version deployed by `kubevirt-operator.yaml`.

## How to test and validate this PR

1. Verify the virtctl version match between the client and the server:
    ``` 
    eve enter kube
    KUBECONFIG=/etc/rancher/k3s/k3s.yaml virtctl version
    Client Version: version.Info{GitVersion:"v1.7.3", GitCommit:"9b20f69c621f367c75a0fb5d1844bbfcae8bd571", GitTreeState:"clean", BuildDate:"2026-04-24T13:10:36Z", GoVersion:"go1.24.9 X:nocoverageredesign", Compiler:"gc", Platform:"linux/amd64"}
    Server Version: version.Info{GitVersion:"v1.7.3", GitCommit:"9b20f69c621f367c75a0fb5d1844bbfcae8bd571", GitTreeState:"clean", BuildDate:"2026-04-24T15:02:48Z", GoVersion:"go1.24.9 X:nocoverageredesign", Compiler:"gc", Platform:"linux/amd64"
    ```
    Both client and server versions should report v1.7.3. Before this fix the client reported v1.6.0.

2. Deploy any container app that requires PVC image upload. With the bug present, all 10 upload retries may fail and the app never starts.

## Changelog notes

eve-k: fix container app deployment failure due to virtctl/KubeVirt version mismatch (virtctl was v1.6.0, KubeVirt v1.7.3).

## PR Backports

- 17.0-stable: to be backported

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
