### PR TITLE
Makefile: stop doubling the platform variant in published image tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -454,10 +454,11 @@ ifeq ($(LINUXKIT_PKG_TARGET),push)
   # only builds from master branch are allowed to be called snapshots
   # everything else gets tagged with a branch name itself UNLESS
   # we're building off of a annotated tag
-  EVE_REL_$(REPO_BRANCH)_$(REPO_TAG):=$(if $(TAGPLAT),$(REPO_TAG)-$(TAGPLAT),$(REPO_TAG))
+  EVE_REL_$(REPO_BRANCH)_$(REPO_TAG):=$(REPO_TAG)
   EVE_REL_$(REPO_BRANCH)_snapshot:=$(REPO_BRANCH)
-  EVE_REL_master_snapshot:=$(if $(TAGPLAT),$(TAGPLAT)-snapshot,snapshot)
+  EVE_REL_master_snapshot:=snapshot
   EVE_REL:=$(EVE_REL_$(REPO_BRANCH)_$(REPO_TAG))
+  # append the platform variant exactly once, as a suffix (matching ROOTFS_VERSION)
   EVE_REL:=$(EVE_REL)$(if $(TAGPLAT),-$(TAGPLAT),)
 endif
 
@@ -997,7 +998,7 @@ eve: $(INSTALLER) $(EVE_ARTIFACTS) current $(RUNME) $(BUILD_YML) | $(BUILD_DIR)
 	$(PARSE_PKGS) pkg/eve/Dockerfile.in > $|/Dockerfile
 	$(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) $(LINUXKIT_OPTS) --platforms linux/$(ZARCH) --hash-path $(CURDIR) --hash $(ROOTFS_VERSION)-$(HV) --docker $(if $(strip $(EVE_REL)),--release) $(EVE_REL)$(if $(strip $(EVE_REL)),-$(HV)) $(FORCE_BUILD) $|
 	$(QUIET)if [ -n "$(EVE_REL)" ] && [ $(HV) = $(HV_DEFAULT) ]; then \
-	   $(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) $(LINUXKIT_OPTS) --platforms linux/$(ZARCH) --hash-path $(CURDIR) --hash $(EVE_REL)-$(if $(TAGPLAT),$(TAGPLAT)-)$(HV) --docker --release $(EVE_REL) $(FORCE_BUILD) $| ;\
+		$(LINUXKIT) $(DASH_V) pkg $(LINUXKIT_PKG_TARGET) $(LINUXKIT_OPTS) --platforms linux/$(ZARCH) --hash-path $(CURDIR) --hash $(EVE_REL)-$(HV) --docker --release $(EVE_REL) $(FORCE_BUILD) $| ;\
 	fi
 	$(QUIET): $@: Succeeded
 


### PR DESCRIPTION
# Description

When building a non-generic `PLATFORM` with `LINUXKIT_PKG_TARGET=push`, the platform variant was folded into the published Docker tag **twice**. `EVE_REL` already embedded the variant (e.g. `nvidia-jp7-snapshot`) and a trailing rule appended it again. The secondary push in the `eve` target made it worse, inserting the variant a third time into its `--hash` argument.

This produced tags like `lfedge/eve:nvidia-jp7-snapshot-nvidia-jp7-k-arm64`. That is wrong on two counts: the immutable tree-hash tag (`ROOTFS_VERSION`) appends the variant exactly once as a suffix, and `.github/workflows/assets.yml` pulls the image as `${TAG}-${PLATFORM}-${HV}-${ARCH}` — i.e. it expects a single trailing variant. The doubled tag does not match what consumers look for.

This PR applies the variant exactly once, as a suffix. Generic builds are unaffected.

### Published tag: before vs. after

| PLATFORM | HV | Before | After |
|---|---|---|---|
| `generic` | kvm | `snapshot-kvm-arm64` | `snapshot-kvm-arm64` (unchanged) |
| `nvidia-jp5` | kvm | `nvidia-jp5-snapshot-nvidia-jp5-kvm-arm64` | `snapshot-nvidia-jp5-kvm-arm64` |
| `nvidia-jp6` | kvm | `nvidia-jp6-snapshot-nvidia-jp6-kvm-arm64` | `snapshot-nvidia-jp6-kvm-arm64` |
| `nvidia-jp7` | k | `nvidia-jp7-snapshot-nvidia-jp7-k-arm64` | `snapshot-nvidia-jp7-k-arm64` |
| `imx8mp_pollux` | kvm | `imx8mp_pollux-snapshot-imx8mp_pollux-kvm-arm64` | `snapshot-imx8mp_pollux-kvm-arm64` |

### Which builds are affected

The doubling depends on the base tag value, not the branch. It hits any build whose base already embeds the variant:

| Build scenario | Pre-fix `EVE_REL` | Affected? |
|---|---|---|
| master + snapshot + platform | `nvidia-jp7-snapshot-nvidia-jp7` | **yes** |
| release tag (any branch) + platform | `16.0.1-nvidia-jp7-nvidia-jp7` | **yes** |
| feature branch (no tag) + platform | `mybranch-nvidia-jp7` | no — already correct |
| any + generic | `snapshot` / `16.0.1` / `mybranch` | no |

So both the `snapshot-*` convenience tags and the versioned `X.Y.Z-*` release-asset tags are affected — including on stable branches, which publish release assets that consumers pull by the versioned tag.

## How to test and validate this PR

No image build is required — the change is purely tag-string construction. You can evaluate the resulting `EVE_REL` and the published tag for any configuration by injecting a throwaway target with `make --eval` (this does not modify the Makefile and builds nothing):

```bash
make --eval='show:
	@echo "EVE_REL       = [$(EVE_REL)]"
	@echo "published tag = [$(EVE_REL)-$(HV)-$(ZARCH)]"' \
  LINUXKIT_PKG_TARGET=push REPO_BRANCH=master \
  PLATFORM=<platform> HV=<hv> ZARCH=<arch> show
```

`EVE_REL` is only defined inside the `ifeq ($(LINUXKIT_PKG_TARGET),push)` block, so passing `LINUXKIT_PKG_TARGET=push` makes Make compute it exactly as it would during a real publish.

Test matrix (run each and confirm the variant appears exactly once, as a suffix):

| `PLATFORM` | `HV` | `ZARCH` | Expected published tag |
|---|---|---|---|
| `generic` | `kvm` | `amd64` | `snapshot-kvm-amd64` |
| `nvidia-jp5` | `kvm` | `arm64` | `snapshot-nvidia-jp5-kvm-arm64` |
| `nvidia-jp6` | `kvm` | `arm64` | `snapshot-nvidia-jp6-kvm-arm64` |
| `nvidia-jp7` | `k` | `arm64` | `snapshot-nvidia-jp7-k-arm64` |
| `imx8mp_pollux` | `kvm` | `arm64` | `snapshot-imx8mp_pollux-kvm-arm64` |

Also verify, by overriding `REPO_TAG=16.0.1`, that a release-tag build now yields `16.0.1-nvidia-jp7-...` (single variant), and that dropping `REPO_BRANCH=master` (feature-branch case) still yields `mybranch-nvidia-jp7` unchanged. The result should match the `${TAG}-${PLATFORM}-${HV}-${ARCH}` form that `.github/workflows/assets.yml` uses to pull the image.

## Changelog notes

No user-facing changes. (Fixes duplicated platform variant in published EVE image tags for non-generic platforms.)

## PR Backports

- [x] 16.0-stable https://github.com/lf-edge/eve/pull/6411
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (n/a — no doc changes)
- [ ] I've tested my PR on amd64 device (n/a — tag-string change, validated via `make --eval`)
- [ ] I've tested my PR on arm64 device (n/a — tag-string change, validated via `make --eval`)
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.