### PR TITLE
kube: make longhorn-generate-support-bundle.sh multi-node safe

### DIFF
--- a/pkg/kube/longhorn-generate-support-bundle.sh
+++ b/pkg/kube/longhorn-generate-support-bundle.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 #
-# Copyright (c) 2024 Zededa, Inc.
+# Copyright (c) 2024-2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 LOG_DIR=/persist/kubelog
+BUNDLE_NAME=support-bundle-collect-info
+BUNDLE_TIMEOUT_SECONDS=${TIMEOUT_SECONDS:-300}
 
 # This script is called from collect-info, help it avoid a timeout
 # by checking for longhorn installed state and return before applying
@@ -23,33 +25,106 @@ echo "============"
 kubectl -n longhorn-system get volume -o json | jq '.items[] | "name:\(.metadata.name) spec.nodeID:\(.spec.nodeID) status.currentNodeID:\(.status.currentNodeID) status.ownerID:\(.status.ownerID) status.pendingNodeId:\(.status.pendingNodeID)"'
 echo "============"
 
-echo "Apply longhorn support bundle yaml at $(date)"
+# Check whether an existing bundle can be reused, needs cleanup, or is stale.
+# Returns: "ready", "wait", "delete", or "none"
+check_existing_bundle() {
+    existing=$(kubectl -n longhorn-system get supportbundle.longhorn.io/"${BUNDLE_NAME}" -o json 2>/dev/null) || { echo "none"; return; }
 
-cat <<EOF | kubectl apply -f -
+    state=$(echo "$existing" | jq -r '.status.state // "Unknown"')
+    creation_ts=$(echo "$existing" | jq -r '.metadata.creationTimestamp // ""')
+
+    age=0
+    if [ -n "$creation_ts" ]; then
+        created_epoch=$(date -d "$creation_ts" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$creation_ts" +%s 2>/dev/null || echo 0)
+        now_epoch=$(date +%s)
+        age=$((now_epoch - created_epoch))
+    fi
+
+    case "$state" in
+        ReadyForDownload)
+            # A previously downloaded bundle that has aged out is safe to delete
+            # on the next run; this avoids a multi-node race where all nodes
+            # simultaneously download and delete the same bundle.
+            if [ "$age" -gt "$BUNDLE_TIMEOUT_SECONDS" ]; then
+                echo "Existing bundle is $age seconds old and ReadyForDownload — treating as stale" >&2
+                echo "delete"
+                return
+            fi
+            echo "ready"
+            return
+            ;;
+        Error)
+            echo "delete"
+            return
+            ;;
+    esac
+
+    # For in-progress states, check how old the bundle is. If it exceeds
+    # BUNDLE_TIMEOUT_SECONDS the node that created it likely died mid-generation.
+    if [ "$age" -gt "$BUNDLE_TIMEOUT_SECONDS" ]; then
+        echo "Existing bundle is $age seconds old and in state '$state' — treating as stale" >&2
+        echo "delete"
+        return
+    fi
+
+    echo "wait"
+}
+
+echo "Checking for existing support bundle at $(date)"
+action=$(check_existing_bundle)
+
+if [ "$action" = "delete" ]; then
+    echo "Deleting existing bundle in error/stale state"
+    kubectl -n longhorn-system delete supportbundle.longhorn.io/"${BUNDLE_NAME}" --ignore-not-found
+    # Wait for the deletion to complete before recreating
+    kubectl -n longhorn-system wait --for=delete supportbundle.longhorn.io/"${BUNDLE_NAME}" --timeout=60s 2>/dev/null || true
+    action="none"
+fi
+
+if [ "$action" = "none" ]; then
+    echo "Applying longhorn support bundle yaml at $(date)"
+    cat <<EOF | kubectl apply -f -
 ---
 apiVersion: longhorn.io/v1beta2
 kind: SupportBundle
 metadata:
-  name: support-bundle-collect-info
+  name: ${BUNDLE_NAME}
   namespace: longhorn-system
 spec:
   description: collect-info
   issueURL: ""
   nodeID: ""
 EOF
+elif [ "$action" = "ready" ]; then
+    echo "Existing support bundle is already ReadyForDownload, skipping generation"
+elif [ "$action" = "wait" ]; then
+    echo "Another node is already generating the support bundle, waiting for it to complete"
+fi
 
+# Wait for bundle to reach ReadyForDownload, with a hard timeout.
+deadline=$(($(date +%s) + BUNDLE_TIMEOUT_SECONDS))
 while true; do
-    state=$(kubectl -n longhorn-system get supportbundle.longhorn.io/support-bundle-collect-info -o json | jq -r .status.state)
+    state=$(kubectl -n longhorn-system get supportbundle.longhorn.io/"${BUNDLE_NAME}" -o json 2>/dev/null | jq -r '.status.state // "Unknown"')
     if [ "$state" = "ReadyForDownload" ]; then
         break
     fi
+    if [ "$state" = "Error" ]; then
+        echo "Support bundle entered Error state, aborting"
+        kubectl -n longhorn-system delete supportbundle.longhorn.io/"${BUNDLE_NAME}" --ignore-not-found
+        exit 1
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+        echo "Timed out waiting for support bundle after ${BUNDLE_TIMEOUT_SECONDS}s (state: $state)"
+        kubectl -n longhorn-system delete supportbundle.longhorn.io/"${BUNDLE_NAME}" --ignore-not-found
+        exit 1
+    fi
     sleep 10
-    progress=$(kubectl -n longhorn-system get supportbundle.longhorn.io/support-bundle-collect-info -o json | jq -r .status.progress)
+    progress=$(kubectl -n longhorn-system get supportbundle.longhorn.io/"${BUNDLE_NAME}" -o json 2>/dev/null | jq -r '.status.progress // 0')
     echo "support bundle progress percentage: $progress"
 done
 
-ip=$(kubectl -n longhorn-system get supportbundle.longhorn.io/support-bundle-collect-info -o json | jq -r .status.managerIP)
-filename=$(kubectl -n longhorn-system get supportbundle.longhorn.io/support-bundle-collect-info -o json | jq -r .status.filename)
+ip=$(kubectl -n longhorn-system get supportbundle.longhorn.io/"${BUNDLE_NAME}" -o json | jq -r .status.managerIP)
+filename=$(kubectl -n longhorn-system get supportbundle.longhorn.io/"${BUNDLE_NAME}" -o json | jq -r .status.filename)
 
 # Sort creation time, keep 4 latest support bundles
 find "${LOG_DIR}" -name "longhornsupportbundle_*" | sort -n | head -n -4 | xargs rm -f
@@ -57,4 +132,6 @@ find "${LOG_DIR}" -name "longhornsupportbundle_*" | sort -n | head -n -4 | xargs
 curl "http://${ip}:8080/bundle" > "${LOG_DIR}/longhorn${filename}"
 echo "longhorn support bundle downloaded to ${LOG_DIR}/longhorn${filename}"
 
-kubectl -n longhorn-system delete supportbundle.longhorn.io/support-bundle-collect-info
+# Bundle is intentionally left in ReadyForDownload state so that other nodes
+# can download it. check_existing_bundle will delete it on the next run once
+# it has aged past BUNDLE_TIMEOUT_SECONDS.


### PR DESCRIPTION
## Description

The script previously applied the SupportBundle CRD and unconditionally deleted it after download. On a multi-node cluster with collect-info invoked on all nodes, this created a race: the first node to see ReadyForDownload would download and delete the bundle before other nodes could download it.

Rewrite the script to be idempotent and multi-node aware:

- Add check_existing_bundle() which inspects the existing bundle state and returns ready/wait/delete/none. Nodes that arrive while a bundle is in progress wait for it rather than creating a second one.
- Add a hard timeout with error-state detection in the wait loop so the script does not hang indefinitely.
- Leave the bundle in ReadyForDownload after download instead of deleting it, giving all nodes a window to retrieve it. The next run will delete and regenerate it once it has aged past BUNDLE_TIMEOUT_SECONDS (default 300s).
- Replace all hardcoded bundle name and kubectl calls with BUNDLE_NAME and BUNDLE_TIMEOUT_SECONDS constants.
- Accept user override of BUNDLE_TIMEOUT_SECONDS as TIMEOUT_SECONDS.

## PR dependencies

None

## How to test and validate this PR

- deploy three HV=k eve nodes, configure a cluster
- ssh to each node concurrently
- run `collect-info.sh` on all nodes, with a small delay between each eg. 20 seconds.
- confirm each collect-info bundle has a longhornsupportbundle:

```
# collect-info.sh
...
...
...
EVE info is collected into '/persist/eve-info/eve-info-v44-519f3563-690b-4862-a303-0f2ea3b9-2026-06-04-22-53-57.tar.gz'
# tar -tvf /persist/eve-info/eve-info-v44-519f3563-690b-4862-a303-0f2ea3b9-2026-06-04-22-53-57.tar.gz | grep longhornsupport
-rw-r--r-- root/root   3117522 2026-06-04 22:56 eve-info-v44-519f3563-690b-4862-a303-0f2ea3b9-2026-06-04-22-53-57/persist-kubelog/longhornsupportbundle_c9c99856-d0a5-4fc2-aff2-cb64610e27a0_2026-06-04T22-54-33Z.zip
```

## Changelog notes

Debug script 'Collect-info' will cleanup longhorn support bundle jobs which are in error.

## PR Backports

- 17.0-stable: To be backported.
- 16.0-stable: No
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
