### PR TITLE
kubeapi: fix ReplicaModeMap/RebuildStatus key format; add longhorninfo unit tests

### DIFF
--- a/pkg/pillar/kubeapi/longhorninfo.go
+++ b/pkg/pillar/kubeapi/longhorninfo.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Zededa, Inc.
+// Copyright (c) 2025-2026 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build k
@@ -117,7 +117,7 @@ func replicaHasNoFsBacking(lhReplica lhv1beta2.Replica) bool {
 
 // replicaModeProgress maps the engine's ReplicaModeMap entry for a single replica
 // to the three KubeVolumeReplicaInfo fields that populateKVIFromPVCName needs to set.
-// It always returns a definitive repStatus (Online for modes that do not change it).
+// It always returns a definitive repStatus for each mode map state.
 // isConsistent is true only for RW replicas that should be counted toward consistentReps.
 func replicaModeProgress(
 	inModeMap bool,
@@ -128,7 +128,10 @@ func replicaModeProgress(
 	repStatus = types.StorageVolumeReplicaStatusOnline
 	switch {
 	case !inModeMap:
-		// Running but not yet registered in the engine — not yet consistent.
+		// Running but not yet registered in the engine's ReplicaModeMap — sync
+		// state is unknown; report Unknown rather than Online to avoid a false
+		// healthy signal during the brief window before the engine registers the replica.
+		repStatus = types.StorageVolumeReplicaStatusUnknown
 	case mode == lhv1beta2.ReplicaModeRW:
 		// Fully synced read-write: the only state that genuinely means 100%.
 		percentage = 100
@@ -151,11 +154,25 @@ func replicaModeProgress(
 // the function is pure so it can be unit-tested without a live cluster.
 func robustnessSubstate(robustness types.StorageVolumeRobustness, onlineReps, consistentReps int) types.StorageHealthStatus {
 	switch robustness {
-	case types.StorageVolumeRobustnessHealthy:
-		return types.StorageHealthStatusHealthy
 	case types.StorageVolumeRobustnessFaulted:
 		return types.StorageHealthStatusFailed
+	case types.StorageVolumeRobustnessHealthy:
+		// Only report Healthy when every Running replica is confirmed RW.
+		// If any Running replica is absent from ReplicaModeMap or in a non-RW
+		// mode, consistentReps < onlineReps and we fall through to the Degraded
+		// branch so the engine-lag window cannot produce a false Healthy signal.
+		// onlineReps == 0 && consistentReps == 0 satisfies this condition and
+		// returns Healthy — Longhorn never marks a volume Healthy with zero
+		// running replicas, so we trust that invariant rather than guarding it.
+		if consistentReps == onlineReps {
+			return types.StorageHealthStatusHealthy
+		}
+		fallthrough
 	case types.StorageVolumeRobustnessDegraded:
+		// The cases below cover EVE's supported replica range (1–3). For a
+		// Healthy volume that falls through (unconfirmed replicas) with ≥4
+		// replicas, none of the conditions match and Unknown is returned — an
+		// acceptable outcome since EVE does not configure volumes with >3 replicas.
 		if onlineReps == 1 {
 			return types.StorageHealthStatusDegraded1ReplicaAvailableNotReplicating
 		}
@@ -179,25 +196,39 @@ func robustnessSubstate(robustness types.StorageVolumeRobustness, onlineReps, co
 	return types.StorageHealthStatusUnknown
 }
 
-// PopulateKVIFromPVCName uses the longhorn api to retrieve volume and replica health
-// to be sent out to the controller as info messages
-func populateKVIFromPVCName(kvi *types.KubeVolumeInfo) (*types.KubeVolumeInfo, error) {
-	config, err := GetKubeConfig()
-	if err != nil {
-		return kvi, fmt.Errorf("PopulateKVIFromPVCName can't get kubeconfig %v", err)
-	}
+// pvcGetter is a minimal subset of the k8s PVC client used by populateKVIInner.
+type pvcGetter interface {
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.PersistentVolumeClaim, error)
+}
 
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return kvi, fmt.Errorf("PopulateKVIFromPVCName can't get clientset %v", err)
-	}
+// lhVolumeGetter is a minimal subset of the Longhorn volume client.
+type lhVolumeGetter interface {
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*lhv1beta2.Volume, error)
+}
 
-	lhClient, err := versioned.NewForConfig(config)
-	if err != nil {
-		return kvi, fmt.Errorf("PopulateKVIFromPVCName can't get versioned config: %v", err)
-	}
+// lhReplicaLister is a minimal subset of the Longhorn replica client.
+type lhReplicaLister interface {
+	List(ctx context.Context, opts metav1.ListOptions) (*lhv1beta2.ReplicaList, error)
+}
 
-	pvc, err := clientset.CoreV1().PersistentVolumeClaims(EVEKubeNameSpace).Get(context.Background(), kvi.Name, metav1.GetOptions{})
+// lhEngineGetter is a minimal subset of the Longhorn engine client.
+type lhEngineGetter interface {
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*lhv1beta2.Engine, error)
+}
+
+// populateKVIInner is the testable core of populateKVIFromPVCName.
+// All Longhorn and k8s I/O is injected through the four interface arguments so
+// unit tests can supply hand-written mocks without a live cluster.
+func populateKVIInner(
+	ctx context.Context,
+	kvi *types.KubeVolumeInfo,
+	pvcs pvcGetter,
+	lhVols lhVolumeGetter,
+	lhReplicas lhReplicaLister,
+	lhEngines lhEngineGetter,
+	snapshotBytes func(string) (int64, error),
+) (*types.KubeVolumeInfo, error) {
+	pvc, err := pvcs.Get(ctx, kvi.Name, metav1.GetOptions{})
 	if err != nil {
 		return kvi, fmt.Errorf("PopulateKVIFromPVCName can't get pvc:%s err:%v", kvi.Name, err)
 	}
@@ -214,12 +245,12 @@ func populateKVIFromPVCName(kvi *types.KubeVolumeInfo) (*types.KubeVolumeInfo, e
 	}
 	lhVolName := pvc.Spec.VolumeName
 
-	lhVol, err := lhClient.LonghornV1beta2().Volumes(longhornNamespace).Get(context.Background(), lhVolName, metav1.GetOptions{})
+	lhVol, err := lhVols.Get(ctx, lhVolName, metav1.GetOptions{})
 	if err != nil {
 		return kvi, fmt.Errorf("PopulateKVIFromPVCName can't get lh vol err:%v", err)
 	}
 	kvi.AllocatedBytes = uint64(lhVol.Status.ActualSize)
-	if snapBytes, snapErr := LonghornVolumeSnapshotBytes(lhVolName); snapErr == nil && snapBytes > 0 {
+	if snapBytes, snapErr := snapshotBytes(lhVolName); snapErr == nil && snapBytes > 0 {
 		kvi.AllocatedBytes += uint64(snapBytes)
 	}
 
@@ -249,7 +280,7 @@ func populateKVIFromPVCName(kvi *types.KubeVolumeInfo) (*types.KubeVolumeInfo, e
 		kvi.State = types.StorageVolumeStateDeleting
 	}
 
-	replicas, err := lhClient.LonghornV1beta2().Replicas(longhornNamespace).List(context.Background(), metav1.ListOptions{
+	replicas, err := lhReplicas.List(ctx, metav1.ListOptions{
 		LabelSelector: "longhornvolume=" + lhVolName,
 	})
 	if err != nil {
@@ -279,28 +310,25 @@ func populateKVIFromPVCName(kvi *types.KubeVolumeInfo) (*types.KubeVolumeInfo, e
 			kviRep.Status = types.StorageVolumeReplicaStatusOnline
 			kviRep.OwnerNode = lhReplica.Status.OwnerID
 
-			engine, err := lhClient.LonghornV1beta2().Engines(longhornNamespace).Get(context.Background(), replicaEngineName, metav1.GetOptions{})
+			engine, err := lhEngines.Get(ctx, replicaEngineName, metav1.GetOptions{})
 			if err != nil {
 				return kvi, fmt.Errorf("PopulateKVIFromPVCName can't get replica engine: %v", err)
 			}
 
-			// Use the canonical address from the engine's own CurrentReplicaAddressMap
-			// rather than constructing tcp://IP:PORT from replica status.  The engine's
-			// ReplicaModeMap and RebuildStatus are both keyed by the address the engine
-			// process itself uses; constructing from replica.Status.IP/Port can diverge
-			// after a pod restart or IP reassignment, causing the lookup to silently miss.
-			replicaAddr, inEngineMap := engine.Status.CurrentReplicaAddressMap[lhReplica.Name]
-			if !inEngineMap {
-				replicaAddr = "tcp://" + net.JoinHostPort(replicaEngineIP, strconv.Itoa(replicaEnginePort))
+			// CurrentReplicaAddressMap values are "IP:PORT" (no tcp:// prefix).
+			// RebuildStatus is keyed by "tcp://IP:PORT"
+			// ReplicaModeMap is keyed by replica name.
+			replicaRawAddr := net.JoinHostPort(replicaEngineIP, strconv.Itoa(replicaEnginePort))
+			if addr, ok := engine.Status.CurrentReplicaAddressMap[lhReplica.Name]; ok {
+				replicaRawAddr = addr
 			}
+			rebuildAddr := "tcp://" + replicaRawAddr
 
-			// ReplicaModeMap is the authoritative oracle for replica sync state.
-			// RebuildStatus is ephemeral: it is absent before the rebuild transfer
-			// starts and cleared when the engine restarts, so "absent from RebuildStatus"
-			// does NOT mean the replica is consistent — it only means consistent when the
-			// replica is in RW mode.
-			replicaMode, inModeMap := engine.Status.ReplicaModeMap[replicaAddr]
-			rebuildEntry, hasRebuildEntry := engine.Status.RebuildStatus[replicaAddr]
+			// ReplicaModeMap is the authoritative sync oracle. RebuildStatus is
+			// ephemeral: absent before transfer starts and cleared on restart —
+			// only RW in ReplicaModeMap means the replica is consistent.
+			replicaMode, inModeMap := engine.Status.ReplicaModeMap[lhReplica.Name]
+			rebuildEntry, hasRebuildEntry := engine.Status.RebuildStatus[rebuildAddr]
 			rebuildProgress := 0
 			if hasRebuildEntry {
 				rebuildProgress = rebuildEntry.Progress
@@ -330,6 +358,35 @@ func populateKVIFromPVCName(kvi *types.KubeVolumeInfo) (*types.KubeVolumeInfo, e
 
 	kvi.RobustnessSubstate = robustnessSubstate(kvi.Robustness, onlineReps, consistentReps)
 	return kvi, nil
+}
+
+// populateKVIFromPVCName uses the longhorn api to retrieve volume and replica health
+// to be sent out to the controller as info messages
+func populateKVIFromPVCName(kvi *types.KubeVolumeInfo) (*types.KubeVolumeInfo, error) {
+	config, err := GetKubeConfig()
+	if err != nil {
+		return kvi, fmt.Errorf("PopulateKVIFromPVCName can't get kubeconfig %v", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return kvi, fmt.Errorf("PopulateKVIFromPVCName can't get clientset %v", err)
+	}
+
+	lhClient, err := versioned.NewForConfig(config)
+	if err != nil {
+		return kvi, fmt.Errorf("PopulateKVIFromPVCName can't get versioned config: %v", err)
+	}
+
+	return populateKVIInner(
+		context.Background(),
+		kvi,
+		clientset.CoreV1().PersistentVolumeClaims(EVEKubeNameSpace),
+		lhClient.LonghornV1beta2().Volumes(longhornNamespace),
+		lhClient.LonghornV1beta2().Replicas(longhornNamespace),
+		lhClient.LonghornV1beta2().Engines(longhornNamespace),
+		LonghornVolumeSnapshotBytes,
+	)
 }
 
 // Return transitionTime and health

--- a/pkg/pillar/kubeapi/longhorninfo_test.go
+++ b/pkg/pillar/kubeapi/longhorninfo_test.go
@@ -6,12 +6,110 @@
 package kubeapi
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// -- mock types for populateKVIInner --
+
+type funcPVCGetter struct {
+	fn func(string) (*corev1.PersistentVolumeClaim, error)
+}
+
+func (m funcPVCGetter) Get(_ context.Context, name string, _ metav1.GetOptions) (*corev1.PersistentVolumeClaim, error) {
+	return m.fn(name)
+}
+
+type funcLHVolGetter struct {
+	fn func(string) (*lhv1beta2.Volume, error)
+}
+
+func (m funcLHVolGetter) Get(_ context.Context, name string, _ metav1.GetOptions) (*lhv1beta2.Volume, error) {
+	return m.fn(name)
+}
+
+type funcLHReplicaLister struct {
+	fn func(metav1.ListOptions) (*lhv1beta2.ReplicaList, error)
+}
+
+func (m funcLHReplicaLister) List(_ context.Context, opts metav1.ListOptions) (*lhv1beta2.ReplicaList, error) {
+	return m.fn(opts)
+}
+
+type funcLHEngineGetter struct {
+	fn func(string) (*lhv1beta2.Engine, error)
+}
+
+func (m funcLHEngineGetter) Get(_ context.Context, name string, _ metav1.GetOptions) (*lhv1beta2.Engine, error) {
+	return m.fn(name)
+}
+
+// -- helper constructors --
+
+func fakePVC(pvcName, volName string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: pvcName},
+		Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: volName},
+		Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+	}
+}
+
+func fakeLHVol(robustness lhv1beta2.VolumeRobustness) *lhv1beta2.Volume {
+	return &lhv1beta2.Volume{
+		Status: lhv1beta2.VolumeStatus{
+			Robustness: robustness,
+			State:      lhv1beta2.VolumeStateAttached,
+		},
+	}
+}
+
+// fakeReplica creates a replica with OwnerID and CurrentImage set (has fs backing).
+func fakeReplica(name, engineName, ip string, port int, state lhv1beta2.InstanceState) lhv1beta2.Replica {
+	return lhv1beta2.Replica{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       lhv1beta2.ReplicaSpec{EngineName: engineName},
+		Status: lhv1beta2.ReplicaStatus{
+			InstanceStatus: lhv1beta2.InstanceStatus{
+				OwnerID:      "node1",
+				CurrentImage: "longhorn-engine:latest",
+				IP:           ip,
+				Port:         port,
+				CurrentState: state,
+			},
+		},
+	}
+}
+
+func fakeEngine(
+	name string,
+	modeMap map[string]lhv1beta2.ReplicaMode,
+	rebuildStatus map[string]*lhv1beta2.RebuildStatus,
+	addrMap map[string]string,
+) *lhv1beta2.Engine {
+	return &lhv1beta2.Engine{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: lhv1beta2.EngineStatus{
+			ReplicaModeMap:           modeMap,
+			RebuildStatus:            rebuildStatus,
+			CurrentReplicaAddressMap: addrMap,
+		},
+	}
+}
+
+func findReplica(kvi *types.KubeVolumeInfo, name string) *types.KubeVolumeReplicaInfo {
+	for i := range kvi.Replicas {
+		if kvi.Replicas[i].Name == name {
+			return &kvi.Replicas[i]
+		}
+	}
+	return nil
+}
 
 func snap(name string, size int64, markRemoved bool) lhv1beta2.Snapshot {
 	return lhv1beta2.Snapshot{
@@ -84,7 +182,7 @@ func TestReplicaModeProgress(t *testing.T) {
 			name:           "not in mode map: not yet registered with engine",
 			inModeMap:      false,
 			wantPct:        0,
-			wantStatus:     types.StorageVolumeReplicaStatusOnline,
+			wantStatus:     types.StorageVolumeReplicaStatusUnknown,
 			wantConsistent: false,
 		},
 		{
@@ -96,8 +194,8 @@ func TestReplicaModeProgress(t *testing.T) {
 			wantConsistent: true,
 		},
 		{
-			// This is the false-100% bug case: WO with no RebuildStatus entry yet.
-			// Old code returned 100% here; correct behavior is 0% (queued, not started).
+			// WO with no RebuildStatus entry: transfer is queued but not yet started.
+			// There is no progress to report; the replica is not consistent.
 			name:            "WO without rebuild entry: transfer queued, not started",
 			inModeMap:       true,
 			mode:            lhv1beta2.ReplicaModeWO,
@@ -236,6 +334,16 @@ func TestRobustnessSubstate(t *testing.T) {
 			consistent:   0,
 			wantSubstate: types.StorageHealthStatusUnknown,
 		},
+		{
+			// Longhorn volume is Healthy but one Running replica is not yet confirmed
+			// RW in ReplicaModeMap (engine-lag window). Guard falls through to Degraded
+			// branch to prevent a false Healthy signal.
+			name:         "healthy volume with unconfirmed replica falls through to degraded",
+			robustness:   H,
+			online:       2,
+			consistent:   1,
+			wantSubstate: types.StorageHealthStatusDegraded1ReplicaAvailableReplicating,
+		},
 	}
 
 	for _, tc := range tests {
@@ -243,6 +351,368 @@ func TestRobustnessSubstate(t *testing.T) {
 			got := robustnessSubstate(tc.robustness, tc.online, tc.consistent)
 			if got != tc.wantSubstate {
 				t.Errorf("robustnessSubstate: got %v, want %v", got, tc.wantSubstate)
+			}
+		})
+	}
+}
+
+func TestReplicaHasNoFsBacking(t *testing.T) {
+	tests := []struct {
+		name    string
+		replica lhv1beta2.Replica
+		want    bool
+	}{
+		{
+			name:    "all empty: no backing",
+			replica: lhv1beta2.Replica{},
+			want:    true,
+		},
+		{
+			name: "OwnerID set: has backing",
+			replica: lhv1beta2.Replica{
+				Status: lhv1beta2.ReplicaStatus{
+					InstanceStatus: lhv1beta2.InstanceStatus{OwnerID: "node1"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "InstanceManagerName set: has backing",
+			replica: lhv1beta2.Replica{
+				Status: lhv1beta2.ReplicaStatus{
+					InstanceStatus: lhv1beta2.InstanceStatus{InstanceManagerName: "im-1"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "CurrentImage set: has backing",
+			replica: lhv1beta2.Replica{
+				Status: lhv1beta2.ReplicaStatus{
+					InstanceStatus: lhv1beta2.InstanceStatus{CurrentImage: "longhorn-engine:latest"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "all three set: has backing",
+			replica: lhv1beta2.Replica{
+				Status: lhv1beta2.ReplicaStatus{
+					InstanceStatus: lhv1beta2.InstanceStatus{
+						OwnerID:             "node1",
+						InstanceManagerName: "im-1",
+						CurrentImage:        "longhorn-engine:latest",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := replicaHasNoFsBacking(tc.replica); got != tc.want {
+				t.Errorf("replicaHasNoFsBacking = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPopulateKVIInner(t *testing.T) {
+	const (
+		testPVC   = "test-pvc"
+		testVol   = "test-vol"
+		eng1      = "engine-1"
+		r1RawAddr = "10.0.0.1:8502" // currentReplicaAddressMap value format (no tcp://)
+		r2RawAddr = "10.0.0.2:8502"
+		r2TcpAddr = "tcp://10.0.0.2:8502" // rebuildStatus key format (with tcp://)
+	)
+
+	noSnapBytes := func(string) (int64, error) { return 0, nil }
+
+	r1 := fakeReplica("r1", eng1, "10.0.0.1", 8502, lhv1beta2.InstanceStateRunning)
+	r2 := fakeReplica("r2", eng1, "10.0.0.2", 8502, lhv1beta2.InstanceStateRunning)
+
+	stdPVC := funcPVCGetter{fn: func(string) (*corev1.PersistentVolumeClaim, error) {
+		return fakePVC(testPVC, testVol), nil
+	}}
+
+	lhVolHealthy := funcLHVolGetter{fn: func(string) (*lhv1beta2.Volume, error) {
+		return fakeLHVol(lhv1beta2.VolumeRobustnessHealthy), nil
+	}}
+	lhVolDegraded := funcLHVolGetter{fn: func(string) (*lhv1beta2.Volume, error) {
+		return fakeLHVol(lhv1beta2.VolumeRobustnessDegraded), nil
+	}}
+
+	tests := []struct {
+		name         string
+		pvcs         pvcGetter
+		lhVols       lhVolumeGetter
+		replicas     lhReplicaLister
+		engines      lhEngineGetter
+		wantSubstate types.StorageHealthStatus
+		wantErr      bool
+		checkFn      func(*testing.T, *types.KubeVolumeInfo)
+	}{
+		{
+			// ReplicaModeMap must be looked up by replica name; CurrentReplicaAddressMap
+			// provides the name→address mapping for RebuildStatus lookups only.
+			name:   "2 RW replicas Degraded vol - modeMap keyed by replica name",
+			pvcs:   stdPVC,
+			lhVols: lhVolDegraded,
+			replicas: funcLHReplicaLister{fn: func(metav1.ListOptions) (*lhv1beta2.ReplicaList, error) {
+				return &lhv1beta2.ReplicaList{Items: []lhv1beta2.Replica{r1, r2}}, nil
+			}},
+			engines: funcLHEngineGetter{fn: func(string) (*lhv1beta2.Engine, error) {
+				return fakeEngine(eng1,
+					map[string]lhv1beta2.ReplicaMode{"r1": lhv1beta2.ReplicaModeRW, "r2": lhv1beta2.ReplicaModeRW},
+					nil,
+					map[string]string{"r1": r1RawAddr, "r2": r2RawAddr},
+				), nil
+			}},
+			wantSubstate: types.StorageHealthStatusDegraded2ReplicaAvailableNotReplicating,
+		},
+		{
+			name:   "2 RW replicas Healthy",
+			pvcs:   stdPVC,
+			lhVols: lhVolHealthy,
+			replicas: funcLHReplicaLister{fn: func(metav1.ListOptions) (*lhv1beta2.ReplicaList, error) {
+				return &lhv1beta2.ReplicaList{Items: []lhv1beta2.Replica{r1, r2}}, nil
+			}},
+			engines: funcLHEngineGetter{fn: func(string) (*lhv1beta2.Engine, error) {
+				return fakeEngine(eng1,
+					map[string]lhv1beta2.ReplicaMode{"r1": lhv1beta2.ReplicaModeRW, "r2": lhv1beta2.ReplicaModeRW},
+					nil,
+					map[string]string{"r1": r1RawAddr, "r2": r2RawAddr},
+				), nil
+			}},
+			wantSubstate: types.StorageHealthStatusHealthy,
+		},
+		{
+			// A WO replica with no RebuildStatus entry is queued but not yet
+			// transferring; it must not be counted as consistent (0% Rebuilding).
+			name:   "WO no RebuildStatus entry",
+			pvcs:   stdPVC,
+			lhVols: lhVolDegraded,
+			replicas: funcLHReplicaLister{fn: func(metav1.ListOptions) (*lhv1beta2.ReplicaList, error) {
+				return &lhv1beta2.ReplicaList{Items: []lhv1beta2.Replica{r1, r2}}, nil
+			}},
+			engines: funcLHEngineGetter{fn: func(string) (*lhv1beta2.Engine, error) {
+				return fakeEngine(eng1,
+					map[string]lhv1beta2.ReplicaMode{"r1": lhv1beta2.ReplicaModeRW, "r2": lhv1beta2.ReplicaModeWO},
+					nil,
+					map[string]string{"r1": r1RawAddr, "r2": r2RawAddr},
+				), nil
+			}},
+			wantSubstate: types.StorageHealthStatusDegraded1ReplicaAvailableReplicating,
+			checkFn: func(t *testing.T, kvi *types.KubeVolumeInfo) {
+				r := findReplica(kvi, "r2")
+				if r == nil {
+					t.Fatal("r2 not found")
+				}
+				if r.Status != types.StorageVolumeReplicaStatusRebuilding {
+					t.Errorf("r2.Status = %v, want Rebuilding", r.Status)
+				}
+				if r.RebuildProgressPercentage != 0 {
+					t.Errorf("r2.RebuildProgressPercentage = %d, want 0", r.RebuildProgressPercentage)
+				}
+			},
+		},
+		{
+			name:   "WO RebuildStatus 47%",
+			pvcs:   stdPVC,
+			lhVols: lhVolDegraded,
+			replicas: funcLHReplicaLister{fn: func(metav1.ListOptions) (*lhv1beta2.ReplicaList, error) {
+				return &lhv1beta2.ReplicaList{Items: []lhv1beta2.Replica{r1, r2}}, nil
+			}},
+			engines: funcLHEngineGetter{fn: func(string) (*lhv1beta2.Engine, error) {
+				return fakeEngine(eng1,
+					map[string]lhv1beta2.ReplicaMode{"r1": lhv1beta2.ReplicaModeRW, "r2": lhv1beta2.ReplicaModeWO},
+					map[string]*lhv1beta2.RebuildStatus{r2TcpAddr: {Progress: 47}},
+					map[string]string{"r1": r1RawAddr, "r2": r2RawAddr},
+				), nil
+			}},
+			wantSubstate: types.StorageHealthStatusDegraded1ReplicaAvailableReplicating,
+			checkFn: func(t *testing.T, kvi *types.KubeVolumeInfo) {
+				r := findReplica(kvi, "r2")
+				if r == nil {
+					t.Fatal("r2 not found")
+				}
+				if r.RebuildProgressPercentage != 47 {
+					t.Errorf("r2.RebuildProgressPercentage = %d, want 47", r.RebuildProgressPercentage)
+				}
+			},
+		},
+		{
+			// Transfer complete but engine has not yet promoted the replica to RW.
+			// It is still not consistent.
+			name:   "WO RebuildStatus 100% not yet promoted",
+			pvcs:   stdPVC,
+			lhVols: lhVolDegraded,
+			replicas: funcLHReplicaLister{fn: func(metav1.ListOptions) (*lhv1beta2.ReplicaList, error) {
+				return &lhv1beta2.ReplicaList{Items: []lhv1beta2.Replica{r1, r2}}, nil
+			}},
+			engines: funcLHEngineGetter{fn: func(string) (*lhv1beta2.Engine, error) {
+				return fakeEngine(eng1,
+					map[string]lhv1beta2.ReplicaMode{"r1": lhv1beta2.ReplicaModeRW, "r2": lhv1beta2.ReplicaModeWO},
+					map[string]*lhv1beta2.RebuildStatus{r2TcpAddr: {Progress: 100}},
+					map[string]string{"r1": r1RawAddr, "r2": r2RawAddr},
+				), nil
+			}},
+			wantSubstate: types.StorageHealthStatusDegraded1ReplicaAvailableReplicating,
+			checkFn: func(t *testing.T, kvi *types.KubeVolumeInfo) {
+				r := findReplica(kvi, "r2")
+				if r == nil {
+					t.Fatal("r2 not found")
+				}
+				if r.Status != types.StorageVolumeReplicaStatusRebuilding {
+					t.Errorf("r2.Status = %v, want Rebuilding", r.Status)
+				}
+				if r.RebuildProgressPercentage != 100 {
+					t.Errorf("r2.RebuildProgressPercentage = %d, want 100", r.RebuildProgressPercentage)
+				}
+			},
+		},
+		{
+			// r2 absent from CurrentReplicaAddressMap; code falls back to constructing
+			// IP:Port from replica status fields, prepends tcp:// for RebuildStatus lookup,
+			// and looks up ReplicaModeMap by replica name regardless.
+			name:   "replica not in CurrentReplicaAddressMap fallback",
+			pvcs:   stdPVC,
+			lhVols: lhVolDegraded,
+			replicas: funcLHReplicaLister{fn: func(metav1.ListOptions) (*lhv1beta2.ReplicaList, error) {
+				return &lhv1beta2.ReplicaList{Items: []lhv1beta2.Replica{r1, r2}}, nil
+			}},
+			engines: funcLHEngineGetter{fn: func(string) (*lhv1beta2.Engine, error) {
+				return fakeEngine(eng1,
+					map[string]lhv1beta2.ReplicaMode{"r1": lhv1beta2.ReplicaModeRW, "r2": lhv1beta2.ReplicaModeWO},
+					map[string]*lhv1beta2.RebuildStatus{r2TcpAddr: {Progress: 50}},
+					map[string]string{"r1": r1RawAddr}, // r2 absent
+				), nil
+			}},
+			wantSubstate: types.StorageHealthStatusDegraded1ReplicaAvailableReplicating,
+			checkFn: func(t *testing.T, kvi *types.KubeVolumeInfo) {
+				r := findReplica(kvi, "r2")
+				if r == nil {
+					t.Fatal("r2 not found")
+				}
+				if r.RebuildProgressPercentage != 50 {
+					t.Errorf("r2.RebuildProgressPercentage = %d, want 50", r.RebuildProgressPercentage)
+				}
+			},
+		},
+		{
+			// No-backing replica has no OwnerID/InstanceManagerName/CurrentImage set.
+			// It should be skipped entirely and not counted toward replicas or onlineReps.
+			name:   "no-backing replica skipped one RW",
+			pvcs:   stdPVC,
+			lhVols: lhVolHealthy,
+			replicas: funcLHReplicaLister{fn: func(metav1.ListOptions) (*lhv1beta2.ReplicaList, error) {
+				noBacking := lhv1beta2.Replica{ObjectMeta: metav1.ObjectMeta{Name: "r2-no-backing"}}
+				return &lhv1beta2.ReplicaList{Items: []lhv1beta2.Replica{r1, noBacking}}, nil
+			}},
+			engines: funcLHEngineGetter{fn: func(string) (*lhv1beta2.Engine, error) {
+				return fakeEngine(eng1,
+					map[string]lhv1beta2.ReplicaMode{"r1": lhv1beta2.ReplicaModeRW},
+					nil,
+					map[string]string{"r1": r1RawAddr},
+				), nil
+			}},
+			wantSubstate: types.StorageHealthStatusHealthy,
+			checkFn: func(t *testing.T, kvi *types.KubeVolumeInfo) {
+				if len(kvi.Replicas) != 1 {
+					t.Errorf("len(Replicas) = %d, want 1 (no-backing replica must be excluded)", len(kvi.Replicas))
+				}
+			},
+		},
+		{
+			// Error-state replica gets Failed status but does not contribute to onlineReps.
+			// If Longhorn marks the volume Healthy (e.g. 3-replica setup with quorum), the
+			// substate is still Healthy.
+			name:   "one replica error state volume healthy",
+			pvcs:   stdPVC,
+			lhVols: lhVolHealthy,
+			replicas: funcLHReplicaLister{fn: func(metav1.ListOptions) (*lhv1beta2.ReplicaList, error) {
+				r2err := fakeReplica("r2", eng1, "10.0.0.2", 8502, lhv1beta2.InstanceStateError)
+				return &lhv1beta2.ReplicaList{Items: []lhv1beta2.Replica{r1, r2err}}, nil
+			}},
+			engines: funcLHEngineGetter{fn: func(string) (*lhv1beta2.Engine, error) {
+				return fakeEngine(eng1,
+					map[string]lhv1beta2.ReplicaMode{"r1": lhv1beta2.ReplicaModeRW},
+					nil,
+					map[string]string{"r1": r1RawAddr},
+				), nil
+			}},
+			wantSubstate: types.StorageHealthStatusHealthy,
+			checkFn: func(t *testing.T, kvi *types.KubeVolumeInfo) {
+				r := findReplica(kvi, "r2")
+				if r == nil {
+					t.Fatal("r2 not found")
+				}
+				if r.Status != types.StorageVolumeReplicaStatusFailed {
+					t.Errorf("r2.Status = %v, want Failed", r.Status)
+				}
+			},
+		},
+		{
+			name:   "engine fetch error",
+			pvcs:   stdPVC,
+			lhVols: lhVolHealthy,
+			replicas: funcLHReplicaLister{fn: func(metav1.ListOptions) (*lhv1beta2.ReplicaList, error) {
+				return &lhv1beta2.ReplicaList{Items: []lhv1beta2.Replica{r1}}, nil
+			}},
+			engines: funcLHEngineGetter{fn: func(string) (*lhv1beta2.Engine, error) {
+				return nil, errors.New("engine not found")
+			}},
+			wantErr: true,
+		},
+		{
+			name: "PVC not found",
+			pvcs: funcPVCGetter{fn: func(string) (*corev1.PersistentVolumeClaim, error) {
+				return nil, errors.New("pvc not found")
+			}},
+			lhVols:   lhVolHealthy,
+			replicas: funcLHReplicaLister{fn: func(metav1.ListOptions) (*lhv1beta2.ReplicaList, error) { return &lhv1beta2.ReplicaList{}, nil }},
+			engines:  funcLHEngineGetter{fn: func(string) (*lhv1beta2.Engine, error) { return nil, nil }},
+			wantErr:  true,
+		},
+		{
+			name: "LH volume not found",
+			pvcs: stdPVC,
+			lhVols: funcLHVolGetter{fn: func(string) (*lhv1beta2.Volume, error) {
+				return nil, errors.New("vol not found")
+			}},
+			replicas: funcLHReplicaLister{fn: func(metav1.ListOptions) (*lhv1beta2.ReplicaList, error) { return &lhv1beta2.ReplicaList{}, nil }},
+			engines:  funcLHEngineGetter{fn: func(string) (*lhv1beta2.Engine, error) { return nil, nil }},
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			kvi := &types.KubeVolumeInfo{Name: testPVC}
+			result, err := populateKVIInner(
+				context.Background(),
+				kvi,
+				tc.pvcs,
+				tc.lhVols,
+				tc.replicas,
+				tc.engines,
+				noSnapBytes,
+			)
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.RobustnessSubstate != tc.wantSubstate {
+				t.Errorf("RobustnessSubstate = %v, want %v", result.RobustnessSubstate, tc.wantSubstate)
+			}
+			if tc.checkFn != nil {
+				tc.checkFn(t, result)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

PR #5955 introduced two address-key bugs while fixing the WO-replica timing hole.

1. ReplicaModeMap is keyed by replica name not by address. PR 5955 looked it up by the plain IP:PORT value from CurrentReplicaAddressMap, failing to lookup entries. For a Degraded volume with two RW replicas this produces Unknown instead of Degraded2ReplicaAvailableNotReplicating substate.

2. RebuildStatus key format (with the "tcp://" prefix) was only used in a fallback case when the replica was not in the engine map. Normal lookups failed to read the RebuildStatus values.

Additional fixes found in manual tests:

3. During the window between a replica reconnecting to the engine and the engine registering it in ReplicaModeMap, the replica was reported as Online at 0% — a false healthy signal. The !inModeMap case in replicaModeProgress now returns StorageVolumeReplicaStatusUnknown.

4. robustnessSubstate unconditionally returned Healthy when Longhorn reported VolumeRobustnessHealthy, regardless of whether all Running replicas were confirmed RW. Added guard: only return Healthy when consistentReps == onlineReps; otherwise fall through to the Degraded branch so the engine-lag window cannot produce a false Healthy substate.

Fix by looking up ReplicaModeMap by lhReplica.Name and constructing the tcp://-prefixed address separately for RebuildStatus.

Extract the body of populateKVIFromPVCName into populateKVIInner() with four injected minimal interfaces (pvcGetter, lhVolumeGetter, lhReplicaLister, lhEngineGetter) so the logic is testable without a live cluster.

Tests added:
- TestReplicaHasNoFsBacking: 5 cases covering the no-fs-backing filter
- TestPopulateKVIInner: 11 table-driven cases exercising the full pipeline, including guards for both address-key bugs and the WO no-RebuildStatus-entry path fixed by PR 5955
- TestRobustnessSubstate: added case for Healthy volume with unconfirmed replica falling through to Degraded

Tests modified:
- TestReplicaModeProgress: updated comment on the "WO without rebuild entry" case to state the invariant rather than reference past behavior
- TestReplicaModeProgress: "not in mode map" case updated to expect Unknown

## PR dependencies

None

## How to test and validate this PR

- cd pkg/pillar; make ZARCH=arm64 HV=k test
- deploy 3 HV=k nodes, setup an EdgeNodeClusterConfig
- deploy more than 2 VM edge apps
- fail a node in the cluster
- wait over 10+ minutes, while writing data to the cluster volumes
- restore node health
- quickly poll volume instance health to view replica state changes offline->unspecified->rebuilding->healthy

## Changelog notes

Resolve incorrect replica health status reporting state changes including intermittent healthy state in between offline and rebuilding.

## PR Backports

- 16.0-stable: 
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
