### PR TITLE
zedagent: fall back to /config/authorized_keys when GlobalConfig is missing

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -341,47 +341,62 @@ func indicateInvalidBootstrapConfig(getconfigCtx *getconfigContext) {
 	getconfigCtx.ledBlinkCount = types.LedBlinkInvalidBootstrapConfig
 }
 
-// Load /config/GlobalConfig/ json file with ConfigItemValueMap provided that:
-//   - the file exists
+// loadGlobalConfig loads /config/GlobalConfig and/or
+// /config/authorized_keys at boot. Precedence:
+//   - GlobalConfig present: authoritative, even with empty
+//     debug.enable.ssh; authorized_keys is ignored.
+//   - GlobalConfig missing: fall back to authorized_keys as the
+//     bootstrap-SSH source on un-onboarded devices.
+//   - Neither present: nothing to load.
 //
-// Note that we need to re-load on each boot since the loaded file content
-// is not persisted anywhere in /persist. Once the device has been onboarded
-// and we have a /persist/checkpoint/lastconfig this file is ignored (by the caller).
-//
-// The function will only load the ConfigItemValueMap items into
-// zedagentCtx,globalConfig. The caller is responsible for publishing those
-// if this returns true
+// Returns true iff zedagentCtx.globalConfig was overwritten; the
+// caller publishes it in that case. Re-runs on every boot; content
+// is not persisted to /persist. Once /persist/checkpoint/lastconfig
+// exists the caller skips this.
 func loadGlobalConfig(getconfigCtx *getconfigContext) bool {
 	return loadGlobalConfigImpl(getconfigCtx, types.ImportGlobalConfigFile, types.BaseAuthorizedKeysFile)
 }
 
-// loadGlobalConfigImpl is the testable core of loadGlobalConfig.
+// loadGlobalConfigImpl is the testable core of loadGlobalConfig
+// with explicit file paths.
 func loadGlobalConfigImpl(getconfigCtx *getconfigContext, globalConfigFile, authorizedKeysFile string) bool {
-	if !fileutils.FileExists(log, globalConfigFile) {
+	globalConfigExists := fileutils.FileExists(log, globalConfigFile)
+	authKeysExists := fileutils.FileExists(log, authorizedKeysFile)
+	if !globalConfigExists && !authKeysExists {
 		return false
 	}
 
 	newConfigPtr := types.DefaultConfigItemValueMap()
-	contents, err := os.ReadFile(globalConfigFile)
-	if err != nil {
-		log.Errorf("Failed to read global config: %v", err)
-		return false
-	}
 
-	var config types.ConfigItemValueMap
-	err = json.Unmarshal(contents, &config)
-	if err != nil {
-		log.Errorf("Could not unmarshall data in file %s: %s", globalConfigFile, err)
-		return false
-	}
-	log.Noticef("/config/GlobalConfig contains: %v", config)
-	newConfigPtr.UpdateItemValues(&config)
-
-	keyData, keyDataValid := readAuthorizedKeys(authorizedKeysFile)
-	if len(keyData) != 0 && keyDataValid {
-		log.Noticef("Found the key data in %s: %v", authorizedKeysFile, keyData)
+	if globalConfigExists {
+		contents, err := os.ReadFile(globalConfigFile)
+		if err != nil {
+			log.Errorf("Failed to read global config: %v", err)
+			return false
+		}
+		var config types.ConfigItemValueMap
+		if err := json.Unmarshal(contents, &config); err != nil {
+			log.Errorf("Could not unmarshall data in file %s: %s",
+				globalConfigFile, err)
+			return false
+		}
+		log.Noticef("/config/GlobalConfig contains: %v", config)
+		newConfigPtr.UpdateItemValues(&config)
+		if authKeysExists {
+			log.Noticef("Ignoring %s: GlobalConfig is authoritative",
+				authorizedKeysFile)
+		}
+	} else {
+		// Bootstrap-SSH path: only authorized_keys, no GlobalConfig.
+		keyData, keyDataValid := readAuthorizedKeys(authorizedKeysFile)
+		if len(keyData) == 0 || !keyDataValid {
+			return false
+		}
+		log.Noticef("Loaded bootstrap SSH keys from %s: %v",
+			authorizedKeysFile, keyData)
 		newConfigPtr.SetGlobalValueString(types.SSHAuthorizedKeys, keyData)
 	}
+
 	getconfigCtx.zedagentCtx.globalConfig = *newConfigPtr
 	return true
 }

--- a/pkg/pillar/cmd/zedagent/handleconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig_test.go
@@ -314,7 +314,9 @@ func TestBootstrapConfigPublishesDPC(t *testing.T) {
 
 // ---- loadGlobalConfigImpl tests ----
 
-func TestLoadGlobalConfigMissingFile(t *testing.T) {
+const testSSHKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKey test@example.com"
+
+func TestLoadGlobalConfigBothMissing(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ctx := initGetConfigCtx(g)
 
@@ -346,26 +348,71 @@ func TestLoadGlobalConfigSuccess(t *testing.T) {
 		To(gomega.Equal(uint32(42)))
 }
 
-func TestLoadGlobalConfigWithAuthorizedKeys(t *testing.T) {
+// TestLoadGlobalConfigPrefersGlobalOverAuthKeys: when GlobalConfig
+// exists, its (possibly empty) debug.enable.ssh wins over the
+// authorized_keys file. Uses a non-default ConfigInterval value as a
+// fingerprint so the test would fail if the bootstrap branch were
+// silently taken instead.
+func TestLoadGlobalConfigPrefersGlobalOverAuthKeys(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ctx := initGetConfigCtx(g)
 
 	dir := t.TempDir()
 
+	// GlobalConfig with EMPTY debug.enable.ssh AND a non-default
+	// ConfigInterval — the latter is the fingerprint that the
+	// GlobalConfig branch ran (bootstrap branch would leave it
+	// at the default).
 	cfg := types.DefaultConfigItemValueMap()
+	cfg.SetGlobalValueString(types.SSHAuthorizedKeys, "")
+	cfg.SetGlobalValueInt(types.ConfigInterval, 17)
 	data, err := json.Marshal(cfg)
 	g.Expect(err).To(gomega.BeNil())
 
 	globalFile := filepath.Join(dir, "global.json")
 	authKeysFile := filepath.Join(dir, "authorized_keys")
-	const sshKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKey test@example.com"
 	g.Expect(os.WriteFile(globalFile, data, 0644)).To(gomega.Succeed())
-	g.Expect(os.WriteFile(authKeysFile, []byte(sshKey+"\n"), 0644)).To(gomega.Succeed())
+	g.Expect(os.WriteFile(authKeysFile, []byte(testSSHKey+"\n"), 0644)).To(gomega.Succeed())
 
 	result := loadGlobalConfigImpl(ctx, globalFile, authKeysFile)
 	g.Expect(result).To(gomega.BeTrue())
 	g.Expect(ctx.zedagentCtx.globalConfig.GlobalValueString(types.SSHAuthorizedKeys)).
-		To(gomega.Equal(sshKey))
+		To(gomega.Equal(""))
+	g.Expect(ctx.zedagentCtx.globalConfig.GlobalValueInt(types.ConfigInterval)).
+		To(gomega.Equal(uint32(17)))
+}
+
+// TestLoadGlobalConfigBootstrapFromAuthorizedKeys: no GlobalConfig
+// on /config, only authorized_keys. Synthesizes a default
+// ConfigItemValueMap with debug.enable.ssh set to the file content.
+func TestLoadGlobalConfigBootstrapFromAuthorizedKeys(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctx := initGetConfigCtx(g)
+
+	dir := t.TempDir()
+	globalFile := filepath.Join(dir, "global.json") // intentionally absent
+	authKeysFile := filepath.Join(dir, "authorized_keys")
+	g.Expect(os.WriteFile(authKeysFile, []byte(testSSHKey+"\n"), 0644)).To(gomega.Succeed())
+
+	result := loadGlobalConfigImpl(ctx, globalFile, authKeysFile)
+	g.Expect(result).To(gomega.BeTrue())
+	g.Expect(ctx.zedagentCtx.globalConfig.GlobalValueString(types.SSHAuthorizedKeys)).
+		To(gomega.Equal(testSSHKey))
+}
+
+// TestLoadGlobalConfigBootstrapEmptyAuthKeys: empty authorized_keys
+// with no GlobalConfig must not publish a default ConfigItemValueMap.
+func TestLoadGlobalConfigBootstrapEmptyAuthKeys(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctx := initGetConfigCtx(g)
+
+	dir := t.TempDir()
+	globalFile := filepath.Join(dir, "global.json") // intentionally absent
+	authKeysFile := filepath.Join(dir, "authorized_keys")
+	g.Expect(os.WriteFile(authKeysFile, []byte(""), 0644)).To(gomega.Succeed())
+
+	result := loadGlobalConfigImpl(ctx, globalFile, authKeysFile)
+	g.Expect(result).To(gomega.BeFalse())
 }
 
 func TestLoadGlobalConfigMalformedJSON(t *testing.T) {


### PR DESCRIPTION
# Description

Fixes a regression introduced by PR #5584 ("Simplify/remove /persist/status/zedagent/*") that broke pre-onboarding SSH access on devices configured with `/config/authorized_keys` but no `/config/GlobalConfig`.

## Symptom

On a fresh device with `/config/authorized_keys` present and no controller config yet, an operator's SSH attempt fails immediately at the protocol-version handshake:

```
$ ssh -i ~/.ssh/key -p 2222 root@localhost
kex_exchange_identification: read: Connection reset by peer
Connection reset by 127.0.0.1 port 2222
```

The TCP connection is accepted by the kernel then immediately reset before sshd writes the SSH banner. Tracing: the iptables INPUT chain installed by `dpcreconciler/linux.go` (around line 1965) carries `REJECT --reject-with tcp-reset` on dport 22, because `gcpAllowSSH := gcp.GlobalValueString(types.SSHAuthorizedKeys) != ""` evaluates to false: `debug.enable.ssh` is empty even though `/config/authorized_keys` exists.

## Root cause

Before PR #5584, `upgradeconverter` ran on every boot, read `/config/authorized_keys` unconditionally when the file existed, and persisted the keys into `/persist/status/zedagent/ConfigItemValueMap`. That set `debug.enable.ssh` and opened the iptables rule. See commit ddfe2b0c3 ("Make upgradeconverter read ssh authorized keys from /config/authorized_keys").

PR #5584 removed that upgradeconverter pass with a commit (c2b3a5335) whose own message foreshadows the risk: *"Next is ConfigItemValueMap which might have some chicken and egg problems at bootup; need to have that published based on the checkpoint lastconfig as the agents start."*

The follow-on commit ffe87b58e2 ("Add back handling of /config/GlobalConfig/ json") re-added GlobalConfig loading in `zedagent/handleconfig.go`'s `loadGlobalConfigImpl` — but the new code only reads `/config/authorized_keys` when `/config/GlobalConfig` ALSO exists. A fresh un-onboarded device has neither, the early-return fires, the keys are never ingested, and iptables REJECTs port 22.

## Fix

Restore the bootstrap-SSH path while preserving the new precedence model:

- **GlobalConfig present** → authoritative, even with empty `debug.enable.ssh`. authorized_keys is ignored (with a `Noticef` log so the unused file is visible).
- **GlobalConfig missing** → fall back to authorized_keys; synthesize a default `ConfigItemValueMap` with `SSHAuthorizedKeys` set from the file.
- **Both missing** → return false.
- **Empty/invalid authorized_keys + no GlobalConfig** → return false.

The precedence rule deliberately gives GlobalConfig priority even when its `debug.enable.ssh` is empty: an operator who set "no SSH" must not have a stale `authorized_keys` file re-enable it against their wishes.

The bool return semantics shifted slightly — `true` can now mean "authorized_keys-only bootstrap" in addition to "successful GlobalConfig load." The only caller in `zedagent.go:443` feeds the bool into `globalConfigPublished = !changed`, which is unconditionally overwritten at line 462 after `pubGlobalConfig.Publish`. So the shift is harmless.

## How to test and validate this PR

Six unit tests covering the precedence matrix (all in `pkg/pillar/cmd/zedagent/handleconfig_test.go`):

- `TestLoadGlobalConfigBothMissing` — both files absent → false
- `TestLoadGlobalConfigSuccess` — GlobalConfig only → true, fields loaded
- `TestLoadGlobalConfigPrefersGlobalOverAuthKeys` — both present, empty `debug.enable.ssh` in GlobalConfig, non-default `ConfigInterval` fingerprint to pin which branch ran → empty SSH wins, ConfigInterval intact
- `TestLoadGlobalConfigBootstrapFromAuthorizedKeys` — authorized_keys only (the regression scenario) → keys loaded
- `TestLoadGlobalConfigBootstrapEmptyAuthKeys` — empty authorized_keys, no GlobalConfig → false
- `TestLoadGlobalConfigMalformedJSON` — GlobalConfig malformed → false

Manual verification:

- Fresh device with `/config/authorized_keys` and NO `/config/GlobalConfig`: confirm `iptables -L INPUT | grep dpt:ssh` shows ACCEPT (not REJECT), and SSH connects on port 22 (or 2222 via qemu host-forward).
- Device with `/config/GlobalConfig` setting `debug.enable.ssh=""` AND a populated `/config/authorized_keys`: confirm SSH remains rejected — precedence is preserved.

## Changelog notes

Restore pre-PR-#5584 behaviour: devices with `/config/authorized_keys` but no `/config/GlobalConfig` regain operator SSH access before the device has been onboarded to a controller. Devices where `/config/GlobalConfig` explicitly sets `debug.enable.ssh=""` continue to deny SSH (precedence is preserved).

## PR Backports

- 16.0-stable: To be backported — regression is present (cherry-pick `c25a471bb` of the upgradeconverter removal landed there; buggy `loadGlobalConfig` early-return on missing `/config/GlobalConfig` is present in `zedagent/handleconfig.go`).
- 14.5-stable: To be backported — regression is present via PR #5753 (cherry-pick `4d64e4ddc`); same buggy `loadGlobalConfig` shape.
- 13.4-stable: NOT needed — neither `c2b3a5335` nor any equivalent cherry-pick of the upgradeconverter removal was applied; the old `upgradeconverter` path still reads `/config/authorized_keys` unconditionally, so the regression does not exist on 13.4-stable.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.