### PR TITLE
types: fix /persist/volumes path in diskmetrics test

### DIFF
--- a/pkg/pillar/types/diskmetrics_test.go
+++ b/pkg/pillar/types/diskmetrics_test.go
@@ -34,8 +34,8 @@ func TestDiskMetricLogKey(t *testing.T) {
 // AppDiskMetric.Key / LogKey
 
 func TestAppDiskMetricLogKey(t *testing.T) {
-	m := AppDiskMetric{DiskPath: "/persist/volumes/vol1"}
-	assert.Equal(t, PathToKey("/persist/volumes/vol1"), m.Key())
+	m := AppDiskMetric{DiskPath: "/persist/vault/volumes/vol1"}
+	assert.Equal(t, PathToKey("/persist/vault/volumes/vol1"), m.Key())
 	assert.Contains(t, m.LogKey(), m.Key())
 }
 
@@ -60,7 +60,7 @@ func TestAppDiskMetricLogCreateModifyDelete(t *testing.T) {
 	logger.SetOutput(&buf)
 	logger.SetLevel(logrus.TraceLevel)
 	log := base.NewSourceLogObject(logger, t.Name(), 0) //nolint:staticcheck
-	m := AppDiskMetric{DiskPath: "/persist/volumes/vol1"}
+	m := AppDiskMetric{DiskPath: "/persist/vault/volumes/vol1"}
 	m.LogCreate(log)
 	assert.NotEmpty(t, buf.String())
 	m.LogModify(log, m)


### PR DESCRIPTION
# Description

Test sample `DiskPath` in `pkg/pillar/types/diskmetrics_test.go` used
`/persist/volumes/vol1`. The canonical path under `SealedDirName` is
`/persist/vault/volumes`, so the test was exercising a path that the
production code never produces. Update both call sites to the
realistic value so the test reflects what runtime code actually sees.

## PR dependencies

None.

## How to test and validate this PR

```sh
cd pkg/pillar
go test ./types/ -run 'TestAppDiskMetricLog'
```

Both `TestAppDiskMetricLogKey` and `TestAppDiskMetricLogCreateModifyDelete`
should pass with the corrected path.