### PR TITLE
zedrouter: restart dnsmasq when an app leaves to evict its stale lease

### DIFF
--- a/pkg/pillar/nireconciler/genericitems/dnsmasq.go
+++ b/pkg/pillar/nireconciler/genericitems/dnsmasq.go
@@ -393,8 +393,16 @@ func (c *DnsmasqConfigurator) Create(ctx context.Context, item dg.Item) error {
 	return nil
 }
 
-// Modify is able to update DHCP/DNS hosts files and apply the changes simply by sending
-// the SIGHUP signal, i.e. without having to restart the dnsmasq process.
+// Modify applies host-file changes. Pure additions (new app, no app removed
+// and no app re-assigned a different IP) are reloaded with SIGHUP. If any
+// DHCP host disappeared or changed IP we must also evict the matching lease
+// from dnsmasq's in-memory state, otherwise the IP stays reserved for the
+// old MAC and a future app trying to take that IP gets a "not using
+// configured address" fallback. SIGHUP does not reload leases (it only
+// reloads dhcp-host files and updates hostnames on existing leases), and
+// dhcp_release cannot reach our dnsmasq from the host netns (see
+// restartToPruneLeases), so in that case we rewrite the lease file without
+// the stale entries and restart dnsmasq.
 func (c *DnsmasqConfigurator) Modify(ctx context.Context, oldItem, newItem dg.Item) (err error) {
 	oldDnsmasq, isDnsmasq := oldItem.(Dnsmasq)
 	if !isDnsmasq {
@@ -430,8 +438,91 @@ func (c *DnsmasqConfigurator) Modify(ctx context.Context, oldItem, newItem dg.It
 			return err
 		}
 	}
+	if len(obsoleteDHCPHosts) > 0 {
+		return c.restartToPruneLeases(ctx, newDnsmasq, obsoleteDHCPHosts)
+	}
 	pm := c.initProcessManager(newDnsmasq.Name())
 	return pm.SendSignal(syscall.SIGHUP)
+}
+
+// restartToPruneLeases stops dnsmasq, rewrites the lease file with the entries
+// for the supplied (now-obsolete) MACs removed, and starts dnsmasq back up.
+// dhcp_release(8) is not usable here: it only delivers reliably on loopback,
+// and our dnsmasq runs with SO_BINDTODEVICE on the bridge interface (one
+// DHCP interface per NI), so DHCPRELEASE packets do not reach it. A cleaner
+// long-term option would be dnsmasq's DBus DeleteDhcpLease method, but the
+// pillar container has no DBus daemon today; that becomes viable once
+// pillar moves to systemd.
+func (c *DnsmasqConfigurator) restartToPruneLeases(
+	ctx context.Context, dnsmasq Dnsmasq, obsolete []MACToIP) error {
+	done := reconciler.ContinueInBackground(ctx)
+	go func() {
+		if err := c.stopDnsmasq(ctx, dnsmasq.Name()); err != nil {
+			done(err)
+			return
+		}
+		if err := c.pruneDnsmasqLeases(dnsmasq.ListenIf.IfName, obsolete); err != nil {
+			done(err)
+			return
+		}
+		done(c.startDnsmasq(ctx, dnsmasq.Name()))
+	}()
+	return nil
+}
+
+// pruneDnsmasqLeases atomically rewrites the dnsmasq leases file for the given
+// bridge, dropping any line whose MAC matches one of the supplied entries.
+// Must only be called while dnsmasq is stopped, otherwise dnsmasq's open file
+// descriptor would overwrite our cleaned copy on the next lease change.
+//
+// Lease line format (from man dnsmasq):
+//
+//	<expire-time> <mac> <ip> <hostname> <client-id>
+func (c *DnsmasqConfigurator) pruneDnsmasqLeases(
+	bridgeIfName string, obsolete []MACToIP) error {
+	if len(obsolete) == 0 {
+		return nil
+	}
+	leasePath := types.DnsmasqLeaseFilePath(bridgeIfName)
+	content, err := os.ReadFile(leasePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("failed to read lease file %s: %w", leasePath, err)
+	}
+	macsToDrop := make(map[string]struct{}, len(obsolete))
+	for _, h := range obsolete {
+		macsToDrop[strings.ToLower(h.MAC.String())] = struct{}{}
+	}
+	var out bytes.Buffer
+	changed := false
+	for _, line := range strings.Split(string(content), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.SplitN(line, " ", 3)
+		if len(fields) >= 2 {
+			if _, drop := macsToDrop[strings.ToLower(fields[1])]; drop {
+				changed = true
+				continue
+			}
+		}
+		out.WriteString(line)
+		out.WriteByte('\n')
+	}
+	if !changed {
+		return nil
+	}
+	tmpPath := leasePath + ".tmp"
+	if err := os.WriteFile(tmpPath, out.Bytes(), 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, leasePath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("failed to rename %s to %s: %w", tmpPath, leasePath, err)
+	}
+	return nil
 }
 
 // Delete stops dnsmasq.


### PR DESCRIPTION
# Description

Scenario the previous behavior broke on (reproduced by the "userdata" eden test):

  1. App "eclient" is created on a Local NI. zedrouter pre-allocates 10.11.12.2 for the app's MAC and writes a dhcp-host stanza. dnsmasq hands out a lease (mac -> 10.11.12.2) and records it in `/run/zedrouter/dnsmasq.leases/<bridge>`.
  2. App "eclient" is deleted. zedrouter removes the dhcp-host file but dnsmasq keeps the lease line. SIGHUP reloads dhcp-host files and refreshes hostnames on existing leases, but it does not prune the lease database.
  3. App "eclient" is deployed again with a different MAC. zedrouter deterministically re-allocates 10.11.12.2 to the new MAC and installs iptables PORTMAP DNAT rules pointing at 10.11.12.2.
  4. The new app's DHCPDISCOVER reaches dnsmasq, which logs `not using configured address 10.11.12.2 because it is leased to <old MAC>` and gives the app some other IP (e.g. 10.11.12.79). The PORTMAP rules still target 10.11.12.2, so external port-forwarded traffic is black-holed.

Until commit f66d3e894 (`dnsmasq: replace custom eve-dnsmasq image with Alpine package`, 2026-05-15) EVE shipped a custom dnsmasq carrying `pkg/dnsmasq/patches/lease_release.patch`, which pruned the stale lease on the conflict and used the configured IP anyway. Moving to stock Alpine dnsmasq dropped that behavior, hence the regression.

An obvious fix, calling `dhcp_release(8)`, does not work here: dhcp_release only delivers reliably on loopback, and our dnsmasq runs with `SO_BINDTODEVICE` on the bridge (one DHCP interface per NI), so the `DHCPRELEASE` never reaches it. A cleaner long-term option would be dnsmasq's DBus `DeleteDhcpLease` method, but the pillar container has no DBus daemon today; that becomes viable once pillar moves to systemd.

Fix:

`DnsmasqConfigurator.Modify` now detects the case where one or more dhcp-host entries disappeared (or changed IP, covered by the same diff). In that case it:

  * stops dnsmasq,
  * rewrites `/run/zedrouter/dnsmasq.leases/<bridge>` with the lines matching the obsolete MACs filtered out (atomic temp+rename),
  * starts dnsmasq back up so it boots with a clean lease set.

The lease-file edit is only safe while dnsmasq is stopped (otherwise dnsmasq's open fd would overwrite our cleaned copy on the next lease change), so the stop/edit/start happen in that order, in the `ContinueInBackground` worker so the reconciler isn't blocked.

Pure additions (new app, no host removed) keep the existing SIGHUP path, so spinning up an app does not interrupt DHCP service for any other app on the same NI. Only the delete/rename case pays the brief per-NI dnsmasq bounce.

## How to test and validate this PR

1. Create a Local Network Instance.
2. Deploy an application on that Network Instance that listens on a specific port (for example, SSH on port 22). Configure a PORTMAP ACL rule to forward a host port (for example, 2222) to the application's listening port. Wait for the application to reach the **RUNNING** state and verify connectivity through the forwarded host port.
3. Delete the application and wait until it has been completely removed.
4. Immediately after, redeploy the same application on the same Network Instance using the same PORTMAP ACL rule. Wait for the application to reach the **RUNNING** state again.
5. Verify that connectivity through the forwarded host port is restored and functioning correctly.

Before this fix, step 5 fails: dnsmasq assigns the redeployed app a different IP because the stale lease from step 2 is still present, the PORTMAP DNAT rule targets the original IP, and the port-forwarded connection times out. You can confirm the bug by running `cat /run/zedrouter/dnsmasq.leases/bn1` on the device and checking whether a line for the deleted app's MAC is still there after step 3.

After this fix, the stale lease is pruned when the app is deleted, dnsmasq assigns the expected IP to the redeployed app, and connectivity is restored.

## Changelog notes

Fixed a regression (introduced in f66d3e894, 2026-05-15) where redeploying an app on a Local NI could silently assign it a different IP than expected, breaking PORTMAP port-forwarding rules.

## PR Backports

- 17.0-stable: At the time of the PR merge, master is still considered to be 17.0 and rc2 will therefore include this fix, without the need to backport anything anywhere.
- 16.0-stable: No, it does not have this regression
- 14.5-stable: No, it does not have this regression
- 13.4-stable: No, it does not have this regression

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
