### PR TITLE
eve-k: reduce log noise on tie-breaker and cluster nodes

### DIFF
--- a/pkg/kube/longhorn-utils.sh
+++ b/pkg/kube/longhorn-utils.sh
@@ -148,38 +148,48 @@ Longhorn_is_ready() {
         return 1
     fi
 
-    # ndm has all nodes
-    ndm=$(kubectl -n longhorn-system get engineimage -o json | jq .items[].status.nodeDeploymentMap)
-    dep=$(echo "$ndm" | jq --arg n "$node" '.[$n]')
-    if [ "$dep" != "true" ]; then
-        logmsg "lh node:$node engine not deployed"
-        # find engine pod name
-        pod=$(kubectl -n longhorn-system get pod -l longhorn.io/component=engine-image -o json | jq -r --arg n "$node" '.items[] | select(.spec.nodeName==$n) | .metadata.name')
-        if [ "$pod" = "" ]; then
-                # maybe restarting or not yet created (new install)
+    # Tie breaker nodes disable scheduling for a node, use the longhorn api to avoid an unnecessary dependency here.
+    # This avoids a regular "not deployed" print.
+    ndm=""
+    schedulable=$(kubectl -n longhorn-system get nodes.longhorn.io "$node" -o json | jq -r '.status.conditions[] | select(.type=="Schedulable") | .status')
+    if [ "$schedulable" = "True" ]; then
+        # ndm has all nodes
+        ndm=$(kubectl -n longhorn-system get engineimage -o json | jq .items[].status.nodeDeploymentMap)
+        dep=$(echo "$ndm" | jq --arg n "$node" '.[$n]')
+        if [ "$dep" != "true" ]; then
+                logmsg "lh node:$node engine not deployed"
+                # find engine pod name
+                pod=$(kubectl -n longhorn-system get pod -l longhorn.io/component=engine-image -o json | jq -r --arg n "$node" '.items[] | select(.spec.nodeName==$n) | .metadata.name')
+                if [ "$pod" = "" ]; then
+                        # maybe restarting or not yet created (new install)
+                        return 1
+                fi
+                phase=$(kubectl -n longhorn-system get "pod/${pod}" -o json | jq -r .status.phase)
+                if [ "$phase" != "Running" ]; then
+                        # maybe restarting
+                        return 1
+                fi
+                # delete it
+                kubectl -n longhorn-system delete "pod/${pod}"
+                logmsg "lh node:$node engine:$pod deleted for re-init due to ndm inconsistency"
+
+                # Find the owner of the node deployment map and cycle that pod so it regenerates.
+                ndmOwnerID=$(kubectl -n longhorn-system get engineimage -o json | jq -r .items[].status.ownerID)
+                if [ "$ndmOwnerID" != "" ]; then
+                    ndmMgrPod=$(kubectl -n longhorn-system get pod -l app=longhorn-manager  -o json | jq -r --arg n "$ndmOwnerID" '.items[] | select(.spec.nodeName==$n) | .metadata.name')
+                    if [ "$ndmMgrPod" != "" ]; then
+                        logmsg "lh ownerID node:$ndmOwnerID manager:$ndmMgrPod deleted for re-init due to ndm inconsistency"
+                        kubectl -n longhorn-system delete "pod/${ndmMgrPod}"
+                    fi
+                fi
+
                 return 1
         fi
-        phase=$(kubectl -n longhorn-system get "pod/${pod}" -o json | jq -r .status.phase)
-        if [ "$phase" != "Running" ]; then
-                # maybe restarting
-                return 1
-        fi
-        # delete it
-        kubectl -n longhorn-system delete "pod/${pod}"
-        logmsg "lh node:$node engine:$pod deleted for re-init due to ndm inconsistency"
-
-        # Find the owner of the node deployment map and cycle that pod so it regenerates.
-        ndmOwnerID=$(kubectl -n longhorn-system get engineimage -o json | jq -r .items[].status.ownerID)
-        if [ "$ndmOwnerID" != "" ]; then
-            ndmMgrPod=$(kubectl -n longhorn-system get pod -l app=longhorn-manager  -o json | jq -r --arg n "$ndmOwnerID" '.items[] | select(.spec.nodeName==$n) | .metadata.name')
-            if [ "$ndmMgrPod" != "" ]; then
-                logmsg "lh ownerID node:$ndmOwnerID manager:$ndmMgrPod deleted for re-init due to ndm inconsistency"
-                kubectl -n longhorn-system delete "pod/${ndmMgrPod}"
-            fi
-        fi
-
+    elif [ "$schedulable" != "False" ]; then
+        logmsg "Unable to determine lh node $node Schedulable status, Condition missing or unexpected value, not ready yet"
         return 1
     fi
+
     if [ -z "${bootLhRdyComplete}" ]; then
         logmsg "longhorn ds ready, node:$node nodedeploymentmap:$(echo "$ndm" | tr -d '\n')"
         bootLhRdyComplete="1"

--- a/pkg/kube/tie-breaker-utils.sh
+++ b/pkg/kube/tie-breaker-utils.sh
@@ -114,7 +114,7 @@ Tie_breaker_configApply() {
         Cdi_config
 
         logmsg "tie-breaker config-apply:longhorn"
-        longhorn_node_set_sched "${node}" "false"
+        longhorn_node_set_sched "${tie_breaker_k8s_node_name}" "false"
         longhorn_rescale 2
 
         logmsg "evicting tie-breaker nodeId:${tie_breaker_node_uuid} node:${tie_breaker_k8s_node_name}"

--- a/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
+++ b/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
@@ -101,6 +101,12 @@ func gcObjects(ctx *volumemgrContext, dirName string) {
 	}
 	var locations []string
 	for _, location := range locationsFileInfo {
+		// Skip entries belonging to other subsystems (e.g. Longhorn's
+		// longhorn-disk.cfg and replicas/) to avoid spurious
+		// "found unknown format volume" errors from getVolumeStatusByLocation.
+		if _, skip := kubeapi.VolumeDirInternalEntriesMap()[location.Name()]; skip {
+			continue
+		}
 		locations = append(locations, filepath.Join(dirName, location.Name()))
 	}
 	gcVolumes(ctx, locations)

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -2307,7 +2307,7 @@ func handleKubeClusterInfoImpl(ctxArg interface{}, key string,
 }
 
 func triggerPublishKubeClusterInfoToDest(ctxPtr *zedagentContext, dest destinationBitset) {
-	log.Notice("Triggered PublishKubeClusterInfo")
+	log.Function("Triggered PublishKubeClusterInfo")
 	select {
 	case ctxPtr.triggerClusterInfo <- dest:
 

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -73,21 +73,42 @@ const (
 
 // VM instance meta data structure.
 type vmiMetaData struct {
-	repPod           *appsv1.ReplicaSet                   // Handle to the replicaSetof pod
-	repVMI           *v1.VirtualMachineInstanceReplicaSet // Handle to the replicaSet of VMI
-	domainID         int                                  // DomainID understood by domainmgr in EVE
-	mtype            MetaDataType                         // switch on is ReplicaSet, Pod or is VMI
-	name             string                               // Display-Name(all lower case) + first 5 bytes of domainName
-	cputotal         uint64                               // total CPU in NS so far
-	maxmem           uint32                               // total Max memory usage in MB so far
-	startUnknownTime time.Time                            // time when the domain returned as unknown status
-	memOverhead      uint64                               // VMM memory overhead in bytes
+	repPod              *appsv1.ReplicaSet                   // Handle to the replicaSetof pod
+	repVMI              *v1.VirtualMachineInstanceReplicaSet // Handle to the replicaSet of VMI
+	domainID            int                                  // DomainID understood by domainmgr in EVE
+	mtype               MetaDataType                         // switch on is ReplicaSet, Pod or is VMI
+	name                string                               // Display-Name(all lower case) + first 5 bytes of domainName
+	cputotal            uint64                               // total CPU in NS so far
+	maxmem              uint32                               // total Max memory usage in MB so far
+	startUnknownTime    time.Time                            // time when the domain returned as unknown status
+	memOverhead         uint64                               // VMM memory overhead in bytes
+	lastVMIPhase        string                               // last VMI phase logged; used to suppress repeated status logs
+	lastVMIBeingDeleted bool                                 // last deletion state logged; DeletionTimestamp nil→non-nil is a loggable transition
+	lastVMIUID          string                               // UID of the VMI object last logged; a new UID means VMIRS replaced the VMI
 	// sriovVFs lists the (PF ifname, VF index) of every SR-IOV VF this VMI
 	// was wired with via attachSRIOVInterfaces.  Used on Stop/Delete/Cleanup
 	// to clear the per-VF admin MAC on the PF — sriov-cni's DEL path doesn't
 	// reliably clear it when the VF is pre-bound to vfio-pci, so EVE owns
 	// the cleanup.
 	sriovVFs []sriovVFRef
+}
+
+// recordPhase updates the tracked observable state of a VMI and returns true
+// if anything changed since the last call. It owns the definition of what
+// "changed" means: either the:
+// - kubevirt phase string
+// - deletion state (DeletionTimestamp nil→non-nil or vice-versa)
+// - or the object uid
+// counts as a transition.
+func (m *vmiMetaData) recordPhase(vmi *v1.VirtualMachineInstance) bool {
+	phase := fmt.Sprintf("%v", vmi.Status.Phase)
+	beingDeleted := vmi.ObjectMeta.DeletionTimestamp != nil
+	uid := string(vmi.ObjectMeta.UID)
+	changed := phase != m.lastVMIPhase || beingDeleted != m.lastVMIBeingDeleted || uid != m.lastVMIUID
+	m.lastVMIPhase = phase
+	m.lastVMIBeingDeleted = beingDeleted
+	m.lastVMIUID = uid
+	return changed
 }
 
 // sriovVFRef identifies a single VF on a Physical Function for cleanup
@@ -1241,12 +1262,12 @@ func getVMIStatus(vmis *vmiMetaData, nodeName string) (string, error) {
 	var nonLocalStatus string
 	var targetVMI *v1.VirtualMachineInstance
 	for _, vmi := range vmiList.Items {
-		logrus.Infof("getVMIStatus: repVmi:%s nodeName:%s vmiList vmi.ObjectMeta.Name:%s vmi.Status.NodeName:%s vmi.ObjectMeta.DeletionTimestamp:%v vmi.Status.Phase:%s",
+		logrus.Debugf("getVMIStatus: repVmi:%s nodeName:%s vmiList vmi.ObjectMeta.Name:%s vmi.Status.NodeName:%s vmi.ObjectMeta.DeletionTimestamp:%v vmi.Status.Phase:%s",
 			repVmiName, nodeName, vmi.ObjectMeta.Name, vmi.Status.NodeName, vmi.ObjectMeta.DeletionTimestamp, vmi.Status.Phase)
 		if vmi.Status.NodeName == nodeName {
 			if vmi.GenerateName == repVmiName {
 				targetVMI = &vmi
-				logrus.Infof("getVMIStatus: repVmi:%s nodeName:%s picked vmi", repVmiName, nodeName)
+				logrus.Debugf("getVMIStatus: repVmi:%s nodeName:%s picked vmi", repVmiName, nodeName)
 				break
 			}
 		} else {
@@ -1258,18 +1279,19 @@ func getVMIStatus(vmis *vmiMetaData, nodeName string) (string, error) {
 	if targetVMI == nil {
 		if nonLocalStatus != "" {
 			_, _ = checkAndReturnStatus(vmis, false) // reset the unknown timestamp
-			logrus.Infof("getVMIStatus: repVmi:%s nodeName:%s nonLocalStatus:%s", repVmiName, nodeName, nonLocalStatus)
+			logrus.Debugf("getVMIStatus: repVmi:%s nodeName:%s nonLocalStatus:%s", repVmiName, nodeName, nonLocalStatus)
 			return nonLocalStatus, nil
 		}
 		retStatus, err2 := checkAndReturnStatus(vmis, true)
 		logError("getVMIStatus: No VMI %s found with the given nodeName %s, return %s", repVmiName, nodeName, retStatus)
 		return retStatus, err2
 	}
-	res := fmt.Sprintf("%v", targetVMI.Status.Phase)
-	logrus.Infof("getVMIStatus: repVmi:%s nodeName:%s targetVMI.ObjectMeta.Name:%s targetVMI.Status.NodeName:%s targetVMI.ObjectMeta.DeletionTimestamp:%v targetVMI.Status.Phase:%s res:%s",
-		repVmiName, nodeName, targetVMI.ObjectMeta.Name, targetVMI.Status.NodeName, targetVMI.ObjectMeta.DeletionTimestamp, targetVMI.Status.Phase, res)
+	if vmis.recordPhase(targetVMI) {
+		logrus.Infof("getVMIStatus: repVmi:%s nodeName:%s vmi:%s phase:%s deletionTimestamp:%v",
+			repVmiName, nodeName, targetVMI.ObjectMeta.Name, targetVMI.Status.Phase, targetVMI.ObjectMeta.DeletionTimestamp)
+	}
 	_, _ = checkAndReturnStatus(vmis, false) // reset the unknown timestamp
-	return res, nil
+	return fmt.Sprintf("%v", targetVMI.Status.Phase), nil
 }
 
 // Inspired from kvm.go
@@ -1945,7 +1967,7 @@ func checkReplicaPodMetrics(ctx kubevirtContext, res map[string]types.DomainMetr
 		}
 	}
 
-	logrus.Infof("checkReplicaPodMetrics: done with vmiList")
+	logrus.Debugf("checkReplicaPodMetrics: done with vmiList")
 }
 
 func getPodMetrics(clientset *metricsv.Clientset, pod k8sv1.Pod, vmis *vmiMetaData,

--- a/pkg/pillar/kubeapi/descheduler.go
+++ b/pkg/pillar/kubeapi/descheduler.go
@@ -75,7 +75,9 @@ func isDeschedulerReadyWithClient(log *base.LogObject, client kubernetes.Interfa
 		return false, fmt.Errorf("IsDeschedulerReady: get node %s: %w", nodeName, err)
 	}
 	if node.Spec.Unschedulable {
-		log.Noticef("IsDeschedulerReady: node %s is unschedulable", nodeName)
+		// Unschedulable is a permanent state on tie-breaker nodes; suppress
+		// repeated Notice logs since this check runs every 15s for 30 minutes.
+		log.Functionf("IsDeschedulerReady: node %s is unschedulable", nodeName)
 		return false, nil
 	}
 	nodeReady := false

--- a/pkg/pillar/kubeapi/longhorninfo.go
+++ b/pkg/pillar/kubeapi/longhorninfo.go
@@ -26,6 +26,19 @@ import (
 
 const longhornNamespace = "longhorn-system"
 
+// VolumeDirInternalEntriesMap returns filenames placed in volume directories
+// (VolumeEncryptedDirName, VolumeClearDirName) by subsystems other than
+// volumemgr. gcObjects skips these entries to avoid spurious errors during
+// garbage collection. Add an entry here when a new subsystem co-locates
+// files alongside EVE volumes.
+func VolumeDirInternalEntriesMap() map[string]struct{} {
+	return map[string]struct{}{
+		"longhorn-disk.cfg": {},
+		"replicas":          {},
+		"backing-images":    {},
+	}
+}
+
 // LonghornVolumeSizeDetails returns the provisionedBytes and allocatedBytes size values for a longhorn volume
 func LonghornVolumeSizeDetails(longhornVolumeName string) (provisionedBytes uint64, allocatedBytes uint64, err error) {
 	apiExists, err := longhornAPIExists()
@@ -214,6 +227,13 @@ type lhReplicaLister interface {
 // lhEngineGetter is a minimal subset of the Longhorn engine client.
 type lhEngineGetter interface {
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*lhv1beta2.Engine, error)
+}
+
+// lhNodeGetUpdater is a minimal subset of the Longhorn node client used by
+// setLonghornNodeDiskReservedInner.
+type lhNodeGetUpdater interface {
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*lhv1beta2.Node, error)
+	Update(ctx context.Context, node *lhv1beta2.Node, opts metav1.UpdateOptions) (*lhv1beta2.Node, error)
 }
 
 // populateKVIInner is the testable core of populateKVIFromPVCName.
@@ -645,6 +665,8 @@ func longhornVolumeSetNode(lhVolName string, kubeNodeName string) error {
 // SetLonghornNodeDiskReserved sets StorageReserved on every disk of the named Longhorn node.
 // Returns (false, nil) if the Longhorn API is absent or the node object does not exist yet,
 // so callers should retry until (true, nil) is returned.
+// Returns (true, nil) for non-schedulable (tie-breaker) nodes: the reservation is not
+// needed and the Longhorn admission webhook would reject any update attempt.
 func SetLonghornNodeDiskReserved(nodeName string, reservedBytes int64) (bool, error) {
 	apiExists, err := longhornAPIExists()
 	if !apiExists && err == nil {
@@ -666,13 +688,37 @@ func SetLonghornNodeDiskReserved(nodeName string, reservedBytes int64) (bool, er
 
 	lhCtx, lhCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
 	defer lhCancel()
-	node, err := lhClient.LonghornV1beta2().Nodes(longhornNamespace).Get(
-		lhCtx, nodeName, metav1.GetOptions{})
+	return setLonghornNodeDiskReservedInner(lhCtx, nodeName, reservedBytes,
+		lhClient.LonghornV1beta2().Nodes(longhornNamespace))
+}
+
+// setLonghornNodeDiskReservedInner is the testable core of SetLonghornNodeDiskReserved.
+// All Longhorn node I/O is injected through the nodes interface argument so unit tests
+// can supply hand-written mocks without a live cluster.
+func setLonghornNodeDiskReservedInner(ctx context.Context, nodeName string,
+	reservedBytes int64, nodes lhNodeGetUpdater) (bool, error) {
+	node, err := nodes.Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return false, nil
 		}
 		return false, fmt.Errorf("SetLonghornNodeDiskReserved: get node %s: %v", nodeName, err)
+	}
+
+	// Tie breaker nodes will have a non-deployed engine and the longhorn
+	// validator will return an error.
+	// example:
+	// 'admission webhook "validator.longhorn.io" denied the request:
+	// spec and status of disks on node <node> are being syncing
+	// and please retry later.'
+	//
+	// Skip this node, the reservation isn't necessary here.
+	// Return true so the caller stops retrying — the reservation is not needed.
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == lhv1beta2.NodeConditionTypeSchedulable &&
+			cond.Status != lhv1beta2.ConditionStatusTrue {
+			return true, nil
+		}
 	}
 
 	changed := false
@@ -687,8 +733,7 @@ func SetLonghornNodeDiskReserved(nodeName string, reservedBytes int64) (bool, er
 		return true, nil
 	}
 
-	_, err = lhClient.LonghornV1beta2().Nodes(longhornNamespace).Update(
-		lhCtx, node, metav1.UpdateOptions{})
+	_, err = nodes.Update(ctx, node, metav1.UpdateOptions{})
 	if err != nil {
 		return false, fmt.Errorf("SetLonghornNodeDiskReserved: update node %s: %v", nodeName, err)
 	}

--- a/pkg/pillar/kubeapi/longhorninfo_test.go
+++ b/pkg/pillar/kubeapi/longhorninfo_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // -- mock types for populateKVIInner --
@@ -713,6 +715,186 @@ func TestPopulateKVIInner(t *testing.T) {
 			}
 			if tc.checkFn != nil {
 				tc.checkFn(t, result)
+			}
+		})
+	}
+}
+
+// -- mock for setLonghornNodeDiskReservedInner --
+
+type funcLHNodeGetUpdater struct {
+	getFn    func(string) (*lhv1beta2.Node, error)
+	updateFn func(*lhv1beta2.Node) (*lhv1beta2.Node, error)
+}
+
+func (m funcLHNodeGetUpdater) Get(_ context.Context, name string, _ metav1.GetOptions) (*lhv1beta2.Node, error) {
+	return m.getFn(name)
+}
+
+func (m funcLHNodeGetUpdater) Update(_ context.Context, node *lhv1beta2.Node, _ metav1.UpdateOptions) (*lhv1beta2.Node, error) {
+	return m.updateFn(node)
+}
+
+func lhNodeWithDisks(reserved int64) *lhv1beta2.Node {
+	return &lhv1beta2.Node{
+		Spec: lhv1beta2.NodeSpec{
+			Disks: map[string]lhv1beta2.DiskSpec{
+				"disk-0": {StorageReserved: reserved},
+			},
+		},
+	}
+}
+
+func schedulableCondition(status lhv1beta2.ConditionStatus) lhv1beta2.Condition {
+	return lhv1beta2.Condition{
+		Type:   lhv1beta2.NodeConditionTypeSchedulable,
+		Status: status,
+	}
+}
+
+func TestSetLonghornNodeDiskReservedInner(t *testing.T) {
+	const (
+		nodeName     = "test-node"
+		wantReserved = int64(10 * 1024 * 1024 * 1024)
+		alreadySet   = wantReserved
+		differentVal = int64(5 * 1024 * 1024 * 1024)
+	)
+
+	nodeNotFound := k8serrors.NewNotFound(schema.GroupResource{Resource: "nodes"}, nodeName)
+
+	tests := []struct {
+		name        string
+		getFn       func(string) (*lhv1beta2.Node, error)
+		updateFn    func(*lhv1beta2.Node) (*lhv1beta2.Node, error)
+		wantApplied bool
+		wantErr     bool
+		// updateCalled asserts whether Update was (or was not) invoked.
+		wantUpdateCalled bool
+	}{
+		{
+			// Non-schedulable node (tie-breaker): reservation is not needed and
+			// the Longhorn admission webhook would reject any update. Return true
+			// so the caller stops retrying.
+			name: "non-schedulable node returns true without updating",
+			getFn: func(string) (*lhv1beta2.Node, error) {
+				node := lhNodeWithDisks(differentVal)
+				node.Status.Conditions = []lhv1beta2.Condition{
+					schedulableCondition(lhv1beta2.ConditionStatusFalse),
+				}
+				return node, nil
+			},
+			updateFn:         func(n *lhv1beta2.Node) (*lhv1beta2.Node, error) { return n, nil },
+			wantApplied:      true,
+			wantErr:          false,
+			wantUpdateCalled: false,
+		},
+		{
+			// Schedulable condition present and True: normal node, proceeds to disk check.
+			name: "schedulable=True node with correct reservation is a no-op",
+			getFn: func(string) (*lhv1beta2.Node, error) {
+				node := lhNodeWithDisks(alreadySet)
+				node.Status.Conditions = []lhv1beta2.Condition{
+					schedulableCondition(lhv1beta2.ConditionStatusTrue),
+				}
+				return node, nil
+			},
+			updateFn:         func(n *lhv1beta2.Node) (*lhv1beta2.Node, error) { return n, nil },
+			wantApplied:      true,
+			wantErr:          false,
+			wantUpdateCalled: false,
+		},
+		{
+			// No schedulable condition at all (node not yet registered by Longhorn): treat as
+			// schedulable and proceed to disk check.
+			name: "no schedulable condition, reservation already set — no-op",
+			getFn: func(string) (*lhv1beta2.Node, error) {
+				return lhNodeWithDisks(alreadySet), nil
+			},
+			updateFn:         func(n *lhv1beta2.Node) (*lhv1beta2.Node, error) { return n, nil },
+			wantApplied:      true,
+			wantErr:          false,
+			wantUpdateCalled: false,
+		},
+		{
+			// Disks have the wrong reservation: Update must be called with the
+			// corrected value and the function must return (true, nil).
+			name: "disks need update — Update called with corrected value",
+			getFn: func(string) (*lhv1beta2.Node, error) {
+				return lhNodeWithDisks(differentVal), nil
+			},
+			updateFn: func(n *lhv1beta2.Node) (*lhv1beta2.Node, error) {
+				for _, disk := range n.Spec.Disks {
+					if disk.StorageReserved != wantReserved {
+						return nil, errors.New("disk not updated to wantReserved")
+					}
+				}
+				return n, nil
+			},
+			wantApplied:      true,
+			wantErr:          false,
+			wantUpdateCalled: true,
+		},
+		{
+			// Node object not yet created by Longhorn: signal retry with (false, nil).
+			name: "node not found returns false without error",
+			getFn: func(string) (*lhv1beta2.Node, error) {
+				return nil, nodeNotFound
+			},
+			updateFn:         func(n *lhv1beta2.Node) (*lhv1beta2.Node, error) { return n, nil },
+			wantApplied:      false,
+			wantErr:          false,
+			wantUpdateCalled: false,
+		},
+		{
+			name: "Get returns non-NotFound error",
+			getFn: func(string) (*lhv1beta2.Node, error) {
+				return nil, errors.New("kube api unavailable")
+			},
+			updateFn:         func(n *lhv1beta2.Node) (*lhv1beta2.Node, error) { return n, nil },
+			wantApplied:      false,
+			wantErr:          true,
+			wantUpdateCalled: false,
+		},
+		{
+			name: "Update returns error",
+			getFn: func(string) (*lhv1beta2.Node, error) {
+				return lhNodeWithDisks(differentVal), nil
+			},
+			updateFn: func(n *lhv1beta2.Node) (*lhv1beta2.Node, error) {
+				return nil, errors.New("webhook denied")
+			},
+			wantApplied:      false,
+			wantErr:          true,
+			wantUpdateCalled: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			updateCalled := false
+			wrappedUpdate := func(n *lhv1beta2.Node) (*lhv1beta2.Node, error) {
+				updateCalled = true
+				return tc.updateFn(n)
+			}
+			mock := funcLHNodeGetUpdater{getFn: tc.getFn, updateFn: wrappedUpdate}
+
+			applied, err := setLonghornNodeDiskReservedInner(
+				context.Background(), nodeName, wantReserved, mock)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+			if applied != tc.wantApplied {
+				t.Errorf("applied = %v, want %v", applied, tc.wantApplied)
+			}
+			if updateCalled != tc.wantUpdateCalled {
+				t.Errorf("updateCalled = %v, want %v", updateCalled, tc.wantUpdateCalled)
 			}
 		})
 	}

--- a/pkg/pillar/kubeapi/nokube.go
+++ b/pkg/pillar/kubeapi/nokube.go
@@ -78,3 +78,9 @@ func EnsureVMsDeschedulerAnnotated(*base.LogObject) error {
 func WaitForLonghornReady(ctx context.Context, log *base.LogObject) error {
 	return nil
 }
+
+// VolumeDirInternalEntriesMap is a stub for non EVE-k builds; returns empty map
+// since Longhorn does not co-locate files in non-k configurations.
+func VolumeDirInternalEntriesMap() map[string]struct{} {
+	return map[string]struct{}{}
+}

--- a/pkg/pillar/kubeapi/storageutils.go
+++ b/pkg/pillar/kubeapi/storageutils.go
@@ -81,19 +81,24 @@ func LonghornGetMajorMinorMaps() (map[string]string, map[string]string, error) {
 	lhNameToMajMinMap := make(map[string]string) // kube-pv-name/lh-volume-name -> maj:min
 
 	lhPvcList, err := os.ReadDir(longhornDevPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Longhorn not active on this node (e.g. tie-breaker); empty maps are valid.
+			return lhMajMinToNameMap, lhNameToMajMinMap, nil
+		}
+		return lhMajMinToNameMap, lhNameToMajMinMap, fmt.Errorf("unable to read longhorn devs: %w", err)
+	}
 	for _, lhDirEnt := range lhPvcList {
 		var lhStat syscall.Stat_t
 		err := syscall.Stat(longhornDevPath+"/"+lhDirEnt.Name(), &lhStat)
-
 		if err != nil {
 			continue
 		}
 		majMinKey := getMajorMinorStr(lhStat)
 		lhMajMinToNameMap[majMinKey] = lhDirEnt.Name()
 		lhNameToMajMinMap[lhDirEnt.Name()] = majMinKey
-
 	}
-	return lhMajMinToNameMap, lhNameToMajMinMap, fmt.Errorf("unable to read longhorn devs: %w", err)
+	return lhMajMinToNameMap, lhNameToMajMinMap, nil
 }
 
 // SCSIGetMajMinMaps builds two maps to assist linking with other devices

--- a/pkg/pillar/kubeapi/storageutils_test.go
+++ b/pkg/pillar/kubeapi/storageutils_test.go
@@ -10,6 +10,21 @@ import (
 	"testing"
 )
 
+// TestLonghornGetMajorMinorMapsNotFound verifies that a missing /dev/longhorn
+// (e.g. tie-breaker node) returns empty maps with a nil error rather than failing.
+func TestLonghornGetMajorMinorMapsNotFound(t *testing.T) {
+	if _, err := os.Stat(longhornDevPath); err == nil {
+		t.Skip("longhorn dev path exists, skipping not-found test")
+	}
+	mmMap, lhVolMap, err := LonghornGetMajorMinorMaps()
+	if err != nil {
+		t.Fatalf("expected nil error when longhorn path absent, got: %v", err)
+	}
+	if mmMap == nil || lhVolMap == nil {
+		t.Fatal("expected non-nil empty maps, got nil")
+	}
+}
+
 func TestLonghornGetMajorMinorMaps(t *testing.T) {
 	if _, err := os.Stat(longhornDevPath); err != nil {
 		t.Skipf("No local longhorn")


### PR DESCRIPTION
## Description

Fix nine sources of excessive logging in eve-k (kubevirt) deployments, some relevant in tie-breaker node behavior:

- longhorn-utils.sh: skip engine deployment check in Longhorn_is_ready for non-schedulable nodes (tie-breaker); gate on Longhorn Schedulable condition rather than logging "engine not deployed" every poll cycle
- tie-breaker-utils.sh: use explicit tie_breaker_k8s_node_name instead of implicit global ${node} in longhorn_node_set_sched call
- kubeapi/longhorninfo.go: skip disk reservation update on non-schedulable nodes to prevent repeated admission webhook errors from zedkube
- kubeapi/storageutils.go: fix unconditional error return in LonghornGetMajorMinorMaps (%!w(<nil>) on success); treat missing /dev/longhorn as valid empty state on tie-breaker nodes
- types/locationconsts.go, volumemgr/initialvolumestatus.go: add VolumeDirInternalEntries skip-list to suppress spurious gcVolumes errors for Longhorn-internal paths (longhorn-disk.cfg, replicas, backing-images) co-located in the volume directory
- hypervisor/kubevirt.go: downgrade high-volume getVMIStatus polling logs (~35k/day) to Debugf; log VMI phase only on change
- hypervisor/kubevirt.go: downgrade checkReplicaPodMetrics heartbeat log (~8k/day) to Debugf
- kubeapi/descheduler.go: downgrade unschedulable notice to Functionf to match expected permanent tie-breaker state
- cmd/zedagent/zedagent.go: fix triggerPublishKubeClusterInfoToDest log level to Function, consistent with all sibling trigger functions

## PR dependencies

None

## How to test and validate this PR

The only externally visible symptom is less log messages in /persist/newlog/.

## Changelog notes

Reduced verbose logging from pillar on HV=k.

## PR Backports

- 17.0-stable: Yes?
- 16.0-stable: No
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
