### PR TITLE
mgmtproxy: cost-aware CONNECT kube proxy for containerd & kubectl image/manifest

### DIFF
--- a/docs/EVE-K-COST-AWARE-CONTAINERD.md
+++ b/docs/EVE-K-COST-AWARE-CONTAINERD.md
@@ -1,0 +1,254 @@
+# Cost-Aware Kubernetes / containerd Downloads
+
+When EVE is built for Kubernetes (`HV=k`), several downloads happen outside
+pillar's own downloader: the kube containerd pulls pod and system images, the
+k3s installer fetches the k3s script and binary, and `kubectl apply -f
+https://...` fetches component manifests. This document describes how EVE makes
+those downloads honor the `network.download.max.cost` configuration through the
+`mgmtproxy` pillar agent.
+
+The `mgmtproxy` agent only exists in `HV=k` builds; on KVM/Xen builds it is a
+no-op stub. Everything described here applies to Kubernetes-driven downloads
+only.
+
+## Overview
+
+`network.download.max.cost` controls which network uplinks EVE uses for
+downloads. Pillar's built-in downloader already honors it: it iterates
+management ports in ascending cost order, binds the outbound socket to each
+port's source IP, and uses the first port that provides working connectivity to
+the destination.
+
+The downloads listed above run in the host network namespace and use the
+kernel's `table main` directly, so they do not participate in that per-port
+selection. When the lowest-cost gateway is unreachable, `table main`'s default
+route still points at it, and these downloads time out with no automatic
+fallback to a healthy higher-cost uplink.
+
+`mgmtproxy` closes that gap. It runs an HTTP CONNECT forward proxy on
+`127.0.0.1:5443`, reusing the same source-IP-binding primitives as pillar's
+downloader, and `HTTPS_PROXY` is injected into the affected subprocesses so
+their HTTPS connections tunnel through it.
+
+## Architecture
+
+```text
+┌──────────────────── pillar (starts before containerd) ───────────────┐
+│                                                                      │
+│  nim ────publishes──► DeviceNetworkStatus                            │
+│                              │                                       │
+│  zedagent ──publishes──► ConfigItemValueMap                          │
+│                              │  (network.download.max.cost)          │
+│  mgmtproxy ◄──subscribes─────┘                                       │
+│     │  127.0.0.1:5443                                                │
+│     └──publishes──► MetricsMap ──► edgeview url                      │
+└──────────────────────────────┬───────────────────────────────────────┘
+                               │ CONNECT registry:443
+                               │
+      ┌────────────────────────┼──────────────────────────────────────┐
+      │ HTTPS_PROXY injected   │                                      │
+      │ at four places:        │                                      │
+      │                        │                                      │
+      ▼                        ▼                                      ▼
+kube containerd       k3s installer + curl                  kubectl subprocess
+(check_start_         (cluster-update.sh)                   (shell mgmtproxy_run
+ containerd)                                                 + Go cmd.Env)
+      │                        │                                      │
+      └────────────────────────┴──────────────────────┬───────────────┘
+                                                      │
+                                            mgmtproxy dials outbound:
+                                                      │
+                        ┌─────────────────────────────┴──────────┐
+                        │                                        │
+                  1. eth0 (cost=0)                        2. eth1 (cost=1)
+                  bind src=192.168.1.89                   bind src=10.0.0.5
+                  ip rule → table-eth0                    ip rule → table-eth1
+                  table-eth0: via gw-eth0 ✗               table-eth1: via gw-eth1 ✓
+                  (dial timeout → skip)                          │
+                                                                 │ TCP tunnel
+                                                                 ▼
+                                                       registry-1.docker.io:443
+                                                       (or github.com:443,
+                                                        raw.githubusercontent.com:443)
+```
+
+Binding the outbound socket to a port's source IP sends the packet through that
+port's per-port routing table, bypassing `table main` entirely — so a dead
+cost-0 gateway in `table main` never pins the connection to a broken uplink.
+
+## How cost-aware routing works
+
+NIM maintains one routing table per management port (kernel table index
+`DPCBaseRTIndex + ifIndex`). For each port source IP it installs an IP rule:
+
+```text
+from <srcIP> lookup table-<port>
+```
+
+Each per-port table carries that port's own default route via its own gateway,
+independent of `table main`. When a process binds its outbound socket to a
+port's source IP, the packet is routed through that port's table — not `table
+main`.
+
+EVE's model is to select, per connection, the cheapest interface that provides
+**working connectivity to the given destination** — it is not a single default
+route shared by all traffic. Pillar's downloader implements this by trying each
+port in cost order and binding to its source IP, treating an actual connection
+attempt as the reachability signal. `mgmtproxy` exposes the same mechanism to
+containerd and to kubectl-spawned HTTP clients via the standard `HTTPS_PROXY`
+environment variable.
+
+## The two containerd processes
+
+An `HV=k` device runs two distinct containerd instances:
+
+- **Pillar containerd** — runs inside the pillar container, used by pillar's own
+  image management. It is already cost-aware via pillar's downloader
+  (`controllerconn/send.go`) and is not involved here.
+- **Kube containerd** — a standalone process launched by `cluster-init.sh`
+  (`check_start_containerd`), used by k3s/Kubernetes to pull pod images, system
+  component images (CoreDNS, Longhorn, KubeVirt, Multus, pause), and user
+  application images. It uses `table main` directly.
+
+The k3s server process (kubelet, apiserver, controller-manager, scheduler) is
+separate from the kube containerd. `HTTPS_PROXY` is scoped to the kube
+containerd process only — exporting it to the k3s server would route
+in-cluster HTTPS through the proxy and break the cluster.
+
+## How mgmtproxy works
+
+- **Listeners.** `127.0.0.1:5443` (`ListenAddr`) serves host processes (kube
+  containerd, k3s installer curl, kubectl subprocesses). On KubeVirt-enabled
+  nodes a second listener on `169.254.100.1:5443` (`CNI0ListenAddr`, the cni0
+  link-local anchor IP) serves CDI importer pods, which run in the pod network
+  and cannot reach loopback. Both bind to specific internal IPs, never
+  `0.0.0.0`.
+- **CONNECT only.** `GET /healthz` returns a JSON state snapshot; anything else
+  is rejected. Plain-HTTP forwarding is not implemented — every relevant target
+  (registries, `get.k3s.io`, GitHub) is HTTPS.
+- **Subscriptions.** `DeviceNetworkStatus` from nim (port enumeration, costs,
+  source IPs, failure flags) and `ConfigItemValueMap` from zedagent
+  (`network.download.max.cost`). The per-attempt dial timeout is taken from the
+  existing `timer.dial.timeout` config item.
+- **Per CONNECT request.** It calls `GetMgmtPortsSortedCostWithoutFailed`,
+  filters out ports above the configured max cost, and tries each port's
+  non-link-local source IP in turn, binding the outbound socket to it. Selection
+  round-robins within a cost tier (the rotation argument) so load is shared
+  across same-cost ports. The first port that connects wins.
+- **Metrics.** It publishes a `MetricsMap` with per-interface, per-target byte
+  counters, visible in `edgeview url` and queryable via `pub/mgmtproxy`.
+- **Resilience.** A failed `listen` (port conflict) is logged and retried rather
+  than crashing pillar.
+
+## Where HTTPS_PROXY is injected
+
+| Egress path | Mechanism | Cost-aware? |
+| --- | --- | --- |
+| k3s installer script + binary download | curl + spawned installer in `cluster-update.sh` | Yes — `HTTPS_PROXY` exported on both |
+| Pod / system images (pause, CoreDNS, Longhorn, KubeVirt, Multus, app images) | kube containerd CRI | Yes — `HTTPS_PROXY` on containerd |
+| External boot image import | `k3s ctr image import` → containerd socket | Yes — covered by containerd's env |
+| KubeVirt CR install | `kubectl apply -f https://...` via `mgmtproxy_run` | Yes |
+| CDI install / uninstall | `kubectl create/delete -f https://...` via `mgmtproxy_run` | Yes |
+| Longhorn uninstall | `kubectl create/delete -f https://...` via `mgmtproxy_run` | Yes |
+| Dynamic component upgrade | Go `KubectlApply` in `update-component`, injects `cmd.Env` for HTTPS paths | Yes |
+| CDI importer pods (`source.http.url` DataVolumes) | CDI CR `importProxy.HTTPSProxy` → cni0 listener | Yes |
+| KubeVirt launcher image | bundled in kube package, `PullNever` | n/a — never pulled at runtime |
+| VM disk images | pillar downloader → PVC | already cost-aware |
+
+Not covered, by design:
+
+- **Pillar containerd** — already cost-aware.
+- **Plain-HTTP targets** — `HTTP_PROXY` is not injected; all relevant targets
+  are HTTPS.
+- **Host-netns traffic outside the inventoried paths** — interactive shell
+  sessions (`eve enter kube`), arbitrary host scripts, k8s components inside the
+  k3s server process.
+- **Local-file kubectl applies** — no external HTTP call; resulting image pulls
+  go through containerd, which is covered.
+- **Build-time downloads** — happen on the build machine, not the edge node.
+
+## HTTPS_PROXY is per-process
+
+The proxy env is injected onto specific subprocesses, never globally. This is
+load-bearing for cluster correctness:
+
+| Command | Through mgmtproxy? |
+| --- | --- |
+| `curl https://registry-1.docker.io/v2/` | No — direct via `table main` |
+| `curl --proxy http://127.0.0.1:5443 https://registry-1.docker.io/v2/` | Yes |
+| `crictl pull <image>` | Yes — real containerd path |
+| `kubectl apply -f https://.../foo.yaml` (bare from shell) | No — direct via `table main` |
+| `mgmtproxy_run kubectl apply -f https://...` (after sourcing `cluster-utils.sh`) | Yes |
+
+- `cluster-init.sh:check_start_containerd` prepends `HTTPS_PROXY=...` inline on
+  the `nohup containerd ...` command, so only the standalone containerd process
+  gets it. The k3s server process does not.
+- `cluster-update.sh` prepends it on the `curl https://get.k3s.io` and the
+  spawned installer subprocess.
+- `cluster-utils.sh:mgmtproxy_run` prepends it on whichever command is passed to
+  it. Local-file kubectl calls are not wrapped.
+- `update-component/upgrades.go:KubectlApply` sets `cmd.Env` on the kubectl
+  subprocess only when the path is an HTTPS URL and the off-switch is absent.
+
+`NO_PROXY` assembled at injection time covers loopback, the k3s pod and service
+CIDRs, link-local (including the metadata server at `169.254.169.254`), the k8s
+DNS suffixes, and the cluster node IP, so in-cluster and local traffic never
+goes through the proxy.
+
+## Off-switch
+
+Creating `/run/kube/mgmtproxy-disable` makes both the shell `mgmtproxy_run`
+helper and the Go `KubectlApply` run wrapped commands directly, without
+`HTTPS_PROXY`. For containerd, `killall containerd` causes `cluster-init.sh` to
+relaunch it without the proxy env. Useful for isolating whether mgmtproxy is the
+cause of a download failure. Remove the flag (and restart containerd if killed)
+to re-enable.
+
+## Observability
+
+- **Pillar logs.** One line per CONNECT at default level, e.g.
+  `mgmtproxy: CONNECT registry-1.docker.io:443 via eth0 src 192.0.2.5 cost 0 (dial 12ms, 0 fallback(s))`.
+  `N fallback(s)` reports how many ports were tried and failed before the
+  winning one — automatic recovery without operator action.
+- **Caller-side audit trail.** Each wrapped fetch logs a `mgmtproxy_run: ...` or
+  `KubectlApply: ...` line in the kube install / upgrade logs that pairs with the
+  pillar-side CONNECT entry.
+- **`edgeview url`.** Shows a `mgmtproxy stats` block with per-target Recv/Sent
+  bytes, connection counts, and total time.
+- **`/healthz`.** `curl -s http://127.0.0.1:5443/healthz | jq` returns listening
+  status, readiness, max port cost, per-port cost/error/addresses, counters, and
+  the last success/error with timestamps.
+- **Sentinel file.** `/run/mgmtproxy-containerd-env` records the exact env
+  containerd was launched with. It is more reliable than `/proc/<pid>/environ`
+  because containerd unsets `HTTPS_PROXY` from its own process env shortly after
+  reading it.
+
+The agent's package README (`pkg/pillar/cmd/mgmtproxy/README.md`) carries the
+full debugging workflow and developer-facing implementation detail.
+
+## Known limitations
+
+- **Stale `NO_PROXY` on node-IP change.** If the cluster node IP changes after
+  containerd starts, `NO_PROXY` is stale until containerd restarts. The wide
+  CIDRs absorb most cases.
+- **CONNECT only.** Plain-HTTP is not proxied.
+- **IPv6.** Inherits `controllerconn`'s IPv4-centric mgmt-port iteration;
+  IPv6-only registries would bypass cost gating.
+- **Half-broken upstream.** A port that accepts the connection but blackholes
+  payload causes a few minutes of `ImagePullBackOff` retries before NIM's
+  failure flag skips it. Self-healing without operator action.
+
+## Underlying gap and follow-up
+
+EVE already selects, per connection, the cheapest interface with working
+connectivity to a given destination — pillar's downloader and `mgmtproxy` both
+work this way. The gap that `mgmtproxy` addresses is narrower: host-namespace
+traffic that uses `table main` (the kube containerd and kubectl URL fetches)
+does not participate in that per-destination selection, because `table main`
+carries a single default route the kernel follows regardless of whether the
+destination is actually reachable through it.
+
+`mgmtproxy` closes the gap for the inventoried containerd and kubectl paths. A
+broader follow-up could extend per-destination, cost-aware selection to all
+host-namespace outbound traffic so that paths outside this inventory benefit
+automatically.

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -160,6 +160,7 @@ for further directions.
 - [Access-control for applications](NETWORK-ACLS.md)
 - [Wireless connectivity](WIRELESS.md)
 - [Metadata (incl. network info) exposed to applications](ECO-METADATA.md)
+- [Cost-aware Kubernetes/containerd downloads (HV=k)](EVE-K-COST-AWARE-CONTAINERD.md)
 - Developer's deep-dive into EVE networking-related microservices:
   - [NIM](../pkg/pillar/docs/nim.md)
   - [zedrouter](../pkg/pillar/docs/zedrouter.md)

--- a/pkg/edgeview/src/basics.go
+++ b/pkg/edgeview/src/basics.go
@@ -85,6 +85,7 @@ func initOpts() {
 		"edgeview",
 		"global",
 		"loguploader",
+		"mgmtproxy",
 		"msrv",
 		"newlogd",
 		"nim",

--- a/pkg/edgeview/src/network.go
+++ b/pkg/edgeview/src/network.go
@@ -405,6 +405,9 @@ func getURL() {
 	getMetricsMap("/run/zedrouter/MetricsMap/", &totalStats, true)
 	getMetricsMap("/run/nim/MetricsMap/", &totalStats, true)
 	getMetricsMap("/run/diag/MetricsMap/", &totalStats, true)
+	// mgmtproxy is the cost-aware HTTP CONNECT proxy used by EVE-K's
+	// containerd and the k3s installer. Stats only present on EVE-K.
+	getMetricsMap("/run/mgmtproxy/MetricsMap/", &totalStats, true)
 
 	printTitle(" - Total Send/Receive stats:\n", colorCYAN, false)
 	fmt.Printf("  send bytes %d, recv bytes %d, send messages %d\n",

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC3043  # 'local' is non-POSIX but supported by busybox ash, EVE's /bin/sh
 #
 # Copyright (c) 2023-2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
@@ -487,9 +488,40 @@ check_start_containerd() {
         pgrep -f "/var/lib/rancher/k3s/data/current/bin/containerd" > /dev/null 2>&1
         if [ $? -eq 1 ]; then
                 mkdir -p /run/containerd-user
-                nohup /var/lib/rancher/k3s/data/current/bin/containerd --config /etc/containerd/config-k3s.toml >> $CTRD_LOG 2>&1 &
-                containerd_pid=$!
-                logmsg "Started k3s-containerd at pid:$containerd_pid"
+                # Route containerd image pulls through pillar's cost-aware
+                # mgmtproxy. Env is scoped to this command only so the k3s
+                # server, kubelet, apiserver, etc. (launched separately in
+                # check_start_k3s) are not affected — only outbound CRI pulls.
+                # The off-switch flag (see cluster-utils.sh) lets operators
+                # disable proxy injection for live triage without a code edit.
+                if mgmtproxy_enabled; then
+                        ctrd_no_proxy="$(mgmtproxy_no_proxy)"
+                        HTTPS_PROXY="$MGMTPROXY_URL" NO_PROXY="$ctrd_no_proxy" \
+                        nohup /var/lib/rancher/k3s/data/current/bin/containerd --config /etc/containerd/config-k3s.toml >> $CTRD_LOG 2>&1 &
+                        containerd_pid=$!
+                        # Record exactly what env this launch passed to containerd.
+                        # /proc/$containerd_pid/environ won't show HTTPS_PROXY for
+                        # long: containerd's Go runtime calls os.Unsetenv("HTTPS_PROXY")
+                        # at startup after reading it for the CRI image-pull client.
+                        # This sentinel file gives operators a stable, post-hoc view.
+                        {
+                                echo "pid=$containerd_pid"
+                                echo "started=$(date -Iseconds)"
+                                echo "HTTPS_PROXY=$MGMTPROXY_URL"
+                                echo "NO_PROXY=$ctrd_no_proxy"
+                        } > /run/mgmtproxy-containerd-env
+                        logmsg "Started k3s-containerd at pid:$containerd_pid HTTPS_PROXY=$MGMTPROXY_URL NO_PROXY=$ctrd_no_proxy"
+                else
+                        nohup /var/lib/rancher/k3s/data/current/bin/containerd --config /etc/containerd/config-k3s.toml >> $CTRD_LOG 2>&1 &
+                        containerd_pid=$!
+                        {
+                                echo "pid=$containerd_pid"
+                                echo "started=$(date -Iseconds)"
+                                echo "HTTPS_PROXY=(disabled — flag $MGMTPROXY_DISABLE_FLAG present)"
+                                echo "NO_PROXY=(none)"
+                        } > /run/mgmtproxy-containerd-env
+                        logmsg "Started k3s-containerd at pid:$containerd_pid (mgmtproxy disabled via $MGMTPROXY_DISABLE_FLAG)"
+                fi
         fi
 }
 
@@ -1326,6 +1358,38 @@ else # a restart case, found all_components_initialized
   fi
 fi
 
+# setup_cni0_proxy_ip: assign the mgmtproxy link-local anchor IP to cni0 so
+# CDI importer pods can reach the local mgmtproxy via HTTPS_PROXY. Returns 1
+# if cni0 does not exist yet (flannel creates it after k3s starts and the
+# first pod is scheduled). Idempotent — safe to call on every boot and on
+# every main-loop iteration for flannel-restart recovery.
+# Only called when install_kubevirt=1 (not in base-k3s-mode, not on arm64).
+setup_cni0_proxy_ip() {
+        local anchor="${MGMTPROXY_CNI0_IP}/32"
+        if ! ip link show cni0 > /dev/null 2>&1; then
+                return 1
+        fi
+        if ip addr show dev cni0 | grep -q "${MGMTPROXY_CNI0_IP}"; then
+                return 0
+        fi
+        ip addr add "${anchor}" dev cni0
+        logmsg "setup_cni0_proxy_ip: assigned ${anchor} to cni0"
+}
+
+# patch_cdi_proxy_config: patch the CDI CR so importer pods (created when a
+# Rancher/Helm chart DataVolumeTemplate uses source.http.url or
+# source.registry.url) receive HTTPS_PROXY=MGMTPROXY_CNI0_URL. Only importer
+# pods are affected; uploader pods (used by virtctl image-upload / source.upload
+# in the EVE-managed app path) do not receive this env. Idempotent.
+patch_cdi_proxy_config() {
+        local proxy_url="${MGMTPROXY_CNI0_URL}"
+        # noProxy is a comma-separated string per the CDI ImportProxy API
+        local no_proxy="10.42.0.0/16,10.43.0.0/16,127.0.0.0/8,localhost,.svc,.cluster.local,169.254.0.0/16"
+        logmsg "patch_cdi_proxy_config: HTTPSProxy=${proxy_url}"
+        kubectl patch cdi cdi --type merge -p \
+                "{\"spec\":{\"config\":{\"importProxy\":{\"HTTPSProxy\":\"${proxy_url}\",\"noProxy\":\"${no_proxy}\"}}}}"
+}
+
 # Stagger cluster node starts to avoid etcd quorum races on simultaneous reboot
 staggered_cluster_startup_delay
 
@@ -1455,11 +1519,18 @@ if [ ! -f /var/lib/all_components_initialized ]; then
 
         if [ "$install_kubevirt" = "1" ]; then
                 if [ ! -f /var/lib/kubevirt_initialized ]; then
+                        # Assign the cni0 link-local proxy anchor before CDI
+                        # installs so the mgmtproxy cni0 listener is ready
+                        # before any importer pod can be created.
+                        while ! setup_cni0_proxy_ip; do
+                                sleep 5
+                        done
                         wait_for_item "kubevirt"
                         Kubevirt_install
 
                         wait_for_item "cdi"
                         Cdi_install
+                        patch_cdi_proxy_config
 
                         touch /var/lib/kubevirt_initialized
                         continue
@@ -1671,6 +1742,19 @@ fi
         check_kubeconfig_yaml_files
         check_and_remove_excessive_k3s_logs
         check_kubevip_lb
+        # Reapply cni0 proxy anchor in case flannel restarted and recreated
+        # cni0 without the link-local IP. No-op if already present or if cni0
+        # does not exist (returns 1 silently). Not gated on kubevirt_initialized
+        # so it also recovers after a flannel restart mid-install.
+        if [ "$install_kubevirt" = "1" ]; then
+                setup_cni0_proxy_ip
+                # Re-patch CDI proxy config on every boot in case the CDI CR
+                # was reset by an upgrade or the device was initialized before
+                # this feature was deployed (kubevirt_initialized already set).
+                if [ -f /var/lib/kubevirt_initialized ]; then
+                        patch_cdi_proxy_config
+                fi
+        fi
         wait_for_item "wait"
         sleep 15
 done

--- a/pkg/kube/cluster-update.sh
+++ b/pkg/kube/cluster-update.sh
@@ -69,11 +69,26 @@ update_k3s() {
     logmsg "Installing K3S version $dst_k3s_version"
     mkdir -p /var/lib/k3s/bin
     k3s_installer=/tmp/k3s-install.sh
+    # Route k3s installer + the binary download it spawns through pillar's
+    # cost-aware mgmtproxy so they honor network.download.max.cost. The
+    # installer subprocess inherits these env vars. Honors the off-switch
+    # flag for live operator triage.
+    if mgmtproxy_enabled; then
+        k3s_https_proxy="$MGMTPROXY_URL"
+        k3s_no_proxy="$(mgmtproxy_no_proxy)"
+        logmsg "k3s installer using mgmtproxy: HTTPS_PROXY=$k3s_https_proxy NO_PROXY=$k3s_no_proxy"
+    else
+        k3s_https_proxy=""
+        k3s_no_proxy=""
+        logmsg "k3s installer running without mgmtproxy (disabled via $MGMTPROXY_DISABLE_FLAG)"
+    fi
+    HTTPS_PROXY="$k3s_https_proxy" NO_PROXY="$k3s_no_proxy" \
     /usr/bin/curl -sfL https://get.k3s.io -o "$k3s_installer" || {
         logmsg "k3s installer download failed $?"
         return 1
     }
     chmod +x "$k3s_installer"
+    HTTPS_PROXY="$k3s_https_proxy" NO_PROXY="$k3s_no_proxy" \
     INSTALL_K3S_VERSION=${dst_k3s_version} INSTALL_K3S_SKIP_ENABLE=true INSTALL_K3S_SKIP_START=true INSTALL_K3S_BIN_DIR=/var/lib/k3s/bin "$k3s_installer" || {
         logmsg "k3s installer failed $?"
         return 1

--- a/pkg/kube/cluster-utils.sh
+++ b/pkg/kube/cluster-utils.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC3043  # 'local' is non-POSIX but supported by busybox ash, EVE's /bin/sh
 #
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
@@ -50,6 +51,93 @@ logmsg() {
         echo "$TIME : $MSG"  >> "$INSTALL_LOG"
 }
 
+# mgmtproxy is pillar's cost-aware HTTP CONNECT proxy on the host loopback.
+# Containerd and the k3s installer reach it via HTTPS_PROXY so their outbound
+# pulls honor network.download.max.cost. See pkg/pillar/cmd/mgmtproxy/README.md.
+# CONNECT-only — only HTTPS_PROXY is injected; HTTP_PROXY is intentionally not set.
+#
+# IMPORTANT: HTTPS_PROXY must be injected per-command, NOT exported globally.
+# A global export would catch the k3s server process (kubelet, apiserver,
+# controller-manager, scheduler) and route intra-cluster HTTPS through the
+# proxy, which would break the cluster. Always prepend the env vars on the
+# specific containerd or curl command line, like the existing call sites do.
+# Operators in `eve enter kube` will NOT inherit HTTPS_PROXY for the same
+# reason — see the README's "How HTTPS_PROXY is scoped" section.
+MGMTPROXY_URL="http://127.0.0.1:5443"
+
+# Operator off-switch: if this file exists, cluster-init.sh skips proxy env
+# injection. Use for live triage when you suspect mgmtproxy is the issue:
+#   touch /run/kube/mgmtproxy-disable && killall containerd
+# Then containerd auto-restarts (via check_start_containerd in the main loop)
+# without HTTPS_PROXY set. Remove the file to re-enable.
+MGMTPROXY_DISABLE_FLAG="/run/kube/mgmtproxy-disable"
+
+# Well-known link-local IP assigned to cni0 on every kubevirt-enabled node.
+# CDI importer pods (created when a Rancher/Helm chart DataVolumeTemplate uses
+# source.http.url) send HTTPS_PROXY connections here to reach the local
+# mgmtproxy. Link-local addresses are not routed by flannel across nodes, so
+# each pod always hits its own node's cni0 and its own node's mgmtproxy.
+# Only used when install_kubevirt=1. Must match mgmtproxy.go:CNI0ListenAddr.
+MGMTPROXY_CNI0_IP="169.254.100.1"
+# shellcheck disable=SC2034  # used in sourced cluster-init.sh
+MGMTPROXY_CNI0_URL="http://${MGMTPROXY_CNI0_IP}:5443"
+
+# mgmtproxy_enabled: returns 0 if the proxy env should be injected, 1 if not.
+mgmtproxy_enabled() {
+        if [ -f "$MGMTPROXY_DISABLE_FLAG" ]; then
+                return 1
+        fi
+        return 0
+}
+
+# mgmtproxy_no_proxy: emit the NO_PROXY value used alongside HTTPS_PROXY.
+# Covers loopback, link-local, k3s default service/pod CIDRs, and cluster DNS
+# suffixes. The k3s service and pod CIDRs are k3s defaults (10.42.0.0/16 and
+# 10.43.0.0/16); pkg/kube/config.yaml does not override them.
+# When the cluster node IP is known, the full ClusterIPPrefix subnet is added
+# so that inter-node traffic in multi-node clusters (e.g. worker kubectl
+# talking to the control-plane cluster IP in kubeconfig) bypasses the proxy.
+# ClusterIPPrefix is user-configured, so the subnet is read dynamically via
+# get_cluster_prefix_len rather than hardcoded. The function is only available
+# after cluster-init.sh has sourced it; the type guard falls back to the bare
+# IP if it is not yet defined.
+mgmtproxy_no_proxy() {
+        local extra=""
+        if [ -n "${cluster_node_ip:-}" ]; then
+                local prefixlen=""
+                if type get_cluster_prefix_len > /dev/null 2>&1; then
+                        prefixlen=$(get_cluster_prefix_len 2>/dev/null)
+                fi
+                if [ -n "$prefixlen" ]; then
+                        extra=",${cluster_node_ip}${prefixlen}"
+                else
+                        extra=",${cluster_node_ip}"
+                fi
+        fi
+        echo "127.0.0.0/8,10.42.0.0/16,10.43.0.0/16,169.254.0.0/16,localhost,.svc,.cluster.local${extra}"
+}
+
+# mgmtproxy_run: run a command with HTTPS_PROXY/NO_PROXY env injected if
+# mgmtproxy is enabled, otherwise run unchanged. Use this for any command that
+# fetches an external HTTPS URL (kubectl apply -f https://..., etc.). Do NOT
+# use it for kubectl calls that only talk to the local apiserver — they don't
+# need the env, and adding it just adds log noise.
+#
+# Logs a single logmsg line per invocation so an operator reading the kube
+# install log can see exactly which command was routed through the proxy
+# (and which were bypassed via the off-switch). Cross-reference these with
+# pillar's "mgmtproxy: CONNECT <target> via <ifName> ..." entries to confirm
+# end-to-end the call hit the proxy and chose the expected uplink.
+mgmtproxy_run() {
+        if mgmtproxy_enabled; then
+                logmsg "mgmtproxy_run: routing through proxy ($MGMTPROXY_URL): $*"
+                HTTPS_PROXY="$MGMTPROXY_URL" NO_PROXY="$(mgmtproxy_no_proxy)" "$@"
+        else
+                logmsg "mgmtproxy_run: bypassing proxy (disabled via $MGMTPROXY_DISABLE_FLAG): $*"
+                "$@"
+        fi
+}
+
 check_network_connection () {
         # Address the case where device is installed and moved to a location with no internet access"
         # If we already installed all the components, no internet access is not an issue.
@@ -59,7 +147,12 @@ check_network_connection () {
         fi
 
         while true; do
-                ret=$(curl -o /dev/null -w "%{http_code}" -s "https://get.k3s.io")
+                if mgmtproxy_enabled; then
+                        ret=$(HTTPS_PROXY="$MGMTPROXY_URL" NO_PROXY="$(mgmtproxy_no_proxy)" \
+                                curl -o /dev/null -w "%{http_code}" -s "https://get.k3s.io")
+                else
+                        ret=$(curl -o /dev/null -w "%{http_code}" -s "https://get.k3s.io")
+                fi
                 if [ "$ret" -eq 200 ]; then
                         logmsg "Network is ready."
                         break;

--- a/pkg/kube/kubevirt-utils.sh
+++ b/pkg/kube/kubevirt-utils.sh
@@ -12,7 +12,7 @@ Kubevirt_install() {
     # so we download kubevirt-operator.yaml and patch it
     logmsg "Installing patched Kubevirt"
     kubectl apply -f /etc/kubevirt-operator.yaml
-    kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
+    mgmtproxy_run kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
     Kubevirt_config 3
     #Add kubevirt feature gates
     kubectl apply -f /etc/kubevirt-features.yaml
@@ -77,15 +77,15 @@ Kubevirt_uninstall() {
 Cdi_install() {
     #CDI (containerzed data importer) is need to convert qcow2/raw formats to Persistent Volumes and Data volumes
     logmsg "Installing CDI version $CDI_VERSION"
-    kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
-    kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
+    mgmtproxy_run kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
+    mgmtproxy_run kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
 }
 
 Cdi_uninstall() {
     #CDI (containerzed data importer) is need to convert qcow2/raw formats to Persistent Volumes and Data volumes
     logmsg "Removing CDI version $CDI_VERSION"
-    kubectl delete -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
-    kubectl delete -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
+    mgmtproxy_run kubectl delete -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
+    mgmtproxy_run kubectl delete -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
 }
 
 Cdi_config() {

--- a/pkg/kube/longhorn-utils.sh
+++ b/pkg/kube/longhorn-utils.sh
@@ -35,7 +35,7 @@ Longhorn_uninstall() {
     done
     logmsg "longhorn_uninstall: set uninstall setting"
 
-    while ! kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/uninstall/uninstall.yaml; do
+    while ! mgmtproxy_run kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/uninstall/uninstall.yaml; do
         sleep 5
     done
     logmsg "longhorn_uninstall job wait begun"
@@ -54,10 +54,10 @@ Longhorn_uninstall() {
     logmsg "longhorn_uninstall job wait stopped"
 
     # Can return failure for non-fatal conditions
-    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/deploy/longhorn.yaml
+    mgmtproxy_run kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/deploy/longhorn.yaml
     logmsg "longhorn_uninstall deploy deleted"
 
-    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/uninstall/uninstall.yaml
+    mgmtproxy_run kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/uninstall/uninstall.yaml
     logmsg "longhorn_uninstall job deletion"
 
     lhScs=$(kubectl get sc -o jsonpath='{range .items[?(@.provisioner=="driver.longhorn.io")]}{.metadata.name}{" "}{end}')

--- a/pkg/kube/update-component/upgrades.go
+++ b/pkg/kube/update-component/upgrades.go
@@ -49,10 +49,25 @@ const (
 	logMaxSize    = 10  // 10 Mbytes in size
 	logMaxBackups = 3   // old log files to retain
 	logMaxAge     = 365 // days to retain old log files
+
+	// Keep these in sync with pkg/kube/cluster-utils.sh: MGMTPROXY_URL,
+	// MGMTPROXY_DISABLE_FLAG, and the body of mgmtproxy_no_proxy().
+	// KubectlApply uses them when fetching upgrade YAMLs from external HTTPS
+	// URLs so the dynamic upgrade path honors network.download.max.cost via
+	// pillar's mgmtproxy. Local-file applies are not routed through the
+	// proxy.
+	// The ClusterIPPrefix subnet appended dynamically by the shell helper is
+	// omitted here: update-component only talks to the local apiserver via
+	// kubeconfig (127.0.0.1, already covered by 127.0.0.0/8), and the HTTPS
+	// URL fetch is the only external traffic that matters for this binary.
+	mgmtproxyURL         = "http://127.0.0.1:5443"
+	mgmtproxyDisableFlag = "/run/kube/mgmtproxy-disable"
+	mgmtproxyNoProxy     = "127.0.0.0/8,10.42.0.0/16,10.43.0.0/16,169.254.0.0/16,localhost,.svc,.cluster.local"
 )
 
 var (
-	ForceUpgrade = false // ForceUpgrade : Ignore component version constraints and request upgrade
+	// ForceUpgrade ignores component version constraints and requests upgrade.
+	ForceUpgrade = false
 	logFile      *lumberjack.Logger
 )
 
@@ -86,8 +101,44 @@ type commonComponent struct {
 	cs *kubernetes.Clientset
 }
 
+// isHTTPSURL reports whether path is an https URL kubectl will fetch over the
+// network rather than a local filesystem path. Used to decide whether the
+// kubectl subprocess needs HTTPS_PROXY for cost-aware routing. Only https is
+// matched: Go's http client consults HTTPS_PROXY exclusively for https
+// requests, and the proxy is CONNECT/https-only by design.
+func isHTTPSURL(path string) bool {
+	return strings.HasPrefix(path, "https://")
+}
+
+// mgmtproxyEnabled mirrors cluster-utils.sh:mgmtproxy_enabled — the operator
+// off-switch is the presence of /run/kube/mgmtproxy-disable. Absent file means
+// proxy injection is enabled; presence means bypass.
+func mgmtproxyEnabled() bool {
+	_, err := os.Stat(mgmtproxyDisableFlag)
+	return os.IsNotExist(err)
+}
+
 func (ctx *commonComponent) KubectlApply(path string) error {
 	cmd := exec.Command("kubectl", "apply", "-f", path)
+	switch {
+	case isHTTPSURL(path) && mgmtproxyEnabled():
+		// Inject HTTPS_PROXY/NO_PROXY so kubectl's manifest fetch routes
+		// through pillar's cost-aware mgmtproxy. Use append(os.Environ(), ...)
+		// so the parent's PATH/KUBECONFIG/HOME are preserved — kubectl needs
+		// them to find the apiserver.
+		cmd.Env = append(os.Environ(),
+			"HTTPS_PROXY="+mgmtproxyURL,
+			"NO_PROXY="+mgmtproxyNoProxy)
+		log.Printf("KubectlApply: routing through mgmtproxy (%s): %s", mgmtproxyURL, path)
+	case isHTTPSURL(path):
+		log.Printf("KubectlApply: mgmtproxy disabled (%s present), fetching direct: %s",
+			mgmtproxyDisableFlag, path)
+	case strings.HasPrefix(path, "http://"):
+		// Plain-HTTP URLs are a network fetch that mgmtproxy does not cover
+		// (HTTPS_PROXY only affects https requests; the proxy is CONNECT-only).
+		// Log so such a fetch is visible rather than silently bypassing.
+		log.Printf("KubectlApply: plain-HTTP URL not routed through mgmtproxy, fetching direct: %s", path)
+	}
 	var outStr strings.Builder
 	var errStr strings.Builder
 	cmd.Stdout = &outStr

--- a/pkg/pillar/cmd/mgmtproxy/README.md
+++ b/pkg/pillar/cmd/mgmtproxy/README.md
@@ -1,0 +1,499 @@
+# mgmtproxy
+
+Cost-aware HTTP CONNECT forward proxy on the loopback interface, used by EVE-K
+to make containerd image pulls and the runtime k3s download honor
+`network.download.max.cost`.
+
+## Routing diagram
+
+**Before — containerd uses `table main` directly:**
+
+```text
+containerd ──────────────► table main ──► eth0 gateway (dead) ──► TIMEOUT
+                            (kernel picks                         ImagePullBackOff
+                             lowest metric; unaware gw is down)       ✗
+```
+
+**After (this change) — containerd tunnels through the cost-aware proxy:**
+
+```text
+  ┌──────────────────────────────── pillar (starts before containerd) ──┐
+  │                                                                      │
+  │  nim ────publishes──► DeviceNetworkStatus                            │
+  │                              │                                       │
+  │  zedagent ──publishes──► ConfigItemValueMap                          │
+  │                              │  (network.download.max.cost)          │
+  │  mgmtproxy ◄──subscribes─────┘                                       │
+  │     │  127.0.0.1:5443                                                │
+  │     └──publishes──► MetricsMap ──► edgeview url                      │
+  └──────────────────────────────┬───────────────────────────────────────┘
+         HTTPS_PROXY=http://127.0.0.1:5443 (injected by cluster-init.sh)
+                                 │ CONNECT registry:443
+  ┌──────────────────────────────▼──────────────────────────────────────────┐
+  │  kube containerd  (check_start_containerd; separate from pillar)        │
+  │  /var/lib/rancher/k3s/data/current/bin/containerd                       │
+  │  NOTE: pillar containerd (used by pillar's own downloader) is a         │
+  │        different process and is already cost-aware — not patched here.  │
+  └─────────────────────────────────────────────────────────────────────────┘
+                                 │ CONNECT registry:443
+                          mgmtproxy dials outbound:
+                                 │
+              ┌──────────────────┴──────────────────────┐
+              │                                          │
+        1. eth0 (cost=0)                          2. eth1 (cost=1)
+        bind src=192.168.1.89                     bind src=10.0.0.5
+        ip rule: from 192.168.1.89                ip rule: from 10.0.0.5
+                 lookup table-eth0                         lookup table-eth1
+        table-eth0: via gw-eth0 ✗                table-eth1: via gw-eth1 ✓
+        (dial timeout → skip)                              │
+                                                           │ TCP tunnel
+                                                           ▼
+                                                 registry-1.docker.io:443
+```
+
+**Key insight:** NIM maintains a per-port routing table (`DPCBaseRTIndex+ifIndex`)
+with a `from <srcIP> lookup <table>` ip rule for each management port IP.  When
+the proxy binds its outbound socket to a port's source IP the packet travels
+through *that port's table* — bypassing `table main` entirely.  A dead cost-0
+gateway in `table main` never pins containerd to a broken uplink.
+
+## Why this exists
+
+Pillar's downloader (`controllerconn/send.go`) iterates management ports in
+ascending cost order and binds the outbound socket to each port's source IP.
+NIM has installed `from <srcIP> lookup <port-table>` IP rules
+(`dpcreconciler/linux.go:getIntendedSrcIPRules`), so packets bound to a port's
+source IP go through that port's per-port routing table — not `table main`.
+This is why pillar's downloader keeps working even when `table main`'s default
+route still points at a dead gateway.
+
+EVE-K has two containerd processes: the **pillar containerd** (inside the
+`pillar` container, used by pillar's own image management, already cost-aware
+via `controllerconn/send.go`) and the **kube containerd** (a standalone process
+launched by `check_start_containerd` in `cluster-init.sh`, used by k3s to pull
+pod and system images).
+The kube containerd does its own image pulls using `table main` directly and has
+no equivalent of the cost-aware loop. When the preferred (cost-0) uplink's
+gateway is unreachable but a higher-cost backup is healthy, NIM updates per-port
+tables and the DPC, but `table main` still points at the dead gateway and the
+kube containerd times out (`ImagePullBackOff`).
+
+`mgmtproxy` exposes pillar's existing source-IP-binding mechanism to
+containerd via the standard `HTTPS_PROXY` env var. Containerd sends
+`CONNECT <registry>:443` to `127.0.0.1:5443`; the proxy iterates mgmt ports
+by ascending cost (filtered by `network.download.max.cost`) and tunnels via
+the first port whose dial succeeds.
+
+## What it covers
+
+- **Kube containerd** image pulls (every k8s/kubevirt component image, plus user
+  app images), via `HTTPS_PROXY` set on the standalone kube containerd at
+  `check_start_containerd` in `pkg/kube/cluster-init.sh`. The pillar containerd
+  is unaffected — it is a
+  separate process already covered by pillar's own cost-aware downloader.
+- `k3s ctr image import` for the external boot image — the `ctr` CLI talks to
+  the running containerd's socket, so its env doesn't matter; what matters is
+  that containerd dials outbound through the proxy.
+- The k3s installer download (`curl https://get.k3s.io`) in `update_k3s`
+  (`pkg/kube/cluster-update.sh`), via the same `HTTPS_PROXY` exported into
+  the curl environment.
+- **`kubectl apply -f https://...` manifest fetches** — KubeVirt CR, CDI
+  operator/CR install + uninstall, and Longhorn uninstall use the
+  `mgmtproxy_run` helper in `pkg/kube/cluster-utils.sh`. These calls
+  bypass containerd entirely (kubectl does its own HTTP fetch) and would
+  otherwise route through `table main` on every install/uninstall. Each call
+  writes a `mgmtproxy_run: routing through proxy ...` line to the kube install
+  log so it pairs 1:1 with the pillar-side `mgmtproxy: CONNECT ...` entry.
+- **Dynamic component upgrades** — the Go `KubectlApply` in
+  `pkg/kube/update-component/upgrades.go` injects `HTTPS_PROXY`/`NO_PROXY`
+  into the `kubectl apply -f https://...` subprocess when the path is an
+  HTTPS URL and the operator off-switch is not set. This covers
+  arbitrary-version YAML pulls at upgrade time over expensive/slow links.
+
+- **CDI importer pods** — when a Rancher/Helm chart deploys a VMIRS with a
+  `DataVolumeTemplate` that uses `source.http.url` or `source.registry.url`,
+  CDI creates an importer pod that fetches the VM disk image from the external
+  URL. These pods run in the k3s pod network (10.42.x.x) and cannot reach
+  `127.0.0.1:5443`. To cover them, `cluster-init.sh:setup_cni0_proxy_ip()`
+  assigns a well-known link-local IP (`169.254.100.1/32`) to `cni0` on every
+  kubevirt-enabled node (only when `install_kubevirt=1`). mgmtproxy gains a
+  second listener on `169.254.100.1:5443`. After CDI installs,
+  `cluster-init.sh:patch_cdi_proxy_config()` patches the CDI CR
+  (`spec.config.importProxy.HTTPSProxy`) to inject
+  `HTTPS_PROXY=http://169.254.100.1:5443` into every importer pod CDI creates.
+  Link-local addresses are not routed by flannel across nodes, so each importer
+  pod always reaches its own node's mgmtproxy — the right uplinks are used even
+  in multi-node clusters. EVE-managed VM volumes (controller-deployed apps)
+  are unaffected: they use `virtctl image-upload` → CDI upload-proxy service
+  (10.43.x.x, already in NO_PROXY), which is a `source.upload` DataVolume —
+  not an importer pod, no external fetch.
+
+What it does **not** cover (by design): VM disk images already flow through
+pillar's cost-aware downloader and are mounted as PVCs, so they need nothing
+extra. KubeVirt launcher images are bundled in the kube package
+(in the kube package `Dockerfile`, `ImagePullPolicy: PullNever`) and never
+pulled at runtime.
+Plain-HTTP forwarding is not implemented — every relevant target
+(`get.k3s.io`, registries, GitHub) is HTTPS, and CONNECT-only keeps the
+implementation small and avoids touching auth headers.
+
+## Port choice and listeners
+
+The proxy listens on two addresses:
+
+- **`127.0.0.1:5443`** (`ListenAddr`) — host processes: kube containerd, k3s
+  installer curl, kubectl subprocesses. Active from pillar startup.
+- **`169.254.100.1:5443`** (`CNI0ListenAddr`) — CDI importer pods via the cni0
+  bridge. Active after `cluster-init.sh:setup_cni0_proxy_ip()` assigns
+  `169.254.100.1/32` to `cni0` (only on kubevirt-enabled amd64 nodes). The
+  second goroutine retries silently every 30s until the IP is assigned, which
+  may be several minutes after pillar starts.
+
+Port 5443 is unused inside EVE and is not a well-known port for anything in
+EVE-K — k8s/k3s use 6443/9345/10250-range, kubevirt and longhorn use other
+ranges, and IANA's nominal `spss` registration is inactive in practice. The
+known external conflict is VMware NSX-T (uses 5443 for its manager API), which
+isn't relevant on EVE.
+
+If a `listen` ever fails (port taken by something unexpected), the agent
+logs an error and retries every 30s rather than crashing pillar. Containerd
+pulls hit `ECONNREFUSED` while listen is blocked; kubelet's
+`ImagePullBackOff` carries the retry. The off-switch flag
+(`/run/kube/mgmtproxy-disable`) lets an operator bypass mgmtproxy entirely
+if the conflict is permanent — see the Debugging section.
+
+To change the port: edit `ListenAddr` and `CNI0ListenAddr` in `mgmtproxy.go`,
+`MGMTPROXY_URL` and `MGMTPROXY_CNI0_URL` in `pkg/kube/cluster-utils.sh`, and
+`mgmtproxyURL` in `pkg/kube/update-component/upgrades.go` together.
+
+## Network exposure and firewall
+
+Both listeners bind to **specific internal IPs** (`127.0.0.1` and the cni0
+link-local `169.254.100.1`), never to `0.0.0.0`, so the proxy is not exposed on
+any uplink IP. Inbound port 5443 from an external interface is blocked at three
+layers:
+
+1. **Binding** — nothing listens on an uplink IP, so an inbound SYN to
+   `<uplink-ip>:5443` has no socket to reach.
+2. **Per-uplink default-DROP** — EVE's filter `INPUT` chain ends with a
+   `-i <uplink> -j DROP` for every L3 port (`dpcreconciler/linux.go`,
+   `getIntendedFilterRules`); 5443 is never accepted, so it is dropped.
+3. **Explicit per-uplink DROP for 5443** — on EVE-K (`HVTypeKube`),
+   `getIntendedFilterRules` additionally emits an explicit
+   `-i <uplink> -p tcp --dport 5443 -j DROP` per L3 uplink, for auditable
+   defense-in-depth. It is **interface-scoped to uplinks**, so it never matches
+   `lo` (host containerd / kubectl) or `cni0` (CDI importer pods,
+   source `10.42.x.x`) — those intended paths keep working.
+
+The cni0 link-local listener needs no NAT and no per-NI rule (unlike the
+metadata server at `169.254.169.254`, which DNATs to the NI bridge IP and adds a
+`physdev` DROP for switch NIs): `cni0` is a single, internal-only pod bridge
+that is never bridged to a physical uplink, so there is no external L2 leak path
+to block.
+
+## Build tag
+
+This agent only ships in EVE-K (`//go:build k`). On KVM/Xen builds the package
+contains a no-op stub (`nomgmtproxy.go`), the same pattern `zedkube` uses.
+
+## Why a dedicated agent
+
+Downloader is RPC-driven (verb-shaped: "download this URL into this volume");
+this proxy is connection-shaped (tunnel arbitrary CONNECT requests for
+arbitrary registries). The lifecycles and concurrency models are different
+enough that grafting the proxy onto downloader (or onto NIM) would mix
+concerns. Following EVE's "one agent per concern" pattern.
+
+## Subscriptions
+
+- `DeviceNetworkStatus` from `nim` — used to enumerate management ports, their
+  costs, source IPs, and `LastFailed` flags.
+- `ConfigItemValueMap` from `zedagent` — reads `network.download.max.cost` (max
+  port cost to use) and `timer.dial.timeout` (per-attempt upstream dial
+  timeout).
+
+## Observability
+
+The proxy is built so a single tail of pillar logs tells you what it's doing.
+
+**At default log level you see:**
+
+- `mgmtproxy: listening on 127.0.0.1:5443` — once at startup.
+- `mgmtproxy: CONNECT <target> from <clientAddr> via <ifName> src <ip> cost N (dial Xms, Y fallback(s))` —
+  one line per CONNECT request, every time. `clientAddr` is the source of the
+  incoming connection: `127.0.0.1:PORT` means a host process (containerd,
+  kubectl); `10.42.x.x:PORT` means a CDI importer pod via the cni0 listener.
+  `Y fallback(s)` is the number of attempts that failed before the winning one
+  — `0` is the happy path, anything `>0` is automatic recovery.
+- `mgmtproxy: CONNECT <target> from <clientAddr> FAILED after Xms: <details>` —
+  one line per fully-failed request, with per-port attempt details.
+- `mgmtproxy: tunnel idle for 30s, closing` — when the idle watchdog fires.
+
+**`edgeview url`** shows mgmtproxy alongside the other agents that publish
+`MetricsMap` (zedagent, downloader, nim, ...). The proxy publishes per-target
+and per-interface byte counts, success/failure history, and total time at
+`/run/mgmtproxy/MetricsMap/global.json`, refreshed every 10s. Read it via:
+
+```sh
+edgeview url
+```
+
+Look for the `- mgmtproxy stats` block. Each registry/host gets its own line
+with `Recv (KBytes)`, `Sent`, `SentMsg`, and `Total Time(sec)`. The "TLS
+resume" column is always 0 — the proxy CONNECTs but doesn't terminate TLS.
+
+**Controller metrics.** `zedagent` subscribes to mgmtproxy's `MetricsMap`
+(`cmd/zedagent/zedagent.go`, `AgentName: "mgmtproxy"`) and folds it into the
+device `ZedcloudMetric` report via `mgmtProxyMetrics.AddInto(cms)` in
+`handlemetrics.go` — the same aggregation path used for nim, downloader,
+loguploader, and zedrouter. So mgmtproxy's per-interface success/failure
+counts and per-URL byte/time counters reach zedcloud alongside the other
+agents' connectivity metrics, not just `edgeview url`. On non-EVE-K builds the
+agent is a no-op stub that never publishes, so the subscription stays empty and
+contributes nothing.
+
+**`/healthz` endpoint** at `http://127.0.0.1:5443/healthz` returns a JSON
+snapshot. From the host (or via `crictl exec` on a debug pod):
+
+```sh
+curl -s http://127.0.0.1:5443/healthz | jq
+```
+
+Returns: `listening` (loopback address), `cni0Listening` (true once
+`169.254.100.1:5443` is active — the CDI importer pod path), `ready` (pubsub
+initialized), `maxPortCost`, an array of mgmt `ports` with their `cost`,
+`hasError`, `lastError`, `numAddrs` and `usableAddr` (the source IP the dialer
+would use), per-port success/failure counters, total bytes transferred, and
+the `lastSuccess` / `lastError` summary with timestamps.
+
+This is the single best signal for "is mgmtproxy seeing my pull, and which
+port is winning?"
+
+## How `HTTPS_PROXY` is scoped (read this first)
+
+The proxy env is **per-command, not per-shell**. Specifically:
+
+- `cluster-init.sh:check_start_containerd` prepends `HTTPS_PROXY=...` inline
+  on the `nohup containerd ...` command — only the standalone containerd
+  process gets the env. Kubelet, apiserver, controller-manager, scheduler
+  (all inside the separate `k3s server` process started by `check_start_k3s`)
+  do **not** see `HTTPS_PROXY`. This is intentional: a global export here would
+  route
+  intra-cluster HTTPS through the proxy and break the cluster.
+- `cluster-update.sh:update_k3s` prepends `HTTPS_PROXY=...` inline on the
+  `curl https://get.k3s.io` and the spawned installer subprocess.
+- `cluster-utils.sh:mgmtproxy_run` (helper) prepends `HTTPS_PROXY=...` on
+  whichever command is passed to it — used by `kubevirt-utils.sh` and
+  `longhorn-utils.sh` to wrap `kubectl apply/create/delete -f https://...`
+  manifest fetches. Local-file `kubectl` calls in those scripts are NOT
+  wrapped — they don't make external HTTP calls.
+- `update-component/upgrades.go:KubectlApply` (Go) sets `cmd.Env` on the
+  `kubectl` subprocess when the path is an HTTPS URL and the off-switch
+  flag is absent. Same scoping principle: only the kubectl subprocess gets
+  the env, never the parent update-component or k3s server.
+
+Practical consequence: when you `eve enter kube` and get an interactive
+shell, you do **not** inherit `HTTPS_PROXY`. A bare `curl https://<host>`
+from that shell goes out via the kernel's `table main` — which is exactly
+the path that's broken when the cost-0 gateway is dead, and *not* the path
+containerd takes.
+
+This matters for diagnosis. These three commands answer different questions:
+
+| Command | Path | Through mgmtproxy? |
+| --- | --- | --- |
+| `curl https://registry-1.docker.io/v2/` | direct via `table main` | **No** |
+| `curl --proxy http://127.0.0.1:5443 https://registry-1.docker.io/v2/` | matches containerd's path | **Yes** |
+| `crictl pull <image>` | real containerd pull | **Yes** |
+| `kubectl apply -f https://github.com/.../foo.yaml` (bare from shell) | direct via `table main` | **No** |
+| `mgmtproxy_run kubectl apply -f https://...` (after `. /usr/bin/cluster-utils.sh`) | matches install/uninstall scripts | **Yes** |
+
+If a bare `curl` from `eve enter kube` succeeds but `crictl pull` fails,
+**don't conclude the network is fine** — the bare `curl` does not exercise
+the same code path as containerd. Use `--proxy` or `crictl pull` to
+reproduce containerd's behavior.
+
+To make a shell session behave like containerd does, source the helpers and
+export the env:
+
+```sh
+. /usr/bin/cluster-utils.sh
+export HTTPS_PROXY="$MGMTPROXY_URL"
+export NO_PROXY="$(mgmtproxy_no_proxy)"
+curl -v https://get.k3s.io/   # now goes through mgmtproxy
+```
+
+Unset both when you're done so the shell stops shadowing direct-path tests.
+
+## Debugging workflow
+
+When a pod is stuck in `ImagePullBackOff` or a VMI fails to start, work
+through this in order:
+
+**1. Did containerd actually get launched with HTTPS_PROXY?**
+
+The authoritative answer is the sentinel file written by `cluster-init.sh`
+at the moment of launch:
+
+```sh
+cat /run/mgmtproxy-containerd-env
+# pid=14398
+# started=2026-05-04T23:28:24+00:00
+# HTTPS_PROXY=http://127.0.0.1:5443
+# NO_PROXY=127.0.0.0/8,10.42.0.0/16,...,10.244.244.2
+```
+
+**Don't rely on `/proc/$PID/environ` for this check.** Containerd reads
+`HTTPS_PROXY` at startup for its CRI image-pull client and then calls
+`os.Unsetenv("HTTPS_PROXY")` to clear it from its own process env (a
+Go-daemon convention). Within ~1s of launch, `cat /proc/$PID/environ`
+will show `NO_PROXY` but **not** `HTTPS_PROXY`, even though the proxy
+is correctly configured internally. Child processes spawned by containerd
+(`containerd-shim-runc-v2`, `runc`, `iptables-restore`) still receive
+`HTTPS_PROXY` in their env — visible via `cat /proc/<child-pid>/environ`
+if you want corroborating evidence.
+
+If the sentinel file says `HTTPS_PROXY=(disabled — flag ... present)`,
+the off-switch is on (`/run/kube/mgmtproxy-disable`).
+If the file is absent, the env-injecting branch of `check_start_containerd`
+hasn't run since boot — check the logmsg in `/persist/kubelog/k3s-install.log`
+for the matching `Started k3s-containerd at pid:N ...` line.
+
+**2. Is mgmtproxy listening?**
+
+```sh
+ss -tln 'sport = :5443'
+nc -zv 127.0.0.1 5443
+curl -s http://127.0.0.1:5443/healthz | jq
+```
+
+If it's not listening, check pillar-side logs for `mgmtproxy:` lines —
+particularly the `listening on` line at startup.
+
+**3. Does the proxy see the pull request?**
+
+Tail pillar logs and trigger a pull (`crictl pull <image>`). You should see:
+
+```text
+mgmtproxy: CONNECT registry-1.docker.io:443 via eth0 src 192.0.2.5 cost 0 (dial 12ms, 0 fallback(s))
+```
+
+Or run `edgeview url` and look at the `- mgmtproxy stats` block — the
+per-target row for the registry should be growing.
+
+If no `CONNECT` line appears and `edgeview url` shows no mgmtproxy entry for
+that target, the pull traffic is bypassing the proxy — likely a `NO_PROXY`
+match (cluster CIDR, etc.) or `HTTPS_PROXY` not set in containerd's env.
+
+**3b. For kubectl URL-fetch failures (KubeVirt/CDI/Longhorn install/upgrade):**
+
+The kubectl path leaves an audit trail in two places that should pair 1:1:
+
+```sh
+# Caller-side: did mgmtproxy_run fire at all?
+grep "mgmtproxy_run:" /persist/kubelog/k3s-install.log
+
+# Pillar-side: did the request reach mgmtproxy?
+# (search via edgeview log search or local pillar log)
+# look for: mgmtproxy: CONNECT github.com:443 ...
+#                    or: raw.githubusercontent.com:443 ...
+```
+
+Equal counts within the same time window → wrapper wired correctly.
+Caller log present but no CONNECT → the wrapper fired but the spawned
+kubectl somehow didn't honor `HTTPS_PROXY` (would be a real bug; file).
+Caller log absent → the call site is missing the `mgmtproxy_run` prefix
+(grep `kubevirt-utils.sh longhorn-utils.sh` for raw `kubectl ... -f https://`).
+
+For the Go upgrade path (`update-component/upgrades.go:KubectlApply`),
+the equivalent caller log is in `/persist/kubelog/upgrade-component.log`:
+`KubectlApply: routing through mgmtproxy: https://...`.
+
+**4. Is the proxy succeeding but pulls still failing?**
+
+Check the tunnel close line at Functionf level (raise log level if needed):
+
+```text
+mgmtproxy: tunnel <target> via <ifName> closed: up=N down=M duration=Xs idle=true|false
+```
+
+`idle=true` means the idle watchdog killed the tunnel — upstream stalled
+mid-stream. `down=0` with a small `up` value means the upstream accepted the
+connection but never sent response bytes (likely a half-broken firewall — the
+"dial succeeds, content blackholes" case). Either way, kubelet retries with
+`ImagePullBackOff` backoff and on retry NIM's `LastFailed` typically routes us
+to a healthy port.
+
+**5. Is mgmtproxy itself the issue? Bypass it temporarily.**
+
+```sh
+touch /run/kube/mgmtproxy-disable
+killall containerd
+# wait ~15s for cluster-init.sh's main loop to restart containerd without HTTPS_PROXY
+```
+
+Re-trigger the pull. If it now succeeds, the proxy or its config is the
+issue; collect `/healthz` output and pillar logs and file. If it still fails,
+the issue is in NIM's port state, the registry, or the network — mgmtproxy is
+not the cause. Re-enable with `rm /run/kube/mgmtproxy-disable && killall containerd`.
+
+**6. Is NIM's view of ports matching reality?**
+
+Cross-reference `/healthz` output with NIM's published status:
+
+```sh
+cat /persist/status/nim/DeviceNetworkStatus/global.json | jq '.Ports[] | {IfName, Cost, IsMgmt, LastError, AddrInfoList: [.AddrInfoList[].Addr]}'
+ip route show table main
+ip rule list
+```
+
+If `/healthz` shows the proxy choosing a port that NIM marks `LastError`,
+it's a fallback after `WithoutFailed` was empty — usually transient, but
+worth investigating if persistent.
+
+## Known v1 limitations / follow-ups
+
+- **Stale `NO_PROXY` on cluster-node-IP change.** Containerd does not reload
+  env on SIGHUP. If `${cluster_node_ip}` changes after containerd starts
+  (e.g. a DHCP lease swap on the cluster interface), the `NO_PROXY` list
+  shipped at launch is stale until containerd restarts. The wide CIDRs
+  (`10.42.0.0/16`, `10.43.0.0/16`, `169.254.0.0/16`) and the full
+  `ClusterIPPrefix` subnet absorb most of this; only if the node moves to
+  an entirely different subnet would traffic misroute through the proxy.
+  Auto-restart on cluster-node-IP change is a future enhancement.
+- **CONNECT only, no plain-HTTP forwarding.** `HTTP_PROXY` is intentionally
+  not injected.
+- **IPv6.** Inherited from `controllerconn`'s mgmt-port iteration, which is
+  IPv4-centric in practice. IPv6-only registries would silently bypass the
+  cost gate; not a concern for any current deployment.
+- **"Dial succeeds, then mid-stream blackhole".** A half-broken upstream that
+  accepts SYN but drops payload packets pins the first attempt to that port.
+  Mitigated by the 30s idle-tunnel timeout, NIM's `LastFailed` skipping on
+  retry, and Kubernetes' `ImagePullBackOff` exponential backoff. Worst-case
+  recovery is a few minutes of retries vs. operator intervention today.
+
+## Underlying gap
+
+The gap this proxy works around is that `table main`'s default route is
+authoritative for host-namespace traffic, and EVE doesn't probe gateway
+reachability before letting the kernel pick that route. A possible future
+enhancement is "NIM owns `table main`'s default route based on per-port gateway
+reachability probing, with hysteresis" (referred to below as Option B). Option B
+and mgmtproxy are complementary, not sequential:
+
+- **Option B** detects first-hop failure only. If the direct gateway responds
+  to ARP/ping but a link several hops away is broken (ISP outage, upstream
+  firewall failure, BGP flap), Option B's probe shows the port healthy and
+  `table main` continues routing through the broken path. It extends
+  cost-aware routing to all host-netns traffic beyond the containerd/kubectl
+  paths, but it does not provide end-to-end reachability verification.
+- **mgmtproxy** probes end-to-end by attempting a real TCP dial to the
+  destination on each CONNECT. The per-attempt dial timeout (`timer.dial.timeout`)
+  fires regardless of where in the path the failure occurs — first hop or ten
+  hops away. This is the same reason pillar's downloader uses actual HTTP
+  round-trips as the failure signal rather than ICMP pings to the gateway.
+
+When Option B ships it will cover host-netns paths not in mgmtproxy's
+inventory. mgmtproxy remains the correct mechanism for the containerd and
+kubectl paths because it provides both cost-preference ordering and
+end-to-end reachability verification on every request.

--- a/pkg/pillar/cmd/mgmtproxy/dialer.go
+++ b/pkg/pillar/cmd/mgmtproxy/dialer.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package mgmtproxy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// dialError carries failures from individual port attempts; the proxy handler
+// translates these into HTTP 502/504 responses.
+type dialError struct {
+	msg      string
+	attempts []attemptResult
+}
+
+type attemptResult struct {
+	IfName string
+	SrcIP  net.IP
+	Cost   uint8
+	Err    error
+}
+
+func (e *dialError) Error() string {
+	if len(e.attempts) == 0 {
+		return e.msg
+	}
+	out := e.msg
+	for _, a := range e.attempts {
+		out += fmt.Sprintf("; %s/%v(cost=%d): %v", a.IfName, a.SrcIP, a.Cost, a.Err)
+	}
+	return out
+}
+
+// Attempts returns the per-port failure list for callers that want to record
+// stats or include them in a structured log line.
+func (e *dialError) Attempts() []attemptResult {
+	return e.attempts
+}
+
+// dialResult carries the metadata of a successful dial so the caller can log
+// which port + cost won.
+type dialResult struct {
+	Conn     net.Conn
+	IfName   string
+	SrcIP    net.IP
+	Cost     uint8
+	Attempts []attemptResult // failed attempts that preceded this success (may be empty)
+}
+
+// dialCostAware iterates management ports in ascending cost order (skipping
+// ports above maxCost and ports flagged failed by NIM) and tries each port's
+// non-link-local source IPs in turn. The first successful TCP connect wins.
+// The rotation argument round-robins selection within each cost tier so load
+// is shared across same-cost ports, matching controllerconn's behavior.
+//
+// This mirrors the shape of pillar's controllerconn.Client.SendOnAllIntf /
+// SendOnIntf — same primitives, no controller-specific HTTP/cert logic.
+//
+// Source-IP binding is what makes the cost-aware routing work: NIM installs
+// `from <srcIP> lookup <port-table>` IP rules, so packets bound to a port's
+// source IP go through that port's per-port routing table and out its own
+// gateway, regardless of what `table main`'s default route currently points
+// at.
+func dialCostAware(parent context.Context, log *base.LogObject,
+	dns types.DeviceNetworkStatus, maxCost uint8, target string,
+	timeout time.Duration, rotation int) (*dialResult, error) {
+
+	intfs := types.GetMgmtPortsSortedCostWithoutFailed(dns, rotation)
+	if len(intfs) == 0 {
+		// Mirror SendOnAllIntf's fallback: during onboarding NIM may not
+		// have set LastFailed/LastSucceeded yet, so try unfiltered.
+		intfs = types.GetMgmtPortsSortedCost(dns, rotation)
+	}
+	if len(intfs) == 0 {
+		return nil, &dialError{msg: fmt.Sprintf("mgmtproxy: no management interfaces available for %s", target)}
+	}
+
+	var attempts []attemptResult
+	for _, intf := range intfs {
+		port := dns.LookupPortByIfName(intf)
+		if port == nil {
+			continue
+		}
+		if port.Cost > maxCost {
+			continue
+		}
+		for _, addr := range port.AddrInfoList {
+			srcIP := addr.Addr
+			if srcIP == nil || srcIP.IsLinkLocalUnicast() {
+				continue
+			}
+			conn, err := dialFromSource(parent, log, intf, srcIP, target, timeout)
+			if err == nil {
+				return &dialResult{
+					Conn:     conn,
+					IfName:   intf,
+					SrcIP:    srcIP,
+					Cost:     port.Cost,
+					Attempts: attempts,
+				}, nil
+			}
+			attempts = append(attempts, attemptResult{
+				IfName: intf, SrcIP: srcIP, Cost: port.Cost, Err: err,
+			})
+			if log != nil {
+				log.Tracef("mgmtproxy: dial %s via %s src %v cost %d failed: %v",
+					target, intf, srcIP, port.Cost, err)
+			}
+		}
+	}
+	return nil, &dialError{
+		msg:      fmt.Sprintf("mgmtproxy: all attempts to %s failed", target),
+		attempts: attempts,
+	}
+}
+
+// dialFromSource binds the outbound socket to srcIP and uses a per-port DNS
+// resolver so the DNS query for the target hostname also flows through the
+// per-port routing table.
+func dialFromSource(parent context.Context, log *base.LogObject,
+	ifName string, srcIP net.IP, target string, timeout time.Duration) (net.Conn, error) {
+
+	resolver := controllerconn.NewResolverWithLocalIP(log, ifName, srcIP).NetResolver()
+
+	dialer := &net.Dialer{
+		Resolver:  resolver,
+		LocalAddr: &net.TCPAddr{IP: srcIP},
+		Timeout:   timeout,
+	}
+
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+	return dialer.DialContext(ctx, "tcp", target)
+}

--- a/pkg/pillar/cmd/mgmtproxy/mgmtproxy.go
+++ b/pkg/pillar/cmd/mgmtproxy/mgmtproxy.go
@@ -1,0 +1,429 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+// Package mgmtproxy implements a small HTTP CONNECT forward proxy on the
+// loopback interface that performs cost-aware outbound dialing. It is intended
+// to be used by EVE-K's standalone containerd (and the curl that fetches the
+// k3s installer) so that container image pulls and the k3s download honor
+// network.download.max.cost in the same way pillar's downloader already does.
+package mgmtproxy
+
+import (
+	"context"
+	"flag"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/agentbase"
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/flextimer"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	agentName   = "mgmtproxy"
+	errorTime   = 3 * time.Minute
+	warningTime = 40 * time.Second
+
+	// ListenAddr is the loopback address the proxy listens on. Containerd
+	// and the k3s installer reach it via HTTPS_PROXY=http://127.0.0.1:5443.
+	// The kube container runs in the host net namespace so it shares this
+	// loopback with pillar.
+	ListenAddr = "127.0.0.1:5443"
+
+	// CNI0ListenAddr is an additional listener on the well-known link-local
+	// anchor IP assigned to cni0 by cluster-init.sh:setup_cni0_proxy_ip().
+	// CDI importer pods (created by Rancher/Helm VMIRS with source.http.url
+	// DataVolumeTemplates) send HTTPS_PROXY connections here to reach the
+	// local mgmtproxy. Link-local addresses are not routed by flannel across
+	// nodes, so each pod reaches its own node's mgmtproxy exclusively.
+	// Must match cluster-utils.sh:MGMTPROXY_CNI0_IP and MGMTPROXY_CNI0_URL.
+	// Only active on kubevirt-enabled nodes (cluster-init.sh assigns the IP
+	// to cni0 only when install_kubevirt=1). This goroutine retries silently
+	// until the IP is assigned, which may be several minutes after pillar
+	// starts. EVE-managed VM volumes (virtctl image-upload / source.upload)
+	// are unaffected — they use the CDI upload-proxy service IP which is
+	// already in NO_PROXY.
+	CNI0ListenAddr = "169.254.100.1:5443"
+
+	// idleTimeout caps how long an established CONNECT tunnel can sit
+	// without bytes flowing in either direction. Bounds the worst case
+	// when an upstream firewall accepts SYN but blackholes mid-stream.
+	idleTimeout = 30 * time.Second
+
+	// defaultDialTimeoutSecs is the per-attempt TCP connect timeout used
+	// until global config arrives. Matches timer.dial.timeout's default.
+	defaultDialTimeoutSecs = 10
+)
+
+var (
+	logger *logrus.Logger
+	log    *base.LogObject
+)
+
+type mgmtProxyContext struct {
+	agentbase.AgentBase
+
+	ps                     *pubsub.PubSub
+	subGlobalConfig        pubsub.Subscription
+	subDeviceNetworkStatus pubsub.Subscription
+
+	mu                  sync.RWMutex
+	deviceNetworkStatus types.DeviceNetworkStatus
+	maxPortCost         uint8
+	gcInitialized       bool
+	dnsInitialized      bool
+
+	// dialTimeout is the per-attempt TCP connect timeout for the upstream
+	// dial, readable by the proxy handler without holding mu.
+	dialTimeout atomic.Int64 // nanoseconds; set from timer.dial.timeout
+
+	// dialRotation is incremented once per CONNECT and passed as the rotation
+	// argument to the mgmt-port selectors, so requests round-robin across
+	// same-cost ports (matching controllerconn's load-sharing).
+	dialRotation atomic.Uint64
+
+	stats proxyStats
+
+	// agentMetrics is published as types.MetricsMap on
+	// /run/mgmtproxy/MetricsMap/global.json so the per-target,
+	// per-interface byte counts and success/failure history show up in
+	// `edgeview url` and in the device ZedcloudMetric report (zedagent
+	// subscribes to this MetricsMap and folds it in via AddInto), alongside
+	// the other controllerconn-using agents (zedagent, downloader, nim, ...).
+	agentMetrics *controllerconn.AgentMetrics
+}
+
+// proxyStats accumulates lightweight counters for /healthz. All counters use
+// atomics so the proxy handler can update them from any goroutine without
+// taking ctx.mu.
+type proxyStats struct {
+	requests          atomic.Uint64
+	dialFailures      atomic.Uint64 // all upstream attempts failed → 502
+	notReady          atomic.Uint64 // CONNECT before pubsub initialized
+	tunnelIdleClosed  atomic.Uint64 // tunnel killed by idle watchdog
+	successByPort     sync.Map      // ifName → *atomic.Uint64
+	failureByPort     sync.Map      // ifName → *atomic.Uint64
+	bytesUp           atomic.Uint64 // client → upstream
+	bytesDown         atomic.Uint64 // upstream → client
+	lastErrorTime     atomic.Int64  // unix nanos
+	lastErrorMu       sync.RWMutex
+	lastError         string
+	lastSuccessTime   atomic.Int64 // unix nanos
+	lastSuccessMu     sync.RWMutex
+	lastSuccessTarget string
+	lastSuccessPort   string
+	lastSuccessCost   uint8
+}
+
+func (s *proxyStats) recordSuccess(target, ifName string, cost uint8) {
+	c, _ := s.successByPort.LoadOrStore(ifName, &atomic.Uint64{})
+	c.(*atomic.Uint64).Add(1)
+	s.lastSuccessTime.Store(time.Now().UnixNano())
+	s.lastSuccessMu.Lock()
+	s.lastSuccessTarget = target
+	s.lastSuccessPort = ifName
+	s.lastSuccessCost = cost
+	s.lastSuccessMu.Unlock()
+}
+
+func (s *proxyStats) recordFailure(target string, attempts []attemptResult, summary string) {
+	for _, a := range attempts {
+		c, _ := s.failureByPort.LoadOrStore(a.IfName, &atomic.Uint64{})
+		c.(*atomic.Uint64).Add(1)
+	}
+	s.dialFailures.Add(1)
+	s.lastErrorTime.Store(time.Now().UnixNano())
+	s.lastErrorMu.Lock()
+	s.lastError = target + ": " + summary
+	s.lastErrorMu.Unlock()
+}
+
+func mapToCounts(m *sync.Map) map[string]uint64 {
+	out := map[string]uint64{}
+	m.Range(func(k, v interface{}) bool {
+		out[k.(string)] = v.(*atomic.Uint64).Load()
+		return true
+	})
+	return out
+}
+
+// AddAgentSpecificCLIFlags satisfies agentbase.AgentBase.
+func (ctx *mgmtProxyContext) AddAgentSpecificCLIFlags(_ *flag.FlagSet) {}
+
+// snapshot returns a copy of the current DeviceNetworkStatus and the
+// effective max-cost. Callers (the proxy handler) take this snapshot once per
+// CONNECT so they don't race with pubsub updates while iterating ports.
+func (ctx *mgmtProxyContext) snapshot() (types.DeviceNetworkStatus, uint8, bool) {
+	ctx.mu.RLock()
+	defer ctx.mu.RUnlock()
+	return ctx.deviceNetworkStatus, ctx.maxPortCost, ctx.gcInitialized && ctx.dnsInitialized
+}
+
+// Run is the entry point for mgmtproxy from zedbox.
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject,
+	arguments []string, baseDir string) int {
+
+	logger = loggerArg
+	log = logArg
+
+	ctx := &mgmtProxyContext{
+		ps:           ps,
+		agentMetrics: controllerconn.NewAgentMetrics(),
+	}
+	// Default to timer.dial.timeout's default (10s) until global config arrives.
+	ctx.dialTimeout.Store(int64(defaultDialTimeoutSecs * time.Second))
+	agentbase.Init(ctx, logger, log, agentName,
+		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
+		agentbase.WithWatchdog(ps, warningTime, errorTime),
+		agentbase.WithArguments(arguments))
+
+	stillRunning := time.NewTicker(25 * time.Second)
+	ps.StillRunning(agentName, warningTime, errorTime)
+
+	metricsPub, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.MetricsMap{},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Publish metrics every 10 seconds, with the same flextimer pattern
+	// other agents use (downloader, zedagent, etc.). Edgeview's `url`
+	// command reads /run/mgmtproxy/MetricsMap/global.json, and zedagent
+	// subscribes to this publication to include it in the device metrics
+	// reported to the controller.
+	publishTimer := flextimer.NewRangeTicker(3*time.Second, 10*time.Second)
+
+	subGlobalConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "zedagent",
+		MyAgentName:   agentName,
+		TopicImpl:     types.ConfigItemValueMap{},
+		Persistent:    false,
+		Activate:      false,
+		Ctx:           ctx,
+		CreateHandler: handleGlobalConfigCreate,
+		ModifyHandler: handleGlobalConfigModify,
+		DeleteHandler: handleGlobalConfigDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.subGlobalConfig = subGlobalConfig
+	subGlobalConfig.Activate()
+
+	subDeviceNetworkStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "nim",
+		MyAgentName:   agentName,
+		TopicImpl:     types.DeviceNetworkStatus{},
+		Activate:      false,
+		Ctx:           ctx,
+		CreateHandler: handleDNSCreate,
+		ModifyHandler: handleDNSModify,
+		DeleteHandler: handleDNSDelete,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.subDeviceNetworkStatus = subDeviceNetworkStatus
+	subDeviceNetworkStatus.Activate()
+
+	server := &http.Server{
+		Addr:        ListenAddr,
+		Handler:     newProxyHandler(ctx),
+		ReadTimeout: 30 * time.Second,
+	}
+	// Listen with retry rather than log.Fatal so a (rare) port-5443 conflict
+	// doesn't crash pillar and trigger a watchdog reboot. The agent will keep
+	// retrying every 30s; in the meantime containerd's pulls hit ECONNREFUSED
+	// and kubelet retries them with ImagePullBackOff backoff. The off-switch
+	// flag in cluster-init.sh is the operator escape valve for this case.
+	go func() {
+		for {
+			listener, err := net.Listen("tcp", ListenAddr)
+			if err != nil {
+				log.Errorf("mgmtproxy: listen %s failed (will retry): %v",
+					ListenAddr, err)
+				time.Sleep(30 * time.Second)
+				continue
+			}
+			log.Noticef("mgmtproxy: listening on %s", ListenAddr)
+			if serveErr := server.Serve(listener); serveErr != nil &&
+				serveErr != http.ErrServerClosed {
+				log.Errorf("mgmtproxy: server.Serve: %v", serveErr)
+			}
+			// If Serve returned (e.g. listener closed externally), retry
+			// listen rather than spin.
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
+	// Second listener on the cni0 link-local anchor. Retries silently until
+	// cluster-init.sh:setup_cni0_proxy_ip() assigns 169.254.100.1/32 to cni0
+	// (only on kubevirt-enabled nodes). Shares the same handler as the
+	// loopback listener — same cost-aware CONNECT logic, same metrics.
+	go func() {
+		server2 := &http.Server{
+			Handler:     newProxyHandler(ctx),
+			ReadTimeout: 30 * time.Second,
+		}
+		for {
+			listener, err := net.Listen("tcp", CNI0ListenAddr)
+			if err != nil {
+				time.Sleep(30 * time.Second)
+				continue
+			}
+			log.Noticef("mgmtproxy: cni0 listener on %s", CNI0ListenAddr)
+			if serveErr := server2.Serve(listener); serveErr != nil &&
+				serveErr != http.ErrServerClosed {
+				log.Errorf("mgmtproxy: cni0 server.Serve: %v", serveErr)
+			}
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
+	for {
+		select {
+		case change := <-subGlobalConfig.MsgChan():
+			subGlobalConfig.ProcessChange(change)
+		case change := <-subDeviceNetworkStatus.MsgChan():
+			subDeviceNetworkStatus.ProcessChange(change)
+		case <-publishTimer.C:
+			if err := ctx.agentMetrics.Publish(log, metricsPub, "global"); err != nil {
+				log.Errorf("mgmtproxy: agentMetrics.Publish: %v", err)
+			}
+		case <-stillRunning.C:
+		}
+		ps.StillRunning(agentName, warningTime, errorTime)
+	}
+}
+
+func handleGlobalConfigCreate(ctxArg interface{}, key string, statusArg interface{}) {
+	handleGlobalConfigImpl(ctxArg, key, statusArg)
+}
+
+func handleGlobalConfigModify(ctxArg interface{}, key string,
+	statusArg interface{}, _ interface{}) {
+	handleGlobalConfigImpl(ctxArg, key, statusArg)
+}
+
+func handleGlobalConfigImpl(ctxArg interface{}, key string, _ interface{}) {
+	ctx := ctxArg.(*mgmtProxyContext)
+	if key != "global" {
+		return
+	}
+	gcp := agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
+		ctx.CLIParams().DebugOverride, logger)
+	if gcp == nil {
+		return
+	}
+	ctx.mu.Lock()
+	ctx.maxPortCost = uint8(gcp.GlobalValueInt(types.DownloadMaxPortCost))
+	ctx.gcInitialized = true
+	ctx.mu.Unlock()
+	dialTimeoutSecs := gcp.GlobalValueInt(types.NetworkDialTimeout)
+	ctx.dialTimeout.Store(int64(time.Duration(dialTimeoutSecs) * time.Second))
+	log.Functionf("mgmtproxy: maxPortCost=%d dialTimeout=%ds", ctx.maxPortCost, dialTimeoutSecs)
+}
+
+func handleGlobalConfigDelete(ctxArg interface{}, key string, _ interface{}) {
+	ctx := ctxArg.(*mgmtProxyContext)
+	if key != "global" {
+		return
+	}
+	agentlog.HandleGlobalConfig(log, ctx.subGlobalConfig, agentName,
+		ctx.CLIParams().DebugOverride, logger)
+}
+
+func handleDNSCreate(ctxArg interface{}, key string, statusArg interface{}) {
+	handleDNSImpl(ctxArg, key, statusArg)
+}
+
+func handleDNSModify(ctxArg interface{}, key string,
+	statusArg interface{}, _ interface{}) {
+	handleDNSImpl(ctxArg, key, statusArg)
+}
+
+func handleDNSImpl(ctxArg interface{}, key string, statusArg interface{}) {
+	ctx := ctxArg.(*mgmtProxyContext)
+	if key != "global" {
+		return
+	}
+	dns := statusArg.(types.DeviceNetworkStatus)
+	ctx.mu.Lock()
+	ctx.deviceNetworkStatus = dns
+	ctx.dnsInitialized = true
+	ctx.mu.Unlock()
+}
+
+func handleDNSDelete(ctxArg interface{}, key string, _ interface{}) {
+	ctx := ctxArg.(*mgmtProxyContext)
+	if key != "global" {
+		return
+	}
+	ctx.mu.Lock()
+	ctx.deviceNetworkStatus = types.DeviceNetworkStatus{}
+	ctx.mu.Unlock()
+}
+
+// dialUpstreamCtx wraps the cost-aware dialer with the agent's snapshot logic.
+// Exposed via this small adapter so proxy.go does not import pubsub or context
+// internals.
+func (ctx *mgmtProxyContext) dialUpstreamCtx(parent context.Context,
+	target string) (*dialResult, error) {
+	dns, maxCost, ready := ctx.snapshot()
+	if !ready {
+		ctx.stats.notReady.Add(1)
+		return nil, &dialError{msg: "mgmtproxy: device network status or global config not yet initialized"}
+	}
+	rotation := int(ctx.dialRotation.Add(1))
+	return dialCostAware(parent, log, dns, maxCost, target,
+		time.Duration(ctx.dialTimeout.Load()), rotation)
+}
+
+// portSummaries returns the current mgmt-port view from DeviceNetworkStatus
+// for /healthz, with the same filtering logic the dialer uses. The element
+// type lives in pillar/types so consumers (e.g. edgeview) can unmarshal it.
+func (ctx *mgmtProxyContext) portSummaries() []types.MgmtProxyPortSummary {
+	dns, _, _ := ctx.snapshot()
+	var out []types.MgmtProxyPortSummary
+	for _, p := range dns.Ports {
+		if !p.IsMgmt {
+			continue
+		}
+		s := types.MgmtProxyPortSummary{
+			IfName:   p.IfName,
+			Cost:     p.Cost,
+			IsMgmt:   p.IsMgmt,
+			HasError: p.HasError(),
+			NumAddrs: len(p.AddrInfoList),
+		}
+		if s.HasError {
+			s.LastError = p.LastError
+		}
+		for _, a := range p.AddrInfoList {
+			if a.Addr == nil || a.Addr.IsLinkLocalUnicast() {
+				continue
+			}
+			s.UsableAddr = a.Addr.String()
+			break
+		}
+		out = append(out, s)
+	}
+	return out
+}

--- a/pkg/pillar/cmd/mgmtproxy/mgmtproxy_test.go
+++ b/pkg/pillar/cmd/mgmtproxy/mgmtproxy_test.go
@@ -1,0 +1,516 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package mgmtproxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/sirupsen/logrus"
+)
+
+// TestMain initializes the package-level logger that the proxy code logs
+// through, so handlers and the dialer don't panic on a nil *base.LogObject.
+func TestMain(m *testing.M) {
+	logger = logrus.StandardLogger()
+	logger.SetLevel(logrus.FatalLevel) // keep test output quiet
+	log = base.NewSourceLogObject(logger, "mgmtproxy-test", 0)
+	m.Run()
+}
+
+// newTestContext returns a context wired with the metrics publisher the proxy
+// handler and dialer expect, and with the given DeviceNetworkStatus already
+// applied (initialized = true so dialUpstreamCtx does not short-circuit).
+func newTestContext(dns types.DeviceNetworkStatus, maxCost uint8) *mgmtProxyContext {
+	ctx := &mgmtProxyContext{
+		agentMetrics:        controllerconn.NewAgentMetrics(),
+		deviceNetworkStatus: dns,
+		maxPortCost:         maxCost,
+		gcInitialized:       true,
+		dnsInitialized:      true,
+	}
+	ctx.dialTimeout.Store(int64(2 * time.Second))
+	return ctx
+}
+
+// mkPort builds a mgmt, L3 NetworkPortStatus with the given cost and source
+// addresses. Passing no addresses yields a port with an empty AddrInfoList.
+func mkPort(ifname string, cost uint8, addrs ...net.IP) types.NetworkPortStatus {
+	var ail []types.AddrInfo
+	for _, a := range addrs {
+		ail = append(ail, types.AddrInfo{Addr: a})
+	}
+	return types.NetworkPortStatus{
+		IfName:       ifname,
+		IsMgmt:       true,
+		IsL3Port:     true,
+		Cost:         cost,
+		AddrInfoList: ail,
+	}
+}
+
+func mkDNS(ports ...types.NetworkPortStatus) types.DeviceNetworkStatus {
+	return types.DeviceNetworkStatus{
+		Version: types.DPCIsMgmt,
+		Ports:   ports,
+	}
+}
+
+// --- dialError -------------------------------------------------------------
+
+func TestDialErrorMessageNoAttempts(t *testing.T) {
+	e := &dialError{msg: "boom"}
+	if got := e.Error(); got != "boom" {
+		t.Fatalf("Error() = %q, want %q", got, "boom")
+	}
+	if e.Attempts() != nil {
+		t.Fatalf("Attempts() = %v, want nil", e.Attempts())
+	}
+}
+
+func TestDialErrorMessageWithAttempts(t *testing.T) {
+	e := &dialError{
+		msg: "all attempts failed",
+		attempts: []attemptResult{
+			{IfName: "eth0", SrcIP: net.ParseIP("192.0.2.1"), Cost: 0, Err: errors.New("refused")},
+			{IfName: "wwan0", SrcIP: net.ParseIP("192.0.2.2"), Cost: 10, Err: errors.New("timeout")},
+		},
+	}
+	got := e.Error()
+	for _, want := range []string{"all attempts failed", "eth0", "wwan0", "cost=0", "cost=10", "refused", "timeout"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Error() = %q, missing %q", got, want)
+		}
+	}
+	if len(e.Attempts()) != 2 {
+		t.Fatalf("Attempts() len = %d, want 2", len(e.Attempts()))
+	}
+}
+
+// --- proxyStats ------------------------------------------------------------
+
+func TestProxyStatsRecordSuccess(t *testing.T) {
+	var s proxyStats
+	s.recordSuccess("registry:443", "eth0", 3)
+	s.recordSuccess("registry:443", "eth0", 3)
+
+	counts := mapToCounts(&s.successByPort)
+	if counts["eth0"] != 2 {
+		t.Errorf("successByPort[eth0] = %d, want 2", counts["eth0"])
+	}
+	if s.lastSuccessTime.Load() == 0 {
+		t.Error("lastSuccessTime not set")
+	}
+	s.lastSuccessMu.RLock()
+	defer s.lastSuccessMu.RUnlock()
+	if s.lastSuccessTarget != "registry:443" || s.lastSuccessPort != "eth0" || s.lastSuccessCost != 3 {
+		t.Errorf("last success = (%q,%q,%d), want (registry:443,eth0,3)",
+			s.lastSuccessTarget, s.lastSuccessPort, s.lastSuccessCost)
+	}
+}
+
+func TestProxyStatsRecordFailure(t *testing.T) {
+	var s proxyStats
+	attempts := []attemptResult{
+		{IfName: "eth0"},
+		{IfName: "wwan0"},
+		{IfName: "eth0"},
+	}
+	s.recordFailure("registry:443", attempts, "all attempts failed")
+
+	if s.dialFailures.Load() != 1 {
+		t.Errorf("dialFailures = %d, want 1", s.dialFailures.Load())
+	}
+	counts := mapToCounts(&s.failureByPort)
+	if counts["eth0"] != 2 || counts["wwan0"] != 1 {
+		t.Errorf("failureByPort = %v, want eth0=2 wwan0=1", counts)
+	}
+	if s.lastErrorTime.Load() == 0 {
+		t.Error("lastErrorTime not set")
+	}
+	s.lastErrorMu.RLock()
+	defer s.lastErrorMu.RUnlock()
+	if !strings.Contains(s.lastError, "registry:443") || !strings.Contains(s.lastError, "all attempts failed") {
+		t.Errorf("lastError = %q, want target + summary", s.lastError)
+	}
+}
+
+func TestMapToCountsEmpty(t *testing.T) {
+	var s proxyStats
+	if got := mapToCounts(&s.successByPort); len(got) != 0 {
+		t.Errorf("mapToCounts(empty) = %v, want empty", got)
+	}
+}
+
+// --- context: snapshot / dialUpstreamCtx -----------------------------------
+
+func TestSnapshotReady(t *testing.T) {
+	dns := mkDNS(mkPort("eth0", 0, net.ParseIP("192.0.2.10")))
+	ctx := newTestContext(dns, 7)
+	gotDNS, maxCost, ready := ctx.snapshot()
+	if !ready {
+		t.Error("ready = false, want true")
+	}
+	if maxCost != 7 {
+		t.Errorf("maxCost = %d, want 7", maxCost)
+	}
+	if len(gotDNS.Ports) != 1 || gotDNS.Ports[0].IfName != "eth0" {
+		t.Errorf("snapshot DNS = %+v, want one eth0 port", gotDNS.Ports)
+	}
+}
+
+func TestDialUpstreamCtxNotReady(t *testing.T) {
+	ctx := newTestContext(types.DeviceNetworkStatus{}, 0)
+	ctx.gcInitialized = false
+	ctx.dnsInitialized = false
+
+	res, err := ctx.dialUpstreamCtx(context.Background(), "registry:443")
+	if res != nil {
+		t.Errorf("res = %v, want nil", res)
+	}
+	if err == nil {
+		t.Fatal("err = nil, want not-initialized error")
+	}
+	if ctx.stats.notReady.Load() != 1 {
+		t.Errorf("notReady = %d, want 1", ctx.stats.notReady.Load())
+	}
+}
+
+// --- portSummaries ---------------------------------------------------------
+
+func TestPortSummaries(t *testing.T) {
+	mgmt := mkPort("eth0", 0, net.ParseIP("fe80::1"), net.ParseIP("192.0.2.10"))
+	highCost := mkPort("wwan0", 10, net.ParseIP("192.0.2.20"))
+	// A non-mgmt port must be excluded from the summary.
+	appPort := mkPort("eth1", 0, net.ParseIP("192.0.2.30"))
+	appPort.IsMgmt = false
+	// A port flagged failed by NIM: HasError() true.
+	failed := mkPort("wlan0", 5, net.ParseIP("192.0.2.40"))
+	failed.LastFailed = time.Now()
+	failed.LastError = "link down"
+
+	ctx := newTestContext(mkDNS(mgmt, highCost, appPort, failed), 255)
+	sums := ctx.portSummaries()
+
+	byName := map[string]types.MgmtProxyPortSummary{}
+	for _, s := range sums {
+		byName[s.IfName] = s
+	}
+	if _, ok := byName["eth1"]; ok {
+		t.Error("non-mgmt eth1 should not appear in summary")
+	}
+	if len(byName) != 3 {
+		t.Fatalf("got %d mgmt summaries, want 3: %+v", len(byName), sums)
+	}
+	// Link-local address must be skipped; the routable v4 addr is reported.
+	if byName["eth0"].UsableAddr != "192.0.2.10" {
+		t.Errorf("eth0 UsableAddr = %q, want 192.0.2.10", byName["eth0"].UsableAddr)
+	}
+	if byName["eth0"].NumAddrs != 2 {
+		t.Errorf("eth0 NumAddrs = %d, want 2", byName["eth0"].NumAddrs)
+	}
+	if !byName["wlan0"].HasError || byName["wlan0"].LastError != "link down" {
+		t.Errorf("wlan0 error not surfaced: %+v", byName["wlan0"])
+	}
+	if byName["wwan0"].Cost != 10 {
+		t.Errorf("wwan0 Cost = %d, want 10", byName["wwan0"].Cost)
+	}
+}
+
+// --- newProxyHandler routing -----------------------------------------------
+
+func TestProxyHandlerRejectsPlainGET(t *testing.T) {
+	ctx := newTestContext(mkDNS(), 0)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://registry/v2/", nil)
+	newProxyHandler(ctx).ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET / status = %d, want 405", rec.Code)
+	}
+}
+
+func TestProxyHandlerBadConnectTarget(t *testing.T) {
+	ctx := newTestContext(mkDNS(mkPort("eth0", 0, net.ParseIP("192.0.2.10"))), 0)
+	rec := httptest.NewRecorder()
+	// No port in the authority → net.SplitHostPort fails → 400.
+	req := httptest.NewRequest(http.MethodConnect, "//registry-no-port", nil)
+	req.URL.Host = "registry-no-port"
+	req.Host = "registry-no-port"
+	newProxyHandler(ctx).ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("bad CONNECT target status = %d, want 400", rec.Code)
+	}
+	if ctx.stats.requests.Load() != 1 {
+		t.Errorf("requests = %d, want 1", ctx.stats.requests.Load())
+	}
+}
+
+func TestProxyHandlerConnectNotReady(t *testing.T) {
+	ctx := newTestContext(types.DeviceNetworkStatus{}, 0)
+	ctx.gcInitialized = false
+	ctx.dnsInitialized = false
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodConnect, "//registry.example:443", nil)
+	req.URL.Host = "registry.example:443"
+	req.Host = "registry.example:443"
+	newProxyHandler(ctx).ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("not-ready CONNECT status = %d, want 502", rec.Code)
+	}
+}
+
+func TestProxyHandlerHealthz(t *testing.T) {
+	dns := mkDNS(mkPort("eth0", 0, net.ParseIP("192.0.2.10")))
+	ctx := newTestContext(dns, 4)
+	ctx.stats.requests.Store(5)
+	ctx.stats.recordSuccess("registry:443", "eth0", 0)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:5443/healthz", nil)
+	newProxyHandler(ctx).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/healthz status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var body struct {
+		Listening       string `json:"listening"`
+		Ready           bool   `json:"ready"`
+		MaxPortCost     uint8  `json:"maxPortCost"`
+		Requests        uint64 `json:"requests"`
+		LastSuccessPort string `json:"lastSuccessPort"`
+		Ports           []struct {
+			IfName string `json:"ifname"`
+		} `json:"ports"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal /healthz body: %v (body=%s)", err, rec.Body.String())
+	}
+	if body.Listening != ListenAddr {
+		t.Errorf("listening = %q, want %q", body.Listening, ListenAddr)
+	}
+	if !body.Ready {
+		t.Error("ready = false, want true")
+	}
+	if body.MaxPortCost != 4 {
+		t.Errorf("maxPortCost = %d, want 4", body.MaxPortCost)
+	}
+	if body.Requests != 5 {
+		t.Errorf("requests = %d, want 5", body.Requests)
+	}
+	if body.LastSuccessPort != "eth0" {
+		t.Errorf("lastSuccessPort = %q, want eth0", body.LastSuccessPort)
+	}
+	if len(body.Ports) != 1 || body.Ports[0].IfName != "eth0" {
+		t.Errorf("ports = %+v, want one eth0", body.Ports)
+	}
+}
+
+// --- copyAndSignal ---------------------------------------------------------
+
+func TestCopyAndSignal(t *testing.T) {
+	src := strings.NewReader("hello mgmtproxy tunnel")
+	var dst strings.Builder
+	activity := make(chan struct{}, 4)
+
+	n := copyAndSignal(&dst, src, activity)
+	if int(n) != len("hello mgmtproxy tunnel") {
+		t.Errorf("copied %d bytes, want %d", n, len("hello mgmtproxy tunnel"))
+	}
+	if dst.String() != "hello mgmtproxy tunnel" {
+		t.Errorf("dst = %q, want the source string", dst.String())
+	}
+	select {
+	case <-activity:
+		// expected: at least one activity poke for the single read.
+	default:
+		t.Error("expected an activity signal after a non-empty copy")
+	}
+}
+
+// errAfterWriter fails the write after recording how many bytes it accepted,
+// so we can assert copyAndSignal returns the best-effort partial total.
+type errAfterWriter struct{ accepted int }
+
+func (w *errAfterWriter) Write(p []byte) (int, error) {
+	w.accepted = len(p)
+	return len(p), errors.New("write error")
+}
+
+func TestCopyAndSignalWriteError(t *testing.T) {
+	src := strings.NewReader("partial payload")
+	w := &errAfterWriter{}
+	activity := make(chan struct{}, 4)
+	n := copyAndSignal(w, src, activity)
+	if int(n) != w.accepted {
+		t.Errorf("returned %d, want best-effort %d", n, w.accepted)
+	}
+}
+
+// --- dialCostAware (network-free paths) ------------------------------------
+
+func TestDialCostAwareNoMgmtInterfaces(t *testing.T) {
+	res, err := dialCostAware(context.Background(), log,
+		types.DeviceNetworkStatus{}, 255, "registry:443", time.Second, 0)
+	if res != nil {
+		t.Errorf("res = %v, want nil", res)
+	}
+	var de *dialError
+	if !errors.As(err, &de) {
+		t.Fatalf("err = %v, want *dialError", err)
+	}
+	if !strings.Contains(de.Error(), "no management interfaces") {
+		t.Errorf("err = %q, want 'no management interfaces'", de.Error())
+	}
+	if len(de.Attempts()) != 0 {
+		t.Errorf("attempts = %v, want none", de.Attempts())
+	}
+}
+
+func TestDialCostAwareAllAboveMaxCost(t *testing.T) {
+	// Both ports usable, but maxCost filters them all out → no dial attempts.
+	dns := mkDNS(
+		mkPort("wwan0", 10, net.ParseIP("192.0.2.10")),
+		mkPort("wlan0", 20, net.ParseIP("192.0.2.20")),
+	)
+	res, err := dialCostAware(context.Background(), log, dns, 5, "registry:443", time.Second, 0)
+	if res != nil {
+		t.Errorf("res = %v, want nil", res)
+	}
+	var de *dialError
+	if !errors.As(err, &de) {
+		t.Fatalf("err = %v, want *dialError", err)
+	}
+	if len(de.Attempts()) != 0 {
+		t.Errorf("attempts = %v, want none (all cost-filtered)", de.Attempts())
+	}
+}
+
+func TestDialCostAwareLinkLocalOnly(t *testing.T) {
+	// Port within budget but its only address is link-local → skipped, no dial.
+	dns := mkDNS(mkPort("eth0", 0, net.ParseIP("fe80::1")))
+	res, err := dialCostAware(context.Background(), log, dns, 255, "registry:443", time.Second, 0)
+	if res != nil {
+		t.Errorf("res = %v, want nil", res)
+	}
+	var de *dialError
+	if !errors.As(err, &de) {
+		t.Fatalf("err = %v, want *dialError", err)
+	}
+	if len(de.Attempts()) != 0 {
+		t.Errorf("attempts = %v, want none (link-local skipped)", de.Attempts())
+	}
+}
+
+// TestDialCostAwareOrdersByCost asserts the dialer tries ports in ascending
+// cost order. Binding the outbound socket to a source IP that is not assigned
+// to any local interface fails immediately with EADDRNOTAVAIL on Linux, so no
+// packets leave the host; we only observe the order of the recorded attempts.
+func TestDialCostAwareOrdersByCost(t *testing.T) {
+	dns := mkDNS(
+		mkPort("wlan0", 20, net.ParseIP("198.51.100.20")),
+		mkPort("eth0", 0, net.ParseIP("198.51.100.10")),
+		mkPort("wwan0", 10, net.ParseIP("198.51.100.30")),
+	)
+	// Target is a literal IP (TEST-NET-2 discard port) so no DNS lookup runs.
+	res, err := dialCostAware(context.Background(), log, dns, 255, "198.51.100.99:9", time.Second, 0)
+	if res != nil {
+		_ = res.Conn.Close()
+		t.Skip("unexpected successful dial in this environment; skipping ordering assertion")
+	}
+	var de *dialError
+	if !errors.As(err, &de) {
+		t.Fatalf("err = %v, want *dialError", err)
+	}
+	attempts := de.Attempts()
+	if len(attempts) != 3 {
+		t.Fatalf("got %d attempts, want 3: %+v", len(attempts), attempts)
+	}
+	wantOrder := []string{"eth0", "wwan0", "wlan0"}
+	for i, want := range wantOrder {
+		if attempts[i].IfName != want {
+			t.Errorf("attempt[%d] = %s, want %s (cost order)", i, attempts[i].IfName, want)
+		}
+	}
+}
+
+// --- tunnel ----------------------------------------------------------------
+
+// TestTunnelCopiesBothDirections drives a full tunnel over two in-memory
+// socket pairs and verifies bytes flow client→upstream and upstream→client,
+// that the per-direction counters are updated, and that closing both peers
+// lets tunnel return promptly (idle watchdog not triggered).
+func TestTunnelCopiesBothDirections(t *testing.T) {
+	clientConn, clientPeer := net.Pipe()
+	upConn, upPeer := net.Pipe()
+
+	ctx := newTestContext(mkDNS(), 0)
+
+	done := make(chan struct{})
+	go func() {
+		tunnel(ctx, "registry:443", "eth0", clientConn, upConn, time.Now())
+		close(done)
+	}()
+
+	upGot := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 64)
+		n, _ := upPeer.Read(buf)
+		upGot <- string(buf[:n])
+	}()
+	clientGot := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 64)
+		n, _ := clientPeer.Read(buf)
+		clientGot <- string(buf[:n])
+	}()
+
+	if _, err := clientPeer.Write([]byte("up-data")); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	if _, err := upPeer.Write([]byte("down-data")); err != nil {
+		t.Fatalf("upstream write: %v", err)
+	}
+
+	if got := <-upGot; got != "up-data" {
+		t.Errorf("upstream received %q, want up-data", got)
+	}
+	if got := <-clientGot; got != "down-data" {
+		t.Errorf("client received %q, want down-data", got)
+	}
+
+	// Closing both peers signals EOF on both copy goroutines so tunnel returns.
+	_ = clientPeer.Close()
+	_ = upPeer.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("tunnel did not return after peers closed")
+	}
+
+	if ctx.stats.bytesUp.Load() != uint64(len("up-data")) {
+		t.Errorf("bytesUp = %d, want %d", ctx.stats.bytesUp.Load(), len("up-data"))
+	}
+	if ctx.stats.bytesDown.Load() != uint64(len("down-data")) {
+		t.Errorf("bytesDown = %d, want %d", ctx.stats.bytesDown.Load(), len("down-data"))
+	}
+	if ctx.stats.tunnelIdleClosed.Load() != 0 {
+		t.Errorf("tunnelIdleClosed = %d, want 0", ctx.stats.tunnelIdleClosed.Load())
+	}
+}

--- a/pkg/pillar/cmd/mgmtproxy/nomgmtproxy.go
+++ b/pkg/pillar/cmd/mgmtproxy/nomgmtproxy.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !k
+
+package mgmtproxy
+
+import (
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/agentbase"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	agentName            = "mgmtproxy"
+	errorTime            = 3 * time.Minute
+	warningTime          = 40 * time.Second
+	stillRunningInterval = 25 * time.Second
+)
+
+type mgmtProxyContext struct {
+	agentbase.AgentBase
+}
+
+// Run is a no-op stub for non-k builds. mgmtproxy is only meaningful in EVE-K
+// where containerd does its own image pulls; on KVM/Xen images all downloads
+// already flow through pillar's cost-aware controllerconn path.
+func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject,
+	arguments []string, baseDir string) int {
+
+	ctx := mgmtProxyContext{}
+	agentbase.Init(&ctx, loggerArg, logArg, agentName,
+		agentbase.WithPidFile(),
+		agentbase.WithBaseDir(baseDir),
+		agentbase.WithWatchdog(ps, warningTime, errorTime),
+		agentbase.WithArguments(arguments))
+
+	tick := time.NewTicker(stillRunningInterval)
+	for range tick.C {
+		ps.StillRunning(agentName, warningTime, errorTime)
+	}
+	return 0
+}

--- a/pkg/pillar/cmd/mgmtproxy/proxy.go
+++ b/pkg/pillar/cmd/mgmtproxy/proxy.go
@@ -1,0 +1,283 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package mgmtproxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// newProxyHandler returns the http.Handler installed on the loopback listener.
+// CONNECT requests are tunneled cost-aware. GET /healthz returns a JSON
+// snapshot of proxy state for live debugging. Anything else is rejected.
+//
+// Plain-HTTP forwarding is intentionally not implemented: the relevant egress
+// paths (containerd image pulls, `curl https://get.k3s.io`) all use HTTPS, and
+// CONNECT-only keeps the implementation small and side-effect-free (no header
+// rewriting, no auth header handling, no risk of leaking credentials in logs).
+func newProxyHandler(ctx *mgmtProxyContext) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method == http.MethodGet && req.URL.Path == "/healthz" {
+			handleHealthz(ctx, w)
+			return
+		}
+		if req.Method != http.MethodConnect {
+			http.Error(w, "mgmtproxy: only CONNECT and GET /healthz are supported", http.StatusMethodNotAllowed)
+			return
+		}
+		handleConnect(ctx, w, req)
+	})
+}
+
+// handleHealthz returns 200 + JSON describing proxy state. Operators can curl
+// http://127.0.0.1:5443/healthz to see whether the proxy is up, what the
+// effective max-cost is, which mgmt ports are visible (with their costs and
+// LastError flags from NIM), traffic counters, and the last success/error.
+func handleHealthz(ctx *mgmtProxyContext, w http.ResponseWriter) {
+	dns, maxCost, ready := ctx.snapshot()
+	_ = dns
+
+	// cni0Listening: probe whether the cni0 link-local listener is up by
+	// attempting a non-binding dial. Avoids tracking state across goroutines.
+	cni0Listening := false
+	if c, err := net.DialTimeout("tcp", CNI0ListenAddr, 200*time.Millisecond); err == nil {
+		c.Close()
+		cni0Listening = true
+	}
+
+	r := types.MgmtProxyHealthz{
+		Listening:        ListenAddr,
+		CNI0Listening:    cni0Listening,
+		Ready:            ready,
+		MaxPortCost:      maxCost,
+		Ports:            ctx.portSummaries(),
+		Requests:         ctx.stats.requests.Load(),
+		DialFailures:     ctx.stats.dialFailures.Load(),
+		NotReady:         ctx.stats.notReady.Load(),
+		TunnelIdleClosed: ctx.stats.tunnelIdleClosed.Load(),
+		BytesUp:          ctx.stats.bytesUp.Load(),
+		BytesDown:        ctx.stats.bytesDown.Load(),
+		SuccessByPort:    mapToCounts(&ctx.stats.successByPort),
+		FailureByPort:    mapToCounts(&ctx.stats.failureByPort),
+	}
+	if t := ctx.stats.lastSuccessTime.Load(); t != 0 {
+		r.LastSuccessTime = time.Unix(0, t).UTC().Format(time.RFC3339)
+		ctx.stats.lastSuccessMu.RLock()
+		r.LastSuccessTarget = ctx.stats.lastSuccessTarget
+		r.LastSuccessPort = ctx.stats.lastSuccessPort
+		r.LastSuccessCost = ctx.stats.lastSuccessCost
+		ctx.stats.lastSuccessMu.RUnlock()
+	}
+	if t := ctx.stats.lastErrorTime.Load(); t != 0 {
+		r.LastErrorTime = time.Unix(0, t).UTC().Format(time.RFC3339)
+		ctx.stats.lastErrorMu.RLock()
+		r.LastError = ctx.stats.lastError
+		ctx.stats.lastErrorMu.RUnlock()
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(&r)
+}
+
+func handleConnect(ctx *mgmtProxyContext, w http.ResponseWriter, req *http.Request) {
+	ctx.stats.requests.Add(1)
+	target := req.URL.Host
+	if target == "" {
+		target = req.Host
+	}
+	if _, _, err := net.SplitHostPort(target); err != nil {
+		http.Error(w, "mgmtproxy: bad CONNECT target", http.StatusBadRequest)
+		return
+	}
+
+	// clientAddr is the source of the incoming CONNECT connection.
+	// 127.0.0.1:PORT  → host process (containerd, kubectl)
+	// 10.42.x.x:PORT  → CDI importer pod (via cni0 link-local listener)
+	clientAddr := req.RemoteAddr
+
+	start := time.Now()
+	res, err := ctx.dialUpstreamCtx(req.Context(), target)
+	if err != nil {
+		// Always logged at Warn so operators see CONNECT failures without
+		// raising the global log level. Includes per-port attempts so the
+		// log line tells you exactly which interfaces failed and why.
+		log.Warnf("mgmtproxy: CONNECT %s from %s FAILED after %v: %v",
+			target, clientAddr, time.Since(start).Round(time.Millisecond), err)
+		var de *dialError
+		if errors.As(err, &de) {
+			ctx.stats.recordFailure(target, de.Attempts(), err.Error())
+			// Record one RecordFailure per attempted interface so the
+			// per-port FailureCount in `edgeview url` reflects which
+			// uplinks the dialer actually tried.
+			for _, a := range de.Attempts() {
+				ctx.agentMetrics.RecordFailure(log, a.IfName, target, 0, 0, false)
+			}
+		} else {
+			ctx.stats.recordFailure(target, nil, err.Error())
+		}
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	dialDur := time.Since(start).Round(time.Millisecond)
+	ctx.stats.recordSuccess(target, res.IfName, res.Cost)
+	// Record dial-time failures for any ports we tried before the winner.
+	// These are real attempts NIM should know failed for this target.
+	for _, a := range res.Attempts {
+		ctx.agentMetrics.RecordFailure(log, a.IfName, target, 0, 0, false)
+	}
+	// Notice level: every CONNECT outcome is visible at the default log
+	// level. clientAddr identifies the caller: 127.0.0.1 = host process
+	// (containerd/kubectl), 10.42.x.x = CDI importer pod via cni0 listener.
+	log.Noticef("mgmtproxy: CONNECT %s from %s via %s src %v cost %d (dial %v, %d fallback(s))",
+		target, clientAddr, res.IfName, res.SrcIP, res.Cost, dialDur, len(res.Attempts))
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		_ = res.Conn.Close()
+		http.Error(w, "mgmtproxy: server does not support hijacking", http.StatusInternalServerError)
+		return
+	}
+
+	// Hijack BEFORE writing the response. Calling w.WriteHeader first lets
+	// the http.ResponseWriter buffer/flush extra headers (Date, Connection,
+	// Content-Type) onto the wire — fine for forgiving clients but not for
+	// the strict TLS clients common in container-registry stacks. Take over
+	// the conn first, then write a clean "HTTP/1.1 200 OK\r\n\r\n" by hand.
+	client, clientBuf, err := hijacker.Hijack()
+	if err != nil {
+		_ = res.Conn.Close()
+		log.Errorf("mgmtproxy: hijack: %v", err)
+		return
+	}
+	if _, err := client.Write([]byte("HTTP/1.1 200 OK\r\n\r\n")); err != nil {
+		_ = client.Close()
+		_ = res.Conn.Close()
+		log.Tracef("mgmtproxy: write CONNECT response: %v", err)
+		return
+	}
+
+	// Some clients pipeline the first TLS bytes immediately after the
+	// CONNECT request; flush any buffered bytes upstream before tunneling.
+	if clientBuf != nil && clientBuf.Reader.Buffered() > 0 {
+		if _, err := io.CopyN(res.Conn, clientBuf, int64(clientBuf.Reader.Buffered())); err != nil {
+			_ = client.Close()
+			_ = res.Conn.Close()
+			log.Tracef("mgmtproxy: drain client buffer to upstream: %v", err)
+			return
+		}
+	}
+
+	tunnel(ctx, target, res.IfName, client, res.Conn, start)
+}
+
+// tunnel performs a bidirectional copy with an idle timeout and accounts
+// bytes per direction. On close it logs a single Functionf line with the
+// totals — visible if operators bump the level to debug a specific pull.
+func tunnel(ctx *mgmtProxyContext, target, ifName string, a, b net.Conn, dialStart time.Time) {
+	idleCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	activity := make(chan struct{}, 4)
+	idleClosed := atomic.Bool{}
+	go idleWatchdog(idleCtx, &idleClosed, activity, a, b)
+
+	var wg sync.WaitGroup
+	var bytesA2B, bytesB2A uint64
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		bytesA2B = copyAndSignal(b, a, activity)
+		_ = a.Close()
+	}()
+	go func() {
+		defer wg.Done()
+		bytesB2A = copyAndSignal(a, b, activity)
+		_ = b.Close()
+	}()
+	wg.Wait()
+	ctx.stats.bytesUp.Add(bytesA2B)
+	ctx.stats.bytesDown.Add(bytesB2A)
+	if idleClosed.Load() {
+		ctx.stats.tunnelIdleClosed.Add(1)
+	}
+	durationMs := time.Since(dialStart).Milliseconds()
+	// Record one RecordSuccess per CONNECT at tunnel close so the per-target
+	// byte counts and total time in `edgeview url` reflect actual transfer,
+	// not just the dial. SessionResume is always false (we don't terminate
+	// TLS so we can't observe it). For the half-broken-firewall case (idle
+	// kill with bytes=0) we still record success — the dial succeeded; the
+	// /healthz tunnelIdleClosed counter and the bytes=0 in edgeview tell
+	// the rest of the story without double-counting.
+	ctx.agentMetrics.RecordSuccess(log, ifName, target,
+		int64(bytesA2B), int64(bytesB2A), durationMs, false)
+	log.Functionf("mgmtproxy: tunnel %s via %s closed: up=%d down=%d duration=%v idle=%v",
+		target, ifName, bytesA2B, bytesB2A,
+		time.Duration(durationMs)*time.Millisecond, idleClosed.Load())
+}
+
+// copyAndSignal copies src→dst and pokes the activity channel periodically so
+// the idle watchdog can tell the tunnel from a stalled one. Returns total
+// bytes copied (best-effort — partial writes on error still counted).
+func copyAndSignal(dst io.Writer, src io.Reader, activity chan<- struct{}) uint64 {
+	buf := make([]byte, 32*1024)
+	var total uint64
+	for {
+		n, err := src.Read(buf)
+		if n > 0 {
+			w, werr := dst.Write(buf[:n])
+			total += uint64(w)
+			if werr != nil {
+				return total
+			}
+			select {
+			case activity <- struct{}{}:
+			default:
+			}
+		}
+		if err != nil {
+			if !errors.Is(err, io.EOF) && !errors.Is(err, net.ErrClosed) {
+				log.Tracef("mgmtproxy: tunnel read: %v", err)
+			}
+			return total
+		}
+	}
+}
+
+func idleWatchdog(ctx context.Context, idleClosed *atomic.Bool,
+	activity <-chan struct{}, conns ...net.Conn) {
+
+	timer := time.NewTimer(idleTimeout)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-activity:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(idleTimeout)
+		case <-timer.C:
+			log.Warnf("mgmtproxy: tunnel idle for %v, closing", idleTimeout)
+			idleClosed.Store(true)
+			for _, c := range conns {
+				_ = c.Close()
+			}
+			return
+		}
+	}
+}

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -377,6 +377,7 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 	diagMetrics.AddInto(cms)
 	nimMetrics.AddInto(cms)
 	zrouterMetrics.AddInto(cms)
+	mgmtProxyMetrics.AddInto(cms)
 	for ifname, cm := range cms {
 		metric := metrics.ZedcloudMetric{IfName: ifname,
 			Failures:          cm.FailureCount,

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -85,6 +85,7 @@ var cipherMetricsWwan types.CipherMetrics
 var diagMetrics types.MetricsMap
 var nimMetrics types.MetricsMap
 var zrouterMetrics types.MetricsMap
+var mgmtProxyMetrics types.MetricsMap
 
 // Context for handleDNSModify
 type DNSContext struct {
@@ -152,6 +153,7 @@ type zedagentContext struct {
 	subDiagMetrics            pubsub.Subscription
 	subNimMetrics             pubsub.Subscription
 	subZRouterMetrics         pubsub.Subscription
+	subMgmtProxyMetrics       pubsub.Subscription
 	subCipherMetricsDL        pubsub.Subscription
 	subCipherMetricsDM        pubsub.Subscription
 	subCipherMetricsNim       pubsub.Subscription
@@ -1047,6 +1049,16 @@ func mainEventLoop(zedagentCtx *zedagentContext, stillRunning *time.Ticker) {
 					err)
 			} else {
 				zrouterMetrics = m.(types.MetricsMap)
+			}
+
+		case change := <-zedagentCtx.subMgmtProxyMetrics.MsgChan():
+			zedagentCtx.subMgmtProxyMetrics.ProcessChange(change)
+			m, err := zedagentCtx.subMgmtProxyMetrics.Get("global")
+			if err != nil {
+				log.Errorf("subMgmtProxyMetrics.Get failed: %s",
+					err)
+			} else {
+				mgmtProxyMetrics = m.(types.MetricsMap)
 			}
 
 		case change := <-zedagentCtx.subNewlogMetrics.MsgChan():
@@ -2047,6 +2059,19 @@ func initPostOnboardSubs(zedagentCtx *zedagentContext) {
 	// cloud metrics of zedrouter
 	zedagentCtx.subZRouterMetrics, err = ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName: "zedrouter",
+		TopicImpl: types.MetricsMap{},
+		Activate:  true,
+		Ctx:       zedagentCtx,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// cloud metrics of mgmtproxy (EVE-K cost-aware HTTP CONNECT proxy). Only
+	// publishes in kubevirt builds; in other builds the agent is a no-op stub
+	// and never creates the publication, so this subscription stays empty.
+	zedagentCtx.subMgmtProxyMetrics, err = ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName: "mgmtproxy",
 		TopicImpl: types.MetricsMap{},
 		Activate:  true,
 		Ctx:       zedagentCtx,

--- a/pkg/pillar/controllerconn/resolver.go
+++ b/pkg/pillar/controllerconn/resolver.go
@@ -118,6 +118,24 @@ func (r *ResolverWithLocalIP) getNetResolver() *net.Resolver {
 	return &net.Resolver{Dial: r.resolverDial, PreferGo: true, StrictErrors: false}
 }
 
+// NewResolverWithLocalIP constructs a ResolverWithLocalIP for callers outside
+// this package (e.g. the mgmtproxy agent for cost-aware container image pulls).
+// localIP must be a routable address on the interface whose per-port routing
+// table should be used. ifName is used only in error messages.
+func NewResolverWithLocalIP(log *base.LogObject, ifName string, localIP net.IP) *ResolverWithLocalIP {
+	return &ResolverWithLocalIP{
+		log:     log,
+		ifName:  ifName,
+		localIP: localIP,
+	}
+}
+
+// NetResolver returns a *net.Resolver wrapping this ResolverWithLocalIP so it
+// can be plugged into net.Dialer.Resolver.
+func (r *ResolverWithLocalIP) NetResolver() *net.Resolver {
+	return r.getNetResolver()
+}
+
 // DialerWithResolverCache provides DialContext function just like regular net.Dialer.
 // The difference is that it will try to avoid DNS query if the target hostname IP is already
 // resolved and stored in the cache.

--- a/pkg/pillar/dpcreconciler/linux.go
+++ b/pkg/pillar/dpcreconciler/linux.go
@@ -2133,6 +2133,32 @@ func (r *LinuxDpcReconciler) getIntendedFilterRules(gcp types.ConfigItemValueMap
 		}
 	}
 
+	// EVE-K only: explicitly drop inbound connections to the mgmtproxy port
+	// (5443) arriving on external (uplink) interfaces. mgmtproxy listens only
+	// on 127.0.0.1:5443 and on the cni0 link-local anchor 169.254.100.1:5443
+	// (see cmd/mgmtproxy/mgmtproxy.go), neither of which is reachable from an
+	// uplink, so this is belt-and-suspenders on top of the per-port default
+	// drop below. Scoped to L3 uplink ports so it never matches lo (host
+	// containerd/kubectl) or cni0 (CDI importer pods, source 10.42.x.x).
+	if r.HVTypeKube {
+		const mgmtProxyPort = "5443"
+		for _, port := range dpc.Ports {
+			if port.IfName == "" || !port.IsL3Port || port.InvalidConfig {
+				continue
+			}
+			blockMgmtProxy := iptables.Rule{
+				RuleLabel: fmt.Sprintf("Block mgmtproxy port on %s", port.IfName),
+				MatchOpts: []string{"-i", port.IfName, "-p", "tcp",
+					"--dport", mgmtProxyPort},
+				Target: "DROP",
+				Description: fmt.Sprintf("Drop inbound connections to the mgmtproxy "+
+					"port (%s) received via uplink port %s", mgmtProxyPort, port.IfName),
+			}
+			inputV4Rules = append(inputV4Rules, blockMgmtProxy)
+			inputV6Rules = append(inputV6Rules, blockMgmtProxy)
+		}
+	}
+
 	// Allow all traffic that belongs to an already established connection.
 	allowEstablishedConn := iptables.Rule{
 		RuleLabel:   "Allow established connection",

--- a/pkg/pillar/dpcreconciler/linux_test.go
+++ b/pkg/pillar/dpcreconciler/linux_test.go
@@ -1347,6 +1347,74 @@ func TestKubeACEService(t *testing.T) {
 	t.Log("TestKubeACEService completed successfully")
 }
 
+// findMgmtProxyDropRule scans the generated IPv4 filter rules for the explicit
+// mgmtproxy port-5443 DROP rule on the given uplink interface. Returns nil if
+// no such rule is present.
+func findMgmtProxyDropRule(acls dg.Graph, ifName string) *iptables.Rule {
+	iter := acls.Items(true)
+	for iter.Next() {
+		item, _ := iter.Item()
+		rule, ok := item.(iptables.Rule)
+		if !ok {
+			continue
+		}
+		if rule.RuleLabel == "Block mgmtproxy port on "+ifName {
+			r := rule
+			return &r
+		}
+	}
+	return nil
+}
+
+// TestMgmtProxyPortBlock verifies that on EVE-K (HVTypeKube) an explicit DROP
+// rule for the mgmtproxy port (5443) is emitted on each L3 uplink interface,
+// and that no such rule is emitted on non-kube devices. The rule must be
+// interface-scoped (-i <uplink>) so it never matches loopback (host
+// containerd/kubectl) or cni0 (CDI importer pods).
+func TestMgmtProxyPortBlock(t *testing.T) {
+	g := initTest(t)
+
+	dpc := types.DevicePortConfig{
+		Version: types.DPCIsMgmt,
+		Key:     "zedagent",
+		Ports: []types.NetworkPortConfig{
+			{
+				IfName:       "eth0",
+				Phylabel:     "eth0",
+				Logicallabel: "mock-eth0",
+				IsMgmt:       true,
+				IsL3Port:     true,
+			},
+		},
+	}
+	clusterStatus := types.EdgeNodeClusterStatus{}
+	gcp := types.DefaultConfigItemValueMap()
+	kubeServices := types.KubeUserServices{}
+
+	genRules := func() dg.Graph {
+		v4 := dg.New(dg.InitArgs{Name: "IPv4ACLs"})
+		v6 := dg.New(dg.InitArgs{Name: "IPv6ACLs"})
+		dpcReconciler.GetIntendedFilterRules(*gcp, dpc, clusterStatus, kubeServices, v4, v6)
+		return v4
+	}
+
+	// EVE-K: the rule must be present, DROP, scoped to eth0, tcp, dport 5443.
+	dpcReconciler.HVTypeKube = true
+	rule := findMgmtProxyDropRule(genRules(), "eth0")
+	g.Expect(rule).ToNot(BeNil(),
+		"mgmtproxy port-block rule should be emitted on EVE-K for an L3 uplink")
+	g.Expect(rule.Target).To(Equal("DROP"), "mgmtproxy port block should DROP")
+	g.Expect(rule.MatchOpts).To(ContainElements("-i", "eth0", "-p", "tcp", "--dport", "5443"),
+		"rule should be interface-scoped to the uplink and match tcp/5443")
+
+	// Non-kube: no mgmtproxy port-block rule (port 5443 is EVE-K only).
+	dpcReconciler.HVTypeKube = false
+	g.Expect(findMgmtProxyDropRule(genRules(), "eth0")).To(BeNil(),
+		"mgmtproxy port-block rule should not be emitted on non-kube devices")
+
+	t.Log("TestMgmtProxyPortBlock completed successfully")
+}
+
 func TestSingleEthInterfaceWithIPv6(test *testing.T) {
 	t := initTest(test)
 	eth0Mac := "02:00:00:00:00:01"

--- a/pkg/pillar/scripts/device-steps.sh
+++ b/pkg/pillar/scripts/device-steps.sh
@@ -21,7 +21,8 @@ FIRSTBOOT=
 AGENTS="diag monitor evalmgr zedagent ledmanager nim nodeagent \
 domainmgr loguploader tpmmgr vaultmgr zedmanager zedrouter \
 downloader verifier baseosmgr wstunnelclient volumemgr watcher \
-zfsmanager usbmanager zedkube vcomlink collectinfo scepclient"
+zfsmanager usbmanager zedkube vcomlink collectinfo scepclient \
+mgmtproxy"
 TPM_DEVICE_PATH="/dev/tpmrm0"
 PATH=$BINDIR:$PATH
 TPMINFOTEMPFILE=/var/tmp/tpminfo.txt

--- a/pkg/pillar/types/mgmtproxytypes.go
+++ b/pkg/pillar/types/mgmtproxytypes.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+// These types describe the JSON payload served by the mgmtproxy agent's
+// GET /healthz endpoint (127.0.0.1:5443/healthz). They are exported here,
+// rather than kept private to the agent, so other components (e.g. edgeview)
+// can unmarshal and process the snapshot, and so the wire contract of
+// /healthz is documented in one place. The JSON tags are the contract — do
+// not change them without updating consumers.
+
+// MgmtProxyPortSummary describes one management port as seen by mgmtproxy's
+// cost-aware dialer, for /healthz output.
+type MgmtProxyPortSummary struct {
+	IfName     string `json:"ifname"`
+	Cost       uint8  `json:"cost"`
+	IsMgmt     bool   `json:"isMgmt"`
+	HasError   bool   `json:"hasError,omitempty"`
+	LastError  string `json:"lastError,omitempty"`
+	NumAddrs   int    `json:"numAddrs"`
+	UsableAddr string `json:"usableAddr,omitempty"`
+}
+
+// MgmtProxyHealthz is the JSON snapshot returned by mgmtproxy's GET /healthz:
+// listener state, the effective max port cost, the visible management ports,
+// traffic counters, and the last success/error with timestamps.
+type MgmtProxyHealthz struct {
+	Listening         string                 `json:"listening"`
+	CNI0Listening     bool                   `json:"cni0Listening"`
+	Ready             bool                   `json:"ready"`
+	MaxPortCost       uint8                  `json:"maxPortCost"`
+	Ports             []MgmtProxyPortSummary `json:"ports"`
+	Requests          uint64                 `json:"requests"`
+	DialFailures      uint64                 `json:"dialFailures"`
+	NotReady          uint64                 `json:"notReady"`
+	TunnelIdleClosed  uint64                 `json:"tunnelIdleClosed"`
+	BytesUp           uint64                 `json:"bytesUp"`
+	BytesDown         uint64                 `json:"bytesDown"`
+	SuccessByPort     map[string]uint64      `json:"successByPort"`
+	FailureByPort     map[string]uint64      `json:"failureByPort"`
+	LastSuccessTime   string                 `json:"lastSuccessTime,omitempty"`
+	LastSuccessTarget string                 `json:"lastSuccessTarget,omitempty"`
+	LastSuccessPort   string                 `json:"lastSuccessPort,omitempty"`
+	LastSuccessCost   uint8                  `json:"lastSuccessCost,omitempty"`
+	LastErrorTime     string                 `json:"lastErrorTime,omitempty"`
+	LastError         string                 `json:"lastError,omitempty"`
+}

--- a/pkg/pillar/types/zedkubetypes.go
+++ b/pkg/pillar/types/zedkubetypes.go
@@ -34,6 +34,7 @@ const (
 // KubeNodeStatus - Enum for the status of a Kubernetes node
 type KubeNodeStatus int8
 
+// KubeNodeStatus values.
 const (
 	KubeNodeStatusUnknown      KubeNodeStatus = iota // KubeNodeStatusUnknown - Node status is unknown
 	KubeNodeStatusReady                              // KubeNodeStatusReady - Node is in ready status
@@ -44,6 +45,7 @@ const (
 // NodeAdmission - Enum for the admission status of a node in a cluster
 type NodeAdmission uint8
 
+// NodeAdmission values.
 const (
 	NodeAdmissionUnknown      NodeAdmission = iota // NodeAdmissionUnknown - Node admission status is unknown
 	NodeAdmissionNotClustered                      // NodeAdmissionNotClustered - Node is not part of the cluster
@@ -107,6 +109,7 @@ func (kni KubeNodeInfo) ZKubeNodeInfo() *info.KubeNodeInfo {
 // KubePodStatus - Enum for the status of a Kubernetes pod
 type KubePodStatus int8
 
+// KubePodStatus values.
 const (
 	KubePodStatusUnknown   KubePodStatus = iota // KubePodStatusUnknown - Pod status is unknown
 	KubePodStatusPending                        // KubePodStatusPending - Pod is in pending status
@@ -176,6 +179,7 @@ type KubePodNameSpaceInfo struct {
 // KubeVMIStatus - Enum for the status of a VirtualMachineInstance
 type KubeVMIStatus int8
 
+// KubeVMIStatus values.
 const (
 	KubeVMIStatusUnset      KubeVMIStatus = iota // KubeVMIStatusUnset - UnSet VMI status
 	KubeVMIStatusPending                         // KubeVMIStatusPending - VMI in pending status
@@ -245,6 +249,7 @@ type KubeClusterInfo struct {
 // StorageHealthStatus - Enum for the redundancy level and replication status of a storage volume
 type StorageHealthStatus uint8
 
+// StorageHealthStatus values.
 const (
 	StorageHealthStatusUnknown                                 StorageHealthStatus = iota // StorageHealthStatusUnknown - Storage health status is unknown
 	StorageHealthStatusHealthy                                                            // StorageHealthStatusHealthy - All replicas healthy
@@ -258,6 +263,7 @@ const (
 // StorageVolumeState - Enum for the attachment state of a storage volume
 type StorageVolumeState uint8
 
+// StorageVolumeState values.
 const (
 	StorageVolumeStateUnknown   StorageVolumeState = iota // StorageVolumeStateUnknown - Volume state is unknown
 	StorageVolumeStateCreating                            // StorageVolumeStateCreating - Volume is being created
@@ -293,6 +299,7 @@ func (svs StorageVolumeState) ZStorageVolumeState() info.StorageVolumeState {
 // StorageVolumeRobustness - Enum for the replica robustness of a storage volume
 type StorageVolumeRobustness uint8
 
+// StorageVolumeRobustness values.
 const (
 	StorageVolumeRobustnessUnknown  StorageVolumeRobustness = iota // StorageVolumeRobustnessUnknown - Volume robustness is unknown
 	StorageVolumeRobustnessHealthy                                 // StorageVolumeRobustnessHealthy - All Volume replicas healthy
@@ -303,6 +310,7 @@ const (
 // StorageVolumePvcStatus - Enum for the status of a PVC associated with a volume instance
 type StorageVolumePvcStatus uint8
 
+// StorageVolumePvcStatus values.
 const (
 	StorageVolumePvcStatusUnknown   StorageVolumePvcStatus = iota // StorageVolumePvcStatusUnknown - PVC status is unknown
 	StorageVolumePvcStatusBound                                   // StorageVolumePvcStatusBound - PVC is bound
@@ -315,6 +323,7 @@ const (
 // StorageVolumeReplicaStatus - Enum for the status of a replica of a storage volume
 type StorageVolumeReplicaStatus uint8
 
+// StorageVolumeReplicaStatus values.
 const (
 	StorageVolumeReplicaStatusUnknown    StorageVolumeReplicaStatus = iota // StorageVolumeReplicaStatusUnknown - Replica status is unknown
 	StorageVolumeReplicaStatusRebuilding                                   // StorageVolumeReplicaStatusRebuilding - Replica is rebuilding
@@ -400,6 +409,7 @@ func (kvi KubeVolumeInfo) ZKubeVolumeInfo() *info.KubeVolumeInfo {
 // ServiceStatus - Enum for the status of a service
 type ServiceStatus int8
 
+// ServiceStatus values.
 const (
 	ServiceStatusUnset    ServiceStatus = iota // ServiceStatusUnset - Service status is unset
 	ServiceStatusFailed                        // ServiceStatusFailed - Service status is failed

--- a/pkg/pillar/zedbox/zedbox.go
+++ b/pkg/pillar/zedbox/zedbox.go
@@ -29,6 +29,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/cmd/ipcmonitor"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/ledmanager"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/loguploader"
+	"github.com/lf-edge/eve/pkg/pillar/cmd/mgmtproxy"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/monitor"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/nim"
 	"github.com/lf-edge/eve/pkg/pillar/cmd/nodeagent"
@@ -111,6 +112,7 @@ var (
 		"usbmanager":       {f: usbmanager.Run},
 		"collectinfo":      {f: collectinfo.Run},
 		"vcomlink":         {f: vcomlink.Run},
+		"mgmtproxy":        {f: mgmtproxy.Run},
 		"monitor":          {f: monitor.Run},
 		"scepclient":       {f: scepclient.Run},
 	}


### PR DESCRIPTION

# Description

- Problem
 `https://...` paths make outbound HTTPS directly via `table main`,
 ignoring `network.download.max.cost`.  When the cost-0 uplink's
 gateway is unreachable but a higher-cost backup is healthy, NIM
 updates per-port routing tables but `table main` still points at the
 dead gateway — pulls time out and pods land in `ImagePullBackOff`. 
 Pillar's own downloader is unaffected (it already binds per-port source IPs).

- Change
  forward proxy on `127.0.0.1:5443` (plus `169.254.100.1:5443` on cni0 for CDI
  importer pods).  Clients reach it via `HTTPS_PROXY`; the proxy iterates management
  ports in ascending cost (filtered by `network.download.max.cost`), binds the
  outbound socket to each port's source IP so packets follow NIM's per-port table,
  and tunnels via the first port whose dial succeeds.

Wired into:
- kube containerd (`cluster-init.sh`) — all k8s/kubevirt/app image pulls
- k3s installer curl (`cluster-update.sh`)
- `kubectl apply -f https://...` for KubeVirt/CDI/Longhorn install & upgrade (`mgmtproxy_run` helper + `update-component/upgrades.go`)
- CDI importer pods (CDI CR `importProxy` patch + cni0 link-local listener)

- Observability
  - `mgmtproxy: listening ...` / `CONNECT <target> via <if> cost N` log lines
  - `GET /healthz` JSON snapshot (ports, costs, per-port counters, last success/error)
  - Publishes `MetricsMap` → visible in `edgeview url` **and** folded into the device
    `ZedcloudMetric` report (zedagent subscribes, same path as nim/downloader)
  - Off-switch: `/run/kube/mgmtproxy-disable`

## PR dependencies

## How to test and validate this PR

- Setup the cluster w/ eve-k w/ this patch
  - verify thie proxy up and configured
     curl -s http://127.0.0.1:5443/healthz | jq
  - verify kube containerd was launched with the proxy env
     cat /run/mgmtproxy-containerd-env
    Pass: /healthz shows "ready":true, "cni0Listening":true, and your uplinks under ports with their costs.
    The sentinel file shows HTTPS_PROXY=http://127.0.0.1:5443.
  - force a manual pull of tiny uncached image
    eve exec kube crictl pull docker.io/library/hello-world:latest
  - use edgeview script to see the mgmtproxy url metrics
     e.g.
     registry-1.docker.io:443
       Recv (KBytes): 36, Sent 22346, SentMsg: 4, TLS resume: 0, Total Time(sec): 6

## Changelog notes

mgmtproxy: cost-aware CONNECT kube proxy for containerd & kubectl image/manifest

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
