### PR TITLE
zfsmanager: fix lost zvol create event on purge

### DIFF
--- a/pkg/pillar/cmd/zfsmanager/zfsmanager.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsmanager.go
@@ -41,8 +41,7 @@ var (
 )
 
 type zVolDeviceEvent struct {
-	delete  bool
-	dataset string
+	delete bool
 }
 
 type zfsContext struct {
@@ -227,6 +226,45 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 }
 
+// zvolReconcileAction is the outcome decided for a stored zVolDeviceEvent.
+type zvolReconcileAction int
+
+const (
+	// zvolRetry leaves the event in the map to re-examine on the next tick.
+	zvolRetry zvolReconcileAction = iota
+	// zvolPublish (re)publishes ZVolStatus and then drops the event.
+	zvolPublish
+	// zvolUnpublish removes a published ZVolStatus and then drops the event.
+	zvolUnpublish
+	// zvolDrop discards the event without changing any ZVolStatus.
+	zvolDrop
+)
+
+// decideZVolAction reconciles a stored device event against reality.
+//
+// The stored event is only a trigger. fsnotify Create/Remove events are kept
+// in a map keyed by device path, so a Remove can overwrite a still-unprocessed
+// Create for the same path when a zvol is removed and recreated in quick
+// succession (e.g. an app purge that recreates the volume, with mdev churning
+// the /dev/zvol symlink). Trusting such a coalesced Remove would leave the
+// live device without a ZVolStatus, stranding volumemgr (and the app) forever.
+// The actual on-disk presence of the device is therefore authoritative, not
+// event.delete: publish whenever the device exists, and only unpublish when it
+// is really gone.
+func decideZVolAction(event zVolDeviceEvent, devicePresent, statusPublished bool) zvolReconcileAction {
+	if devicePresent {
+		return zvolPublish
+	}
+	if !event.delete {
+		// Create event but the device has not appeared yet: wait for it.
+		return zvolRetry
+	}
+	if statusPublished {
+		return zvolUnpublish
+	}
+	return zvolDrop
+}
+
 // processZVolDeviceEvents iterates over saved zVolDeviceEvent, check for device existence and publish ZVolStatus
 func processZVolDeviceEvents(ctxPtr *zfsContext) {
 	var processedKeys []string
@@ -235,41 +273,51 @@ func processZVolDeviceEvents(ctxPtr *zfsContext) {
 		if !ok {
 			log.Fatalf("unexpected type for key: %s", key)
 		}
+		log.Functionf("key %s event %+v", key, event)
+
+		// The device path deterministically maps to its dataset; recompute
+		// it because a coalesced Remove event carries an empty dataset and
+		// ZVolStatus.Key() (hence publish/unpublish) is derived from it.
+		dataset := zfs.GetDatasetByDevice(key)
+		if dataset == "" {
+			log.Errorf("cannot determine dataset for device: %s", key)
+			processedKeys = append(processedKeys, key)
+			return true
+		}
 		zvolStatus := types.ZVolStatus{
 			Device:  key,
-			Dataset: event.dataset,
+			Dataset: dataset,
 		}
-		log.Functionf("key %s event %+v", key, event)
-		if event.delete {
-			if el, _ := ctxPtr.zVolStatusPub.Get(zvolStatus.Key()); el == nil {
-				processedKeys = append(processedKeys, key)
+
+		devicePresent := false
+		if l, err := filepath.EvalSymlinks(key); err == nil {
+			if _, err := os.Stat(l); err == nil {
+				devicePresent = true
+			}
+		}
+		el, _ := ctxPtr.zVolStatusPub.Get(zvolStatus.Key())
+		statusPublished := el != nil
+
+		switch decideZVolAction(event, devicePresent, statusPublished) {
+		case zvolPublish:
+			if err := ctxPtr.zVolStatusPub.Publish(zvolStatus.Key(), zvolStatus); err != nil {
+				log.Errorf("cannot publish device: %s", err)
 				return true
 			}
+			log.Functionf("processed add for %s", key)
+		case zvolUnpublish:
 			if err := ctxPtr.zVolStatusPub.Unpublish(zvolStatus.Key()); err != nil {
 				log.Errorf("cannot unpublish device: %s", err)
 				return true
 			}
-			processedKeys = append(processedKeys, key)
 			log.Functionf("processed delete for %s", key)
+		case zvolRetry:
+			log.Warnf("device %s not present yet; will retry", key)
 			return true
-		}
-		l, err := filepath.EvalSymlinks(key)
-		if err != nil {
-			log.Warnf("failed to EvalSymlinks: %s", err)
-			return true
-		}
-		_, err = os.Stat(l)
-		if err != nil {
-			log.Warnf("failed to Stat device: %s", err)
-			return true
-		}
-
-		if err := ctxPtr.zVolStatusPub.Publish(zvolStatus.Key(), zvolStatus); err != nil {
-			log.Errorf("cannot publish device: %s", err)
-			return true
+		case zvolDrop:
+			// Nothing to (un)publish; just forget the stale event.
 		}
 		processedKeys = append(processedKeys, key)
-		log.Functionf("processed add for %s", key)
 		return true
 	}
 	ctxPtr.zVolDeviceEvents.Range(checker)
@@ -302,9 +350,7 @@ func deviceWatcherLoop(ctxPtr *zfsContext) {
 						return nil
 					}
 					log.Functionf("adding dataset %s", dataset)
-					ctxPtr.zVolDeviceEvents.Store(walkPath, zVolDeviceEvent{
-						dataset: dataset,
-					})
+					ctxPtr.zVolDeviceEvents.Store(walkPath, zVolDeviceEvent{})
 				}
 			}
 			return nil
@@ -348,17 +394,15 @@ func deviceWatcherLoop(ctxPtr *zfsContext) {
 				log.Errorf("cannot determine dataset for device: %s", fileName)
 				continue
 			}
-			ctxPtr.zVolDeviceEvents.Store(fileName, zVolDeviceEvent{
-				dataset: dataset,
-			})
+			ctxPtr.zVolDeviceEvents.Store(fileName, zVolDeviceEvent{})
 		} else if event.Op&fsnotify.Remove != 0 {
-			ctxPtr.zVolDeviceEvents.Store(fileName, zVolDeviceEvent{
-				delete: true,
-			})
 			if fileName == types.ZVolDevicePrefix {
-				// Need to restart to recreate watcher when ZVolDevicePrefix is recreated
+				// The whole /dev/zvol tree went away; restart the loop to
+				// recreate the watcher when it reappears. There is no
+				// per-zvol ZVolStatus to reconcile for the root itself.
 				break
 			}
+			ctxPtr.zVolDeviceEvents.Store(fileName, zVolDeviceEvent{delete: true})
 		}
 	}
 }

--- a/pkg/pillar/cmd/zfsmanager/zfsmanager_test.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsmanager_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zfsmanager
+
+import "testing"
+
+// TestDecideZVolAction covers the reconcile truth table that decides, for a
+// stored fsnotify device event, whether to publish, unpublish, retry, or drop.
+//
+// The "device present" rows are authoritative over the event flag. The second
+// row is the regression guard for the app-purge race: a Remove event that
+// coalesced over an unprocessed Create for a device that actually exists must
+// still publish ZVolStatus, otherwise volumemgr never sees the recreated zvol
+// and the purged app is stranded in HALTING forever.
+func TestDecideZVolAction(t *testing.T) {
+	tests := []struct {
+		name            string
+		event           zVolDeviceEvent
+		devicePresent   bool
+		statusPublished bool
+		want            zvolReconcileAction
+	}{
+		{
+			name:          "create event, device present -> publish",
+			event:         zVolDeviceEvent{},
+			devicePresent: true,
+			want:          zvolPublish,
+		},
+		{
+			name:          "coalesced delete over create, device present -> publish",
+			event:         zVolDeviceEvent{delete: true}, // dataset lost to coalescing
+			devicePresent: true,
+			want:          zvolPublish,
+		},
+		{
+			name:          "create event, device absent -> retry",
+			event:         zVolDeviceEvent{},
+			devicePresent: false,
+			want:          zvolRetry,
+		},
+		{
+			name:            "delete event, device absent, status published -> unpublish",
+			event:           zVolDeviceEvent{delete: true},
+			devicePresent:   false,
+			statusPublished: true,
+			want:            zvolUnpublish,
+		},
+		{
+			name:            "delete event, device absent, nothing published -> drop",
+			event:           zVolDeviceEvent{delete: true},
+			devicePresent:   false,
+			statusPublished: false,
+			want:            zvolDrop,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decideZVolAction(tt.event, tt.devicePresent, tt.statusPublished)
+			if got != tt.want {
+				t.Errorf("decideZVolAction(%+v, present=%v, published=%v) = %v, want %v",
+					tt.event, tt.devicePresent, tt.statusPublished, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

**Summary:** Purging an app can cause it to hang (stuck shutting down and
never restarting) when `/persist` is backed by ZFS.

During an app purge the volume's zvol is removed and recreated, and mdev
briefly churns the `/dev/zvol` symlink. `zfsmanager`'s device watcher stores
fsnotify events in a map keyed by device path, so a Remove event can overwrite
a still-unprocessed Create for the same path. The processing tick then trusted
the Remove and never published `ZVolStatus` for the live device — so
`volumemgr` kept the new volume out of `CREATED_VOLUME`, `zedmanager` blocked at
"Waiting for all new volumes", and the app stayed in `RUN_STATE_HALTING` until
the config was withdrawn.

This reconciles against the actual on-disk device instead of the possibly
coalesced event flag: publish whenever the device symlink resolves, only
unpublish when it is really gone, and recompute the dataset from the device
path (a coalesced Remove carries an empty dataset, which also broke
`ZVolStatus.Key()`). The decision is extracted into `decideZVolAction` with a
unit-test truth table.

Fixes #6028

## How to test and validate this PR

- Unit test: `make -C pkg/pillar test` (new `TestDecideZVolAction` covers the
  reconcile truth table; the key regression case is a coalesced Remove over an
  unprocessed Create while the device exists → publish).
- E2E (ZFS `persist` backend): deploy a VM app on a zvol-backed volume, then
  trigger a purge that recreates the volume (config change that bumps the purge
  counter). The app should halt, recreate the volume, and come back with an
  advanced `bootTime`. Before this fix the purge intermittently strands the app
  in `RUN_STATE_HALTING` with `volumemgr` repeating `FileLocation is empty` and
  `lookupZVolStatusByDataset: not found`. Repeat the purge several times to
  exercise the race.

## Changelog notes

Fixes an intermittent hang where purging/restarting an app on a ZFS-backed
volume could leave the app stuck shutting down and never restart.

## PR Backports

The affected `zfsmanager` code is present on master; I have not yet confirmed
the stable branches carry the identical path.

- 16.0-stable: Candidate — confirm the same code is present before backporting.
- 14.5-stable: Candidate — confirm the same code is present before backporting.
- 13.4-stable: Candidate — confirm the same code is present before backporting.

## Checklist

- [x] I've provided a proper description
- [x] I've written the test verification instructions
- [ ] I've added the proper documentation (n/a — internal bug fix)
- [x] I've tested my PR on amd64 device (overnight E2E run in progress)
- [ ] I've tested my PR on arm64 device
- [ ] I've set the proper labels to this PR
