### PR TITLE
[16.0-stable] sriov: poll GetVf directly in GetVfByTimeout instead of AsyncGetVF

### DIFF
--- a/pkg/pillar/sriov/sriov.go
+++ b/pkg/pillar/sriov/sriov.go
@@ -17,9 +17,12 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+// NicLinuxPath is the sysfs root for network devices. It is a var rather than
+// a const so tests can repoint GetVf at a fake sysfs tree.
+var NicLinuxPath = "/sys/class/net/"
+
 // constants for Linux paths for devices
 const (
-	NicLinuxPath      = "/sys/class/net/"
 	NumVfsDevicePath  = "/device/sriov_numvfs"
 	TotalVfsPath      = "/device/sriov_totalvfs"
 	AutoprobePath     = "/device/sriov_drivers_autoprobe"

--- a/pkg/pillar/sriov/sriov.go
+++ b/pkg/pillar/sriov/sriov.go
@@ -156,15 +156,39 @@ func GetVfIfaceName(index uint8, ifname string) string {
 	return fmt.Sprintf("%svf%d", ifname, index)
 }
 
-// ParseVfIfaceName returns index of VF and its PF from name
+// ParseVfIfaceName splits a VF iface/phylabel like "eth2vf5" into its PF name
+// ("eth2") and VF index (5).  Mirrors the inverse of GetVfIfaceName.
+//
+// Implementation note: the previous version used fmt.Sscanf with format
+// "%svf%d", which is broken — Go's %s verb is greedy and consumes the entire
+// input, leaving nothing for the literal "vf" or the trailing %d to match.
+// Sscanf returns an error and zero values for both fields.  Use a manual
+// split on the LAST "vf" occurrence instead, so "eth2vf5" parses correctly
+// and the (extremely unusual) case of a PF named "...vf..." is handled by
+// only treating the final "vf<digits>" as the suffix.
 func ParseVfIfaceName(ifname string) (uint8, string, error) {
-	var iface string
-	var index uint8
-	n, err := fmt.Sscanf(ifname, "%svf%d", &iface, &index)
-	if n != 2 {
-		err = fmt.Errorf("ParseVfIfaceName: could not parse all arguments for %s expected 2, got %d", ifname, n)
+	// Scan backwards for the last "vf" that's followed by a valid uint8.
+	// i is the position where the digit suffix begins; we need at least
+	// two characters before it (for "vf") and at least one char after.
+	for i := len(ifname) - 1; i >= 2; i-- {
+		if ifname[i-2:i] != "vf" {
+			continue
+		}
+		suffix := ifname[i:]
+		if suffix == "" {
+			continue
+		}
+		idx, err := strconv.ParseUint(suffix, 10, 8)
+		if err != nil {
+			continue
+		}
+		pf := ifname[:i-2]
+		if pf == "" {
+			return 0, "", fmt.Errorf("ParseVfIfaceName: empty PF in %q", ifname)
+		}
+		return uint8(idx), pf, nil
 	}
-	return index, iface, err
+	return 0, "", fmt.Errorf("ParseVfIfaceName: no 'vf<digits>' suffix in %q", ifname)
 }
 
 // GetVf retrieve information about VFs for NIC given

--- a/pkg/pillar/sriov/sriov.go
+++ b/pkg/pillar/sriov/sriov.go
@@ -4,7 +4,6 @@
 package sriov
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"os"
@@ -216,36 +215,17 @@ func GetVf(device string) (*VFList, error) { //nolint:gocyclo
 
 // GetVfByTimeout returns Vf for given PF by timeout
 func GetVfByTimeout(timeout time.Duration, device string, expectedVfCount uint8) (*VFList, error) {
-	toCtx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	c := AsyncGetVF(toCtx, device, expectedVfCount)
+	deadline := time.Now().Add(timeout)
 	for {
-		select {
-		case answer := <-c:
-			return answer, nil
-		case <-toCtx.Done():
+		vfs, err := GetVf(device)
+		if err == nil && vfs != nil && len(vfs.Data) == int(expectedVfCount) {
+			return vfs, nil
+		}
+		if time.Now().After(deadline) {
 			return nil, fmt.Errorf("getVfByTimeout reached timeout %v", timeout)
 		}
+		time.Sleep(1 * time.Second)
 	}
-}
-
-// AsyncGetVF returns Vf for given PF asynchronously
-func AsyncGetVF(ctx context.Context, device string, expectedVfCount uint8) chan *VFList {
-	ch := make(chan *VFList)
-	go func() {
-		select {
-		default:
-			time.Sleep(1 * time.Second)
-			vfs, _ := GetVf(device)
-			if len(vfs.Data) == int(expectedVfCount) {
-				ch <- vfs
-				break
-			}
-		case <-ctx.Done():
-			return
-		}
-	}()
-	return ch
 }
 
 // EthVF must match EthVF structure in devcommon.proto

--- a/pkg/pillar/sriov/sriov_test.go
+++ b/pkg/pillar/sriov/sriov_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package sriov
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestParseVfIfaceName covers the round-trip with GetVfIfaceName plus a few
+// edge cases.  The previous implementation used fmt.Sscanf with "%svf%d",
+// which always returned ("", 0, error) because %s is greedy — regression
+// test guards against falling back to that.
+func TestParseVfIfaceName(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantIdx uint8
+		wantPF  string
+		wantErr bool
+	}{
+		{"basic", "eth2vf0", 0, "eth2", false},
+		{"two_digit", "eth3vf19", 19, "eth3", false},
+		{"five", "eth2vf5", 5, "eth2", false},
+		{"renamed_pf", "keth2vf7", 7, "keth2", false},
+		{"max_uint8", "ethxvf255", 255, "ethx", false},
+
+		// Failure modes — must error, not silently return zero.
+		{"no_vf_suffix", "eth2", 0, "", true},
+		{"empty", "", 0, "", true},
+		{"vf_only", "vf0", 0, "", true},
+		{"non_numeric", "eth2vfabc", 0, "", true},
+		{"overflow_uint8", "eth2vf256", 0, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			idx, pf, err := ParseVfIfaceName(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v, wantErr=%v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if idx != tc.wantIdx {
+				t.Errorf("idx=%d want %d", idx, tc.wantIdx)
+			}
+			if pf != tc.wantPF {
+				t.Errorf("pf=%q want %q", pf, tc.wantPF)
+			}
+		})
+	}
+}
+
+// TestGetVfByTimeoutMissingDevice is a regression test for the old AsyncGetVF
+// implementation: GetVf returns (nil, err) when the PF sysfs path is absent,
+// and AsyncGetVF dereferenced the result unconditionally (len(vfs.Data)),
+// panicking in a background goroutine. GetVfByTimeout must instead surface a
+// timeout error and never panic. timeout=0 expires the deadline right after
+// the first failing poll, so the test is fast and never hits the 1s sleep.
+func TestGetVfByTimeoutMissingDevice(t *testing.T) {
+	vfs, err := GetVfByTimeout(0, "definitely-not-a-real-nic", 2)
+	if err == nil {
+		t.Fatalf("expected timeout error, got vfs=%+v", vfs)
+	}
+	if vfs != nil {
+		t.Errorf("expected nil VFList on timeout, got %+v", vfs)
+	}
+}
+
+// TestGetVfByTimeoutFindsVFs builds a fake PF sysfs tree and checks that
+// GetVfByTimeout polls GetVf and returns once the expected number of VFs is
+// present. GetVf discovers VFs via virtfnN symlinks whose canonical target
+// path ends in a PCI BDF, so the fake tree mirrors that layout.
+func TestGetVfByTimeoutFindsVFs(t *testing.T) {
+	root := t.TempDir()
+	netDir := filepath.Join(root, "net")
+	devDir := filepath.Join(netDir, "eth9", "device")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	bdfs := []string{"0000:03:10.0", "0000:03:10.1"}
+	for i, bdf := range bdfs {
+		pciDir := filepath.Join(root, "pci", bdf)
+		if err := os.MkdirAll(pciDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		link := filepath.Join(devDir, fmt.Sprintf("virtfn%d", i))
+		if err := os.Symlink(pciDir, link); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	old := NicLinuxPath
+	NicLinuxPath = netDir + "/"
+	defer func() { NicLinuxPath = old }()
+
+	vfs, err := GetVfByTimeout(2*time.Second, "eth9", uint8(len(bdfs)))
+	if err != nil {
+		t.Fatalf("GetVfByTimeout: %v", err)
+	}
+	if vfs == nil || int(vfs.Count) != len(bdfs) {
+		t.Fatalf("expected %d VFs, got %+v", len(bdfs), vfs)
+	}
+	got := make(map[string]bool, len(vfs.Data))
+	for _, vf := range vfs.Data {
+		got[vf.PciLong] = true
+	}
+	for _, bdf := range bdfs {
+		if !got[bdf] {
+			t.Errorf("missing VF %s in %+v", bdf, vfs.Data)
+		}
+	}
+}
+
+// TestParseVfIfaceNameRoundtrip ensures Parse(Get(idx, pf)) == (idx, pf) for
+// every plausible (PF, VF index) combination — protects against a future
+// rename mismatch between the two helpers.
+func TestParseVfIfaceNameRoundtrip(t *testing.T) {
+	pfs := []string{"eth0", "eth2", "keth2", "enp1s0f0"}
+	for _, pf := range pfs {
+		for _, idx := range []uint8{0, 1, 5, 19, 63, 255} {
+			name := GetVfIfaceName(idx, pf)
+			gotIdx, gotPF, err := ParseVfIfaceName(name)
+			if err != nil {
+				t.Errorf("PF=%s idx=%d name=%q parse error: %v", pf, idx, name, err)
+				continue
+			}
+			if gotIdx != idx || gotPF != pf {
+				t.Errorf("PF=%s idx=%d name=%q -> (%d, %q)", pf, idx, name, gotIdx, gotPF)
+			}
+		}
+	}
+}


### PR DESCRIPTION
# Description

Backport of https://github.com/lf-edge/eve/pull/6061 and https://github.com/lf-edge/eve/pull/5908

## How to test and validate this PR

Use `make test`.
See also https://github.com/lf-edge/eve/pull/5908 for it's specific test procedure.

## Changelog notes

Fixes a potential pillar crash and a long stall when setting up SR-IOV
virtual functions for device passthrough.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
