### PR TITLE
[17.0] kube: add stale-mount-cleanup daemon to kube container

### DIFF
--- a/.spdxignore
+++ b/.spdxignore
@@ -22,3 +22,4 @@ pkg/vtpm/swtpm-vtpm/vendor/
 pkg/wwan/mmagent/vendor/
 tools/get-deps/vendor/
 pkg/alpine/dnstest/vendor/
+pkg/kube/stale-mount-cleanup/vendor/

--- a/conf/server
+++ b/conf/server
@@ -1,1 +1,1 @@
-zedcloud.alpha.zededa.net
+zedcloud.zededa.net

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -37,6 +37,10 @@ COPY update-component /plugins/update-component
 WORKDIR /plugins/update-component
 RUN GO111MODULE=on go build -v -ldflags "-s -w" -mod=vendor -o /out/usr/bin/update-component .
 
+COPY stale-mount-cleanup /plugins/stale-mount-cleanup
+WORKDIR /plugins/stale-mount-cleanup
+RUN GO111MODULE=on CGO_ENABLED=0 go build -v -ldflags "-s -w" -mod=vendor -o /out/usr/bin/stale-mount-cleanup .
+
 FROM scratch
 COPY --from=build /out/ /
 RUN mkdir -p /usr/bin/kube/

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -1539,6 +1539,10 @@ else
                         # launch CNI dhcp service
                         /opt/cni/bin/dhcp daemon &
                 fi
+                if ! pgrep -f "stale-mount-cleanup" > /dev/null 2>&1; then
+                        logmsg "starting stale-mount-cleanup daemon"
+                        /usr/bin/stale-mount-cleanup &
+                fi
                 # setup debug user credential, role and binding
                 if [ ! -f /var/lib/debuguser-initialized ]; then
                         config_cluster_roles

--- a/pkg/kube/stale-mount-cleanup/go.mod
+++ b/pkg/kube/stale-mount-cleanup/go.mod
@@ -1,0 +1,5 @@
+module github.com/lf-edge/eve/pkg/kube/stale-mount-cleanup
+
+go 1.24.1
+
+require gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/pkg/kube/stale-mount-cleanup/go.sum
+++ b/pkg/kube/stale-mount-cleanup/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=

--- a/pkg/kube/stale-mount-cleanup/main.go
+++ b/pkg/kube/stale-mount-cleanup/main.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// stale-mount-cleanup detects and clears stale Longhorn CSI block volume
+// staging mounts. It runs as a daemon inside the kube container, which shares
+// the kubelet mount namespace and can see /var/lib/kubelet/...
+//
+// A stale staging mount occurs when a Longhorn iSCSI session is replaced
+// (engine restart, auto-salvage) without NodeUnstageVolume being called. The
+// old bind mount references a deleted device inode while the live
+// /dev/longhorn/<pv> device has a new minor number. Longhorn's restageRequired
+// check only calls IsMountPoint (which returns true for stale bind mounts), so
+// kubelet never retriggers NodeStageVolume and every NodePublishVolume attempt
+// fails with a misleading ENOENT against the publish path.
+//
+// Detection signals:
+//
+//	nlink==0     : device inode deleted (shows as //deleted in findmnt)
+//	Rdev mismatch: iSCSI session replaced; live device has a different minor
+//
+// A stale condition must persist for staleThreshold before the mount is
+// cleared. This avoids a TOCTOU race where NodeStageVolume completes a fresh
+// bind mount between detection and unmount: if Longhorn fixes the condition
+// itself, it will clear within seconds and the daemon will log the
+// self-resolution without unmounting.
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+const (
+	logPrefix      = "stale-mount-cleanup"
+	csiStagingBase = "/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging"
+	scanInterval   = 15 * time.Second
+	staleThreshold = 2 * scanInterval
+	logfileDir     = "/persist/kubelog/"
+	logfile        = logfileDir + logPrefix + ".log"
+	logMaxSize     = 10 // MB
+	logMaxBackups  = 3
+	logMaxAge      = 365 // days
+)
+
+func main() {
+	if _, err := os.Stat(logfileDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(logfileDir, 0755); err != nil {
+			return
+		}
+	}
+	logFile := &lumberjack.Logger{
+		Filename:   logfile,
+		MaxSize:    logMaxSize,
+		MaxBackups: logMaxBackups,
+		MaxAge:     logMaxAge,
+		Compress:   true,
+		LocalTime:  true,
+	}
+	log.SetOutput(logFile)
+	defer logFile.Close()
+
+	log.Printf(logPrefix+": starting")
+	firstSeenStale := make(map[string]time.Time)
+	for {
+		cleanStaleStagingMounts(firstSeenStale)
+		time.Sleep(scanInterval)
+	}
+}
+
+func cleanStaleStagingMounts(firstSeenStale map[string]time.Time) {
+	entries, err := os.ReadDir(csiStagingBase)
+	if err != nil {
+		// Base dir absent — kubelet not yet started or no block volumes ever staged.
+		return
+	}
+
+	seen := make(map[string]bool)
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		pvName := e.Name()
+		stagingFile := filepath.Join(csiStagingBase, pvName, pvName)
+
+		stagedInfo, err := os.Stat(stagingFile)
+		if err != nil {
+			continue
+		}
+		stagedSys := stagedInfo.Sys().(*syscall.Stat_t)
+
+		longhornDev := filepath.Join("/dev/longhorn", pvName)
+
+		// Signal 1: nlink==0 — the device inode was deleted.
+		// Gate on Longhorn: only act if /dev/longhorn/<pv> exists, confirming
+		// this is a Longhorn-provisioned volume.
+		stale := stagedSys.Nlink == 0
+		if stale {
+			if _, err := os.Stat(longhornDev); err != nil {
+				stale = false
+			}
+		}
+
+		if !stale {
+			// Signal 2: Rdev mismatch with the live Longhorn device — the iSCSI
+			// session was replaced (new device minor) without NodeUnstageVolume.
+			if liveInfo, err := os.Stat(longhornDev); err == nil {
+				liveSys := liveInfo.Sys().(*syscall.Stat_t)
+				if stagedSys.Rdev != liveSys.Rdev {
+					stale = true
+					log.Printf(logPrefix+": PV %s staged rdev %d != live rdev %d",
+						pvName, stagedSys.Rdev, liveSys.Rdev)
+				}
+			}
+		}
+
+		if !stale {
+			if first, ok := firstSeenStale[pvName]; ok {
+				// Condition cleared before threshold — Longhorn resolved it.
+				log.Printf(logPrefix+": PV %s stale condition self-resolved after %s, skipping unmount",
+					pvName, time.Since(first).Round(time.Second))
+				delete(firstSeenStale, pvName)
+			}
+			continue
+		}
+
+		seen[pvName] = true
+
+		first, known := firstSeenStale[pvName]
+		if !known {
+			// Condition 1: first time we see this PV as stale.
+			firstSeenStale[pvName] = time.Now()
+			log.Printf(logPrefix+": PV %s first observed stale (nlink=%d), waiting %s before unmount",
+				pvName, stagedSys.Nlink, staleThreshold)
+			continue
+		}
+
+		if time.Since(first) < staleThreshold {
+			continue
+		}
+
+		// Condition 3: stale for longer than threshold — unmount.
+		log.Printf(logPrefix+": PV %s stale for %s (nlink=%d), unmounting",
+			pvName, time.Since(first).Round(time.Second), stagedSys.Nlink)
+		if err := syscall.Unmount(stagingFile, syscall.MNT_DETACH); err != nil {
+			log.Printf(logPrefix+": umount failed for %s: %v", stagingFile, err)
+		} else {
+			log.Printf(logPrefix+": cleared stale staging for PV %s", pvName)
+			delete(firstSeenStale, pvName)
+		}
+	}
+
+	// Clean up tracking for PVs whose staging directories have disappeared.
+	for pvName := range firstSeenStale {
+		if !seen[pvName] {
+			log.Printf(logPrefix+": PV %s staging directory gone, dropping stale tracking", pvName)
+			delete(firstSeenStale, pvName)
+		}
+	}
+}

--- a/pkg/kube/stale-mount-cleanup/vendor/gopkg.in/natefinch/lumberjack.v2/.gitignore
+++ b/pkg/kube/stale-mount-cleanup/vendor/gopkg.in/natefinch/lumberjack.v2/.gitignore
@@ -1,0 +1,23 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test

--- a/pkg/kube/stale-mount-cleanup/vendor/gopkg.in/natefinch/lumberjack.v2/.travis.yml
+++ b/pkg/kube/stale-mount-cleanup/vendor/gopkg.in/natefinch/lumberjack.v2/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+
+go:
+  - tip
+  - 1.15.x
+  - 1.14.x
+  - 1.13.x
+  - 1.12.x
+  
+env:
+  - GO111MODULE=on

--- a/pkg/kube/stale-mount-cleanup/vendor/gopkg.in/natefinch/lumberjack.v2/LICENSE
+++ b/pkg/kube/stale-mount-cleanup/vendor/gopkg.in/natefinch/lumberjack.v2/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Nate Finch 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkg/kube/stale-mount-cleanup/vendor/gopkg.in/natefinch/lumberjack.v2/README.md
+++ b/pkg/kube/stale-mount-cleanup/vendor/gopkg.in/natefinch/lumberjack.v2/README.md
@@ -1,0 +1,179 @@
+# lumberjack  [![GoDoc](https://godoc.org/gopkg.in/natefinch/lumberjack.v2?status.png)](https://godoc.org/gopkg.in/natefinch/lumberjack.v2) [![Build Status](https://travis-ci.org/natefinch/lumberjack.svg?branch=v2.0)](https://travis-ci.org/natefinch/lumberjack) [![Build status](https://ci.appveyor.com/api/projects/status/00gchpxtg4gkrt5d)](https://ci.appveyor.com/project/natefinch/lumberjack) [![Coverage Status](https://coveralls.io/repos/natefinch/lumberjack/badge.svg?branch=v2.0)](https://coveralls.io/r/natefinch/lumberjack?branch=v2.0)
+
+### Lumberjack is a Go package for writing logs to rolling files.
+
+Package lumberjack provides a rolling logger.
+
+Note that this is v2.0 of lumberjack, and should be imported using gopkg.in
+thusly:
+
+    import "gopkg.in/natefinch/lumberjack.v2"
+
+The package name remains simply lumberjack, and the code resides at
+https://github.com/natefinch/lumberjack under the v2.0 branch.
+
+Lumberjack is intended to be one part of a logging infrastructure.
+It is not an all-in-one solution, but instead is a pluggable
+component at the bottom of the logging stack that simply controls the files
+to which logs are written.
+
+Lumberjack plays well with any logging package that can write to an
+io.Writer, including the standard library's log package.
+
+Lumberjack assumes that only one process is writing to the output files.
+Using the same lumberjack configuration from multiple processes on the same
+machine will result in improper behavior.
+
+
+**Example**
+
+To use lumberjack with the standard library's log package, just pass it into the SetOutput function when your application starts.
+
+Code:
+
+```go
+log.SetOutput(&lumberjack.Logger{
+    Filename:   "/var/log/myapp/foo.log",
+    MaxSize:    500, // megabytes
+    MaxBackups: 3,
+    MaxAge:     28, //days
+    Compress:   true, // disabled by default
+})
+```
+
+
+
+## type Logger
+``` go
+type Logger struct {
+    // Filename is the file to write logs to.  Backup log files will be retained
+    // in the same directory.  It uses <processname>-lumberjack.log in
+    // os.TempDir() if empty.
+    Filename string `json:"filename" yaml:"filename"`
+
+    // MaxSize is the maximum size in megabytes of the log file before it gets
+    // rotated. It defaults to 100 megabytes.
+    MaxSize int `json:"maxsize" yaml:"maxsize"`
+
+    // MaxAge is the maximum number of days to retain old log files based on the
+    // timestamp encoded in their filename.  Note that a day is defined as 24
+    // hours and may not exactly correspond to calendar days due to daylight
+    // savings, leap seconds, etc. The default is not to remove old log files
+    // based on age.
+    MaxAge int `json:"maxage" yaml:"maxage"`
+
+    // MaxBackups is the maximum number of old log files to retain.  The default
+    // is to retain all old log files (though MaxAge may still cause them to get
+    // deleted.)
+    MaxBackups int `json:"maxbackups" yaml:"maxbackups"`
+
+    // LocalTime determines if the time used for formatting the timestamps in
+    // backup files is the computer's local time.  The default is to use UTC
+    // time.
+    LocalTime bool `json:"localtime" yaml:"localtime"`
+
+    // Compress determines if the rotated log files should be compressed
+    // using gzip. The default is not to perform compression.
+    Compress bool `json:"compress" yaml:"compress"`
+    // contains filtered or unexported fields
+}
+```
+Logger is an io.WriteCloser that writes to the specified filename.
+
+Logger opens or creates the logfile on first Write.  If the file exists and
+is less than MaxSize megabytes, lumberjack will open and append to that file.
+If the file exists and its size is >= MaxSize megabytes, the file is renamed
+by putting the current time in a timestamp in the name immediately before the
+file's extension (or the end of the filename if there's no extension). A new
+log file is then created using original filename.
+
+Whenever a write would cause the current log file exceed MaxSize megabytes,
+the current file is closed, renamed, and a new log file created with the
+original name. Thus, the filename you give Logger is always the "current" log
+file.
+
+Backups use the log file name given to Logger, in the form `name-timestamp.ext`
+where name is the filename without the extension, timestamp is the time at which
+the log was rotated formatted with the time.Time format of
+`2006-01-02T15-04-05.000` and the extension is the original extension.  For
+example, if your Logger.Filename is `/var/log/foo/server.log`, a backup created
+at 6:30pm on Nov 11 2016 would use the filename
+`/var/log/foo/server-2016-11-04T18-30-00.000.log`
+
+### Cleaning Up Old Log Files
+Whenever a new logfile gets created, old log files may be deleted.  The most
+recent files according to the encoded timestamp will be retained, up to a
+number equal to MaxBackups (or all of them if MaxBackups is 0).  Any files
+with an encoded timestamp older than MaxAge days are deleted, regardless of
+MaxBackups.  Note that the time encoded in the timestamp is the rotation
+time, which may differ from the last time that file was written to.
+
+If MaxBackups and MaxAge are both 0, no old log files will be deleted.
+
+
+
+
+
+
+
+
+
+
+
+### func (\*Logger) Close
+``` go
+func (l *Logger) Close() error
+```
+Close implements io.Closer, and closes the current logfile.
+
+
+
+### func (\*Logger) Rotate
+``` go
+func (l *Logger) Rotate() error
+```
+Rotate causes Logger to close the existing log file and immediately create a
+new one.  This is a helper function for applications that want to initiate
+rotations outside of the normal rotation rules, such as in response to
+SIGHUP.  After rotating, this initiates a cleanup of old log files according
+to the normal rules.
+
+**Example**
+
+Example of how to rotate in response to SIGHUP.
+
+Code:
+
+```go
+l := &lumberjack.Logger{}
+log.SetOutput(l)
+c := make(chan os.Signal, 1)
+signal.Notify(c, syscall.SIGHUP)
+
+go func() {
+    for {
+        <-c
+        l.Rotate()
+    }
+}()
+```
+
+### func (\*Logger) Write
+``` go
+func (l *Logger) Write(p []byte) (n int, err error)
+```
+Write implements io.Writer.  If a write would cause the log file to be larger
+than MaxSize, the file is closed, renamed to include a timestamp of the
+current time, and a new log file is created using the original log file name.
+If the length of the write is greater than MaxSize, an error is returned.
+
+
+
+
+
+
+
+
+
+- - -
+Generated by [godoc2md](http://godoc.org/github.com/davecheney/godoc2md)

--- a/pkg/kube/stale-mount-cleanup/vendor/gopkg.in/natefinch/lumberjack.v2/chown.go
+++ b/pkg/kube/stale-mount-cleanup/vendor/gopkg.in/natefinch/lumberjack.v2/chown.go
@@ -1,0 +1,11 @@
+// +build !linux
+
+package lumberjack
+
+import (
+	"os"
+)
+
+func chown(_ string, _ os.FileInfo) error {
+	return nil
+}

--- a/pkg/kube/stale-mount-cleanup/vendor/gopkg.in/natefinch/lumberjack.v2/chown_linux.go
+++ b/pkg/kube/stale-mount-cleanup/vendor/gopkg.in/natefinch/lumberjack.v2/chown_linux.go
@@ -1,0 +1,19 @@
+package lumberjack
+
+import (
+	"os"
+	"syscall"
+)
+
+// osChown is a var so we can mock it out during tests.
+var osChown = os.Chown
+
+func chown(name string, info os.FileInfo) error {
+	f, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return err
+	}
+	f.Close()
+	stat := info.Sys().(*syscall.Stat_t)
+	return osChown(name, int(stat.Uid), int(stat.Gid))
+}

--- a/pkg/kube/stale-mount-cleanup/vendor/gopkg.in/natefinch/lumberjack.v2/lumberjack.go
+++ b/pkg/kube/stale-mount-cleanup/vendor/gopkg.in/natefinch/lumberjack.v2/lumberjack.go
@@ -1,0 +1,541 @@
+// Package lumberjack provides a rolling logger.
+//
+// Note that this is v2.0 of lumberjack, and should be imported using gopkg.in
+// thusly:
+//
+//   import "gopkg.in/natefinch/lumberjack.v2"
+//
+// The package name remains simply lumberjack, and the code resides at
+// https://github.com/natefinch/lumberjack under the v2.0 branch.
+//
+// Lumberjack is intended to be one part of a logging infrastructure.
+// It is not an all-in-one solution, but instead is a pluggable
+// component at the bottom of the logging stack that simply controls the files
+// to which logs are written.
+//
+// Lumberjack plays well with any logging package that can write to an
+// io.Writer, including the standard library's log package.
+//
+// Lumberjack assumes that only one process is writing to the output files.
+// Using the same lumberjack configuration from multiple processes on the same
+// machine will result in improper behavior.
+package lumberjack
+
+import (
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	backupTimeFormat = "2006-01-02T15-04-05.000"
+	compressSuffix   = ".gz"
+	defaultMaxSize   = 100
+)
+
+// ensure we always implement io.WriteCloser
+var _ io.WriteCloser = (*Logger)(nil)
+
+// Logger is an io.WriteCloser that writes to the specified filename.
+//
+// Logger opens or creates the logfile on first Write.  If the file exists and
+// is less than MaxSize megabytes, lumberjack will open and append to that file.
+// If the file exists and its size is >= MaxSize megabytes, the file is renamed
+// by putting the current time in a timestamp in the name immediately before the
+// file's extension (or the end of the filename if there's no extension). A new
+// log file is then created using original filename.
+//
+// Whenever a write would cause the current log file exceed MaxSize megabytes,
+// the current file is closed, renamed, and a new log file created with the
+// original name. Thus, the filename you give Logger is always the "current" log
+// file.
+//
+// Backups use the log file name given to Logger, in the form
+// `name-timestamp.ext` where name is the filename without the extension,
+// timestamp is the time at which the log was rotated formatted with the
+// time.Time format of `2006-01-02T15-04-05.000` and the extension is the
+// original extension.  For example, if your Logger.Filename is
+// `/var/log/foo/server.log`, a backup created at 6:30pm on Nov 11 2016 would
+// use the filename `/var/log/foo/server-2016-11-04T18-30-00.000.log`
+//
+// Cleaning Up Old Log Files
+//
+// Whenever a new logfile gets created, old log files may be deleted.  The most
+// recent files according to the encoded timestamp will be retained, up to a
+// number equal to MaxBackups (or all of them if MaxBackups is 0).  Any files
+// with an encoded timestamp older than MaxAge days are deleted, regardless of
+// MaxBackups.  Note that the time encoded in the timestamp is the rotation
+// time, which may differ from the last time that file was written to.
+//
+// If MaxBackups and MaxAge are both 0, no old log files will be deleted.
+type Logger struct {
+	// Filename is the file to write logs to.  Backup log files will be retained
+	// in the same directory.  It uses <processname>-lumberjack.log in
+	// os.TempDir() if empty.
+	Filename string `json:"filename" yaml:"filename"`
+
+	// MaxSize is the maximum size in megabytes of the log file before it gets
+	// rotated. It defaults to 100 megabytes.
+	MaxSize int `json:"maxsize" yaml:"maxsize"`
+
+	// MaxAge is the maximum number of days to retain old log files based on the
+	// timestamp encoded in their filename.  Note that a day is defined as 24
+	// hours and may not exactly correspond to calendar days due to daylight
+	// savings, leap seconds, etc. The default is not to remove old log files
+	// based on age.
+	MaxAge int `json:"maxage" yaml:"maxage"`
+
+	// MaxBackups is the maximum number of old log files to retain.  The default
+	// is to retain all old log files (though MaxAge may still cause them to get
+	// deleted.)
+	MaxBackups int `json:"maxbackups" yaml:"maxbackups"`
+
+	// LocalTime determines if the time used for formatting the timestamps in
+	// backup files is the computer's local time.  The default is to use UTC
+	// time.
+	LocalTime bool `json:"localtime" yaml:"localtime"`
+
+	// Compress determines if the rotated log files should be compressed
+	// using gzip. The default is not to perform compression.
+	Compress bool `json:"compress" yaml:"compress"`
+
+	size int64
+	file *os.File
+	mu   sync.Mutex
+
+	millCh    chan bool
+	startMill sync.Once
+}
+
+var (
+	// currentTime exists so it can be mocked out by tests.
+	currentTime = time.Now
+
+	// os_Stat exists so it can be mocked out by tests.
+	osStat = os.Stat
+
+	// megabyte is the conversion factor between MaxSize and bytes.  It is a
+	// variable so tests can mock it out and not need to write megabytes of data
+	// to disk.
+	megabyte = 1024 * 1024
+)
+
+// Write implements io.Writer.  If a write would cause the log file to be larger
+// than MaxSize, the file is closed, renamed to include a timestamp of the
+// current time, and a new log file is created using the original log file name.
+// If the length of the write is greater than MaxSize, an error is returned.
+func (l *Logger) Write(p []byte) (n int, err error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	writeLen := int64(len(p))
+	if writeLen > l.max() {
+		return 0, fmt.Errorf(
+			"write length %d exceeds maximum file size %d", writeLen, l.max(),
+		)
+	}
+
+	if l.file == nil {
+		if err = l.openExistingOrNew(len(p)); err != nil {
+			return 0, err
+		}
+	}
+
+	if l.size+writeLen > l.max() {
+		if err := l.rotate(); err != nil {
+			return 0, err
+		}
+	}
+
+	n, err = l.file.Write(p)
+	l.size += int64(n)
+
+	return n, err
+}
+
+// Close implements io.Closer, and closes the current logfile.
+func (l *Logger) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.close()
+}
+
+// close closes the file if it is open.
+func (l *Logger) close() error {
+	if l.file == nil {
+		return nil
+	}
+	err := l.file.Close()
+	l.file = nil
+	return err
+}
+
+// Rotate causes Logger to close the existing log file and immediately create a
+// new one.  This is a helper function for applications that want to initiate
+// rotations outside of the normal rotation rules, such as in response to
+// SIGHUP.  After rotating, this initiates compression and removal of old log
+// files according to the configuration.
+func (l *Logger) Rotate() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.rotate()
+}
+
+// rotate closes the current file, moves it aside with a timestamp in the name,
+// (if it exists), opens a new file with the original filename, and then runs
+// post-rotation processing and removal.
+func (l *Logger) rotate() error {
+	if err := l.close(); err != nil {
+		return err
+	}
+	if err := l.openNew(); err != nil {
+		return err
+	}
+	l.mill()
+	return nil
+}
+
+// openNew opens a new log file for writing, moving any old log file out of the
+// way.  This methods assumes the file has already been closed.
+func (l *Logger) openNew() error {
+	err := os.MkdirAll(l.dir(), 0755)
+	if err != nil {
+		return fmt.Errorf("can't make directories for new logfile: %s", err)
+	}
+
+	name := l.filename()
+	mode := os.FileMode(0600)
+	info, err := osStat(name)
+	if err == nil {
+		// Copy the mode off the old logfile.
+		mode = info.Mode()
+		// move the existing file
+		newname := backupName(name, l.LocalTime)
+		if err := os.Rename(name, newname); err != nil {
+			return fmt.Errorf("can't rename log file: %s", err)
+		}
+
+		// this is a no-op anywhere but linux
+		if err := chown(name, info); err != nil {
+			return err
+		}
+	}
+
+	// we use truncate here because this should only get called when we've moved
+	// the file ourselves. if someone else creates the file in the meantime,
+	// just wipe out the contents.
+	f, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("can't open new logfile: %s", err)
+	}
+	l.file = f
+	l.size = 0
+	return nil
+}
+
+// backupName creates a new filename from the given name, inserting a timestamp
+// between the filename and the extension, using the local time if requested
+// (otherwise UTC).
+func backupName(name string, local bool) string {
+	dir := filepath.Dir(name)
+	filename := filepath.Base(name)
+	ext := filepath.Ext(filename)
+	prefix := filename[:len(filename)-len(ext)]
+	t := currentTime()
+	if !local {
+		t = t.UTC()
+	}
+
+	timestamp := t.Format(backupTimeFormat)
+	return filepath.Join(dir, fmt.Sprintf("%s-%s%s", prefix, timestamp, ext))
+}
+
+// openExistingOrNew opens the logfile if it exists and if the current write
+// would not put it over MaxSize.  If there is no such file or the write would
+// put it over the MaxSize, a new file is created.
+func (l *Logger) openExistingOrNew(writeLen int) error {
+	l.mill()
+
+	filename := l.filename()
+	info, err := osStat(filename)
+	if os.IsNotExist(err) {
+		return l.openNew()
+	}
+	if err != nil {
+		return fmt.Errorf("error getting log file info: %s", err)
+	}
+
+	if info.Size()+int64(writeLen) >= l.max() {
+		return l.rotate()
+	}
+
+	file, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		// if we fail to open the old log file for some reason, just ignore
+		// it and open a new log file.
+		return l.openNew()
+	}
+	l.file = file
+	l.size = info.Size()
+	return nil
+}
+
+// filename generates the name of the logfile from the current time.
+func (l *Logger) filename() string {
+	if l.Filename != "" {
+		return l.Filename
+	}
+	name := filepath.Base(os.Args[0]) + "-lumberjack.log"
+	return filepath.Join(os.TempDir(), name)
+}
+
+// millRunOnce performs compression and removal of stale log files.
+// Log files are compressed if enabled via configuration and old log
+// files are removed, keeping at most l.MaxBackups files, as long as
+// none of them are older than MaxAge.
+func (l *Logger) millRunOnce() error {
+	if l.MaxBackups == 0 && l.MaxAge == 0 && !l.Compress {
+		return nil
+	}
+
+	files, err := l.oldLogFiles()
+	if err != nil {
+		return err
+	}
+
+	var compress, remove []logInfo
+
+	if l.MaxBackups > 0 && l.MaxBackups < len(files) {
+		preserved := make(map[string]bool)
+		var remaining []logInfo
+		for _, f := range files {
+			// Only count the uncompressed log file or the
+			// compressed log file, not both.
+			fn := f.Name()
+			if strings.HasSuffix(fn, compressSuffix) {
+				fn = fn[:len(fn)-len(compressSuffix)]
+			}
+			preserved[fn] = true
+
+			if len(preserved) > l.MaxBackups {
+				remove = append(remove, f)
+			} else {
+				remaining = append(remaining, f)
+			}
+		}
+		files = remaining
+	}
+	if l.MaxAge > 0 {
+		diff := time.Duration(int64(24*time.Hour) * int64(l.MaxAge))
+		cutoff := currentTime().Add(-1 * diff)
+
+		var remaining []logInfo
+		for _, f := range files {
+			if f.timestamp.Before(cutoff) {
+				remove = append(remove, f)
+			} else {
+				remaining = append(remaining, f)
+			}
+		}
+		files = remaining
+	}
+
+	if l.Compress {
+		for _, f := range files {
+			if !strings.HasSuffix(f.Name(), compressSuffix) {
+				compress = append(compress, f)
+			}
+		}
+	}
+
+	for _, f := range remove {
+		errRemove := os.Remove(filepath.Join(l.dir(), f.Name()))
+		if err == nil && errRemove != nil {
+			err = errRemove
+		}
+	}
+	for _, f := range compress {
+		fn := filepath.Join(l.dir(), f.Name())
+		errCompress := compressLogFile(fn, fn+compressSuffix)
+		if err == nil && errCompress != nil {
+			err = errCompress
+		}
+	}
+
+	return err
+}
+
+// millRun runs in a goroutine to manage post-rotation compression and removal
+// of old log files.
+func (l *Logger) millRun() {
+	for range l.millCh {
+		// what am I going to do, log this?
+		_ = l.millRunOnce()
+	}
+}
+
+// mill performs post-rotation compression and removal of stale log files,
+// starting the mill goroutine if necessary.
+func (l *Logger) mill() {
+	l.startMill.Do(func() {
+		l.millCh = make(chan bool, 1)
+		go l.millRun()
+	})
+	select {
+	case l.millCh <- true:
+	default:
+	}
+}
+
+// oldLogFiles returns the list of backup log files stored in the same
+// directory as the current log file, sorted by ModTime
+func (l *Logger) oldLogFiles() ([]logInfo, error) {
+	files, err := ioutil.ReadDir(l.dir())
+	if err != nil {
+		return nil, fmt.Errorf("can't read log file directory: %s", err)
+	}
+	logFiles := []logInfo{}
+
+	prefix, ext := l.prefixAndExt()
+
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		if t, err := l.timeFromName(f.Name(), prefix, ext); err == nil {
+			logFiles = append(logFiles, logInfo{t, f})
+			continue
+		}
+		if t, err := l.timeFromName(f.Name(), prefix, ext+compressSuffix); err == nil {
+			logFiles = append(logFiles, logInfo{t, f})
+			continue
+		}
+		// error parsing means that the suffix at the end was not generated
+		// by lumberjack, and therefore it's not a backup file.
+	}
+
+	sort.Sort(byFormatTime(logFiles))
+
+	return logFiles, nil
+}
+
+// timeFromName extracts the formatted time from the filename by stripping off
+// the filename's prefix and extension. This prevents someone's filename from
+// confusing time.parse.
+func (l *Logger) timeFromName(filename, prefix, ext string) (time.Time, error) {
+	if !strings.HasPrefix(filename, prefix) {
+		return time.Time{}, errors.New("mismatched prefix")
+	}
+	if !strings.HasSuffix(filename, ext) {
+		return time.Time{}, errors.New("mismatched extension")
+	}
+	ts := filename[len(prefix) : len(filename)-len(ext)]
+	return time.Parse(backupTimeFormat, ts)
+}
+
+// max returns the maximum size in bytes of log files before rolling.
+func (l *Logger) max() int64 {
+	if l.MaxSize == 0 {
+		return int64(defaultMaxSize * megabyte)
+	}
+	return int64(l.MaxSize) * int64(megabyte)
+}
+
+// dir returns the directory for the current filename.
+func (l *Logger) dir() string {
+	return filepath.Dir(l.filename())
+}
+
+// prefixAndExt returns the filename part and extension part from the Logger's
+// filename.
+func (l *Logger) prefixAndExt() (prefix, ext string) {
+	filename := filepath.Base(l.filename())
+	ext = filepath.Ext(filename)
+	prefix = filename[:len(filename)-len(ext)] + "-"
+	return prefix, ext
+}
+
+// compressLogFile compresses the given log file, removing the
+// uncompressed log file if successful.
+func compressLogFile(src, dst string) (err error) {
+	f, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open log file: %v", err)
+	}
+	defer f.Close()
+
+	fi, err := osStat(src)
+	if err != nil {
+		return fmt.Errorf("failed to stat log file: %v", err)
+	}
+
+	if err := chown(dst, fi); err != nil {
+		return fmt.Errorf("failed to chown compressed log file: %v", err)
+	}
+
+	// If this file already exists, we presume it was created by
+	// a previous attempt to compress the log file.
+	gzf, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, fi.Mode())
+	if err != nil {
+		return fmt.Errorf("failed to open compressed log file: %v", err)
+	}
+	defer gzf.Close()
+
+	gz := gzip.NewWriter(gzf)
+
+	defer func() {
+		if err != nil {
+			os.Remove(dst)
+			err = fmt.Errorf("failed to compress log file: %v", err)
+		}
+	}()
+
+	if _, err := io.Copy(gz, f); err != nil {
+		return err
+	}
+	if err := gz.Close(); err != nil {
+		return err
+	}
+	if err := gzf.Close(); err != nil {
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Remove(src); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// logInfo is a convenience struct to return the filename and its embedded
+// timestamp.
+type logInfo struct {
+	timestamp time.Time
+	os.FileInfo
+}
+
+// byFormatTime sorts by newest time formatted in the name.
+type byFormatTime []logInfo
+
+func (b byFormatTime) Less(i, j int) bool {
+	return b[i].timestamp.After(b[j].timestamp)
+}
+
+func (b byFormatTime) Swap(i, j int) {
+	b[i], b[j] = b[j], b[i]
+}
+
+func (b byFormatTime) Len() int {
+	return len(b)
+}

--- a/pkg/kube/stale-mount-cleanup/vendor/modules.txt
+++ b/pkg/kube/stale-mount-cleanup/vendor/modules.txt
@@ -1,0 +1,3 @@
+# gopkg.in/natefinch/lumberjack.v2 v2.2.1
+## explicit; go 1.13
+gopkg.in/natefinch/lumberjack.v2


### PR DESCRIPTION
# Description

Backport of #6004 

Longhorn auto-salvage replaces iSCSI sessions without calling
NodeUnstageVolume, leaving stale CSI block volume staging bind mounts
that reference deleted device inodes. Longhorn's restageRequired check
only calls IsMountPoint (returns true for stale mounts), so kubelet
never retriggers NodeStageVolume and all subsequent NodePublishVolume
calls fail, leaving pods stuck in ContainerCreating indefinitely.

The new stale-mount-cleanup daemon runs inside the kube container (which
shares the kubelet mount namespace) and scans CSI staging paths every
15s. It detects stale mounts via two signals: nlink==0 (deleted inode)
and Rdev mismatch between the staged bind mount and the live
/dev/longhorn/ device.

A stale condition must persist for 2 scan cycles (staleThreshold =
2 * scanInterval = 30s) before the daemon acts, avoiding a TOCTOU race
where NodeStageVolume completes a fresh bind mount between detection and
unmount. All three lifecycle transitions are logged for post-mortem
analysis: first observation, self-resolution by Longhorn, and threshold-
triggered unmount with duration. Stale mounts are cleared with
MNT_DETACH.

Logs go to /persist/kubelog/stale-mount-cleanup.log via lumberjack,
consistent with update-component and eve-bridge.

cluster-init.sh starts the daemon in both the first-boot and normal-boot
paths of the main loop, restarting it automatically if it exits.

kube/stale-mount-cleanup: vendor lumberjack for log rotation

gopkg.in/natefinch/lumberjack.v2
Ignore all this vendor dir in .spdxignore

## PR dependencies

None

## How to test and validate this PR

- deploy 3 or more eve HV=k nodes, configure as cluster
- deploy a VM app instance with appconfig affinity_type_required to pin it to a node.
- Find the longhorn instance manager pod on that node: `$ kubectl -n longhorn-system get pod -l longhorn.io/component=instance-manager,longhorn.io/node=INSERT_TEST_NODE_NAME -o name`
- Delete that pod: `kubectl -n longhorn-system delete pod/instance-manager-db25e69927302b0c4eca7fb5302bb232`
- Pinned app will stop
- Verify pinned app restarts correctly.
- Logging entries in /persist/kubelog/stale-mount-cleanup.log will be seen:

```
2026/06/04 18:23:22 stale-mount-cleanup: PV pvc-447912b2-73c2-4b7c-8561-bdd695cfd75b first observed stale (nlink=0), waiting 30s before unmount
2026/06/04 18:23:52 stale-mount-cleanup: PV pvc-447912b2-73c2-4b7c-8561-bdd695cfd75b stale for 30s (nlink=0), unmounting
2026/06/04 18:23:52 stale-mount-cleanup: cleared stale staging for PV pvc-447912b2-73c2-4b7c-8561-bdd695cfd75b
```

## Changelog notes

Cleanup stale mounts from old VM app instances on eve-k.

## PR Backports

This is the backport.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
