### PR TITLE
pkg/fw: add HV=k Ubuntu firmware variant

### DIFF
--- a/images/modifiers/hv/k.yq
+++ b/images/modifiers/hv/k.yq
@@ -1,1 +1,2 @@
-.services += [{"name": "kube","image": "KUBE_TAG", "cgroupsPath": "/eve/services/kube", "oomScoreAdj": -999}]
+.services += [{"name": "kube","image": "KUBE_TAG", "cgroupsPath": "/eve/services/kube", "oomScoreAdj": -999}] |
+(.init[] | select(. == "FW_TAG")) |= "FW_K_TAG"

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -1,5 +1,11 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 ARG PLATFORM=generic
+# Firmware source selector: "upstream" (Alpine + kernel.org tarball, the default for
+# kvm/xen/mini/nvidia) or "ubuntu" (apt-installed full linux-firmware, used by HV=k).
+ARG FW_SOURCE=upstream
+# ubuntu:24.04 pinned by digest (the tag floats across point releases). Declared once
+# here and referenced by every ubuntu stage below so a bump is a single-line change.
+ARG UBUNTU_DIGEST=sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
 
 FROM lfedge/eve-alpine:956e170f3908aa5148b0ddb130e60fd862c7988b AS build-base
 
@@ -257,11 +263,67 @@ FROM compactor-common AS compactor-nvidia-jp7
 
 FROM compactor-${PLATFORM} AS compactor
 
-FROM scratch
+# =============================================================================
+# Ubuntu firmware variant (FW_SOURCE=ubuntu) — used by HV=k builds.
+# Ships the FULL Ubuntu linux-firmware set (no per-device filtering, no SBOM),
+# plus firmware that is not part of Ubuntu's linux-firmware package:
+# wireless-regdb (regulatory.db — a separate Ubuntu package) and the Hailo-8
+# accelerator blob (third-party, not in any Ubuntu package).
+# ubuntu:24.04 pinned by digest (tag floats across point releases).
+# =============================================================================
+FROM ubuntu:24.04@${UBUNTU_DIGEST} AS fwsrc-ubuntu
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        linux-firmware firmware-sof-signed wireless-regdb \
+ && rm -rf /var/lib/apt/lists/*
+# Ubuntu is usr-merged: firmware lands under /usr/lib/firmware.
+
+# Hailo-8 AI accelerator firmware — not shipped by Ubuntu, fetched directly.
+ENV HAILO_FW_VERSION=4.21.0
+ADD https://hailo-hailort.s3.eu-west-2.amazonaws.com/Hailo8/${HAILO_FW_VERSION}/FW/hailo8_fw.${HAILO_FW_VERSION}.bin /usr/lib/firmware/hailo/hailo8_fw.bin
+
+# --- Ubuntu microcode (x86_64 only) -----------------------------------------
+FROM ubuntu:24.04@${UBUNTU_DIGEST} AS ucode-ubuntu-amd64
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        intel-microcode amd64-microcode iucode-tool cpio \
+ && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /boot /tmp/ucode/amd/kernel/x86/microcode /usr/share/licenses/ucode \
+ && iucode_tool -l --write-earlyfw=/tmp/ucode/intel-ucode.img --overwrite \
+        /usr/lib/firmware/intel-ucode/ \
+ && cat /usr/lib/firmware/amd-ucode/microcode_amd*.bin \
+        > /tmp/ucode/amd/kernel/x86/microcode/AuthenticAMD.bin \
+ && ( cd /tmp/ucode/amd && echo kernel/x86/microcode/AuthenticAMD.bin \
+        | cpio -o -H newc -R 0:0 > /tmp/ucode/amd/amd-ucode.img ) \
+ && cat /tmp/ucode/intel-ucode.img /tmp/ucode/amd/amd-ucode.img > /boot/ucode.img \
+ && cp /usr/share/doc/intel-microcode/copyright /usr/share/licenses/ucode/intel-license.txt \
+ && cp /usr/share/doc/amd64-microcode/copyright /usr/share/licenses/ucode/amd-license.txt
+
+# No microcode on non-x86 — provide empty /boot and license dir so the COPY below works.
+FROM ubuntu:24.04@${UBUNTU_DIGEST} AS ucode-ubuntu-arm64
+RUN mkdir -p /boot /usr/share/licenses/ucode
+
+FROM ubuntu:24.04@${UBUNTU_DIGEST} AS ucode-ubuntu-riscv64
+RUN mkdir -p /boot /usr/share/licenses/ucode
+
+FROM ucode-ubuntu-${TARGETARCH} AS ucode-ubuntu
+
+# Existing (upstream) assembly — unchanged content, now a named stage.
+FROM scratch AS out-upstream
 ENTRYPOINT []
 WORKDIR /
-
 COPY --from=compactor /lib/firmware /lib/firmware
 COPY --from=compactor /lib/apk/db/installed /lib/apk/db/installed
 COPY --from=ucode-build /boot/ /boot/
 COPY --from=ucode-build /usr/share/licenses/ucode /usr/share/licenses/ucode
+
+# Ubuntu assembly — full firmware + Ubuntu ucode, no SBOM apk db.
+FROM scratch AS out-ubuntu
+ENTRYPOINT []
+WORKDIR /
+COPY --from=fwsrc-ubuntu /usr/lib/firmware /lib/firmware
+COPY --from=ucode-ubuntu /boot/ /boot/
+COPY --from=ucode-ubuntu /usr/share/licenses/ucode /usr/share/licenses/ucode
+
+# Final image = the selected assembly.
+FROM out-${FW_SOURCE}

--- a/pkg/fw/build-k.yml
+++ b/pkg/fw/build-k.yml
@@ -1,0 +1,14 @@
+# linuxkit build template
+#
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+image: eve-fw
+org: lfedge
+tag: "{{.Hash}}-generic-k"
+# Installing the Ubuntu firmware/microcode via apt needs network during the build.
+network: true
+buildArgs:
+  - PLATFORM=generic
+  - FW_SOURCE=ubuntu

--- a/tools/parse-pkgs.sh
+++ b/tools/parse-pkgs.sh
@@ -97,6 +97,7 @@ cat <<EOF
 CURDIR=$(pwd)
 KERNEL_TAG=${KERNEL_TAG}
 FW_TAG=${FW_TAG}
+FW_K_TAG=${FW_K_TAG}
 XENTOOLS_TAG=${XENTOOLS_TAG}
 NODE_EXPORTER_TAG=${NODE_EXPORTER_TAG}
 VECTOR_TAG=${VECTOR_TAG}
@@ -143,6 +144,7 @@ EOF
 }
 
 FW_TAG=$(linuxkit_fw_tag pkg/fw)
+FW_K_TAG=$(linuxkit_k_tag pkg/fw)
 NODE_EXPORTER_TAG=$(linuxkit_tag pkg/node-exporter)
 VECTOR_TAG=$(linuxkit_tag pkg/vector)
 XENTOOLS_TAG=$(linuxkit_tag pkg/xen-tools)


### PR DESCRIPTION
# Description

**NOTE:** this is a draft PR to discover and address problems that we may have using Ubuntu packages

For `HV=k` (eve-k) builds, ship the **full Ubuntu `linux-firmware` set** plus Ubuntu microcode in the `eve-fw` image, instead of the curated Alpine / kernel.org firmware used by the `kvm`/`xen`/`mini` variants. This matches the broad hardware enablement of the Ubuntu-HWE-based 6.18 kernel.

- A new `FW_SOURCE` build arg in `pkg/fw/Dockerfile` selects, via the `FROM <stage>-${FW_SOURCE}` idiom, between the existing upstream path (Alpine + kernel.org tarball, the default) and new apt-based Ubuntu stages: `fwsrc-ubuntu` (installs `linux-firmware` + `firmware-sof-signed`) and arch-gated `ucode-ubuntu-*` (builds `/boot/ucode.img` from `intel-microcode`/`amd64-microcode` on x86). The result is assembled into a `FROM scratch` image (full `/lib/firmware`, no per-device filtering, no SBOM).
- `pkg/fw/build-k.yml` sets `FW_SOURCE=ubuntu` and `network: true` (apt needs network during the build; linuxkit defaults to `--nonetwork`). It is auto-selected when `HV=k` via the existing `get_pkg_build_k_yml` mechanism, and produces a distinct `{{.Hash}}-generic-k` image.
- `tools/parse-pkgs.sh` emits that tag as `FW_K_TAG`, and the existing `images/modifiers/hv/k.yq` HV=k modifier swaps `FW_TAG` -> `FW_K_TAG` in the rootfs `init:` list.
- `kvm`/`xen`/`mini` firmware is unchanged.

The Ubuntu base image is pinned by digest (`ARG UBUNTU_DIGEST`).

> Note: Ubuntu ships firmware zstd-compressed, so the kernel must have `CONFIG_FW_LOADER_COMPRESS_ZSTD=y` (already expected in the Ubuntu-HWE-based defconfig).

## How to test and validate this PR

```
# HV=k -> full Ubuntu firmware image, tagged -generic-k
make HV=k eve-fw
# inspect: full /lib/firmware tree (thousands of files), /boot/ucode.img present, no apk db
linuxkit cache export --platform linux/amd64 --format filesystem --outfile - \
  $(linuxkit pkg show-tag --build-yml build-k.yml pkg/fw) | tar tf - | grep -c lib/firmware

# Other HVs unchanged (curated firmware, -generic tag)
make HV=kvm eve-fw
```

Verified locally: `make HV=k eve-fw` builds an image with ~6900 firmware files across all vendors, `/boot/ucode.img`, and no SBOM apk db; the `-generic-k` tag flows into `rootfs-k-*.yml` while `kvm` keeps `-generic`.

## Changelog notes

eve-k images now ship the full Ubuntu `linux-firmware` set (broader device coverage) instead of the curated firmware subset. No change for kvm/xen.

## PR Backports

- 16.0-stable: No - new feature tied to the in-progress 6.18 HWE kernel work
- 14.5-stable: No - same
- 13.4-stable: No - same

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.