### PR TITLE
[WIP] volumemgr: import OCI archive served by a non-OCI datastore

### DIFF
--- a/pkg/pillar/cas/cas.go
+++ b/pkg/pillar/cas/cas.go
@@ -22,6 +22,18 @@ type BlobInfo struct {
 	Labels map[string]string
 }
 
+// ImageLayer describes one layer of an image as recorded in its manifest.
+type ImageLayer struct {
+	// Digest of the layer blob, format <algo>:<hash>.
+	Digest string
+	// MediaType of the layer.
+	MediaType string
+	// Size of the layer blob in bytes.
+	Size int64
+	// Annotations on the layer descriptor in the manifest.
+	Annotations map[string]string
+}
+
 // CAS provides methods to interact with CAS clients
 // Context handling should be taken care by the underlying implementor.
 //
@@ -75,6 +87,11 @@ type CAS interface {
 	// GetImageHash: returns a blob hash of format <algo>:<hash> (currently supporting only sha256:<hash>) which the given 'reference' is pointing to.
 	// Returns error if the given 'reference' is not found.
 	GetImageHash(reference string) (string, error)
+	// GetImageLayers returns the layers of the manifest that 'reference' points
+	// to, in manifest order. If the reference points at a multi-manifest index,
+	// the platform-matching manifest is used (falling back to the first).
+	// Returns error if the reference is not found or its manifest cannot be read.
+	GetImageLayers(reference string) ([]ImageLayer, error)
 	// GetImageLabels  returns the labels set on the image.
 	// Returns error if the given reference is not found
 	GetImageLabels(reference string) (map[string]string, error)

--- a/pkg/pillar/cas/cas.go
+++ b/pkg/pillar/cas/cas.go
@@ -84,6 +84,14 @@ type CAS interface {
 	// Arg 'blobHash' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
 	// Returns error if no blob is found matching the given 'blobHash' or if the given 'blobHash' does not belong to an index.
 	CreateImage(reference, mediaType, blobHash string) error
+	// ImportImageArchive: imports a packaged image archive (an OCI image-layout
+	// or docker-save archive, optionally gzip-compressed) read from the file at
+	// 'archivePath' into the blob store, and creates 'reference' pointing at the
+	// imported index/manifest. Used when a packaged image is served by a non-OCI
+	// datastore (S3/HTTP) as a single file, so its real multi-layer manifest is
+	// used rather than wrapping the whole archive as one bare blob.
+	// Returns the index/manifest digest of format <algo>:<hash>.
+	ImportImageArchive(reference, archivePath string) (string, error)
 	// GetImageHash: returns a blob hash of format <algo>:<hash> (currently supporting only sha256:<hash>) which the given 'reference' is pointing to.
 	// Returns error if the given 'reference' is not found.
 	GetImageHash(reference string) (string, error)

--- a/pkg/pillar/cas/containerd.go
+++ b/pkg/pillar/cas/containerd.go
@@ -1,7 +1,9 @@
 package cas
 
 import (
+	"bufio"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -525,6 +527,45 @@ func (c *containerdCAS) CreateImage(reference, mediaType, blobHash string) error
 		return fmt.Errorf("CreateImage: Exception while creating reference: %s. %s", reference, err.Error())
 	}
 	return nil
+}
+
+// ImportImageArchive imports a packaged image archive (OCI image-layout or
+// docker-save, optionally gzip-compressed) from archivePath into the blob store
+// and creates 'reference' pointing at the imported index/manifest. Returns the
+// index/manifest digest of format sha256:<hash>.
+func (c *containerdCAS) ImportImageArchive(reference, archivePath string) (string, error) {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return "", fmt.Errorf("ImportImageArchive: cannot open %s: %v", archivePath, err)
+	}
+	defer f.Close()
+
+	// Transparently de-gzip; the eserver/S3 artifact is a .tar.gz.
+	br := bufio.NewReader(f)
+	var reader io.Reader = br
+	if magic, _ := br.Peek(2); len(magic) == 2 && magic[0] == 0x1f && magic[1] == 0x8b {
+		zr, err := gzip.NewReader(br)
+		if err != nil {
+			return "", fmt.Errorf("ImportImageArchive: cannot create gzip reader for %s: %v", archivePath, err)
+		}
+		defer zr.Close()
+		reader = zr
+	}
+
+	// CtrImportImageArchive (high-level containerd Import) ingests the blobs,
+	// sets gc.ref labels so they survive GC, and creates the image 'reference'.
+	// It manages its own lease, so a plain namespaced context is enough here.
+	ctrdCtx, done := c.ctrdClient.CtrNewUserServicesCtx()
+	defer done()
+
+	desc, err := c.ctrdClient.CtrImportImageArchive(ctrdCtx, reference, reader)
+	if err != nil {
+		return "", fmt.Errorf("ImportImageArchive: import of %s failed: %v", archivePath, err)
+	}
+	if desc.Digest == "" {
+		return "", fmt.Errorf("ImportImageArchive: import of %s returned an empty index digest", archivePath)
+	}
+	return desc.Digest.String(), nil
 }
 
 // GetImageHash: returns a blob hash of format sha256:<hash> which the given 'reference' is pointing to.

--- a/pkg/pillar/cas/containerd.go
+++ b/pkg/pillar/cas/containerd.go
@@ -544,6 +544,44 @@ func (c *containerdCAS) GetImageHash(reference string) (string, error) {
 	return image.Target().Digest.String(), nil
 }
 
+// GetImageLayers returns the layers of the manifest that 'reference' points to.
+// If the reference is an index, the platform-matching manifest is selected
+// (falling back to the first); if it is a plain manifest, its layers are
+// returned directly.
+func (c *containerdCAS) GetImageLayers(reference string) ([]ImageLayer, error) {
+	hash, err := c.GetImageHash(reference)
+	if err != nil {
+		return nil, err
+	}
+	manifestHash := hash
+	// Descend through an index to the (platform) manifest. A plain manifest
+	// parses as an index with no entries, in which case we use it directly.
+	if index, ierr := getIndexManifest(c, hash); ierr == nil && len(index.Manifests) > 0 {
+		manifestHash = index.Manifests[0].Digest.String()
+		for _, m := range index.Manifests {
+			if m.Platform != nil && m.Platform.OS == runtime.GOOS &&
+				m.Platform.Architecture == runtime.GOARCH {
+				manifestHash = m.Digest.String()
+				break
+			}
+		}
+	}
+	manifest, err := getManifest(c, manifestHash)
+	if err != nil {
+		return nil, err
+	}
+	layers := make([]ImageLayer, 0, len(manifest.Layers))
+	for _, l := range manifest.Layers {
+		layers = append(layers, ImageLayer{
+			Digest:      l.Digest.String(),
+			MediaType:   string(l.MediaType),
+			Size:        l.Size,
+			Annotations: l.Annotations,
+		})
+	}
+	return layers, nil
+}
+
 // GetImageLabels returns the Image Labels of the reference
 // Returns error if the given 'reference' is not found.
 func (c *containerdCAS) GetImageLabels(reference string) (map[string]string, error) {

--- a/pkg/pillar/cmd/baseosmgr/handlebaseos.go
+++ b/pkg/pillar/cmd/baseosmgr/handlebaseos.go
@@ -320,32 +320,11 @@ func doBaseOsActivate(ctx *baseOsMgrContext, uuidStr string,
 
 	log.Functionf("doBaseOsActivate: %s activating", uuidStr)
 
-	// Before writing to partition lets make sure we have enough space on the partition
-	// 1. Get the size of the image using contenttree status
-	// 2. Get the size of the partition using zboot
-	// 3. If partition size is < image size, error out
-
-	cts := lookupContentTreeStatus(ctx, status.ContentTreeUUID)
-
-	if cts == nil {
-		errString := fmt.Sprintf("doBaseOsActivate: ContentTreeStatus not found for %s", status.ContentTreeUUID)
-		log.Error(errString)
-		status.SetErrorNow(errString)
-		changed = true
-		return changed
-	}
-
-	if cts.State == types.LOADED {
-		partSize := zboot.GetPartitionSizeInBytes(status.PartitionLabel)
-		imageSize := cts.MaxDownloadSize
-		if partSize < imageSize {
-			errString := fmt.Sprintf("doBaseOsActivate: Image size %v bytes greater than partition size %v bytes", imageSize, partSize)
-			log.Error(errString)
-			status.SetErrorNow(errString)
-			changed = true
-			return changed
-		}
-	}
+	// The partition-fit guard is enforced in zboot.WriteToPartition against the
+	// actual rootfs (disk-root) written to the partition. The whole content-tree
+	// download size is not a valid proxy here: an image may carry additional
+	// disks beyond the rootfs (e.g. the split-rootfs Extension) that are not
+	// written to this partition.
 
 	// install the image at proper partition; dd etc
 	changed, proceed, err = installDownloadedObjects(ctx, uuidStr, status.PartitionLabel,

--- a/pkg/pillar/cmd/volumemgr/handlework.go
+++ b/pkg/pillar/cmd/volumemgr/handlework.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	workCreate  = "create"
-	workIngest  = "ingest"
-	workPrepare = "prepare"
+	workCreate        = "create"
+	workIngest        = "ingest"
+	workPrepare       = "prepare"
+	workImportArchive = "importarchive"
 )
 
 // volumeWorkDescription volume creation/deletion work we feed into the worker go routine.
@@ -57,6 +58,25 @@ type volumePrepareResult struct {
 type casIngestWorkResult struct {
 	worker.WorkResult // Error etc
 	loaded            []string
+}
+
+// importArchiveWorkDescription describes the work of importing a downloaded
+// image archive (an OCI image-layout or docker-save tar served as a single
+// file by a non-OCI datastore) into the CAS. The blocking part of the import
+// (de-gzip plus writing the multi-gigabyte layers into containerd) runs in the
+// worker goroutine so it does not stall volumemgr's main loop and trip the
+// watchdog.
+type importArchiveWorkDescription struct {
+	refID       string
+	archivePath string
+	// used for results
+	indexDigest string
+}
+
+// importArchiveWorkResult result of importing an image archive
+type importArchiveWorkResult struct {
+	worker.WorkResult // Error etc
+	indexDigest       string
 }
 
 // AddWorkCreate adds a Work job to create a volume
@@ -124,6 +144,30 @@ func DeleteWorkPrepare(ctx *volumemgrContext, status *types.VolumeStatus) {
 
 // DeleteWorkLoad is called by user when work is done
 func DeleteWorkLoad(ctx *volumemgrContext, key string) {
+	ctx.worker.Cancel(key)
+}
+
+// AddWorkImportArchive adds a Work job to import a downloaded image archive
+// into the CAS. The blocking de-gzip and CAS write happen in the worker.
+func AddWorkImportArchive(ctx *volumemgrContext, status *types.ContentTreeStatus, refID, archivePath string) {
+	d := importArchiveWorkDescription{
+		refID:       refID,
+		archivePath: archivePath,
+	}
+	w := worker.Work{Kind: workImportArchive, Key: status.Key(), Description: d}
+	// Don't fail on errors to make idempotent (Submit returns an error if
+	// the work was already submitted)
+	done, err := ctx.worker.TrySubmit(w)
+	if err != nil {
+		log.Errorf("TrySubmit %s failed: %s", status.Key(), err)
+	} else if !done {
+		log.Fatalf("Failed to submit work due to queue length for %s",
+			status.Key())
+	}
+}
+
+// DeleteWorkImportArchive is called by user when work is done
+func DeleteWorkImportArchive(ctx *volumemgrContext, key string) {
 	ctx.worker.Cancel(key)
 }
 
@@ -254,6 +298,26 @@ func casIngestWorker(ctxPtr interface{}, w worker.Work) worker.WorkResult {
 	return result
 }
 
+// importArchiveWorker implementation of work.WorkFunction that imports a
+// downloaded image archive into the CAS. It only touches the CAS (no pubsub),
+// so it is safe to run in the worker goroutine.
+func importArchiveWorker(ctxPtr interface{}, w worker.Work) worker.WorkResult {
+	ctx := ctxPtr.(*volumemgrContext)
+	d := w.Description.(importArchiveWorkDescription)
+
+	indexDigest, err := ctx.casClient.ImportImageArchive(d.refID, d.archivePath)
+	d.indexDigest = indexDigest
+	result := worker.WorkResult{
+		Key:         w.Key,
+		Description: d,
+	}
+	if err != nil {
+		result.Error = err
+		result.ErrorTime = time.Now()
+	}
+	return result
+}
+
 // volumePrepareWorker implementation of work.WorkFunction that prepares volume creation
 func volumePrepareWorker(ctxPtr interface{}, w worker.Work) worker.WorkResult {
 	ctx := ctxPtr.(*volumemgrContext)
@@ -317,6 +381,38 @@ func processCasIngestWorkResult(ctxPtr interface{}, res worker.WorkResult) error
 	}
 	updateStatusByBlob(ctx, d.status.Blobs...)
 	return nil
+}
+
+// processImportArchiveWorkResult handles the work result of an image-archive
+// import. The actual finalization (swapping the content tree's bare blob for
+// the imported index/manifest/config/layer blobs) happens in doUpdateContentTree
+// when it re-runs; here we just re-trigger that evaluation, mirroring
+// processCasIngestWorkResult.
+func processImportArchiveWorkResult(ctxPtr interface{}, res worker.WorkResult) error {
+	ctx := ctxPtr.(*volumemgrContext)
+	status := ctx.LookupContentTreeStatus(res.Key)
+	if status == nil {
+		log.Functionf("processImportArchiveWorkResult(%s): ContentTreeStatus not found", res.Key)
+		return nil
+	}
+	// The content tree still references the single bare archive blob; re-run
+	// its state machine so doUpdateContentTree pops the import result and
+	// swaps in the imported index/manifest/config/layer blobs.
+	updateStatusByBlob(ctx, status.Blobs...)
+	return nil
+}
+
+// popImportArchiveWorkResult get the result exactly once
+func popImportArchiveWorkResult(ctx *volumemgrContext, key string) *importArchiveWorkResult {
+	res := ctx.worker.Pop(key)
+	if res == nil {
+		return nil
+	}
+	d := res.Description.(importArchiveWorkDescription)
+	return &importArchiveWorkResult{
+		WorkResult:  *res,
+		indexDigest: d.indexDigest,
+	}
 }
 
 // popasIngestWorkResult get the result exactly once

--- a/pkg/pillar/cmd/volumemgr/imagearchive.go
+++ b/pkg/pillar/cmd/volumemgr/imagearchive.go
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	v1types "github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/lf-edge/eve/pkg/pillar/cas"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// imageArchiveKind classifies a downloaded file that turned out to be a
+// packaged container image rather than a raw disk image.
+type imageArchiveKind int
+
+const (
+	notImageArchive  imageArchiveKind = iota
+	ociLayoutArchive                  // tar containing oci-layout + index.json
+	dockerArchive                     // tar containing manifest.json (docker save format)
+)
+
+// detectImageArchive peeks at a downloaded file to determine whether it is
+// actually a packaged container image (an OCI image-layout or docker-save
+// archive) rather than a raw disk image. It transparently handles gzip and
+// scans only the leading (small) tar entries, so it is cheap even for a
+// multi-gigabyte artifact. Returns notImageArchive if the file is not such an
+// archive or cannot be read.
+func detectImageArchive(filePath string) imageArchiveKind {
+	if filePath == "" {
+		return notImageArchive
+	}
+	f, err := os.Open(filePath)
+	if err != nil {
+		return notImageArchive
+	}
+	defer f.Close()
+
+	br := bufio.NewReader(f)
+	var r io.Reader = br
+	if magic, _ := br.Peek(2); len(magic) == 2 && magic[0] == 0x1f && magic[1] == 0x8b {
+		zr, err := gzip.NewReader(br)
+		if err != nil {
+			return notImageArchive
+		}
+		defer zr.Close()
+		r = zr
+	}
+
+	tr := tar.NewReader(r)
+	var haveLayout, haveIndex bool
+	// The OCI layout metadata files appear before the large blobs, so scanning a
+	// bounded number of entries is enough to classify the archive.
+	for i := 0; i < 64; i++ {
+		hdr, err := tr.Next()
+		if err != nil {
+			break
+		}
+		switch strings.TrimPrefix(filepath.Clean(hdr.Name), "./") {
+		case "oci-layout":
+			haveLayout = true
+		case "index.json":
+			haveIndex = true
+		case "manifest.json":
+			return dockerArchive
+		}
+		if haveLayout && haveIndex {
+			return ociLayoutArchive
+		}
+	}
+	return notImageArchive
+}
+
+// contentTreeIsImageArchive reports whether the content tree currently consists
+// of a single "bare" blob that is actually a packaged container image (an OCI
+// image-layout or docker-save archive served as one file by a non-OCI
+// datastore such as HTTP, AWS S3, Azure Blob Storage, Google Cloud Storage or
+// SFTP). Such a content tree is imported into the CAS via the import worker so
+// the proper multi-layer manifest is used, instead of being wrapped as a single
+// raw disk-root layer (see getManifestsForBareBlob).
+//
+// It re-derives the answer from the downloaded file rather than caching it, so
+// it stays correct across volumemgr restarts and is the single routing point
+// shared by the VERIFIED and LOADING state-machine branches. The check is cheap
+// (a bounded peek of the archive's leading tar headers).
+func contentTreeIsImageArchive(ctx *volumemgrContext, status *types.ContentTreeStatus) bool {
+	blobStatuses := lookupBlobStatuses(ctx, status.Blobs...)
+	if len(blobStatuses) != 1 {
+		return false
+	}
+	b := blobStatuses[0]
+	if b.IsManifest() || b.IsIndex() {
+		return false
+	}
+	return detectImageArchive(b.Path) != notImageArchive
+}
+
+// finalizeImageArchive replaces the content tree's single bare archive blob with
+// the index/manifest/config/layer blobs produced by a completed CAS import
+// (indexDigest, as returned by the import worker). The blocking import itself
+// already ran in the worker goroutine; this only updates pubsub state and runs
+// on the main loop. The caller's LOADING state machine then marks the content
+// tree LOADED once all blobs and the image reference are confirmed in the CAS.
+//
+// This handles a packaged image (e.g. a split-rootfs image of Core + Extension)
+// served by a non-OCI datastore as a single file. Without it, the whole archive
+// would be wrapped as one raw disk-root layer, which is both structurally wrong
+// and far larger than the target partition.
+func finalizeImageArchive(ctx *volumemgrContext, status *types.ContentTreeStatus,
+	rootBlob *types.BlobStatus, indexDigest string) error {
+
+	indexSha := strings.TrimPrefix(indexDigest, "sha256:")
+
+	// The import wrote the index and all its descendants (manifest, config,
+	// layers) into the CAS. Build LOADED BlobStatuses for them and make the
+	// content tree reference the index instead of the bare archive blob.
+	newBlobs, err := buildLoadedBlobStatuses(ctx.casClient, indexSha)
+	if err != nil {
+		return err
+	}
+	publishBlobStatus(ctx, newBlobs...)
+	AddRefToBlobStatus(ctx, newBlobs...)
+
+	blobHashes := make([]string, 0, len(newBlobs))
+	for _, b := range newBlobs {
+		blobHashes = append(blobHashes, b.Sha256)
+	}
+	status.Blobs = blobHashes
+
+	// Drop the original "bare" archive blob: release its downloader/verifier
+	// references and its content-tree reference. It was never loaded into the
+	// CAS as a usable layer, so there is nothing to remove from the blob store
+	// itself.
+	MaybeRemoveDownloaderConfig(ctx, rootBlob)
+	MaybeRemoveVerifyImageConfig(ctx, rootBlob)
+	RemoveRefFromBlobStatus(ctx, rootBlob)
+	return nil
+}
+
+// buildLoadedBlobStatuses enumerates the index blob and all its descendants
+// (manifest, config, layers) already present in the CAS and returns LOADED
+// BlobStatuses for them, index first. It has no side effects, which makes the
+// CAS-content-to-BlobStatus mapping unit-testable with a fake CAS.
+func buildLoadedBlobStatuses(casClient cas.CAS, indexSha string) ([]*types.BlobStatus, error) {
+	hashes, err := collectImageBlobTree(casClient, indexSha)
+	if err != nil {
+		return nil, err
+	}
+	mediaMap, err := casClient.ListBlobsMediaTypes()
+	if err != nil {
+		return nil, fmt.Errorf("buildLoadedBlobStatuses: cannot list CAS media types: %v", err)
+	}
+	blobs := make([]*types.BlobStatus, 0, len(hashes))
+	for _, h := range hashes {
+		full := "sha256:" + h
+		var size int64
+		if info, err := casClient.GetBlobInfo(full); err == nil {
+			size = info.Size
+		}
+		blobs = append(blobs, &types.BlobStatus{
+			Sha256:                 h,
+			State:                  types.LOADED,
+			MediaType:              mediaMap[full],
+			Size:                   uint64(size),
+			CurrentSize:            size,
+			TotalSize:              size,
+			Progress:               100,
+			CreateTime:             time.Now(),
+			LastRefCountChangeTime: time.Now(),
+		})
+	}
+	return blobs, nil
+}
+
+// collectImageBlobTree returns the index blob and all of its descendant blob
+// hashes (manifest, config, layers) by walking CAS children breadth-first.
+// Hashes are returned without the "sha256:" prefix, index first.
+//
+// It recurses only into index and manifest blobs. Config and layer blobs are
+// leaves: CAS.Children mis-parses them (it speculatively parses any blob as a
+// manifest, so a config blob yields a bogus empty Config.Digest), which would
+// otherwise inject an empty "sha256:" digest into the walk and fail it. The
+// blob's media type (from the image just imported) tells us whether recursing
+// is meaningful.
+func collectImageBlobTree(casClient cas.CAS, indexSha string) ([]string, error) {
+	mediaMap, err := casClient.ListBlobsMediaTypes()
+	if err != nil {
+		return nil, fmt.Errorf("collectImageBlobTree: cannot list CAS media types: %v", err)
+	}
+	ordered := []string{}
+	seen := map[string]bool{}
+	queue := []string{indexSha}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		if cur == "" || seen[cur] {
+			continue
+		}
+		seen[cur] = true
+		ordered = append(ordered, cur)
+		// Only index/manifest blobs reference children worth recursing into.
+		if !isImageIndexOrManifest(mediaMap["sha256:"+cur]) {
+			continue
+		}
+		children, err := casClient.Children("sha256:" + cur)
+		if err != nil {
+			return nil, fmt.Errorf("collectImageBlobTree: children of %s: %v", cur, err)
+		}
+		for _, child := range children {
+			queue = append(queue, strings.TrimPrefix(child, "sha256:"))
+		}
+	}
+	return ordered, nil
+}
+
+// isImageIndexOrManifest reports whether the media type is an image index or
+// manifest (a blob that legitimately has child descriptors).
+func isImageIndexOrManifest(mediaType string) bool {
+	switch v1types.MediaType(mediaType) {
+	case v1types.OCIImageIndex, v1types.DockerManifestList,
+		v1types.OCIManifestSchema1, v1types.DockerManifestSchema2,
+		v1types.DockerManifestSchema1, v1types.DockerManifestSchema1Signed:
+		return true
+	}
+	return false
+}

--- a/pkg/pillar/cmd/volumemgr/imagearchive_test.go
+++ b/pkg/pillar/cmd/volumemgr/imagearchive_test.go
@@ -1,0 +1,282 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/agentlog"
+	"github.com/lf-edge/eve/pkg/pillar/cas"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub/socketdriver"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	utils "github.com/lf-edge/eve/pkg/pillar/utils/file"
+	"github.com/sirupsen/logrus"
+)
+
+// fakeCAS embeds the cas.CAS interface so that only the methods exercised by a
+// test need real implementations; any other call dereferences the nil embedded
+// interface and panics, which is the desired behavior for a focused unit test.
+type fakeCAS struct {
+	cas.CAS
+	children   map[string][]string // "sha256:<h>" -> children ["sha256:<h>", ...]
+	mediaTypes map[string]string   // "sha256:<h>" -> media type
+	sizes      map[string]int64    // "sha256:<h>" -> size
+}
+
+func (f *fakeCAS) Children(blobHash string) ([]string, error) {
+	return f.children[blobHash], nil
+}
+
+func (f *fakeCAS) ListBlobsMediaTypes() (map[string]string, error) {
+	return f.mediaTypes, nil
+}
+
+func (f *fakeCAS) GetBlobInfo(blobHash string) (*cas.BlobInfo, error) {
+	return &cas.BlobInfo{Digest: blobHash, Size: f.sizes[blobHash]}, nil
+}
+
+// makeTarFile writes a tar (optionally gzip-compressed) containing zero-length
+// entries with the given names, and returns its path.
+func makeTarFile(t *testing.T, gz bool, names ...string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "artifact")
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer f.Close()
+
+	var underlying io.Writer = f
+	var zw *gzip.Writer
+	if gz {
+		zw = gzip.NewWriter(f)
+		underlying = zw
+	}
+	tw := tar.NewWriter(underlying)
+	for _, n := range names {
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     n,
+			Mode:     0644,
+			Size:     0,
+			Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatalf("write header %s: %v", n, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if zw != nil {
+		if err := zw.Close(); err != nil {
+			t.Fatalf("gzip close: %v", err)
+		}
+	}
+	return p
+}
+
+func makeRawFile(t *testing.T, content []byte) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "raw")
+	if err := os.WriteFile(p, content, 0644); err != nil {
+		t.Fatalf("write raw: %v", err)
+	}
+	return p
+}
+
+func TestDetectImageArchive(t *testing.T) {
+	ociNames := []string{"oci-layout", "index.json", "manifest.json", "blobs/sha256/abc"}
+	dockerNames := []string{"manifest.json", "blobs/sha256/abc"}
+
+	tests := []struct {
+		name string
+		path string
+		want imageArchiveKind
+	}{
+		{"gzip oci-layout", makeTarFile(t, true, ociNames...), ociLayoutArchive},
+		{"plain oci-layout", makeTarFile(t, false, ociNames...), ociLayoutArchive},
+		{"gzip docker-save", makeTarFile(t, true, dockerNames...), dockerArchive},
+		{"plain docker-save", makeTarFile(t, false, dockerNames...), dockerArchive},
+		{"unrelated tar", makeTarFile(t, false, "disk.raw", "boot/kernel"), notImageArchive},
+		{"raw bytes", makeRawFile(t, []byte("this is just a raw disk image, not a tar")), notImageArchive},
+		{"empty path", "", notImageArchive},
+		{"missing file", filepath.Join(t.TempDir(), "does-not-exist"), notImageArchive},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := detectImageArchive(tc.path); got != tc.want {
+				t.Fatalf("detectImageArchive(%s) = %d, want %d", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// split-rootfs-shaped tree: index -> manifest -> {config, root layer, ext layer}.
+func splitRootfsFakeCAS() *fakeCAS {
+	return &fakeCAS{
+		children: map[string][]string{
+			"sha256:idx": {"sha256:man"},
+			"sha256:man": {"sha256:cfg", "sha256:rootlayer", "sha256:extlayer"},
+			// Leaves: the real CAS.Children mis-parses a config/layer blob and
+			// returns a bogus empty digest. The walk must NOT recurse here
+			// (guarded by media type); if it does, this "sha256:" leaks in.
+			"sha256:cfg":       {"sha256:"},
+			"sha256:rootlayer": {"sha256:"},
+			"sha256:extlayer":  {"sha256:"},
+		},
+		mediaTypes: map[string]string{
+			"sha256:idx":       "application/vnd.oci.image.index.v1+json",
+			"sha256:man":       "application/vnd.oci.image.manifest.v1+json",
+			"sha256:cfg":       "application/vnd.oci.image.config.v1+json",
+			"sha256:rootlayer": "application/vnd.oci.image.layer.v1.tar",
+			"sha256:extlayer":  "application/vnd.oci.image.layer.v1.tar",
+		},
+		sizes: map[string]int64{
+			"sha256:idx":       300,
+			"sha256:man":       1623,
+			"sha256:cfg":       3367,
+			"sha256:rootlayer": 268435456,  // ~256 MB Core
+			"sha256:extlayer":  1503564288, // ~1.4 GB Extension
+		},
+	}
+}
+
+func TestCollectImageBlobTree(t *testing.T) {
+	got, err := collectImageBlobTree(splitRootfsFakeCAS(), "idx")
+	if err != nil {
+		t.Fatalf("collectImageBlobTree: %v", err)
+	}
+	want := []string{"idx", "man", "cfg", "rootlayer", "extlayer"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v (index first, BFS)", got, want)
+		}
+	}
+	for _, h := range got {
+		if h == "" {
+			t.Fatalf("walk recursed into a leaf blob and produced an empty digest: %v", got)
+		}
+	}
+}
+
+func TestCollectImageBlobTreeDedup(t *testing.T) {
+	// A blob shared by two parents must appear only once.
+	f := &fakeCAS{
+		children: map[string][]string{
+			"sha256:idx":  {"sha256:man1", "sha256:man2"},
+			"sha256:man1": {"sha256:shared"},
+			"sha256:man2": {"sha256:shared"},
+		},
+		mediaTypes: map[string]string{
+			"sha256:idx":    "application/vnd.oci.image.index.v1+json",
+			"sha256:man1":   "application/vnd.oci.image.manifest.v1+json",
+			"sha256:man2":   "application/vnd.oci.image.manifest.v1+json",
+			"sha256:shared": "application/vnd.oci.image.config.v1+json",
+		},
+	}
+	got, err := collectImageBlobTree(f, "idx")
+	if err != nil {
+		t.Fatalf("collectImageBlobTree: %v", err)
+	}
+	seen := map[string]int{}
+	for _, h := range got {
+		seen[h]++
+	}
+	if seen["shared"] != 1 {
+		t.Fatalf("shared blob appeared %d times, want 1 (got %v)", seen["shared"], got)
+	}
+}
+
+// TestContentTreeIsImageArchive exercises the routing predicate used by the
+// VERIFIED and LOADING state-machine branches to decide whether a single
+// downloaded blob is a packaged image archive (imported via the worker) rather
+// than a genuine bare blob. It needs /run and /persist writable for pubsub.
+func TestContentTreeIsImageArchive(t *testing.T) {
+	if !utils.Writable(types.PersistDir) || !utils.Writable("/run") {
+		t.Logf("Required directories not writeable; SKIP")
+		return
+	}
+	pubLogger, pubLog := agentlog.Init(agentName)
+	pubLogger.SetLevel(logrus.InfoLevel)
+	pubPs := pubsub.New(
+		&socketdriver.SocketDriver{Logger: pubLogger, Log: pubLog},
+		pubLogger, pubLog)
+	pub, err := pubPs.NewPublication(pubsub.PublicationOptions{
+		AgentName:  agentName,
+		TopicType:  types.BlobStatus{},
+		Persistent: false,
+	})
+	if err != nil {
+		t.Fatalf("unable to publish: %v", err)
+	}
+	ctx := volumemgrContext{pubBlobStatus: pub}
+
+	archivePath := makeTarFile(t, true, "oci-layout", "index.json", "blobs/sha256/abc")
+	rawPath := makeRawFile(t, []byte("not a tar at all"))
+
+	// publish blobs the test refers to
+	for _, b := range []types.BlobStatus{
+		{Sha256: "archiveblob", Path: archivePath},
+		{Sha256: "rawblob", Path: rawPath},
+		{Sha256: "manifestblob", Path: archivePath, MediaType: "application/vnd.oci.image.manifest.v1+json"},
+	} {
+		pub.Publish(b.Key(), b)
+	}
+
+	tests := []struct {
+		name  string
+		blobs []string
+		want  bool
+	}{
+		{"single archive blob", []string{"archiveblob"}, true},
+		{"single raw blob", []string{"rawblob"}, false},
+		{"single manifest blob", []string{"manifestblob"}, false},
+		{"two blobs", []string{"archiveblob", "rawblob"}, false},
+		{"zero blobs", []string{}, false},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			status := &types.ContentTreeStatus{Blobs: tc.blobs}
+			if got := contentTreeIsImageArchive(&ctx, status); got != tc.want {
+				t.Fatalf("contentTreeIsImageArchive(%v) = %v, want %v", tc.blobs, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildLoadedBlobStatuses(t *testing.T) {
+	f := splitRootfsFakeCAS()
+	blobs, err := buildLoadedBlobStatuses(f, "idx")
+	if err != nil {
+		t.Fatalf("buildLoadedBlobStatuses: %v", err)
+	}
+	if len(blobs) != 5 {
+		t.Fatalf("got %d blobs, want 5", len(blobs))
+	}
+	if blobs[0].Sha256 != "idx" {
+		t.Fatalf("first blob = %s, want idx", blobs[0].Sha256)
+	}
+	for _, b := range blobs {
+		if b.State != types.LOADED {
+			t.Fatalf("blob %s state = %v, want LOADED", b.Sha256, b.State)
+		}
+		full := "sha256:" + b.Sha256
+		if b.MediaType != f.mediaTypes[full] {
+			t.Fatalf("blob %s media type = %q, want %q", b.Sha256, b.MediaType, f.mediaTypes[full])
+		}
+		if int64(b.Size) != f.sizes[full] {
+			t.Fatalf("blob %s size = %d, want %d", b.Sha256, b.Size, f.sizes[full])
+		}
+	}
+}

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -328,35 +328,45 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 		// to add a manifest to it.
 		log.Functionf("doUpdateContentTree(%s) checking if we need to add a manifest, have %d blobs", status.Key(), len(blobStatuses))
 		if len(blobStatuses) == 1 && !blobStatuses[0].IsManifest() && !blobStatuses[0].IsIndex() {
-			blobs, err := getManifestsForBareBlob(ctx, refID, blobStatuses[0].Sha256, int64(blobStatuses[0].Size))
-			if err != nil {
-				err = fmt.Errorf("doUpdateContentTree(%s): Exception while getting manifest and config for bare blob: %s",
-					status.ContentID, err.Error())
-				log.Error(err.Error())
-				status.SetErrorWithSource(err.Error(), types.ContentTreeStatus{}, time.Now())
-				return changed, false
-			}
-			// if we have any, append them
-			if len(blobs) > 0 {
-				publishBlobStatus(ctx, blobs...)
-				// order is important; prepend to existing
-				blobStatuses = append(blobs, blobStatuses...)
-
-				// we changed it, so update the ContentTreeStatus
-				blobHashes := []string{}
-				for _, b := range blobStatuses {
-					blobHashes = append(blobHashes, b.Sha256)
+			// A single downloaded file from a non-OCI datastore (HTTP, AWS S3,
+			// Azure Blob Storage, Google Cloud Storage, SFTP) may actually be a
+			// packaged image archive (OCI image-layout or docker-save). If so,
+			// leave the single blob in place; once VERIFIED it is imported into
+			// the CAS asynchronously (via the import worker) so the real
+			// multi-layer manifest is used instead of wrapping the whole archive
+			// as one raw disk-root blob. Only a genuine bare blob gets a
+			// synthesized manifest/config here.
+			if !contentTreeIsImageArchive(ctx, status) {
+				blobs, err := getManifestsForBareBlob(ctx, refID, blobStatuses[0].Sha256, int64(blobStatuses[0].Size))
+				if err != nil {
+					err = fmt.Errorf("doUpdateContentTree(%s): Exception while getting manifest and config for bare blob: %s",
+						status.ContentID, err.Error())
+					log.Error(err.Error())
+					status.SetErrorWithSource(err.Error(), types.ContentTreeStatus{}, time.Now())
+					return changed, false
 				}
-				status.Blobs = blobHashes
-				// Adding a blob to ContentTreeStatus and incrementing the refcount of that blob should be atomic as
-				// we would depend on that while we remove a blob from ContentTreeStatus and decrement
-				// the RefCount of that blob. In case if the blobs in a ContentTreeStatus in not in sync with the
-				// corresponding Blob's Refcount, then that would lead to Fatal error.
-				// If the same sha appears in multiple places in the ContentTree we intentionally add it twice to the list of
-				// Blobs so that we can have two reference counts on that blob.
-				// Add for the new ones
-				for _, b := range blobs {
-					AddRefToBlobStatus(ctx, b)
+				// if we have any, append them
+				if len(blobs) > 0 {
+					publishBlobStatus(ctx, blobs...)
+					// order is important; prepend to existing
+					blobStatuses = append(blobs, blobStatuses...)
+
+					// we changed it, so update the ContentTreeStatus
+					blobHashes := []string{}
+					for _, b := range blobStatuses {
+						blobHashes = append(blobHashes, b.Sha256)
+					}
+					status.Blobs = blobHashes
+					// Adding a blob to ContentTreeStatus and incrementing the refcount of that blob should be atomic as
+					// we would depend on that while we remove a blob from ContentTreeStatus and decrement
+					// the RefCount of that blob. In case if the blobs in a ContentTreeStatus in not in sync with the
+					// corresponding Blob's Refcount, then that would lead to Fatal error.
+					// If the same sha appears in multiple places in the ContentTree we intentionally add it twice to the list of
+					// Blobs so that we can have two reference counts on that blob.
+					// Add for the new ones
+					for _, b := range blobs {
+						AddRefToBlobStatus(ctx, b)
+					}
 				}
 			}
 		}
@@ -370,6 +380,19 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 
 	// at this point, the image is VERIFIED or higher
 	if status.State == types.VERIFIED {
+		// A single bare blob that is really a packaged image archive is
+		// imported into the CAS by the import worker (de-gzip plus writing the
+		// multi-gigabyte layers blocks for minutes, so it must not run on the
+		// main loop). Kick that off and move to LOADING; the result is handled
+		// in the LOADING branch below.
+		if contentTreeIsImageArchive(ctx, status) {
+			archiveBlob := lookupBlobStatuses(ctx, status.Blobs...)[0]
+			log.Functionf("doUpdateContentTree(%s): VERIFIED image archive, starting async import", status.Key())
+			status.State = types.LOADING
+			publishContentTreeStatus(ctx, status)
+			AddWorkImportArchive(ctx, status, status.ReferenceID(), archiveBlob.Path)
+			return true, false
+		}
 		// we need to check root blob state to wait for another loading process if exists
 		blobStatuses := lookupBlobStatuses(ctx, status.Blobs...)
 		root := blobStatuses[0]
@@ -400,6 +423,37 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 	// if it is LOADING, check each blob until all are loaded
 	if status.State == types.LOADING {
 		log.Functionf("doUpdateContentTree(%s): ContentTree status is LOADING", status.Key())
+
+		// An image archive is still represented by its single bare blob until
+		// the import worker finishes. Once it has, swap the bare blob for the
+		// imported index/manifest/config/layer blobs; the generic blob loop
+		// below then marks the content tree LOADED.
+		if contentTreeIsImageArchive(ctx, status) {
+			ires := popImportArchiveWorkResult(ctx, status.Key())
+			if ires == nil {
+				// Import still running; wait for the worker to complete.
+				return changed, false
+			}
+			if ires.Error != nil {
+				err := fmt.Errorf("doUpdateContentTree(%s): failed to import image archive: %v", status.Key(), ires.Error)
+				log.Error(err.Error())
+				status.SetErrorWithSource(err.Error(), types.ContentTreeStatus{}, ires.ErrorTime)
+				changed = true
+				return changed, false
+			}
+			archiveBlob := lookupBlobStatuses(ctx, status.Blobs...)[0]
+			if err := finalizeImageArchive(ctx, status, archiveBlob, ires.indexDigest); err != nil {
+				err = fmt.Errorf("doUpdateContentTree(%s): failed to finalize image archive: %v", status.Key(), err)
+				log.Error(err.Error())
+				status.SetErrorWithSource(err.Error(), types.ContentTreeStatus{}, time.Now())
+				changed = true
+				return changed, false
+			}
+			changed = true
+			// status.Blobs now references the imported, already-LOADED blobs;
+			// fall through to the generic loop to confirm and mark LOADED.
+		}
+
 		// get the work result - see if it succeeded
 		wres := popCasIngestWorkResult(ctx, status.Key())
 		if wres != nil {

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -385,9 +385,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	// Create the background worker
 	ctx.worker = worker.NewPool(log, &ctx, 20, map[string]worker.Handler{
-		workCreate:  {Request: volumeWorker, Response: processVolumeWorkResult},
-		workIngest:  {Request: casIngestWorker, Response: processCasIngestWorkResult},
-		workPrepare: {Request: volumePrepareWorker, Response: processVolumePrepareResult},
+		workCreate:        {Request: volumeWorker, Response: processVolumeWorkResult},
+		workIngest:        {Request: casIngestWorker, Response: processCasIngestWorkResult},
+		workPrepare:       {Request: volumePrepareWorker, Response: processVolumePrepareResult},
+		workImportArchive: {Request: importArchiveWorker, Response: processImportArchiveWorkResult},
 	})
 
 	// Set up our publications before the subscriptions so ctx is set

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -180,6 +180,50 @@ func (client *Client) CtrWriteBlob(ctx context.Context, blobHash string, expecte
 	return nil
 }
 
+// CtrImportImageArchive imports an OCI image-layout or docker-save archive
+// (read from reader; the caller is responsible for any decompression) into the
+// content store and creates the image reference 'reference' pointing at the
+// imported index. It returns that index descriptor.
+//
+// It uses the high-level containerd Import (not the low-level
+// archive.ImportIndex) on purpose: Import sets the containerd.io/gc.ref.content
+// labels on the index -> manifest -> config/layers chain, so the ingested blobs
+// stay referenced and survive garbage collection. The earlier low-level path
+// left those blobs unreferenced, so GC reaped everything except the index and
+// the subsequent blob walk failed.
+func (client *Client) CtrImportImageArchive(ctx context.Context, reference string, reader io.Reader) (imagespecs.Descriptor, error) {
+	if err := client.verifyCtr(ctx, true); err != nil {
+		return imagespecs.Descriptor{}, fmt.Errorf("CtrImportImageArchive: exception while verifying ctrd client: %s", err.Error())
+	}
+	// Import does its own lease, ingests all blobs, sets gc.ref labels, and
+	// creates an image named `reference` (WithIndexName) pointing at the index.
+	imgs, err := client.ctrdClient.Import(ctx, reader, containerd.WithIndexName(reference))
+	if err != nil {
+		return imagespecs.Descriptor{}, fmt.Errorf("CtrImportImageArchive: exception while importing archive: %s", err.Error())
+	}
+	// The archive's per-manifest annotations (e.g. io.containerd.image.name) make
+	// Import also create image refs we do not own. Drop everything except
+	// `reference` so the content tree alone controls the image lifecycle and
+	// removing the content tree later frees the blobs (no leak).
+	is := client.ctrdClient.ImageService()
+	var target imagespecs.Descriptor
+	var found bool
+	for _, img := range imgs {
+		if img.Name == reference {
+			target = img.Target
+			found = true
+			continue
+		}
+		if err := is.Delete(ctx, img.Name); err != nil && !errdefs.IsNotFound(err) {
+			logrus.Warnf("CtrImportImageArchive: could not remove extra image ref %s: %v", img.Name, err)
+		}
+	}
+	if !found {
+		return imagespecs.Descriptor{}, fmt.Errorf("CtrImportImageArchive: imported image %s not found in result", reference)
+	}
+	return target, nil
+}
+
 // CtrUpdateBlobInfo updates blobs info
 func (client *Client) CtrUpdateBlobInfo(ctx context.Context, updatedContentInfo content.Info, updatedFields []string) error {
 	if err := client.verifyCtr(ctx, true); err != nil {

--- a/pkg/pillar/zboot/diskrootlayersize_test.go
+++ b/pkg/pillar/zboot/diskrootlayersize_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+package zboot
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lf-edge/edge-containers/pkg/registry"
+	"github.com/lf-edge/eve/pkg/pillar/cas"
+)
+
+// fakeCAS embeds cas.CAS so only GetImageLayers needs a real implementation;
+// any other call panics via the nil embedded interface.
+type fakeCAS struct {
+	cas.CAS
+	layers []cas.ImageLayer
+	err    error
+}
+
+func (f *fakeCAS) GetImageLayers(string) ([]cas.ImageLayer, error) {
+	return f.layers, f.err
+}
+
+func rootDisk(size int64) cas.ImageLayer {
+	return cas.ImageLayer{Size: size, Annotations: map[string]string{registry.AnnotationRole: registry.RoleRootDisk}}
+}
+
+func extDisk(size int64) cas.ImageLayer {
+	return cas.ImageLayer{Size: size, Annotations: map[string]string{registry.AnnotationRole: "disk-1"}}
+}
+
+func TestDiskRootLayerSize(t *testing.T) {
+	const wantSize = int64(268435456) // ~256 MB Core rootfs
+
+	tests := []struct {
+		name      string
+		layers    []cas.ImageLayer
+		err       error
+		wantSize  int64
+		wantFound bool
+		wantErr   bool
+	}{
+		{
+			name:      "split-rootfs: pick disk-root, ignore extension",
+			layers:    []cas.ImageLayer{rootDisk(wantSize), extDisk(1503564288)},
+			wantSize:  wantSize,
+			wantFound: true,
+		},
+		{
+			name:      "single raw image wrapped as disk-root",
+			layers:    []cas.ImageLayer{rootDisk(wantSize)},
+			wantSize:  wantSize,
+			wantFound: true,
+		},
+		{
+			name:      "no disk-root layer",
+			layers:    []cas.ImageLayer{extDisk(123)},
+			wantFound: false,
+		},
+		{
+			name:    "CAS error",
+			err:     fmt.Errorf("boom"),
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeCAS{layers: tc.layers, err: tc.err}
+			size, found, err := diskRootLayerSize(f, "ref")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if found != tc.wantFound || size != tc.wantSize {
+				t.Fatalf("got size=%d found=%v, want %d/%v", size, found, tc.wantSize, tc.wantFound)
+			}
+		})
+	}
+}

--- a/pkg/pillar/zboot/zboot.go
+++ b/pkg/pillar/zboot/zboot.go
@@ -420,6 +420,28 @@ func GetOtherPartitionDevName() string {
 	return GetPartitionDevname(partName)
 }
 
+// diskRootLayerSize returns the size in bytes of the image's disk-root layer —
+// the rootfs that WriteToPartition writes to this partition. For a split-rootfs
+// image this is only the Core (rootfs); the Extension and any other disks the
+// image carries are not written here, so the whole-image size is not a valid
+// bound. The rootfs is a squashfs stored as a raw (uncompressed) OCI layer, so
+// the manifest descriptor size equals the bytes written to the partition.
+//
+// found is false when the image has no disk-root layer (an unexpected manifest
+// shape); the caller then skips the size check rather than blocking the install.
+func diskRootLayerSize(casClient cas.CAS, image string) (size int64, found bool, err error) {
+	layers, err := casClient.GetImageLayers(image)
+	if err != nil {
+		return 0, false, err
+	}
+	for _, l := range layers {
+		if l.Annotations[registry.AnnotationRole] == registry.RoleRootDisk {
+			return l.Size, true, nil
+		}
+	}
+	return 0, false, nil
+}
+
 // WriteToPartition write the image to partition partName
 func WriteToPartition(log *base.LogObject, image string, partName string) error {
 
@@ -464,6 +486,24 @@ func WriteToPartition(log *base.LogObject, image string, partName string) error 
 		return errors.New(errStr)
 	}
 
+	// Reject an oversized rootfs before pulling and writing gigabytes: compare
+	// the disk-root layer size (what actually lands in the partition) against
+	// the partition capacity. This is exact for the squashfs rootfs and avoids
+	// wrongly rejecting an image whose extra disks (e.g. a split-rootfs
+	// Extension) push the whole-image size beyond the partition.
+	if size, found, derr := diskRootLayerSize(casClient, image); derr != nil {
+		log.Warnf("WriteToPartition(%s): cannot determine rootfs size (%v); relying on partition write bound", partName, derr)
+	} else if found {
+		partSize := GetPartitionSizeInBytes(partName)
+		if partSize > 0 && uint64(size) > partSize {
+			errStr := fmt.Sprintf("rootfs does not fit: rootfs %d bytes exceeds partition %s size %d bytes",
+				size, partName, partSize)
+			log.Error(errStr)
+			return errors.New(errStr)
+		}
+		log.Functionf("WriteToPartition(%s): rootfs %d bytes fits partition size %d", partName, size, partSize)
+	}
+
 	// Make sure we have nothing mounted on the target
 	for {
 		if err := syscall.Unmount(devName, 0); err != nil {
@@ -482,6 +522,8 @@ func WriteToPartition(log *base.LogObject, image string, partName string) error 
 	}
 	defer f.Close()
 
+	// The rootfs fit was checked above against the partition capacity, so write
+	// the disk-root layer straight to the partition device.
 	if _, _, err := puller.Pull(&registry.FilesTarget{Root: f, AcceptHash: true}, 0, false, os.Stderr, resolver); err != nil {
 		errStr := fmt.Sprintf("error pulling %s from containerd: %v", image, err)
 		log.Error(errStr)


### PR DESCRIPTION
# Description

> **Stacked on #6044 — review that first.** Until #6044 merges, this PR's diff
> also includes #6044's commits.

A packaged image (an OCI image-layout or docker-save archive) served by a
non-OCI datastore is downloaded by EVE as a single file. "Non-OCI" here means
every datastore type except `DsContainerRegistry` — i.e. HTTP(S), AWS S3
(`DsS3`), Azure Blob Storage (`DsAzureBlob`), Google Cloud Storage
(`DsGoogleStorage`) and SFTP. Today volumemgr wraps that whole file as one
opaque `disk-root` blob and synthesizes a single-layer manifest, so a multi-disk
image (one whose artifact carries additional disk layers beyond the root) loses
its structure: the entire archive is treated as the rootfs and written to the
IMGA/IMGB partition.

When a content tree resolves to a single non-manifest blob, volumemgr now peeks
at it; if it is actually such an archive it is imported into the CAS (index,
manifest, config and per-disk layers), an image reference is created, and the
content tree is repointed at the imported index. The image then resolves with
its real per-disk layout — the root disk is written to the partition and any
additional disks are placed per their roles — matching how the same image
behaves when pulled from an OCI registry. Detection is by content (gzip + tar
with `oci-layout`/`index.json`, or a docker-save `manifest.json`), so genuine
raw disk images are unaffected.

The import (de-gzip plus a CAS write of the whole archive, well over a gigabyte
for an EVE rootfs) runs on a `worker` goroutine rather than inline in
volumemgr's main loop. The content tree moves to LOADING while the import is in
flight and is re-evaluated when the worker reports back. This keeps the main
loop responsive — an inline import was observed to block it long enough to
approach the agent watchdog threshold.

## How to test and validate this PR

- Unit tests (`make -C pkg/pillar test`) cover archive detection
  (`TestDetectImageArchive`), CAS tree walking (`TestCollectImageBlobTree`,
  `TestCollectImageBlobTreeDedup`), the CAS-to-BlobStatus mapping
  (`TestBuildLoadedBlobStatuses`) and the predicate that gates the async import
  (`TestContentTreeIsImageArchive`).
- E2E: in eden, start a device on a regular EVE image and trigger a base-OS
  update to a multi-disk image served via a non-OCI datastore (the eden
  eserver). Before this change the device wraps the whole archive as a single
  disk-root and cannot install it; with this change EVE imports the multi-layer
  manifest (root disk to the partition, additional disks per their roles) and
  the update completes — the same result as serving the image from an OCI
  registry.

## Changelog notes

Base-OS and app images served as a single packaged OCI/docker archive over any
non-OCI datastore (HTTP, AWS S3, Azure Blob Storage, Google Cloud Storage, SFTP)
are now imported with their real multi-layer structure, so multi-disk images
install correctly without requiring an OCI registry. The import runs
asynchronously so it does not stall volumemgr.

## PR Backports

To be decided — this is a general fix to how packaged image archives are handled
on non-OCI datastores, so backporting to the LTS branches may be worthwhile.

- 16.0-stable: TBD
- 14.5-stable: TBD
- 13.4-stable: TBD

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
