### PR TITLE
vaultmgr,diag: surface how the vault was unlocked

### DIFF
--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -66,6 +66,8 @@ type diagContext struct {
 	subDevicePortConfigList pubsub.Subscription
 	subZedAgentStatus       pubsub.Subscription
 	zedagentStatus          types.ZedAgentStatus
+	subVaultStatus          pubsub.Subscription
+	vaultStatus             types.VaultStatus
 	subAppInstanceSummary   pubsub.Subscription
 	appInstanceSummary      types.AppInstanceSummary
 	subAppInstanceStatus    pubsub.Subscription
@@ -328,6 +330,25 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	ctx.subZedAgentStatus = subZedAgentStatus
 	subZedAgentStatus.Activate()
 
+	// Look for VaultStatus from vaultmgr, to show how the vault was unlocked
+	// (local TPM seal vs controller-provided key).
+	subVaultStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "vaultmgr",
+		MyAgentName:   agentName,
+		TopicImpl:     types.VaultStatus{},
+		Activate:      false,
+		Ctx:           &ctx,
+		CreateHandler: handleVaultStatusCreate,
+		ModifyHandler: handleVaultStatusModify,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.subVaultStatus = subVaultStatus
+	subVaultStatus.Activate()
+
 	// Look for AppInstanceSummary from zedmanager
 	subAppInstanceSummary, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedmanager",
@@ -424,6 +445,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 		case change := <-subZedAgentStatus.MsgChan():
 			subZedAgentStatus.ProcessChange(change)
+
+		case change := <-subVaultStatus.MsgChan():
+			subVaultStatus.ProcessChange(change)
 
 		case change := <-subAppInstanceSummary.MsgChan():
 			subAppInstanceSummary.ProcessChange(change)
@@ -522,6 +546,29 @@ func handleZedAgentStatusImpl(ctxArg interface{}, key string,
 	// or modify
 	triggerPrintOutput(ctx, "DeviceState")
 	ctx.zedagentStatus = status
+}
+
+func handleVaultStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleVaultStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleVaultStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleVaultStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleVaultStatusImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	ctx := ctxArg.(*diagContext)
+	status := statusArg.(types.VaultStatus)
+	// only the default vault feeds the summary line
+	if status.Name != types.DefaultVaultName {
+		return
+	}
+	ctx.vaultStatus = status
+	triggerPrintOutput(ctx, "VaultStatus")
 }
 
 func handleAppInstanceSummaryCreate(ctxArg interface{}, key string,
@@ -788,6 +835,27 @@ func printOutput(ctx *diagContext, caller string) {
 		ctx.zedagentStatus.VaultStatus != info.DataSecAtRestStatus_DATASEC_AT_REST_DISABLED {
 		level = "ERROR"
 		vaultStatus += " error " + ctx.zedagentStatus.VaultErr
+	}
+	// Show how the vault was unlocked this boot (from vaultmgr's VaultStatus).
+	// A controller-key unlock means the local TPM unseal failed (PCR mismatch);
+	// a recreated vault means the local unseal failed and no escrowed key was
+	// available, so the vault was wiped. Both are worth flagging even though the
+	// vault ends up enabled.
+	if ctx.vaultStatus.UnlockMethod != types.VaultUnlockNone {
+		vaultStatus += " unlock:" + ctx.vaultStatus.UnlockMethod.String()
+		switch ctx.vaultStatus.UnlockMethod {
+		case types.VaultUnlockControllerKey:
+			if level == "INFO" {
+				level = "WARNING"
+			}
+			if len(ctx.vaultStatus.MismatchingPCRs) > 0 {
+				vaultStatus += fmt.Sprintf(" mismatchPCRs:%v", ctx.vaultStatus.MismatchingPCRs)
+			}
+		case types.VaultUnlockRecreated:
+			if level == "INFO" {
+				level = "WARNING"
+			}
+		}
 	}
 	pcrStatus := strings.TrimPrefix(ctx.zedagentStatus.PCRStatus.String(),
 		"PCR_")

--- a/pkg/pillar/cmd/vaultmgr/vaultmgr.go
+++ b/pkg/pillar/cmd/vaultmgr/vaultmgr.go
@@ -13,8 +13,8 @@
 //in clear text, but instead be encrypted using a TPM based key, so that,
 //the key is protected from being exposed in the Controller. To that requirement,
 //in this PR, we add support to encrypt (aka key wrapping), the vault key
-//using a TPM based key (we re-use ECDH key here) the device public key. Basically
-//we are re-using a simplified ECDH exchange here, with both the parties being
+//using a TPM based key (we reuse ECDH key here) the device public key. Basically
+//we are reusing a simplified ECDH exchange here, with both the parties being
 //the same device. To decrypt the key, one has to be on the same device with
 //access to the same TPM, where the private part of the ECDH key resides.
 //publishVaultKey and handleVaultKeyFromControllerModify are the relevant
@@ -56,8 +56,13 @@ type vaultMgrContext struct {
 	GCInitialized             bool // GlobalConfig initialized
 	defaultVaultUnlocked      bool
 	vaultUCDone               bool
-	ps                        *pubsub.PubSub
-	ucChan                    chan struct{}
+	// How the default vault was unlocked this boot, surfaced on VaultStatus.
+	unlockMethod types.VaultUnlockMethod
+	// PCRs that did not match on a failed local unseal; retained so it is still
+	// reported after the controller-key recovery re-seals.
+	lastMismatchingPCRs []int
+	ps                  *pubsub.PubSub
+	ucChan              chan struct{}
 	// cli options
 	args []string
 }
@@ -287,10 +292,31 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	// if TPM available, this sets up the fscrypt and eventually calls FetchSealedVaultKey
 	if err := handler.SetupDefaultVault(); err != nil {
 		log.Errorf("SetupDefaultVault failed, err: %v", err)
+		// Local unseal failed. On a TPM device this is usually a PCR policy
+		// mismatch; record which PCRs differ so it is visible on VaultStatus and
+		// in one clear log line, instead of being inferable only from the unseal
+		// error. The vault will be unlocked later via the controller key.
+		if tpmEnabled {
+			if mism, perr := etpm.FindMismatchingPCRs(); perr == nil {
+				ctx.lastMismatchingPCRs = mism
+				log.Noticef("vault %s local TPM unseal FAILED; mismatching PCRs=%v; awaiting controller key",
+					types.DefaultVaultName, mism)
+			} else {
+				log.Warnf("vault %s local TPM unseal FAILED; could not determine mismatching PCRs: %v",
+					types.DefaultVaultName, perr)
+			}
+		}
 		getAndPublishAllVaultStatuses(&ctx)
 	} else {
 		log.Noticef("vault is setup and unlocked successfully")
 		ctx.defaultVaultUnlocked = true
+		if tpmEnabled {
+			ctx.unlockMethod = types.VaultUnlockTPMLocalSealed
+		} else {
+			ctx.unlockMethod = types.VaultUnlockNoTPM
+		}
+		log.Noticef("vault %s unlocked: method=%s",
+			types.DefaultVaultName, ctx.unlockMethod)
 	}
 	if ctx.defaultVaultUnlocked || !tpmEnabled {
 		// Now that vault is unlocked, run any upgrade converter handler if needed
@@ -472,6 +498,13 @@ func handleVaultKeyFromControllerImpl(ctxArg interface{}, key string,
 			return
 		}
 
+		// The local unseal had failed (that is why we are here); record that the
+		// unlock came from the controller key, so the distinction is visible on
+		// VaultStatus rather than only inferable from the log sequence.
+		ctx.unlockMethod = types.VaultUnlockControllerKey
+		log.Noticef("vault %s unlocked: method=controller-key mismatchingPCRs=%v",
+			types.DefaultVaultName, ctx.lastMismatchingPCRs)
+
 		//Log the type of key used for unlocking default vault
 		log.Noticef("%s unlocked using key type %s", types.DefaultVaultName,
 			etpm.CompareLegacyandSealedKey(log).String())
@@ -501,6 +534,7 @@ func handleVaultKeyFromControllerImpl(ctxArg interface{}, key string,
 			return
 		}
 		ctx.defaultVaultUnlocked = true
+		ctx.unlockMethod = types.VaultUnlockRecreated
 		log.Noticef("%s re-created", types.DefaultVaultName)
 	}
 
@@ -574,6 +608,19 @@ func getAndPublishAllVaultStatuses(ctx *vaultMgrContext) {
 	for _, status := range statuses {
 		// adjust ConversionComplete field with information from context
 		status.ConversionComplete = ctx.vaultUCDone
+		// The unlock method and retained mismatching PCRs are tracked only for
+		// the default vault; the deprecated vaults returned here have no unlock
+		// method of their own, so leave their fields untouched.
+		if status.Name == types.DefaultVaultName {
+			// surface how the vault was unlocked this boot
+			status.UnlockMethod = ctx.unlockMethod
+			// If a local unseal failed, keep reporting the mismatching PCRs even
+			// after the controller-key recovery unlocked (and re-sealed) the vault,
+			// so the diagnostic is not lost the moment recovery succeeds.
+			if len(status.MismatchingPCRs) == 0 && len(ctx.lastMismatchingPCRs) > 0 {
+				status.MismatchingPCRs = ctx.lastMismatchingPCRs
+			}
+		}
 		publishVaultStatus(ctx, *status)
 	}
 }

--- a/pkg/pillar/types/vaultmgrtypes.go
+++ b/pkg/pillar/types/vaultmgrtypes.go
@@ -10,6 +10,44 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 )
 
+// VaultUnlockMethod records how a vault was unlocked this boot, so an operator
+// can tell a clean local TPM unseal apart from a controller-key recovery (both
+// of which end with Status enabled).
+type VaultUnlockMethod uint8
+
+const (
+	// VaultUnlockNone means the vault is not (yet) unlocked.
+	VaultUnlockNone VaultUnlockMethod = iota
+	// VaultUnlockTPMLocalSealed means the locally TPM-sealed key unsealed
+	// against the current PCRs, with no controller involvement.
+	VaultUnlockTPMLocalSealed
+	// VaultUnlockControllerKey means the local unseal failed (e.g. a PCR policy
+	// mismatch) and the controller-provided escrowed key was used instead.
+	VaultUnlockControllerKey
+	// VaultUnlockNoTPM means the platform has no TPM; the key is not sealed.
+	VaultUnlockNoTPM
+	// VaultUnlockRecreated means the local unseal failed and the controller had
+	// no escrowed key to return, so the vault was wiped and recreated empty. No
+	// key unlocked the existing vault; its prior contents were lost.
+	VaultUnlockRecreated
+)
+
+// String implements fmt.Stringer.
+func (m VaultUnlockMethod) String() string {
+	switch m {
+	case VaultUnlockTPMLocalSealed:
+		return "tpm-local-sealed"
+	case VaultUnlockControllerKey:
+		return "controller-key"
+	case VaultUnlockNoTPM:
+		return "no-tpm"
+	case VaultUnlockRecreated:
+		return "recreated"
+	default:
+		return "none"
+	}
+}
+
 // VaultStatus represents running status of a Vault
 type VaultStatus struct {
 	Name               string
@@ -18,6 +56,14 @@ type VaultStatus struct {
 	ConversionComplete bool
 	// only valid if TPM is enabled and Sealed key is used
 	MismatchingPCRs []int
+	// UnlockMethod records how the vault was unlocked this boot (local TPM key,
+	// controller-provided key, no TPM, or a wipe-and-recreate). VaultUnlockNone
+	// until unlocked. VaultUnlockTPMLocalSealed means the locally TPM-sealed key
+	// unsealed on the first attempt; VaultUnlockControllerKey means the local
+	// unseal failed and the device is relying on the controller-key fallback;
+	// VaultUnlockRecreated means the local unseal failed with no escrowed key, so
+	// the vault was wiped and recreated (prior contents lost).
+	UnlockMethod VaultUnlockMethod
 	// ErrorAndTime provides SetErrorNow() and ClearError()
 	ErrorAndTime
 }


### PR DESCRIPTION
# Description

This was motivated by it being very hard (for a test or claude manually) to detect whether the vault was unlocked locally i.e., it would have worked without controller connectivity, vs. the controller approved the remote attestation and that resulted in the unlock.

Both paths end with the vault enabled, the
`successfully unsealed the disk key from TPM` log line is emitted on both, and
the boot-time vaultmgr logs rotate out of the in-memory log ring — so
diagnosing whether measured boot is healthy (local unseal works) currently
requires digging through `/persist/newlog/`.

This PR records the unlock method explicitly on `VaultStatus`
(`UnlockMethod` = `tpm-local-sealed` / `controller-key` / `no-tpm`, plus
`LocalUnsealSucceeded`), set at each unlock site in vaultmgr, and keeps
reporting the mismatching PCRs from a failed local unseal even after the
controller-key recovery re-seals (so the diagnostic is not lost the moment
recovery succeeds). `diag` subscribes to `VaultStatus` and appends the method
to its device line, flagging a controller-key unlock (with the mismatching
PCRs) as a WARNING.

## How to test and validate this PR

1. Boot a TPM-enabled device and run `eve diag` (or watch the diag console):
   the device line shows `vault: ENABLED unlock:tpm-local-sealed` on a healthy
   local unseal.
2. Perturb a sealed PCR input so the local unseal fails (the controller then
   returns the escrowed key): the line becomes
   `vault: ENABLED unlock:controller-key mismatchPCRs:[..]` at WARNING level,
   and `VaultStatus.UnlockMethod`/`MismatchingPCRs` reflect the same.

No automated test added (observability-only; touches the boot-time unlock
paths in vaultmgr and a console line in diag).

## Changelog notes

`diag` now reports how the device vault was unlocked this boot — by the local
TPM-sealed key or, if that failed, by the controller-provided key — making it
easy to spot a device silently relying on the controller-key fallback.

## PR Backports

No backport requested; this is an observability enhancement for master.
