### PR TITLE
[13.4-stable] assets.yml: harden release-asset publishing

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -119,7 +119,9 @@ jobs:
           cd ../
           mv "$sha256_file" assets/
           mv "$sizes_file" assets/
-          # Upload files
+          # Upload files. Track failures and fail the job at the end so that
+          # all assets are attempted before the run is marked failed.
+          upload_failed=0
           for file in assets/*; do
             file_name=$(basename $file)
             echo "Uploading ${file_name}..."
@@ -131,6 +133,8 @@ jobs:
             if echo "$upload_response" | jq -e .id > /dev/null; then
               echo "$file_name uploaded successfully."
             else
-              echo "Error uploading $file_name: $upload_response"
+              echo "::error::Failed to upload $file_name: $upload_response"
+              upload_failed=1
             fi
           done
+          exit "$upload_failed"

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -87,13 +87,13 @@ jobs:
              docker run "$EVE" installer_iso > assets/installer.iso
              docker run "$EVE" installer_net > assets/installer-net.tar
           fi
-      - name: Pull eve-sources and publish collected_sources.tar.gz to assets
+      - name: Export eve-sources to assets/collected_sources.tar
         run: |
           HV=${{ matrix.hv }}
           EVE_SOURCES=lfedge/eve-sources:${TAG}-${{ env.PLATFORMVER }}${HV}-${{ env.ARCH }}
           docker pull "$EVE_SOURCES"
           docker create --name eve_sources "$EVE_SOURCES" bash
-          docker export --output assets/collected_sources.tar.gz eve_sources
+          docker export --output assets/collected_sources.tar eve_sources
           docker rm eve_sources
       - name: Rename, create SHA256 checksums and upload files
         env:


### PR DESCRIPTION
# Description

Two reliability improvements to the release-asset publishing workflow on `13.4-stable` (one commit each):

1. **Fail the job when a release-asset upload fails.** The upload loop logged a message on a failed upload but did not affect the job's exit status, so a release could be published with missing assets while the workflow still reported success. Failures are now tracked and the job exits non-zero after all assets are attempted.
2. **Name the eve-sources export `collected_sources.tar`.** `docker export` produces a plain (uncompressed) tar, so the previous `.tar.gz` suffix was misleading; renamed accordingly.

Both changes are derived from the asset-handling part of #5907; the compression and new image-variant changes from that PR are intentionally **not** included (the evaluation image that motivated compression does not exist on this branch, so its assets stay within the GitHub release-asset size limit).

## How to test and validate this PR

- Push a release tag built from `13.4-stable`; confirm the eve-sources asset is named `*.collected_sources.tar` and that a failed asset upload now fails the job instead of reporting success.

## Changelog notes

The release-sources asset is now published as `collected_sources.tar` (previously `collected_sources.tar.gz`, although it was never actually gzip-compressed).

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.