### PR TITLE
pillar, kube: fix VMI Init-phase state mis-report, stuck detection, and debug tooling

### DIFF
--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -54,6 +54,22 @@ ifeq ($(COVER),y)
 	COVERFLAGS:=-cover -covermode=atomic
 endif
 
+# Controls gotestsum display format. Override on the command line for per-test detail.
+#   pkgname          (default) one line per package: ✓ cmd/zedkube (1.1s)
+#   standard-verbose one line per test:  --- PASS: TestFoo/case (0.00s)
+#   testdox          human-readable test names grouped by package
+#   dots             a dot per test, compact for large suites
+GOTESTSUM_FORMAT ?= pkgname
+
+# Restrict which packages are tested. Default is all packages.
+# Example: make TESTPKGS=./cmd/domainmgr/... test
+TESTPKGS ?= ./...
+
+# Filter tests by name (passed to go test -run). Default runs all tests.
+# Example: make TESTRUN=TestVerifyStatus test
+# Example: make TESTPKGS=./cmd/domainmgr/... TESTRUN=TestVerifyStatus test
+TESTRUN ?=
+
 ifneq ($(HV),)
        LDFLAGS=-extldflags '-fuse-ld=bfd -no-pie'
 else
@@ -108,10 +124,11 @@ test: build-docker-test
 		--mount type=bind,source=./results.xml,target=/pillar/results.xml \
 		--mount type=bind,source=./coverage.txt,target=/pillar/coverage.txt \
 		--entrypoint /final/opt/gotestsum $(DOCKER_TAG) \
+		--format $(GOTESTSUM_FORMAT) \
 		--jsonfile /pillar/results.json \
 		--junitfile /pillar/results.xml \
 		--raw-command -- go test -tags k -coverprofile=coverage.txt -covermode=atomic -race -json \
-		./...
+		$(if $(TESTRUN),-run $(TESTRUN)) $(TESTPKGS)
 
 fuzz-test: build-docker-test
 	docker run --platform linux/$(ZARCH) -w /pillar \

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1167,6 +1167,20 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 			status.State = types.RUNNING
 			status.KubeTrustLoggedState = 0
 			publishDomainStatus(ctx, status)
+		} else if status.Activated &&
+			(domainStatus == types.SCHEDULING || domainStatus == types.PENDING) &&
+			status.State != types.BOOTING {
+			// Domain was running but has re-entered a pre-running phase
+			// (e.g. virt-launcher pod stuck in Init after a reschedule).
+			// Report BOOTING — the same state doActivateTail uses for this
+			// transitional window — so AppInstanceStatus stops reflecting
+			// stale RUNNING state. Activated=false primes the recovery path
+			// to promote back to RUNNING once Info() observes RUNNING again.
+			log.Noticef("verifyDomain(%s) domain rescheduling (%s): state %s -> BOOTING",
+				status.Key(), domainStatus, status.State)
+			status.Activated = false
+			status.State = types.BOOTING
+			publishDomainStatus(ctx, status)
 		} else if domainID != status.DomainId {
 			// XXX shutdown + create?
 			log.Warnf("verifyDomain(%s) domainID changed from %d to %d",

--- a/pkg/pillar/cmd/domainmgr/verifystatus_test.go
+++ b/pkg/pillar/cmd/domainmgr/verifystatus_test.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package domainmgr
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/hypervisor"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Minimal mock: pubsub.Publication
+// ---------------------------------------------------------------------------
+
+type mockPublication struct {
+	items map[string]interface{}
+}
+
+func newMockPublication() *mockPublication {
+	return &mockPublication{items: make(map[string]interface{})}
+}
+
+func (m *mockPublication) CheckMaxSize(_ string, _ interface{}) error { return nil }
+func (m *mockPublication) SignalRestarted() error                     { return nil }
+func (m *mockPublication) ClearRestarted() error                      { return nil }
+func (m *mockPublication) Close() error                               { return nil }
+func (m *mockPublication) Iterate(_ base.StrMapFunc)                  {}
+func (m *mockPublication) Unpublish(key string) error                 { delete(m.items, key); return nil }
+func (m *mockPublication) Get(key string) (interface{}, error) {
+	v, ok := m.items[key]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+	return v, nil
+}
+func (m *mockPublication) GetAll() map[string]interface{} {
+	out := make(map[string]interface{}, len(m.items))
+	for k, v := range m.items {
+		out[k] = v
+	}
+	return out
+}
+func (m *mockPublication) Publish(key string, item interface{}) error {
+	m.items[key] = item
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Minimal mock: pubsub.Subscription (used by lookupDomainConfig — returns nil)
+// ---------------------------------------------------------------------------
+
+type mockSubscription struct{}
+
+func (m *mockSubscription) Get(_ string) (interface{}, error) { return nil, fmt.Errorf("not found") }
+func (m *mockSubscription) GetAll() map[string]interface{}    { return nil }
+func (m *mockSubscription) Iterate(_ base.StrMapFunc)         {}
+func (m *mockSubscription) Restarted() bool                   { return false }
+func (m *mockSubscription) RestartCounter() int               { return 0 }
+func (m *mockSubscription) Synchronized() bool                { return true }
+func (m *mockSubscription) ProcessChange(_ pubsub.Change)     {}
+func (m *mockSubscription) MsgChan() <-chan pubsub.Change     { return nil }
+func (m *mockSubscription) Activate() error                   { return nil }
+func (m *mockSubscription) Close() error                      { return nil }
+
+// ---------------------------------------------------------------------------
+// Minimal mock: types.Task — only Info() is meaningful for verifyStatus tests
+// ---------------------------------------------------------------------------
+
+type mockKubeTask struct {
+	infoState types.SwState
+	infoID    int
+	infoErr   error
+}
+
+func (m *mockKubeTask) Info(_ string) (int, types.SwState, error) {
+	return m.infoID, m.infoState, m.infoErr
+}
+func (m *mockKubeTask) Setup(_ types.DomainStatus, _ types.DomainConfig, _ *types.AssignableAdapters, _ *types.ConfigItemValueMap, _ *os.File) error {
+	return nil
+}
+func (m *mockKubeTask) VirtualTPMSetup(_ string, _ *types.WatchdogParam) error     { return nil }
+func (m *mockKubeTask) VirtualTPMTerminate(_ string, _ *types.WatchdogParam) error { return nil }
+func (m *mockKubeTask) VirtualTPMTeardown(_ string, _ *types.WatchdogParam) error  { return nil }
+func (m *mockKubeTask) OemWindowsLicenseKeySetup(_ *types.OemWindowsLicenseKeyInfo) error {
+	return nil
+}
+func (m *mockKubeTask) Create(_ string, _ string, _ *types.DomainConfig) (int, error) {
+	return 0, nil
+}
+func (m *mockKubeTask) Start(_ string) error        { return nil }
+func (m *mockKubeTask) Stop(_ string, _ bool) error { return nil }
+func (m *mockKubeTask) Delete(_ string) error       { return nil }
+func (m *mockKubeTask) Cleanup(_ string) error      { return nil }
+
+// ---------------------------------------------------------------------------
+// Minimal mock: hypervisor.Hypervisor — only Task() is called by verifyStatus
+// ---------------------------------------------------------------------------
+
+type mockKubeHypervisor struct {
+	task *mockKubeTask
+}
+
+func (m *mockKubeHypervisor) Name() string                          { return "mock-kube" }
+func (m *mockKubeHypervisor) Task(_ *types.DomainStatus) types.Task { return m.task }
+func (m *mockKubeHypervisor) PCIReserve(_ string) error             { return nil }
+func (m *mockKubeHypervisor) PCIRelease(_ string) error             { return nil }
+func (m *mockKubeHypervisor) PCISameController(_, _ string) bool    { return false }
+func (m *mockKubeHypervisor) GetHostCPUMem() (types.HostMemory, error) {
+	return types.HostMemory{}, nil
+}
+func (m *mockKubeHypervisor) GetDomsCPUMem() (map[string]types.DomainMetric, error) {
+	return nil, nil
+}
+func (m *mockKubeHypervisor) GetCapabilities() (*types.Capabilities, error) { return nil, nil }
+func (m *mockKubeHypervisor) CountMemOverhead(_ string, _ uuid.UUID, _, _, _, _ int64, _ []types.IoAdapter, _ *types.AssignableAdapters, _ *types.ConfigItemValueMap) (uint64, error) {
+	return 0, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func newTestDomainContext(pub *mockPublication) *domainContext {
+	return &domainContext{
+		subDomainConfig: &mockSubscription{},
+		pubDomainStatus: pub,
+	}
+}
+
+func newTestDomainStatus(name string, state types.SwState, activated bool) *types.DomainStatus {
+	return &types.DomainStatus{
+		DomainName: name,
+		State:      state,
+		Activated:  activated,
+	}
+}
+
+func swapHyper(t *testing.T, h hypervisor.Hypervisor) {
+	t.Helper()
+	saved := hyper
+	hyper = h
+	t.Cleanup(func() { hyper = saved })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestVerifyStatusKubeRescheduleToBooting: a previously Running domain whose
+// VMI enters the Scheduling phase (Init:0/1 pod) should transition to BOOTING
+// with Activated=false so the recovery path can fire later.
+func TestVerifyStatusKubeRescheduleToBooting(t *testing.T) {
+	pub := newMockPublication()
+	swapHyper(t, &mockKubeHypervisor{task: &mockKubeTask{infoState: types.SCHEDULING, infoID: 1}})
+
+	ctx := newTestDomainContext(pub)
+	status := newTestDomainStatus("test-domain", types.RUNNING, true)
+
+	verifyStatus(ctx, status)
+
+	assert.Equal(t, types.BOOTING, status.State, "rescheduling VMI should report BOOTING")
+	assert.False(t, status.Activated, "Activated must be false to enable recovery path")
+	assert.NotEmpty(t, pub.items, "DomainStatus should be published after transition")
+}
+
+// TestVerifyStatusKubeRecoveryToRunning: a domain that was set to BOOTING
+// (Activated=false) while the VMI was rescheduling should recover to RUNNING
+// once Info() reports the domain is Running again.
+func TestVerifyStatusKubeRecoveryToRunning(t *testing.T) {
+	pub := newMockPublication()
+	swapHyper(t, &mockKubeHypervisor{task: &mockKubeTask{infoState: types.RUNNING, infoID: 1}})
+
+	ctx := newTestDomainContext(pub)
+	status := newTestDomainStatus("test-domain", types.BOOTING, false)
+
+	verifyStatus(ctx, status)
+
+	assert.Equal(t, types.RUNNING, status.State, "recovered VMI should report RUNNING")
+	assert.True(t, status.Activated, "Activated must be true after recovery")
+	assert.NotEmpty(t, pub.items, "DomainStatus should be published after recovery")
+}
+
+// TestVerifyStatusKubeRoundTrip: exercises the full RUNNING → BOOTING → RUNNING
+// cycle that occurs when a virt-launcher pod goes through Init:0/1 and recovers.
+func TestVerifyStatusKubeRoundTrip(t *testing.T) {
+	pub := newMockPublication()
+	mockTask := &mockKubeTask{infoState: types.SCHEDULING, infoID: 1}
+	swapHyper(t, &mockKubeHypervisor{task: mockTask})
+
+	ctx := newTestDomainContext(pub)
+	status := newTestDomainStatus("test-domain", types.RUNNING, true)
+
+	// Phase 1: VMI enters Scheduling — should go BOOTING
+	verifyStatus(ctx, status)
+	assert.Equal(t, types.BOOTING, status.State)
+	assert.False(t, status.Activated)
+
+	// Phase 2: VMI recovers to Running — should go RUNNING
+	mockTask.infoState = types.RUNNING
+	verifyStatus(ctx, status)
+	assert.Equal(t, types.RUNNING, status.State)
+	assert.True(t, status.Activated)
+}
+
+// TestVerifyStatusKubeAlreadyBooting: if the domain is already in BOOTING
+// state (Activated=false), a subsequent SCHEDULING observation must not
+// re-publish or double-transition.
+func TestVerifyStatusKubeAlreadyBooting(t *testing.T) {
+	pub := newMockPublication()
+	// infoID must match status.DomainId (both 0) so the domainID-changed branch
+	// does not fire and trigger a spurious publish.
+	swapHyper(t, &mockKubeHypervisor{task: &mockKubeTask{infoState: types.SCHEDULING, infoID: 0}})
+
+	ctx := newTestDomainContext(pub)
+	status := newTestDomainStatus("test-domain", types.BOOTING, false)
+
+	verifyStatus(ctx, status)
+
+	// State and Activated unchanged; nothing published for this domain
+	assert.Equal(t, types.BOOTING, status.State, "state should not change when already BOOTING")
+	assert.False(t, status.Activated)
+	assert.Empty(t, pub.items, "should not publish when already in BOOTING state")
+}

--- a/pkg/pillar/cmd/zedkube/pendingvmi.go
+++ b/pkg/pillar/cmd/zedkube/pendingvmi.go
@@ -114,13 +114,7 @@ func (z *zedkube) checkStuckPendingVMI() {
 			continue
 		}
 
-		if vmi.Status.Phase == virtv1.Running {
-			delete(z.vmiPendingSince, appUUID)
-			delete(z.vmiDeleteCount, appUUID)
-			continue
-		}
-
-		if vmi.Status.Phase != virtv1.Pending {
+		if !vmiPhaseIsPreRunning(vmi.Status.Phase) {
 			delete(z.vmiPendingSince, appUUID)
 			delete(z.vmiDeleteCount, appUUID)
 			continue
@@ -185,12 +179,47 @@ func findAppVMI(vmis []virtv1.VirtualMachineInstance, appKubeName string) *virtv
 	return nil
 }
 
+// vmiPhaseIsPreRunning reports whether the VMI phase represents a not-yet-running
+// state. Returns true for Pending and Scheduling — both indicate the VM has not
+// started. All other phases (Running, Succeeded, Failed, Unknown) return false.
+func vmiPhaseIsPreRunning(phase virtv1.VirtualMachineInstancePhase) bool {
+	return phase == virtv1.Pending || phase == virtv1.Scheduling
+}
+
+// virtLauncherPodIsActiveOnNode reports whether any virt-launcher pod for
+// appKubeName is assigned to nodeName and in an active state. Active means
+// the pod is Running, Failed, has a container-level error, or is in the
+// Pending phase with Spec.NodeName already set (i.e. the init container is
+// running but has not yet completed — Init:0/1 in kubectl STATUS).
+//
+// Pods are matched by name prefix rather than label selector because the
+// App-Domain-Name label is set to the domain name (UUID.Version.AppNum),
+// not appKubeName.
+func virtLauncherPodIsActiveOnNode(pods []corev1.Pod, appKubeName, nodeName string) bool {
+	vlPrefix := base.VMIPodNamePrefix + appKubeName
+	for _, p := range pods {
+		if !strings.HasPrefix(p.Name, vlPrefix) {
+			continue
+		}
+		if p.Spec.NodeName != nodeName {
+			continue
+		}
+		if isPodTerminating(p) {
+			continue
+		}
+		if p.Status.Phase == corev1.PodRunning ||
+			p.Status.Phase == corev1.PodFailed ||
+			podHasContainerError(p) ||
+			p.Status.Phase == corev1.PodPending {
+			return true
+		}
+	}
+	return false
+}
+
 // virtLauncherActiveOnThisNode returns true iff a virt-launcher pod for the
-// given app is on the local node and either in Running phase or in a pod-level
-// error state (Failed, or Running with a container stuck in CrashLoopBackOff /
-// error-waiting / terminated-with-error). In all of these, the cluster has
-// placed the launcher here but the VMI is not making progress, which is the
-// signature of the kubevirt/longhorn stuck-Pending-VMI condition.
+// given app is on the local node and in an active state. See
+// virtLauncherPodIsActiveOnNode for the full definition of active.
 //
 // The pod is identified by name prefix "virt-launcher-<appKubeName>" since the
 // App-Domain-Name label is set to status.DomainName (UUID.Version.AppNum)
@@ -208,24 +237,7 @@ func (z *zedkube) virtLauncherActiveOnThisNode(appKubeName string) bool {
 		log.Errorf("virtLauncherActiveOnThisNode: list pods: %v", err)
 		return false
 	}
-	vlPrefix := base.VMIPodNamePrefix + appKubeName
-	for _, p := range pods.Items {
-		if !strings.HasPrefix(p.Name, vlPrefix) {
-			continue
-		}
-		if p.Spec.NodeName != z.nodeName {
-			continue
-		}
-		if isPodTerminating(p) {
-			continue
-		}
-		if p.Status.Phase == corev1.PodRunning ||
-			p.Status.Phase == corev1.PodFailed ||
-			podHasContainerError(p) {
-			return true
-		}
-	}
-	return false
+	return virtLauncherPodIsActiveOnNode(pods.Items, appKubeName, z.nodeName)
 }
 
 // podHasContainerError returns true if any container in the pod is in a

--- a/pkg/pillar/cmd/zedkube/pendingvmi_test.go
+++ b/pkg/pillar/cmd/zedkube/pendingvmi_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package zedkube
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	virtv1 "kubevirt.io/api/core/v1"
+)
+
+func TestVMIPhaseIsPreRunning(t *testing.T) {
+	tests := []struct {
+		phase virtv1.VirtualMachineInstancePhase
+		want  bool
+	}{
+		{virtv1.Pending, true},
+		{virtv1.Scheduling, true},
+		{virtv1.Scheduled, false},
+		{virtv1.Running, false},
+		{virtv1.Succeeded, false},
+		{virtv1.Failed, false},
+		{virtv1.Unknown, false},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.phase), func(t *testing.T) {
+			assert.Equal(t, tc.want, vmiPhaseIsPreRunning(tc.phase))
+		})
+	}
+}
+
+func TestVirtLauncherPodIsActiveOnNode(t *testing.T) {
+	const node = "andrew-cherry"
+	const appKubeName = "enc-a2-84c66"
+
+	mkPod := func(name, specNode string, phase corev1.PodPhase) corev1.Pod {
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       corev1.PodSpec{NodeName: specNode},
+			Status:     corev1.PodStatus{Phase: phase},
+		}
+	}
+	launcherName := "virt-launcher-" + appKubeName + "-x"
+
+	tests := []struct {
+		name string
+		pods []corev1.Pod
+		want bool
+	}{
+		{
+			name: "Pending phase with NodeName set (Init:0/1 on this node)",
+			pods: []corev1.Pod{mkPod(launcherName, node, corev1.PodPending)},
+			want: true,
+		},
+		{
+			name: "Pending phase with NodeName empty (unscheduled)",
+			pods: []corev1.Pod{mkPod(launcherName, "", corev1.PodPending)},
+			want: false,
+		},
+		{
+			name: "Running phase on this node",
+			pods: []corev1.Pod{mkPod(launcherName, node, corev1.PodRunning)},
+			want: true,
+		},
+		{
+			name: "Failed phase on this node",
+			pods: []corev1.Pod{mkPod(launcherName, node, corev1.PodFailed)},
+			want: true,
+		},
+		{
+			name: "Running phase on a different node",
+			pods: []corev1.Pod{mkPod(launcherName, "other-node", corev1.PodRunning)},
+			want: false,
+		},
+		{
+			name: "Terminating pod on this node",
+			pods: []corev1.Pod{func() corev1.Pod {
+				p := mkPod(launcherName, node, corev1.PodRunning)
+				now := metav1.Now()
+				p.DeletionTimestamp = &now
+				return p
+			}()},
+			want: false,
+		},
+		{
+			name: "Pod name does not match app prefix",
+			pods: []corev1.Pod{mkPod("virt-launcher-other-app-x", node, corev1.PodRunning)},
+			want: false,
+		},
+		{
+			name: "No pods",
+			pods: nil,
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, virtLauncherPodIsActiveOnNode(tc.pods, appKubeName, node))
+		})
+	}
+}

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -776,6 +776,21 @@ func (ctx kubevirtContext) Create(domainName string, cfgFilename string, config 
 	return ctx.vmiList[domainName].domainID, nil
 }
 
+// podListToSchedulingState derives the node-placement decision from a
+// pre-fetched list of virt-launcher pods. Spec.NodeName is the authoritative
+// signal for node assignment; Status.Phase is deliberately not used because a
+// pod in Init:0/1 carries Phase="Pending" even after it has been bound to a
+// node by the scheduler.
+func podListToSchedulingState(pods []k8sv1.Pod, nodeName string) (onMe bool, anyNode bool, err error) {
+	for _, p := range pods {
+		if p.ObjectMeta.DeletionTimestamp != nil {
+			continue
+		}
+		return p.Spec.NodeName == nodeName, true, nil
+	}
+	return false, false, fmt.Errorf("unhandled scheduling state")
+}
+
 // replicaVmiScheduledOnMe is the VMI replicaset implementation of scheduledOnMe()
 func (ctx kubevirtContext) replicaVmiScheduledOnMe(vmirsName string) (scheduledOnMe bool, scheduledOnNone bool, err error) {
 	err = getConfig(&ctx)
@@ -838,23 +853,7 @@ func (ctx kubevirtContext) replicaVmiScheduledOnMe(vmirsName string) (scheduledO
 	if len(vlPods.Items) == 0 {
 		return false, false, nil
 	}
-	for _, vlPod := range vlPods.Items {
-		if vlPod.ObjectMeta.DeletionTimestamp != nil {
-			// copy is terminating
-			// could be a leftover from a vmi currently failing over
-			continue
-		}
-		if vlPod.Status.Phase == "Pending" {
-			return false, true, nil
-		}
-		if vlPod.Spec.NodeName == "" {
-			// Not scheduled yet, move on
-			continue
-		}
-		return (vlPod.Spec.NodeName == nodeName), true, nil
-	}
-	// No VMI or virt-launcher pod (which isn't terminating)
-	return false, false, fmt.Errorf("Unhandled scheduling state")
+	return podListToSchedulingState(vlPods.Items, nodeName)
 }
 
 // replicaPodScheduledOnMe is the ReplicaSet Pod implementation of scheduledOnMe()

--- a/pkg/pillar/hypervisor/kubevirt_test.go
+++ b/pkg/pillar/hypervisor/kubevirt_test.go
@@ -14,6 +14,8 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // k3sPem is used for a mock k3s.yaml file
@@ -36,6 +38,83 @@ users:
   user:
     client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJrVENDQVRlZ0F3SUJBZ0lJRG1FcTFOaTZGdDR3Q2dZSUtvWkl6ajBFQXdJd0l6RWhNQjhHQTFVRUF3d1kKYXpOekxXTnNhV1Z1ZEMxallVQXhOekk0TkRFek16YzFNQjRYRFRJME1UQXdPREU0TkRrek5Wb1hEVEkxTVRBdwpPREU0TkRrek5Wb3dNREVYTUJVR0ExVUVDaE1PYzNsemRHVnRPbTFoYzNSbGNuTXhGVEFUQmdOVkJBTVRESE41CmMzUmxiVHBoWkcxcGJqQlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VIQTBJQUJGR01VS2R4VFJobVR2MlcKNm50Z2UyVm9VUXRuWFRpeWpBTUptL01STTdkbnRTa3g5OXRGWGJUNUMxSUhkQmVLMXFSZ3RXclpjMmlZcWNMYQpzTTVVTlg2alNEQkdNQTRHQTFVZER3RUIvd1FFQXdJRm9EQVRCZ05WSFNVRUREQUtCZ2dyQmdFRkJRY0RBakFmCkJnTlZIU01FR0RBV2dCUzRIZjU3TjU1Nzl6ajRyTVdqK0hvSWp0MWcyakFLQmdncWhrak9QUVFEQWdOSUFEQkYKQWlCK0d2cDMwQnJJazk4UzZUeVdXbzI0VmRNZU1JZkdheW90REhhb0NsTnFrQUloQUxZTnZQK3dwTVFFV2pHRApkMDRvTWh0ckN3akNUblZFT3pvMXRtV3lQK0ZOCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0KLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJkakNDQVIyZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQWpNU0V3SHdZRFZRUUREQmhyTTNNdFkyeHAKWlc1MExXTmhRREUzTWpnME1UTXpOelV3SGhjTk1qUXhNREE0TVRnME9UTTFXaGNOTXpReE1EQTJNVGcwT1RNMQpXakFqTVNFd0h3WURWUVFEREJock0zTXRZMnhwWlc1MExXTmhRREUzTWpnME1UTXpOelV3V1RBVEJnY3Foa2pPClBRSUJCZ2dxaGtqT1BRTUJCd05DQUFRaXBVL3BoeWtINHFBYThsK3VwZmhtUk43M2tsbFI3VnhiZ1FGMU5GemcKTVRvUk5zSkxaYnFIY1NpMkk4RnMvNnBPZ1g4TlBlUHVOb01YYlFqaGJJTW9vMEl3UURBT0JnTlZIUThCQWY4RQpCQU1DQXFRd0R3WURWUjBUQVFIL0JBVXdBd0VCL3pBZEJnTlZIUTRFRmdRVXVCMytlemVlZS9jNCtLekZvL2g2CkNJN2RZTm93Q2dZSUtvWkl6ajBFQXdJRFJ3QXdSQUlnZklMeDNVUTlwZ2Z3VmZCRmh5aEo2YUhMeGkyQk03aGQKZ0YwalNhc1U1UndDSUE0OFN6NXpkaVhoNFJpdTVlZ2NtRnBXdkpyMXRKc1dCS25PQWt3clExdFgKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
     client-key-data: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUNRK1NkV2QrdkwwaE5DOU4yeTVFMUxmMzF6a0I2SHdvTUw3UlVFTkZVTWpvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFVVl4UXAzRk5HR1pPL1picWUyQjdaV2hSQzJkZE9MS01Bd21iOHhFenQyZTFLVEgzMjBWZAp0UGtMVWdkMEY0cldwR0MxYXRsemFKaXB3dHF3emxRMWZnPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=`
+
+func TestPodListToSchedulingState(t *testing.T) {
+	const node = "andrew-cherry"
+
+	mkPod := func(specNode string, phase corev1.PodPhase) corev1.Pod {
+		return corev1.Pod{
+			Spec:   corev1.PodSpec{NodeName: specNode},
+			Status: corev1.PodStatus{Phase: phase},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		pods        []corev1.Pod
+		wantOnMe    bool
+		wantAnyNode bool
+		wantErr     bool
+	}{
+		{
+			name:        "Pending phase with NodeName set (Init:0/1) on this node",
+			pods:        []corev1.Pod{mkPod(node, corev1.PodPending)},
+			wantOnMe:    true,
+			wantAnyNode: true,
+		},
+		{
+			name:        "Pending phase with NodeName set (Init:0/1) on another node",
+			pods:        []corev1.Pod{mkPod("other-node", corev1.PodPending)},
+			wantOnMe:    false,
+			wantAnyNode: true,
+		},
+		{
+			name:        "Running pod on this node",
+			pods:        []corev1.Pod{mkPod(node, corev1.PodRunning)},
+			wantOnMe:    true,
+			wantAnyNode: true,
+		},
+		{
+			name:        "Running pod on another node",
+			pods:        []corev1.Pod{mkPod("other-node", corev1.PodRunning)},
+			wantOnMe:    false,
+			wantAnyNode: true,
+		},
+		{
+			name:        "Pending pod with NodeName empty (not yet scheduled)",
+			pods:        []corev1.Pod{mkPod("", corev1.PodPending)},
+			wantOnMe:    false,
+			wantAnyNode: true,
+		},
+		{
+			name:    "No pods",
+			pods:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Terminating pod only — skipped",
+			pods: []corev1.Pod{func() corev1.Pod {
+				p := mkPod(node, corev1.PodRunning)
+				now := metav1.Now()
+				p.DeletionTimestamp = &now
+				return p
+			}()},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			onMe, anyNode, err := podListToSchedulingState(tc.pods, node)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantOnMe, onMe)
+			assert.Equal(t, tc.wantAnyNode, anyNode)
+		})
+	}
+}
 
 // TestCreateReplicaPodConfig tests the CreateReplicaPodConfig function
 func TestCreateReplicaPodConfig(t *testing.T) {

--- a/tools/hold-vmi-init.sh
+++ b/tools/hold-vmi-init.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# hold-vmi-init.sh <app-prefix> [hold-seconds]
+#
+# Continually freezes virt-launcher pods for an app until the hold timer
+# expires. Kubernetes creates a replacement pod every 1-3 minutes when it
+# detects the launcher is stuck; this script freezes each replacement as it
+# appears, maintaining the stuck-in-Init state for the full hold duration.
+#
+# Detection: kubectl get pods -w streams new pods from the API server the
+# moment the VMI controller creates them — before kubelet, before containerd.
+# Freeze: pod-level cgroup freezer is atomically written (FROZEN/THAWED).
+#
+# Usage:
+#   ./hold-vmi-init.sh enc-pin-cherry1-390a4
+#   ./hold-vmi-init.sh enc-pin-cherry1-390a4 120
+#
+# Override namespace: NS=other-namespace ./hold-vmi-init.sh <prefix>
+
+[ -d /sys/fs/cgroup/freezer ] || { echo "error: cgroup v1 freezer not mounted — this script requires cgroup v1" >&2; exit 1; }
+
+APP_PREFIX="${1:?Usage: $0 <app-prefix> [hold-seconds]}"
+HOLD_SECS="${2:-600}"
+NS="${NS:-eve-kube-app}"
+LAUNCHER_PREFIX="virt-launcher-${APP_PREFIX}"
+
+# ---------------------------------------------------------------------------
+# Temp files and cleanup
+# ---------------------------------------------------------------------------
+
+SEEN_PODS=$(mktemp)      # pod names already dispatched (dedup across iterations)
+FROZEN_CGROUPS=$(mktemp) # cgroup freezer.state paths to thaw on exit
+WATCH_PIPE=$(mktemp -u)  # FIFO for kubectl watch output
+
+cleanup() {
+    thaw_all
+    kill "$WATCH_PID" 2>/dev/null
+    rm -f "$SEEN_PODS" "$FROZEN_CGROUPS" "$WATCH_PIPE"
+}
+trap cleanup EXIT INT TERM
+
+# ---------------------------------------------------------------------------
+# Functions
+# ---------------------------------------------------------------------------
+
+find_vmi() {
+    kubectl -n "$NS" get vmi --no-headers 2>/dev/null \
+        | awk -v p="$APP_PREFIX" '$1 ~ "^"p {print $1}' | head -1
+}
+
+delete_vmi_async() {
+    kubectl -n "$NS" delete vmi "$1" &
+    echo "Deleting $1 (async)..."
+}
+
+# Pre-populate SEEN_PODS with pods already on the node so the watch stream's
+# initial state dump does not cause us to freeze already-running pods.
+seed_seen_pods() {
+    kubectl -n "$NS" get pods --no-headers 2>/dev/null \
+        | awk -v p="$LAUNCHER_PREFIX" '$1 ~ "^"p {print $1}' \
+        >> "$SEEN_PODS"
+}
+
+# Returns 0 (true) if this pod should be frozen: matches our prefix, is in an
+# early phase (Pending/Init/ContainerCreating), and has not been seen before.
+pod_is_new() {
+    local name="$1" status="$2"
+    case "$name" in
+        ${LAUNCHER_PREFIX}*) ;;
+        *) return 1 ;;
+    esac
+    case "$status" in
+        Running|Terminating|Succeeded|Failed|Completed|Error) return 1 ;;
+    esac
+    grep -qxF "$name" "$SEEN_PODS" 2>/dev/null && return 1
+    return 0
+}
+
+mark_seen() {
+    echo "$1" >> "$SEEN_PODS"
+}
+
+get_pod_uid() {
+    kubectl -n "$NS" get pod "$1" \
+        -o jsonpath='{.metadata.uid}' 2>/dev/null
+}
+
+# Polls for the pod-level freezer.state path up to 2 seconds.
+find_cgroup() {
+    local uid="$1" i=0 cgroup
+    while [ "$i" -lt 20 ]; do
+        cgroup=$(find /sys/fs/cgroup/freezer/kubepods -name "freezer.state" \
+                 -path "*pod${uid}*" 2>/dev/null | sort | head -1)
+        [ -n "$cgroup" ] && echo "$cgroup" && return 0
+        sleep 0.1
+        i=$((i + 1))
+    done
+    return 1
+}
+
+freeze_pod() {
+    local pod="$1" uid="$2" cgroup="$3"
+    echo FROZEN > "$cgroup" || { echo "$(date '+%H:%M:%S') ERROR: could not freeze $pod" >&2; return; }
+    echo "$cgroup" >> "$FROZEN_CGROUPS"
+    echo "$(date '+%H:%M:%S') Frozen:  $pod"
+    echo "          UID:     $uid"
+    echo "          Cgroup:  $cgroup"
+}
+
+thaw_all() {
+    [ ! -s "$FROZEN_CGROUPS" ] && return
+    echo "Thawing all frozen pods..."
+    while IFS= read -r cgroup; do
+        [ -f "$cgroup" ] && echo THAWED > "$cgroup" \
+            && echo "  Thawed: $cgroup"
+    done < "$FROZEN_CGROUPS"
+}
+
+# Called for each new pod event. Marks it seen immediately to prevent
+# duplicate processing if the watch stream emits multiple events for it.
+handle_pod() {
+    local pod="$1"
+    mark_seen "$pod"
+
+    local uid
+    uid=$(get_pod_uid "$pod")
+    if [ -z "$uid" ]; then
+        echo "$(date '+%H:%M:%S') Skip: could not get UID for $pod"
+        return
+    fi
+
+    local cgroup
+    cgroup=$(find_cgroup "$uid")
+    if [ -z "$cgroup" ]; then
+        echo "$(date '+%H:%M:%S') Skip: cgroup not found for $pod (UID $uid)"
+        return
+    fi
+
+    freeze_pod "$pod" "$uid" "$cgroup"
+}
+
+# Streams pod watch events from the API server via a FIFO (avoiding a
+# subshell so SEEN_PODS and FROZEN_CGROUPS remain writable). Exits when
+# HOLD_SECS have elapsed or the watch stream closes.
+watch_and_freeze() {
+    local deadline=$(($(date +%s) + HOLD_SECS))
+
+    mkfifo "$WATCH_PIPE"
+    timeout "$HOLD_SECS" \
+        kubectl -n "$NS" get pods -w --no-headers 2>/dev/null \
+        > "$WATCH_PIPE" &
+    WATCH_PID=$!
+
+    local name status
+    while IFS= read -r line; do
+        [ "$(date +%s)" -ge "$deadline" ] && break
+
+        name=$(echo "$line" | awk '{print $1}')
+        status=$(echo "$line" | awk '{print $3}')
+
+        pod_is_new "$name" "$status" || continue
+        handle_pod "$name"
+    done < "$WATCH_PIPE"
+
+    kill "$WATCH_PID" 2>/dev/null
+    rm -f "$WATCH_PIPE"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+VMI=$(find_vmi)
+[ -z "$VMI" ] && { echo "error: no VMI for '${APP_PREFIX}' in ${NS}" >&2; exit 1; }
+
+OLD_POD=$(kubectl -n "$NS" get pods --no-headers 2>/dev/null \
+          | awk -v p="$LAUNCHER_PREFIX" '$1 ~ "^"p {print $1}' | head -1)
+
+echo "VMI:     $VMI"
+echo "Old pod: ${OLD_POD:-<none>}"
+echo "Hold:    ${HOLD_SECS}s"
+echo ""
+
+seed_seen_pods
+delete_vmi_async "$VMI"
+echo "Watching for replacement pods to freeze..."
+echo ""
+
+watch_and_freeze
+
+echo ""
+echo "Hold period expired — thawing and exiting."


### PR DESCRIPTION
## Description

A virt-launcher pod in Init:0/1 carries Status.Phase="Pending" even after the scheduler binds it to a node (Spec.NodeName is set). Three bugs in the EVE-k stack caused this to be permanently reported as RUNNING/115 in AppInstanceStatus with no auto-remediation:

replicaVmiScheduledOnMe (hypervisor/kubevirt.go): the virt-launcher pod fallback loop returned scheduledOnMe=false for any Pending-phase pod before checking Spec.NodeName. For an Init:0/1 pod already bound to a node this caused Info() to return UNKNOWN, leaving DomainStatus.State stuck at its previous RUNNING value. Fixed by extracting podListToSchedulingState(), which uses Spec.NodeName as the authoritative node-assignment signal.

checkStuckPendingVMI / virtLauncherActiveOnThisNode (cmd/zedkube/pendingvmi.go): the stuck-VMI detector only matched virtv1.Pending, silently skipping VMIs in virtv1.Scheduling (the phase active during Init:0/1). virtLauncherActiveOnThisNode also excluded pods in PodPending phase, so a pod assigned to a node but still running init containers was never considered active. Fixed by extracting vmiPhaseIsPreRunning() (true for Pending and Scheduling) and virtLauncherPodIsActiveOnNode() (includes PodPending with Spec.NodeName set).

verifyStatus (cmd/domainmgr/domainmgr.go): when Info() correctly returns SCHEDULING for a rescheduling VMI, verifyStatus had no branch to update DomainStatus. Added a branch that transitions State to BOOTING and sets Activated=false when a previously-running domain enters a pre-running phase. Setting Activated=false primes the existing recovery path (!Activated && RUNNING) to promote back to RUNNING once the VMI recovers, matching the pattern already used by doActivateTail.

Unit tests added for all three extracted pure functions:
- TestPodListToSchedulingState covers Init:0/1 on same/other node, Running, unscheduled Pending, no pods, and terminating-only cases.
- TestVMIPhaseIsPreRunning covers the full KubeVirt VMI phase enum.
- TestVirtLauncherPodIsActiveOnNode covers Init:0/1, unscheduled Pending, Running, Failed, terminating, wrong prefix, and empty pod list.
- TestVerifyStatusKubeRescheduleToBooting, TestVerifyStatusKubeRecoveryToRunning, TestVerifyStatusKubeRoundTrip, and TestVerifyStatusKubeAlreadyBooting exercise the RUNNING→BOOTING→RUNNING state machine end-to-end.

pillar/Makefile: add GOTESTSUM_FORMAT, TESTPKGS, and TESTRUN overrides to allow targeted test runs without rebuilding the full suite.

tools/hold-vmi-init.sh: new debug script that deletes a VMI and continually freezes each replacement virt-launcher pod (via the cgroup v1 freezer) as Kubernetes creates them, maintaining the Init:0/1 stuck state for the full hold duration. Uses a FIFO-based kubectl watch loop with per-pod dedup and a trap-based thaw-all on exit.

## PR dependencies

None

## How to test and validate this PR

- deploy an HV=k eve node
- deploy a VM app instance to the system
- copy tools/hold-vmi-init.sh to /persist/ and run it with the name of the vmi and a timer value to hold the vmi in Init:
eg. `/persist/hold-vmi-init.sh vmi-name 300`
- watch as virt launcher is deleted, and all new. copies are held in Init
- EVE AppInstanceStatus should report BOOTING

## Changelog notes

Resolve app status reporting for VM app instances stuck in Init. 

## PR Backports

- 16.0-stable: No
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
