### PR TITLE
[16.0-stable] downloader: add HTTP/HTTPS Basic, Bearer and NTLM auth suppo

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -39,6 +39,7 @@
 | debug.enable.ssh | authorized ssh key | empty string(ssh disabled) | - | - | allow ssh to EVE |
 | debug.enable.console | boolean | false | - | - | allow console access to EVE (reboot required to disable) |
 | debug.enable.vnc.shim.vm | boolean | false | - | - | allow VNC access to the container application shim VM (reboot required to disable) |
+| datastore.http.security.allowinsecureauth | boolean | false | - | - | allow sending authorization header over unencrypted http connection |
 | storage.dom0.disk.minusage.percent | integer percent | 20 | 20 | 80 | min. percent of persist partition reserved for dom0 |
 | storage.zfs.reserved.percent | integer percent | 20 | 1 | 99 | min. percent of persist partition reserved for zfs performance |
 | storage.apps.ignore.disk.check | boolean | false | - | - | Ignore disk usage check for Apps. Allows apps to create images bigger than available disk|

--- a/pkg/pillar/cmd/downloader/download.go
+++ b/pkg/pillar/cmd/downloader/download.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lf-edge/eve-libs/zedUpload/types"
 	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
 	"github.com/lf-edge/eve/pkg/pillar/netdump"
+	pillartypes "github.com/lf-edge/eve/pkg/pillar/types"
 	utils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 )
 
@@ -138,7 +139,10 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 	// create Endpoint
 	var dEndPoint zedUpload.DronaEndPoint
 	switch trType {
-	case zedUpload.SyncHttpTr, zedUpload.SyncSftpTr:
+	case zedUpload.SyncHttpTr:
+		allow := ctx.globalConfig.GlobalValueBool(pillartypes.DataStoreAllowInsecureAuth)
+		dEndPoint, err = ctx.dCtx.NewSyncerDest(trType, downloadURL, nettracePATH, dpath, auth, zedUpload.WithAllowInsecureAuth(allow))
+	case zedUpload.SyncSftpTr:
 		dEndPoint, err = ctx.dCtx.NewSyncerDest(trType, downloadURL, nettracePATH, dpath, auth)
 	case zedUpload.SyncAzureTr:
 		dEndPoint, err = ctx.dCtx.NewSyncerDest(trType, downloadURL, nettracePATH, dpath, auth)

--- a/pkg/pillar/cmd/downloader/syncop.go
+++ b/pkg/pillar/cmd/downloader/syncop.go
@@ -143,8 +143,14 @@ func handleSyncOp(ctx *downloaderContext, key string,
 		serverURL = dst.Fqdn
 
 	case zconfig.DsType_DsHttp.String(), zconfig.DsType_DsHttps.String(), "":
+		// APIKey holds the auth scheme (e.g. "Bearer", "Basic", "NTLM"),
+		// Password holds the corresponding credential token.
+		// The Authorization header is "<APIKey> <Password>", matching the
+		// convention used in collectinfo.go.
 		auth = &zedUpload.AuthInput{
 			AuthType: "http",
+			Uname:    dsCtx.APIKey,
+			Password: dsCtx.Password,
 		}
 		trType = zedUpload.SyncHttpTr
 		// pass in the config.Name instead of 'filename' which

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -437,6 +437,9 @@ const (
 	LpsNetworkInterval GlobalSettingKey = "timer.lps.network.interval"
 	// LpsAppBootInfoInterval defines interval between LPS app boot info POSTs.
 	LpsAppBootInfoInterval GlobalSettingKey = "timer.lps.appbootinfo.interval"
+
+	// DataStoreAllowInsecureAuth allows authentication header via http
+	DataStoreAllowInsecureAuth GlobalSettingKey = "datastore.http.security.allowinsecureauth"
 )
 
 // AgentSettingKey - keys for per-agent settings
@@ -1092,6 +1095,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddBoolItem(WwanModemRecoveryRestartModemManager, false)
 	configItemSpecMap.AddBoolItem(NetworkLocalLegacyMACAddress, false)
 	configItemSpecMap.AddBoolItem(MemoryMonitorEnabled, false)
+	configItemSpecMap.AddBoolItem(DataStoreAllowInsecureAuth, false)
 
 	// Add TriState Items
 	configItemSpecMap.AddTriStateItem(NetworkFallbackAnyEth, TS_DISABLED)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -253,6 +253,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		LpsDevInfoInterval,
 		LpsNetworkInterval,
 		LpsAppBootInfoInterval,
+		DataStoreAllowInsecureAuth,
 	}
 	if len(specMap.GlobalSettings) != len(gsKeys) {
 		t.Errorf("GlobalSettings has more (%d) than expected keys (%d)",


### PR DESCRIPTION
# Description

APIKey carries the auth scheme (e.g. "Bearer", "Basic", "NTLM") and Password carries the credential token, matching the convention already used in collectinfo.go.  The Authorization header is set verbatim as "<scheme> <credential>" on every HTTP request made by the downloader.

Backport of https://github.com/lf-edge/eve/pull/5999



## How to test and validate this PR

1. add an https datastore, check that auth (f.e. basic auth) works
2. add an http datastore with auth, check that it fails with an error, that auth via plaintext http is insecure
3. add ann http datastore with auth and set datastore.http.security.allowinsecureauth, check that auth via plaintext works

## Changelog notes

Allow http auth header for datastore download

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
