### PR TITLE
edgeview: extend VNC port range to 5963 to match controller's 64-bitmap

### DIFF
--- a/pkg/edgeview/src/policy.go
+++ b/pkg/edgeview/src/policy.go
@@ -24,6 +24,16 @@ const (
 	tcpSyntaxErr = "TCP syntax error"
 )
 
+const (
+	// vncPortMin is the TCP port of the first VNC display (display :0).
+	vncPortMin = 5900
+	// vncPortCount is the number of consecutive VNC ports supported,
+	// matching the controller's 64-bit VNC display bitmap.
+	vncPortCount = 1 << 6
+	// vncPortMax is the TCP port of the last supported VNC display (5963).
+	vncPortMax = vncPortMin + vncPortCount - 1
+)
+
 var (
 	devIntfIPs []string
 	appIntfIPs []appIPvnc
@@ -321,7 +331,7 @@ func checkAppConsole(addr, port string) (bool, bool, string) {
 	if err != nil {
 		return false, false, ""
 	}
-	if portnum < 5900 || portnum > 5915 {
+	if portnum < vncPortMin || portnum > vncPortMax {
 		return false, false, ""
 	}
 
@@ -329,7 +339,7 @@ func checkAppConsole(addr, port string) (bool, bool, string) {
 	var appName string
 
 	for _, a := range appIntfIPs {
-		if a.vncPort+5900 == portnum {
+		if a.vncPort+vncPortMin == portnum {
 			allowVNC = a.vncEnable
 			appName = a.appName
 			break

--- a/pkg/edgeview/src/tcp.go
+++ b/pkg/edgeview/src/tcp.go
@@ -187,7 +187,7 @@ func clientTCPtunnel(here net.Conn, idx, chNum int, rport int) {
 
 	buf := make([]byte, chunkSize)
 	var justEnterVNC bool
-	if rport >= 5900 && rport <= 5910 { // VNC does not send any data initially
+	if rport >= vncPortMin && rport <= vncPortMax { // VNC does not send any data initially
 		justEnterVNC = true
 	}
 	var reqLen int


### PR DESCRIPTION

# Description

 - since controller side has the 64 possible numbers, change edgeview to match that.

## PR dependencies

## Changelog notes

edgeview: extend VNC port range to 5963 to match controller's 64-bitmap

## PR Backports

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
