### PR TITLE
Fix an install regression on some devices

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -1439,10 +1439,6 @@ install_sriov_manifests() {
 #Forever loop every 15 secs
 while true;
 do
-        # Re-apply optional manifests on every iteration so EVE upgrades pick
-        # them up without forcing a cluster re-init (the
-        # all_components_initialized guard would otherwise skip the copy below).
-        install_sriov_manifests
 if [ ! -f /var/lib/all_components_initialized ]; then
         if [ ! -f /var/lib/k3s_installed_unpacked ]; then
                 #
@@ -1735,6 +1731,9 @@ else
                 fi
         fi
 fi
+        # Re-apply optional manifests on every iteration so EVE upgrades pick
+        # them up without forcing a cluster re-init
+        install_sriov_manifests
         fix_node_password_secret
         cleanup_stale_masterleases
         save_cluster_startup_rank


### PR DESCRIPTION
sriov manifests are being installed during initial install of the k3s components. That caused regression in installation process where sriov pods are not starting on some devices. The installation script is stuck in all_pods_ready loop.

Moved the sriov manifests copy to end of loop.




## How to test and validate this PR

USB install eve-k with this fix and verify that all components are initialized without any issue ie
all pods started.
Also verify that sriov daemon set is also up and running once all components are initialized.

Also tested upgrades from previous version and verified sriov daemon set got started.


## Changelog notes

None.

This fix should go to 17.0.0.rc2 release

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR



And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
