### PR TITLE
Kernel update - [amd64-next, amd64-generic, arm64-nvidia-jp5, arm64-n…

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,7 +1,7 @@
-KERNEL_COMMIT_amd64_next_generic = 3152b8fe36ea
-KERNEL_COMMIT_amd64_v6.12.49_generic = b21691f37d8d
-KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = be4828dfe4e1
-KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = dbf1688d4cb1
-KERNEL_COMMIT_arm64_v6.8.12_nvidia-jp7 = a9757a5802c2
-KERNEL_COMMIT_arm64_v6.1.155_generic = 04d922430698
-KERNEL_COMMIT_riscv64_v6.1.112_generic = a6bc06835103
+KERNEL_COMMIT_amd64_next_generic = a65e45508b45
+KERNEL_COMMIT_amd64_v6.12.49_generic = dcdba3ddf871
+KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = 2e0dcfd3260d
+KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 4929f15eda41
+KERNEL_COMMIT_arm64_v6.8.12_nvidia-jp7 = 452eaffef5ed
+KERNEL_COMMIT_arm64_v6.1.155_generic = da7d6950689c
+KERNEL_COMMIT_riscv64_v6.1.112_generic = 30aa75d58cdd


### PR DESCRIPTION
# Description

main purpose is to pick up iGPU related changes but we also update kernel for all platfroms

eve-kernel-amd64-next
    a65e45508b45: crypto: af_alg/algif_aead: fix CVE-2026-31431 splice write-to-page-cache

eve-kernel-amd64-v6.12.49-generic
    dcdba3ddf871: KVM: x86/mmu: emulate (not -EFAULT) guest access to a disabled passthrough BAR
    2fe05e1131ca: vfio/pci: Set up BAR resources and maps in vfio_pci_core_enable()
    465d242734dc: crypto: af_alg/algif_aead: fix CVE-2026-31431 splice write-to-page-cache

eve-kernel-arm64-v5.10.192-nvidia-jp5
    2e0dcfd3260d: crypto: af_alg/algif_aead: fix CVE-2026-31431 splice write-to-page-cache

eve-kernel-arm64-v5.15.136-nvidia-jp6
    4929f15eda41: crypto: af_alg/algif_aead: fix CVE-2026-31431 splice write-to-page-cache

eve-kernel-arm64-v6.1.155-generic
    da7d6950689c: crypto: af_alg/algif_aead: fix CVE-2026-31431 splice write-to-page-cache

eve-kernel-arm64-v6.8.12-nvidia-jp7
    452eaffef5ed: crypto: af_alg/algif_aead: fix CVE-2026-31431 splice write-to-page-cache

eve-kernel-riscv64-v6.1.112-generic
    30aa75d58cdd: crypto: af_alg/algif_aead: fix CVE-2026-31431 splice write-to-page-cache



## PR dependencies

none

## How to test and validate this PR


## Changelog notes

None

## PR Backports

- 16.0-stable - no
- 14.5-stable - no
- 13.4-stable - no

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR


- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

