### PR TITLE
[16.0-stable] GHA: fix release-asset publishing on 16.0-stable

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -149,7 +149,9 @@ jobs:
           cd ../
           mv "$sha256_file" assets/
           mv "$sizes_file" assets/
-          # Upload files
+          # Upload files. Track failures and fail the job at the end so that
+          # all assets are attempted before the run is marked failed.
+          upload_failed=0
           for file in assets/*; do
             file_name=$(basename $file)
             echo "Uploading ${file_name}..."
@@ -161,6 +163,8 @@ jobs:
             if echo "$upload_response" | jq -e .id > /dev/null; then
               echo "$file_name uploaded successfully."
             else
-              echo "Error uploading $file_name: $upload_response"
+              echo "::error::Failed to upload $file_name: $upload_response"
+              upload_failed=1
             fi
           done
+          exit "$upload_failed"

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -115,14 +115,14 @@ jobs:
              docker run "$EVE" installer_iso > assets/installer.iso
              docker run "$EVE" installer_net > assets/installer-net.tar
           fi
-      - name: Pull eve-sources and publish collected_sources.tar.gz to assets
+      - name: Export eve-sources to assets/collected_sources.tar
         run: |
           if [ "${{ matrix.platform }}" != "evaluation" ]; then
             HV=${{ matrix.hv }}
             EVE_SOURCES=lfedge/eve-sources:${TAG}-${{ env.PLATFORMVER }}${HV}-${{ env.ARCH }}
             docker pull "$EVE_SOURCES"
             docker create --name eve_sources "$EVE_SOURCES" bash
-            docker export --output assets/collected_sources.tar.gz eve_sources
+            docker export --output assets/collected_sources.tar eve_sources
             docker rm eve_sources
           fi
       - name: Rename, create SHA256 checksums and upload files

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -315,7 +315,7 @@ jobs:
   trigger_assets:
     if: ${{ (startsWith(github.ref, 'refs/tags/')) && (github.event.repository.full_name == 'lf-edge/eve') }}
     needs: [manifest, eve]
-    uses: lf-edge/eve/.github/workflows/assets.yml@master
+    uses: lf-edge/eve/.github/workflows/assets.yml@16.0-stable
     secrets:
       DOCKERHUB_PULL_TOKEN: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
       DOCKERHUB_PULL_USER: ${{ secrets.DOCKERHUB_PULL_USER }}


### PR DESCRIPTION
# Description

This PR fixes release-asset publishing on `16.0-stable`. It contains three independent changes (one commit each):

1. **Pin the reusable assets workflow to this branch.** `publish.yml` referenced `assets.yml@master`, so tagged release builds on `16.0-stable` ran master's `assets.yml` instead of the branch's own copy. After master gained additional EVE image variants (arm64 kubevirt and nvidia-jp7, #5907), `16.0-stable` tagged builds began attempting to publish assets for variants this branch does not build. Pinning the reference to `@16.0-stable` keeps the branch on its own asset matrix.
2. **Fail the job when a release-asset upload fails.** The upload loop logged a message on a failed upload but did not affect the job's exit status, so a release could be published with missing assets while the workflow still reported success. Failures are now tracked and the job exits non-zero after all assets are attempted.
3. **Name the eve-sources export `collected_sources.tar`.** `docker export` produces a plain (uncompressed) tar, so the previous `.tar.gz` suffix was misleading; renamed accordingly.

Changes 2 and 3 are derived from the asset-handling part of #5907; the compression and new image-variant changes from that PR are intentionally **not** included here.

## How to test and validate this PR

- Push a release tag built from `16.0-stable` and confirm the `trigger_assets` job loads `assets.yml` from `@16.0-stable` and publishes only this branch's variants (no arm64-`k` / nvidia-jp7 assets).
- Confirm the eve-sources asset is named `*.collected_sources.tar`.
- Force an upload error (e.g. an invalid token in a fork run) and confirm the job now fails instead of reporting success.

## Changelog notes

The release-sources asset is now published as `collected_sources.tar` (previously `collected_sources.tar.gz`, although it was never actually gzip-compressed).

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.