### PR TITLE
pubsub: detect persistence mismatches between publishers and subscribers

### DIFF
--- a/.github/workflows/check-pubsub-persistence.yml
+++ b/.github/workflows/check-pubsub-persistence.yml
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+name: Check PubSub Persistence Consistency
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - "master"
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-stable"
+      - "feature/*"
+    paths-ignore:
+      - '**/*.md'
+      - '.github/**'
+  pull_request:
+    branches:
+      - "master"
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-stable"
+      - "feature/*"
+    paths-ignore:
+      - '**/*.md'
+      - '.github/**'
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        with:
+          go-version-file: pkg/pillar/go.mod
+
+      - name: Run pubsubcheck unit tests
+        shell: bash
+        run: |
+          go -C pkg/pillar test ./tools/pubsubcheck/
+
+      - name: Check pubsub persistence consistency
+        shell: bash
+        run: |
+          make check-pubsub-persistence

--- a/Makefile
+++ b/Makefile
@@ -567,6 +567,16 @@ check-docker-hashes-consistency: $(DOCKERFILE_FROM_CHECKER)
 		$(IGNORE_DOCKERFILE_EVETEST_DIR) \
 		$(IGNORE_DOCKERFILE_DIST_DIR)
 
+# checks that the Persistent flag of pubsub subscriptions matches the
+# Persistent flag of the publications they subscribe to, and that all
+# persistent publications live in pkg/pillar, from which the pillar image
+# build generates the boot-time cleanup list of upgradeconverter
+# (see docs/IPC.md)
+.PHONY: check-pubsub-persistence
+check-pubsub-persistence:
+	@echo "Checking pubsub publications and subscriptions for persistence mismatches"
+	cd pkg/pillar && go run ./tools/pubsubcheck ../../pkg
+
 yetus:
 	@echo Running yetus
 	mkdir -p yetus-output
@@ -1378,6 +1388,7 @@ help:
 	@echo "                                    MYETUS_DBRANCH, in addition if MYETUS_VERBOSE is set to"
 	@echo "                                    Y, the output will be echoed to the console"
 	@echo "   check-docker-hashes-consistency  check for Dockerfile image inconsistencies"
+	@echo "   check-pubsub-persistence  check pubsub publications/subscriptions for persistence mismatches"
 	@echo "   kernel-tag                       show current KERNEL_TAG"
 	@echo
 	@echo "Eden testing targets:"

--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -312,6 +312,37 @@ This uses the same `<name>` algorithm as above.
 
 This socket is unique to this table; each table has its own socket.
 
+#### Wire Protocol
+
+The messages exchanged over the socket connection are space-separated plain
+text, sent as individual `unixpacket` datagrams. Keys and values are
+base64-encoded so that they cannot contain spaces. The subscriber opens the
+conversation by requesting the topic; the publisher answers with a greeting,
+a dump of the current table state and then a stream of incremental updates:
+
+| Direction | Message | Meaning |
+|-----------|---------|---------|
+| subscriber → publisher | `request <topic>` | Request the initial state and subsequent updates of the topic. |
+| publisher → subscriber | `hello <topic> <persistent>` | Greeting. `<persistent>` (`true`/`false`) advertises whether the publication is persistent, so that the subscriber can detect a mismatch with its own `Persistent` option. Older publishers omit this field and older subscribers ignore it. |
+| publisher → subscriber | `update <topic> <key> <value>` | A new or modified table entry. |
+| publisher → subscriber | `delete <topic> <key>` | The entry with `<key>` was removed. |
+| publisher → subscriber | `complete <topic>` | The initial dump of the table is complete; the subscription is synchronized. |
+| publisher → subscriber | `restarted <topic> <counter>` | The publisher marked the topic as restarted. |
+
+After `complete`, further `update`, `delete` and `restarted` messages are sent
+as the table changes.
+
+A persistent subscription participates in this conversation like any other:
+when the publisher comes up, the subscriber receives the full table dump over
+the socket (entries identical to already-known state are filtered out before
+the agent's handlers are invoked). In addition, however, it pre-loads the
+persisted files of the publication at activation time, so that it has the
+last known state available even before the publisher runs. This pre-load
+silently depends on the publication actually being persistent — if it is
+not, the pre-load finds nothing, or stale files left behind by an older EVE
+version. The `<persistent>` field of the `hello` message allows the
+subscriber to detect this mismatch and report it.
+
 #### `socketdriver.Subscriber` Subscriptions
 
 Upon receiving a request to subscribe to a table, `socketdriver.Subscriber` determines the filename for the Unix domain socket using the same

--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -343,6 +343,22 @@ not, the pre-load finds nothing, or stale files left behind by an older EVE
 version. The `<persistent>` field of the `hello` message allows the
 subscriber to detect this mismatch and report it.
 
+Two more safeguards protect this contract. In CI, the
+`make check-pubsub-persistence` check (`pkg/pillar/tools/pubsubcheck`)
+cross-references the `Persistent` flags of all publications and
+subscriptions. At boot, before any pubsub process starts, `upgradeconverter`
+(pre-vault) removes the directories under `/persist/status` that belong to a
+topic which is non-persistent in the running EVE version, so that a pre-load
+can never consume state left behind by a previous version whose publication
+was persistent while the current one is not. The list of non-persistent
+topics it consults is extracted from the sources by the same `pubsubcheck`
+tool while the pillar container image is built, so it can never go out of
+sync with the code. Only topics statically known to be non-persistent are
+removed: state of publishers removed entirely, of non-Go components, or of
+publications declared outside the pillar sources is intentionally left in
+place, since the generated list cannot see them and leaving unknown state
+alone is the safe direction.
+
 #### `socketdriver.Subscriber` Subscriptions
 
 Upon receiving a request to subscribe to a table, `socketdriver.Subscriber` determines the filename for the Unix domain socket using the same

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -117,6 +117,18 @@ RUN --mount=type=cache,target=/root/.cache/go-build echo "Running go vet" && mak
        if [ -n "$ERR" ] ; then printf 'go fmt Failed - ERR: %s' "$ERR" ; exit 1 ; fi && \
        make ZARCH=${TARGETARCH} HV="$HV" DEV="$DEV" COVER="$COVER" RSTATS=$RSTATS RSTATS_ENDPOINT=$RSTATS_ENDPOINT RSTATS_TAG=$RSTATS_TAG IMM_PROFILING=$IMM_PROFILING ARTIFICIAL_LEAK=$ARTIFICIAL_LEAK DISTDIR=/final/opt/zededa/bin BUILD_VERSION=${GOPKGVERSION} build
 
+# Generate the list of non-persistent pubsub topics from the sources being
+# built; upgradeconverter removes the matching directories under
+# /persist/status at boot (see docs/IPC.md). Generating it here keeps the
+# list in sync with the code by construction. The build fails on an empty
+# list as a sanity check: pillar always has non-persistent publications, so
+# an empty list means the generator is broken (the resulting failure mode is
+# benign - upgradeconverter would simply clean up nothing).
+RUN --mount=type=cache,target=/root/.cache/go-build mkdir -p /final/opt/zededa/etc && \
+    GOOS='' GOARCH='' go run ./tools/pubsubcheck -list-non-persistent . \
+      > /final/opt/zededa/etc/non-persistent-pubsub-topics && \
+    test -s /final/opt/zededa/etc/non-persistent-pubsub-topics
+
 WORKDIR /
 
 ENV DELVE_VERSION 1.20.1
@@ -126,7 +138,7 @@ ADD ${DELVE_SOURCE} /delve.tar.gz
 RUN if [ ${DEV} = "y" ]; then tar --absolute-names -xz < /delve.tar.gz; fi
 WORKDIR /delve-${DELVE_VERSION}
 RUN --mount=type=cache,target=/root/.cache/go-build if [ ${DEV} = "y" ]; then \
-    GOFLAGS= CGO_ENABLED=0 go build -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv && \
+    GOFLAGS='' CGO_ENABLED=0 go build -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv && \
     cp dlv /final/opt/ ; \
 fi
 WORKDIR /
@@ -157,7 +169,7 @@ ENV PKGS alpine-baselayout musl-utils libtasn1-progs pciutils yajl xz bash iptab
 RUN eve-alpine-deploy.sh
 
 # Snapshot collector's own apk DB (alpine PKGS installed above) before the
-# cross-stage COPYs below would overwrite /out/lib/apk/db/installed.
+# cross-stage COPY instructions below would overwrite /out/lib/apk/db/installed.
 RUN cp /out/lib/apk/db/installed /tmp/apk-collector.installed
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]

--- a/pkg/pillar/cmd/upgradeconverter/removestalepubsub.go
+++ b/pkg/pillar/cmd/upgradeconverter/removestalepubsub.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgradeconverter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// nonPersistentTopicsFile lists every pubsub publication of this EVE version
+// that is published only non-persistently, as "<agentName>/<topic>", one per
+// line. It is generated from the pillar sources by
+// pkg/pillar/tools/pubsubcheck while building the pillar container image, so
+// it can never go out of sync with the code.
+const nonPersistentTopicsFile = "/opt/zededa/etc/non-persistent-pubsub-topics"
+
+// removeStalePersistentTopics deletes the directories under /persist/status
+// that belong to a topic which is non-persistent in the current EVE version,
+// per the generated nonPersistentTopicsFile.
+//
+// Such a directory is left behind when a publication that used to be
+// persistent stops being persistent in an EVE upgrade. It must go away
+// before any pubsub process starts: a persistent subscriber pre-loads its
+// initial state from these directories at activation time and would
+// otherwise consume the stale state of the previous EVE version. This
+// handler runs in the pre-vault phase from the pillar-onboot container, i.e.
+// strictly before any subscriber service is started.
+//
+// Only topics statically known to be non-persistent are removed. State of
+// publishers removed entirely, of non-Go components, or of publications
+// outside the pillar sources is intentionally left in place: the generated
+// list cannot see them, and leaving unknown state alone is the safe
+// direction (the opposite mistake would delete live state). For the same
+// reason a missing or unreadable list removes nothing.
+//
+// This handler must run after any handler that moves or converts persistent
+// pubsub state (it removes whatever those leave behind).
+func removeStalePersistentTopics(ctxPtr *ucContext) error {
+	nonPersistent, err := readNonPersistentTopics(ctxPtr.nonPersistentTopicsFile)
+	if err != nil {
+		// Without a list we do not know which topics turned
+		// non-persistent. Remove nothing; this is the safe direction.
+		log.Warnf("removeStalePersistentTopics: not removing any pubsub state: %v", err)
+		return nil
+	}
+	removeListedTopics(ctxPtr.persistStatusDir, "", nonPersistent)
+	return nil
+}
+
+// readNonPersistentTopics parses the generated list of non-persistent topics.
+// An empty list is fine: removeListedTopics then removes nothing.
+func readNonPersistentTopics(file string) (map[string]bool, error) {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	topics := make(map[string]bool)
+	for line := range strings.SplitSeq(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			topics[line] = true
+		}
+	}
+	return topics, nil
+}
+
+// removeListedTopics removes the subdirectories of dir whose list key
+// (prefix + directory name) is listed. It recurses into directories that are
+// not listed themselves but are a prefix of a listed entry (the AgentScope
+// case, where the listed topic sits one level deeper). Everything else,
+// including all plain files, is left untouched: the current pubsub
+// implementation writes no plain files here, so they are not ours to remove.
+func removeListedTopics(dir, prefix string, nonPersistent map[string]bool) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Errorf("removeListedTopics: %v", err)
+		}
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		key := prefix + entry.Name()
+		subDir := filepath.Join(dir, entry.Name())
+		if nonPersistent[key] {
+			log.Noticef("removeListedTopics: removing stale persistent pubsub state %s",
+				subDir)
+			if err := os.RemoveAll(subDir); err != nil {
+				log.Errorf("removeListedTopics: failed to remove %s: %v", subDir, err)
+			}
+			continue
+		}
+		if hasEntryWithPrefix(nonPersistent, key+"/") {
+			removeListedTopics(subDir, key+"/", nonPersistent)
+		}
+	}
+}
+
+func hasEntryWithPrefix(topics map[string]bool, prefix string) bool {
+	for entry := range topics {
+		if strings.HasPrefix(entry, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/pillar/cmd/upgradeconverter/removestalepubsub_test.go
+++ b/pkg/pillar/cmd/upgradeconverter/removestalepubsub_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgradeconverter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveStalePersistentTopics(t *testing.T) {
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
+	statusDir := t.TempDir()
+
+	makeTopic := func(parts ...string) string {
+		dir := filepath.Join(append([]string{statusDir}, parts...)...)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		for _, file := range []string{"global.json", "restarted", "global.json.bak"} {
+			if err := os.WriteFile(filepath.Join(dir, file), []byte("x"), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return dir
+	}
+
+	// Listed (now non-persistent) topics must be removed.
+	stale1 := makeTopic("zedagent", "ConfigItemValueMap")
+	// A listed topic one level deeper (the AgentScope case).
+	stale2 := makeTopic("nim", "global", "DeviceNetworkStatus")
+	// Topics not on the list must survive, including their backup files:
+	// a still-persistent publication, and state we cannot reason about
+	// (removed publisher, non-Go component, ...).
+	kept1 := makeTopic("zedclient", "OnboardingStatus")
+	kept2 := makeTopic("goneagent", "GoneTopic")
+	// A plain file at the top level is not ours; leave it alone.
+	plainFile := filepath.Join(statusDir, "somefile")
+	if err := os.WriteFile(plainFile, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	topicsFile := filepath.Join(t.TempDir(), "non-persistent-pubsub-topics")
+	topics := "zedagent/ConfigItemValueMap\nnim/global/DeviceNetworkStatus\n"
+	if err := os.WriteFile(topicsFile, []byte(topics), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := &ucContext{
+		persistStatusDir:        statusDir,
+		nonPersistentTopicsFile: topicsFile,
+	}
+	assert.NoError(t, removeStalePersistentTopics(ctx))
+
+	assert.NoDirExists(t, stale1)
+	assert.NoDirExists(t, stale2)
+	// Removing the only listed topic of an agent leaves its (now empty)
+	// parent directories in place; only the topic directory itself goes.
+	assert.DirExists(t, kept1)
+	assert.FileExists(t, filepath.Join(kept1, "restarted"))
+	assert.FileExists(t, filepath.Join(kept1, "global.json.bak"))
+	assert.DirExists(t, kept2)
+	assert.FileExists(t, plainFile)
+}
+
+// TestRemoveStalePersistentTopicsNoList verifies that nothing is removed when
+// the generated topics list is missing or empty: with a deny-list that is the
+// safe direction, so the handler must not fail.
+func TestRemoveStalePersistentTopicsNoList(t *testing.T) {
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
+
+	check := func(topicsFile string) {
+		statusDir := t.TempDir()
+		topicDir := filepath.Join(statusDir, "zedagent", "ConfigItemValueMap")
+		if err := os.MkdirAll(topicDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		ctx := &ucContext{
+			persistStatusDir:        statusDir,
+			nonPersistentTopicsFile: topicsFile,
+		}
+		assert.NoError(t, removeStalePersistentTopics(ctx))
+		assert.DirExists(t, topicDir)
+	}
+
+	// Missing list file.
+	check(filepath.Join(t.TempDir(), "missing"))
+
+	// Empty list file.
+	emptyFile := filepath.Join(t.TempDir(), "empty")
+	if err := os.WriteFile(emptyFile, []byte("\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	check(emptyFile)
+}

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
@@ -36,6 +36,13 @@ var preVaultconversionHandlers = []ConversionHandler{
 		description: "Move /status/zedrouter/AppInstMetaData to /status/msrv/AppInstMetaData",
 		handlerFunc: movePersistPubsub,
 	},
+	{
+		// Must run last: earlier handlers move/convert persistent
+		// pubsub state and this one removes whatever stale state the
+		// previous EVE version (or the handlers above) left behind.
+		description: "Remove stale persistent pubsub topics",
+		handlerFunc: removeStalePersistentTopics,
+	},
 }
 
 // postVaultconversionHandlers run after vault is setup
@@ -62,10 +69,11 @@ type ucContext struct {
 	noFlag    bool
 
 	// FilePaths. These are defined here instead of consts for easier unit tests
-	persistDir       string
-	persistConfigDir string
-	persistStatusDir string
-	ps               *pubsub.PubSub
+	persistDir              string
+	persistConfigDir        string
+	persistStatusDir        string
+	nonPersistentTopicsFile string
+	ps                      *pubsub.PubSub
 	// cli options
 	persistPtr *string
 	noFlagPtr  *bool
@@ -142,10 +150,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	logger = loggerArg
 	log = logArg
 	ctx := &ucContext{agentName: "upgradeconverter",
-		persistDir:       types.PersistDir,
-		persistConfigDir: types.PersistConfigDir,
-		persistStatusDir: types.PersistStatusDir,
-		ps:               ps,
+		persistDir:              types.PersistDir,
+		persistConfigDir:        types.PersistConfigDir,
+		persistStatusDir:        types.PersistStatusDir,
+		nonPersistentTopicsFile: nonPersistentTopicsFile,
+		ps:                      ps,
 	}
 	agentbase.Init(ctx, logger, log, agentName,
 		agentbase.WithPidFile(),
@@ -192,10 +201,11 @@ func RunPostVaultHandlers(moduleName string,
 	logger = loggerArg
 	log = logArg
 	ctx := &ucContext{agentName: moduleName,
-		persistDir:       types.PersistDir,
-		persistConfigDir: types.PersistConfigDir,
-		persistStatusDir: types.PersistStatusDir,
-		ps:               ps,
+		persistDir:              types.PersistDir,
+		persistConfigDir:        types.PersistConfigDir,
+		persistStatusDir:        types.PersistStatusDir,
+		nonPersistentTopicsFile: nonPersistentTopicsFile,
+		ps:                      ps,
 	}
 	runPhase(ctx, UCPhasePostVault)
 	log.Notice("RunPostVaultHandlers completed, notifying caller")
@@ -215,10 +225,11 @@ func RunPreVaultHandlers(moduleName string,
 	logger = loggerArg
 	log = logArg
 	ctx := &ucContext{agentName: moduleName,
-		persistDir:       types.PersistDir,
-		persistConfigDir: types.PersistConfigDir,
-		persistStatusDir: types.PersistStatusDir,
-		ps:               ps,
+		persistDir:              types.PersistDir,
+		persistConfigDir:        types.PersistConfigDir,
+		persistStatusDir:        types.PersistStatusDir,
+		nonPersistentTopicsFile: nonPersistentTopicsFile,
+		ps:                      ps,
 	}
 	runPhase(ctx, UCPhasePreVault)
 	log.Notice("RunPreVaultHandlers completed, notifying caller")

--- a/pkg/pillar/pubsub/socketdriver/driver.go
+++ b/pkg/pillar/pubsub/socketdriver/driver.go
@@ -201,6 +201,7 @@ func (s *SocketDriver) Subscriber(global bool, name, topic string, persistent bo
 	doneChan := make(chan struct{})
 	return &Subscriber{
 		subscribeFromDir: subFromDir,
+		persistent:       persistent,
 		dirName:          dirName,
 		name:             name,
 		topic:            topic,

--- a/pkg/pillar/pubsub/socketdriver/persistence_test.go
+++ b/pkg/pillar/pubsub/socketdriver/persistence_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package socketdriver_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+	"github.com/sirupsen/logrus"
+)
+
+// handshakeTestID makes the log source name of each handshake run unique.
+var handshakeTestID atomic.Int32
+
+// syncBuffer is a goroutine-safe bytes.Buffer for capturing log output.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// runHandshake connects a subscriber to a publisher with the given
+// persistence settings and returns the log output produced by the
+// subscriber once the initial handshake (hello..complete) is done.
+func runHandshake(t *testing.T, pubPersistent, subPersistent bool) string {
+	t.Helper()
+	rootPath, err := os.MkdirTemp("", "handshake_test")
+	if err != nil {
+		t.Fatalf("TempDir failed: %s", err)
+	}
+	defer os.RemoveAll(rootPath)
+
+	var logOutput syncBuffer
+	logger := logrus.New()
+	logger.SetOutput(&logOutput)
+	// NewSourceLogObject caches objects (and thus loggers) per source name,
+	// so use a unique name to get a LogObject bound to this test's logger.
+	source := fmt.Sprintf("test-%d", handshakeTestID.Add(1))
+	log := base.NewSourceLogObject(logger, source, 1234)
+
+	driver := socketdriver.SocketDriver{
+		Logger:  logger,
+		Log:     log,
+		RootDir: rootPath,
+	}
+
+	publisher, err := driver.Publisher(false, "testagent/item", "item",
+		pubPersistent, &pubsub.Updaters{}, mockPubSub{}, mockPubSub{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := publisher.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer publisher.Stop()
+
+	changes := make(chan pubsub.Change, 10)
+	subscriber, err := driver.Subscriber(false, "testagent/item", "item",
+		subPersistent, changes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := subscriber.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer subscriber.Stop()
+
+	// The publisher sends "hello" followed by "complete"; the latter is
+	// translated into a Sync change. By then the hello message, including
+	// the persistence handshake, has been processed.
+	select {
+	case change := <-changes:
+		if change.Operation != pubsub.Sync {
+			t.Fatalf("expected Sync change, got %v", change.Operation)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the initial handshake")
+	}
+	return logOutput.String()
+}
+
+// TestPersistenceMismatchLogged verifies that a persistent subscription to a
+// non-persistent publication produces an error log during the handshake,
+// and that matched configurations do not.
+func TestPersistenceMismatchLogged(t *testing.T) {
+	const mismatchMsg = "but the publisher is not"
+
+	output := runHandshake(t, false, true)
+	if !strings.Contains(output, mismatchMsg) {
+		t.Errorf("expected mismatch error in log output, got: %s", output)
+	}
+
+	output = runHandshake(t, true, true)
+	if strings.Contains(output, mismatchMsg) {
+		t.Errorf("unexpected mismatch error in log output: %s", output)
+	}
+
+	output = runHandshake(t, false, false)
+	if strings.Contains(output, mismatchMsg) {
+		t.Errorf("unexpected mismatch error in log output: %s", output)
+	}
+}

--- a/pkg/pillar/pubsub/socketdriver/publish.go
+++ b/pkg/pillar/pubsub/socketdriver/publish.go
@@ -308,7 +308,11 @@ func (s *Publisher) serveConnection(conn net.Conn, instance int) {
 		return
 	}
 
-	_, err = conn.Write([]byte(fmt.Sprintf("hello %s", s.topic)))
+	// Advertise our persistence so that the subscriber can detect a mismatch
+	// between its Persistent option and ours. Older subscribers ignore the
+	// extra field.
+	hello := fmt.Sprintf("hello %s %t", s.topic, s.persistent)
+	_, err = conn.Write([]byte(hello))
 	if err != nil {
 		s.log.Errorf("serveConnection(%s/%d) failed %s\n", s.name, instance, err)
 		return

--- a/pkg/pillar/pubsub/socketdriver/subscribe.go
+++ b/pkg/pillar/pubsub/socketdriver/subscribe.go
@@ -29,6 +29,7 @@ type Subscriber struct {
 	sockName         string   // there is one socket per publishing agent
 	sock             net.Conn // For socket subscriptions
 	subscribeFromDir bool     // Handle special case of file only info
+	persistent       bool     // initial Load() is from the persistent dir
 	name             string
 	topic            string
 	dirName          string
@@ -308,6 +309,9 @@ func (s *Subscriber) read() (string, string, []byte) {
 	switch msg {
 	case "hello", "complete":
 		s.log.Tracef("connectAndRead(%s) Got message %s type %s\n", s.name, msg, t)
+		if msg == "hello" && count >= 3 {
+			s.checkPublisherPersistence(reply[2])
+		}
 		return msg, "", nil
 
 	case "restarted":
@@ -371,10 +375,31 @@ func (s *Subscriber) read() (string, string, []byte) {
 	}
 }
 
+// checkPublisherPersistence compares the publisher's persistence, as
+// advertised in its hello message, with the Persistent option of this
+// subscription. A persistent subscription to a non-persistent publication is
+// a bug: the initial Load() done by Activate() reads from the persistent
+// directory which the publisher never writes, so it silently loads nothing,
+// or worse, stale state left behind by an older EVE version.
+func (s *Subscriber) checkPublisherPersistence(pubPersistent string) {
+	persistent, err := strconv.ParseBool(pubPersistent)
+	if err != nil {
+		s.log.Errorf("checkPublisherPersistence(%s): malformed persistence flag %q in hello message",
+			s.name, pubPersistent)
+		return
+	}
+	if s.persistent && !persistent {
+		s.log.Errorf("checkPublisherPersistence(%s): subscription for topic %s is persistent, "+
+			"but the publisher is not; the initial load of this subscription is unreliable "+
+			"(empty or stale data); fix the Persistent flag on one of the two sides",
+			s.name, s.topic)
+	}
+}
+
 // translate takes file notifications from a file watcher and converts them
 // pubsub operations. Normally this is 1-1 but since the file watcher can not
 // ensure ordering for the restarted file we delay those until a bit to ensure
-// they are delivered after any notifictions for other files.
+// they are delivered after any notifications for other files.
 func (s *Subscriber) translate(in <-chan string, out chan<- pubsub.Change) {
 	statusDirName := s.dirName
 	gotRestarted := false
@@ -382,10 +407,10 @@ func (s *Subscriber) translate(in <-chan string, out chan<- pubsub.Change) {
 
 	// Delay sending restarted until we have seen other changes
 	interval := 3 * time.Second
-	max := float64(interval)
-	min := max / 3
-	ticker := flextimer.NewRangeTicker(time.Duration(1000*min),
-		time.Duration(1000*max))
+	maxDelay := float64(interval)
+	minDelay := maxDelay / 3
+	ticker := flextimer.NewRangeTicker(time.Duration(1000*minDelay),
+		time.Duration(1000*maxDelay))
 
 	for {
 		select {
@@ -399,8 +424,8 @@ func (s *Subscriber) translate(in <-chan string, out chan<- pubsub.Change) {
 				restartedValue)
 			gotRestarted = false
 			restartedValue = ""
-			ticker.UpdateRangeTicker(time.Duration(1000*min),
-				time.Duration(1000*max))
+			ticker.UpdateRangeTicker(time.Duration(1000*minDelay),
+				time.Duration(1000*maxDelay))
 
 		case change, ok := <-in:
 			if !ok {
@@ -446,9 +471,9 @@ func (s *Subscriber) translate(in <-chan string, out chan<- pubsub.Change) {
 				restartedValue = string(cb)
 				s.log.Functionf("Starting timer restarted %s for %v %v",
 					restartedValue,
-					time.Duration(min), time.Duration(max))
-				ticker.UpdateRangeTicker(time.Duration(min),
-					time.Duration(max))
+					time.Duration(minDelay), time.Duration(maxDelay))
+				ticker.UpdateRangeTicker(time.Duration(minDelay),
+					time.Duration(maxDelay))
 
 			case !strings.HasSuffix(fileName, ".json"):
 				// s.log.Tracef("Ignoring file <%s> operation %s\n",

--- a/pkg/pillar/tools/pubsubcheck/main.go
+++ b/pkg/pillar/tools/pubsubcheck/main.go
@@ -1,0 +1,414 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// pubsubcheck statically analyzes the Persistent flag of pubsub
+// publications and subscriptions. It parses all Go sources under the given
+// root directories (skipping vendor directories and tests), collects every
+// pubsub.PublicationOptions and pubsub.SubscriptionOptions composite
+// literal and resolves the agent name and scope (string literals and
+// package-level string constants). It serves two purposes:
+//
+// As a CI check (make check-pubsub-persistence), it reports every
+// persistent subscription whose publication is known not to be persistent.
+// Such a subscription pre-loads the publisher's persisted state from disk
+// at activation time; with a non-persistent publication the pre-load
+// silently finds nothing, or stale state left behind by an older EVE
+// version. Publisher and subscriber often live in different containers and
+// even different Go modules, so the compiler cannot catch the disagreement
+// and at runtime it surfaces only as an error log once both sides are up.
+// Entries whose agent name or persistence cannot be resolved statically are
+// skipped: the runtime check in the socketdriver remains the backstop.
+//
+// As a build-time generator (-list-non-persistent), it emits the list of
+// non-persistent publications that the pillar container image embeds for
+// upgradeconverter. At boot upgradeconverter removes the matching directories
+// under /persist/status: a topic that is non-persistent now but whose
+// directory still exists was persistent in a previous EVE version, and its
+// stale state would otherwise be pre-loaded by a persistent subscriber. Only
+// statically resolvable non-persistent publications are listed; anything
+// ambiguous, removed entirely, or published outside these sources is left in
+// place, which is the safe direction.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// optionsLit is one parsed pubsub.PublicationOptions or
+// pubsub.SubscriptionOptions composite literal.
+type optionsLit struct {
+	pos             token.Position
+	isSubscription  bool
+	agent           string // empty if not statically resolvable
+	scope           string // AgentScope, usually empty
+	topic           string // bare type name, empty if not resolvable
+	persistent      bool
+	persistentKnown bool // false if Persistent is not a true/false literal
+}
+
+// key returns the "<agent>[/<scope>]/<topic>" path of the topic relative to
+// the pubsub directory, mirroring nameString() of the pubsub package.
+func (o optionsLit) key() string {
+	if o.scope != "" {
+		return o.agent + "/" + o.scope + "/" + o.topic
+	}
+	return o.agent + "/" + o.topic
+}
+
+// analysis is the result of scanning the source tree.
+type analysis struct {
+	errors   []string
+	warnings []string
+	// nonPersistentPublications are the keys of all topics that are
+	// statically known to be published only non-persistently, sorted and
+	// unique. A topic with any persistent or any unresolvable publication
+	// is excluded, so that its /persist/status directory is never removed.
+	nonPersistentPublications []string
+}
+
+func main() {
+	verbose := flag.Bool("v", false, "verbose output (warnings and skipped entries)")
+	listNonPersistent := flag.Bool("list-non-persistent", false,
+		"list all topics published only non-persistently and exit")
+	flag.Parse()
+
+	roots := flag.Args()
+	if len(roots) == 0 {
+		roots = []string{"."}
+	}
+
+	result, err := analyze(roots)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pubsubcheck: %v\n", err)
+		os.Exit(2)
+	}
+	if *listNonPersistent {
+		for _, key := range result.nonPersistentPublications {
+			fmt.Println(key)
+		}
+		return
+	}
+	if *verbose {
+		for _, warning := range result.warnings {
+			fmt.Printf("WARNING: %s\n", warning)
+		}
+	}
+	for _, errMsg := range result.errors {
+		fmt.Printf("ERROR: %s\n", errMsg)
+	}
+	if len(result.errors) > 0 {
+		os.Exit(1)
+	}
+	fmt.Println("pubsubcheck: no persistence mismatches found")
+}
+
+func analyze(roots []string) (*analysis, error) {
+	packageDirs, err := collectPackageDirs(roots)
+	if err != nil {
+		return nil, err
+	}
+
+	var subscriptions []optionsLit
+	publications := make(map[string][]optionsLit)
+	fset := token.NewFileSet()
+	for _, dir := range packageDirs {
+		entries, err := parsePackageDir(fset, dir)
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range entries {
+			if entry.isSubscription {
+				subscriptions = append(subscriptions, entry)
+			} else {
+				publications[entry.key()] = append(publications[entry.key()], entry)
+			}
+		}
+	}
+
+	result := &analysis{}
+	for _, sub := range subscriptions {
+		if !sub.persistentKnown || !sub.persistent {
+			continue
+		}
+		if sub.agent == "" || sub.topic == "" {
+			result.warnings = append(result.warnings, fmt.Sprintf(
+				"%s: cannot statically resolve agent or topic of a persistent subscription",
+				sub.pos))
+			continue
+		}
+		result.check(sub, publications[sub.key()])
+	}
+	result.collectNonPersistentPublications(publications)
+	sort.Strings(result.errors)
+	sort.Strings(result.warnings)
+	return result, nil
+}
+
+// collectNonPersistentPublications fills nonPersistentPublications with the
+// keys of all topics published only non-persistently. A topic is included
+// only if it has at least one statically resolvable non-persistent
+// publication and no publication that is persistent or whose persistence
+// cannot be resolved statically. upgradeconverter removes the matching
+// directories under /persist/status at boot, so any ambiguity must keep a
+// topic off the list rather than risk removing live state.
+func (a *analysis) collectNonPersistentPublications(publications map[string][]optionsLit) {
+	for key, pubs := range publications {
+		var hasNonPersistent, blocked bool
+		for _, pub := range pubs {
+			if pub.agent == "" || pub.topic == "" {
+				// Cannot form a /persist/status path for it anyway.
+				continue
+			}
+			if !pub.persistentKnown {
+				// Persistence set from a variable: cannot rule out that
+				// it is persistent, so do not list the topic.
+				a.warnings = append(a.warnings, fmt.Sprintf(
+					"%s: cannot statically resolve persistence of the publication of %s",
+					pub.pos, pub.key()))
+				blocked = true
+				continue
+			}
+			if pub.persistent {
+				blocked = true
+				continue
+			}
+			hasNonPersistent = true
+		}
+		if hasNonPersistent && !blocked {
+			a.nonPersistentPublications = append(a.nonPersistentPublications, key)
+		}
+	}
+	sort.Strings(a.nonPersistentPublications)
+}
+
+// check validates one persistent subscription against the publications of
+// the same agent and topic.
+func (a *analysis) check(sub optionsLit, pubs []optionsLit) {
+	if len(pubs) == 0 {
+		a.warnings = append(a.warnings, fmt.Sprintf(
+			"%s: no statically resolvable publication found for persistent subscription to %s",
+			sub.pos, sub.key()))
+		return
+	}
+	var nonPersistent []optionsLit
+	for _, pub := range pubs {
+		if !pub.persistentKnown {
+			// Persistence set from a variable; cannot judge.
+			a.warnings = append(a.warnings, fmt.Sprintf(
+				"%s: cannot statically resolve persistence of the publication of %s",
+				pub.pos, pub.key()))
+			return
+		}
+		if pub.persistent {
+			// At least one persistent publication exists.
+			return
+		}
+		nonPersistent = append(nonPersistent, pub)
+	}
+	for _, pub := range nonPersistent {
+		a.errors = append(a.errors, fmt.Sprintf(
+			"%s: persistent subscription to %s, but the publication at %s is not persistent",
+			sub.pos, sub.key(), pub.pos))
+	}
+}
+
+// collectPackageDirs returns all directories under the given roots that
+// contain Go files, skipping vendor and hidden directories.
+func collectPackageDirs(roots []string) ([]string, error) {
+	dirSet := make(map[string]bool)
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				name := d.Name()
+				if name == "vendor" || name == "testdata" ||
+					(strings.HasPrefix(name, ".") && path != root) {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
+				dirSet[filepath.Dir(path)] = true
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	dirs := make([]string, 0, len(dirSet))
+	for dir := range dirSet {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+	return dirs, nil
+}
+
+// parsePackageDir parses all non-test Go files of one directory and returns
+// the pubsub options literals found in them. Package-level string constants
+// of the same package are used to resolve agent names.
+func parsePackageDir(fset *token.FileSet, dir string) ([]optionsLit, error) {
+	files, err := filepath.Glob(filepath.Join(dir, "*.go"))
+	if err != nil {
+		return nil, err
+	}
+	var parsed []*ast.File
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+		astFile, err := parser.ParseFile(fset, file, nil, parser.SkipObjectResolution)
+		if err != nil {
+			// Tolerate unparsable files (e.g. build-tag exotica);
+			// they will be caught by the regular build.
+			continue
+		}
+		parsed = append(parsed, astFile)
+	}
+
+	consts := collectStringConsts(parsed)
+	var entries []optionsLit
+	for _, astFile := range parsed {
+		ast.Inspect(astFile, func(node ast.Node) bool {
+			lit, ok := node.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			selector, ok := lit.Type.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			var isSubscription bool
+			switch selector.Sel.Name {
+			case "SubscriptionOptions":
+				isSubscription = true
+			case "PublicationOptions":
+				isSubscription = false
+			default:
+				return true
+			}
+			entry := parseOptionsLit(fset, lit, isSubscription, consts)
+			entries = append(entries, entry)
+			return true
+		})
+	}
+	return entries, nil
+}
+
+// collectStringConsts returns the package-level string constants defined in
+// the given files.
+func collectStringConsts(files []*ast.File) map[string]string {
+	consts := make(map[string]string)
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				valueSpec, ok := spec.(*ast.ValueSpec)
+				if !ok || len(valueSpec.Names) != len(valueSpec.Values) {
+					continue
+				}
+				for i, name := range valueSpec.Names {
+					if value := stringLiteral(valueSpec.Values[i]); value != "" {
+						consts[name.Name] = value
+					}
+				}
+			}
+		}
+	}
+	return consts
+}
+
+// parseOptionsLit extracts agent, topic and persistence from one options
+// composite literal.
+func parseOptionsLit(fset *token.FileSet, lit *ast.CompositeLit,
+	isSubscription bool, consts map[string]string) optionsLit {
+
+	entry := optionsLit{
+		pos:             fset.Position(lit.Pos()),
+		isSubscription:  isSubscription,
+		persistentKnown: true, // absent Persistent field means false
+	}
+	for _, element := range lit.Elts {
+		keyValue, ok := element.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := keyValue.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		switch key.Name {
+		case "AgentName":
+			if value := stringLiteral(keyValue.Value); value != "" {
+				entry.agent = value
+			} else if ident, ok := keyValue.Value.(*ast.Ident); ok {
+				entry.agent = consts[ident.Name]
+			}
+		case "AgentScope":
+			if value := stringLiteral(keyValue.Value); value != "" {
+				entry.scope = value
+			} else if ident, ok := keyValue.Value.(*ast.Ident); ok {
+				entry.scope = consts[ident.Name]
+			}
+		case "TopicImpl", "TopicType":
+			entry.topic = bareTypeName(keyValue.Value)
+		case "Persistent":
+			ident, ok := keyValue.Value.(*ast.Ident)
+			switch {
+			case ok && ident.Name == "true":
+				entry.persistent = true
+			case ok && ident.Name == "false":
+				entry.persistent = false
+			default:
+				entry.persistentKnown = false
+			}
+		}
+	}
+	return entry
+}
+
+// stringLiteral returns the value of a string literal expression, or "".
+func stringLiteral(expr ast.Expr) string {
+	basicLit, ok := expr.(*ast.BasicLit)
+	if !ok || basicLit.Kind != token.STRING {
+		return ""
+	}
+	value, err := strconv.Unquote(basicLit.Value)
+	if err != nil {
+		return ""
+	}
+	return value
+}
+
+// bareTypeName returns the bare type name of a composite literal expression
+// like types.DomainStatus{} or localType{}. The package qualifier is
+// dropped on purpose: pubsub derives the topic name from the bare type name
+// via reflection, so this mirrors the runtime matching.
+func bareTypeName(expr ast.Expr) string {
+	lit, ok := expr.(*ast.CompositeLit)
+	if !ok {
+		return ""
+	}
+	switch litType := lit.Type.(type) {
+	case *ast.SelectorExpr:
+		return litType.Sel.Name
+	case *ast.Ident:
+		return litType.Name
+	}
+	return ""
+}

--- a/pkg/pillar/tools/pubsubcheck/main_test.go
+++ b/pkg/pillar/tools/pubsubcheck/main_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAnalyzeMismatch(t *testing.T) {
+	result, err := analyze([]string{"testdata/mismatch"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.errors) != 1 {
+		t.Fatalf("expected exactly one error, got %v", result.errors)
+	}
+	if !strings.Contains(result.errors[0], "pubagent/Foo") {
+		t.Errorf("unexpected error message: %s", result.errors[0])
+	}
+}
+
+func TestAnalyzeMatched(t *testing.T) {
+	result, err := analyze([]string{"testdata/ok"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.errors) != 0 {
+		t.Fatalf("expected no errors, got %v", result.errors)
+	}
+}
+
+func TestListNonPersistentPublications(t *testing.T) {
+	// testdata/mismatch publishes pubagent/Foo non-persistently, so it is
+	// listed; testdata/ok publishes it persistently, so the list is empty.
+	result, err := analyze([]string{"testdata/mismatch"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.nonPersistentPublications) != 1 ||
+		result.nonPersistentPublications[0] != "pubagent/Foo" {
+		t.Fatalf("expected [pubagent/Foo], got %v", result.nonPersistentPublications)
+	}
+
+	result, err = analyze([]string{"testdata/ok"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.nonPersistentPublications) != 0 {
+		t.Fatalf("expected no non-persistent publications, got %v",
+			result.nonPersistentPublications)
+	}
+}

--- a/pkg/pillar/tools/pubsubcheck/testdata/mismatch/publisher/publisher.go
+++ b/pkg/pillar/tools/pubsubcheck/testdata/mismatch/publisher/publisher.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build ignore
+
+// Test fixture: a non-persistent publication of pubagent/Foo.
+package publisher
+
+const agentName = "pubagent"
+
+func setup(ps PS) {
+	ps.NewPublication(pubsub.PublicationOptions{
+		AgentName:  agentName,
+		TopicType:  types.Foo{},
+		Persistent: false,
+	})
+}

--- a/pkg/pillar/tools/pubsubcheck/testdata/mismatch/subscriber/subscriber.go
+++ b/pkg/pillar/tools/pubsubcheck/testdata/mismatch/subscriber/subscriber.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build ignore
+
+// Test fixture: a persistent subscription to the non-persistent
+// publication of pubagent/Foo.
+package subscriber
+
+func setup(ps PS) {
+	ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:  "pubagent",
+		TopicImpl:  types.Foo{},
+		Persistent: true,
+	})
+}

--- a/pkg/pillar/tools/pubsubcheck/testdata/ok/publisher/publisher.go
+++ b/pkg/pillar/tools/pubsubcheck/testdata/ok/publisher/publisher.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build ignore
+
+// Test fixture: a persistent publication of pubagent/Foo.
+package publisher
+
+const agentName = "pubagent"
+
+func setup(ps PS) {
+	ps.NewPublication(pubsub.PublicationOptions{
+		AgentName:  agentName,
+		TopicType:  types.Foo{},
+		Persistent: true,
+	})
+}

--- a/pkg/pillar/tools/pubsubcheck/testdata/ok/subscriber/subscriber.go
+++ b/pkg/pillar/tools/pubsubcheck/testdata/ok/subscriber/subscriber.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build ignore
+
+// Test fixture: a persistent subscription to the persistent publication
+// of pubagent/Foo.
+package subscriber
+
+func setup(ps PS) {
+	ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:  "pubagent",
+		TopicImpl:  types.Foo{},
+		Persistent: true,
+	})
+}


### PR DESCRIPTION
# Description

A subscription with `Persistent=true` pre-loads the publisher's persisted state
from `/persist/status/<agent>/<topic>` at activation time. This silently breaks
when the publication is not persistent: the pre-load finds an empty directory —
or worse, stale state left behind by an older EVE version that did persist the
topic — and no error is ever raised. Publisher and subscriber often live in
different containers and even different Go modules, so the compiler cannot
catch the disagreement. #5584 hit exactly this: it made zedagent's
ConfigItemValueMap and ControllerCert publications in-memory only, and the
persistent subscriptions of newlogd, mmagent and scepclient kept silently
pre-loading nothing (fixed in #6031).

This PR makes the contract violation impossible to miss, at three layers:

1. **Runtime**: the publisher advertises its persistence in the `hello`
   greeting of the socket protocol (`hello <topic> <persistent>`); a
   persistent subscriber logs an error when the publisher is not persistent.
   Older peers ignore/omit the extra field, so mixed container versions remain
   wire-compatible.
2. **Upgrade hygiene**: `upgradeconverter` removes stale `/persist/status`
   directories at boot, *before any pubsub process starts*. It runs from the
   `pillar-onboot` container, which linuxkit completes before any service
   starts, so it cannot race a pre-load — unlike cleaning up from the
   publisher, which comes up long after early subscribers such as newlogd. The
   directories to remove are a deny-list of non-persistent topics generated
   from the pillar sources by `pubsubcheck` at image build and embedded into
   the image. A deny-list (rather than an allow-list of persistent topics) is
   used because `pubsubcheck` sees only pillar's Go sources: state it cannot
   account for — non-Go publishers, publications outside pillar, or publishers
   removed entirely — is left untouched, which is the safe direction.
3. **CI**: a new AST-based checker (`make check-pubsub-persistence`, plus a
   workflow) cross-references every statically resolvable PublicationOptions
   and SubscriptionOptions literal under `pkg/` and fails when a persistent
   subscription points at a non-persistent publication. Entries that cannot be
   resolved statically are skipped; for those the runtime check is the
   backstop.

The previously undocumented socket wire protocol is now described in
`docs/IPC.md`, including the new handshake field.

## PR dependencies

Depended on #6031, which is now merged. After rebasing onto current master the
"Check PubSub Persistence Consistency" workflow passes: the four persistence
mismatches it originally flagged (newlogd, mmagent ×2, scepclient) — a live
demonstration that it catches exactly the class of bug that motivated this
work — were fixed in #6031.

## How to test and validate this PR

1. The "Check PubSub Persistence Consistency" workflow runs the checker against
   the real codebase and is now green. Locally: `make check-pubsub-persistence`.
2. Unit tests (in `pkg/pillar`): `go test ./pubsub/socketdriver/` covers the
   handshake mismatch logging (`persistence_test.go`); `go test
   ./cmd/upgradeconverter/` covers the boot-time stale-directory cleanup
   (`removestalepubsub_test.go`); `go test ./tools/pubsubcheck/` covers the
   checker and list generator itself.
3. On a booted device with #6031 included, `grep checkPublisherPersistence`
   over the device logs must yield no hits; on an image without #6031 the
   error is logged for the affected subscriptions as soon as zedagent starts.

## Changelog notes

No user-facing changes.

## PR Backports

- 16.0-stable: No, hardening and CI tooling, not a bug fix.
- 14.5-stable: No, hardening and CI tooling, not a bug fix.
- 13.4-stable: No, hardening and CI tooling, not a bug fix.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
