### PR TITLE
[16.0-stable] Fix eve-k logging and newlog message cleaning

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -313,7 +313,7 @@ external_boot_image_import() {
         eve_external_boot_img_name="docker.io/lfedge/eve-external-boot-image"
         eve_external_boot_img_tag=$(cat /run/eve-release)
         eve_external_boot_img="${eve_external_boot_img_name}:${eve_external_boot_img_tag}"
-        if /var/lib/k3s/bin/k3s crictl --runtime-endpoint=unix:///run/containerd-user/containerd.sock inspecti "$eve_external_boot_img"; then
+        if /var/lib/k3s/bin/k3s crictl --runtime-endpoint=unix:///run/containerd-user/containerd.sock inspecti "$eve_external_boot_img" > /dev/null 2>&1; then
                 # Already imported
                 return 0
         fi
@@ -335,7 +335,36 @@ external_boot_image_import() {
                 return 1
         fi
         logmsg "Successfully installed external-boot-image $import_name_tag as $eve_external_boot_img"
+
+        # Clean up old eve-external-boot-image versions that don't match current release
+        cleanup_old_external_boot_images "$eve_external_boot_img_name" "$eve_external_boot_img_tag"
         return 0
+}
+
+# Remove old eve-external-boot-image images that don't match the current tag
+# Usage: cleanup_old_external_boot_images <image_name> <current_tag>
+cleanup_old_external_boot_images() {
+        local img_name="$1"
+        local current_tag="$2"
+
+        logmsg "Cleaning up old external-boot-image versions, keeping tag: $current_tag"
+
+        # List all images and filter for eve-external-boot-image
+        old_images=$(/var/lib/k3s/bin/k3s ctr -a /run/containerd-user/containerd.sock images list -q | grep "^${img_name}:" | grep -v ":${current_tag}$")
+
+        if [ -z "$old_images" ]; then
+                logmsg "No old external-boot-image versions to clean up"
+                return 0
+        fi
+
+        for old_img in $old_images; do
+                logmsg "Removing old external-boot-image: $old_img"
+                if ! /var/lib/k3s/bin/k3s ctr -a /run/containerd-user/containerd.sock image rm "$old_img" 2>/dev/null; then
+                        logmsg "Warning: Failed to remove old image $old_img (may be in use)"
+                fi
+        done
+
+        logmsg "Old external-boot-image cleanup completed"
 }
 
 check_start_containerd() {

--- a/pkg/newlog/cmd/getMemlogMsg.go
+++ b/pkg/newlog/cmd/getMemlogMsg.go
@@ -95,7 +95,7 @@ func parseMemlogEntry(rawBytes []byte) (inputEntry, error) {
 	logInfo := parseLogInfo(logEntry)
 
 	// don't process kube logs, since they are handled separately in /persist/kubelog
-	if logInfo.Source == "kube" {
+	if logInfo.Source == "kube" || logInfo.Source == "kube.out" {
 		return inputEntry{}, nil
 	}
 

--- a/pkg/newlog/cmd/getMemlogMsg.go
+++ b/pkg/newlog/cmd/getMemlogMsg.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	ansi = "\u001B\\[[0-9;]*[A-Za-z]|\u001B[\\(\\)\\[\\]#;?]*[A-Za-z0-9]|\u009B[0-9;]*[A-Za-z]"
+	ansi = "(?:\u001B|\\\\u001[bB])\\[[0-9;]*[A-Za-z]|(?:\u001B|\\\\u001[bB])[\\(\\)\\[\\]#;?]*[A-Za-z0-9]|(?:\u009B|\\\\u009[bB])[0-9;]*[A-Za-z]"
 )
 
 var (
@@ -171,8 +171,8 @@ func parseLogInfo(memlogEntry MemlogLogEntry) Loginfo {
 			if logInfo.Source == "" {
 				logInfo.Source = memlogEntry.Source
 			}
-			// and keep the original message text and fields
-			logInfo.Msg = memlogEntry.Msg
+			// and keep the cleaned message text and fields
+			logInfo.Msg = cleanMsg
 		} else {
 			// Some messages have attr=val syntax
 			// If the inner message has Level, Time or Msg set they take

--- a/pkg/newlog/cmd/getMemlogMsg_test.go
+++ b/pkg/newlog/cmd/getMemlogMsg_test.go
@@ -138,7 +138,18 @@ func TestParseMemlogEntryIndividual(t *testing.T) {
 				"timestamp": "2025-10-06T18:31:44.311128265Z",
 				"source":    "zedmanager",
 				"severity":  "info",
-				"content":   "{\"file\":\"/pillar/types/zedmanagertypes.go:364\",\"func\":\"github.com/lf-edge/eve/pkg/pillar/types.AppInstanceStatus.LogModify\",\"level\":\"info\",\"log_event_type\":\"log\",\"msg\":\"App instance status modify\",\"obj_key\":\"app_instance_status-173ee6b9-c454-45b8-959e-5c1e9c91a0ce\",\"obj_name\":\"nginx\",\"obj_type\":\"app_instance_status\",\"obj_uuid\":\"173ee6b9-c454-45b8-959e-5c1e9c91a0ce\",\"old-purge-in-progress\":0,\"old-restart-in-progress\":0,\"old-state\":\"BOOTING\",\"pid\":2221,\"purge-in-progress\":0,\"restart-in-progress\":0,\"source\":\"zedmanager\",\"state\":\"RUNNING\",\"time\":\"2025-10-06T18:31:44.311128265Z\"}",
+				"content":   `{"file":"/pillar/types/zedmanagertypes.go:364","func":"github.com/lf-edge/eve/pkg/pillar/types.AppInstanceStatus.LogModify","level":"info","log_event_type":"log","msg":"App instance status modify","obj_key":"app_instance_status-173ee6b9-c454-45b8-959e-5c1e9c91a0ce","obj_name":"nginx","obj_type":"app_instance_status","obj_uuid":"173ee6b9-c454-45b8-959e-5c1e9c91a0ce","old-purge-in-progress":0,"old-restart-in-progress":0,"old-state":"BOOTING","pid":2221,"purge-in-progress":0,"restart-in-progress":0,"source":"zedmanager","state":"RUNNING","time":"2025-10-06T18:31:44.311128265Z"}`,
+			},
+		},
+		{
+			name:        "Entry with ANSI color codes in a JSON message",
+			input:       `{"time":"2026-02-05T18:52:28.551352594Z","source":"pillar","msg":"{\"appuuid\":\"ff9d588b-e22c-4256-abe4-9da5bae810d9\",\"level\":\"info\",\"msg\":\"Hello, \\u001b[31m this is my text \\u001b[0m. How does it look?\",\"time\":\"2026-02-05T18:52:28.551046324Z\"}"}`,
+			expectError: false,
+			expectedFields: map[string]string{
+				"timestamp": "2026-02-05T18:52:28.551046324Z",
+				"source":    "pillar",
+				"severity":  "info",
+				"content":   `{"appuuid":"ff9d588b-e22c-4256-abe4-9da5bae810d9","level":"info","msg":"Hello,  this is my text . How does it look?","time":"2026-02-05T18:52:28.551046324Z"}`,
 			},
 		},
 		{
@@ -267,6 +278,11 @@ func TestCleanForLogParsing(t *testing.T) {
 			name:     "ANSI color codes",
 			input:    "\x1b[31mRed text\x1b[0m",
 			expected: "Red text",
+		},
+		{
+			name:     "ANSI color codes (unicode)",
+			input:    "\u001b[31m this is my text \u001b[0m.",
+			expected: " this is my text .",
 		},
 		{
 			name:     "Newlines at start and end",

--- a/pkg/newlog/cmd/writelogFile.go
+++ b/pkg/newlog/cmd/writelogFile.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Zededa, Inc.
+// Copyright (c) 2025-2026 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package main
@@ -212,7 +212,10 @@ func checkAppEntry(entry *inputEntry) string {
 	var appSplitArr []string
 	if entry.appUUID != "" {
 		appuuid = entry.appUUID
-		entry.content = "{\"container\":\"" + entry.acName + "\",\"time\":\"" + entry.acLogTime + "\",\"msg\":\"" + entry.content + "\"}"
+		// Only for container runtime logs, not appending those if it is kubernetes pod logs
+		if entry.acName != "" {
+			entry.content = "{\"container\":\"" + entry.acName + "\",\"time\":\"" + entry.acLogTime + "\",\"msg\":\"" + entry.content + "\"}"
+		}
 	} else if strings.HasPrefix(entry.source, "guest_vm-") {
 		appSplitArr = strings.SplitN(entry.source, "guest_vm-", 2)
 		appVMlog = true

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -345,7 +345,9 @@ func (ctx kubevirtContext) CreateReplicaVMIConfig(domainName string, config type
 				// The concept is same in kubevirt too. Kubevirt supports this functionality through feature
 				// https://kubevirt.io/user-guide/virtual_machines/boot_from_external_source/
 				// Since disks are virtio disks we assume /dev/vda is the boot disk
-				kernelArgs := "console=tty0 root=/dev/vda dhcp=1 rootfstype=ext4"
+				// Include both tty0 (video) and ttyS0 (serial) consoles so that logs are captured
+				// by kubevirt's guest-console-log container
+				kernelArgs := "console=tty0 console=ttyS0 root=/dev/vda dhcp=1 rootfstype=ext4"
 				eveRelease, err := os.ReadFile("/run/eve-release")
 				if err != nil {
 					return logError("Failed to fetch eve-release %v", err)


### PR DESCRIPTION
# Description

Backport of #5555, #5570, #5571, #5574, #5596

This backports the eve-k (KubeVirt) logging fixes and the newlog
message-cleaning fixes to `16.0-stable`. The commits are cherry-picked in
their original master order (they build on each other and several touch
`pkg/newlog/cmd/getMemlogMsg.go`):

- #5555 — Fix the issue of eve-k VM logging
- #5570 — Remove noisy logging and remove previous external boot images
- #5571 — Fix the issue of eve-k shim/container VMI logging
- #5574 — fix: clean log w/o removing non-standard fields
- #5596 — newlog: fix ANSI escape code stripping

## How to test and validate this PR

- Build an eve-k rootfs/image for `16.0-stable` with `HV=k` and deploy a
  KubeVirt app instance; confirm VM and shim/container VMI logs are
  collected and forwarded (previously missing/garbled).
- Confirm log messages with non-standard fields are preserved rather than
  dropped during cleaning, and that ANSI escape sequences are correctly
  stripped.
- Unit tests: `cd pkg/pillar && go test ./...` for the newlog cleaning logic
  (`pkg/newlog/cmd` — `getMemlogMsg_test.go` covers the cleaning/ANSI cases).

## Changelog notes

See original PRs.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs:

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.