### PR TITLE
mkimage-raw-efi: add reserved second ESP partition (ESP-B)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ DEVICETREE_DTB_arm64=$(DIST)/dtb/eve.dtb
 DEVICETREE_DTB=$(DEVICETREE_DTB_$(ZARCH))
 
 CONF_FILES=$(shell ls -d $(CONF_DIR)/*)
-LIVE_PART_SPEC=efi conf imga
+LIVE_PART_SPEC=efi efi_b conf imga
 
 # parallels settings
 # https://github.com/qemu/qemu/blob/595123df1d54ed8fbab9e1a73d5a58c5bb71058f/docs/interop/prl-xml.txt

--- a/docs/BOOTING.md
+++ b/docs/BOOTING.md
@@ -65,6 +65,56 @@ squashfs). Next to that 2nd stage GRUB is its own [configuration](../pkg/grub/ro
 more complex and is tasked with figuring out how to load appropriate hypervisor and control domain kernels
 (if needed).
 
+### The two EFI System partitions (ESP-A and ESP-B)
+
+EVE's GPT layout contains **two** EFI System partitions. Both carry the EFI
+System Partition type GUID `C12A7328-F81F-11D2-BA4B-00A0C93EC93B` (`sgdisk`
+typecode `ef00`) and both carry the GPT partition label `EFI System`:
+
+* **ESP-A** — partition 1, unique partition GUID `ad6871ee-...-30051`. This is
+  the active ESP: it holds the 1st stage GRUB (`BOOTX64.EFI`/`BOOTAA64.EFI`) and
+  is the partition the firmware actually boots from. Everything described in this
+  section refers to ESP-A.
+* **ESP-B** — partition 7, unique partition GUID `ad6871ee-...-30056`, 2 GiB. It
+  is created with an **empty FAT32 filesystem** and is otherwise unused. It is
+  pre-formatted (rather than left as raw space) so that future code can simply
+  mount it and add files — EVE has no runtime `mkfs` path for this partition, and
+  unlike the rootfs partitions it is not updated by writing a whole filesystem
+  image. It is reserved up front so that EVE can later adopt a second-ESP
+  capability — for example EFI-variable A/B booting of the bootloader + kernel
+  (via `BootXXXX`/`BootOrder`/`BootNext`) or a recovery OS — without having to
+  change the on-disk layout, which is immutable on already-deployed devices.
+
+Because both partitions share the same type GUID **and** the same `EFI System`
+label, they can only be told apart by their unique partition GUID (the same
+identifier a future `BootXXXX` boot entry would reference). Consequently, code
+that locates the active ESP selects ESP-A by its unique partition GUID rather
+than by label: the 1st stage GRUB's [embedded fallback](../pkg/grub/embedded.cfg)
+uses `search.part_uuid` for ESP-A, and the [installer](../pkg/installer/install)
+matches ESP-A's PARTUUID. Reserving ESP-B does not otherwise change the boot
+flow — EVE still boots the active rootfs (IMGA/IMGB) selected by `gptprio.next`,
+and ESP-B plays no role until a future change populates and uses it.
+
+Note: because `embedded.cfg` selects ESP-A by its fixed unique partition GUID,
+this fallback assumes the **fixed** partition-UUID scheme (the default). Images
+built with `make-raw -r` (`eve_install_random_disk_uuids`) randomize the GUIDs,
+so the hardcoded `search.part_uuid` would not match; that opt-in mode is not used
+in practice, and the primary `gptprio.next` boot path (keyed off the partition
+*type* GUID and attribute bits) is unaffected regardless.
+
+Compatibility with already-installed devices: the 1st stage GRUB cannot be
+upgraded after install, so a device installed before this change keeps an
+`embedded.cfg` that locates the ESP **by label** (`search.part_label "EFI
+System"`). Such a device has only one ESP today, but should a future change (e.g.
+partition resizing) ever add a second `EFI System` partition to it, the old
+label-based search stays correct: GRUB iterates GPT partitions in ascending
+partition-number order and `search … <var>` stops at the **first** match, so it
+selects the lowest-numbered `EFI System` partition. **Invariant:** the active,
+bootable ESP (ESP-A) must therefore always be the lowest-numbered ESP — which is
+why ESP-A is partition 1 and ESP-B is partition 7. (Verified against EVE's patched
+GRUB for the coreos/~2.02, 2.06 and 2.12 lineages; the EVE gpt/gptprio patches add
+a separate `lib/gpt.c` and do not change `partmap/gpt.c`'s iteration order.)
+
 After 1st stage GRUB determines which partition is active (IMGA or IMGB) it chainloads the 2nd stage GRUB.
 This chainloading is done through the mechanism that is specific to UEFI payloads and is different from
 legacy PC bootloader chainloading (read: don't try to chainload UEFI from legacy and vice versa).
@@ -170,7 +220,9 @@ The first problem presented by a legacy PC BIOS is that it doesn't understand GP
 luckily GPT specification allows for a [Hybryd MBR/GPT](https://wiki.archlinux.org/index.php/Multiboot_USB_drive#Hybrid_UEFI_GPT_+_BIOS_GPT/MBR_boot)
 scheme and we can use the MBR boot sector to bootstrap the entire sequence.
 
-Thus, in addition to creating a UEFI compatible `EFI System` partition every disk with EVE also gets:
+Thus, in addition to creating a UEFI compatible `EFI System` partition every disk with EVE also gets
+(the `EFI System` partition referenced below is always ESP-A — the active ESP at partition 1; the
+reserved ESP-B takes no part in the hybrid MBR / legacy boot scheme):
 
 * an MBR boot sector with GRUB's [stage1 one bootblock code](https://thestarman.pcministry.com/asm/mbr/GRUB.htm)
 * an MBR partition table (last 64 bytes of the MBR sector) with the following two partitions specified:

--- a/docs/BOOTING.md
+++ b/docs/BOOTING.md
@@ -93,14 +93,9 @@ than by label: the 1st stage GRUB's [embedded fallback](../pkg/grub/embedded.cfg
 uses `search.part_uuid` for ESP-A, and the [installer](../pkg/installer/install)
 matches ESP-A's PARTUUID. Reserving ESP-B does not otherwise change the boot
 flow — EVE still boots the active rootfs (IMGA/IMGB) selected by `gptprio.next`,
-and ESP-B plays no role until a future change populates and uses it.
-
-Note: because `embedded.cfg` selects ESP-A by its fixed unique partition GUID,
-this fallback assumes the **fixed** partition-UUID scheme (the default). Images
-built with `make-raw -r` (`eve_install_random_disk_uuids`) randomize the GUIDs,
-so the hardcoded `search.part_uuid` would not match; that opt-in mode is not used
-in practice, and the primary `gptprio.next` boot path (keyed off the partition
-*type* GUID and attribute bits) is unaffected regardless.
+and ESP-B plays no role until a future change populates and uses it. Partition
+GUIDs are always the fixed values listed above, so `search.part_uuid` reliably
+resolves ESP-A.
 
 Compatibility with already-installed devices: the 1st stage GRUB cannot be
 upgraded after install, so a device installed before this change keeps an

--- a/pkg/grub/embedded.cfg
+++ b/pkg/grub/embedded.cfg
@@ -12,7 +12,7 @@ configfile /EFI/BOOT/grub.cfg
 
 root=$saved_root
 cmddevice=$saved_cmddevice
-search.part_label "EFI System" dev $cmddevice,
+search.part_uuid ad6871ee-31f9-4cf3-9e09-6f7a25c30051 dev $cmddevice,
 root=$dev
 cmddevice=$dev
 configfile /efi/boot/grub.cfg
@@ -20,7 +20,7 @@ configfile /EFI/BOOT/grub.cfg
 
 root=$saved_root
 cmddevice=$saved_cmddevice
-search.part_label "EFI System" dev $root,
+search.part_uuid ad6871ee-31f9-4cf3-9e09-6f7a25c30051 dev $root,
 root=$dev
 cmddevice=$dev
 configfile /efi/boot/grub.cfg

--- a/pkg/installer/install
+++ b/pkg/installer/install
@@ -143,7 +143,9 @@ mount_part() {
 
 # Find EFI partition and copy files
 copy_native_efi() {
-    EFI_PART=$(lsblk -anl -o "NAME,PARTLABEL" | grep "EFI System" | awk '{print $1}' | sed "s#.*#/dev/&#")
+    # Both ESP-A and the reserved ESP-B share the "EFI System" label, so select
+    # ESP-A specifically by its unique partition GUID (the active/populated ESP).
+    EFI_PART=$(lsblk -anl -o "NAME,PARTUUID" | awk 'tolower($2)=="ad6871ee-31f9-4cf3-9e09-6f7a25c30051"{print "/dev/"$1; exit}')
     if [ -n "$EFI_PART" ]; then
         # EFI partition was found, copy files
         mkdir -p "$BOOT_DIR"
@@ -453,11 +455,11 @@ if [ "$INSTALL_DEV" != "$INSTALL_PERSIST" ]; then
    if echo "$INSTALL_PERSIST"| grep -q ","; then
      MULTIPLE_DISKS=true
      INSTALL_ZFS=true
-     MAKE_RAW_PARTS="efi $ROOTFS_PARTITIONS conf"
+     MAKE_RAW_PARTS="efi efi_b $ROOTFS_PARTITIONS conf"
      for dev in $(echo "$INSTALL_PERSIST" | tr ',' ' '); do
         if [ "$dev" = "$INSTALL_DEV" ]; then
            # in case we want to have one of P3 on the bootable disk
-           MAKE_RAW_PARTS="efi $ROOTFS_PARTITIONS conf persist"
+           MAKE_RAW_PARTS="efi efi_b $ROOTFS_PARTITIONS conf persist"
            DISK_WITH_P3="$dev"
            POOL_CREATION_COMMAND_SUFFIX="$POOL_CREATION_COMMAND_SUFFIX $P3_ON_BOOT_PLACEHOLDER"
            DISKS_TO_MERGE_COUNT=$((DISKS_TO_MERGE_COUNT+1))
@@ -489,7 +491,7 @@ if [ "$INSTALL_DEV" != "$INSTALL_PERSIST" ]; then
 
      if [ $DISKS_TO_MERGE_COUNT -eq 0 ] || [ "$INSTALL_ZFS" = false ]; then
           # in case of only comma provided or zfs requirements are not met
-          MAKE_RAW_PARTS="efi $ROOTFS_PARTITIONS conf persist"
+          MAKE_RAW_PARTS="efi efi_b $ROOTFS_PARTITIONS conf persist"
           DISK_WITH_P3="$INSTALL_DEV"
           POOL_CREATION_COMMAND_SUFFIX=$P3_ON_BOOT_PLACEHOLDER
           DISKS_TO_MERGE_COUNT=1
@@ -505,7 +507,7 @@ if [ "$INSTALL_DEV" != "$INSTALL_PERSIST" ]; then
         sgdisk --partition-guid="1:$PERSIST_UUID" "$PDEV"
      fi
      # force make-raw to skip persist
-     MAKE_RAW_PARTS="efi $ROOTFS_PARTITIONS conf"
+     MAKE_RAW_PARTS="efi efi_b $ROOTFS_PARTITIONS conf"
      # We will be here if persist is being installed on single disk. In ZFS case update pool creation command
      if [ "$INSTALL_ZFS" = true ]; then
          POOL_CREATION_COMMAND_SUFFIX=$PDEV

--- a/pkg/installer/install
+++ b/pkg/installer/install
@@ -18,7 +18,6 @@
 #   eve_pause_before_install
 #   eve_pause_after_install
 #   eve_reboot_after_install
-#   eve_install_random_disk_uuids
 #   eve_install_skip_config
 #   eve_install_skip_persist
 #   eve_install_skip_rootfs
@@ -397,11 +396,6 @@ for i in rootfs config persist; do
    cmdline "eve_install_skip_$i" && trunc "${ARTIFACTS_DIR}/$i.img"
 done
 
-# Do we want random or fixed disk and partition UUIDs?
-RANDOM_DISK_UUIDS=
-cmdline eve_install_random_disk_uuids && RANDOM_DISK_UUIDS="-r"
-logmsg "INFO: RANDOM_DISK_UUIDS = $RANDOM_DISK_UUIDS"
-
 # User may have requested to skip the zfs requirements checks.
 SKIP_ZFS_CHECKS=false
 cmdline eve_install_skip_zfs_checks && SKIP_ZFS_CHECKS=true
@@ -503,9 +497,7 @@ if [ "$INSTALL_DEV" != "$INSTALL_PERSIST" ]; then
      sgdisk -Z --clear "$PDEV" 2>/dev/null || :
      sgdisk --new 1:2048:0 --typecode=1:5f24425a-2dfa-11e8-a270-7b663faccc2c --change-name=1:P3 "$PDEV"
      sgdisk -v "$PDEV"
-     if [ -z "$RANDOM_DISK_UUIDS" ]; then
-        sgdisk --partition-guid="1:$PERSIST_UUID" "$PDEV"
-     fi
+     sgdisk --partition-guid="1:$PERSIST_UUID" "$PDEV"
      # force make-raw to skip persist
      MAKE_RAW_PARTS="efi efi_b $ROOTFS_PARTITIONS conf"
      # We will be here if persist is being installed on single disk. In ZFS case update pool creation command
@@ -526,7 +518,7 @@ fi
 # MAKE_RAW_PARTS="efi imga imgb conf persist" or MAKE_RAW_PARTS="efi imga imgb conf"
 # for some reason, it now is blank.
 # shellcheck disable=SC2086
-cmdline eve_blackbox || make_raw $RANDOM_DISK_UUIDS "/dev/$INSTALL_DEV" $MAKE_RAW_PARTS || bail "Installation failed. Entering shell..."
+cmdline eve_blackbox || make_raw "/dev/$INSTALL_DEV" $MAKE_RAW_PARTS || bail "Installation failed. Entering shell..."
 
 if [ "$INSTALL_ZFS" = true ]; then
   if [ "$DISK_WITH_P3" != "" ]; then
@@ -547,15 +539,13 @@ if [ "$INSTALL_ZFS" = true ]; then
   logmsg "Creating ZFS pool with raid level: $RAID_LEVEL"
   logmsg "Pool creation command: $POOL_CREATION_COMMAND_SUFFIX $INSTALL_CLUSTERED_STORAGE $RESERVE_EVE_STORAGE_SIZEGB"
   prepare_mounts_and_zfs_pool "$POOL_CREATION_COMMAND_SUFFIX" "$INSTALL_CLUSTERED_STORAGE" "$RESERVE_EVE_STORAGE_SIZEGB"
-  if [ -z "$RANDOM_DISK_UUIDS" ]; then
-      # Walk disks and set fixed UUIDs
-      # We assume that as part of adding to the zpool there is partition 1 and 9
-      for dev in $PDEV_LIST; do
-          sgdisk --disk-guid=$DISK_UUID "$dev"
-          sgdisk --partition-guid="1:$EFI_UUID" "$dev"
-          sgdisk --partition-guid="9:$PERSIST_UUID" "$dev"
-      done
-  fi
+  # Walk disks and set fixed UUIDs
+  # We assume that as part of adding to the zpool there is partition 1 and 9
+  for dev in $PDEV_LIST; do
+      sgdisk --disk-guid=$DISK_UUID "$dev"
+      sgdisk --partition-guid="1:$EFI_UUID" "$dev"
+      sgdisk --partition-guid="9:$PERSIST_UUID" "$dev"
+  done
 else
   P3="$(find_part P3 "$INSTALL_PERSIST")"
   [ -z "$P3" ] && bail "Installation failed. Cannot found P3. Entering shell..."

--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -24,10 +24,9 @@
 # The script CLI UX is really not user friendly for now, since it is expected
 # to be called mostly from other scripts (and also linuxkit VMs).
 # The syntax is:
-#   [-C] [-r] <img> [part1...]
+#   [-C] <img> [part1...]
 #
 # -C          recreate disk image
-# -r          use random_disk_uuids (old behavior)
 # <img>       file name of the raw disk image (we expect it to be pre-created and
 #             sized correctly OR be an actual physical device)
 # [part1...]  list of partitions to be created: efi imga imgb conf persist
@@ -44,12 +43,10 @@
 set -e
 [ -n "$DEBUG" ] && set -x
 
-RANDOM_DISK_UUIDS=
-while getopts Cr o
+while getopts C o
 do      case "$o" in
         C)      CREATE_IMG=1;;
-        r)      RANDOM_DISK_UUIDS="-r";;
-        [?])    echo "Usage: $0 [-C] [-r] <img> [parts...]"
+        [?])    echo "Usage: $0 [-C] <img> [parts...]"
                 exit 1;;
         esac
 done
@@ -366,9 +363,7 @@ EOF
     $customparts
   fi
   do_system_vfat_part "$1" "$EFI_PART_SIZE" $SYSTEM_VFAT_PART /efifs
-  if [ -z "$RANDOM_DISK_UUIDS" ]; then
-      sgdisk --partition-guid="$EFI_PART:$EFI_UUID" "$IMGFILE"
-  fi
+  sgdisk --partition-guid="$EFI_PART:$EFI_UUID" "$IMGFILE"
 }
 
 do_efiinstaller() {
@@ -407,9 +402,7 @@ do_efi_b() {
          --change-name="$NUM_PART:$partlabel" \
          "$IMGFILE"
 
-  if [ -z "$RANDOM_DISK_UUIDS" ]; then
-      sgdisk --partition-guid="$NUM_PART:$EFI_B_UUID" "$IMGFILE"
-  fi
+  sgdisk --partition-guid="$NUM_PART:$EFI_B_UUID" "$IMGFILE"
 
   # Pre-format as an empty FAT32 filesystem (same mechanism as the other vfat
   # partitions): build a sized empty FAT image from an empty directory and write
@@ -442,9 +435,7 @@ do_rootfs() {
            --typecode="$NUM_PART:$PARTITION_TYPE_USR_X86_64" \
            --change-name="$NUM_PART:$LABEL" "$IMGFILE"
 
-    if [ -z "$RANDOM_DISK_UUIDS" ]; then
-      sgdisk --partition-guid="$NUM_PART:$IMG_UUID" "$IMGFILE"
-    fi
+    sgdisk --partition-guid="$NUM_PART:$IMG_UUID" "$IMGFILE"
 
     if [ -n "$IMG" ]; then
       # Copy rootfs or installer
@@ -491,10 +482,8 @@ do_vfat() {
 
 do_conf() {
     do_vfat "$1" $CONF_PART_SIZE $VFAT_PART 13307e62-cd9c-4920-8f9b-91b45828b798 CONFIG $CONF_FILE
-    if [ -z "$RANDOM_DISK_UUIDS" ]; then
-        local NUM_PART=$CONF_PART
-        sgdisk --partition-guid="$NUM_PART:$CONF_UUID" "$IMGFILE"
-    fi
+    local NUM_PART=$CONF_PART
+    sgdisk --partition-guid="$NUM_PART:$CONF_UUID" "$IMGFILE"
 }
 
 do_conf_win() {
@@ -532,9 +521,7 @@ do_persist() {
            --typecode=$NUM_PART:5f24425a-2dfa-11e8-a270-7b663faccc2c \
            --change-name=$NUM_PART:'P3' "$IMGFILE"
 
-    if [ -z "$RANDOM_DISK_UUIDS" ]; then
-        sgdisk --partition-guid="$NUM_PART:$PERSIST_UUID" "$IMGFILE"
-    fi
+    sgdisk --partition-guid="$NUM_PART:$PERSIST_UUID" "$IMGFILE"
     dd if="$PERSIST_FILE" of="$IMGFILE" bs=1M conv=notrunc seek="$(( SEC_START * 512 ))" oflag=seek_bytes
 
     eval "$1=0"
@@ -656,9 +643,7 @@ case "$(sgdisk -p "$IMGFILE" 2>/dev/null | sed -ne '/^Number/,$s/^.* //p' | tr '
       ;;
 esac
 
-if [ -z "$RANDOM_DISK_UUIDS" ]; then
-  sgdisk --disk-guid=$DISK_UUID "$IMGFILE"
-fi
+sgdisk --disk-guid=$DISK_UUID "$IMGFILE"
 
 # at this point, the base PART_OFFSET is set, so we can calculate the rest
 SYSTEM_VFAT_PART=$(( PART_OFFSET + SYSTEM_VFAT_PART_OFFSET ))

--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -69,6 +69,7 @@ EFI_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30051
 IMGA_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30052
 IMGB_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30053
 CONF_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30054
+EFI_B_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30056
 PERSIST_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30059
 INSTALLER_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30060
 
@@ -92,6 +93,8 @@ IMX8_CONF=/parts/imx8-flash.conf
 
 # EFI partition size in bytes
 EFI_PART_SIZE=$((2 * 1024 * 1024 * 1024))
+# Second (reserved) ESP-B partition size in bytes; same as ESP-A for symmetry
+EFI_B_PART_SIZE=$EFI_PART_SIZE
 # Min rootfs partition size in bytes
 # Warning: don't change the rootfs partition size, before
 # Warning: fixing the EVE upgrade logic, which should find
@@ -110,7 +113,7 @@ if [ -z "$PLATFORM" ]; then
   fi
 fi
 
-PARTS=${*:-"efi imga imgb conf persist"}
+PARTS=${*:-"efi efi_b imga imgb conf persist"}
 # only one rootfs is populated at build time; wipe the IMGB image
 ROOTFS_IMG_B=
 
@@ -135,6 +138,7 @@ VFAT_PART_OFFSET=4
 IMGA_PART_OFFSET=2
 IMGB_PART_OFFSET=3
 EFI_PART_OFFSET=1
+EFI_B_PART_OFFSET=7
 CONF_PART_OFFSET=4
 PERSIST_PART_OFFSET=9
 INVENTORY_WIN_PART_OFFSET=5
@@ -221,6 +225,9 @@ calc_image_size() {
       case $p in
           efi)
               SIZE=$((SIZE + EFI_PART_SIZE))
+              ;;
+          efi_b)
+              SIZE=$((SIZE + EFI_B_PART_SIZE))
               ;;
           conf_win | conf)
               SIZE=$((SIZE + CONF_PART_SIZE))
@@ -377,6 +384,39 @@ efi_installer_extension() {
   touch /efifs/boot/.boot_repository
   od -An -x -N 16 /dev/random | tr -d ' ' > /efifs/boot/.uuid
   cp /UsbInvocationScript.txt /efifs
+}
+
+# do_efi_b creates the reserved second ESP (ESP-B). It carries no payload for now;
+# future work may populate it (e.g. EFI-variable A/B boot or a recovery OS). It is
+# pre-formatted with an empty FAT32 filesystem so that future code can simply mount
+# it and drop files on it (EVE has no runtime mkfs path for this partition, and -
+# unlike the rootfs partitions - it is not updated by writing a whole FS image).
+# It shares the "EFI System" label and ef00 type with ESP-A and is distinguished
+# only by its unique partition GUID ($EFI_B_UUID).
+do_efi_b() {
+  eval "local SEC_START=\$$1"
+  local SEC_END
+  local NUM_PART=$EFI_B_PART
+  local PART_TYPE="ef00"
+  local partlabel='EFI System'
+
+  SEC_END="$(grow_part "$SEC_START" "$EFI_B_PART_SIZE")"
+
+  sgdisk --new "$NUM_PART:$SEC_START:$SEC_END" \
+         --typecode="$NUM_PART:$PART_TYPE" \
+         --change-name="$NUM_PART:$partlabel" \
+         "$IMGFILE"
+
+  if [ -z "$RANDOM_DISK_UUIDS" ]; then
+      sgdisk --partition-guid="$NUM_PART:$EFI_B_UUID" "$IMGFILE"
+  fi
+
+  # Pre-format as an empty FAT32 filesystem (same mechanism as the other vfat
+  # partitions): build a sized empty FAT image from an empty directory and write
+  # it into the partition. No files are copied in.
+  dd if="$(dir2vfat "$(mktemp -d)" $(( (SEC_END - SEC_START) / 2 )))" of="$IMGFILE" bs=1M conv=notrunc seek="$(( SEC_START * 512 ))" oflag=seek_bytes
+
+  eval "$1=$((SEC_END + 1))"
 }
 
 # do_installer prepares an installation image:
@@ -603,7 +643,7 @@ case "$(sgdisk -p "$IMGFILE" 2>/dev/null | sed -ne '/^Number/,$s/^.* //p' | tr '
       EMBED_BOOT_START=$(sgdisk -i 6 "$IMGFILE" 2>/dev/null | awk '/First sector:/{ print $3; }')
       EMBED_BOOT_SIZE=$(sgdisk -i 6 "$IMGFILE" 2>/dev/null | awk '/Partition size:/{ print $3; }')
       ;;
-  "Name System IMGA IMGB CONFIG P3"*)
+  "Name System IMGA IMGB CONFIG"*)
       echo "Found EVE GPT partition table on $IMGFILE"
       # apparently sgdisk -Z doesn't clear MBR and keeps complaining
       dd if=/dev/zero of="$IMGFILE" bs=512 count=1 conv=notrunc
@@ -627,6 +667,7 @@ INSTALLER_PART=$(( PART_OFFSET + INSTALLER_PART_OFFSET ))
 IMGA_PART=$(( PART_OFFSET + IMGA_PART_OFFSET ))
 IMGB_PART=$(( PART_OFFSET + IMGB_PART_OFFSET ))
 EFI_PART=$(( PART_OFFSET + EFI_PART_OFFSET ))
+EFI_B_PART=$(( PART_OFFSET + EFI_B_PART_OFFSET ))
 CONF_PART=$(( PART_OFFSET + CONF_PART_OFFSET ))
 PERSIST_PART=$(( PART_OFFSET + PERSIST_PART_OFFSET ))
 INVENTORY_WIN_PART=$(( PART_OFFSET + INVENTORY_WIN_PART_OFFSET ))


### PR DESCRIPTION
# Description

Add a second, reserved EFI System Partition (ESP-B) to EVE's GPT layout, as groundwork for a possible future second-ESP capability — EFI-variable A/B booting of the bootloader+kernel (`BootXXXX`/`BootOrder`/`BootNext`) or a recovery OS — **without committing to either now**. The on-disk layout is immutable on already-deployed devices, so the partition has to be reserved up  front; until a later change uses it, ESP-B is created empty and unused and the boot flow is unchanged.

Key points:

- ESP-B is GPT **partition 7** (within the reserved 1–8 system range; persist  stays at 9), 2 GiB, type `ef00`, unique partition GUID `ad6871ee-…-30056`.
- **Both** ESPs keep the `EFI System` label and `ef00` type; they are  distinguished **only** by their unique partition GUID (ESP-A = `…-30051`,  ESP-B = `…-30056`) — the same handle a future `BootXXXX` entry would use.
- Existing partition numbers are **not** renumbered (append-only), so  installer / storage-init / persist layout assumptions are preserved.
- Because both ESPs now share the `EFI System` label, consumers that located the  ESP by label now select ESP-A explicitly by unique partition GUID:  GRUB `embedded.cfg` uses `search.part_uuid`, and the installer's
  `copy_native_efi` matches ESP-A's PARTUUID.
- ESP-B is added to the live/default layout and to the installer's **target**  partition list, but **not** to the installer media itself.

This is plumbing only; no boot-logic change. ESP-B plays no role until a future change populates and uses it.

## How to test and validate this PR

1. Build a live image (`make live`), then `sgdisk -p <image>`: confirm ESP-A at
   **1** (label `EFI System`, type `ef00`, unique GUID `…-30051`) and ESP-B at
   **8** (label `EFI System`, type `ef00`, unique GUID `…-30056`, 2 GiB).   `sgdisk -i 1` / `sgdisk -i 8` should show identical type GUID + label but   **different** unique partition GUIDs.
2. Boot the image (UEFI/OVMF): it boots normally via the existing   `gptprio.next` rootfs (IMGA/IMGB) selection; ESP-B is ignored.
3. Force the `embedded.cfg` fallback (boot with no successful rootfs) and confirm   GRUB's `search.part_uuid …-30051` resolves ESP-A and loads its grub.cfg, never   the empty ESP-B.
4. `lsblk -o NAME,PARTLABEL,PARTUUID,PARTTYPE`: two `EFI System` rows with   distinct PARTUUIDs; the installer's `copy_native_efi` GUID selector returns   exactly one device (ESP-A).
5. Build an installer image: confirm the installer media has **no** ESP-B, and a   disk it installs **does** get ESP-B at index 8.
6. `storage-init.sh` expansion path on a disk with ESP-B: `partx -a --nr 3:9`   does not error and P3 lands at 9.

## Changelog notes

No user-facing behavior change. New installations reserve an additional empty,unused 2 GiB `EFI System` partition for future use; existing devices are unaffected.

## PR Backports

- 16.0-stable: No
- 14.5-stable: No
- 13.4-stable: No

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them: on-device amd64/arm64 testing not yet done (draft PR; validation
  steps above to be run before marking ready); no `stable` label as this is not
  backported.
