### PR TITLE
sriov: poll GetVf directly in GetVfByTimeout instead of AsyncGetVF

### DIFF
--- a/pkg/pillar/sriov/sriov.go
+++ b/pkg/pillar/sriov/sriov.go
@@ -17,9 +17,12 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+// NicLinuxPath is the sysfs root for network devices. It is a var rather than
+// a const so tests can repoint GetVf at a fake sysfs tree.
+var NicLinuxPath = "/sys/class/net/"
+
 // constants for Linux paths for devices
 const (
-	NicLinuxPath      = "/sys/class/net/"
 	PciDevicesPath    = "/sys/bus/pci/devices/"
 	NumVfsDevicePath  = "/device/sriov_numvfs"
 	TotalVfsPath      = "/device/sriov_totalvfs"

--- a/pkg/pillar/sriov/sriov.go
+++ b/pkg/pillar/sriov/sriov.go
@@ -4,7 +4,6 @@
 package sriov
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"os"
@@ -365,36 +364,17 @@ func GetVf(device string) (*VFList, error) { //nolint:gocyclo
 
 // GetVfByTimeout returns Vf for given PF by timeout
 func GetVfByTimeout(timeout time.Duration, device string, expectedVfCount uint8) (*VFList, error) {
-	toCtx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	c := AsyncGetVF(toCtx, device, expectedVfCount)
+	deadline := time.Now().Add(timeout)
 	for {
-		select {
-		case answer := <-c:
-			return answer, nil
-		case <-toCtx.Done():
+		vfs, err := GetVf(device)
+		if err == nil && vfs != nil && len(vfs.Data) == int(expectedVfCount) {
+			return vfs, nil
+		}
+		if time.Now().After(deadline) {
 			return nil, fmt.Errorf("getVfByTimeout reached timeout %v", timeout)
 		}
+		time.Sleep(1 * time.Second)
 	}
-}
-
-// AsyncGetVF returns Vf for given PF asynchronously
-func AsyncGetVF(ctx context.Context, device string, expectedVfCount uint8) chan *VFList {
-	ch := make(chan *VFList)
-	go func() {
-		select {
-		default:
-			time.Sleep(1 * time.Second)
-			vfs, _ := GetVf(device)
-			if len(vfs.Data) == int(expectedVfCount) {
-				ch <- vfs
-				break
-			}
-		case <-ctx.Done():
-			return
-		}
-	}()
-	return ch
 }
 
 // EthVF must match EthVF structure in devcommon.proto

--- a/pkg/pillar/sriov/sriov_test.go
+++ b/pkg/pillar/sriov/sriov_test.go
@@ -4,7 +4,11 @@
 package sriov
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 )
 
 // TestParseVfIfaceName covers the round-trip with GetVfIfaceName plus a few
@@ -48,6 +52,68 @@ func TestParseVfIfaceName(t *testing.T) {
 				t.Errorf("pf=%q want %q", pf, tc.wantPF)
 			}
 		})
+	}
+}
+
+// TestGetVfByTimeoutMissingDevice is a regression test for the old AsyncGetVF
+// implementation: GetVf returns (nil, err) when the PF sysfs path is absent,
+// and AsyncGetVF dereferenced the result unconditionally (len(vfs.Data)),
+// panicking in a background goroutine. GetVfByTimeout must instead surface a
+// timeout error and never panic. timeout=0 expires the deadline right after
+// the first failing poll, so the test is fast and never hits the 1s sleep.
+func TestGetVfByTimeoutMissingDevice(t *testing.T) {
+	vfs, err := GetVfByTimeout(0, "definitely-not-a-real-nic", 2)
+	if err == nil {
+		t.Fatalf("expected timeout error, got vfs=%+v", vfs)
+	}
+	if vfs != nil {
+		t.Errorf("expected nil VFList on timeout, got %+v", vfs)
+	}
+}
+
+// TestGetVfByTimeoutFindsVFs builds a fake PF sysfs tree and checks that
+// GetVfByTimeout polls GetVf and returns once the expected number of VFs is
+// present. GetVf discovers VFs via virtfnN symlinks whose canonical target
+// path ends in a PCI BDF, so the fake tree mirrors that layout.
+func TestGetVfByTimeoutFindsVFs(t *testing.T) {
+	root := t.TempDir()
+	netDir := filepath.Join(root, "net")
+	devDir := filepath.Join(netDir, "eth9", "device")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	bdfs := []string{"0000:03:10.0", "0000:03:10.1"}
+	for i, bdf := range bdfs {
+		pciDir := filepath.Join(root, "pci", bdf)
+		if err := os.MkdirAll(pciDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		link := filepath.Join(devDir, fmt.Sprintf("virtfn%d", i))
+		if err := os.Symlink(pciDir, link); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	old := NicLinuxPath
+	NicLinuxPath = netDir + "/"
+	defer func() { NicLinuxPath = old }()
+
+	vfs, err := GetVfByTimeout(2*time.Second, "eth9", uint8(len(bdfs)))
+	if err != nil {
+		t.Fatalf("GetVfByTimeout: %v", err)
+	}
+	if vfs == nil || int(vfs.Count) != len(bdfs) {
+		t.Fatalf("expected %d VFs, got %+v", len(bdfs), vfs)
+	}
+	got := make(map[string]bool, len(vfs.Data))
+	for _, vf := range vfs.Data {
+		got[vf.PciLong] = true
+	}
+	for _, bdf := range bdfs {
+		if !got[bdf] {
+			t.Errorf("missing VF %s in %+v", bdf, vfs.Data)
+		}
 	}
 }
 


### PR DESCRIPTION
# Description

Reworks `sriov.GetVfByTimeout` to poll `GetVf` directly instead of going
through the one-shot `AsyncGetVF` helper.

The old path had two problems:

- `AsyncGetVF` polled `GetVf` exactly once (its `select` always took the
  `default` branch). If the VFs were not ready on that single check the
  goroutine simply exited, the channel never produced a value, and
  `GetVfByTimeout` blocked for the full timeout (`VfCreationTimeout = 150s`,
  as called from `domainmgr`) before failing — it never actually retried.
- `GetVf` returns `(nil, err)` when the PF sysfs path is missing, and
  `AsyncGetVF` dereferenced the result unconditionally (`len(vfs.Data)`),
  panicking in a background goroutine and crashing the process. This path
  is reachable from `domainmgr` during VF setup.

The fix replaces the channel/goroutine machinery with a straightforward
poll loop that calls `GetVf` every second until the expected VF count
appears or the deadline passes, guarding against a nil `VFList`. The now
unused `AsyncGetVF` is removed.

The first commit is a cherry-pick of 757c250b (`-x` reference preserved);
the unused `context` import is dropped as part of adapting it to this
branch. The second commit adds unit tests.

## How to test and validate this PR

Automated (added in this PR):

```sh
make -C pkg/pillar test            # or, natively: go test ./sriov/ -run TestGetVfByTimeout -v
```

- `TestGetVfByTimeoutMissingDevice` — regression guard: a missing PF makes
  `GetVf` return `(nil, err)`; `GetVfByTimeout` must return a timeout error
  and must not panic (the old `AsyncGetVF` panicked here).
- `TestGetVfByTimeoutFindsVFs` — builds a fake PF sysfs tree (`virtfnN`
  symlinks resolving to PCI BDF dirs) and verifies the VFs are discovered.

Manual (SR-IOV hardware): configure an app with SR-IOV VF passthrough on a
PF and confirm VF setup completes promptly and that an unconfigurable /
absent PF no longer hangs VF creation for ~150s or crashes pillar.

## Changelog notes

Fixes a potential pillar crash and a long stall when setting up SR-IOV
virtual functions for device passthrough.

## PR Backports

The affected code (`GetVfByTimeout` / `AsyncGetVF`) predates the current LTS
branches, so this is backport-eligible — please confirm before merge:

- 16.0-stable: To be decided.
- 14.5-stable: To be decided.
- 13.4-stable: To be decided.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
