### PR TITLE
kube: avoid longhorn install on K3S_BASE devices

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -1083,6 +1083,27 @@ check_kubevip_lb() {
     fi
 }
 
+# maybe_set_basek3s_from_encc: if the controller has published an ENCC whose
+# ClusterType is CLUSTER_TYPE_K3S_BASE, set /var/lib/base-k3s-mode up front so
+# the longhorn / kubevirt / descheduler install blocks in the main loop skip
+# the install rather than installing and later removing them via
+# uninstall_components. Returns 0 if the flag was just set or was already set
+# (caller can treat as "we are in base-k3s mode"); returns 1 otherwise.
+maybe_set_basek3s_from_encc() {
+        # Already in base-k3s mode (this boot or a prior one): nothing to do.
+        [ -f /var/lib/base-k3s-mode ] && return 0
+        Config_cluster_type_get
+        ct=$?
+        [ "$ct" -eq "$CLUSTER_TYPE_K3S_BASE" ] || return 1
+        logmsg "ENCC ClusterType=K3S_BASE; setting /var/lib/base-k3s-mode before any install"
+        touch /var/lib/base-k3s-mode
+        # k3s default local-path-provisioner backs PVCs in K3S_BASE mode, so
+        # remove the disable-local-path drop-in if a prior run installed it.
+        rm -f "${K3S_CONFIG_DIR}/${K3S_CONFIG_FILE_DISABLE_LOCAL_PATH}"
+        install_kubevirt=0
+        return 0
+}
+
 # started when we detect registration addition
 # start cleaning up some components
 # these are cluster-wide operations, only one nodes initiates it
@@ -1485,6 +1506,10 @@ if [ ! -f /var/lib/all_components_initialized ]; then
         fi
         All_PODS_READY=true
 
+        # Decide K3S_BASE up front so we never install longhorn/kubevirt only
+        # to remove them later via uninstall_components.
+        maybe_set_basek3s_from_encc
+
         if [ ! -f /var/lib/multus_initialized ]; then
                 if [ ! -f /etc/multus-daemonset-new.yaml ]; then
                         assign_multus_nodeip "$cluster_node_ip"
@@ -1552,33 +1577,37 @@ if [ ! -f /var/lib/all_components_initialized ]; then
         # picked up on upgrades without requiring a re-init of the cluster.
 
         #
-        # Longhorn
+        # Longhorn — skipped in base-k3s mode (PVCs use local-path-provisioner)
         #
-        wait_for_item "longhorn"
-        if [ ! -f /var/lib/longhorn_initialized ]; then
-                if ! longhorn_install "$HOSTNAME"; then
-                        continue
+        if [ ! -f /var/lib/base-k3s-mode ]; then
+                wait_for_item "longhorn"
+                if [ ! -f /var/lib/longhorn_initialized ]; then
+                        if ! longhorn_install "$HOSTNAME"; then
+                                continue
+                        fi
+                        if ! Longhorn_is_ready; then
+                                # It can take a moment for the new pods to get to ContainerCreating
+                                # Just back off until they are caught by the earlier are_all_pods_ready
+                                sleep 30
+                                continue
+                        fi
+                        logmsg "longhorn ready"
+                        touch /var/lib/longhorn_initialized
                 fi
-                if ! Longhorn_is_ready; then
-                        # It can take a moment for the new pods to get to ContainerCreating
-                        # Just back off until they are caught by the earlier are_all_pods_ready
-                        sleep 30
-                        continue
-                fi
-                logmsg "longhorn ready"
-                touch /var/lib/longhorn_initialized
         fi
 
         #
-        # Descheduler
+        # Descheduler — skipped in base-k3s mode
         #
-        wait_for_item "descheduler"
-        logmsg "Applying Descheduler ${DESCHEDULER_VERSION}"
-        if ! descheduler_install; then
-                continue
+        if [ ! -f /var/lib/base-k3s-mode ]; then
+                wait_for_item "descheduler"
+                logmsg "Applying Descheduler ${DESCHEDULER_VERSION}"
+                if ! descheduler_install; then
+                        continue
+                fi
         fi
 
-        if [ -f /var/lib/longhorn_initialized ]; then
+        if [ -f /var/lib/longhorn_initialized ] || [ -f /var/lib/base-k3s-mode ]; then
                 sleep 5
                 logmsg "stop the k3s server and wait for copy /var/lib"
                 terminate_k3s


### PR DESCRIPTION
# Description

When `EdgeNodeClusterConfig.ClusterType` is `K3S_BASE`, the device
runs k3s only (no kubevirt, no longhorn) — it provides the
Kubernetes API to consumers without hosting VMs or persistent
storage itself. Today the device still pulls and installs the
longhorn DaemonSet+CRD set on first boot, which is dead weight
and (more importantly) is what trips the single-node
`RolloutDiskToPVC` scheduling stall reported in
lf-edge/eve#6032 for devices that get a K3S_BASE ClusterType at
the same time the controller pushes an application Volume during
testing.

cluster-init.sh now skips `install_longhorn` / `wait_for_longhorn`
when the resolved ClusterType is `K3S_BASE`, matching the existing
skip on `kubevirt`. Devices that come up under a different
ClusterType first and later receive `K3S_BASE` from the controller
still go through `uninstall_components` in
`check_cluster_config_change` as before — the skip only short-
circuits a fresh install.

## PR dependencies

None.

## How to test and validate this PR

1. Build EVE-k.
2. Bring up an eden device with `default ClusterType = K3S_BASE`
   (the eden-cluster-stub branch has this configured by default).
3. Confirm the device boots with no `longhorn-system` namespace
   ever created (`eve exec kube kubectl get ns | grep -c longhorn`
   should be 0).
4. kubevirt and longhorn install times should also drop out of
   first-boot wall-clock.

## Changelog notes

K3S_BASE devices no longer attempt to install longhorn. This is the
intended behavior — K3S_BASE is the controller-only k8s role and
does not host volumes.

