### PR TITLE
baseosmgr/upgradeconverter/volumemgr: enable kvm→k BaseOs upgrade with blob reuse

### DIFF
--- a/docs/EVE-K.md
+++ b/docs/EVE-K.md
@@ -71,8 +71,29 @@ To override previously set config it is required to follow the k3s config merge 
 ## Upgrades
 
 Upgrades of `HV=k` EVE-OS are supported through the existing interfaces.
-Upgrade from other `HV=` types is not supported and upgrade from `HV=k` to
-other `HV=` types is not supported.
+
+Upgrading a device from another `HV=` type to `HV=k` is supported only while
+the device holds no volumes: the `/persist/vault/volumes` layout differs
+between the flavors, so baseosmgr refuses the update while the controller has
+any volume configured for the device or volumemgr still reports one — an app
+deleted shortly beforehand keeps the update refused until its volume has
+finished being purged. Content trees and blobs already on `/persist` do not
+refuse the update; they are carried across the flavor change and reused rather
+than re-downloaded. A device that is not receiving configuration cannot
+establish its volume set, and is refused for that reason.
+
+The new rootfs must also fit the device's existing IMGA/IMGB partition, which
+an installation predating EVE 17.0.0 is unlikely to satisfy. Converting such a
+device additionally needs the boot-disk repartition.
+
+On a device whose `/persist` is ZFS, the vault carried over from the old flavor
+is a filesystem dataset, which `HV=k` cannot use; the first `HV=k` boot
+migrates it to the zvol layout, and declines when the pool has too little free
+space to stage the copy. See [vaultmgr.md](../pkg/pillar/docs/vaultmgr.md).
+
+Upgrading from `HV=k` to another `HV=` type is not supported in any case: a
+vault migrated to the `HV=k` zvol layout has no path back to a filesystem
+dataset the other flavors can read.
 
 ## Tie Breaker Node
 

--- a/pkg/pillar/base/execwrapper.go
+++ b/pkg/pillar/base/execwrapper.go
@@ -18,10 +18,10 @@ import (
 
 const (
 	/*
-	 * execution timeout is supposed to be less than the watchdog timeout,
-	 * as otherwise the watchdog might fire and reboot the system before
-	 * the timeout fires
-	 * exceptions are when an executable is started from a different goroutine
+	 * timeoutLimit caps the timeout WithLimitedTimeout accepts: a command that
+	 * hangs is then reported as an error rather than left to trip the
+	 * watchdog. WithUnlimitedTimeout lifts the cap and instead relies on the
+	 * touch-file refresh execCommand performs while waiting.
 	 * source of the error timeout and the watchdog timeout:
 	 * error timeout: $ grep -r errorTime pkg/pillar/cmd/ | grep time
 	 * watchdog timeout: $ grep hv_watchdog_timer pkg/grub/rootfs.cfg
@@ -123,7 +123,13 @@ func (c *Command) WithLimitedTimeout(timeout time.Duration) *Command {
 	return c
 }
 
-// WithUnlimitedTimeout set custom timeout for command not bound to any limits for when run in a separate goroutine
+// WithUnlimitedTimeout sets a timeout for the command that is not capped by
+// timeoutLimit. While waiting, execCommand refreshes the calling agent's
+// watchdog touch file every 25 seconds, so a timeout longer than the watchdog
+// interval is safe on an agent's main goroutine as well. That refresh requires
+// getAgentName to resolve an agent from the calling goroutine's stack, which
+// only holds when a pkg/pillar/cmd/<agent> frame is on it: a command issued
+// from a goroutine started inside a library package gets no refresh.
 func (c *Command) WithUnlimitedTimeout(timeout time.Duration) *Command {
 	c.timeout = timeout
 

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -29,6 +29,11 @@ const (
 	// Time limits for event loop handlers
 	errorTime   = 3 * time.Minute
 	warningTime = 40 * time.Second
+	// volumePublishersRestartTimeout bounds the startup wait for the Volume
+	// publishers to signal restart. baseosmgr must not be gated forever on
+	// them (see Run): on timeout we proceed treating the volume state as
+	// unknown.
+	volumePublishersRestartTimeout = 2 * time.Minute
 )
 
 type baseOsMgrContext struct {
@@ -43,16 +48,24 @@ type baseOsMgrContext struct {
 	subBaseOsConfig      pubsub.Subscription
 	subZbootConfig       pubsub.Subscription
 	subContentTreeStatus pubsub.Subscription
-	subNodeAgentStatus   pubsub.Subscription
-	subZedAgentStatus    pubsub.Subscription
-	subNodeDrainStatus   pubsub.Subscription
-	pubNodeDrainRequest  pubsub.Publication
-	deferredBaseOsID     string
-	rebootReason         string    // From last reboot
-	rebootTime           time.Time // From last reboot
-	rebootImage          string    // Image from which the last reboot happened
-	currentUpdateRetry   uint32    // UpdateRetryCounter from last retry; it will be sent for info
-	configUpdateRetry    uint32    // UpdateRetryCounter from config; to avoid loop after reboot with failed testing
+	subVolumeConfig      pubsub.Subscription
+	subVolumeStatus      pubsub.Subscription
+	// volumeStateKnown is set once both the VolumeConfig and VolumeStatus
+	// publishers have signalled restart, i.e. the volume sets we read via
+	// GetAll() reflect the full post-startup state. Until then the volume
+	// state is treated as unknown (hence as if volumes may exist) so the
+	// cross-flavor upgrade block stays conservative.
+	volumeStateKnown    bool
+	subNodeAgentStatus  pubsub.Subscription
+	subZedAgentStatus   pubsub.Subscription
+	subNodeDrainStatus  pubsub.Subscription
+	pubNodeDrainRequest pubsub.Publication
+	deferredBaseOsID    string
+	rebootReason        string    // From last reboot
+	rebootTime          time.Time // From last reboot
+	rebootImage         string    // Image from which the last reboot happened
+	currentUpdateRetry  uint32    // UpdateRetryCounter from last retry; it will be sent for info
+	configUpdateRetry   uint32    // UpdateRetryCounter from config; to avoid loop after reboot with failed testing
 
 	worker worker.Worker // For background work
 
@@ -152,8 +165,51 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	log.Functionf("user containerd ready")
 
+	// Wait for the Volume publishers to signal restart, i.e. zedagent
+	// has parsed its first EdgeDevConfig and volumemgr has reflected
+	// that plus its on-disk recovery into VolumeStatus. Restarted()
+	// is the right primitive here: Synchronized() only confirms the
+	// socket handshake and can fire before zedagent's first parse.
+	//
+	// The wait is bounded: baseosmgr is on the A/B rollback path and must
+	// not be gated indefinitely (e.g. on a device stuck in maintenance mode
+	// or never onboarded, where neither publisher signals). On timeout we
+	// proceed with volumeStateKnown false, so the cross-flavor block in
+	// doBaseOsStatusUpdate treats the volume set as possibly non-empty and
+	// stays conservative.
+	volRestartDeadline := time.Now().Add(volumePublishersRestartTimeout)
+	for !ctx.subVolumeConfig.Restarted() || !ctx.subVolumeStatus.Restarted() {
+		if time.Now().After(volRestartDeadline) {
+			log.Warnf("volume publishers did not signal restart within %v; proceeding with unknown volume state",
+				volumePublishersRestartTimeout)
+			break
+		}
+		log.Functionf("waiting for Volume publishers to signal restart")
+		select {
+		case change := <-ctx.subGlobalConfig.MsgChan():
+			ctx.subGlobalConfig.ProcessChange(change)
+		case change := <-ctx.subVolumeConfig.MsgChan():
+			ctx.subVolumeConfig.ProcessChange(change)
+		case change := <-ctx.subVolumeStatus.MsgChan():
+			ctx.subVolumeStatus.ProcessChange(change)
+		case <-stillRunning.C:
+		}
+		ps.StillRunning(agentName, warningTime, errorTime)
+	}
+	if ctx.subVolumeConfig.Restarted() && ctx.subVolumeStatus.Restarted() {
+		ctx.volumeStateKnown = true
+	}
+	log.Functionf("volume state known: %t", ctx.volumeStateKnown)
+
 	// start the forever loop for event handling
 	for {
+		// Once both volume publishers have signalled restart the volume
+		// sets are complete; latch that so the cross-flavor gate stops
+		// treating the volume state as unknown.
+		if !ctx.volumeStateKnown &&
+			ctx.subVolumeConfig.Restarted() && ctx.subVolumeStatus.Restarted() {
+			ctx.volumeStateKnown = true
+		}
 		select {
 		case change := <-ctx.subGlobalConfig.MsgChan():
 			ctx.subGlobalConfig.ProcessChange(change)
@@ -166,6 +222,12 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 		case change := <-ctx.subContentTreeStatus.MsgChan():
 			ctx.subContentTreeStatus.ProcessChange(change)
+
+		case change := <-ctx.subVolumeConfig.MsgChan():
+			ctx.subVolumeConfig.ProcessChange(change)
+
+		case change := <-ctx.subVolumeStatus.MsgChan():
+			ctx.subVolumeStatus.ProcessChange(change)
 
 		case change := <-ctx.subNodeAgentStatus.MsgChan():
 			ctx.subNodeAgentStatus.ProcessChange(change)
@@ -454,6 +516,24 @@ func initializeZedagentHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
 	}
 	ctx.subBaseOsConfig = subBaseOsConfig
 	subBaseOsConfig.Activate()
+
+	// VolumeConfig and VolumeStatus are read via GetAll() to gate the
+	// EVE-k vs non-EVE-k upgrade block; no per-event handlers needed.
+	subVolumeConfig, err := ps.NewSubscription(
+		pubsub.SubscriptionOptions{
+			AgentName:   "zedagent",
+			MyAgentName: agentName,
+			TopicImpl:   types.VolumeConfig{},
+			Activate:    false,
+			Ctx:         ctx,
+			WarningTime: warningTime,
+			ErrorTime:   errorTime,
+		})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.subVolumeConfig = subVolumeConfig
+	subVolumeConfig.Activate()
 }
 
 func initializeVolumemgrHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
@@ -476,6 +556,22 @@ func initializeVolumemgrHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
 	}
 	ctx.subContentTreeStatus = subContentTreeStatus
 	subContentTreeStatus.Activate()
+
+	subVolumeStatus, err := ps.NewSubscription(
+		pubsub.SubscriptionOptions{
+			AgentName:   "volumemgr",
+			MyAgentName: agentName,
+			TopicImpl:   types.VolumeStatus{},
+			Activate:    false,
+			Ctx:         ctx,
+			WarningTime: warningTime,
+			ErrorTime:   errorTime,
+		})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.subVolumeStatus = subVolumeStatus
+	subVolumeStatus.Activate()
 }
 
 func handleNodeAgentStatusCreate(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/baseosmgr/baseosmgr.go
+++ b/pkg/pillar/cmd/baseosmgr/baseosmgr.go
@@ -43,6 +43,8 @@ type baseOsMgrContext struct {
 	subBaseOsConfig      pubsub.Subscription
 	subZbootConfig       pubsub.Subscription
 	subContentTreeStatus pubsub.Subscription
+	subVolumeConfig      pubsub.Subscription
+	subVolumeStatus      pubsub.Subscription
 	subNodeAgentStatus   pubsub.Subscription
 	subZedAgentStatus    pubsub.Subscription
 	subNodeDrainStatus   pubsub.Subscription
@@ -140,6 +142,26 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	log.Functionf("user containerd ready")
 
+	// Wait for the Volume publishers to signal restart, i.e. zedagent
+	// has parsed its first EdgeDevConfig and volumemgr has reflected
+	// that plus its on-disk recovery into VolumeStatus. Restarted()
+	// is the right primitive here: Synchronized() only confirms the
+	// socket handshake and can fire before zedagent's first parse.
+	for !ctx.subVolumeConfig.Restarted() || !ctx.subVolumeStatus.Restarted() {
+		log.Functionf("waiting for Volume publishers to signal restart")
+		select {
+		case change := <-ctx.subGlobalConfig.MsgChan():
+			ctx.subGlobalConfig.ProcessChange(change)
+		case change := <-ctx.subVolumeConfig.MsgChan():
+			ctx.subVolumeConfig.ProcessChange(change)
+		case change := <-ctx.subVolumeStatus.MsgChan():
+			ctx.subVolumeStatus.ProcessChange(change)
+		case <-stillRunning.C:
+		}
+		ps.StillRunning(agentName, warningTime, errorTime)
+	}
+	log.Functionf("Volume publishers restarted")
+
 	// start the forever loop for event handling
 	for {
 		select {
@@ -154,6 +176,12 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 		case change := <-ctx.subContentTreeStatus.MsgChan():
 			ctx.subContentTreeStatus.ProcessChange(change)
+
+		case change := <-ctx.subVolumeConfig.MsgChan():
+			ctx.subVolumeConfig.ProcessChange(change)
+
+		case change := <-ctx.subVolumeStatus.MsgChan():
+			ctx.subVolumeStatus.ProcessChange(change)
 
 		case change := <-ctx.subNodeAgentStatus.MsgChan():
 			ctx.subNodeAgentStatus.ProcessChange(change)
@@ -442,6 +470,24 @@ func initializeZedagentHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
 	}
 	ctx.subBaseOsConfig = subBaseOsConfig
 	subBaseOsConfig.Activate()
+
+	// VolumeConfig and VolumeStatus are read via GetAll() to gate the
+	// EVE-k vs non-EVE-k upgrade block; no per-event handlers needed.
+	subVolumeConfig, err := ps.NewSubscription(
+		pubsub.SubscriptionOptions{
+			AgentName:   "zedagent",
+			MyAgentName: agentName,
+			TopicImpl:   types.VolumeConfig{},
+			Activate:    false,
+			Ctx:         ctx,
+			WarningTime: warningTime,
+			ErrorTime:   errorTime,
+		})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.subVolumeConfig = subVolumeConfig
+	subVolumeConfig.Activate()
 }
 
 func initializeVolumemgrHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
@@ -464,6 +510,22 @@ func initializeVolumemgrHandles(ps *pubsub.PubSub, ctx *baseOsMgrContext) {
 	}
 	ctx.subContentTreeStatus = subContentTreeStatus
 	subContentTreeStatus.Activate()
+
+	subVolumeStatus, err := ps.NewSubscription(
+		pubsub.SubscriptionOptions{
+			AgentName:   "volumemgr",
+			MyAgentName: agentName,
+			TopicImpl:   types.VolumeStatus{},
+			Activate:    false,
+			Ctx:         ctx,
+			WarningTime: warningTime,
+			ErrorTime:   errorTime,
+		})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.subVolumeStatus = subVolumeStatus
+	subVolumeStatus.Activate()
 }
 
 func handleNodeAgentStatusCreate(ctxArg interface{}, key string,

--- a/pkg/pillar/cmd/baseosmgr/dobaseos_test.go
+++ b/pkg/pillar/cmd/baseosmgr/dobaseos_test.go
@@ -107,6 +107,10 @@ func TestDoBaseOsStatusUpdate_AlreadyInOtherPartition_DeactivatedPath(t *testing
 	}
 }
 
+// TestDoBaseOsStatusUpdate_RejectsKubeMixSwitch covers the conservative
+// arm: volumeStateKnown is false, so the volume set is treated as
+// possibly non-empty and kvm -> EVE-k is refused whatever the
+// subscriptions hold.
 func TestDoBaseOsStatusUpdate_RejectsKubeMixSwitch(t *testing.T) {
 	tc := newTestCtx(t)
 	tc.pubZbootStatus.items["IMGA"] = types.ZbootStatus{
@@ -133,6 +137,104 @@ func TestDoBaseOsStatusUpdate_RejectsKubeMixSwitch(t *testing.T) {
 	}
 	if !strings.Contains(st.Error, "EVE-k") {
 		t.Fatalf("error text doesn't mention EVE-k: %q", st.Error)
+	}
+}
+
+// seedKubeMixSwitch prepares a kvm -> EVE-k cross-flavor update: IMGA
+// active on a kvm version, IMGB unused, and a config naming an EVE-k
+// version. No ContentTreeStatus is seeded, so a config that clears the
+// cross-flavor gate stops in checkBaseOsVolumeStatus without an error
+// and the assertions isolate the gate.
+func (tc *testCtx) seedKubeMixSwitch() (types.BaseOsConfig, types.BaseOsStatus) {
+	tc.pubZbootStatus.items["IMGA"] = types.ZbootStatus{
+		PartitionLabel: "IMGA", PartitionState: "active", ShortVersion: "13-kvm",
+	}
+	tc.pubZbootStatus.items["IMGB"] = types.ZbootStatus{
+		PartitionLabel: "IMGB", PartitionState: "unused",
+	}
+	tc.currentIsKube = false
+	tc.versionIsKube = map[string]bool{"14-k": true}
+	cfg := types.BaseOsConfig{
+		BaseOsVersion:   "14-k",
+		ContentTreeUUID: "uuid-x",
+		Activate:        true,
+	}
+	return cfg, types.BaseOsStatus{ContentTreeUUID: "uuid-x"}
+}
+
+func TestDoBaseOsStatusUpdate_AllowsKubeSwitchWithoutVolumes(t *testing.T) {
+	tc := newTestCtx(t)
+	cfg, st := tc.seedKubeMixSwitch()
+	tc.ctx.volumeStateKnown = true
+
+	doBaseOsStatusUpdate(tc.ctx, "uuid-x", cfg, &st)
+	if st.HasError() {
+		t.Fatalf("kvm -> EVE-k with no volumes must not be refused: %q", st.Error)
+	}
+}
+
+func TestDoBaseOsStatusUpdate_RejectsKubeSwitchWithVolumes(t *testing.T) {
+	tests := []struct {
+		name  string
+		place func(tc *testCtx)
+	}{
+		{
+			name: "VolumeConfig",
+			place: func(tc *testCtx) {
+				tc.subVolumeConfig.items["vol-1"] = types.VolumeConfig{}
+			},
+		},
+		{
+			name: "VolumeStatus",
+			place: func(tc *testCtx) {
+				tc.subVolumeStatus.items["vol-1"] = types.VolumeStatus{}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := newTestCtx(t)
+			cfg, st := tc.seedKubeMixSwitch()
+			tc.ctx.volumeStateKnown = true
+			tt.place(tc)
+
+			changed := doBaseOsStatusUpdate(tc.ctx, "uuid-x", cfg, &st)
+			if !changed || !st.HasError() {
+				t.Fatalf("expected reject: changed=%v err=%q", changed, st.Error)
+			}
+			if !strings.Contains(st.Error, "while volumes exist") {
+				t.Fatalf("error text doesn't name the volume gate: %q", st.Error)
+			}
+		})
+	}
+}
+
+// The EVE-k -> kvm direction is refused whether or not volumes exist:
+// a vault migrated to the EVE-k zvol layout has no path back.
+func TestDoBaseOsStatusUpdate_RejectsKubeToKvmWithoutVolumes(t *testing.T) {
+	tc := newTestCtx(t)
+	tc.pubZbootStatus.items["IMGA"] = types.ZbootStatus{
+		PartitionLabel: "IMGA", PartitionState: "active", ShortVersion: "13-k",
+	}
+	tc.pubZbootStatus.items["IMGB"] = types.ZbootStatus{
+		PartitionLabel: "IMGB", PartitionState: "unused",
+	}
+	tc.currentIsKube = true
+	tc.versionIsKube = map[string]bool{"14-kvm": false}
+	tc.ctx.volumeStateKnown = true
+
+	cfg := types.BaseOsConfig{
+		BaseOsVersion:   "14-kvm",
+		ContentTreeUUID: "uuid-x",
+		Activate:        true,
+	}
+	st := types.BaseOsStatus{ContentTreeUUID: "uuid-x"}
+	changed := doBaseOsStatusUpdate(tc.ctx, "uuid-x", cfg, &st)
+	if !changed || !st.HasError() {
+		t.Fatalf("expected reject: changed=%v err=%q", changed, st.Error)
+	}
+	if !strings.Contains(st.Error, "from EVE-k") {
+		t.Fatalf("error text doesn't name the direction: %q", st.Error)
 	}
 }
 

--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -214,20 +214,24 @@ func doBaseOsStatusUpdate(ctx *baseOsMgrContext, uuidStr string,
 
 	// Check to avoid upgrading from not-EVE-k (e.g., kvm) to EVE-k
 	// and vice versa since that can result in odd failures due to
-	// different /persist layout etc.
+	// different /persist layout etc. The block only applies when the
+	// device has volume instances — without them there is no
+	// /persist/vault/volumes/ state to disturb.
 	// TBD Remove this if EVE-k in the future can have kvm personality.
+	hasVolumes := len(ctx.subVolumeConfig.GetAll()) > 0 ||
+		len(ctx.subVolumeStatus.GetAll()) > 0
 	isCurrentKube := base.IsHVTypeKube()
 	isUpdateKube, err := base.IsVersionHVTypeKube(config.BaseOsVersion)
 	if err != nil {
 		log.Warnf("doBaseOsStatusUpdate(%s): %s",
 			config.BaseOsVersion, err)
-	} else if isCurrentKube != isUpdateKube {
+	} else if isCurrentKube != isUpdateKube && hasVolumes {
 		var errString string
 		if isUpdateKube {
-			errString = fmt.Sprintf("Upgrade to EVE-k (%s) from non EVE-k (%s) is not supported",
+			errString = fmt.Sprintf("Upgrade to EVE-k (%s) from non EVE-k (%s) is not supported while volumes exist",
 				config.BaseOsVersion, shortVerCurPart)
 		} else {
-			errString = fmt.Sprintf("Upgrade to non EVE-k (%s) from  EVE-k (%s) is not supported",
+			errString = fmt.Sprintf("Upgrade to non EVE-k (%s) from EVE-k (%s) is not supported while volumes exist",
 				config.BaseOsVersion, shortVerCurPart)
 		}
 		log.Error(errString)

--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -213,19 +213,33 @@ func doBaseOsStatusUpdate(ctx *baseOsMgrContext, uuidStr string,
 	// Check to avoid upgrading from not-EVE-k (e.g., kvm) to EVE-k
 	// and vice versa since that can result in odd failures due to
 	// different /persist layout etc.
+	// The block is asymmetric because the two directions are not
+	// symmetric in what they can disturb:
+	//   - kvm -> EVE-k is allowed when no volume instances exist; without
+	//     them there is no /persist/vault/volumes/ state to disturb.
+	//   - EVE-k -> kvm is always blocked: once the vault has been migrated
+	//     to the EVE-k zvol layout there is no back-migration to a kvm
+	//     filesystem dataset, and EVE-kvm cannot read a zvol-backed vault.
 	// TBD Remove this if EVE-k in the future can have kvm personality.
+	// Until volumeStateKnown is true (both volume publishers have signalled
+	// restart), the sets below may be incomplete, so treat the volume state
+	// as if volumes exist — keep the kvm->EVE-k block conservative rather
+	// than potentially wiping existing volumes.
+	hasVolumes := !ctx.volumeStateKnown ||
+		len(ctx.subVolumeConfig.GetAll()) > 0 ||
+		len(ctx.subVolumeStatus.GetAll()) > 0
 	isCurrentKube := ctx.seams.isHVTypeKube()
 	isUpdateKube, err := ctx.seams.isVersionHVTypeKube(config.BaseOsVersion)
 	if err != nil {
 		log.Warnf("doBaseOsStatusUpdate(%s): %s",
 			config.BaseOsVersion, err)
-	} else if isCurrentKube != isUpdateKube {
+	} else if isCurrentKube != isUpdateKube && (isCurrentKube || hasVolumes) {
 		var errString string
 		if isUpdateKube {
-			errString = fmt.Sprintf("Upgrade to EVE-k (%s) from non EVE-k (%s) is not supported",
+			errString = fmt.Sprintf("Upgrade to EVE-k (%s) from non EVE-k (%s) is not supported while volumes exist",
 				config.BaseOsVersion, shortVerCurPart)
 		} else {
-			errString = fmt.Sprintf("Upgrade to non EVE-k (%s) from  EVE-k (%s) is not supported",
+			errString = fmt.Sprintf("Upgrade to non EVE-k (%s) from EVE-k (%s) is not supported",
 				config.BaseOsVersion, shortVerCurPart)
 		}
 		log.Error(errString)

--- a/pkg/pillar/cmd/baseosmgr/mocks_test.go
+++ b/pkg/pillar/cmd/baseosmgr/mocks_test.go
@@ -241,6 +241,8 @@ type testCtx struct {
 	pubNodeDrainRequest  *mockPubSub
 	subBaseOsConfig      *mockPubSub
 	subContentTreeStatus *mockPubSub
+	subVolumeConfig      *mockPubSub
+	subVolumeStatus      *mockPubSub
 	subZbootConfig       *mockPubSub
 	subNodeAgentStatus   *mockPubSub
 	subZedAgentStatus    *mockPubSub
@@ -269,7 +271,10 @@ type testCtx struct {
 // mock publications/subscriptions, default global config, paths
 // pointed at a per-test temporary directory so counter persistence
 // doesn't touch /persist/, and a mockZboot defaulting to IMGA=active /
-// IMGB=unused.
+// IMGB=unused. The volume subscriptions start empty and
+// volumeStateKnown false, i.e. on the conservative arm of the
+// cross-flavor gate; a test exercising the volume set must set
+// volumeStateKnown itself.
 func newTestCtx(t *testing.T) *testCtx {
 	t.Helper()
 	initTestLog()
@@ -281,6 +286,8 @@ func newTestCtx(t *testing.T) *testCtx {
 		pubNodeDrainRequest:  newMockPubSub(),
 		subBaseOsConfig:      newMockPubSub(),
 		subContentTreeStatus: newMockPubSub(),
+		subVolumeConfig:      newMockPubSub(),
+		subVolumeStatus:      newMockPubSub(),
 		subZbootConfig:       newMockPubSub(),
 		subNodeAgentStatus:   newMockPubSub(),
 		subZedAgentStatus:    newMockPubSub(),
@@ -304,6 +311,8 @@ func newTestCtx(t *testing.T) *testCtx {
 		pubNodeDrainRequest:  tc.pubNodeDrainRequest,
 		subBaseOsConfig:      tc.subBaseOsConfig,
 		subContentTreeStatus: tc.subContentTreeStatus,
+		subVolumeConfig:      tc.subVolumeConfig,
+		subVolumeStatus:      tc.subVolumeStatus,
 		subZbootConfig:       tc.subZbootConfig,
 		subNodeAgentStatus:   tc.subNodeAgentStatus,
 		subZedAgentStatus:    tc.subZedAgentStatus,

--- a/pkg/pillar/cmd/upgradeconverter/containerd_namespace.go
+++ b/pkg/pillar/cmd/upgradeconverter/containerd_namespace.go
@@ -1,0 +1,249 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgradeconverter
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	bolt "go.etcd.io/bbolt"
+)
+
+// portContainerdNamespaceForKube ports user-containerd content-blob metadata
+// records from the EVE-kvm namespace ("eve-user-apps") to the EVE-k namespace
+// ("k8s.io") in the user containerd's bolt metadata DB.
+//
+// Why: pillar's containerd client switches its namespace from "eve-user-apps"
+// to "k8s.io" on EVE-k boot (see pkg/pillar/containerd/containerd.go init()).
+// The user containerd's content store at /persist/vault/containerd survives
+// the kvm->k upgrade — blob files at .../sha256/<digest> are intact and the
+// bolt metadata DB still records them — but only under "eve-user-apps". From
+// pillar's "k8s.io" view the store appears empty, so any ContentTree it tries
+// to process triggers a full re-download from the registry, overwriting the
+// on-disk blob with bit-identical content.
+//
+// This handler runs in the post-vault phase, after /persist/vault is decrypted
+// but before the user containerd has been started (k3s starts it later via
+// pkg/kube/cluster-init.sh). With containerd idle, it is safe to mutate the
+// bolt DB directly.
+//
+// The port is metadata-only: each blob record under v1/eve-user-apps/content/
+// blob/<digest>/ gets copied into v1/k8s.io/content/blob/<digest>/. No HTTP
+// fetch, no blob copy. Idempotent — skips digests already present in the
+// destination namespace. A sentinel file at /persist/vault/containerd/
+// .eve-namespace-port-done short-circuits subsequent boots.
+//
+// No-op on EVE-kvm (only relevant on the post-upgrade EVE-k boot).
+func portContainerdNamespaceForKube(ctx *ucContext) error {
+	if !base.IsHVTypeKube() {
+		log.Functionf("portContainerdNamespaceForKube: not EVE-k, skipping")
+		return nil
+	}
+	return portContainerdNamespace(
+		userContainerdBoltDBPath(ctx.persistDir),
+		userContainerdPortSentinelPath(ctx.persistDir),
+		ctrdKvmNamespace, ctrdKubeNamespace)
+}
+
+// userContainerdBoltDBPath returns the path of the user containerd's bolt
+// metadata DB. containerd's metadata plugin stores it at
+// <root>/io.containerd.metadata.v1.bolt/meta.db — note that the
+// io.containerd.metadata.v1.bolt component is a *directory* (the plugin's
+// own root), not the bolt file itself. Verified on
+// /persist/vault/containerd/io.containerd.metadata.v1.bolt/meta.db in
+// EVE 16.x; matches containerd 1.x's metadata.Plugin layout.
+func userContainerdBoltDBPath(persistDir string) string {
+	return filepath.Join(persistDir, "vault", "containerd",
+		"io.containerd.metadata.v1.bolt", "meta.db")
+}
+
+// userContainerdPortSentinelPath returns the path of the sentinel file that
+// records whether the namespace port has already run.
+func userContainerdPortSentinelPath(persistDir string) string {
+	return filepath.Join(persistDir, "vault", "containerd",
+		".eve-namespace-port-done")
+}
+
+// Pillar's user-containerd namespace names. Mirror the constants in
+// pkg/pillar/containerd/containerd.go (ctrdServicesNamespace,
+// ctrdKubeServicesNamespace) — duplicated here to avoid an import cycle
+// (the containerd package depends on types/pubsub, which this package
+// also uses, and pulling in containerd here would also drag in the
+// containerd client library at upgradeconverter link time).
+const (
+	ctrdKvmNamespace  = "eve-user-apps"
+	ctrdKubeNamespace = "k8s.io"
+)
+
+// portContainerdNamespace is the testable core: open the bolt DB at dbPath,
+// copy content/blob and images records from the kvm namespace to the kube
+// namespace, and write a sentinel at sentinelPath on success. If the
+// sentinel already exists, this is a no-op. If the DB does not exist, the
+// sentinel is written and no other work is done.
+//
+// We port TWO buckets, not just blobs:
+//   - v1/<ns>/content/blob/<digest> — the blob metadata (labels carry GC
+//     refs and the EVEDownloadedLabel pillar checks).
+//   - v1/<ns>/images/<ref>         — pillar's CAS treats images as the GC
+//     roots and as the source of digest→mediaType lookups. Pillar's
+//     populateInitBlobStatus() (cmd/volumemgr/blob.go) gets media types
+//     by walking images via ListBlobsMediaTypes() (cas/containerd.go:170),
+//     not blobs directly. Without the images bucket, blobs are visible
+//     but their media types are unknown, so populateInitBlobStatus
+//     skips them with "could not get mediaType" — the same end result
+//     as if they weren't ported at all (re-download).
+func portContainerdNamespace(dbPath, sentinelPath, fromNamespace, toNamespace string) error {
+	const schemaVersion = "v1"
+	if _, err := os.Stat(sentinelPath); err == nil {
+		log.Functionf("portContainerdNamespace: sentinel %s exists, skipping",
+			sentinelPath)
+		return nil
+	}
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		// Fresh install — no prior kvm boot left a bolt DB. Mark done so we
+		// don't probe every boot.
+		log.Noticef("portContainerdNamespace: %s does not exist (fresh install); marking done",
+			dbPath)
+		return writeSentinel(sentinelPath)
+	} else if err != nil {
+		return fmt.Errorf("portContainerdNamespace: stat %s: %w", dbPath, err)
+	}
+
+	db, err := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: 5 * time.Second})
+	if err != nil {
+		return fmt.Errorf("portContainerdNamespace: open %s: %w", dbPath, err)
+	}
+	defer db.Close()
+
+	type subPath struct {
+		// Path components from the namespace bucket down to the bucket
+		// whose direct children we walk (one bucket per key).
+		path []string
+		// Human name used in log messages.
+		label string
+	}
+	subPaths := []subPath{
+		{path: []string{"content", "blob"}, label: "blob"},
+		{path: []string{"images"}, label: "image"},
+	}
+
+	totals := map[string][2]int{} // label → {ported, skipped}
+	err = db.Update(func(tx *bolt.Tx) error {
+		v1 := tx.Bucket([]byte(schemaVersion))
+		if v1 == nil {
+			log.Noticef("portContainerdNamespace: schema bucket %q absent; nothing to port",
+				schemaVersion)
+			return nil
+		}
+		src := v1.Bucket([]byte(fromNamespace))
+		if src == nil {
+			log.Noticef("portContainerdNamespace: source namespace %q absent; nothing to port",
+				fromNamespace)
+			return nil
+		}
+		dst, err := v1.CreateBucketIfNotExists([]byte(toNamespace))
+		if err != nil {
+			return fmt.Errorf("create %q namespace: %w", toNamespace, err)
+		}
+		for _, sp := range subPaths {
+			ported, skipped, err := portSubBucket(src, dst, sp.path, sp.label)
+			if err != nil {
+				return err
+			}
+			totals[sp.label] = [2]int{ported, skipped}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("portContainerdNamespace: %w", err)
+	}
+
+	for _, sp := range subPaths {
+		t := totals[sp.label]
+		log.Noticef("portContainerdNamespace: ported %d %s record(s) from %q to %q (%d already present)",
+			t[0], sp.label, fromNamespace, toNamespace, t[1])
+	}
+	return writeSentinel(sentinelPath)
+}
+
+// portSubBucket walks src/<path...>/<key> and copies each <key>'s sub-bucket
+// (recursively, including the labels/ sub-bucket containerd uses for GC refs
+// and the EVEDownloadedLabel) into dst/<path...>/<key>. Returns ported and
+// skipped counts. If the source path doesn't exist, returns (0,0,nil) — the
+// namespace may legitimately have only blobs or only images.
+func portSubBucket(src, dst *bolt.Bucket, path []string, label string) (int, int, error) {
+	cur := src
+	for _, p := range path {
+		next := cur.Bucket([]byte(p))
+		if next == nil {
+			log.Functionf("portSubBucket: source has no %s/%s bucket; nothing to port",
+				path[0], label)
+			return 0, 0, nil
+		}
+		cur = next
+	}
+	srcLeaf := cur
+	dstCur := dst
+	for _, p := range path {
+		next, err := dstCur.CreateBucketIfNotExists([]byte(p))
+		if err != nil {
+			return 0, 0, fmt.Errorf("create dst %s: %w", p, err)
+		}
+		dstCur = next
+	}
+	dstLeaf := dstCur
+	var ported, skipped int
+	err := srcLeaf.ForEach(func(key, _ []byte) error {
+		if dstLeaf.Bucket(key) != nil {
+			skipped++
+			return nil
+		}
+		srcSub := srcLeaf.Bucket(key)
+		if srcSub == nil {
+			// Unexpected key shape — skip, don't fail the whole port.
+			return nil
+		}
+		dstSub, err := dstLeaf.CreateBucket(key)
+		if err != nil {
+			return fmt.Errorf("create dst %s bucket %s: %w", label, key, err)
+		}
+		if err := copyBucket(srcSub, dstSub); err != nil {
+			return fmt.Errorf("copy %s %s: %w", label, key, err)
+		}
+		ported++
+		return nil
+	})
+	return ported, skipped, err
+}
+
+// copyBucket copies every key/value pair from src into dst, recursing into
+// sub-buckets. dst is expected to be freshly created and empty.
+func copyBucket(src, dst *bolt.Bucket) error {
+	return src.ForEach(func(k, v []byte) error {
+		if v == nil {
+			// Sub-bucket
+			srcSub := src.Bucket(k)
+			if srcSub == nil {
+				return nil
+			}
+			dstSub, err := dst.CreateBucket(k)
+			if err != nil {
+				return fmt.Errorf("create sub-bucket %s: %w", k, err)
+			}
+			return copyBucket(srcSub, dstSub)
+		}
+		return dst.Put(k, v)
+	})
+}
+
+func writeSentinel(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("write sentinel %s: %w", path, err)
+	}
+	return f.Close()
+}

--- a/pkg/pillar/cmd/upgradeconverter/containerd_namespace_test.go
+++ b/pkg/pillar/cmd/upgradeconverter/containerd_namespace_test.go
@@ -1,0 +1,534 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgradeconverter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	bolt "go.etcd.io/bbolt"
+)
+
+const (
+	tFrom = "eve-user-apps"
+	tTo   = "k8s.io"
+)
+
+// initTestLog wires the package-level log var so log.Noticef etc. don't NPE.
+// Mirrors the pattern in upgradeconverter_test.go.
+func initTestLog() {
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
+}
+
+// seedSourceBlobs creates a bolt DB at dbPath with the supplied blob digests
+// in the source namespace. Each blob bucket gets a `size` key and a
+// `labels/category` sub-bucket entry so the recursive copy path is exercised.
+func seedSourceBlobs(t *testing.T, dbPath string, digests []string) {
+	t.Helper()
+	db, err := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("seedSourceBlobs: open: %v", err)
+	}
+	defer db.Close()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		v1, _ := tx.CreateBucketIfNotExists([]byte("v1"))
+		ns, _ := v1.CreateBucketIfNotExists([]byte(tFrom))
+		content, _ := ns.CreateBucketIfNotExists([]byte("content"))
+		blob, _ := content.CreateBucketIfNotExists([]byte("blob"))
+		for _, d := range digests {
+			b, err := blob.CreateBucket([]byte(d))
+			if err != nil {
+				return err
+			}
+			if err := b.Put([]byte("size"), []byte("1234")); err != nil {
+				return err
+			}
+			labels, err := b.CreateBucket([]byte("labels"))
+			if err != nil {
+				return err
+			}
+			if err := labels.Put([]byte("category"), []byte("test")); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seedSourceBlobs: update: %v", err)
+	}
+}
+
+// destBlobDigests returns the set of digests present in the destination
+// namespace's content/blob bucket.
+func destBlobDigests(t *testing.T, dbPath string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	db, err := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: 5 * time.Second, ReadOnly: true})
+	if err != nil {
+		t.Fatalf("destBlobDigests: open: %v", err)
+	}
+	defer db.Close()
+	_ = db.View(func(tx *bolt.Tx) error {
+		v1 := tx.Bucket([]byte("v1"))
+		if v1 == nil {
+			return nil
+		}
+		ns := v1.Bucket([]byte(tTo))
+		if ns == nil {
+			return nil
+		}
+		content := ns.Bucket([]byte("content"))
+		if content == nil {
+			return nil
+		}
+		blob := content.Bucket([]byte("blob"))
+		if blob == nil {
+			return nil
+		}
+		return blob.ForEach(func(k, _ []byte) error {
+			out[string(k)] = true
+			return nil
+		})
+	})
+	return out
+}
+
+// seedSourceImages creates an images sub-bucket under the source namespace
+// with the supplied image refs. Each image gets a target/digest key and an
+// EVEDownloadedLabel in its labels/ sub-bucket — mirrors what pillar's
+// cas.CreateImage() writes.
+func seedSourceImages(t *testing.T, dbPath string, imageRefs []string) {
+	t.Helper()
+	db, err := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("seedSourceImages: open: %v", err)
+	}
+	defer db.Close()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		v1, _ := tx.CreateBucketIfNotExists([]byte("v1"))
+		ns, _ := v1.CreateBucketIfNotExists([]byte(tFrom))
+		images, _ := ns.CreateBucketIfNotExists([]byte("images"))
+		for _, ref := range imageRefs {
+			ib, err := images.CreateBucket([]byte(ref))
+			if err != nil {
+				return err
+			}
+			tgt, _ := ib.CreateBucket([]byte("target"))
+			_ = tgt.Put([]byte("digest"), []byte("sha256:adda3d3f"))
+			_ = tgt.Put([]byte("mediatype"), []byte("application/vnd.oci.image.manifest.v1+json"))
+			labels, _ := ib.CreateBucket([]byte("labels"))
+			_ = labels.Put([]byte("eve-downloaded"), []byte("true"))
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seedSourceImages: update: %v", err)
+	}
+}
+
+// destImageRefs returns the set of image refs present in dst namespace.
+func destImageRefs(t *testing.T, dbPath string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	db, err := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: 5 * time.Second, ReadOnly: true})
+	if err != nil {
+		t.Fatalf("destImageRefs: open: %v", err)
+	}
+	defer db.Close()
+	_ = db.View(func(tx *bolt.Tx) error {
+		v1 := tx.Bucket([]byte("v1"))
+		if v1 == nil {
+			return nil
+		}
+		ns := v1.Bucket([]byte(tTo))
+		if ns == nil {
+			return nil
+		}
+		images := ns.Bucket([]byte("images"))
+		if images == nil {
+			return nil
+		}
+		return images.ForEach(func(k, _ []byte) error {
+			out[string(k)] = true
+			return nil
+		})
+	})
+	return out
+}
+
+// destImageLabel reads dst namespace's images/<ref>/labels/<key>.
+func destImageLabel(t *testing.T, dbPath, ref, key string) string {
+	t.Helper()
+	var val string
+	db, err := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: 5 * time.Second, ReadOnly: true})
+	if err != nil {
+		t.Fatalf("destImageLabel: open: %v", err)
+	}
+	defer db.Close()
+	_ = db.View(func(tx *bolt.Tx) error {
+		v1 := tx.Bucket([]byte("v1"))
+		img := v1.Bucket([]byte(tTo)).Bucket([]byte("images")).Bucket([]byte(ref))
+		if img == nil {
+			return nil
+		}
+		labels := img.Bucket([]byte("labels"))
+		if labels == nil {
+			return nil
+		}
+		if v := labels.Get([]byte(key)); v != nil {
+			val = string(v)
+		}
+		return nil
+	})
+	return val
+}
+
+// destImageTarget reads dst namespace's images/<ref>/target/<key>.
+func destImageTarget(t *testing.T, dbPath, ref, key string) string {
+	t.Helper()
+	var val string
+	db, err := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: 5 * time.Second, ReadOnly: true})
+	if err != nil {
+		t.Fatalf("destImageTarget: open: %v", err)
+	}
+	defer db.Close()
+	_ = db.View(func(tx *bolt.Tx) error {
+		v1 := tx.Bucket([]byte("v1"))
+		img := v1.Bucket([]byte(tTo)).Bucket([]byte("images")).Bucket([]byte(ref))
+		if img == nil {
+			return nil
+		}
+		tgt := img.Bucket([]byte("target"))
+		if tgt == nil {
+			return nil
+		}
+		if v := tgt.Get([]byte(key)); v != nil {
+			val = string(v)
+		}
+		return nil
+	})
+	return val
+}
+
+// destBlobLabel reads the destination's <digest>/labels/<key> for verification.
+func destBlobLabel(t *testing.T, dbPath, digest, key string) string {
+	t.Helper()
+	var val string
+	db, err := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: 5 * time.Second, ReadOnly: true})
+	if err != nil {
+		t.Fatalf("destBlobLabel: open: %v", err)
+	}
+	defer db.Close()
+	_ = db.View(func(tx *bolt.Tx) error {
+		v1 := tx.Bucket([]byte("v1"))
+		ns := v1.Bucket([]byte(tTo))
+		blob := ns.Bucket([]byte("content")).Bucket([]byte("blob")).Bucket([]byte(digest))
+		if blob == nil {
+			return nil
+		}
+		labels := blob.Bucket([]byte("labels"))
+		if labels == nil {
+			return nil
+		}
+		v := labels.Get([]byte(key))
+		if v != nil {
+			val = string(v)
+		}
+		return nil
+	})
+	return val
+}
+
+func TestPortContainerdNamespace_SentinelShortCircuits(t *testing.T) {
+	initTestLog()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "bolt.db")
+	sentinel := filepath.Join(dir, "done")
+	// Pre-create the sentinel.
+	if err := os.WriteFile(sentinel, nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Also create a bolt DB with seeded data; we expect it untouched.
+	seedSourceBlobs(t, dbPath, []string{"sha256:aaa"})
+
+	err := portContainerdNamespace(dbPath, sentinel, tFrom, tTo)
+	assert.NoError(t, err)
+	// Destination must remain empty — port did not run.
+	assert.Empty(t, destBlobDigests(t, dbPath))
+}
+
+func TestPortContainerdNamespace_FreshInstallNoDB(t *testing.T) {
+	initTestLog()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "bolt.db")
+	sentinel := filepath.Join(dir, "done")
+	// dbPath does NOT exist.
+
+	err := portContainerdNamespace(dbPath, sentinel, tFrom, tTo)
+	assert.NoError(t, err)
+	// Sentinel must be written so we don't probe every boot.
+	_, statErr := os.Stat(sentinel)
+	assert.NoError(t, statErr, "sentinel should be created on fresh-install path")
+	// And the DB itself should still not exist (we didn't create it).
+	_, statErr = os.Stat(dbPath)
+	assert.True(t, os.IsNotExist(statErr), "must not create the DB ourselves")
+}
+
+func TestPortContainerdNamespace_DBExistsNoSchema(t *testing.T) {
+	initTestLog()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "bolt.db")
+	sentinel := filepath.Join(dir, "done")
+	// Create an empty DB (no v1 bucket).
+	db, err := bolt.Open(dbPath, 0600, nil)
+	assert.NoError(t, err)
+	db.Close()
+
+	err = portContainerdNamespace(dbPath, sentinel, tFrom, tTo)
+	assert.NoError(t, err)
+	_, statErr := os.Stat(sentinel)
+	assert.NoError(t, statErr)
+	assert.Empty(t, destBlobDigests(t, dbPath))
+}
+
+func TestPortContainerdNamespace_NoSourceNamespace(t *testing.T) {
+	initTestLog()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "bolt.db")
+	sentinel := filepath.Join(dir, "done")
+	// Create a v1 bucket but no eve-user-apps namespace.
+	db, err := bolt.Open(dbPath, 0600, nil)
+	assert.NoError(t, err)
+	assert.NoError(t, db.Update(func(tx *bolt.Tx) error {
+		_, e := tx.CreateBucketIfNotExists([]byte("v1"))
+		return e
+	}))
+	db.Close()
+
+	err = portContainerdNamespace(dbPath, sentinel, tFrom, tTo)
+	assert.NoError(t, err)
+	_, statErr := os.Stat(sentinel)
+	assert.NoError(t, statErr)
+	assert.Empty(t, destBlobDigests(t, dbPath))
+}
+
+func TestPortContainerdNamespace_HappyPath(t *testing.T) {
+	initTestLog()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "bolt.db")
+	sentinel := filepath.Join(dir, "done")
+	digests := []string{
+		"sha256:587eecb3b19b7369b22aa6276c2663162f0c7d869fa315462fe7829e8aa8725c",
+		"sha256:da570fff24b1cb07f0e430b3969e16d8dc819501b48307163e9a331b3a437acf",
+		"sha256:adda3d3f34fd86576e7b29ddbfe98a0d98f14b9681820055a45f177e8727d40f",
+	}
+	seedSourceBlobs(t, dbPath, digests)
+
+	err := portContainerdNamespace(dbPath, sentinel, tFrom, tTo)
+	assert.NoError(t, err)
+	// Sentinel written.
+	_, statErr := os.Stat(sentinel)
+	assert.NoError(t, statErr)
+	// All 3 ported.
+	got := destBlobDigests(t, dbPath)
+	for _, d := range digests {
+		assert.True(t, got[d], "digest %q should be in dest", d)
+	}
+	assert.Len(t, got, len(digests))
+	// Labels sub-bucket was copied recursively.
+	for _, d := range digests {
+		assert.Equal(t, "test", destBlobLabel(t, dbPath, d, "category"),
+			"labels sub-bucket should have been copied for %q", d)
+	}
+}
+
+func TestPortContainerdNamespace_IdempotentPartialDestination(t *testing.T) {
+	initTestLog()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "bolt.db")
+	sentinel := filepath.Join(dir, "done")
+	srcDigests := []string{
+		"sha256:aaa", "sha256:bbb", "sha256:ccc",
+	}
+	seedSourceBlobs(t, dbPath, srcDigests)
+	// Pre-populate destination with one digest (different label value, so
+	// we can verify it was NOT overwritten).
+	db, err := bolt.Open(dbPath, 0600, nil)
+	assert.NoError(t, err)
+	assert.NoError(t, db.Update(func(tx *bolt.Tx) error {
+		v1 := tx.Bucket([]byte("v1"))
+		dst, _ := v1.CreateBucketIfNotExists([]byte(tTo))
+		c, _ := dst.CreateBucketIfNotExists([]byte("content"))
+		b, _ := c.CreateBucketIfNotExists([]byte("blob"))
+		existing, _ := b.CreateBucket([]byte("sha256:aaa"))
+		l, _ := existing.CreateBucket([]byte("labels"))
+		return l.Put([]byte("category"), []byte("preexisting"))
+	}))
+	db.Close()
+
+	err = portContainerdNamespace(dbPath, sentinel, tFrom, tTo)
+	assert.NoError(t, err)
+	got := destBlobDigests(t, dbPath)
+	assert.Len(t, got, 3, "all 3 digests should now be in dest")
+	// The preexisting entry must NOT have been overwritten.
+	assert.Equal(t, "preexisting", destBlobLabel(t, dbPath, "sha256:aaa", "category"),
+		"existing destination record should be left untouched")
+	// The freshly-ported entries should have the seeded value.
+	assert.Equal(t, "test", destBlobLabel(t, dbPath, "sha256:bbb", "category"))
+	assert.Equal(t, "test", destBlobLabel(t, dbPath, "sha256:ccc", "category"))
+}
+
+// TestPortContainerdNamespace_RealOnDevicePathLayout exercises the actual
+// on-device path layout: a persistDir whose vault/containerd/ subtree
+// contains an io.containerd.metadata.v1.bolt/ DIRECTORY (containerd 1.x's
+// metadata-plugin layout), with the bolt meta.db file INSIDE that
+// directory. Regression guard against the v8 bug where the converter
+// constructed dbPath = .../io.containerd.metadata.v1.bolt (the dir) and
+// bolt.Open failed with EISDIR, silently no-op'ing the whole port and
+// leaving the sentinel un-written.
+func TestPortContainerdNamespace_RealOnDevicePathLayout(t *testing.T) {
+	initTestLog()
+	dir := t.TempDir()
+	// Mirror the on-device tree under /persist/.
+	dbDir := filepath.Join(dir, "vault", "containerd",
+		"io.containerd.metadata.v1.bolt")
+	if err := os.MkdirAll(dbDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := userContainerdBoltDBPath(dir)
+	sentinelPath := userContainerdPortSentinelPath(dir)
+	// Confirm path helpers point at the expected on-device layout.
+	assert.Equal(t,
+		filepath.Join(dir, "vault", "containerd",
+			"io.containerd.metadata.v1.bolt", "meta.db"),
+		dbPath)
+	assert.Equal(t,
+		filepath.Join(dir, "vault", "containerd",
+			".eve-namespace-port-done"),
+		sentinelPath)
+	// Seed the meta.db file with source-namespace blobs.
+	seedSourceBlobs(t, dbPath, []string{"sha256:aaa", "sha256:bbb"})
+	// The dbPath we used above must really be a regular file, not a dir.
+	st, err := os.Stat(dbPath)
+	assert.NoError(t, err)
+	assert.False(t, st.IsDir(), "%s must be a file, not a dir", dbPath)
+
+	err = portContainerdNamespace(dbPath, sentinelPath, tFrom, tTo)
+	assert.NoError(t, err)
+	// Sentinel landed at the expected path under /persist/vault/containerd/.
+	_, statErr := os.Stat(sentinelPath)
+	assert.NoError(t, statErr)
+	// Records were ported.
+	got := destBlobDigests(t, dbPath)
+	assert.True(t, got["sha256:aaa"])
+	assert.True(t, got["sha256:bbb"])
+}
+
+// TestPortContainerdNamespace_PortsImages verifies the IMAGES bucket gets
+// copied alongside content/blob. Pillar's populateInitBlobStatus() depends
+// on ListBlobsMediaTypes() walking from IMAGES (cas/containerd.go:170) to
+// learn each blob's mediaType; without ported image entries, mediaTypes are
+// unknown and populateInitBlobStatus skips every blob — defeating the whole
+// purpose of porting the blob bucket. Regression guard against the v10 bug.
+func TestPortContainerdNamespace_PortsImages(t *testing.T) {
+	initTestLog()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "bolt.db")
+	sentinel := filepath.Join(dir, "done")
+	// Seed both blobs and images under the source namespace.
+	seedSourceBlobs(t, dbPath, []string{"sha256:aaa"})
+	seedSourceImages(t, dbPath, []string{
+		"docker.io/lfedge/eden-eclient:7a72275",
+		"docker.io/aaa-content/manifest",
+	})
+
+	err := portContainerdNamespace(dbPath, sentinel, tFrom, tTo)
+	assert.NoError(t, err)
+
+	// Both buckets ported.
+	gotBlobs := destBlobDigests(t, dbPath)
+	assert.True(t, gotBlobs["sha256:aaa"])
+
+	gotImages := destImageRefs(t, dbPath)
+	assert.True(t, gotImages["docker.io/lfedge/eden-eclient:7a72275"])
+	assert.True(t, gotImages["docker.io/aaa-content/manifest"])
+
+	// Image target/digest + target/mediatype are preserved (recursive copy
+	// into the target/ sub-bucket).
+	assert.Equal(t, "sha256:adda3d3f",
+		destImageTarget(t, dbPath, "docker.io/lfedge/eden-eclient:7a72275", "digest"))
+	assert.Equal(t, "application/vnd.oci.image.manifest.v1+json",
+		destImageTarget(t, dbPath, "docker.io/lfedge/eden-eclient:7a72275", "mediatype"))
+
+	// EVEDownloadedLabel on the image survives — pillar's hvTypeKube
+	// filter in populateInitBlobStatus blob.go:543 relies on this.
+	assert.Equal(t, "true",
+		destImageLabel(t, dbPath, "docker.io/lfedge/eden-eclient:7a72275", "eve-downloaded"))
+}
+
+// TestPortContainerdNamespace_BlobsOnlyNoImages exercises the case where the
+// source namespace has blob records but no images bucket (e.g. a freshly-
+// downloaded but not-yet-imported blob). Should port blobs cleanly with no
+// error.
+func TestPortContainerdNamespace_BlobsOnlyNoImages(t *testing.T) {
+	initTestLog()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "bolt.db")
+	sentinel := filepath.Join(dir, "done")
+	seedSourceBlobs(t, dbPath, []string{"sha256:bbb"})
+	// No seedSourceImages.
+
+	err := portContainerdNamespace(dbPath, sentinel, tFrom, tTo)
+	assert.NoError(t, err)
+	assert.True(t, destBlobDigests(t, dbPath)["sha256:bbb"])
+	assert.Empty(t, destImageRefs(t, dbPath))
+}
+
+// TestPortContainerdNamespace_ImagesOnlyNoBlobs exercises the symmetric case —
+// source has images but no blobs (unusual but possible if the test sequence
+// only manipulates images). Both bucket-port loops should tolerate either
+// side being absent.
+func TestPortContainerdNamespace_ImagesOnlyNoBlobs(t *testing.T) {
+	initTestLog()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "bolt.db")
+	sentinel := filepath.Join(dir, "done")
+	seedSourceImages(t, dbPath, []string{"docker.io/foo"})
+
+	err := portContainerdNamespace(dbPath, sentinel, tFrom, tTo)
+	assert.NoError(t, err)
+	assert.Empty(t, destBlobDigests(t, dbPath))
+	assert.True(t, destImageRefs(t, dbPath)["docker.io/foo"])
+}
+
+func TestPortContainerdNamespace_SecondRunIsNoop(t *testing.T) {
+	initTestLog()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "bolt.db")
+	sentinel := filepath.Join(dir, "done")
+	seedSourceBlobs(t, dbPath, []string{"sha256:aaa", "sha256:bbb"})
+
+	// First run: ports.
+	assert.NoError(t, portContainerdNamespace(dbPath, sentinel, tFrom, tTo))
+	firstSet := destBlobDigests(t, dbPath)
+	// Sentinel mtime captured.
+	st1, err := os.Stat(sentinel)
+	assert.NoError(t, err)
+
+	// Sleep one filesystem tick so a re-create would have a visibly newer mtime.
+	time.Sleep(10 * time.Millisecond)
+
+	// Second run: sentinel exists → must short-circuit, must not touch the DB
+	// or rewrite the sentinel.
+	assert.NoError(t, portContainerdNamespace(dbPath, sentinel, tFrom, tTo))
+	secondSet := destBlobDigests(t, dbPath)
+	assert.Equal(t, firstSet, secondSet, "second run must not change destination")
+	st2, err := os.Stat(sentinel)
+	assert.NoError(t, err)
+	assert.Equal(t, st1.ModTime(), st2.ModTime(),
+		"second run must not rewrite the sentinel file")
+}

--- a/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
+++ b/pkg/pillar/cmd/upgradeconverter/upgradeconverter.go
@@ -61,6 +61,10 @@ var postVaultconversionHandlers = []ConversionHandler{
 		description: "Move old files to user containerd",
 		handlerFunc: moveToUserContainerd,
 	},
+	{
+		description: "Port user-containerd namespace from eve-user-apps to k8s.io on EVE-k",
+		handlerFunc: portContainerdNamespaceForKube,
+	},
 }
 
 type ucContext struct {

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -226,6 +226,28 @@ func checkAndPublishVaultConfig(ctx *vaultMgrContext) (bool, bool) {
 	return vaultConfig.TpmKeyOnly, vaultSupported
 }
 
+// runVaultOp runs a vault setup, unlock or removal on a separate goroutine and
+// waits for it, refreshing the watchdog touch file while it runs. On EVE-k a
+// vault carried over from EVE-kvm is copied into a new zvol, so these
+// operations block for a time that scales with the vault contents, and the
+// libzfs and mount calls they make can neither be interrupted nor report
+// progress.
+func runVaultOp(ps *pubsub.PubSub, op func() error) error {
+	done := make(chan error, 1)
+	go func() { done <- op() }()
+
+	stillRunning := time.NewTicker(25 * time.Second)
+	defer stillRunning.Stop()
+	for {
+		select {
+		case err := <-done:
+			return err
+		case <-stillRunning.C:
+			ps.StillRunning(agentName, warningTime, errorTime)
+		}
+	}
+}
+
 // Run is the entrypoint for running vaultmgr as a standalone program
 func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int {
 	logger = loggerArg
@@ -348,7 +370,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		log.Noticef("about to setup the vault without TPM")
 	}
 	// if TPM available, this sets up the fscrypt and eventually calls FetchSealedVaultKey
-	if err := handler.SetupDefaultVault(); err != nil {
+	if err := runVaultOp(ps, handler.SetupDefaultVault); err != nil {
 		log.Errorf("SetupDefaultVault failed, err: %v", err)
 		// Local unseal failed. On a TPM device this is usually a PCR policy
 		// mismatch; record which PCRs differ so it is visible on VaultStatus and
@@ -556,7 +578,7 @@ func handleVaultKeyFromControllerImpl(ctxArg interface{}, key string,
 		}
 
 		log.Noticef("Sealed key in TPM, unlocking %s", types.DefaultVaultName)
-		err = handler.UnlockDefaultVault()
+		err = runVaultOp(ctx.ps, handler.UnlockDefaultVault)
 		if err != nil {
 			log.Errorf("Failed to unlock vault after receiving Controller key, %v",
 				err)
@@ -588,12 +610,12 @@ func handleVaultKeyFromControllerImpl(ctxArg interface{}, key string,
 		// which indicates that we receive no keys from the controller,
 		// than we cannot unlock the vault.
 		// Try to remove and re-create default vault now
-		if err := handler.RemoveDefaultVault(); err != nil {
+		if err := runVaultOp(ctx.ps, handler.RemoveDefaultVault); err != nil {
 			log.Errorf("Failed to remove vault after receiving dummy Controller key: %v", err)
 			return
 		}
 		log.Warnln("default vault removed")
-		if err := handler.SetupDefaultVault(); err != nil {
+		if err := runVaultOp(ctx.ps, handler.SetupDefaultVault); err != nil {
 			log.Errorf("SetupDefaultVault failed, err: %v", err)
 			getAndPublishAllVaultStatuses(ctx)
 			return

--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -537,6 +537,21 @@ func populateInitBlobStatus(ctx *volumemgrContext) {
 		log.Errorf("populateInitBlobStatus: exception while fetching existing media types from CAS: %v", err)
 		return
 	}
+	// In Kubevirt eve, we share the user containerd repository between eve
+	// and k3s. To avoid publishing BlobStatus for k3s/longhorn/etc. pod
+	// images, we filter blobs by the EVEDownloadedLabel that pillar's CAS
+	// sets at write time. The label is only set on manifest-shaped blobs
+	// (and on the named image), not on the individual layer blobs the
+	// manifest references. To recognize layer blobs as eve-owned we walk
+	// containerd.io/gc.ref.content.* labels transitively from each
+	// directly-labeled blob — those refs are how containerd's GC retains
+	// the layers, and they are the same set of blobs pillar pulled.
+	var eveOwnedDigests map[string]bool
+	if ctx.hvTypeKube {
+		eveOwnedDigests = transitivelyEVEDownloaded(blobInfoList)
+		log.Noticef("populateInitBlobStatus: %d blob(s) in CAS are eve-owned (directly labeled + transitively GC-referenced)",
+			len(eveOwnedDigests))
+	}
 	newBlobStatus := make([]*types.BlobStatus, 0)
 	for _, blobInfo := range blobInfoList {
 		mediaType, ok := mediaMap[blobInfo.Digest]
@@ -545,12 +560,8 @@ func populateInitBlobStatus(ctx *volumemgrContext) {
 			log.Functionf("populateInitBlobStatus: blob %s in CAS could not get mediaType", blobInfo.Digest)
 			continue
 		}
-		// In Kubevirt eve, we share same user containerd repository between eve and k3s containers.
-		// So volumemgr should ignore publishing blobs which are not downloaded through eve download mechanism
-		// In /run/volumemgr/BlobStatus we should only see the blobs downloaded by eve.
 		if ctx.hvTypeKube {
-			label := blobInfo.Labels
-			if _, found := label[types.EVEDownloadedLabel]; !found {
+			if !eveOwnedDigests[blobInfo.Digest] {
 				log.Noticef("populateInitBlobStatus: Ignoring the blob %s not downloaded by eve", blobInfo.Digest)
 				continue
 			}
@@ -649,4 +660,67 @@ func gcImagesFromCAS(ctx *volumemgrContext) {
 func lookupImageCAS(reference string, client cas.CAS) bool {
 	hash, err := client.GetImageHash(reference)
 	return err == nil && hash != ""
+}
+
+// gcRefLabelPrefix is the prefix containerd uses on metadata labels that
+// declare a blob's references to other blobs. The keys take forms like
+//
+//	containerd.io/gc.ref.content.0
+//	containerd.io/gc.ref.content.1
+//	containerd.io/gc.ref.content.config
+//	containerd.io/gc.ref.content.l.0
+//
+// and the value is the referenced blob's digest. Containerd's GC keeps
+// referenced blobs alive when the referencing blob is reachable.
+const gcRefLabelPrefix = "containerd.io/gc.ref.content."
+
+// transitivelyEVEDownloaded returns the set of blob digests that pillar
+// considers its own — every blob whose Labels carry the EVEDownloadedLabel,
+// plus every blob transitively reachable from those via containerd.io/
+// gc.ref.content.* labels.
+//
+// Why the transitive walk: pillar's CAS write path (cas/containerd.go)
+// sets the EVEDownloadedLabel on the manifest blob (and on the named image
+// entry), but NOT on the individual layer blobs the manifest references.
+// On EVE-k, where the user containerd is shared with k3s, the populate
+// path filters by the label per-blob and would reject every layer with
+// "Ignoring the blob ... not downloaded by eve" — forcing a full
+// re-download even though the blobs are physically present on /persist.
+// The manifest's containerd.io/gc.ref.content.* labels identify exactly
+// the layer set pillar pulled, so following them recovers the correct
+// answer.
+func transitivelyEVEDownloaded(blobs []*cas.BlobInfo) map[string]bool {
+	byDigest := make(map[string]map[string]string, len(blobs))
+	for _, b := range blobs {
+		byDigest[b.Digest] = b.Labels
+	}
+	owned := make(map[string]bool, len(blobs))
+	work := make([]string, 0, len(blobs))
+	for _, b := range blobs {
+		if _, ok := b.Labels[types.EVEDownloadedLabel]; ok {
+			owned[b.Digest] = true
+			work = append(work, b.Digest)
+		}
+	}
+	for len(work) > 0 {
+		cur := work[0]
+		work = work[1:]
+		for k, v := range byDigest[cur] {
+			if !strings.HasPrefix(k, gcRefLabelPrefix) {
+				continue
+			}
+			if v == "" || owned[v] {
+				continue
+			}
+			if _, present := byDigest[v]; !present {
+				// Reference points at a digest we didn't get from
+				// ListBlobInfo — skip rather than seed work with a
+				// missing key whose label map is empty.
+				continue
+			}
+			owned[v] = true
+			work = append(work, v)
+		}
+	}
+	return owned
 }

--- a/pkg/pillar/cmd/volumemgr/blob_test.go
+++ b/pkg/pillar/cmd/volumemgr/blob_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
+	"github.com/lf-edge/eve/pkg/pillar/cas"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -64,4 +65,118 @@ func TestLookupBlobStatus(t *testing.T) {
 	assert.False(t, blobPtrs[0].HasVerifierRef)
 	assert.True(t, blobPtrs[1].HasVerifierRef)
 	assert.False(t, blobPtrs[2].HasVerifierRef)
+}
+
+// blobInfo is a tiny constructor that mirrors the fields of cas.BlobInfo we
+// care about — keeps the test cases readable without dragging cas details in.
+func blobInfo(digest string, labels map[string]string) *cas.BlobInfo {
+	return &cas.BlobInfo{Digest: digest, Labels: labels}
+}
+
+func TestTransitivelyEVEDownloaded_NoSeeds(t *testing.T) {
+	got := transitivelyEVEDownloaded([]*cas.BlobInfo{
+		blobInfo("sha256:a", nil),
+		blobInfo("sha256:b", nil),
+	})
+	assert.Empty(t, got, "no eve-downloaded labels → no eve-owned blobs")
+}
+
+func TestTransitivelyEVEDownloaded_DirectLabelOnly(t *testing.T) {
+	got := transitivelyEVEDownloaded([]*cas.BlobInfo{
+		blobInfo("sha256:a", map[string]string{types.EVEDownloadedLabel: "true"}),
+		blobInfo("sha256:b", nil),
+	})
+	assert.True(t, got["sha256:a"], "directly-labeled blob is eve-owned")
+	assert.False(t, got["sha256:b"], "unrelated blob is not eve-owned")
+	assert.Len(t, got, 1)
+}
+
+// TestTransitivelyEVEDownloaded_ManifestPlusLayers is the load-bearing case:
+// a manifest blob carries the eve-downloaded label AND containerd.io/
+// gc.ref.content.* labels pointing at each layer. The layers themselves
+// carry no labels — same shape pillar's CAS writes on EVE-k after pulling
+// an OCI image (verified empirically against /persist/vault/containerd's
+// metadata DB, 2026-06-09).
+func TestTransitivelyEVEDownloaded_ManifestPlusLayers(t *testing.T) {
+	manifestLabels := map[string]string{
+		types.EVEDownloadedLabel:              "true",
+		"containerd.io/gc.ref.content.0":      "sha256:layer1",
+		"containerd.io/gc.ref.content.1":      "sha256:layer2",
+		"containerd.io/gc.ref.content.config": "sha256:cfg",
+	}
+	got := transitivelyEVEDownloaded([]*cas.BlobInfo{
+		blobInfo("sha256:manifest", manifestLabels),
+		blobInfo("sha256:layer1", nil),
+		blobInfo("sha256:layer2", nil),
+		blobInfo("sha256:cfg", nil),
+		blobInfo("sha256:unrelated", nil),
+	})
+	assert.True(t, got["sha256:manifest"])
+	assert.True(t, got["sha256:layer1"], "layer1 reached via gc.ref.content.0")
+	assert.True(t, got["sha256:layer2"], "layer2 reached via gc.ref.content.1")
+	assert.True(t, got["sha256:cfg"], "config reached via gc.ref.content.config")
+	assert.False(t, got["sha256:unrelated"])
+}
+
+// TestTransitivelyEVEDownloaded_OCIImageIndex covers multi-arch /
+// imageIndex shapes where an index points at manifests which in turn
+// point at layers. The eve-downloaded label is typically on the index;
+// the walk should traverse through manifest entries to the layers.
+func TestTransitivelyEVEDownloaded_OCIImageIndex(t *testing.T) {
+	got := transitivelyEVEDownloaded([]*cas.BlobInfo{
+		blobInfo("sha256:index", map[string]string{
+			types.EVEDownloadedLabel:         "true",
+			"containerd.io/gc.ref.content.0": "sha256:manifestAmd64",
+			"containerd.io/gc.ref.content.1": "sha256:manifestArm64",
+		}),
+		blobInfo("sha256:manifestAmd64", map[string]string{
+			"containerd.io/gc.ref.content.l.0": "sha256:layerAmd64a",
+			"containerd.io/gc.ref.content.l.1": "sha256:layerAmd64b",
+		}),
+		blobInfo("sha256:manifestArm64", map[string]string{
+			"containerd.io/gc.ref.content.l.0": "sha256:layerArm64a",
+		}),
+		blobInfo("sha256:layerAmd64a", nil),
+		blobInfo("sha256:layerAmd64b", nil),
+		blobInfo("sha256:layerArm64a", nil),
+	})
+	for _, d := range []string{
+		"sha256:index", "sha256:manifestAmd64", "sha256:manifestArm64",
+		"sha256:layerAmd64a", "sha256:layerAmd64b", "sha256:layerArm64a",
+	} {
+		assert.True(t, got[d], "expected %s to be eve-owned via transitive walk", d)
+	}
+	assert.Len(t, got, 6)
+}
+
+// TestTransitivelyEVEDownloaded_DanglingRef guards against a manifest
+// whose gc.ref.content.* label points at a digest that isn't itself in the
+// blobInfoList (e.g. a long-pruned layer). The walk should not panic and
+// should not include the dangling digest in the owned set.
+func TestTransitivelyEVEDownloaded_DanglingRef(t *testing.T) {
+	got := transitivelyEVEDownloaded([]*cas.BlobInfo{
+		blobInfo("sha256:manifest", map[string]string{
+			types.EVEDownloadedLabel:         "true",
+			"containerd.io/gc.ref.content.0": "sha256:missing",
+		}),
+	})
+	assert.True(t, got["sha256:manifest"])
+	assert.False(t, got["sha256:missing"], "dangling ref not in blob list → not owned")
+	assert.Len(t, got, 1)
+}
+
+// TestTransitivelyEVEDownloaded_NoFalsePositiveFromForeignManifest
+// guards against the bug where a k3s-pulled image's manifest holds
+// gc.ref.content.* labels pointing at the same digests as a pillar
+// blob (in some hypothetical collision). Since the k3s manifest does
+// NOT carry the eve-downloaded label, the walk doesn't seed from it and
+// the pillar blob remains the only seed.
+func TestTransitivelyEVEDownloaded_NoFalsePositiveFromForeignManifest(t *testing.T) {
+	got := transitivelyEVEDownloaded([]*cas.BlobInfo{
+		blobInfo("sha256:k3sManifest", map[string]string{
+			"containerd.io/gc.ref.content.0": "sha256:shared",
+		}),
+		blobInfo("sha256:shared", nil),
+	})
+	assert.Empty(t, got, "neither blob carries eve-downloaded → none owned")
 }

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -218,6 +218,22 @@ func handleVolumeRestart(ctxArg interface{}, restartCount int) {
 		handleDeferredVolumeCreate(ctx, key, config)
 		delete(ctx.volumeConfigCreateDeferredMap, key)
 	}
+	// Signal restart on pubVolumeStatus on zedagent's first restart of
+	// pubVolumeConfig. By then on-disk recovery
+	// (populateExistingVolumesFormat*) plus the controller-intended
+	// set have both been reflected in VolumeStatus, so subscribers can
+	// use Restarted() to gate decisions on volume presence. Guarding on
+	// the first restart avoids inflating the restart counter if zedagent
+	// restarts again later. Note that the restart count might jump from
+	// zero to any non-zero number depending on how much is going on in
+	// zedagent.
+	if !ctx.signalledRestartedStatus {
+		if err := ctx.pubVolumeStatus.SignalRestarted(); err != nil {
+			log.Errorf("handleVolumeRestart: SignalRestarted failed: %s", err)
+		} else {
+			ctx.signalledRestartedStatus = true
+		}
+	}
 	log.Tracef("handleVolumeRestart done: %d", restartCount)
 }
 

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -83,6 +83,8 @@ type volumemgrContext struct {
 
 	worker worker.Worker // For background work
 
+	signalledRestartedStatus bool
+
 	verifierRestarted    bool // Wait for verifier to restart
 	contentTreeRestarted bool // Wait to receive all contentTree after restart
 	usingConfig          bool // From zedagent

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -93,6 +93,8 @@ type volumemgrContext struct {
 
 	worker worker.Worker // For background work
 
+	signalledRestartedStatus bool
+
 	verifierRestarted    bool // Wait for verifier to restart
 	contentTreeRestarted bool // Wait to receive all contentTree after restart
 	usingConfig          bool // From zedagent

--- a/pkg/pillar/docs/baseosmgr.md
+++ b/pkg/pillar/docs/baseosmgr.md
@@ -56,6 +56,13 @@ the rootfs image into the partition device.
   * `ContentTreeStatus` from `volumemgr`
   * the download/load progress for the rootfs blob; baseosmgr will not
     even consider installing until `State == LOADED`.
+* volume sets (the cross-flavor gate)
+  * `VolumeConfig` from `zedagent` and `VolumeStatus` from `volumemgr`
+  * read only as set sizes, via `GetAll()`. A device with volumes in
+    either set cannot switch HV flavor, because the
+    `/persist/vault/volumes` layout differs between EVE-k and the other
+    flavors. Individual fields are never consumed and there are no
+    handlers.
 * zboot config (the test-complete signal)
   * `ZbootConfig` from `nodeagent`, one entry per partition (`IMGA`,
     `IMGB`); only `TestComplete` is meaningful. When it flips to `true`
@@ -105,7 +112,9 @@ the rootfs image into the partition device.
     the vault is open,
   * `containerd.WaitForUserContainerd` (user containerd ready) — needed
     because the rootfs image lands as an OCI ref and the install worker
-    has to be able to read blobs out of it.
+    has to be able to read blobs out of it,
+  * `VolumeConfig`/`VolumeStatus` `Restarted()` (bounded at 2 minutes) —
+    so the first `BaseOsConfig` after boot sees the real volume set.
 
 **baseosmgr publishes**:
 
@@ -158,8 +167,19 @@ retry counters, calls `updateAndPublishZbootStatusAll` to seed `ZbootStatus`
 from `zboot`, then activates all subscriptions. The 25-second `stillRunning`
 ticker is the only periodic work — the rest is pure event handling. The
 event loop blocks on `subGlobalConfig`, `subBaseOsConfig`, `subZbootConfig`,
-`subContentTreeStatus`, `subNodeAgentStatus`, `subZedAgentStatus`,
-`subNodeDrainStatus`, `worker.MsgChan()`, and the watchdog ticker.
+`subContentTreeStatus`, `subVolumeConfig`, `subVolumeStatus`,
+`subNodeAgentStatus`, `subZedAgentStatus`, `subNodeDrainStatus`,
+`worker.MsgChan()`, and the watchdog ticker.
+
+Between the user-containerd wait and the event loop, `Run()` also waits for
+`subVolumeConfig` and `subVolumeStatus` to signal restart, which is what makes
+their `GetAll()` sets trustworthy for the cross-flavor gate in step 4 below;
+`Synchronized()` would not, since it confirms only the socket handshake.
+The wait is bounded at `volumePublishersRestartTimeout` (2 minutes) because
+baseosmgr sits on the A/B rollback path and must not be gated indefinitely on a
+device that never onboards or is in maintenance mode. On timeout
+`volumeStateKnown` stays false and the gate treats the volume set as
+non-empty.
 
 The same file contains the pubsub dispatch wrappers
 (`handleBaseOsConfigCreate/Modify/Delete`, `handleZbootConfigCreate/Modify/Delete`,
@@ -176,7 +196,11 @@ agent. The decision tree, in order, is:
 3. version already in `other` partition (and `Activate=true`) → mark
    `DOWNLOADED`, fall through to overwrite anyway (ContentTree might
    have been re-downloaded),
-4. EVE-k vs non-EVE-k personality switch → reject with an error,
+4. EVE-k vs non-EVE-k personality switch → reject with an error, except
+   that a switch *to* EVE-k is allowed on a device holding no volumes
+   (`VolumeConfig` and `VolumeStatus` both empty, and both publishers
+   having signalled restart so the sets can be trusted); a switch *from*
+   EVE-k is rejected unconditionally,
 5. `doBaseOsInstall`: `validatePartition` (refuse if other = `inprogress`
    with same version — that's the "previous attempt failed" case), then
    `checkBaseOsVolumeStatus` (returns *not done* until ContentTree is
@@ -308,6 +332,7 @@ Run()
   └─ wait for GCInitialized
   └─ wait.WaitForVault()
   └─ containerd.WaitForUserContainerd()
+  └─ wait for VolumeConfig+VolumeStatus Restarted()   (bounded, 2 min)
   └─ event loop
 ```
 
@@ -332,6 +357,7 @@ zedagent → BaseOsConfig{ContentTreeUUID, BaseOsVersion, Activate=true}
         ├─ same version in current?            → INSTALLED/Activated, return
         ├─ same version in other?              → DOWNLOADED, fall through
         ├─ EVE-k personality mismatch?         → error, return
+        │    (to EVE-k with no volumes → allowed, fall through)
         ├─ doBaseOsInstall
         │    ├─ validatePartition              (other=inprogress same ver? → fail)
         │    └─ checkBaseOsVolumeStatus        (waits for ContentTreeStatus.LOADED)

--- a/pkg/pillar/docs/vaultmgr.md
+++ b/pkg/pillar/docs/vaultmgr.md
@@ -285,6 +285,21 @@ Uses native ZFS encryption. Key paths:
   `MS_DIRSYNC|MS_NOATIME` unless the kernel cmdline carries
   `eve_no_dirsync`, which is set when EVE itself runs as a VM (to
   avoid the I/O penalty of nested DIRSYNC).
+* **Carried-over kvm vault → EVE-k zvol**: a device converted in the
+  field from EVE-kvm to EVE-k arrives with `persist/vault` as a
+  filesystem dataset, which the EVE-k layout cannot use.
+  `migrateVaultFsToZvol` stages a second zvol, copies the vault
+  contents into its ext4, then renames the old dataset aside, renames
+  the staging zvol into place and only then destroys the old one; an
+  interruption mid-swap is picked up on the next boot by
+  `recoverInterruptedVaultMigration`. The staging zvol is sized to the
+  pool's free space and the migration declines up front if the vault
+  holds more than that. Sizing at migration time has a lasting
+  consequence: the migrated vault is smaller than the one a fresh
+  EVE-k install creates on a nearly empty pool — smaller by whatever
+  else `/persist` holds at conversion time — and the space the old
+  vault frees goes back to the pool rather than into the vault's
+  `volsize`, which is fixed when the zvol is created.
 * **No-TPM ZFS** is supported: a plain unencrypted dataset (or zvol
   on kube) is created instead — `Status` becomes
   `DATASEC_AT_REST_DISABLED`.

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/tatsushid/go-fastping v0.0.0-20160109021039-d7bb493dee3e
 	github.com/vishvananda/netlink v1.3.1
 	github.com/zededa/ghw v0.0.0-20260427124750-9a7dc80ae71c
+	go.etcd.io/bbolt v1.3.11
 	go.uber.org/mock v0.5.1
 	golang.org/x/crypto v0.52.0
 	golang.org/x/net v0.55.0
@@ -266,7 +267,6 @@ require (
 	github.com/spiffe/go-spiffe/v2 v2.7.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
-	go.etcd.io/bbolt v1.3.11 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect

--- a/pkg/pillar/vault/handler.go
+++ b/pkg/pillar/vault/handler.go
@@ -18,7 +18,13 @@ type HandlerOptions struct {
 	TpmKeyOnlyMode bool
 }
 
-// Handler is an interface for handling vault operations
+// Handler is an interface for handling vault operations.
+//
+// The vault lifecycle operations (SetupDefaultVault, UnlockDefaultVault,
+// RemoveDefaultVault) may block for as long as the underlying storage takes:
+// on EVE-k a vault carried over from EVE-kvm is copied into a new zvol, so
+// the duration scales with the vault contents. Callers run them off the
+// agent's main goroutine.
 type Handler interface {
 	RemoveDefaultVault() error
 	UnlockDefaultVault() error

--- a/pkg/pillar/vault/handler_zfs.go
+++ b/pkg/pillar/vault/handler_zfs.go
@@ -100,7 +100,31 @@ func (h *ZFSHandler) SetupDefaultVault() error {
 	if !etpm.IsTpmEnabled() {
 		if base.IsHVTypeKube() {
 			if zfs.DatasetExist(h.log, types.SealedDataset) {
-				return MountVaultZvol(h.log, types.SealedDataset)
+				// A device converted from EVE-kvm carries a filesystem-dataset
+				// vault here, not the native EVE-k zvol+etcd layout. Migrate it
+				// so a converted no-TPM device ends up with the same layout a
+				// fresh EVE-k install has, including the etcd-storage zvol. Once
+				// migrated the vault is a zvol and we just mount it. (Field
+				// devices take the TPM path in unlockVault instead.)
+				isZvol, err := zfs.IsDatasetTypeZvol(types.SealedDataset)
+				if err != nil {
+					return fmt.Errorf("error checking vault dataset type for %s: %v",
+						types.SealedDataset, err)
+				}
+				if vaultNeedsZvolMigration(true, isZvol) {
+					// Mount the carried-over fs vault as the copy source, then
+					// migrate to the zvol layout unencrypted: no-TPM ZFS vaults
+					// carry no key.
+					if mounted, merr := zfs.IsDatasetMounted(types.SealedDataset); merr != nil {
+						return merr
+					} else if !mounted {
+						if err := zfs.MountDataset(types.SealedDataset); err != nil {
+							return err
+						}
+					}
+					return h.migrateVaultFsToZvol(types.SealedDataset, "", false)
+				}
+				return h.mountVaultByDatasetType(types.SealedDataset)
 			}
 			if err := CreateZvolEtcd(h.log, types.EtcdZvol, "", false); err != nil {
 				return fmt.Errorf("error creating zfs etcd zvol %s, error=%v",
@@ -151,6 +175,30 @@ func (h *ZFSHandler) unlockVault(vaultPath string) error {
 
 	// zfs mount
 	if base.IsHVTypeKube() {
+		isZvol, err := zfs.IsDatasetTypeZvol(vaultPath)
+		if err != nil {
+			h.log.Errorf("Error checking vault dataset type for %s: %v", vaultPath, err)
+			return err
+		}
+		if vaultNeedsZvolMigration(true, isZvol) {
+			// Carried-over kvm filesystem vault on an EVE-k device (the device
+			// was converted from EVE-kvm). Mount it as a filesystem so the
+			// device boots, then migrate it in place to the zvol layout EVE-k
+			// expects. The unlock key is still staged for the encrypted creates.
+			h.log.Noticef("Detected carried-over kvm filesystem vault %s on EVE-k; migrating to zvol layout",
+				vaultPath)
+			if mounted, merr := zfs.IsDatasetMounted(vaultPath); merr != nil {
+				h.log.Errorf("Error checking mount state of %s: %v", vaultPath, merr)
+				return merr
+			} else if !mounted {
+				if err := zfs.MountDataset(vaultPath); err != nil {
+					h.log.Errorf("Error mounting carried-over fs vault %s: %v", vaultPath, err)
+					return err
+				}
+			}
+			return h.migrateVaultFsToZvol(vaultPath, zfsKeyFile, true)
+		}
+		// Native EVE-k zvol vault.
 		// zfs load-key here separately for types.EtcdZvol because we don't mount it here, only in kube.
 		args := []string{"load-key", types.EtcdZvol}
 		if stdOut, stdErr, err := execCmd(types.ZFSBinary, args...); err != nil {
@@ -169,6 +217,149 @@ func (h *ZFSHandler) unlockVault(vaultPath string) error {
 		}
 	}
 
+	return nil
+}
+
+// vaultNeedsZvolMigration reports whether a just-unlocked ZFS vault must be
+// migrated from the EVE-kvm filesystem-dataset layout to the EVE-k zvol
+// layout. It is true only on EVE-k when the existing vault is a filesystem
+// dataset (i.e. carried over from a kvm install during a cross-flavor update).
+func vaultNeedsZvolMigration(isKube bool, vaultIsZvol bool) bool {
+	return isKube && !vaultIsZvol
+}
+
+// mountVaultByDatasetType mounts vaultPath according to its actual ZFS dataset
+// type: as a zvol-backed ext4 filesystem if it is a zvol (the native EVE-k
+// layout), otherwise as a ZFS filesystem dataset (a carried-over EVE-kvm vault
+// not yet migrated to the zvol layout). It assumes any required key is already
+// loaded. Used where the type is not known up front (the no-TPM
+// SetupDefaultVault path); unlockVault drives the type-aware migration itself.
+func (h *ZFSHandler) mountVaultByDatasetType(vaultPath string) error {
+	isZvol, err := zfs.IsDatasetTypeZvol(vaultPath)
+	if err != nil {
+		h.log.Errorf("mountVaultByDatasetType: IsDatasetTypeZvol(%s) failed: %v; assuming filesystem",
+			vaultPath, err)
+	}
+	if isZvol {
+		return MountVaultZvol(h.log, vaultPath)
+	}
+	h.log.Noticef("mountVaultByDatasetType: %s is a filesystem dataset (carried-over EVE-kvm vault); mounting as filesystem",
+		vaultPath)
+	return zfs.MountDataset(vaultPath)
+}
+
+// vaultMigrateMountpoint is the temporary mountpoint used while copying the
+// carried-over filesystem vault into the new zvol-backed ext4 during migration.
+const vaultMigrateMountpoint = "/run/vaultmgr/vault-migrate"
+
+// migrateVaultFsToZvol migrates a carried-over EVE-kvm filesystem vault to the
+// EVE-k zvol+ext4 layout, preserving the vault contents (containerd content
+// store and metadata, downloader, verifier, configs). It must be called with
+// the source filesystem vault mounted at /<vaultPath>. When encrypt is true the
+// new zvols are created encrypted, which requires the vault unlock key already
+// staged (the TPM path via unlockVault); when false they are created
+// unencrypted (the no-TPM path via SetupDefaultVault).
+//
+// The sequence stages a new zvol "<vaultPath>2", copies the vault contents into
+// it, then destroys the old filesystem vault and renames the new one into
+// place. It is re-entrant: a leftover staging zvol from an interrupted attempt
+// is removed first, and once the rename has happened the vault is a zvol and
+// the caller takes the native path instead of calling this.
+func (h *ZFSHandler) migrateVaultFsToZvol(vaultPath, keyFile string, encrypt bool) error {
+	stagingDataset := vaultPath + "2"
+
+	// Re-entrancy: drop any staging zvol left behind by an interrupted attempt.
+	if zfs.DatasetExist(h.log, stagingDataset) {
+		h.log.Warnf("Removing stale migration zvol %s from a previous attempt", stagingDataset)
+		_ = unix.Unmount(vaultMigrateMountpoint, 0)
+		_ = zfs.UnmountDataset(stagingDataset)
+		if err := zfs.DestroyDataset(stagingDataset); err != nil {
+			return fmt.Errorf("cannot remove stale migration zvol %s: %v", stagingDataset, err)
+		}
+	}
+
+	// Empty etcd zvol: etcd/k3s start fresh on EVE-k, there is nothing to carry
+	// over. Skip if a prior attempt already created it.
+	if !zfs.DatasetExist(h.log, types.EtcdZvol) {
+		if err := CreateZvolEtcd(h.log, types.EtcdZvol, keyFile, encrypt); err != nil {
+			return fmt.Errorf("error creating etcd zvol %s: %v", types.EtcdZvol, err)
+		}
+	}
+
+	// Size the staging zvol to the currently-free pool space (the source vault
+	// is still present). Reusing CreateVaultVolumeDataset gives the staging zvol
+	// the same treatment a fresh-install EVE-k vault gets, just sized to free
+	// space rather than the whole pool; peak usage is then ~the vault contents.
+	availBytes, err := zfs.GetDatasetAvailableBytes(types.PersistDataset)
+	if err != nil {
+		return fmt.Errorf("cannot read %s available bytes: %v", types.PersistDataset, err)
+	}
+	if availBytes <= zfs.VolBlockSizeBytes {
+		return fmt.Errorf("insufficient free space (%d bytes) to migrate vault %s",
+			availBytes, vaultPath)
+	}
+	sizeBytes := availBytes - zfs.VolBlockSizeBytes
+	if err := zfs.CreateVaultVolumeDataset(h.log, stagingDataset, keyFile, encrypt,
+		sizeBytes, "zstd", zfs.VolBlockSizeBytes); err != nil {
+		return fmt.Errorf("error creating migration zvol %s: %v", stagingDataset, err)
+	}
+
+	devPath := zfs.GetZvolPath(stagingDataset)
+	if err := waitPath(h.log, devPath, vaultZvolPathWaitSeconds); err != nil {
+		return fmt.Errorf("migration zvol dev path missing: %v", err)
+	}
+	if err := formatZvol(h.log, devPath, vaultFsType); err != nil {
+		return fmt.Errorf("migration zvol format error: %v", err)
+	}
+
+	if err := os.MkdirAll(vaultMigrateMountpoint, 0755); err != nil {
+		return fmt.Errorf("cannot create migration mountpoint %s: %v", vaultMigrateMountpoint, err)
+	}
+	mountFlags := uintptr(unix.MS_DIRSYNC | unix.MS_NOATIME)
+	if noDirsyncRequested() {
+		mountFlags = unix.MS_NOATIME
+	}
+	if err := unix.Mount(devPath, vaultMigrateMountpoint, vaultFsType, mountFlags, ""); err != nil {
+		return fmt.Errorf("mount of migration zvol %s at %s: %v", devPath, vaultMigrateMountpoint, err)
+	}
+
+	// Copy the carried-over vault contents into the new zvol-backed ext4. The
+	// destination is the already-mounted zvol; fileutils.CopyDir cannot be used
+	// here because it requires the destination not to exist and silently drops
+	// symlinks. cp -a copies into the existing mountpoint and preserves
+	// symlinks, permissions, and xattrs, which the containerd content store and
+	// metadata DB depend on.
+	srcDir := "/" + vaultPath
+	ctx := context.Background()
+	if out, err := base.Exec(h.log, "/bin/cp", "-a", srcDir+"/.", vaultMigrateMountpoint+"/").
+		WithContext(ctx).WithUnlimitedTimeout(3600 * time.Second).CombinedOutput(); err != nil {
+		_ = unix.Unmount(vaultMigrateMountpoint, 0)
+		return fmt.Errorf("copy vault contents %s -> %s: %v (%s)", srcDir, vaultMigrateMountpoint, err, out)
+	}
+
+	// Swap: unmount both, destroy the old filesystem vault, rename the staging
+	// zvol into place. The destroy+rename is the only non-idempotent window; the
+	// re-entry guard above reconstructs from the staging zvol if interrupted
+	// before the rename completes.
+	if err := unix.Unmount(vaultMigrateMountpoint, 0); err != nil {
+		return fmt.Errorf("unmount migration zvol at %s: %v", vaultMigrateMountpoint, err)
+	}
+	if err := zfs.UnmountDataset(vaultPath); err != nil {
+		return fmt.Errorf("unmount old fs vault %s: %v", vaultPath, err)
+	}
+	if err := zfs.DestroyDataset(vaultPath); err != nil {
+		return fmt.Errorf("destroy old fs vault %s: %v", vaultPath, err)
+	}
+	if err := zfs.RenameDataset(stagingDataset, vaultPath); err != nil {
+		return fmt.Errorf("rename %s -> %s: %v", stagingDataset, vaultPath, err)
+	}
+
+	// Mount the migrated zvol vault at /<vaultPath> for the rest of this boot.
+	if err := MountVaultZvol(h.log, vaultPath); err != nil {
+		return fmt.Errorf("mount migrated zvol vault %s: %v", vaultPath, err)
+	}
+
+	h.log.Noticef("Migrated ZFS vault %s from kvm filesystem layout to EVE-k zvol layout", vaultPath)
 	return nil
 }
 

--- a/pkg/pillar/vault/handler_zfs.go
+++ b/pkg/pillar/vault/handler_zfs.go
@@ -99,8 +99,38 @@ func (h *ZFSHandler) RemoveDefaultVault() error {
 func (h *ZFSHandler) SetupDefaultVault() error {
 	if !etpm.IsTpmEnabled() {
 		if base.IsHVTypeKube() {
+			// A migration interrupted by power loss can leave the vault path
+			// absent with the data under a staging/backup dataset; recover
+			// before the dataset-exists check below would create an empty vault.
+			if err := h.recoverInterruptedVaultMigration(types.SealedDataset); err != nil {
+				return err
+			}
 			if zfs.DatasetExist(h.log, types.SealedDataset) {
-				return MountVaultZvol(h.log, types.SealedDataset)
+				// A device converted from EVE-kvm carries a filesystem-dataset
+				// vault here, not the native EVE-k zvol+etcd layout. Migrate it
+				// so a converted no-TPM device ends up with the same layout a
+				// fresh EVE-k install has, including the etcd-storage zvol. Once
+				// migrated the vault is a zvol and we just mount it. (Field
+				// devices take the TPM path in unlockVault instead.)
+				isZvol, err := zfs.IsDatasetTypeZvol(types.SealedDataset)
+				if err != nil {
+					return fmt.Errorf("error checking vault dataset type for %s: %v",
+						types.SealedDataset, err)
+				}
+				if vaultNeedsZvolMigration(true, isZvol) {
+					// Mount the carried-over fs vault as the copy source, then
+					// migrate to the zvol layout unencrypted: no-TPM ZFS vaults
+					// carry no key.
+					if mounted, merr := zfs.IsDatasetMounted(types.SealedDataset); merr != nil {
+						return merr
+					} else if !mounted {
+						if err := zfs.MountDataset(types.SealedDataset); err != nil {
+							return err
+						}
+					}
+					return h.migrateVaultFsToZvol(types.SealedDataset, "", false)
+				}
+				return h.mountVaultByDatasetType(types.SealedDataset)
 			}
 			if err := CreateZvolEtcd(h.log, types.EtcdZvol, "", false); err != nil {
 				return fmt.Errorf("error creating zfs etcd zvol %s, error=%v",
@@ -151,6 +181,36 @@ func (h *ZFSHandler) unlockVault(vaultPath string) error {
 
 	// zfs mount
 	if base.IsHVTypeKube() {
+		// A migration whose swap completed but whose cleanup was interrupted
+		// can leave vaultPath as the migrated zvol with a leftover .old backup.
+		// Recover before deciding the native vs migration path.
+		if err := h.recoverInterruptedVaultMigration(vaultPath); err != nil {
+			return err
+		}
+		isZvol, err := zfs.IsDatasetTypeZvol(vaultPath)
+		if err != nil {
+			h.log.Errorf("Error checking vault dataset type for %s: %v", vaultPath, err)
+			return err
+		}
+		if vaultNeedsZvolMigration(true, isZvol) {
+			// Carried-over kvm filesystem vault on an EVE-k device (the device
+			// was converted from EVE-kvm). Mount it as a filesystem so the
+			// device boots, then migrate it in place to the zvol layout EVE-k
+			// expects. The unlock key is still staged for the encrypted creates.
+			h.log.Noticef("Detected carried-over kvm filesystem vault %s on EVE-k; migrating to zvol layout",
+				vaultPath)
+			if mounted, merr := zfs.IsDatasetMounted(vaultPath); merr != nil {
+				h.log.Errorf("Error checking mount state of %s: %v", vaultPath, merr)
+				return merr
+			} else if !mounted {
+				if err := zfs.MountDataset(vaultPath); err != nil {
+					h.log.Errorf("Error mounting carried-over fs vault %s: %v", vaultPath, err)
+					return err
+				}
+			}
+			return h.migrateVaultFsToZvol(vaultPath, zfsKeyFile, true)
+		}
+		// Native EVE-k zvol vault.
 		// zfs load-key here separately for types.EtcdZvol because we don't mount it here, only in kube.
 		args := []string{"load-key", types.EtcdZvol}
 		if stdOut, stdErr, err := execCmd(types.ZFSBinary, args...); err != nil {
@@ -169,6 +229,246 @@ func (h *ZFSHandler) unlockVault(vaultPath string) error {
 		}
 	}
 
+	return nil
+}
+
+// vaultNeedsZvolMigration reports whether a just-unlocked ZFS vault must be
+// migrated from the EVE-kvm filesystem-dataset layout to the EVE-k zvol
+// layout. It is true only on EVE-k when the existing vault is a filesystem
+// dataset (i.e. carried over from a kvm install during a cross-flavor update).
+func vaultNeedsZvolMigration(isKube bool, vaultIsZvol bool) bool {
+	return isKube && !vaultIsZvol
+}
+
+// mountVaultByDatasetType mounts vaultPath according to its actual ZFS dataset
+// type: as a zvol-backed ext4 filesystem if it is a zvol (the native EVE-k
+// layout), otherwise as a ZFS filesystem dataset (a carried-over EVE-kvm vault
+// not yet migrated to the zvol layout). It assumes any required key is already
+// loaded. Used where the type is not known up front (the no-TPM
+// SetupDefaultVault path); unlockVault drives the type-aware migration itself.
+func (h *ZFSHandler) mountVaultByDatasetType(vaultPath string) error {
+	isZvol, err := zfs.IsDatasetTypeZvol(vaultPath)
+	if err != nil {
+		h.log.Errorf("mountVaultByDatasetType: IsDatasetTypeZvol(%s) failed: %v; assuming filesystem",
+			vaultPath, err)
+	}
+	if isZvol {
+		return MountVaultZvol(h.log, vaultPath)
+	}
+	h.log.Noticef("mountVaultByDatasetType: %s is a filesystem dataset (carried-over EVE-kvm vault); mounting as filesystem",
+		vaultPath)
+	return zfs.MountDataset(vaultPath)
+}
+
+// vaultMigrateMountpoint is the temporary mountpoint used while copying the
+// carried-over filesystem vault into the new zvol-backed ext4 during migration.
+const vaultMigrateMountpoint = "/run/vaultmgr/vault-migrate"
+
+// migrateVaultFsToZvol migrates a carried-over EVE-kvm filesystem vault to the
+// EVE-k zvol+ext4 layout, preserving the vault contents (containerd content
+// store and metadata, downloader, verifier, configs). It must be called with
+// the source filesystem vault mounted at /<vaultPath>. When encrypt is true the
+// new zvols are created encrypted, which requires the vault unlock key already
+// staged (the TPM path via unlockVault); when false they are created
+// unencrypted (the no-TPM path via SetupDefaultVault).
+//
+// The sequence stages a new zvol "<vaultPath>2", copies the vault contents into
+// it, then swaps it into place: the old filesystem vault is renamed to
+// "<vaultPath>.old", the staging zvol is renamed to "<vaultPath>", and only
+// then is the old vault destroyed. The caller reaches this only when a
+// filesystem vault is present at vaultPath (i.e. the source is intact), so a
+// leftover staging/backup dataset left by an interrupted copy attempt is safe
+// to drop here. Interruption mid-swap (vaultPath briefly absent) is recovered
+// by recoverInterruptedVaultMigration at the EVE-k call sites.
+func (h *ZFSHandler) migrateVaultFsToZvol(vaultPath, keyFile string, encrypt bool) error {
+	stagingDataset := vaultPath + "2"
+	backupDataset := vaultPath + ".old"
+
+	// Re-entrancy: the source fs vault at vaultPath is intact, so any leftover
+	// staging/backup dataset from an interrupted copy attempt is safe to drop.
+	if zfs.DatasetExist(h.log, stagingDataset) {
+		h.log.Warnf("Removing stale migration zvol %s from a previous attempt", stagingDataset)
+		_ = unix.Unmount(vaultMigrateMountpoint, 0)
+		_ = zfs.UnmountDataset(stagingDataset)
+		if err := zfs.DestroyDataset(stagingDataset); err != nil {
+			return fmt.Errorf("cannot remove stale migration zvol %s: %v", stagingDataset, err)
+		}
+	}
+	if zfs.DatasetExist(h.log, backupDataset) {
+		h.log.Warnf("Removing stale migration backup %s from a previous attempt", backupDataset)
+		_ = zfs.UnmountDataset(backupDataset)
+		if err := zfs.DestroyDataset(backupDataset); err != nil {
+			return fmt.Errorf("cannot remove stale migration backup %s: %v", backupDataset, err)
+		}
+	}
+
+	// Empty etcd zvol: etcd/k3s start fresh on EVE-k, there is nothing to carry
+	// over. Skip if a prior attempt already created it.
+	if !zfs.DatasetExist(h.log, types.EtcdZvol) {
+		if err := CreateZvolEtcd(h.log, types.EtcdZvol, keyFile, encrypt); err != nil {
+			return fmt.Errorf("error creating etcd zvol %s: %v", types.EtcdZvol, err)
+		}
+	}
+
+	// Size the staging zvol to the currently-free pool space (the source vault
+	// is still present). Reusing CreateVaultVolumeDataset gives the staging zvol
+	// the same treatment a fresh-install EVE-k vault gets, just sized to free
+	// space rather than the whole pool; peak usage is then ~the vault contents.
+	availBytes, err := zfs.GetDatasetAvailableBytes(types.PersistDataset)
+	if err != nil {
+		return fmt.Errorf("cannot read %s available bytes: %v", types.PersistDataset, err)
+	}
+	if availBytes <= zfs.VolBlockSizeBytes {
+		return fmt.Errorf("insufficient free space (%d bytes) to migrate vault %s",
+			availBytes, vaultPath)
+	}
+	sizeBytes := availBytes - zfs.VolBlockSizeBytes
+	// Decline up front when the free space cannot hold a second copy of the
+	// vault: the copy below would run out of room part-way, and since the
+	// source is left intact every following boot would retry and fail the same
+	// way. A marginal pass can still hit ENOSPC because the ext4 on the zvol
+	// spends some of its capacity on metadata; that leaves the source intact
+	// too, it just reports the failure later.
+	usedBytes, err := zfs.GetDatasetUsedBytes(vaultPath)
+	if err != nil {
+		return fmt.Errorf("cannot read %s used bytes: %v", vaultPath, err)
+	}
+	if sizeBytes < usedBytes {
+		return fmt.Errorf("insufficient free space to migrate vault %s: %d bytes free, %d bytes in use",
+			vaultPath, sizeBytes, usedBytes)
+	}
+	if err := zfs.CreateVaultVolumeDataset(h.log, stagingDataset, keyFile, encrypt,
+		sizeBytes, "zstd", zfs.VolBlockSizeBytes); err != nil {
+		return fmt.Errorf("error creating migration zvol %s: %v", stagingDataset, err)
+	}
+
+	devPath := zfs.GetZvolPath(stagingDataset)
+	if err := waitPath(h.log, devPath, vaultZvolPathWaitSeconds); err != nil {
+		return fmt.Errorf("migration zvol dev path missing: %v", err)
+	}
+	if err := formatZvol(h.log, devPath, vaultFsType); err != nil {
+		return fmt.Errorf("migration zvol format error: %v", err)
+	}
+
+	if err := os.MkdirAll(vaultMigrateMountpoint, 0755); err != nil {
+		return fmt.Errorf("cannot create migration mountpoint %s: %v", vaultMigrateMountpoint, err)
+	}
+	mountFlags := uintptr(unix.MS_DIRSYNC | unix.MS_NOATIME)
+	if noDirsyncRequested() {
+		mountFlags = unix.MS_NOATIME
+	}
+	if err := unix.Mount(devPath, vaultMigrateMountpoint, vaultFsType, mountFlags, ""); err != nil {
+		return fmt.Errorf("mount of migration zvol %s at %s: %v", devPath, vaultMigrateMountpoint, err)
+	}
+
+	// Copy the carried-over vault contents into the new zvol-backed ext4. The
+	// destination is the already-mounted zvol; fileutils.CopyDir cannot be used
+	// here because it requires the destination not to exist and silently drops
+	// symlinks. cp -a copies into the existing mountpoint and preserves
+	// symlinks, permissions, and xattrs, which the containerd content store and
+	// metadata DB depend on.
+	srcDir := "/" + vaultPath
+	ctx := context.Background()
+	if out, err := base.Exec(h.log, "/bin/cp", "-a", srcDir+"/.", vaultMigrateMountpoint+"/").
+		WithContext(ctx).WithUnlimitedTimeout(3600 * time.Second).CombinedOutput(); err != nil {
+		_ = unix.Unmount(vaultMigrateMountpoint, 0)
+		return fmt.Errorf("copy vault contents %s -> %s: %v (%s)", srcDir, vaultMigrateMountpoint, err, out)
+	}
+
+	// Swap: unmount both, then rename the old fs vault out of the way, rename
+	// the staging zvol into place, and only then destroy the old vault.
+	// Renaming (not destroying) the old vault first means no window leaves
+	// vaultPath absent with the only surviving copy in a differently-named
+	// dataset: power loss at any point leaves the old data under
+	// <vaultPath>.old and/or the migrated data under the staging zvol or
+	// vaultPath, and the next boot recovers it via
+	// recoverInterruptedVaultMigration.
+	if err := unix.Unmount(vaultMigrateMountpoint, 0); err != nil {
+		return fmt.Errorf("unmount migration zvol at %s: %v", vaultMigrateMountpoint, err)
+	}
+	if err := zfs.UnmountDataset(vaultPath); err != nil {
+		return fmt.Errorf("unmount old fs vault %s: %v", vaultPath, err)
+	}
+	if err := zfs.RenameDataset(vaultPath, backupDataset); err != nil {
+		return fmt.Errorf("rename %s -> %s: %v", vaultPath, backupDataset, err)
+	}
+	if err := zfs.RenameDataset(stagingDataset, vaultPath); err != nil {
+		return fmt.Errorf("rename %s -> %s: %v", stagingDataset, vaultPath, err)
+	}
+	// Best effort: the migrated zvol is now at vaultPath, so the old vault may
+	// be torn down. On failure it is left as an .old leftover for the next
+	// boot's recovery to clean up.
+	if err := zfs.UnmountDataset(backupDataset); err != nil {
+		h.log.Warnf("migrateVaultFsToZvol: unmount leftover %s: %v", backupDataset, err)
+	}
+	if err := zfs.DestroyDataset(backupDataset); err != nil {
+		h.log.Warnf("migrateVaultFsToZvol: destroy leftover %s: %v", backupDataset, err)
+	}
+
+	// Mount the migrated zvol vault at /<vaultPath> for the rest of this boot.
+	if err := MountVaultZvol(h.log, vaultPath); err != nil {
+		return fmt.Errorf("mount migrated zvol vault %s: %v", vaultPath, err)
+	}
+
+	h.log.Noticef("Migrated ZFS vault %s from kvm filesystem layout to EVE-k zvol layout", vaultPath)
+	return nil
+}
+
+// recoverInterruptedVaultMigration reconstructs a ZFS vault migration that
+// was interrupted by power loss mid-swap, so the EVE-k callers do not mistake
+// it for a fresh install and create an empty vault (losing all blobs) or fail
+// to unlock. It is a no-op when no migration staging/backup datasets are
+// present.
+//
+// In migrateVaultFsToZvol the swap renames the old fs vault to
+// <vaultPath>.old, then renames the staging zvol to <vaultPath>. If power is
+// lost between those two renames, vaultPath is absent while the migrated data
+// sits under the staging zvol (and the old data under .old). This finishes
+// that swap; if only the old vault survived, it is restored so migration can
+// restart.
+func (h *ZFSHandler) recoverInterruptedVaultMigration(vaultPath string) error {
+	staging := vaultPath + "2"
+	backup := vaultPath + ".old"
+	stagingExists := zfs.DatasetExist(h.log, staging)
+	backupExists := zfs.DatasetExist(h.log, backup)
+	if !stagingExists && !backupExists {
+		return nil
+	}
+	vaultExists := zfs.DatasetExist(h.log, vaultPath)
+	h.log.Noticef("recoverInterruptedVaultMigration(%s): leftover migration state (staging=%v backup=%v vault=%v)",
+		vaultPath, stagingExists, backupExists, vaultExists)
+
+	if !vaultExists {
+		if stagingExists {
+			// Swap interrupted after the old vault was renamed away but before
+			// the migrated zvol landed at vaultPath; finish it.
+			if err := zfs.RenameDataset(staging, vaultPath); err != nil {
+				return fmt.Errorf("finish interrupted migration rename %s -> %s: %v", staging, vaultPath, err)
+			}
+		} else if backupExists {
+			// Only the old vault survives; restore it so migration restart.
+			if err := zfs.RenameDataset(backup, vaultPath); err != nil {
+				return fmt.Errorf("restore interrupted migration rename %s -> %s: %v", backup, vaultPath, err)
+			}
+		}
+	}
+
+	// Clean up any leftover backup or redundant staging dataset now that
+	// vaultPath is valid. Re-check existence since a rename above may have
+	// moved the data; a destroy here is best-effort and a failure just leaves
+	// the leftover for the next boot.
+	if zfs.DatasetExist(h.log, backup) {
+		_ = zfs.UnmountDataset(backup)
+		if err := zfs.DestroyDataset(backup); err != nil {
+			h.log.Warnf("recoverInterruptedVaultMigration: destroy leftover %s: %v", backup, err)
+		}
+	}
+	if zfs.DatasetExist(h.log, staging) {
+		_ = zfs.UnmountDataset(staging)
+		if err := zfs.DestroyDataset(staging); err != nil {
+			h.log.Warnf("recoverInterruptedVaultMigration: destroy leftover %s: %v", staging, err)
+		}
+	}
 	return nil
 }
 
@@ -214,6 +514,14 @@ func (h *ZFSHandler) checkZfsKeyStatus(vaultPath string) error {
 }
 
 func (h *ZFSHandler) setupVault(vaultPath string) error {
+	// A migration interrupted by power loss can leave vaultPath absent with
+	// the data under a staging/backup dataset; recover before deciding this is
+	// a fresh install, which would create an empty vault and lose the blobs.
+	if base.IsHVTypeKube() {
+		if err := h.recoverInterruptedVaultMigration(vaultPath); err != nil {
+			return err
+		}
+	}
 	// zfs get keystatus returns success as long as vaultPath is a dataset,
 	// (even if not mounted yet), so use it to check dataset presence
 	if err := h.checkZfsKeyStatus(vaultPath); err == nil {

--- a/pkg/pillar/vault/handler_zfs_test.go
+++ b/pkg/pillar/vault/handler_zfs_test.go
@@ -16,3 +16,29 @@ func TestFstrimBinaryExists(t *testing.T) {
 	_, err := exec.LookPath("fstrim")
 	assert.NoError(t, err, "fstrim must be present on PATH; TrimVault will fail without it")
 }
+
+// TestVaultNeedsZvolMigration covers the decision that drives whether a
+// just-unlocked ZFS vault is migrated from the EVE-kvm filesystem layout to
+// the EVE-k zvol layout. Migration is needed only on EVE-k when the existing
+// vault is still a filesystem dataset.
+func TestVaultNeedsZvolMigration(t *testing.T) {
+	tests := []struct {
+		name        string
+		isKube      bool
+		vaultIsZvol bool
+		want        bool
+	}{
+		{name: "kvm fs vault", isKube: false, vaultIsZvol: false, want: false},
+		{name: "kvm zvol (n/a)", isKube: false, vaultIsZvol: true, want: false},
+		{name: "k carried-over fs vault", isKube: true, vaultIsZvol: false, want: true},
+		{name: "k native zvol vault", isKube: true, vaultIsZvol: true, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := vaultNeedsZvolMigration(tc.isKube, tc.vaultIsZvol); got != tc.want {
+				t.Errorf("vaultNeedsZvolMigration(%t, %t) = %t, want %t",
+					tc.isKube, tc.vaultIsZvol, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/pillar/zfs/zfs.go
+++ b/pkg/pillar/zfs/zfs.go
@@ -238,6 +238,30 @@ func DestroyDataset(datasetName string) error {
 	return err
 }
 
+// IsDatasetMounted returns true if the dataset is currently mounted.
+func IsDatasetMounted(datasetName string) (bool, error) {
+	dataset, err := libzfs.DatasetOpen(datasetName)
+	if err != nil {
+		return false, err
+	}
+	defer dataset.Close()
+	mounted, _ := dataset.IsMounted()
+	return mounted, nil
+}
+
+// RenameDataset renames a dataset from oldName to newName. The dataset
+// must not be mounted (mountpoints follow the dataset name).
+func RenameDataset(oldName, newName string) error {
+	dataset, err := libzfs.DatasetOpen(oldName)
+	if err != nil {
+		return err
+	}
+	defer dataset.Close()
+
+	// recur=false (single dataset), forceUnmount=false (caller unmounts first)
+	return dataset.Rename(newName, false, false)
+}
+
 // DatasetExist return true if dataset exists or false when it does not exist
 func DatasetExist(log *base.LogObject, datasetPath string) bool {
 	dataset, err := libzfs.DatasetOpen(datasetPath)

--- a/pkg/pillar/zfs/zfs.go
+++ b/pkg/pillar/zfs/zfs.go
@@ -143,6 +143,25 @@ func GetDatasetAvailableBytes(datasetName string) (uint64, error) {
 	return size, nil
 }
 
+// GetDatasetUsedBytes Read Zfs dataset 'used' space property (the dataset, its
+// descendants and its snapshots), parse as uint64
+func GetDatasetUsedBytes(datasetName string) (uint64, error) {
+	ds, err := libzfs.DatasetOpen(datasetName)
+	if err != nil {
+		return 0, fmt.Errorf("Open dataset %s failure: %v", datasetName, err)
+	}
+	defer ds.Close()
+	propUsed, err := ds.GetProperty(libzfs.DatasetPropUsed)
+	if err != nil {
+		return 0, fmt.Errorf("Read dataset %s used space failure: %v", datasetName, err)
+	}
+	size, err := strconv.ParseUint(propUsed.Value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("dataset %s used space parse failure: %v", datasetName, err)
+	}
+	return size, nil
+}
+
 // GetZvolPath Helper to build the /dev/zvol/<dataset> path
 func GetZvolPath(datasetName string) string {
 	return types.ZVolDevicePrefix + "/" + datasetName
@@ -236,6 +255,30 @@ func DestroyDataset(datasetName string) error {
 	}
 
 	return err
+}
+
+// IsDatasetMounted returns true if the dataset is currently mounted.
+func IsDatasetMounted(datasetName string) (bool, error) {
+	dataset, err := libzfs.DatasetOpen(datasetName)
+	if err != nil {
+		return false, err
+	}
+	defer dataset.Close()
+	mounted, _ := dataset.IsMounted()
+	return mounted, nil
+}
+
+// RenameDataset renames a dataset from oldName to newName. The dataset
+// must not be mounted (mountpoints follow the dataset name).
+func RenameDataset(oldName, newName string) error {
+	dataset, err := libzfs.DatasetOpen(oldName)
+	if err != nil {
+		return err
+	}
+	defer dataset.Close()
+
+	// recur=false (single dataset), forceUnmount=false (caller unmounts first)
+	return dataset.Rename(newName, false, false)
 }
 
 // DatasetExist return true if dataset exists or false when it does not exist


### PR DESCRIPTION
# Description

Enable the cross-HV-flavor BaseOs upgrade from EVE-kvm to EVE-k on a
device holding no volumes, make the post-upgrade BlobStatus
reconstruction work for the EVE-k variant, and migrate a carried-over
ZFS vault to the zvol layout EVE-k expects.

Note that this assumes that EVE-k fits in the IMGx partition otherwise it is rejected. Later work will add the partition resizing as part of an EVE-kvm to EVE-k upgrade.

The blocker was a four-part problem:

1. **baseosmgr rejected the flavor change unconditionally.** The
   kvm → EVE-k direction is now allowed on a device that holds no
   volumes: baseosmgr subscribes to `VolumeConfig` and `VolumeStatus`
   and rejects only when either set is non-empty, i.e. when there is
   volume state whose on-disk layout could diverge between flavors.
   The EVE-k → kvm direction stays rejected in every case — a vault
   already migrated to the EVE-k zvol layout has no path back to a
   filesystem dataset EVE-kvm can read. The wait for both
   `Restarted()` is necessary because `Synchronized()` only signals
   the socket handshake, not that zedagent and volumemgr have
   re-published; `volumemgr` now signals restart on `VolumeStatus`
   for that wait to converge. Until both have signalled (bounded at
   two minutes), the volume state counts as non-empty and the upgrade
   is refused rather than risk existing volumes.

2. **Boot-time `populateInitBlobStatus` discarded the blobs.** On
   EVE-k the user-containerd metadata lives in the `k8s.io`
   namespace, but the CAS records the kvm-side `eve-user-apps`
   namespace from the prior BaseOs. `upgradeconverter`'s new
   post-vault `containerd_namespace.go` phase ports the relevant
   blob + image records across namespaces directly in `meta.db`
   (read-only-style: writes to the new namespace, leaves the old
   one in place) so the eve-k containerd sees the pre-upgrade
   blobs at startup.

3. **The blob accept filter was too narrow.** It counted only blobs
   carrying the `EVEDownloadedLabel`, which pillar's CAS writes on the
   manifest but not on the layers the manifest references, so every
   layer was discarded as "not downloaded by eve". The filter now
   walks the manifest's `containerd.io/gc.ref.content.*` labels
   transitively — the same references containerd's GC uses — so the
   full DAG survives the namespace port. Foreign (k3s) manifests
   carry no label and so never seed the walk.

4. **A carried-over ZFS vault never mounted on EVE-k.** On a device
   whose `/persist` is ZFS, EVE-kvm stores the vault as a filesystem
   dataset, but EVE-k expects it as an ext4-formatted zvol alongside
   a separate etcd-storage zvol. The carried-over filesystem vault
   therefore never reached a mounted state on the first EVE-k boot,
   attestation escrow could not complete, and the device reboot-looped
   back to kvm. The first-boot unlock path now detects the
   filesystem-dataset vault, mounts it so the device boots, and
   migrates it in place to the zvol layout: it stages a new encrypted
   zvol, copies the vault contents into it (the containerd content
   store and metadata, downloader, verifier, and configs all live
   inside the vault, so blobs and content trees come across), destroys
   the old dataset, and renames the new zvol into place. An empty
   etcd-storage zvol is created since etcd starts fresh on EVE-k. The
   staging zvol survives until the rename and remount succeed, so an
   interrupted migration is reconstructed on the next boot. The no-TPM
   boot path performs the same migration unencrypted, so a converted
   no-TPM device also gains the etcd-storage zvol and zvol vault
   layout. This covers a ZFS device carrying content trees and blobs
   but no app volumes; app-volume conversion is handled separately.

## PR dependencies

None. The seven commits in this PR are self-contained.

## How to test and validate this PR

**Blob reuse across the flavor change (ext4 or ZFS `/persist`).** A
standalone eden test draft lives in
`/tmp/eden-test-drafts/update_eve_image_cross_hv_with_app_recreate.txt`
on the author's workstation and validates the full operator-facing
recipe end-to-end:

1. Deploy an eclient app on EVE-kvm; wait RUNNING + SSH-functional.
2. Set `timer.defer.content.delete=86400` (24h).
3. Delete the app + wait for its volume to fully clear (~10 min).
4. Push the kvm→k baseos upgrade.
5. After eve-k boots and volumemgr publishes
   `/run/volumemgr/VolumeMgrStatus/volumemgr.json` with
   `"Initialized":true`, redeploy the SAME app on eve-k.
6. Assert: pillar's downloader received **0 additional bytes** for
   the redeploy. The eclient blobs (~44 MiB) were reused from CAS
   via the transitive-label-walk and namespace-port paths.
7. SSH-probe the redeployed app (Ubuntu /etc/issue check).

**ZFS vault fs→zvol migration.** On a device with ZFS `/persist`
carrying content trees and blobs (no app volumes), run the kvm→k
conversion under eden + swtpm and confirm that after the first EVE-k
boot the vault comes up on a zvol (rather than reboot-looping back to
kvm) and that `VaultStatus.UnlockMethod` reflects a successful
TPM-sealed unlock. This path was validated end-to-end under eden +
swtpm.

Unit coverage:
- `pkg/pillar/cmd/upgradeconverter/containerd_namespace_test.go` covers
  the namespace port in isolation against a synthetic bbolt store.
- `pkg/pillar/cmd/volumemgr/blob_test.go` covers the transitive
  label walk for the GC-ref filter.
- `pkg/pillar/vault/handler_zfs_test.go` covers the ZFS vault
  fs-dataset detection and zvol migration.

## Changelog notes

An in-field EVE-kvm → EVE-k upgrade now succeeds on a device that has no
volumes, and reuses the container images already on the device instead of
downloading them again. Deleting an app is not enough on its own — its
volume must have finished being purged. The reverse direction, EVE-k →
EVE-kvm, remains unsupported.

The upgrade needs the new rootfs to fit the device's existing IMGA/IMGB
partition. EVE grew those partitions to 10 GiB in 17.0.0, so this is
mostly useful where e.g. 17.0.0 EVE-kvm has been installed and the user
wants to move to 17.X.Y or later EVE-k. Converting a device installed
with an older layout needs the follow-on work which resizes the
partitions.

On a device with a ZFS `/persist` the vault is converted to the layout
EVE-k requires, and the conversion is declined when the pool has too
little free space for it. A converted device ends up with a smaller vault
than a fresh EVE-k install of the same hardware.

## PR Backports

This is new EVE-k in-field conversion functionality that is not
present in the current LTS branches.

- 16.7-stable: No.
- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

