### PR TITLE
yetus: Replace old --out-format golangci-lint argument

### DIFF
--- a/tools/yetus/Dockerfile
+++ b/tools/yetus/Dockerfile
@@ -52,6 +52,11 @@ RUN rm /usr/local/bin/golangci-lint
 RUN ln -s /usr/bin/golangci-lint /usr/local/bin/golangci-lint
 RUN rm /golangci-lint.deb
 
+# Patch Yetus golangci-lint plugin to work with the new version
+COPY golangci-lint-plugin.patch /tmp/golangci-lint-plugin.patch
+WORKDIR /
+RUN patch -Np1 < /tmp/golangci-lint-plugin.patch && rm /tmp/golangci-lint-plugin.patch
+
 # Clean up
 RUN rm -r /tmp/zfs
 

--- a/tools/yetus/golangci-lint-plugin.patch
+++ b/tools/yetus/golangci-lint-plugin.patch
@@ -1,0 +1,15 @@
+--- a/usr/lib/precommit/plugins.d/golangci.sh	2025-03-04 05:12:28.000000000 +0000
++++ b/usr/lib/precommit/plugins.d/golangci.sh	2026-06-05 08:46:31.999178321 +0000
+@@ -86,9 +86,9 @@ function golangcilint_exec
+   args+=("--max-issues-per-linter=0")
+   args+=("--max-same-issues=0")
+   args+=("--uniq-by-line=false")
+-  args+=("--out-format=line-number")
+-  args+=("--print-issued-lines=false")
+-  args+=("--color=never")
++  args+=("--output.text.path=stdout")
++  args+=("--output.text.print-issued-lines=false")
++  args+=("--output.text.colors=false")
+ 
+   if [[ -f "${GOLANGCI_CONFIG}" ]]; then
+     args+=("--config" "${GOLANGCI_CONFIG}")


### PR DESCRIPTION
# Description

We use upstream golangci-lint inside our Yetus container in order to work with newer Go versions. However, Yetus still uses an old (not supported anymore) --out-format argument. This commit patches the Yetus golangci-lint plugin to use the corresponding new arguments.

PS: This just fixes our Yetus image. Follow-up PRs will update the version and activate the usage of the new image properly.

## How to test and validate this PR

Run CI/CD with the updated image. This PR was tested locally.

## Changelog notes

None. (CI/CD stuff).

## PR Backports

None because stable branches still uses old Yetus.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.