### PR TITLE
Bump eve-libs to fix nettrace infinite loops

### DIFF
--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.5.0
 	github.com/lf-edge/edge-containers v0.0.0-20260502192833-bdbe764faf59
 	github.com/lf-edge/eve-api/go v0.0.0-20260520095750-2a982d0b4ddb
-	github.com/lf-edge/eve-libs v0.0.0-20260601101747-0b8f9993a3cc
+	github.com/lf-edge/eve-libs v0.0.0-20260605082929-e518b59e99d2
 	github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d
 	github.com/lf-edge/go-qemu v0.0.0-20231121152149-4c467eda0c56
 	github.com/linuxkit/linuxkit/src/cmd/linuxkit v0.0.0-20240507172735-6d37353ca1ee

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -583,8 +583,8 @@ github.com/lf-edge/edge-containers v0.0.0-20260502192833-bdbe764faf59 h1:fuyDqWU
 github.com/lf-edge/edge-containers v0.0.0-20260502192833-bdbe764faf59/go.mod h1:DoK51ifLgVh2GQ+IXTvmkhTuf8THijPCwYlNAbs2Nz0=
 github.com/lf-edge/eve-api/go v0.0.0-20260520095750-2a982d0b4ddb h1:KFvz8X8V/h6NpjkR6Ka24f1zh1Gvv988Jaz7SL2Z580=
 github.com/lf-edge/eve-api/go v0.0.0-20260520095750-2a982d0b4ddb/go.mod h1:6HxNA/qKJVEqwpuOFkcQ0h3QyotvAs/cjHLC961FPOY=
-github.com/lf-edge/eve-libs v0.0.0-20260601101747-0b8f9993a3cc h1:I3EfbxNSO1RUfMCUN/VOXxQTp+yi0NyaudD6NNs29aQ=
-github.com/lf-edge/eve-libs v0.0.0-20260601101747-0b8f9993a3cc/go.mod h1:AfK4OlUgnJymZnPEuqzm7sJoCCtRgFhKtRU1kib+VBY=
+github.com/lf-edge/eve-libs v0.0.0-20260605082929-e518b59e99d2 h1:Q15Ycd0cq1aNTGlAst/IMLgkAagfu9CIwESWaaqmPD4=
+github.com/lf-edge/eve-libs v0.0.0-20260605082929-e518b59e99d2/go.mod h1:AfK4OlUgnJymZnPEuqzm7sJoCCtRgFhKtRU1kib+VBY=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d h1:tUBb9M6u42LXwHAYHyh22wJeUUQlTpDkXwRXalpRqbo=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d/go.mod h1:Nn3juMJJ1G8dyHOebdZyS4jOB/fuxAd5fIajBaWjHr8=
 github.com/lf-edge/go-qemu v0.0.0-20231121152149-4c467eda0c56 h1:LmFp0jbNSwPLuxJA+nQ+mMQrQ53ESkvHP4CVMqR0zrY=

--- a/pkg/pillar/vendor/github.com/lf-edge/eve-libs/nettrace/conn.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve-libs/nettrace/conn.go
@@ -85,7 +85,7 @@ func (tc *tracedConn) parseDNSQuery(data []byte, sentAt Timestamp) {
 			tc.log.Warningf(
 				"nettrace: networkTracer id=%s: failed to parse DNS query question: %v "+
 					"(conn %v)", tc.tracer.getTracerID(), err, tc)
-			continue
+			break
 		}
 		resType := DNSResType(q.Type)
 		if _, recognized := DNSResTypeToString[resType]; !recognized {
@@ -102,7 +102,7 @@ func (tc *tracedConn) parseDNSQuery(data []byte, sentAt Timestamp) {
 	var udpMaxSize uint16
 	for {
 		ad, err := p.AdditionalHeader()
-		if err == dnsmessage.ErrSectionDone {
+		if err != nil {
 			break
 		}
 		if ad.Type == dnsmessage.TypeOPT {
@@ -145,7 +145,7 @@ func (tc *tracedConn) parseDNSReply(data []byte, recvAt Timestamp) {
 			tc.log.Warningf(
 				"nettrace: networkTracer id=%s: failed to parse DNS reply answer: %v "+
 					"(conn %v)", tc.tracer.getTracerID(), err, tc)
-			continue
+			break
 		}
 		var resolvedVal string
 		switch a.Type {
@@ -155,6 +155,7 @@ func (tc *tracedConn) parseDNSReply(data []byte, recvAt Timestamp) {
 				tc.log.Warningf(
 					"nettrace: networkTracer id=%s: failed to parse A resource from DNS "+
 						"reply: %v (conn %v)", tc.tracer.getTracerID(), err, tc)
+				_ = p.SkipAnswer()
 				continue
 			}
 			resolvedVal = net.IP(r.A[:]).String()
@@ -164,6 +165,7 @@ func (tc *tracedConn) parseDNSReply(data []byte, recvAt Timestamp) {
 				tc.log.Warningf(
 					"nettrace: networkTracer id=%s: failed to parse AAAA resource from DNS "+
 						"reply: %v (conn %v)", tc.tracer.getTracerID(), err, tc)
+				_ = p.SkipAnswer()
 				continue
 			}
 			resolvedVal = net.IP(r.AAAA[:]).String()
@@ -173,6 +175,7 @@ func (tc *tracedConn) parseDNSReply(data []byte, recvAt Timestamp) {
 				tc.log.Warningf(
 					"nettrace: networkTracer id=%s: failed to parse CNAME resource from DNS "+
 						"reply: %v (conn %v)", tc.tracer.getTracerID(), err, tc)
+				_ = p.SkipAnswer()
 				continue
 			}
 			resolvedVal = r.CNAME.String()
@@ -182,6 +185,7 @@ func (tc *tracedConn) parseDNSReply(data []byte, recvAt Timestamp) {
 				tc.log.Warningf(
 					"nettrace: networkTracer id=%s: failed to parse NS resource from DNS "+
 						"reply: %v (conn %v)", tc.tracer.getTracerID(), err, tc)
+				_ = p.SkipAnswer()
 				continue
 			}
 			resolvedVal = r.NS.String()
@@ -191,6 +195,7 @@ func (tc *tracedConn) parseDNSReply(data []byte, recvAt Timestamp) {
 				tc.log.Warningf(
 					"nettrace: networkTracer id=%s: failed to parse PTR resource from DNS "+
 						"reply: %v (conn %v)", tc.tracer.getTracerID(), err, tc)
+				_ = p.SkipAnswer()
 				continue
 			}
 			resolvedVal = r.PTR.String()
@@ -200,6 +205,7 @@ func (tc *tracedConn) parseDNSReply(data []byte, recvAt Timestamp) {
 				tc.log.Warningf(
 					"nettrace: networkTracer id=%s: failed to parse MX resource from DNS "+
 						"reply: %v (conn %v)", tc.tracer.getTracerID(), err, tc)
+				_ = p.SkipAnswer()
 				continue
 			}
 			resolvedVal = r.MX.String()

--- a/pkg/pillar/vendor/github.com/lf-edge/eve-libs/zedUpload/datastore.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve-libs/zedUpload/datastore.go
@@ -159,16 +159,20 @@ func (ctx *DronaCtx) postResponse(req *DronaRequest, status error) {
 	req.result <- req
 }
 
-func isToken(str string) bool {
+// IsToken checks whether the given string is a valid HTTP token
+// as defined in RFC 7230, Section 3.2.6.
+func IsToken(str string) bool {
 	// https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6
 	rex := regexp.MustCompile(`^[a-zA-Z0-9-._~+/!#\$%&'\*\+^` + "`" + `|']*$`)
 
 	return rex.MatchString(str)
 }
 
-func isToken68(str string) bool {
+// IsToken68 checks whether the given string is a valid token68
+// as defined in RFC 7235, Appendix C.
+func IsToken68(str string) bool {
 	// https://datatracker.ietf.org/doc/html/rfc7235#appendix-C
-	rex := regexp.MustCompile(`^[a-zA-Z0-9-._~+/]*=?$`)
+	rex := regexp.MustCompile(`^[a-zA-Z0-9-._~+/]*={0,2}$`)
 
 	return rex.MatchString(str)
 }
@@ -221,10 +225,10 @@ func (ctx *DronaCtx) NewSyncerDest(tr SyncTransportType, UrlOrRegion, nettraceDi
 	case SyncHttpTr:
 		syncEp := &HttpTransportMethod{transport: tr, hurl: UrlOrRegion, path: PathOrBkt, ctx: ctx}
 		if auth != nil {
-			if !isToken(auth.Uname) {
+			if !IsToken(auth.Uname) {
 				return nil, errors.New("auth.Uname is not token-conform")
 			}
-			if !isToken68(auth.Password) {
+			if !IsToken68(auth.Password) {
 				return nil, errors.New("auth.Password is not token68-conform")
 			}
 			syncEp.authType = auth.AuthType

--- a/pkg/pillar/vendor/github.com/lf-edge/eve-libs/zedUpload/datastore_http.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve-libs/zedUpload/datastore_http.go
@@ -153,13 +153,9 @@ func (ep *HttpTransportMethod) processHttpUpload(req *DronaRequest) (error, int)
 
 // File download from HTTP Datastore
 func (ep *HttpTransportMethod) processHttpDownload(req *DronaRequest) (error, int) {
-	file := req.name
-	if ep.hurl != "" {
-		var err error
-		file, err = url.JoinPath(ep.hurl, ep.path, req.name)
-		if err != nil {
-			return err, 0
-		}
+	file, err := ep.concatenateFile(req)
+	if err != nil {
+		return err, 0
 	}
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
@@ -176,6 +172,25 @@ func (ep *HttpTransportMethod) processHttpDownload(req *DronaRequest) (error, in
 		req.objloc, req.sizelimit, prgChan, doneParts, hClient, ep.inactivityTimeout,
 		ep.buildAuthHeader())
 	return stats.Error, resp.BodyLength
+}
+
+func (ep *HttpTransportMethod) concatenateFile(req *DronaRequest) (string, error) {
+	file := req.name
+	if ep.hurl != "" {
+		var err error
+		file, err = url.JoinPath(ep.hurl, ep.path)
+		if err != nil {
+			return "", err
+		}
+
+		file = strings.TrimSuffix(file, "/")
+		reqName := req.name
+		for strings.HasPrefix(reqName, "/") {
+			reqName = strings.TrimPrefix(reqName, "/")
+		}
+		file += "/" + reqName
+	}
+	return file, nil
 }
 
 // File delete from HTTP Datastore
@@ -208,14 +223,11 @@ func (ep *HttpTransportMethod) processHttpList(req *DronaRequest) ([]string, err
 
 // Object Metadata from HTTP datastore
 func (ep *HttpTransportMethod) processHttpObjectMetaData(req *DronaRequest) (error, int64) {
-	file := req.name
-	if ep.hurl != "" {
-		var err error
-		file, err = url.JoinPath(ep.hurl, ep.path, req.name)
-		if err != nil {
-			return err, 0
-		}
+	file, err := ep.concatenateFile(req)
+	if err != nil {
+		return err, 0
 	}
+
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -882,8 +882,8 @@ github.com/lf-edge/eve-api/go/nestedappinstancemetrics
 github.com/lf-edge/eve-api/go/profile
 github.com/lf-edge/eve-api/go/proxy
 github.com/lf-edge/eve-api/go/register
-# github.com/lf-edge/eve-libs v0.0.0-20260601101747-0b8f9993a3cc
-## explicit; go 1.24.0
+# github.com/lf-edge/eve-libs v0.0.0-20260605082929-e518b59e99d2
+## explicit; go 1.25.0
 github.com/lf-edge/eve-libs/depgraph
 github.com/lf-edge/eve-libs/nettrace
 github.com/lf-edge/eve-libs/nettraceStorage
@@ -1265,7 +1265,7 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/request
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/semconv
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/semconvutil
 # go.opentelemetry.io/otel v1.43.0
-## explicit; go 1.24.0
+## explicit; go 1.25.0
 go.opentelemetry.io/otel
 go.opentelemetry.io/otel/attribute
 go.opentelemetry.io/otel/attribute/internal
@@ -1285,18 +1285,18 @@ go.opentelemetry.io/otel/semconv/v1.37.0
 go.opentelemetry.io/otel/semconv/v1.40.0
 go.opentelemetry.io/otel/semconv/v1.40.0/otelconv
 # go.opentelemetry.io/otel/metric v1.43.0
-## explicit; go 1.24.0
+## explicit; go 1.25.0
 go.opentelemetry.io/otel/metric
 go.opentelemetry.io/otel/metric/embedded
 go.opentelemetry.io/otel/metric/noop
 # go.opentelemetry.io/otel/sdk v1.43.0
-## explicit; go 1.24.0
+## explicit; go 1.25.0
 go.opentelemetry.io/otel/sdk
 go.opentelemetry.io/otel/sdk/instrumentation
 go.opentelemetry.io/otel/sdk/internal/x
 go.opentelemetry.io/otel/sdk/resource
 # go.opentelemetry.io/otel/sdk/metric v1.43.0
-## explicit; go 1.24.0
+## explicit; go 1.25.0
 go.opentelemetry.io/otel/sdk/metric
 go.opentelemetry.io/otel/sdk/metric/exemplar
 go.opentelemetry.io/otel/sdk/metric/internal
@@ -1305,7 +1305,7 @@ go.opentelemetry.io/otel/sdk/metric/internal/observ
 go.opentelemetry.io/otel/sdk/metric/internal/reservoir
 go.opentelemetry.io/otel/sdk/metric/metricdata
 # go.opentelemetry.io/otel/trace v1.43.0
-## explicit; go 1.24.0
+## explicit; go 1.25.0
 go.opentelemetry.io/otel/trace
 go.opentelemetry.io/otel/trace/embedded
 go.opentelemetry.io/otel/trace/internal/telemetry
@@ -1378,7 +1378,7 @@ golang.org/x/oauth2/jwt
 golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.42.0
-## explicit; go 1.24.0
+## explicit; go 1.25.0
 golang.org/x/sys/cpu
 golang.org/x/sys/plan9
 golang.org/x/sys/unix


### PR DESCRIPTION
# Description

Bump eve-libs to pick up a [fix for infinite loops in nettrace DNS query/reply parsing](https://github.com/lf-edge/eve-libs/pull/77).  When the `dnsmessage` parser encounters a malformed DNS message (e.g. a reserved label prefix in a question or answer name), it returns an error without advancing its internal offset.  The parsing loops used `continue`/`break` incorrectly, causing them to call the same failing method forever, flooding logs with repeated warnings and blocking the caller goroutine indefinitely.  On EVE, this caused the caller microservice (e.g. zedagent) to get permanently stuck inside a traced HTTP request.

## PR dependencies

https://github.com/lf-edge/eve/pull/6023 (latest eve-libs requires Go 1.25)

## How to test and validate this PR

This issue only manifests when nettrace intercepts a malformed DNS packet (e.g. one containing a reserved label prefix in a question or answer name). Such packets are rare in practice and hard to reproduce on demand.

The fix is validated by unit tests added to eve-libs (`nettrace/conn_test.go`), which feed crafted malformed DNS wire data directly to the affected parsing functions. Each test runs the parser in a goroutine with a strict timeout — a timeout failure means the infinite loop has regressed. The tests cover all fixed cases: a malformed question name, a malformed answer resource-header name, a CNAME answer with malformed RDATA, and the latter followed by a valid A record to confirm parsing resumes correctly after skipping a broken answer.

## Changelog notes

Fixed an issue where a malformed DNS packet could cause `zedagent` or `downloader` microservice to enter an infinite loop, flooding logs and permanently getting stuck until the edge node was rebooted (manually or by watchdog).

## PR Backports

```text
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.
```

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.