### PR TITLE
hypervisor/kubevirt: attach USB tablet so VNC pointer works

### DIFF
--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -431,6 +431,20 @@ func (ctx kubevirtContext) CreateReplicaVMIConfig(domainName string, config type
 		Type: "virtio",
 	}
 
+	// Attach a USB tablet so VNC sends absolute pointer coordinates to the
+	// guest. With no explicit input device, libvirt falls back to an
+	// emulated PS/2 mouse, which only reports relative deltas — the
+	// resulting coordinate mismatch makes the VNC cursor drift, jump, fail
+	// to reach screen edges, and lag (most visibly on Windows guests).
+	// USB tablet is supported in-box by all common guest OSes.
+	vmi.Spec.Domain.Devices.Inputs = []v1.Input{
+		{
+			Name: "tablet",
+			Type: v1.InputTypeTablet,
+			Bus:  v1.InputBusUSB,
+		},
+	}
+
 	// Disable app log collection if user asked for it
 	if config.DisableLogs {
 		vmi.Spec.Domain.Devices.LogSerialConsole = ptrBool(false)


### PR DESCRIPTION
The VMI spec configures disks, interfaces, and video, but leaves Devices.Inputs empty. With no input device declared, libvirt falls back to an emulated PS/2 mouse — a relative pointing device. VNC, however, sends absolute coordinates. QEMU has to translate between the two, and any drift between its internal cursor model and the guest's makes the pointer jump, drift, fail to reach screen edges, and lag behind the client cursor. Windows guests show it worst because of their own pointer acceleration.

Attach a USB tablet (an absolute pointing device) so the coordinates VNC sends are consumed as-is. USB bus is chosen over virtio so the device works in every common guest OS without extra drivers.



## How to test and validate this PR

Install Windows VM
Before this fix using VNC to access windows is little difficult with mouse pointer jumping and drifting all over the screen.

After this fix mouse pointer is pretty stable and rarely see a lag.

## Changelog notes

Users will have a better experience in using VNC to access windows.



## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR



And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
