### PR TITLE
[14.5-stable] datastore: fix IsToken68 for base64 tokens

### DIFF
--- a/pkg/pillar/cmd/collectinfo/collectinfo.go
+++ b/pkg/pillar/cmd/collectinfo/collectinfo.go
@@ -89,7 +89,7 @@ func isToken(str string) bool {
 
 func isToken68(str string) bool {
 	// https://datatracker.ietf.org/doc/html/rfc7235#appendix-C
-	rex := regexp.MustCompile(`^[a-zA-Z0-9-._~+/]*=?$`)
+	rex := regexp.MustCompile(`^[a-zA-Z0-9-._~+/]*={0,2}$`)
 
 	return rex.MatchString(str)
 }

--- a/pkg/pillar/cmd/collectinfo/collectinfo_test.go
+++ b/pkg/pillar/cmd/collectinfo/collectinfo_test.go
@@ -4,6 +4,8 @@
 package collectinfo
 
 import (
+	"encoding/base64"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -218,6 +220,16 @@ func TestIsToken68(t *testing.T) {
 			}
 		})
 	}
+}
+
+func FuzzIsToken68(f *testing.F) {
+	f.Fuzz(func(t *testing.T, username, password string) {
+		bs := []byte(fmt.Sprintf("%s:%s", username, password))
+		str64 := base64.StdEncoding.EncodeToString(bs)
+		if !isToken68(str64) {
+			t.Fatalf("encoding of %s/%s '%s' failed:", username, password, str64)
+		}
+	})
 }
 
 func TestCreateHttpURLFromDatastore(t *testing.T) {


### PR DESCRIPTION
# Description

f.e. "foo:bar" in base64 is Zm9vOmJhcg== and ends with two '='; allow this

this is a backport of https://github.com/lf-edge/eve-libs/pull/75, https://github.com/lf-edge/eve/pull/6034

## How to test and validate this PR

Use collect-info upload with a token that ends with `==`

## Changelog notes

Fix authentication for collect-info upload

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
