### PR TITLE
mkimage-raw-efi/storage-init: drop leftover evaluation/IMGC support

### DIFF
--- a/pkg/installer/install
+++ b/pkg/installer/install
@@ -52,12 +52,6 @@ BOOT_DIR="${ARTIFACTS_DIR}/boot"
 
 ROOTFS_PARTITIONS="imga imgb"
 
-# if we have a third rootfs, we will use it as the third partition
-if [ -f "${ARTIFACTS_DIR}/rootfs-c.img" ]; then
-  logmsg "Found rootfs-c.img, will use it as the third partition (IMGC)"
-  ROOTFS_PARTITIONS="$ROOTFS_PARTITIONS imgc"
-fi
-
 # This is a temp file to capture various stages of install
 # the contents of this file are saved to $REPORT/installer.log
 # After the USB install, users can see the installation status under /Volumes/INVENTORY/<serial#>/installer.log

--- a/pkg/mkimage-raw-efi/make-raw
+++ b/pkg/mkimage-raw-efi/make-raw
@@ -69,14 +69,12 @@ EFI_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30051
 IMGA_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30052
 IMGB_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30053
 CONF_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30054
-IMGC_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30055
 PERSIST_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30059
 INSTALLER_UUID=ad6871ee-31f9-4cf3-9e09-6f7a25c30060
 
 # content of rootfs partition
 ROOTFS_IMG=/parts/rootfs.img
 ROOTFS_IMG_B=/parts/rootfs-b.img
-ROOTFS_IMG_C=/parts/rootfs-c.img
 # contents of installer partition
 INSTALLER_IMG=/parts/installer.img
 # content of conf partition
@@ -112,16 +110,9 @@ if [ -z "$PLATFORM" ]; then
   fi
 fi
 
-if [ "$PLATFORM" = "evaluation" ]; then
-    PARTS=${*:-"efi imga imgb imgc conf persist"}
-    # we do not update any rootfs for evaluation platform
-    # so we do not reserve any space in the partition
-    ROOTFS_PART_SIZE_MIN=0
-else
-    PARTS=${*:-"efi imga imgb conf persist"}
-    # wipe IMGB for non-evaluation platforms
-    ROOTFS_IMG_B=
-fi
+PARTS=${*:-"efi imga imgb conf persist"}
+# only one rootfs is populated at build time; wipe the IMGB image
+ROOTFS_IMG_B=
 
 
 # conf partition size in bytes
@@ -143,7 +134,6 @@ SYSTEM_VFAT_PART_OFFSET=1
 VFAT_PART_OFFSET=4
 IMGA_PART_OFFSET=2
 IMGB_PART_OFFSET=3
-IMGC_PART_OFFSET=7
 EFI_PART_OFFSET=1
 CONF_PART_OFFSET=4
 PERSIST_PART_OFFSET=9
@@ -198,16 +188,6 @@ calc_rootfs_part_b_size() {
   echo $SIZE
 }
 
-calc_rootfs_part_c_size() {
-  local SIZE
-
-  SIZE=$(file_size "$ROOTFS_IMG_C")
-  # Take max
-  SIZE=$((SIZE > ROOTFS_PART_SIZE_MIN ? SIZE : ROOTFS_PART_SIZE_MIN))
-
-  echo $SIZE
-}
-
 calc_installer_part_size() {
   local MB
   local SIZE
@@ -253,9 +233,6 @@ calc_image_size() {
               ;;
           imgb)
               SIZE=$((SIZE + $(calc_rootfs_part_b_size)))
-              ;;
-          imgc)
-              SIZE=$((SIZE + $(calc_rootfs_part_c_size)))
               ;;
           installer)
               SIZE=$((SIZE + $(calc_installer_part_size)))
@@ -446,12 +423,9 @@ do_imga() {
 }
 
 do_imgb() {
-  # if ROOTFS_IMG_B is empty we are wiping IMGB
-  do_rootfs "$1" IMGB "$(calc_rootfs_part_b_size)" $IMGB_PART $IMGB_UUID $ROOTFS_IMG_B
-}
-
-do_imgc() {
-  do_rootfs "$1" IMGC "$(calc_rootfs_part_c_size)" $IMGC_PART $IMGC_UUID $ROOTFS_IMG_C
+  # if ROOTFS_IMG_B is empty we are wiping IMGB; do_rootfs treats an empty
+  # image argument the same as an absent one, so quoting is safe here
+  do_rootfs "$1" IMGB "$(calc_rootfs_part_b_size)" $IMGB_PART $IMGB_UUID "$ROOTFS_IMG_B"
 }
 
 # create a VFAT partition with the specified UUID
@@ -652,7 +626,6 @@ VFAT_PART=$(( PART_OFFSET + VFAT_PART_OFFSET ))
 INSTALLER_PART=$(( PART_OFFSET + INSTALLER_PART_OFFSET ))
 IMGA_PART=$(( PART_OFFSET + IMGA_PART_OFFSET ))
 IMGB_PART=$(( PART_OFFSET + IMGB_PART_OFFSET ))
-IMGC_PART=$(( PART_OFFSET + IMGC_PART_OFFSET ))
 EFI_PART=$(( PART_OFFSET + EFI_PART_OFFSET ))
 CONF_PART=$(( PART_OFFSET + CONF_PART_OFFSET ))
 PERSIST_PART=$(( PART_OFFSET + PERSIST_PART_OFFSET ))
@@ -687,8 +660,7 @@ done
 # set the appropriate boot partition for grub gptprio.next
 # Partition attribute initialization - can apply multiple:
 #   1. Installer partition (if installer present) - installer bootable
-#   2. Evaluation rootfs partitions (if platform=evaluation) - all rootfs scheduled
-#   3. Regular rootfs partition (otherwise) - one rootfs bootable
+#   2. Regular rootfs partition (otherwise) - one rootfs bootable
 
 # Step 1: Initialize installer partition if present
 if echo "$PARTS" | grep -q "installer"; then
@@ -696,45 +668,17 @@ if echo "$PARTS" | grep -q "installer"; then
   sgdisk --attributes=$INSTALLER_PART:set:49 --attributes=$INSTALLER_PART:set:56 "$IMGFILE"
 fi
 
-# Step 2: Initialize rootfs partitions for evaluation platform
-if [ "$PLATFORM" = "evaluation" ]; then
-  # Evaluation EVE image: All three rootfs partitions start in "scheduled" state
-  # Priority is encoded in GPT attribute bits 48-51 (4 bits, 0-15)
-  # Tries left is encoded in bits 52-55 (4 bits, 0-15)
-  # Bit 56 = successful flag
-  # Initial state: all priority=3, tries=1, successful=0 (0x013 = "scheduled")
-  # This allows evalmgr to test all three partitions during evaluation
-  # GRUB will boot IMGA first (alphabetically first at priority=3)
+# Step 2: Only one rootfs partition is bootable (imga > imgb)
+BOOTABLE_PART=""
+if echo "$PARTS" | grep -q "imga"; then
+  BOOTABLE_PART=$IMGA_PART
+elif echo "$PARTS" | grep -q "imgb"; then
+  BOOTABLE_PART=$IMGB_PART
+fi
 
-  if echo "$PARTS" | grep -q "imga"; then
-    # IMGA: priority=3 (bits 48,49), tries=1 (bit 52), successful=0 - creates 0x013 "scheduled"
-    sgdisk --attributes=$IMGA_PART:set:48 --attributes=$IMGA_PART:set:49 --attributes=$IMGA_PART:set:52 "$IMGFILE"
-  fi
-
-  if echo "$PARTS" | grep -q "imgb"; then
-    # IMGB: priority=3 (bits 48,49), tries=1 (bit 52), successful=0 - creates 0x013 "scheduled"
-    sgdisk --attributes=$IMGB_PART:set:48 --attributes=$IMGB_PART:set:49 --attributes=$IMGB_PART:set:52 "$IMGFILE"
-  fi
-
-  if echo "$PARTS" | grep -q "imgc"; then
-    # IMGC: priority=3 (bits 48,49), tries=1 (bit 52), successful=0 - creates 0x013 "scheduled"
-    sgdisk --attributes=$IMGC_PART:set:48 --attributes=$IMGC_PART:set:49 --attributes=$IMGC_PART:set:52 "$IMGFILE"
-  fi
-else
-  # Regular EVE image: Only one rootfs partition bootable (imga > imgb > imgc)
-  BOOTABLE_PART=""
-  if echo "$PARTS" | grep -q "imga"; then
-    BOOTABLE_PART=$IMGA_PART
-  elif echo "$PARTS" | grep -q "imgb"; then
-    BOOTABLE_PART=$IMGB_PART
-  elif echo "$PARTS" | grep -q "imgc"; then
-    BOOTABLE_PART=$IMGC_PART
-  fi
-
-  if [ -n "$BOOTABLE_PART" ]; then
-    # Set priority bits and successful flag (creates "active" state)
-    sgdisk --attributes=$BOOTABLE_PART:set:49 --attributes=$BOOTABLE_PART:set:56 "$IMGFILE"
-  fi
+if [ -n "$BOOTABLE_PART" ]; then
+  # Set priority bits and successful flag (creates "active" state)
+  sgdisk --attributes=$BOOTABLE_PART:set:49 --attributes=$BOOTABLE_PART:set:56 "$IMGFILE"
 fi
 
 if [ "$PARTS" = usb_conf ]; then

--- a/pkg/storage-init/storage-init.sh
+++ b/pkg/storage-init/storage-init.sh
@@ -121,21 +121,18 @@ if [ "$eve_flavor" = "k" ]; then
 fi
 
 # First lets see if we're running with the disk that hasn't been properly
-# initialized. This could happen in two situations:
-#   1. when we run in a virtualized cloud environment
-#       where the initial disk image gets resized to its proper
-#       size when EVE is started (it can also happen when you're preparing a
-#       live image for something like HiKey and put it directly on the flash
-#       card bypassing using EVE's installer).
+# initialized. This could happen when we run in a virtualized cloud
+# environment where the initial disk image gets resized to its proper
+# size when EVE is started (it can also happen when you're preparing a
+# live image for something like HiKey and put it directly on the flash
+# card bypassing using EVE's installer).
 #
-#       The criteria we're using to determine if the disk hasn't been fully
-#       initialized is when it is missing both P3 (/persist) and IMGB partition
-#       entries. If that's the case we're willing to (potentially destructively)
-#       manipulate partition table. The logic here is simple: if we're missing
-#       both IMGB and P3 the following code is probably the *least* risky thing
-#       we can do.
-#
-#   2. PLATFORM=evaluation where there are three OS image slots.
+# The criteria we're using to determine if the disk hasn't been fully
+# initialized is when it is missing both P3 (/persist) and IMGB partition
+# entries. If that's the case we're willing to (potentially destructively)
+# manipulate partition table. The logic here is simple: if we're missing
+# both IMGB and P3 the following code is probably the *least* risky thing
+# we can do.
 #
 #   Its possible that P3 is missing in cases where the EVE installer was
 #   configured to place persist on a zfs pool which could span 1 or more
@@ -144,21 +141,14 @@ fi
 P3=$(findfs PARTLABEL=P3)
 IMGA=$(findfs PARTLABEL=IMGA)
 IMGB=$(findfs PARTLABEL=IMGB)
-IMGC=$(findfs PARTLABEL=IMGC)
 is_first_boot_virt_eve() {
     if [ -n "$IMGA" ] && [ -z "$P3" ] && [ -z "$IMGB" ]; then
         return 0
     fi
     return 1
 }
-is_first_boot_eval_eve() {
-    if [ -n "$IMGA" ] && [ -z "$P3" ] && [ -n "$IMGC" ]; then
-        return 0
-    fi
-    return 1
-}
 
-if is_first_boot_virt_eve || is_first_boot_eval_eve; then
+if is_first_boot_virt_eve; then
    DEV=$(echo /sys/block/*/"${IMGA#/dev/}")
    DEV="/dev/$(echo "$DEV" | cut -f4 -d/)"
 


### PR DESCRIPTION
# Description

Follow-up to PR #6022, which removed the EVALUATION platform from the build system but did not touch the image-creation and first-boot scripts. Their IMGC (third rootfs) support and the evaluation-specific GPT attribute initialization were therefore left behind as dead code: with no evaluation images being built, nothing produces a `rootfs-c.img` or requests an `imgc` partition anymore.

This continues the move toward eve-k with an HWE kernel as the default, where the evaluation platform has no place — and leaves no IMGC/evaluation leftovers in these scripts.

`make-raw`:
- Remove `IMGC_UUID`, `ROOTFS_IMG_C`, `IMGC_PART_OFFSET`, `IMGC_PART`, `calc_rootfs_part_c_size`, the `imgc` case in `calc_image_size`, and `do_imgc`.
- Remove the `PLATFORM=evaluation` PARTS branch and the evaluation attribute-init block, collapsing to the regular single bootable-rootfs path. The `PLATFORM` detection itself is kept — it is still useful; only the evaluation-specific handling is dropped.

`installer/install`:
- Remove the `rootfs-c.img`/`imgc` branch that appended an `imgc` partition to the make-raw partition list.

`storage-init`:
- Remove the `IMGC` partition lookup and the `is_first_boot_eval_eve()` evaluation first-boot path; first-boot GPT repair now keys off the virtualized-cloud case only.

This is build-time and first-boot scripting only. The pillar Go side (`evalmgr` and friends) is removed separately.

## How to test and validate this PR

- `make ZARCH=amd64 PLATFORM=generic live-raw` (and `installer-raw`) still build a normal image with the `efi imga imgb conf persist` layout; the generated disk has no IMGC partition.
- `make HV=k ZARCH=amd64 PLATFORM=generic live-raw` (eve-k) builds unchanged.
- `shellcheck pkg/mkimage-raw-efi/make-raw pkg/installer/install pkg/storage-init/storage-init.sh` passes.
- `grep -rn "imgc\|IMGC\|rootfs-c" pkg/mkimage-raw-efi/make-raw pkg/installer/install pkg/storage-init/storage-init.sh` returns nothing.

## Changelog notes

No user-facing changes. Removes dead build-time and first-boot IMGC/evaluation code from the raw image, installer, and storage-init scripts.

## PR dependencies

Follows #6022 (merged). Independent of the pillar Go-side removal (#6041).

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them. This is a build-time/first-boot scripting change validated by building images locally; no runtime behavior changes for non-evaluation devices.
