### PR TITLE
Detect hardware watchdog resets as a boot reason

### DIFF
--- a/pkg/pillar/cmd/nodeagent/nodeagent.go
+++ b/pkg/pillar/cmd/nodeagent/nodeagent.go
@@ -607,6 +607,11 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 	if rebootReason == "" {
 		rebootTime = time.Now()
 		dateStr := rebootTime.Format(time.RFC3339Nano)
+		// The hardware watchdog latches WDIOF_CARDRESET when it reset the
+		// device. Recorded at boot by pkg/watchdog; used to disambiguate the
+		// reboots that SMART power-cycle counters and EVE's own bookkeeping
+		// cannot otherwise explain.
+		hwWatchdogReset := hwWatchdogCardReset()
 		var reason string
 		if fileutils.FileExists(log, firstbootFile) {
 			reason = fmt.Sprintf("NORMAL: First boot of device - at %s",
@@ -623,11 +628,19 @@ func handleLastRebootReason(ctx *nodeagentContext) {
 				reason = fmt.Sprintf("Reboot reason - device powered off. Restarted at %s",
 					dateStr)
 				bootReason = types.BootReasonPowerFail
+			} else if hwWatchdogReset {
+				reason = fmt.Sprintf("Reboot reason - hardware watchdog reset the device - at %s",
+					dateStr)
+				bootReason = types.BootReasonHWWatchdog
 			} else {
 				reason = fmt.Sprintf("Reboot reason - system reset, reboot or kernel panic due to watchdog or kernel bug (no kdump) - at %s",
 					dateStr)
 				bootReason = types.BootReasonKernel
 			}
+		} else if hwWatchdogReset && bootReason == types.BootReasonNone {
+			reason = fmt.Sprintf("Reboot reason - hardware watchdog reset the device - at %s",
+				dateStr)
+			bootReason = types.BootReasonHWWatchdog
 		} else {
 			reason = fmt.Sprintf("Unknown reboot reason - power failure or crash - at %s",
 				dateStr)
@@ -859,6 +872,30 @@ func parseSMARTData() {
 
 	parseData(currentSMARTfilename, smartData)
 	parseData(previousSMARTfilename, previousSmartData)
+}
+
+// hwWatchdogCardReset reports whether the hardware watchdog reset the device
+// on the previous boot. It reads the boot status recorded by pkg/watchdog,
+// which lists the WDIOF_* flag names that were set; CARDRESET is the flag the
+// kernel sets when the watchdog timer expired and reset the board. Platforms
+// whose watchdog driver does not report this flag never produce the entry, so
+// a missing or absent file simply yields false.
+func hwWatchdogCardReset() bool {
+	data, err := fileutils.ReadWithMaxSize(log, types.HWWatchdogBootStatusFile,
+		maxReadSize)
+	if err != nil {
+		// Expected on platforms with no hardware watchdog or none that
+		// reports a boot status; not an error worth flagging.
+		log.Functionf("hwWatchdogCardReset: %s not readable: %v",
+			types.HWWatchdogBootStatusFile, err)
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "CARDRESET" {
+			return true
+		}
+	}
+	return false
 }
 
 func handleTpmStatusCreate(ctxArg interface{}, key string,

--- a/pkg/pillar/docs/nodeagent.md
+++ b/pkg/pillar/docs/nodeagent.md
@@ -82,6 +82,11 @@ is delegated to `baseosmgr`/`zboot` and `zedagent`.
     when no reboot reason was recorded, to distinguish a dirty power-off
     (counter incremented) from a kernel panic / watchdog reset
     (counter unchanged),
+  * `/persist/hw_watchdog_bootstatus` — hardware watchdog boot status flags
+    recorded by `pkg/watchdog` at boot; a `CARDRESET` entry attributes a
+    reset with no other recorded reason to the hardware watchdog
+    (`BootReasonHWWatchdog`) instead of guessing a kernel panic. Only
+    populated on platforms whose watchdog driver reports the flag,
   * `/run/global/first-boot` — marker dropped by the installer on the very
     first boot; presence sets the boot reason to `BootReasonFirst`,
   * `/persist/installer/installer.log` plus

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -45,6 +45,10 @@ const (
 	PersistCachePatchEnvelopes = PersistDir + "/patchEnvelopesCache"
 	// PersistCachePatchEnvelopesUsage - folder to store patch envelopes usage stat per app
 	PersistCachePatchEnvelopesUsage = PersistDir + "/patchEnvelopesUsageCache"
+	// HWWatchdogBootStatusFile holds the hardware watchdog boot status flag
+	// names (one per line) recorded by pkg/watchdog at boot. A "CARDRESET"
+	// entry means the watchdog reset the device on the previous boot.
+	HWWatchdogBootStatusFile = PersistDir + "/hw_watchdog_bootstatus"
 
 	// IdentityDirname - Config dir
 	IdentityDirname = "/config"

--- a/pkg/pillar/types/zedagenttypes.go
+++ b/pkg/pillar/types/zedagenttypes.go
@@ -265,6 +265,7 @@ const (
 	BootReasonVaultFailure         // Vault was not ready within the expected time
 	BootReasonPoweroffCmd          // Start after Local Profile Server poweroff
 	BootReasonKubeTransition       // Transition to/from kubernetes single/cluster modes
+	BootReasonHWWatchdog           // Hardware watchdog reset the device; only on drivers reporting WDIOF_CARDRESET
 	BootReasonParseFail      = 255 // BootReasonFromString didn't find match
 )
 
@@ -303,6 +304,8 @@ func (br BootReason) String() string {
 		return "BootReasonPoweroffCmd"
 	case BootReasonKubeTransition:
 		return "BootReasonKubeTransition"
+	case BootReasonHWWatchdog:
+		return "BootReasonHWWatchdog"
 	default:
 		return fmt.Sprintf("Unknown BootReason %d", br)
 	}
@@ -345,6 +348,8 @@ func (br BootReason) StartWithSavedConfig() bool {
 		return true
 	case BootReasonKubeTransition:
 		return true
+	case BootReasonHWWatchdog:
+		return false
 	default:
 		return false
 	}
@@ -388,6 +393,8 @@ func BootReasonFromString(str string) BootReason {
 		return BootReasonPoweroffCmd
 	case "BootReasonKubeTransition":
 		return BootReasonKubeTransition
+	case "BootReasonHWWatchdog":
+		return BootReasonHWWatchdog
 	default:
 		return BootReasonParseFail
 	}

--- a/pkg/pillar/types/zedagenttypes_test.go
+++ b/pkg/pillar/types/zedagenttypes_test.go
@@ -39,6 +39,7 @@ func TestBootReasonFromString(t *testing.T) {
 		{"BootReasonVaultFailure", BootReasonVaultFailure},
 		{"BootReasonPoweroffCmd", BootReasonPoweroffCmd},
 		{"BootReasonKubeTransition", BootReasonKubeTransition},
+		{"BootReasonHWWatchdog", BootReasonHWWatchdog},
 		{"BadValue", BootReasonParseFail},
 		// Whitespace trimming
 		{"  BootReasonFirst\n", BootReasonFirst},
@@ -127,6 +128,7 @@ func TestBootReasonString(t *testing.T) {
 		{BootReasonVaultFailure, "BootReasonVaultFailure"},
 		{BootReasonPoweroffCmd, "BootReasonPoweroffCmd"},
 		{BootReasonKubeTransition, "BootReasonKubeTransition"},
+		{BootReasonHWWatchdog, "BootReasonHWWatchdog"},
 		{BootReason(99), fmt.Sprintf("Unknown BootReason %d", 99)},
 	}
 	for _, tc := range cases {
@@ -149,7 +151,8 @@ func TestBootReasonStartWithSavedConfig(t *testing.T) {
 	for _, br := range []BootReason{
 		BootReasonNone, BootReasonFirst, BootReasonFallback,
 		BootReasonFatal, BootReasonOOM, BootReasonWatchdogHung,
-		BootReasonWatchdogPid, BootReasonVaultFailure, BootReason(99),
+		BootReasonWatchdogPid, BootReasonVaultFailure, BootReasonHWWatchdog,
+		BootReason(99),
 	} {
 		assert.False(t, br.StartWithSavedConfig(), "br=%s", br)
 	}

--- a/pkg/watchdog/init.sh
+++ b/pkg/watchdog/init.sh
@@ -13,7 +13,7 @@ adjust_parent_oom_score() {
 }
 
 reload_watchdog() {
-    # Firs thinsg first: kill it!
+    # First things first: kill it!
     if [ -f /var/run/watchdog.pid ]; then
         wp=$(cat /var/run/watchdog.pid)
         log "Killing watchdog $wp"
@@ -56,6 +56,23 @@ run_watchdog() {
    done
 }
 
+# record_hw_watchdog_bootstatus captures the hardware watchdog boot status
+# (WDIOC_GETBOOTSTATUS) once, before the watchdog daemon takes over the device.
+# The boot status latches the cause of the *previous* reset; a CARDRESET flag
+# means the watchdog timer expired and reset the board. nodeagent reads this
+# file to attribute the reboot reason. Flag names whose boot-status column is 1
+# are written one per line; an empty file means nothing was latched or the
+# driver does not report a boot status (e.g. Intel iTCO always reports zero).
+#
+# NOTE: opening /dev/watchdog can arm the timer on some drivers. This runs
+# immediately before run_watchdog starts watchdog(8), which then keeps petting
+# the device, so the exposure window is short; validate per target platform.
+record_hw_watchdog_bootstatus() {
+    wdctl /dev/watchdog 2>/dev/null | awk 'NR > 1 && $NF == 1 { print $1 }' \
+        > /persist/hw_watchdog_bootstatus
+    log "Recorded hardware watchdog boot status: $(tr '\n' ' ' < /persist/hw_watchdog_bootstatus)"
+}
+
 # Lets get this party started
 
 if [ -z "${WATCHDOG_CHANGE_TIME}" ]; then
@@ -64,6 +81,7 @@ if [ -z "${WATCHDOG_CHANGE_TIME}" ]; then
 fi
 
 if [ -c /dev/watchdog ]; then
+    record_hw_watchdog_bootstatus
     if [ $USE_HW_WATCHDOG = 0 ]; then
         log "Disabling use of /dev/watchdog"
         wdctl /dev/watchdog


### PR DESCRIPTION
**Motivation:** opportunity for this improvement was discovered during kvm-to-k offline-resize watchdog stress testing — hardware-watchdog resets shouldbe surfaced as a boot reason if possible so that users (and tests) can   distinguish a watchdog-forced reboot from other reboots.

# Description

On a reboot for which EVE recorded no reason of its own, nodeagent guesses
the cause: if the storage controller's SMART power-cycle counter increased it
reports a dirty power-off (`BootReasonPowerFail`), otherwise it reports a
kernel panic (`BootReasonKernel`) or, when SMART is unavailable,
`BootReasonUnknown`. A device reset by its hardware watchdog (counter
unchanged) is therefore indistinguishable from a kernel bug.

This PR adds a `BootReasonHWWatchdog` and the signal needed to set it. The
watchdog container reads the watchdog boot status (`WDIOC_GETBOOTSTATUS`) once
at startup, before it arms the device, and records the set flag names to
`/persist/hw_watchdog_bootstatus`. When nodeagent reaches the
counter-unchanged / unknown branches and that file shows `CARDRESET`, it
reports `BootReasonHWWatchdog` instead of guessing a kernel panic.

`BootReasonHWWatchdog.StartWithSavedConfig()` returns `false` — like the
software watchdog reasons, a device returning from an unexplained hard hang
should wait for the controller rather than immediately restart saved
application config. **This is an operator-visible behavior change**: resets
that previously fell to `BootReasonKernel`/`BootReasonUnknown` and auto-resumed
apps will, on CARDRESET-reporting platforms, no longer auto-resume.

The flag is only reported by some watchdog drivers (e.g. AMD `sp5100_tco`,
many ARM SoC watchdogs); Intel `iTCO` always reports a zero boot status, so on
that hardware behavior is unchanged.

## PR dependencies

- Depends on lf-edge/eve-api#148 (adds `BOOT_REASON_HW_WATCHDOG = 16` and
  `BOOT_REASON_KUBE_TRANSITION = 15`). Once that merges, a `Bump eve-api`
  commit will be added here to vendor the new enum value. Pillar already
  compiles without it (the reason maps to the proto via a numeric cast).

## How to test and validate this PR

- Unit tests: `BootReasonFromString` / `String` / `StartWithSavedConfig` in
  `pkg/pillar/types/zedagenttypes_test.go` cover the new value.
- On hardware whose watchdog driver reports `WDIOF_CARDRESET`: trigger a
  watchdog reset, then confirm `/persist/hw_watchdog_bootstatus` contains
  `CARDRESET` and the device info message reports `BootReasonHWWatchdog`
  (rather than `BootReasonKernel`).
- The `wdctl`-before-arm read needs per-platform validation: opening
  `/dev/watchdog` can arm the timer on some drivers, so confirm the device is
  not left ticking before `watchdog(8)` starts petting it.

## Changelog notes

A device reset by its hardware watchdog is now reported with the dedicated
boot reason "hardware watchdog" instead of being attributed to a kernel panic,
on platforms whose watchdog driver supports it.

## PR Backports

- 16.0-stable: No — new enhancement, not a bug fix.
- 14.5-stable: No — new enhancement, not a bug fix.
- 13.4-stable: No — new enhancement, not a bug fix.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

