### PR TITLE
evetest: list-tests to work without EVETEST_NAME

### DIFF
--- a/evetest/Makefile
+++ b/evetest/Makefile
@@ -34,10 +34,8 @@ DOCKER_IT := $(shell [ -t 1 ] && echo '-it' || echo '-i')
 
 .PHONY: evetest list-tests _run_protoc proto clone-eve-api _install-broker
 
-list-tests: ensure-evetest-image
-	@docker run --rm $(DOCKER_IT) \
-		-v $(REPO_ROOT)/evetest/tests:/evetest/tests \
-		$(EVETEST_IMAGE)
+list-tests:
+	go run ./cmd/list-tests/ ./tests
 
 evetest: ensure-evetest-image
 ifndef EVETEST_NAME


### PR DESCRIPTION
# Description

The list-tests target ran via the Docker container entrypoint, which requires EVETEST_NAME to be set — creating a chicken-and-egg problem since list-tests is how users discover available test names.

Run the list-tests tool directly on the host with `go run` instead, which also removes the dependency on having the container image built.

## How to test and validate this PR

run `make -C evetest list-tests`

## Changelog notes

Internal change to fix inconvenience in evetest framework

## PR Backports



- 16.0-stable: no
- 14.5-stable: no
- 13.4-stable: no

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
