### PR TITLE
[14.5-stable] pkg/pillar: bump eve-libs

### DIFF
--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.5.0
 	github.com/lf-edge/edge-containers v0.0.0-20240207093504-5dfda0619b80
 	github.com/lf-edge/eve-api/go v0.0.0-20260323170505-58819a210744
-	github.com/lf-edge/eve-libs v0.0.0-20260204163417-9242372ba77c
+	github.com/lf-edge/eve-libs v0.0.0-20260609144600-8fd1f70f4533
 	github.com/lf-edge/eve-tools/runtimemetrics/go v0.0.0-20250625152713-6890d8e138ae
 	github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d
 	github.com/lf-edge/go-qemu v0.0.0-20231121152149-4c467eda0c56

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -1527,8 +1527,8 @@ github.com/lf-edge/edge-containers v0.0.0-20240207093504-5dfda0619b80 h1:kiqB1Rk
 github.com/lf-edge/edge-containers v0.0.0-20240207093504-5dfda0619b80/go.mod h1:4yXdumKdTzF0URMtxOl8Xnzdxnoy1QR+2dzfOr4CIZY=
 github.com/lf-edge/eve-api/go v0.0.0-20260323170505-58819a210744 h1:CAjr1umpuSqqKhJylVcu7bq/URyGVIo72jo1wf3fsT8=
 github.com/lf-edge/eve-api/go v0.0.0-20260323170505-58819a210744/go.mod h1:6HxNA/qKJVEqwpuOFkcQ0h3QyotvAs/cjHLC961FPOY=
-github.com/lf-edge/eve-libs v0.0.0-20260204163417-9242372ba77c h1:ZdeTQT9Po9ev8fg9N6XbpHSpKSGVsCyxIAsJ3ov1Ywc=
-github.com/lf-edge/eve-libs v0.0.0-20260204163417-9242372ba77c/go.mod h1:ufjb7/KrUA5Znb8w7BF7ZjM1YKz8IvvAq6kzrtozYBs=
+github.com/lf-edge/eve-libs v0.0.0-20260609144600-8fd1f70f4533 h1:OLi6AshW/dIyVWmlNIQq3EjHNl5akXYIVmuPcWyHA9M=
+github.com/lf-edge/eve-libs v0.0.0-20260609144600-8fd1f70f4533/go.mod h1:ufjb7/KrUA5Znb8w7BF7ZjM1YKz8IvvAq6kzrtozYBs=
 github.com/lf-edge/eve-tools/runtimemetrics/go v0.0.0-20250625152713-6890d8e138ae h1:XogrfsHt9Z6UZqMnBNso4ltNj/Ph5ACEwUhdoE0jxXc=
 github.com/lf-edge/eve-tools/runtimemetrics/go v0.0.0-20250625152713-6890d8e138ae/go.mod h1:l5jh2deQzJnZ7gW4F7dvzJcLRlkYBgFjcHs+eBnBUxo=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d h1:tUBb9M6u42LXwHAYHyh22wJeUUQlTpDkXwRXalpRqbo=

--- a/pkg/pillar/vendor/github.com/lf-edge/eve-libs/zedUpload/datastore_http.go
+++ b/pkg/pillar/vendor/github.com/lf-edge/eve-libs/zedUpload/datastore_http.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/lf-edge/eve-libs/nettrace"
@@ -130,13 +131,9 @@ func (ep *HttpTransportMethod) processHttpUpload(req *DronaRequest) (error, int)
 
 // File download from HTTP Datastore
 func (ep *HttpTransportMethod) processHttpDownload(req *DronaRequest) (error, int) {
-	file := req.name
-	if ep.hurl != "" {
-		var err error
-		file, err = url.JoinPath(ep.hurl, ep.path, req.name)
-		if err != nil {
-			return err, 0
-		}
+	file, err := ep.concatenateFile(req)
+	if err != nil {
+		return err, 0
 	}
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
@@ -150,6 +147,25 @@ func (ep *HttpTransportMethod) processHttpDownload(req *DronaRequest) (error, in
 	stats, resp := zedHttp.ExecCmd(req.cancelContext, "get", file, "",
 		req.objloc, req.sizelimit, prgChan, hClient, ep.inactivityTimeout)
 	return stats.Error, resp.BodyLength
+}
+
+func (ep *HttpTransportMethod) concatenateFile(req *DronaRequest) (string, error) {
+	file := req.name
+	if ep.hurl != "" {
+		var err error
+		file, err = url.JoinPath(ep.hurl, ep.path)
+		if err != nil {
+			return "", err
+		}
+
+		file = strings.TrimSuffix(file, "/")
+		reqName := req.name
+		for strings.HasPrefix(reqName, "/") {
+			reqName = strings.TrimPrefix(reqName, "/")
+		}
+		file += "/" + reqName
+	}
+	return file, nil
 }
 
 // File delete from HTTP Datastore
@@ -179,14 +195,11 @@ func (ep *HttpTransportMethod) processHttpList(req *DronaRequest) ([]string, err
 
 // Object Metadata from HTTP datastore
 func (ep *HttpTransportMethod) processHttpObjectMetaData(req *DronaRequest) (error, int64) {
-	file := req.name
-	if ep.hurl != "" {
-		var err error
-		file, err = url.JoinPath(ep.hurl, ep.path, req.name)
-		if err != nil {
-			return err, 0
-		}
+	file, err := ep.concatenateFile(req)
+	if err != nil {
+		return err, 0
 	}
+
 	prgChan := make(types.StatsNotifChan)
 	defer close(prgChan)
 	if req.ackback {

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -901,7 +901,7 @@ github.com/lf-edge/eve-api/go/logs
 github.com/lf-edge/eve-api/go/metrics
 github.com/lf-edge/eve-api/go/profile
 github.com/lf-edge/eve-api/go/register
-# github.com/lf-edge/eve-libs v0.0.0-20260204163417-9242372ba77c
+# github.com/lf-edge/eve-libs v0.0.0-20260609144600-8fd1f70f4533
 ## explicit; go 1.23.0
 github.com/lf-edge/eve-libs/depgraph
 github.com/lf-edge/eve-libs/nettrace


### PR DESCRIPTION
# Description

pkg/pillar: bump eve-libs

* fix query parameters

Backport of https://github.com/lf-edge/eve/pull/6030
   
## How to test and validate this PR

Add a query parameter to the image that should be downloaded and check that `?` does not get encoded.

## Changelog notes

Bump eve-libs / fix query parameter encoding


## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
