### PR TITLE
feat(volumemgr): wait for Longhorn ready before CSI volume prepare

### DIFF
--- a/pkg/pillar/kubeapi/descheduler.go
+++ b/pkg/pillar/kubeapi/descheduler.go
@@ -90,7 +90,7 @@ func isDeschedulerReadyWithClient(log *base.LogObject, client kubernetes.Interfa
 		return false, nil
 	}
 
-	if err := waitForLonghornReady(client, nodeName); err != nil {
+	if err := checkLonghornReady(client, nodeName); err != nil {
 		log.Noticef("IsDeschedulerReady: longhorn not ready: %v", err)
 		return false, nil
 	}

--- a/pkg/pillar/kubeapi/kubeapi.go
+++ b/pkg/pillar/kubeapi/kubeapi.go
@@ -246,7 +246,7 @@ func WaitForKubernetes(agentName string, ps *pubsub.PubSub, stillRunning *time.T
 				}
 			}
 			if opts.WaitForLonghorn {
-				if err := waitForLonghornReady(client, hostname); err != nil {
+				if err := checkLonghornReady(client, hostname); err != nil {
 					return false, nil
 				}
 			}
@@ -268,7 +268,7 @@ func WaitForKubernetes(agentName string, ps *pubsub.PubSub, stillRunning *time.T
 	return nodeReadyErr
 }
 
-func waitForLonghornReady(client kubernetes.Interface, hostname string) error {
+func checkLonghornReady(client kubernetes.Interface, nodeName string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
 	defer cancel()
 	// First we'll gate on the longhorn daemonsets existing
@@ -297,7 +297,7 @@ func waitForLonghornReady(client kubernetes.Interface, hostname string) error {
 			labelSelectors = append(labelSelectors, dsLabelK+"="+dsLabelV)
 		}
 		pods, err := client.CoreV1().Pods("longhorn-system").List(ctx, metav1.ListOptions{
-			FieldSelector: "spec.nodeName=" + hostname,
+			FieldSelector: "spec.nodeName=" + nodeName,
 			LabelSelector: strings.Join(labelSelectors, ","),
 		})
 		if err != nil {
@@ -325,6 +325,54 @@ func waitForLonghornReady(client kubernetes.Interface, hostname string) error {
 	}
 
 	return nil
+}
+
+// WaitForLonghornReady blocks until all required Longhorn daemonsets are running
+// and ready on this node, or until ctx is cancelled. It is safe to call from a
+// worker goroutine; it never touches pubsub or the watchdog.
+// All setup steps (kubeconfig, client, node name lookup) are retried inside the
+// loop so that a slow k3s start after a reboot is handled transparently.
+func WaitForLonghornReady(ctx context.Context, log *base.LogObject) error {
+	devUUID, err := os.Hostname()
+	if err != nil {
+		return fmt.Errorf("WaitForLonghornReady: hostname: %v", err)
+	}
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			// Retry kubeconfig and client setup each tick: k3s may not have written
+			// the kubeconfig file yet if called early after a reboot.
+			config, err := GetKubeConfig()
+			if err != nil {
+				log.Noticef("WaitForLonghornReady: kubeconfig not ready: %v", err)
+				continue
+			}
+			client, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				log.Noticef("WaitForLonghornReady: client error: %v", err)
+				continue
+			}
+			// Resolve the k3s node name from the device UUID label — the OS hostname
+			// is the device UUID, not the Kubernetes node name used in pod field selectors.
+			nodeName, err := waitForNodeReady(client, devUUID)
+			if err != nil {
+				log.Noticef("WaitForLonghornReady: node not ready: %v", err)
+				continue
+			}
+			if err := checkLonghornReady(client, nodeName); err != nil {
+				log.Noticef("WaitForLonghornReady: not ready yet: %v", err)
+				continue
+			}
+			log.Noticef("WaitForLonghornReady: Longhorn is ready on node %s", nodeName)
+			return nil
+		}
+	}
 }
 
 func waitForKubevirtReady(kubeConfig *rest.Config) error {

--- a/pkg/pillar/kubeapi/nokube.go
+++ b/pkg/pillar/kubeapi/nokube.go
@@ -6,6 +6,7 @@
 package kubeapi
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -70,5 +71,10 @@ func GetStorageClassForReplicaCount(count int) string {
 
 // EnsureVMsDeschedulerAnnotated is a stub for non EVE-k builds.
 func EnsureVMsDeschedulerAnnotated(*base.LogObject) error {
+	return nil
+}
+
+// WaitForLonghornReady is a stub for non EVE-k builds.
+func WaitForLonghornReady(ctx context.Context, log *base.LogObject) error {
 	return nil
 }

--- a/pkg/pillar/volumehandlers/csihandler.go
+++ b/pkg/pillar/volumehandlers/csihandler.go
@@ -57,8 +57,35 @@ func (handler *volumeHandlerCSI) UsageFromStatus() uint64 {
 }
 
 func (handler *volumeHandlerCSI) PrepareVolume() error {
-	handler.log.Noticef("PrepareVolume called for PVC %s", handler.status.GetPVCName())
-	return nil
+	pvcName := handler.status.GetPVCName()
+	handler.log.Noticef("PrepareVolume: waiting for Longhorn before creating PVC %s", pvcName)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{}, 1)
+	defer func() {
+		done <- struct{}{}
+	}()
+
+	// Cancel the Longhorn wait if VolumeStatus disappears (volume config deleted while waiting).
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if handler.volumeManager.LookupVolumeStatus(handler.status.Key()) == nil {
+					handler.log.Warnf("PrepareVolume: VolumeStatus(%s) disappeared, cancelling Longhorn wait", pvcName)
+					cancel()
+					return
+				}
+			case <-done:
+				cancel()
+				return
+			}
+		}
+	}()
+
+	return kubeapi.WaitForLonghornReady(ctx, handler.log)
 }
 
 func (handler *volumeHandlerCSI) HandlePrepared() (bool, error) {
@@ -120,6 +147,14 @@ func (handler *volumeHandlerCSI) CreateVolume() (string, error) {
 		pvcSize = uint64(handler.status.TotalSize)
 	}
 	handler.log.Noticef("CreateVolume called for PVC %s size %v", pvcName, pvcSize)
+
+	// Guard against re-creation on reboot: if the PVC already exists (created in a
+	// prior boot where VolumeStatus was not persisted as CREATED_VOLUME), skip the
+	// entire create path — the content is already in place.
+	if found, err := kubeapi.FindPVC(pvcName, handler.log); err == nil && found {
+		handler.log.Noticef("CreateVolume: PVC %s already exists, skipping creation", pvcName)
+		return pvcName, nil
+	}
 
 	repCount, err := kubeapi.GetSupportedReplicaCountForCluster()
 	if err != nil {
@@ -249,6 +284,19 @@ func (handler *volumeHandlerCSI) DestroyVolume() (string, error) {
 	return pvcName, nil
 }
 
+// Populate reports whether the PVC for this volume already exists.
+// It never returns a non-nil error: all failure cases are treated as
+// "not yet created" ((false, nil)) so that handleDeferredVolumeCreate
+// routes the volume through the normal create path (PrepareVolume →
+// CreateVolume) rather than setting a hard error on VolumeStatus with
+// no retry mechanism. Specifically:
+//   - Non-replicated, PVC found:            (true,  nil)
+//   - Non-replicated, PVC not found (404):  (false, nil)
+//   - Non-replicated, any other error:      (false, nil) — transient (kubeconfig
+//     unavailable, API server not ready, etc.); CreateVolume guards against
+//     double-creation with its own FindPVC check.
+//   - Replicated, WaitForPVCReady succeeds: (true,  nil)
+//   - Replicated, WaitForPVCReady error:    (false, nil) — loops or returns nil
 func (handler *volumeHandlerCSI) Populate() (bool, error) {
 	pvcName := handler.status.GetPVCName()
 	isReplicated := handler.status.IsReplicated
@@ -286,9 +334,13 @@ func (handler *volumeHandlerCSI) Populate() (bool, error) {
 			if kerr.IsNotFound(err) {
 				handler.log.Noticef("PVC %s not found", pvcName)
 				return false, nil
-			} else {
-				return false, err
 			}
+			// Any other error (kubeconfig unavailable, API server not ready, etc.)
+			// is transient — return (false, nil) so handleDeferredVolumeCreate
+			// routes this through the normal create path (which waits in PrepareVolume)
+			// rather than setting a hard error on VolumeStatus with no retry.
+			handler.log.Noticef("Populate: FindPVC(%s) transient error, treating as not-yet-created: %v", pvcName, err)
+			return false, nil
 		}
 	}
 	return true, nil


### PR DESCRIPTION
## Description

Add kubeapi.WaitForLonghornReady, a context-aware blocking poll for use
in worker goroutines. It retries kubeconfig availability, client creation,
and k3s node name resolution (via waitForNodeReady) on every tick so that
a slow k3s start after a reboot does not cause an immediate failure. The
k3s node name is resolved from the device UUID label rather than using
os.Hostname() directly, since the OS hostname is the device UUID, not the
Kubernetes node name used in pod field selectors.

Use WaitForLonghornReady in PrepareVolume() to block PVC creation until
Longhorn is ready. A watcher goroutine cancels the wait immediately if
VolumeStatus disappears (volume config deleted while waiting).

Add an idempotency guard at the top of CreateVolume(): if the PVC already
exists (created in a prior boot where VolumeStatus was not persisted as
CREATED_VOLUME before a power outage), skip creation entirely.

Change Populate() to treat all non-404 errors from FindPVC as (false, nil)
rather than propagating the error. A transient failure (kubeconfig not yet
written by k3s, API server not reachable) no longer sets a hard error on
VolumeStatus with no retry path; instead the volume is routed through the
normal PrepareVolume → CreateVolume path, which waits for k3s and Longhorn
and is protected by the idempotency guard above.

Rename the unexported single-shot probe waitForLonghornReady → checkLonghornReady
to distinguish it from the new blocking WaitForLonghornReady.

Add a no-op WaitForLonghornReady stub in nokube.go for non-k builds.

## PR dependencies

None

## How to test and validate this PR

- install an eve HV=k node
- deploy a new volume instance immediately after onboarding
- verify no error state

## Changelog notes

TODO

## PR Backports

```text
- 16.0-stable: No
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
