### PR TITLE
vault: name mismatching PCRs in unlock failure

### DIFF
--- a/pkg/pillar/cmd/nodeagent/handletimers.go
+++ b/pkg/pillar/cmd/nodeagent/handletimers.go
@@ -125,8 +125,12 @@ func handleRebootOnVaultLocked(ctxPtr *nodeagentContext) {
 	if timePassed > vaultCutOffTime {
 		if ctxPtr.updateInprogress {
 			// fail the upgrade by rebooting now
-			errStr := fmt.Sprintf("Exceeded time for vault to be ready %d by %d seconds, rebooting",
+			errStr := fmt.Sprintf("Exceeded time for vault to be ready %d by %d seconds",
 				vaultCutOffTime, timePassed-vaultCutOffTime)
+			if pcrsStr := types.FormatMismatchingPCRs(ctxPtr.vaultMismatchingPCRs); pcrsStr != "" {
+				errStr += "; " + pcrsStr
+			}
+			errStr += ", rebooting"
 			log.Error(errStr)
 			scheduleNodeOperation(ctxPtr, errStr, types.BootReasonVaultFailure,
 				types.DeviceOperationReboot)

--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -111,6 +111,7 @@ type nodeagentContext struct {
 	rebootTime                  time.Time        // From last reboot
 	restartCounter              uint32
 	vaultOperational            types.TriState                   // Is the vault fully operational?
+	vaultMismatchingPCRs        []int                            // PCR indexes that probably blocked unsealing the vault key
 	vaultTestStartTime          uint32                           // Time at which we should start waiting for vault to be operational
 	maintMode                   bool                             // whether Maintenance mode should be triggered
 	maintModeReasons            types.MaintenanceModeMultiReason // reasons for entering Maintenance mode
@@ -796,6 +797,7 @@ func handleVaultStatusImpl(ctxArg interface{}, key string,
 		return
 	}
 	if vault.Status != info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR {
+		ctx.vaultMismatchingPCRs = nil
 		if vault.ConversionComplete {
 			ctx.vaultOperational = types.TS_ENABLED
 			// Do we need to clear maintenance?
@@ -806,6 +808,9 @@ func handleVaultStatusImpl(ctxArg interface{}, key string,
 		}
 	} else {
 		ctx.vaultOperational = types.TS_DISABLED
+		// Remember why the vault could not be unlocked so we can record it in
+		// the reboot reason if the vault never becomes operational.
+		ctx.vaultMismatchingPCRs = vault.MismatchingPCRs
 	}
 }
 

--- a/pkg/pillar/types/vaultmgrtypes.go
+++ b/pkg/pillar/types/vaultmgrtypes.go
@@ -4,6 +4,8 @@
 package types
 
 import (
+	"fmt"
+
 	"github.com/lf-edge/eve-api/go/info"
 
 	"github.com/google/go-cmp/cmp"
@@ -197,4 +199,17 @@ func (key EncryptedVaultKeyFromController) LogKey() string {
 // IsVaultInError :
 func (status VaultStatus) IsVaultInError() bool {
 	return (status.Status == info.DataSecAtRestStatus_DATASEC_AT_REST_ERROR) && len(status.MismatchingPCRs) > 0
+}
+
+// FormatMismatchingPCRs returns a human-readable clause naming the PCR indexes
+// that probably prevented the sealed vault key from being unsealed, or an empty
+// string when none are known. The wording is shared by vaultmgr (which folds it
+// into VaultStatus.Error) and nodeagent (which adds it to the reboot reason), so
+// the explanation reads the same wherever it surfaces - VaultStatus, diag, and
+// the controller-visible BaseOsStatus error.
+func FormatMismatchingPCRs(mismatchingPCRs []int) string {
+	if len(mismatchingPCRs) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("possibly mismatching PCR indexes %v", mismatchingPCRs)
 }

--- a/pkg/pillar/types/vaultmgrtypes_test.go
+++ b/pkg/pillar/types/vaultmgrtypes_test.go
@@ -29,6 +29,18 @@ func TestVaultStatusIsVaultInError(t *testing.T) {
 	assert.True(t, s.IsVaultInError())
 }
 
+// FormatMismatchingPCRs
+
+func TestFormatMismatchingPCRs(t *testing.T) {
+	// No mismatching PCRs → empty string so callers can omit the clause
+	assert.Equal(t, "", FormatMismatchingPCRs(nil))
+	assert.Equal(t, "", FormatMismatchingPCRs([]int{}))
+
+	// Known mismatching PCRs → descriptive clause with the "possibly" qualifier
+	assert.Equal(t, "possibly mismatching PCR indexes [4 8 9 13 14]",
+		FormatMismatchingPCRs([]int{4, 8, 9, 13, 14}))
+}
+
 // VaultConfig / VaultStatus / EncryptedVaultKeyFromDevice / EncryptedVaultKeyFromController Key / LogKey
 
 func TestVaultConfigKey(t *testing.T) {

--- a/pkg/pillar/vault/handler_ext4.go
+++ b/pkg/pillar/vault/handler_ext4.go
@@ -433,7 +433,11 @@ func (h *Ext4Handler) getVaultStatus(vaultName string, vaultPath string,
 						status.MismatchingPCRs = pcrs
 					}
 				}
-				status.SetErrorDescription(types.ErrorDescription{Error: "Vault key unavailable"})
+				errStr := "Vault key unavailable"
+				if pcrsStr := types.FormatMismatchingPCRs(status.MismatchingPCRs); pcrsStr != "" {
+					errStr += "; " + pcrsStr
+				}
+				status.SetErrorDescription(types.ErrorDescription{Error: errStr})
 			}
 		}
 	}

--- a/pkg/pillar/vault/handler_zfs.go
+++ b/pkg/pillar/vault/handler_zfs.go
@@ -259,7 +259,11 @@ func (h *ZFSHandler) getVaultStatus(vaultName, vaultPath string) *types.VaultSta
 					status.MismatchingPCRs = pcrs
 				}
 			}
-			status.SetErrorDescription(types.ErrorDescription{Error: err.Error()})
+			errStr := err.Error()
+			if pcrsStr := types.FormatMismatchingPCRs(status.MismatchingPCRs); pcrsStr != "" {
+				errStr += "; " + pcrsStr
+			}
+			status.SetErrorDescription(types.ErrorDescription{Error: errStr})
 		} else {
 			h.log.Functionf("checkOperStatus returns ok for %s", vaultPath)
 			status.Status = info.DataSecAtRestStatus_DATASEC_AT_REST_ENABLED


### PR DESCRIPTION
# Description

When a sealed vault key cannot be unsealed — typically after a base OS
upgrade whose new rootfs changes the measured-boot PCR values the key is
bound to — the device only surfaced a generic reason: `Vault key
unavailable` from vaultmgr, and, when an in-progress upgrade was rolled
back, `Exceeded time for vault to be ready ..., rebooting` from nodeagent.
Which PCRs actually failed validation was invisible to an operator: the
controller's attestation response only returns a coarse `QUOTE_FAILED`
code, so the offending PCR indexes lived only in controller-side logs.

The device already determines the responsible PCR indexes locally from the
failed TPM unseal (`evetpm.FindMismatchingPCRs`). This PR surfaces them:

- **vaultmgr** folds the probable PCR list into the vault status error.
  That string flows into the data-at-rest info reported to the controller
  and is printed by `diag` (e.g. `vault: ERROR error Vault key unavailable;
  possibly mismatching PCR indexes [4 8 9 13 14]`).
- **nodeagent** appends the same list to the reboot reason it records when
  it fails an in-progress upgrade, so the rolled-back partition's
  `BaseOsStatus` error names the PCRs too.

A shared formatter keeps the `possibly mismatching PCR indexes ...` wording
identical everywhere. No eve-api/controller change is required.

## How to test and validate this PR

On a TPM-enabled device with an encrypted vault, trigger a sealed-key
unseal failure (e.g. a base OS upgrade that changes the measured-boot PCRs,
or otherwise perturb a PCR the disk key is sealed to so the unseal fails):

- `diag` output for the vault line should now read
  `vault: ERROR error Vault key unavailable; possibly mismatching PCR
  indexes [...]` (ext4) or the zfs operational error followed by the same
  clause.
- The data-at-rest vault error reported to the controller carries the same
  clause.
- If the failure happens during an in-progress upgrade, the recorded reboot
  reason (and the resulting `BaseOsStatus` error on the rolled-back
  partition) reads `Exceeded time for vault to be ready N by M seconds;
  possibly mismatching PCR indexes [...], rebooting ...`.

Unit test added for the shared formatter (`TestFormatMismatchingPCRs`).
Builds clean via `make pkg/pillar` and a full `eve` image build (HV=kvm,
amd64).

## Changelog notes

When the encrypted vault cannot be unlocked, EVE now reports the TPM PCR
indexes that probably caused it, in diag, the controller status, and the
reboot reason for a failed upgrade.

## PR Backports

- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.
