### PR TITLE
github/workflows: replace zededa-ubuntu-latest runner label

### DIFF
--- a/.github/workflows/buildondemand.yml
+++ b/.github/workflows/buildondemand.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: zededa-ubuntu-latest
+          - os: zededa-ubuntu-2204-arm64
             arch: arm64
           - os: zededa-ubuntu-2204
             arch: amd64
@@ -134,7 +134,7 @@ jobs:
   manifest:
     # Only run for the default branch
     if: github.ref_name == github.event.repository.default_branch
-    runs-on: zededa-ubuntu-latest
+    runs-on: zededa-ubuntu-2204
     needs: packages
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
             arch: arm64
           - os: zededa-ubuntu-2204
             arch: amd64
-          - os: zededa-ubuntu-latest
+          - os: zededa-ubuntu-2204
             arch: riscv64
     steps:
       - name: Starting Report
@@ -108,7 +108,7 @@ jobs:
   eve:
     if: github.event.repository.full_name == 'lf-edge/eve'
     needs: packages
-    runs-on: zededa-ubuntu-latest
+    runs-on: zededa-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:
@@ -142,7 +142,7 @@ jobs:
 
   manifest:
     if: github.event.repository.full_name == 'lf-edge/eve'
-    runs-on: zededa-ubuntu-latest
+    runs-on: zededa-ubuntu-2204
     needs: packages
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2


### PR DESCRIPTION
# Description

The zededa-ubuntu-latest runner label is no longer provisioned in
Zededa's self-hosted runner pool. Workflows still referencing it queue
forever waiting for a matching runner.

Replace the five remaining occurrences in this branch with concrete
labels:
- buildondemand.yml arm64 packages matrix entry now uses
  zededa-ubuntu-2204-arm64 so arm64 builds run natively
- the riscv64 publish matrix entry and the three standalone manifest /
  eve composition jobs use zededa-ubuntu-2204, matching the pattern
  already in place on the master, 14.5-stable and 16.0-stable branches.

## How to test and validate this PR

- Trigger the \`Build On Demand\` workflow on \`13.4-stable\` (or this PR
  branch) and confirm the arm64 matrix entry now picks up a
  \`zededa-ubuntu-2204-arm64\` runner instead of hanging in the queue.
- Wait for the next scheduled or tag-triggered \`publish\` run and
  confirm the \`packages\` (riscv64), \`eve\`, and \`manifest\` jobs all
  schedule onto runners (no \"Waiting for a runner with label
  zededa-ubuntu-latest\" message).
- No code changes are made to EVE itself, so no functional testing on
  amd64 / arm64 devices is required.

## Changelog notes

No user-facing changes.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them. (CI-only change; no device-side behavior to test.)