### PR TITLE
[WIP] baseosmgr: gate EVE-k vs non-EVE-k upgrade block on volumes

### DIFF
--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -48,6 +48,8 @@ type baseOsMgrContext struct {
 	subBaseOsConfig      pubsub.Subscription
 	subZbootConfig       pubsub.Subscription
 	subContentTreeStatus pubsub.Subscription
+	subVolumeConfig      pubsub.Subscription
+	subVolumeStatus      pubsub.Subscription
 	subNodeAgentStatus   pubsub.Subscription
 	subZedAgentStatus    pubsub.Subscription
 	subNodeDrainStatus   pubsub.Subscription
@@ -140,6 +142,26 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	log.Functionf("user containerd ready")
 
+	// Wait for the Volume publishers to signal restart, i.e. zedagent
+	// has parsed its first EdgeDevConfig and volumemgr has reflected
+	// that plus its on-disk recovery into VolumeStatus. Restarted()
+	// is the right primitive here: Synchronized() only confirms the
+	// socket handshake and can fire before zedagent's first parse.
+	for !ctx.subVolumeConfig.Restarted() || !ctx.subVolumeStatus.Restarted() {
+		log.Functionf("waiting for Volume publishers to signal restart")
+		select {
+		case change := <-ctx.subGlobalConfig.MsgChan():
+			ctx.subGlobalConfig.ProcessChange(change)
+		case change := <-ctx.subVolumeConfig.MsgChan():
+			ctx.subVolumeConfig.ProcessChange(change)
+		case change := <-ctx.subVolumeStatus.MsgChan():
+			ctx.subVolumeStatus.ProcessChange(change)
+		case <-stillRunning.C:
+		}
+		ps.StillRunning(agentName, warningTime, errorTime)
+	}
+	log.Functionf("Volume publishers restarted")
+
 	// start the forever loop for event handling
 	for {
 		select {
@@ -154,6 +176,12 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 		case change := <-ctx.subContentTreeStatus.MsgChan():
 			ctx.subContentTreeStatus.ProcessChange(change)
+
+		case change := <-ctx.subVolumeConfig.MsgChan():
+			ctx.subVolumeConfig.ProcessChange(change)
+
+		case change := <-ctx.subVolumeStatus.MsgChan():
+			ctx.subVolumeStatus.ProcessChange(change)
 
 		case change := <-ctx.subNodeAgentStatus.MsgChan():
 			ctx.subNodeAgentStatus.ProcessChange(change)
@@ -434,6 +462,24 @@ func initializeZedagentHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
 	}
 	ctx.subBaseOsConfig = subBaseOsConfig
 	subBaseOsConfig.Activate()
+
+	// VolumeConfig and VolumeStatus are read via GetAll() to gate the
+	// EVE-k vs non-EVE-k upgrade block; no per-event handlers needed.
+	subVolumeConfig, err := ps.NewSubscription(
+		pubsub.SubscriptionOptions{
+			AgentName:   "zedagent",
+			MyAgentName: agentName,
+			TopicImpl:   types.VolumeConfig{},
+			Activate:    false,
+			Ctx:         ctx,
+			WarningTime: warningTime,
+			ErrorTime:   errorTime,
+		})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.subVolumeConfig = subVolumeConfig
+	subVolumeConfig.Activate()
 }
 
 func initializeVolumemgrHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
@@ -456,6 +502,22 @@ func initializeVolumemgrHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
 	}
 	ctx.subContentTreeStatus = subContentTreeStatus
 	subContentTreeStatus.Activate()
+
+	subVolumeStatus, err := ps.NewSubscription(
+		pubsub.SubscriptionOptions{
+			AgentName:   "volumemgr",
+			MyAgentName: agentName,
+			TopicImpl:   types.VolumeStatus{},
+			Activate:    false,
+			Ctx:         ctx,
+			WarningTime: warningTime,
+			ErrorTime:   errorTime,
+		})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.subVolumeStatus = subVolumeStatus
+	subVolumeStatus.Activate()
 }
 
 func handleNodeAgentStatusCreate(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -214,20 +214,24 @@ func doBaseOsStatusUpdate(ctx *baseOsMgrContext, uuidStr string,
 
 	// Check to avoid upgrading from not-EVE-k (e.g., kvm) to EVE-k
 	// and vice versa since that can result in odd failures due to
-	// different /persist layout etc.
+	// different /persist layout etc. The block only applies when the
+	// device has volume instances — without them there is no
+	// /persist/vault/volumes/ state to disturb.
 	// TBD Remove this if EVE-k in the future can have kvm personality.
+	hasVolumes := len(ctx.subVolumeConfig.GetAll()) > 0 ||
+		len(ctx.subVolumeStatus.GetAll()) > 0
 	isCurrentKube := base.IsHVTypeKube()
 	isUpdateKube, err := base.IsVersionHVTypeKube(config.BaseOsVersion)
 	if err != nil {
 		log.Warnf("doBaseOsStatusUpdate(%s): %s",
 			config.BaseOsVersion, err)
-	} else if isCurrentKube != isUpdateKube {
+	} else if isCurrentKube != isUpdateKube && hasVolumes {
 		var errString string
 		if isUpdateKube {
-			errString = fmt.Sprintf("Upgrade to EVE-k (%s) from non EVE-k (%s) is not supported",
+			errString = fmt.Sprintf("Upgrade to EVE-k (%s) from non EVE-k (%s) is not supported while volumes exist",
 				config.BaseOsVersion, shortVerCurPart)
 		} else {
-			errString = fmt.Sprintf("Upgrade to non EVE-k (%s) from  EVE-k (%s) is not supported",
+			errString = fmt.Sprintf("Upgrade to non EVE-k (%s) from EVE-k (%s) is not supported while volumes exist",
 				config.BaseOsVersion, shortVerCurPart)
 		}
 		log.Error(errString)

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -200,6 +200,14 @@ func handleVolumeRestart(ctxArg interface{}, restartCount int) {
 		handleDeferredVolumeCreate(ctx, key, config)
 		delete(ctx.volumeConfigCreateDeferredMap, key)
 	}
+	// Signal restart on pubVolumeStatus once zedagent has restarted
+	// pubVolumeConfig at least once. After this, on-disk recovery
+	// (populateExistingVolumesFormat*) plus the controller-intended
+	// set have both been reflected in VolumeStatus, so subscribers
+	// can use Restarted() to gate decisions on volume presence.
+	if err := ctx.pubVolumeStatus.SignalRestarted(); err != nil {
+		log.Errorf("handleVolumeRestart: SignalRestarted failed: %s", err)
+	}
 	log.Tracef("handleVolumeRestart done: %d", restartCount)
 }
 

--- a/pkg/pillar/types/diskmetrics_test.go
+++ b/pkg/pillar/types/diskmetrics_test.go
@@ -34,8 +34,8 @@ func TestDiskMetricLogKey(t *testing.T) {
 // AppDiskMetric.Key / LogKey
 
 func TestAppDiskMetricLogKey(t *testing.T) {
-	m := AppDiskMetric{DiskPath: "/persist/volumes/vol1"}
-	assert.Equal(t, PathToKey("/persist/volumes/vol1"), m.Key())
+	m := AppDiskMetric{DiskPath: "/persist/vault/volumes/vol1"}
+	assert.Equal(t, PathToKey("/persist/vault/volumes/vol1"), m.Key())
 	assert.Contains(t, m.LogKey(), m.Key())
 }
 
@@ -60,7 +60,7 @@ func TestAppDiskMetricLogCreateModifyDelete(t *testing.T) {
 	logger.SetOutput(&buf)
 	logger.SetLevel(logrus.TraceLevel)
 	log := base.NewSourceLogObject(logger, t.Name(), 0) //nolint:staticcheck
-	m := AppDiskMetric{DiskPath: "/persist/volumes/vol1"}
+	m := AppDiskMetric{DiskPath: "/persist/vault/volumes/vol1"}
 	m.LogCreate(log)
 	assert.NotEmpty(t, buf.String())
 	m.LogModify(log, m)


### PR DESCRIPTION
# Description

The cross-flavor BaseOs upgrade between EVE-k and non-EVE-k flavors is
unconditionally rejected by `baseosmgr` with "Upgrade to EVE-k ... is
not supported" (or its inverse). The rationale is that the on-disk
`/persist` layout used by volumes differs across flavors, so existing
volumes can break across the switch. On a device with no volumes there
is nothing to disturb, so the block is overly strict.

This PR gates the check on volume presence:

- `baseosmgr` subscribes to `VolumeConfig` (from zedagent) and
  `VolumeStatus` (from volumemgr). When either set is non-empty, the
  cross-flavor mismatch errors out as before — the error now reads
  `... is not supported while volumes exist`. With both sets empty the
  upgrade proceeds.
- A startup wait in baseosmgr blocks until both publications signal
  restart, so the first `BaseOsConfig` arrival after boot evaluates
  against the true volume set. `Synchronized()` is insufficient — it
  only confirms the socket-level handshake and can fire before zedagent
  has parsed its first `EdgeDevConfig`.
- `volumemgr` now calls `pubVolumeStatus.SignalRestarted()` at the tail
  of `handleVolumeRestart`. After zedagent restarts `pubVolumeConfig`,
  volumemgr has reconciled its on-disk recovery
  (`populateExistingVolumesFormat*`) with the controller-intended set
  into `VolumeStatus`, so subscribers have a `Restarted()` gate to
  reason about.
- Drive-by: `pkg/pillar/types/diskmetrics_test.go` used
  `/persist/volumes/vol1` as a sample `DiskPath`; updated to
  `/persist/vault/volumes/vol1` to match the canonical path
  (`SealedDirName + "/volumes"`).

## How to test and validate this PR

Same-flavor regression (covered by eden):

- `eden test ./tests/update_eve_image -e update_eve_image_oci` — PASS
  locally (12 min).
- `eden test ./tests/update_eve_image -e update_eve_image_http` — PASS
  locally (~10 min).
- Both verify the new baseosmgr startup wait does not block the upgrade
  flow and `BaseOsConfig` is processed across reboots.

Cross-flavor relaxation (manual):

- On a device with no app volumes, push a `BaseOsConfig` pointing at an
  EVE-k image from a running non-EVE-k image (or vice versa). The prior
  behavior errored out; the new behavior allows the upgrade.
- Deploy an app with a volume and retry the cross-flavor upgrade — the
  block returns with the new wording.

## Changelog notes

- 16.0-stable: To be backported.
- 14.5-stable: No, this is a behavior change, not a bug fix.
- 13.4-stable: No, same reason.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — operator-visible change is
      covered by the error-message text
- [x] I've tested my PR on amd64 device — eden update tests on amd64
      qemu
- [ ] I've tested my PR on arm64 device — not tested
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR — leaving to reviewers on
      mark-ready