### PR TITLE
evetest: add EVE installer support

### DIFF
--- a/evetest/Dockerfile.broker
+++ b/evetest/Dockerfile.broker
@@ -46,7 +46,7 @@ FROM alpine:${ALPINE_VERSION}
 
 # Install runtime dependencies
 # hadolint ignore=DL3018
-RUN apk add --no-cache libvirt iptables ip6tables
+RUN apk add --no-cache libvirt iptables ip6tables qemu-img
 
 # Copy the built broker binary from builder
 COPY --from=builder /go/bin/evetest-broker /usr/local/bin/evetest-broker

--- a/evetest/Dockerfile.evetest
+++ b/evetest/Dockerfile.evetest
@@ -70,6 +70,7 @@ RUN apk add --no-cache iptables dnsmasq radvd swtpm
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
     qemu \
+    qemu-img \
     qemu-system-x86_64 \
     qemu-system-aarch64
 

--- a/evetest/README.md
+++ b/evetest/README.md
@@ -197,9 +197,10 @@ See `HypervisorParameter` for an example.
 ### Test Requirements and Setup
 
 `evetest.Setup(requirements...)` declares what the test needs. The framework handles
-all the behind-the-scenes work: building EVE images, creating VMs, configuring
-networks, waiting for devices to boot and onboard, and establishing tunnels for
-seamless connectivity between EVE devices, Adam controller and the test framework itself.
+all the behind-the-scenes work: building EVE images (live or installer), creating VMs,
+running the two-step installer boot when requested, configuring networks, waiting for
+devices to boot and onboard, and establishing tunnels for seamless connectivity between
+EVE devices, starting and initializing the Adam controller and the test framework itself.
 
 **RequireEdgeDevice** -- deploy an EVE device VM:
 
@@ -207,8 +208,8 @@ seamless connectivity between EVE devices, Adam controller and the test framewor
 evetest.RequireEdgeDevice{
     Name:              "dev1",          // logical name to reference the device
     MinCPUs:           4,               // default: 4
-    MinRAMInMB:        8192,            // default: 8192
-    MinDiskSizeInMB:   28576,           // default: 28576
+    MinRAMInMiB:       8192,            // default: 8 GiB
+    MinDiskSizeInMiB:  36864,           // default: 36 GiB
     WithHypervisor:    evetest.HypervisorKVM,
     WithFilesystem:    evetest.FilesystemZFS,
     WithTPM:           true,

--- a/evetest/broker/broker.go
+++ b/evetest/broker/broker.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -83,6 +84,17 @@ type device struct {
 	// Flag to indicate that device has been successfully set up and should be eventually
 	// torn down.
 	created bool
+
+	// installerImage is set only for devices that boot an EVE installer image first.
+	// When non-nil, SetupDevices runs the installer VM (which writes EVE onto the
+	// target disk), then reconfigures the device to boot from disks only.
+	// Nil for live (non-installer) devices and for the SDN device.
+	installerImage *provider.DiskImage
+
+	// disks holds the persistent disk image(s). For live devices this is the
+	// live QCOW2; for installer devices this is the blank target QCOW2 that the
+	// installer writes EVE into. Also set for the SDN device.
+	disks []provider.DiskImage
 }
 
 func newBroker(log *logrus.Logger, provider provider.DeviceProvider,
@@ -395,7 +407,7 @@ func (b *broker) BuildImage(
 
 	// Check if image already exists for this device
 	eveDevice, exists := clientSession.eveDevices[req.DeviceName]
-	if exists && (eveDevice.Qcow2ImagePath != "" || eveDevice.RawImagePath != "") {
+	if exists && len(eveDevice.Disks) > 0 {
 		err := fmt.Errorf("image for EVE device %q already exists", req.DeviceName)
 		log.Error(err)
 		return nil, err
@@ -429,8 +441,14 @@ func (b *broker) BuildImage(
 	// Build QCOW2 or RAW image
 	providerDevName := fmt.Sprintf("eve-%s-%s", clientSession.clientID, req.DeviceName)
 	imageDirPath := filepath.Join(b.imageDir, providerDevName)
-	imageSpec, err := buildEVEImage(ctx, log, imageDirPath, dockerImageName,
-		req.Config, b.proxyCACerts, req.DiskBytes, req.MakeInstaller)
+	eveImage, err := buildEVEImage(ctx, log, buildEVEImageParams{
+		imageDirPath:    imageDirPath,
+		dockerImageName: dockerImageName,
+		config:          req.Config,
+		proxyCACerts:    b.proxyCACerts,
+		diskSize:        req.DiskBytes,
+		installer:       req.MakeInstaller,
+	})
 	if err != nil {
 		err = fmt.Errorf("failed to build EVE image for device %q: %v",
 			req.DeviceName, err)
@@ -438,11 +456,19 @@ func (b *broker) BuildImage(
 		return nil, err
 	}
 
-	// Register the new device image
+	// For installer builds, prepend the installer image to disks for the first boot.
+	firstBootDisks := eveImage.disks
+	if eveImage.installerImage != nil {
+		firstBootDisks = append(
+			[]provider.DiskImage{*eveImage.installerImage}, eveImage.disks...)
+	}
+
+	// Register the new device image.
 	eveDevice = &device{
 		DeviceSpec: provider.DeviceSpec{
-			ImageSpec: imageSpec,
-			Arch:      imageArch,
+			Disks:               firstBootDisks,
+			UEFIFirmwareDirPath: eveImage.firmwareDir,
+			Arch:                imageArch,
 
 			// These fields are set by SetupDevices.
 			CPUs:              0,
@@ -451,12 +477,13 @@ func (b *broker) BuildImage(
 		},
 		deviceName:      req.DeviceName,
 		providerDevName: providerDevName,
+		installerImage:  eveImage.installerImage,
+		disks:           eveImage.disks,
 		created:         false, // device is created by SetupDevices
 	}
 	clientSession.eveDevices[req.DeviceName] = eveDevice
 
-	log.Infof("Built EVE image for device %q at %q", req.DeviceName,
-		imageSpec.ImageFilePath())
+	log.Infof("Built EVE image for device %q at %q", req.DeviceName, imageDirPath)
 	return &api.BuildImageResponse{MissingEveContainerImage: false}, nil
 }
 
@@ -688,7 +715,7 @@ func (b *broker) SetupDevices(
 
 	// Build the SDN Qcow2 image.
 	sdnImageDirPath := filepath.Join(b.imageDir, sdnProvDevName)
-	sdnImageSpec, err := buildSdnImage(ctx, log, sdnImageDirPath, sdnDockerImageName, arch)
+	sdnDisks, err := buildSdnImage(ctx, log, sdnImageDirPath, sdnDockerImageName, arch)
 	if err != nil {
 		err = fmt.Errorf("failed to build SDN image: %w", err)
 		log.Error(err)
@@ -697,8 +724,9 @@ func (b *broker) SetupDevices(
 	sdnDevice := &device{
 		deviceName:      constants.SDNDeviceName,
 		providerDevName: sdnProvDevName,
+		disks:           sdnDisks,
 		DeviceSpec: provider.DeviceSpec{
-			ImageSpec:   sdnImageSpec,
+			Disks:       sdnDisks,
 			Arch:        arch,
 			CPUs:        constants.SDNDeviceCPUCount,
 			MemoryBytes: constants.SDNDeviceMemBytes,
@@ -717,8 +745,7 @@ func (b *broker) SetupDevices(
 		// The BuildImage step should have created the QCOW2 image for this device.
 		deviceName := eveDevice.DeviceName
 		dev, exists := clientSession.eveDevices[deviceName]
-		if !exists ||
-			(dev.DeviceSpec.Qcow2ImagePath == "" && dev.DeviceSpec.RawImagePath == "") {
+		if !exists || len(dev.DeviceSpec.Disks) == 0 {
 			err = fmt.Errorf("disk image for EVE device %q not found", deviceName)
 			log.Error(err)
 			b.teardownDevices(ctx, clientSession)
@@ -779,18 +806,12 @@ func (b *broker) SetupDevices(
 				})
 		}
 
-		// Create EVE device
-		err := b.provider.SetupDevice(ctx, dev.providerDevName, dev.DeviceSpec)
-		if err != nil {
-			err = fmt.Errorf("failed to setup EVE device %q: %w",
-				deviceName, err)
-			log.Error(err)
-			b.teardownDevices(ctx, clientSession)
-			return nil, err
-		}
-		dev.created = true
-		log.Infof("EVE device %q provisioned using %s with name %q",
-			deviceName, b.providerName, dev.providerDevName)
+	}
+
+	// Provision all EVE devices in parallel (live or installer).
+	if err = b.provisionEVEDevices(ctx, log, clientSession); err != nil {
+		b.teardownDevices(ctx, clientSession)
+		return nil, err
 	}
 
 	// Add uplink interface connecting SDN with the host network.
@@ -866,6 +887,114 @@ func (b *broker) SetupDevices(
 	}, nil
 }
 
+// provisionEVEDevices provisions all EVE devices in the client session in parallel.
+// Each device is handled by provisionEVEDevice, which selects the appropriate
+// flow (live one-step or installer two-step). Called from SetupDevices while
+// b.mutex is held; goroutines only call provider methods (provider has its own
+// mutex) so there is no deadlock.
+func (b *broker) provisionEVEDevices(ctx context.Context, log *logrus.Entry,
+	clientSession *session) error {
+	errCh := make(chan error, len(clientSession.eveDevices))
+	for _, dev := range clientSession.eveDevices {
+		dev := dev
+		go func() {
+			errCh <- b.provisionEVEDevice(ctx, log, dev)
+		}()
+	}
+	var errs []string
+	for range clientSession.eveDevices {
+		if err := <-errCh; err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, ", "))
+	}
+	return nil
+}
+
+// provisionEVEDevice provisions a single EVE device. For live (non-installer) devices
+// it calls provider.SetupDevice directly. For installer devices it delegates to
+// runDeviceInstaller, which runs the full two-step installation flow.
+func (b *broker) provisionEVEDevice(ctx context.Context, log *logrus.Entry,
+	dev *device) error {
+	if dev.installerImage == nil {
+		if err := b.provider.SetupDevice(ctx, dev.providerDevName, dev.DeviceSpec); err != nil {
+			return fmt.Errorf("failed to setup EVE device %q: %w", dev.deviceName, err)
+		}
+		dev.created = true
+		log.Infof("EVE device %q provisioned using %s with name %q",
+			dev.deviceName, b.providerName, dev.providerDevName)
+		return nil
+	}
+	return b.runDeviceInstaller(ctx, log, dev)
+}
+
+// runDeviceInstaller performs the EVE installer two-step for a single device:
+//  1. Set up the device with the installer image prepended to the disk list.
+//  2. Power it on and wait for the installer to stop (installation complete).
+//  3. Reconfigure the disk list to remove the installer image.
+//
+// Reusing the same provider device across both phases preserves TPM state,
+// UEFI NVRAM, and all other device-local state without any explicit migration.
+func (b *broker) runDeviceInstaller(ctx context.Context, log *logrus.Entry,
+	dev *device) error {
+	log.Infof("Running EVE installer for device %q", dev.deviceName)
+
+	if err := b.provider.SetupDevice(ctx, dev.providerDevName, dev.DeviceSpec); err != nil {
+		return fmt.Errorf("failed to setup device %q for installation: %w",
+			dev.deviceName, err)
+	}
+	if err := b.provider.PowerOnDevice(ctx, dev.providerDevName); err != nil {
+		if err2 := b.provider.TeardownDevice(ctx, dev.providerDevName); err2 != nil {
+			log.Warnf("Failed to teardown device %q after power-on failure: %v",
+				dev.deviceName, err2)
+		}
+		return fmt.Errorf("failed to power on installer for device %q: %w",
+			dev.deviceName, err)
+	}
+	log.Infof("EVE installer running for device %q, waiting for completion...",
+		dev.deviceName)
+
+	installCtx, cancel := context.WithTimeout(ctx, constants.EVEInstallationTimeout)
+	defer cancel()
+	statusCh := b.provider.WatchDeviceStatus(installCtx, dev.providerDevName)
+	installed := false
+	for status := range statusCh {
+		if status == provider.DeviceStatusStopped {
+			installed = true
+			break
+		}
+	}
+	if !installed {
+		if err2 := b.provider.TeardownDevice(ctx, dev.providerDevName); err2 != nil {
+			log.Warnf("Failed to teardown device %q after installation timeout: %v",
+				dev.deviceName, err2)
+		}
+		return fmt.Errorf("EVE installation timed out or failed for device %q",
+			dev.deviceName)
+	}
+	log.Infof("EVE installation completed for device %q", dev.deviceName)
+
+	// Reconfigure the device to boot from the persistent disks only (no installer).
+	dev.DeviceSpec.Disks = dev.disks
+	dev.installerImage = nil
+	err := b.provider.ReconfigureDeviceDisks(ctx, dev.providerDevName, dev.DeviceSpec.Disks)
+	if err != nil {
+		if err2 := b.provider.TeardownDevice(ctx, dev.providerDevName); err2 != nil {
+			log.Warnf("Failed to teardown device %q after disk reconfiguration failure: %v",
+				dev.deviceName, err2)
+		}
+		return fmt.Errorf("failed to reconfigure disks for device %q "+
+			"after installation: %w", dev.deviceName, err)
+	}
+
+	dev.created = true
+	log.Infof("EVE device %q provisioned after installation using %s",
+		dev.deviceName, b.providerName)
+	return nil
+}
+
 // generateSDNUplinkMAC generates a unique MAC address for an SDN uplink port.
 // The first 3 bytes are the fixed prefix. The last 3 bytes are randomly generated.
 // Ensures uniqueness across all client sessions in this broker process.
@@ -934,7 +1063,7 @@ func (b *broker) teardownDevices(ctx context.Context, clientSession *session) {
 				log.Infof("EVE device %q was torn down", deviceName)
 			}
 		}
-		imageDir := filepath.Dir(dev.ImageFilePath())
+		imageDir := filepath.Join(b.imageDir, dev.providerDevName)
 		if imageDir != "" {
 			err := os.RemoveAll(imageDir)
 			if err != nil {
@@ -959,7 +1088,7 @@ func (b *broker) teardownDevices(ctx context.Context, clientSession *session) {
 				log.Infof("SDN device was torn down")
 			}
 		}
-		imageDir := filepath.Dir(clientSession.sdnDevice.ImageFilePath())
+		imageDir := filepath.Join(b.imageDir, clientSession.sdnDevice.providerDevName)
 		if imageDir != "" {
 			err := os.RemoveAll(imageDir)
 			if err != nil {

--- a/evetest/broker/image.go
+++ b/evetest/broker/image.go
@@ -8,6 +8,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -32,12 +33,12 @@ import (
 //
 // Returns an error if the build or any Docker operation fails.
 func buildSdnImage(ctx context.Context, log *logrus.Entry, imageDirPath,
-	dockerImageName string, arch api.ArchType) (imageSpec provider.ImageSpec, err error) {
+	dockerImageName string, arch api.ArchType) (disks []provider.DiskImage, err error) {
 
 	// Ensure the target directory exists.
 	if err = os.MkdirAll(imageDirPath, 0o755); err != nil {
 		err = fmt.Errorf("failed to create SDN image directory %q: %w", imageDirPath, err)
-		return imageSpec, err
+		return nil, err
 	}
 	defer func() {
 		if err != nil {
@@ -57,7 +58,7 @@ func buildSdnImage(ctx context.Context, log *logrus.Entry, imageDirPath,
 		platform = "linux/arm64"
 	default:
 		err = fmt.Errorf("unsupported architecture: %s", arch)
-		return imageSpec, err
+		return nil, err
 	}
 
 	// Construct the command to run inside the container.
@@ -69,88 +70,100 @@ func buildSdnImage(ctx context.Context, log *logrus.Entry, imageDirPath,
 	}
 
 	// Run the SDN docker container to build the SDN Qcow2 image.
-	imageSpec.Qcow2ImagePath = filepath.Join(imageDirPath, "evetest-sdn.img.qcow2")
-	log.Infof("Building SDN image into the file %q", imageSpec.ImageFilePath())
+	imagePath := filepath.Join(imageDirPath, "evetest-sdn.img.qcow2")
+	log.Infof("Building SDN image into the file %q", imagePath)
 	result, err := utils.RunDockerCommand(
 		ctx, log, dockerImageName, cmd, volumeMap, platform)
 	if err != nil {
 		err = fmt.Errorf("failed to run docker command for SDN image build: %w", err)
-		return imageSpec, err
+		return nil, err
 	}
 
 	// Check that the generated image file exists and is non-empty
-	info, statErr := os.Stat(imageSpec.ImageFilePath())
+	info, statErr := os.Stat(imagePath)
 	if statErr != nil {
 		log.Infof("Docker output:\n%s", result)
 		err = fmt.Errorf("expected SDN image file %q not found: %w",
-			imageSpec.ImageFilePath(), statErr)
-		return imageSpec, err
+			imagePath, statErr)
+		return nil, err
 	}
 	if info.Size() == 0 {
 		log.Infof("Docker output:\n%s", result)
-		err = fmt.Errorf("SDN image file %q is empty", imageSpec.ImageFilePath())
-		return imageSpec, err
+		err = fmt.Errorf("SDN image file %q is empty", imagePath)
+		return nil, err
 	}
 
 	log.Infof("Successfully built SDN image from %s for %s: %s",
-		dockerImageName, arch, imageSpec.ImageFilePath())
+		dockerImageName, arch, imagePath)
 	log.Debugf("Docker output:\n%s", result)
-	return imageSpec, nil
+	disks = []provider.DiskImage{
+		{Format: provider.DiskImageFormatQcow2, Path: imagePath},
+	}
+	return disks, nil
+}
+
+// buildEVEImageParams groups the inputs to buildEVEImage.
+type buildEVEImageParams struct {
+	// imageDirPath is the path to the output directory.
+	imageDirPath string
+	// dockerImageName is the name of the EVE Docker image to build from.
+	dockerImageName string
+	// config provides server, certificates, keys, and JSON configs. May be nil.
+	config *api.EveConfig
+	// proxyCACerts is an optional slice of PEM blocks containing trusted proxy CA
+	// certificates to include in the image.
+	proxyCACerts []*pem.Block
+	// diskSize is the desired disk size in bytes. Zero means use the image default.
+	diskSize uint64
+	// installer, when true, builds a RAW installer image instead of a live QCOW2 image.
+	installer bool
+}
+
+// buildEVEImageResult holds the outputs of buildEVEImage (excluding the error).
+type buildEVEImageResult struct {
+	// installerImage is non-nil only for installer builds. It points to the RAW
+	// installer image that is prepended to disks for the first (installer) boot,
+	// then discarded — subsequent boots use only disks.
+	installerImage *provider.DiskImage
+	// disks is the list of persistent disk images for the device. Currently always
+	// a single disk (live QCOW2 for live builds, blank target QCOW2 for installer
+	// builds), but structured as a slice to accommodate multiple disks in the future.
+	disks []provider.DiskImage
+	// firmwareDir is the path to the directory containing the extracted UEFI firmware
+	// (OVMF_CODE.fd, OVMF_VARS.fd).
+	firmwareDir string
 }
 
 // buildEVEImage builds an EVE image (QCOW2 or RAW) using EVE Docker image as the builder.
-// It optionally extracts UEFI firmware, mounts configuration files, and invokes the
-// EVE container to produce the final disk image.
-//
-// Parameters:
-//   - ctx: Context for cancellation and timeouts.
-//   - log: Logrus entry for structured logging.
-//   - imageDirPath: Path to the output directory.
-//   - dockerImageName: Name of the EVE Docker image to build from.
-//   - config: Optional EveConfig providing server, certificates, keys, and JSON configs.
-//   - proxyCACerts: Optional slice of PEM blocks containing trusted proxy CA certificates.
-//   - installer: If true, builds a RAW installer image instead of the live QCOW2 image.
-//
-// Behavior:
-//   - Ensures the target directory exists.
-//   - Extracts UEFI firmware from the Docker image unless building an installer.
-//   - Creates a temporary configuration directory with the contents of `config`.
-//   - Runs the Docker container with appropriate args and mounts to generate the EVE image.
-//   - Cleans up temporary configuration directory after execution.
-//
-// Returns an error if any step fails (directory creation, firmware extraction,
-// Docker run, etc.).
+// It extracts UEFI firmware, mounts configuration files, and invokes the EVE container
+// to produce the final disk image. For installer builds it also creates a blank target
+// disk.
 func buildEVEImage(ctx context.Context, log *logrus.Entry,
-	imageDirPath, dockerImageName string, config *api.EveConfig, proxyCACerts []*pem.Block,
-	diskSize uint64, installer bool) (imageSpec provider.ImageSpec, err error) {
+	params buildEVEImageParams) (result buildEVEImageResult, err error) {
 
 	// Ensure the target directory exists.
-	if err = os.MkdirAll(imageDirPath, 0o755); err != nil {
-		err = fmt.Errorf("failed to create EVE image directory %q: %w", imageDirPath, err)
-		return imageSpec, err
+	if err = os.MkdirAll(params.imageDirPath, 0o755); err != nil {
+		err = fmt.Errorf("failed to create EVE image directory %q: %w",
+			params.imageDirPath, err)
+		return result, err
 	}
 	defer func() {
 		if err != nil {
-			if removeErr := os.RemoveAll(imageDirPath); removeErr != nil {
+			if removeErr := os.RemoveAll(params.imageDirPath); removeErr != nil {
 				log.Warnf("Failed to remove EVE image directory %q : %v",
-					imageDirPath, removeErr)
+					params.imageDirPath, removeErr)
 			}
 		}
 	}()
 
-	if !installer {
-		imageSpec.Qcow2ImagePath = filepath.Join(imageDirPath, "live.raw.qcow2")
-		// Extract UEFI firmware for EVE.
-		imageSpec.UEFIFirmwareDirPath = filepath.Join(imageDirPath, "firmware")
-		err = utils.ExtractFromDockerImage(ctx, log,
-			dockerImageName, imageDirPath, "/bits/firmware")
-		if err != nil {
-			err = fmt.Errorf("failed to extract UEFI firmware from EVE image %s: %w",
-				dockerImageName, err)
-			return imageSpec, err
-		}
-	} else {
-		imageSpec.RawImagePath = filepath.Join(imageDirPath, "installer.raw")
+	// Extract UEFI firmware (needed for both live and post-installation boots).
+	result.firmwareDir = filepath.Join(params.imageDirPath, "firmware")
+	err = utils.ExtractFromDockerImage(ctx, log,
+		params.dockerImageName, params.imageDirPath, "/bits/firmware")
+	if err != nil {
+		err = fmt.Errorf("failed to extract UEFI firmware from EVE image %s: %w",
+			params.dockerImageName, err)
+		return result, err
 	}
 
 	// Build the volume mapping: container target → host source.
@@ -158,13 +171,14 @@ func buildEVEImage(ctx context.Context, log *logrus.Entry,
 	// runs inside a container, the path also exists on the host (it's bind-
 	// mounted at the same path) and can be passed to docker-out-of-docker.
 	var configDir string
-	configDir, err = makeEVEConfigDir(imageDirPath, config, proxyCACerts)
+	configDir, err = makeEVEConfigDir(
+		params.imageDirPath, params.config, params.proxyCACerts)
 	if err != nil {
 		err = fmt.Errorf("failed to prepare EVE config dir: %w", err)
-		return imageSpec, err
+		return result, err
 	}
 	volumeMap := map[string]string{
-		"/out": imageDirPath,
+		"/out": params.imageDirPath,
 	}
 	if configDir != "" {
 		volumeMap["/in"] = configDir
@@ -172,20 +186,26 @@ func buildEVEImage(ctx context.Context, log *logrus.Entry,
 	}
 
 	// Run the EVE docker container to build the EVE disk image.
-	cmd := "-f qcow2 live"
-	if installer {
+	// Disk size is appended for live images only; the installer image has a fixed size.
+	var builtImagePath string
+	var cmd string
+	if !params.installer {
+		builtImagePath = filepath.Join(params.imageDirPath, "live.raw.qcow2")
+		cmd = "-f qcow2 live"
+		if params.diskSize != 0 {
+			cmd += fmt.Sprintf(" %d", params.diskSize>>20)
+		}
+	} else {
+		builtImagePath = filepath.Join(params.imageDirPath, "installer.raw")
 		cmd = "-f raw installer_raw"
 	}
-	if diskSize != 0 {
-		diskSizeMB := diskSize >> 20
-		cmd += fmt.Sprintf(" %d", diskSizeMB)
-	}
-	log.Infof("Building EVE image into the file %q", imageSpec.ImageFilePath())
-	result, err := utils.RunDockerCommand(
-		ctx, log, dockerImageName, cmd, volumeMap, "")
+
+	log.Infof("Building EVE image into the file %q", builtImagePath)
+	dockerOutput, err := utils.RunDockerCommand(
+		ctx, log, params.dockerImageName, cmd, volumeMap, "")
 	if err != nil {
 		err = fmt.Errorf("failed to run docker command for EVE image build: %w", err)
-		return imageSpec, err
+		return result, err
 	}
 
 	const maxOutputLen = 256
@@ -196,28 +216,61 @@ func buildEVEImage(ctx context.Context, log *logrus.Entry,
 		return output[:maxOutputLen] + "…"
 	}
 
-	// Check that the generated image file exists and is non-empty
-	info, statErr := os.Stat(imageSpec.ImageFilePath())
-	truncatedResult := truncateOutput(result)
+	// Check that the generated image file exists and is non-empty.
+	info, statErr := os.Stat(builtImagePath)
+	truncatedOutput := truncateOutput(dockerOutput)
 
 	if statErr != nil {
 		log.Infof("Docker output (truncated to %d chars):\n%s",
-			maxOutputLen, truncatedResult)
+			maxOutputLen, truncatedOutput)
 		err = fmt.Errorf("expected EVE image file %q not found: %w",
-			imageSpec.ImageFilePath(), statErr)
-		return imageSpec, err
+			builtImagePath, statErr)
+		return result, err
 	}
 	if info.Size() == 0 {
 		log.Infof("Docker output (truncated to %d chars):\n%s",
-			maxOutputLen, truncatedResult)
-		err = fmt.Errorf("EVE image file %q is empty", imageSpec.ImageFilePath())
-		return imageSpec, err
+			maxOutputLen, truncatedOutput)
+		err = fmt.Errorf("EVE image file %q is empty", builtImagePath)
+		return result, err
 	}
 
-	log.Infof("Successfully built EVE image from %s: %s",
-		dockerImageName, imageSpec.ImageFilePath())
-	log.Debugf("Docker output:\n%s", result)
-	return imageSpec, nil
+	log.Infof("Successfully built EVE image from %s: %s", params.dockerImageName,
+		builtImagePath)
+	log.Debugf("Docker output:\n%s", dockerOutput)
+
+	if !params.installer {
+		result.disks = []provider.DiskImage{
+			{Format: provider.DiskImageFormatQcow2, Path: builtImagePath},
+		}
+		return result, nil
+	}
+
+	// For installer mode, create a blank target disk that EVE will be installed onto.
+	// The installer image is prepended to disks for the first boot only.
+	if params.diskSize == 0 {
+		err = fmt.Errorf("diskSize must be non-zero for installer builds")
+		return result, err
+	}
+	targetDiskPath := filepath.Join(params.imageDirPath, "installed.qcow2")
+	diskSizeMiB := params.diskSize >> 20
+	log.Infof("Creating blank target disk for EVE installation: %s (%d MiB)",
+		targetDiskPath, diskSizeMiB)
+	out, err2 := exec.CommandContext(ctx, "qemu-img", "create", "-f", "qcow2",
+		targetDiskPath, fmt.Sprintf("%dM", diskSizeMiB)).CombinedOutput()
+	if err2 != nil {
+		err = fmt.Errorf("failed to create installer target disk %q: %v: %s",
+			targetDiskPath, err2, out)
+		return result, err
+	}
+	log.Infof("Created blank target disk for EVE installation: %s", targetDiskPath)
+
+	installerImage := provider.DiskImage{
+		Format: provider.DiskImageFormatRaw, Path: builtImagePath}
+	result.installerImage = &installerImage
+	result.disks = []provider.DiskImage{
+		{Format: provider.DiskImageFormatQcow2, Path: targetDiskPath},
+	}
+	return result, nil
 }
 
 // makeEVEConfigDir creates a temporary directory containing EVE configuration

--- a/evetest/broker/provider/libvirt.go
+++ b/evetest/broker/provider/libvirt.go
@@ -170,40 +170,27 @@ func (p *LibvirtProvider) SetupDevice(
 		interfaces = append(interfaces, ifaceXML)
 	}
 
-	// Disk definition (local qcow2 or raw). Optionally configure UEFI firmware
-	// if UEFIFirmwareDirPath is set on the device spec.
+	// Disk definitions. Optionally configure UEFI firmware if
+	// UEFIFirmwareDirPath is set on the device spec.
 	var disks []libvirtxml.DomainDisk
 
-	// Ensure we have exactly one image specified
-	if spec.Qcow2ImagePath == "" && spec.RawImagePath == "" {
-		err := fmt.Errorf(
-			"no disk image specified: either Qcow2ImagePath or RawImagePath must be set")
+	if len(spec.Disks) == 0 {
+		err := fmt.Errorf("no disk images specified for device %q", name)
 		log.Error(err)
 		return err
 	}
-	if spec.Qcow2ImagePath != "" && spec.RawImagePath != "" {
-		err := fmt.Errorf(
-			"both Qcow2ImagePath and RawImagePath are set; only one must be defined")
-		log.Error(err)
-		return err
-	}
-
-	var imagePath, diskType string
-	if spec.Qcow2ImagePath != "" {
-		imagePath = spec.Qcow2ImagePath
-		diskType = "qcow2"
-	} else {
-		imagePath = spec.RawImagePath
-		diskType = "raw"
-	}
-	imageAbsPath, err := utils.ResolveFile(imagePath)
-	if err != nil {
-		err = fmt.Errorf("failed to resolve path %q: %w", imagePath, err)
-		log.Error(err)
-		return err
-	}
-	disks = []libvirtxml.DomainDisk{
-		{
+	for i, disk := range spec.Disks {
+		diskType := "qcow2"
+		if disk.Format == DiskImageFormatRaw {
+			diskType = "raw"
+		}
+		absPath, err := utils.ResolveFile(disk.Path)
+		if err != nil {
+			err = fmt.Errorf("failed to resolve disk path %q: %w", disk.Path, err)
+			log.Error(err)
+			return err
+		}
+		disks = append(disks, libvirtxml.DomainDisk{
 			Device: "disk",
 			Driver: &libvirtxml.DomainDiskDriver{
 				Name: "qemu",
@@ -211,14 +198,14 @@ func (p *LibvirtProvider) SetupDevice(
 			},
 			Source: &libvirtxml.DomainDiskSource{
 				File: &libvirtxml.DomainDiskSourceFile{
-					File: imageAbsPath,
+					File: absPath,
 				},
 			},
 			Target: &libvirtxml.DomainDiskTarget{
-				Dev: "vda",
+				Dev: fmt.Sprintf("vd%c", rune('a'+i)),
 				Bus: "virtio",
 			},
-		},
+		})
 	}
 
 	// Console definition
@@ -901,6 +888,96 @@ func (p *LibvirtProvider) lookupDomainByName(name string) (*libvirt.Domain, erro
 	return dom, nil
 }
 
+// ReconfigureDeviceDisks updates the disk list of a stopped domain by
+// undefining and redefining it with a new disk set. The domain UUID is
+// preserved so libvirt's swtpm state (keyed by UUID) survives the operation.
+// UEFI NVRAM is preserved by undefining without the NVRAM flag.
+// The domain must be in the stopped (shut-off) state before calling this.
+func (p *LibvirtProvider) ReconfigureDeviceDisks(
+	ctx context.Context, name string, newDisks []DiskImage) error {
+	log := logger.FromContext(ctx)
+
+	dom, err := p.lookupDomainByName(name)
+	if err != nil {
+		return fmt.Errorf("failed to lookup domain %q: %w", name, err)
+	}
+	defer dom.Free()
+
+	state, _, err := dom.GetState()
+	if err != nil {
+		return fmt.Errorf("failed to get state of domain %q: %w", name, err)
+	}
+	if state != libvirt.DOMAIN_SHUTOFF {
+		err = fmt.Errorf(
+			"domain %q must be stopped before reconfiguring disks (state: %v)",
+			name, state)
+		return err
+	}
+
+	xmlDesc, err := dom.GetXMLDesc(0)
+	if err != nil {
+		return fmt.Errorf("failed to get XML description for domain %q: %w", name, err)
+	}
+	var domain libvirtxml.Domain
+	if err := domain.Unmarshal(xmlDesc); err != nil {
+		return fmt.Errorf("failed to unmarshal domain XML for %q: %w", name, err)
+	}
+
+	// Rebuild virtio data disks; leave any non-virtio entries (e.g. CDROMs) in place.
+	var keep []libvirtxml.DomainDisk
+	for _, d := range domain.Devices.Disks {
+		if d.Target == nil || d.Target.Bus != "virtio" {
+			keep = append(keep, d)
+		}
+	}
+	for i, disk := range newDisks {
+		diskType := "qcow2"
+		if disk.Format == DiskImageFormatRaw {
+			diskType = "raw"
+		}
+		absPath, err := utils.ResolveFile(disk.Path)
+		if err != nil {
+			return fmt.Errorf("failed to resolve disk path %q: %w", disk.Path, err)
+		}
+		keep = append(keep, libvirtxml.DomainDisk{
+			Device: "disk",
+			Driver: &libvirtxml.DomainDiskDriver{
+				Name: "qemu",
+				Type: diskType,
+			},
+			Source: &libvirtxml.DomainDiskSource{
+				File: &libvirtxml.DomainDiskSourceFile{
+					File: absPath,
+				},
+			},
+			Target: &libvirtxml.DomainDiskTarget{
+				Dev: fmt.Sprintf("vd%c", rune('a'+i)),
+				Bus: "virtio",
+			},
+		})
+	}
+	domain.Devices.Disks = keep
+
+	updatedXML, err := domain.Marshal()
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated domain XML for %q: %w", name, err)
+	}
+
+	// Keep NVRAM so OVMF_VARS.fd survives the undefine/redefine cycle.
+	if err := dom.UndefineFlags(libvirt.DOMAIN_UNDEFINE_KEEP_NVRAM); err != nil {
+		return fmt.Errorf("failed to undefine domain %q: %w", name, err)
+	}
+
+	if _, err := p.conn.DomainDefineXML(updatedXML); err != nil {
+		// Best-effort rollback: restore the original definition so teardown can proceed.
+		_, _ = p.conn.DomainDefineXML(xmlDesc)
+		return fmt.Errorf("failed to redefine domain %q after disk reconfiguration: %w",
+			name, err)
+	}
+	log.Infof("Reconfigured disk list for domain %q (%d disk(s))", name, len(newDisks))
+	return nil
+}
+
 // getDeviceConsoleLogFile returns the filesystem path for storing the console log
 // for a given device name.
 func (p *LibvirtProvider) getDeviceConsoleLogFile(name string) string {
@@ -1134,12 +1211,14 @@ func (p *LibvirtProvider) domainLifecycleCallback(
 		// ignore domains we can't identify
 		return
 	}
+	// libvirt returns the full prefixed name; watchers are keyed by unprefixed name.
+	name := unprefixedName(domName)
 	status := deviceStatusFromLibvirtEvent(*event)
 
 	// Send the status update to all registered watchers for this domain
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
-	for _, ch := range p.watchers[domName] {
+	for _, ch := range p.watchers[name] {
 		select {
 		case ch <- status:
 		default:
@@ -1173,8 +1252,7 @@ func deviceStatusFromLibvirtEvent(event libvirt.DomainEventLifecycle) DeviceStat
 	switch event.Event {
 	case libvirt.DOMAIN_EVENT_STARTED:
 		return DeviceStatusRunning
-	case libvirt.DOMAIN_EVENT_STOPPED,
-		libvirt.DOMAIN_EVENT_SHUTDOWN:
+	case libvirt.DOMAIN_EVENT_STOPPED:
 		return DeviceStatusStopped
 	case libvirt.DOMAIN_EVENT_CRASHED:
 		return DeviceStatusCrashed

--- a/evetest/broker/provider/libvirt_stub.go
+++ b/evetest/broker/provider/libvirt_stub.go
@@ -101,6 +101,11 @@ func (p *LibvirtProvider) TeardownAll(_ context.Context) error {
 	panic("unreachable")
 }
 
+// ReconfigureDeviceDisks is not implemented in CGO-disabled builds.
+func (p *LibvirtProvider) ReconfigureDeviceDisks(_ context.Context, _ string, _ []DiskImage) error {
+	panic("unreachable")
+}
+
 // Close is not implemented in CGO-disabled builds.
 func (p *LibvirtProvider) Close() error {
 	panic("unreachable")

--- a/evetest/broker/provider/provider.go
+++ b/evetest/broker/provider/provider.go
@@ -34,8 +34,11 @@ type DeviceProvider interface {
 	//   - Resource allocation fails
 	SetupDevice(ctx context.Context, name string, spec DeviceSpec) error
 
-	// TeardownDevice stops the device (if running) and removes it completely,
-	// including all associated resources (disks, network interfaces, etc.).
+	// TeardownDevice stops the device (if running) and removes the device definition
+	// from the provider (e.g. undefines the libvirt domain). It also removes any
+	// provider-managed side-files such as NVRAM (OVMF_VARS.fd) and unused virtual
+	// networks. It does NOT delete the disk image files referenced in DeviceSpec.Disks;
+	// disk cleanup is the caller's responsibility.
 	TeardownDevice(ctx context.Context, name string) error
 
 	// PowerOnDevice starts a previously created device.
@@ -94,42 +97,48 @@ type DeviceProvider interface {
 	// TeardownAll removes all VMs, networks, etc., created by the provider.
 	TeardownAll(ctx context.Context) error
 
+	// ReconfigureDeviceDisks updates the disk list of a stopped device in place,
+	// without tearing it down and recreating it. All other device state (TPM,
+	// UEFI NVRAM, console port, network interfaces) is preserved.
+	//
+	// Intended for the EVE installer two-step flow: after the installer VM has
+	// finished writing EVE to disk, call this to drop the installer image from
+	// the disk list so the next PowerOnDevice boots directly into EVE.
+	//
+	// The device must be set up and powered off when this is called.
+	ReconfigureDeviceDisks(ctx context.Context, name string, newDisks []DiskImage) error
+
 	// Close releases all resources associated with the provider connection.
 	Close() error
 }
 
-// ImageSpec defines the input disk images and UEFI firmware needed to
-// provision a virtual device.
-//
-// Either Qcow2ImagePath or RawImagePath should be specified, but not both.
-// Qcow2ImagePath refers to a QCOW2 disk image, while RawImagePath refers to
-// a raw disk image. UEFIFirmwareDirPath points to a directory containing the
-// UEFI firmware binaries required to boot QCOW2-based devices.
-type ImageSpec struct {
-	// Qcow2ImagePath is the path to the base qcow2 image to use for the device.
-	Qcow2ImagePath string
+// DiskImageFormat is the on-disk format of a disk image file.
+type DiskImageFormat int32
 
-	// UEFIFirmwareDirPath specifies the path to a directory containing UEFI
-	// firmware binaries (e.g., OVMF_CODE.fd, OVMF_VARS.fd) used by the provider
-	// to boot a QCOW2-based machine.
-	UEFIFirmwareDirPath string
+const (
+	// DiskImageFormatQcow2 is the QCOW2 disk image format.
+	DiskImageFormatQcow2 DiskImageFormat = iota
+	// DiskImageFormatRaw is the raw disk image format.
+	DiskImageFormatRaw
+)
 
-	// RawImagePath specifies the path to a RAW disk image.
-	// Either this or Qcow2ImagePath should be defined, but not both.
-	RawImagePath string
-}
-
-// ImageFilePath returns the actual disk image path for the device.
-func (spec ImageSpec) ImageFilePath() string {
-	if spec.Qcow2ImagePath != "" {
-		return spec.Qcow2ImagePath
-	}
-	return spec.RawImagePath
+// DiskImage describes a single disk to attach to a device.
+type DiskImage struct {
+	// Format is the on-disk format of the image file.
+	Format DiskImageFormat
+	// Path is the filesystem path to the image file.
+	// The file must already exist when SetupDevice is called.
+	Path string
 }
 
 // DeviceSpec defines the configuration for a compute device.
 type DeviceSpec struct {
-	ImageSpec
+	// Disks is an ordered list of disk images to attach to the device, in boot order.
+	Disks []DiskImage
+
+	// UEFIFirmwareDirPath is the path to a directory containing UEFI firmware
+	// binaries (OVMF_CODE.fd, OVMF_VARS.fd). Leave empty to omit UEFI.
+	UEFIFirmwareDirPath string
 
 	// CPU architecture.
 	Arch api.ArchType
@@ -149,9 +158,6 @@ type DeviceSpec struct {
 
 	// NetworkInterfaces defines the network configuration for the device.
 	NetworkInterfaces []NetworkInterfaceSpec
-
-	// Future considerations:
-	// - AdditionalDisks []DiskSpec // For multiple disks
 }
 
 // NetworkInterfaceSpec defines a single network interface for a device.
@@ -214,7 +220,7 @@ const (
 	TransportProtocolUDP TransportProtocol = "udp"
 )
 
-// DeviceStatus represents the current state of a device.
+// DeviceStatus represents the current power/lifecycle state of a device.
 type DeviceStatus string
 
 const (

--- a/evetest/broker/provider/qemu.go
+++ b/evetest/broker/provider/qemu.go
@@ -444,87 +444,14 @@ func (p *QemuProvider) SetupDevice(
 		log.Warnf("Failed to enable LACP forwarding: %v", err)
 	}
 
-	// Build arguments for the Qemu process.
-	dev.args = []string{
-		"-enable-kvm",
-		"-machine", "q35",
-		"-cpu", "host",
-		"-smp", fmt.Sprintf("%d", dev.spec.CPUs),
-		"-m", fmt.Sprintf("%d", dev.spec.MemoryBytes>>20),
-		"-nographic",
-	}
-
-	// -> SMBIOS (system serial number)
-	if spec.SerialNumber != "" {
-		dev.args = append(dev.args,
-			"-smbios", fmt.Sprintf("type=1,serial=%s", spec.SerialNumber),
-		)
-	}
-
-	if spec.WithTPM {
-		tpmDev := "tpm-tis"
-		if qemuArch() == "arm64" {
-			tpmDev = "tpm-tis-device"
-		}
-		dev.args = append(dev.args,
-			"-chardev", fmt.Sprintf("socket,id=chrtpm,path=%s", dev.tpm.socket),
-			"-tpmdev", "emulator,id=tpm0,chardev=chrtpm",
-			"-device", fmt.Sprintf("%s,tpmdev=tpm0", tpmDev),
-		)
-	}
-
-	// -> disks (virtio)
-	if dev.spec.Qcow2ImagePath != "" {
-		dev.args = append(dev.args,
-			"-drive", fmt.Sprintf("file=%s,if=virtio,format=qcow2",
-				dev.spec.Qcow2ImagePath))
-	} else {
-		dev.args = append(dev.args,
-			"-drive", fmt.Sprintf("file=%s,if=virtio,format=raw",
-				dev.spec.RawImagePath))
-	}
-
-	// -> UEFI (pflash)
-	if dev.spec.UEFIFirmwareDirPath != "" {
-		code := filepath.Join(dev.spec.UEFIFirmwareDirPath, "OVMF_CODE.fd")
-		vars := filepath.Join(dev.spec.UEFIFirmwareDirPath, "OVMF_VARS.fd")
-		dev.args = append(dev.args,
-			"-drive", fmt.Sprintf("if=pflash,format=raw,readonly=on,file=%s", code),
-			"-drive", fmt.Sprintf("if=pflash,format=raw,file=%s", vars),
-		)
-	}
-
-	// -> networking (virtio-net-pci)
-	for i, tap := range dev.taps {
-		dev.args = append(dev.args,
-			"-netdev", fmt.Sprintf(
-				"tap,id=net%d,ifname=%s,script=no,downscript=no", i, tap.name),
-			"-device", fmt.Sprintf(
-				"virtio-net-pci,netdev=net%d,mac=%s,speed=1000,duplex=full",
-				i, tap.guestMAC.String()),
-		)
-	}
-
-	// Console: TCP telnet socket + output file
+	// Allocate the console port now so buildArgs can embed it.
 	consolePort, err := utils.FindUnusedPort(ipv4Loopback)
 	if err != nil {
 		log.Error(err)
 		return err
 	}
 	dev.consolePort = consolePort
-
-	dev.args = append(dev.args,
-		"-chardev", fmt.Sprintf(
-			"socket,id=char0,host=127.0.0.1,port=%d,server=on,wait=off,telnet=on,"+
-				"logfile=%s,logappend=on", consolePort, dev.consoleLog,
-		),
-		"-serial", "chardev:char0",
-	)
-
-	// -> QMP used for shutdown/reboot/status
-	dev.args = append(dev.args,
-		"-qmp", "unix:"+dev.qmpSocket+",server,nowait",
-	)
+	dev.args = dev.buildArgs()
 	log.Debugf("Device %q arguments: %s", name, dev.args)
 
 	p.devices[name] = dev
@@ -1046,17 +973,19 @@ func (p *QemuProvider) WatchDeviceStatus(
 
 	go func() {
 		defer func() {
-			// Remove watcher from the list when context is canceled
+			// Remove this watcher from the list and close the channel.
+			// If teardownStoppedDevice already closed and removed it, skip the close
+			// to avoid a double-close panic.
 			p.mutex.Lock()
 			defer p.mutex.Unlock()
 			wlist := p.watchers[name]
 			for i, c := range wlist {
 				if c == ch {
 					p.watchers[name] = append(wlist[:i], wlist[i+1:]...)
+					close(ch)
 					break
 				}
 			}
-			close(ch)
 		}()
 
 		// Send initial status
@@ -1108,6 +1037,30 @@ func (p *QemuProvider) TeardownAll(ctx context.Context) error {
 
 	// Garbage-collect unused networks
 	p.teardownUnusedNetworks(ctx, log)
+	return nil
+}
+
+// ReconfigureDeviceDisks swaps the disk list of a stopped device in place.
+// The swtpm state, UEFI NVRAM, console socket, and network taps are all
+// preserved because the same qemuDevice entry is reused.
+func (p *QemuProvider) ReconfigureDeviceDisks(
+	ctx context.Context, name string, newDisks []DiskImage) error {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	log := logger.FromContext(ctx)
+
+	dev, ok := p.devices[name]
+	if !ok {
+		return fmt.Errorf("device %q not found", name)
+	}
+	if dev.cmd != nil {
+		return fmt.Errorf("device %q is running; stop it before reconfiguring disks",
+			name)
+	}
+
+	dev.spec.Disks = newDisks
+	dev.args = dev.buildArgs()
+	log.Infof("Reconfigured disk list for device %q (%d disk(s))", name, len(newDisks))
 	return nil
 }
 
@@ -1394,6 +1347,11 @@ func (p *QemuProvider) teardownStoppedDevice(log *logrus.Entry, dev *qemuDevice)
 	dev.taps = nil
 
 	_ = os.RemoveAll(dev.tmpDir)
+	// Close all watcher channels so callers blocked on WatchDeviceStatus unblock.
+	for _, ch := range p.watchers[dev.name] {
+		close(ch)
+	}
+	delete(p.watchers, dev.name)
 	delete(p.devices, dev.name)
 	log.Infof("Device %q was torn-down", dev.name)
 	return nil
@@ -1529,6 +1487,78 @@ func qemuArch() string {
 	default:
 		return runtime.GOARCH
 	}
+}
+
+// buildArgs assembles the full QEMU command-line argument list from the
+// current device spec. It must be called after dev.consolePort is set.
+func (dev *qemuDevice) buildArgs() []string {
+	args := []string{
+		"-enable-kvm",
+		"-machine", "q35",
+		"-cpu", "host",
+		"-smp", fmt.Sprintf("%d", dev.spec.CPUs),
+		"-m", fmt.Sprintf("%d", dev.spec.MemoryBytes>>20),
+		"-nographic",
+	}
+
+	if dev.spec.SerialNumber != "" {
+		args = append(args,
+			"-smbios", fmt.Sprintf("type=1,serial=%s", dev.spec.SerialNumber),
+		)
+	}
+
+	if dev.spec.WithTPM {
+		tpmDev := "tpm-tis"
+		if qemuArch() == "arm64" {
+			tpmDev = "tpm-tis-device"
+		}
+		args = append(args,
+			"-chardev", fmt.Sprintf("socket,id=chrtpm,path=%s", dev.tpm.socket),
+			"-tpmdev", "emulator,id=tpm0,chardev=chrtpm",
+			"-device", fmt.Sprintf("%s,tpmdev=tpm0", tpmDev),
+		)
+	}
+
+	for _, disk := range dev.spec.Disks {
+		format := "qcow2"
+		if disk.Format == DiskImageFormatRaw {
+			format = "raw"
+		}
+		args = append(args, "-drive",
+			fmt.Sprintf("file=%s,if=virtio,format=%s", disk.Path, format))
+	}
+
+	if dev.spec.UEFIFirmwareDirPath != "" {
+		code := filepath.Join(dev.spec.UEFIFirmwareDirPath, "OVMF_CODE.fd")
+		vars := filepath.Join(dev.spec.UEFIFirmwareDirPath, "OVMF_VARS.fd")
+		args = append(args,
+			"-drive", fmt.Sprintf("if=pflash,format=raw,readonly=on,file=%s", code),
+			"-drive", fmt.Sprintf("if=pflash,format=raw,file=%s", vars),
+		)
+	}
+
+	for i, tap := range dev.taps {
+		args = append(args,
+			"-netdev", fmt.Sprintf(
+				"tap,id=net%d,ifname=%s,script=no,downscript=no", i, tap.name),
+			"-device", fmt.Sprintf(
+				"virtio-net-pci,netdev=net%d,mac=%s,speed=1000,duplex=full",
+				i, tap.guestMAC.String()),
+		)
+	}
+
+	args = append(args,
+		"-chardev", fmt.Sprintf(
+			"socket,id=char0,host=127.0.0.1,port=%d,server=on,wait=off,telnet=on,"+
+				"logfile=%s,logappend=on", dev.consolePort, dev.consoleLog,
+		),
+		"-serial", "chardev:char0",
+	)
+
+	args = append(args,
+		"-qmp", "unix:"+dev.qmpSocket+",server,nowait",
+	)
+	return args
 }
 
 func (p *QemuProvider) deviceArtifactDir(name string) string {

--- a/evetest/constants/eve.go
+++ b/evetest/constants/eve.go
@@ -3,13 +3,21 @@
 
 package constants
 
+import "time"
+
 const (
 	// DefaultEVEDeviceCPUs is the default number of virtual CPUs for an EVE device VM.
 	DefaultEVEDeviceCPUs = 4
-	// DefaultEVEDeviceRAMInMB is the default amount of RAM in megabytes for an EVE device VM.
-	DefaultEVEDeviceRAMInMB = 8192
-	// DefaultEVEDeviceDiskSizeInMB is the default disk size in megabytes for an EVE device VM.
-	DefaultEVEDeviceDiskSizeInMB = 28576
+	// DefaultEVEDeviceRAMInMiB is the default amount of RAM (in MiB) for an EVE device VM.
+	DefaultEVEDeviceRAMInMiB = 8192
+	// DefaultEVEDeviceDiskSizeInMiB is the default disk size (in MiB) for an EVE device VM.
+	// 36 GiB ensures /persist has enough free space above EVE's 4096 MiB cleanup threshold
+	// regardless of image type (live or installer) and HV type (including eve-k system pods).
+	DefaultEVEDeviceDiskSizeInMiB = 36864
+	// EVEInstallationTimeout is the maximum time allowed for the EVE installer to complete.
+	// Used by both the broker (to bound the installer wait) and the harness (to extend
+	// the SetupDevices RPC deadline when installation is requested).
+	EVEInstallationTimeout = 10 * time.Minute
 )
 
 const (

--- a/evetest/devconfig.go
+++ b/evetest/devconfig.go
@@ -25,14 +25,14 @@ import (
 
 const (
 	_ = iota
-	// KB is the number of bytes in a kilobyte.
-	KB uint64 = 1 << (10 * iota)
-	// MB is the number of bytes in a megabyte.
-	MB
-	// GB is the number of bytes in a gigabyte.
-	GB
-	// TB is the number of bytes in a terabyte.
-	TB
+	// KiB is the number of bytes in a kibibyte.
+	KiB uint64 = 1 << (10 * iota)
+	// MiB is the number of bytes in a mebibyte.
+	MiB
+	// GiB is the number of bytes in a gibibyte.
+	GiB
+	// TiB is the number of bytes in a tebibyte.
+	TiB
 )
 
 // NilUUID is special form of UUID that is specified to have all
@@ -839,7 +839,7 @@ func (config ApplicationInstanceConfig) toProto(th *TestHarness, devName string,
 		EnforceNetworkInterfaceOrder: config.EnforceNetIntfOrder,
 	}
 	if config.MemoryBytes != 0 {
-		vmConfig.Memory = uint32(config.MemoryBytes / KB)
+		vmConfig.Memory = uint32(config.MemoryBytes / KiB)
 	}
 	appInstConfig := &eveconfig.AppInstanceConfig{
 		Uuidandversion: &eveconfig.UUIDandVersion{

--- a/evetest/grpcserver.go
+++ b/evetest/grpcserver.go
@@ -795,7 +795,9 @@ func (th *TestHarness) ConnectConsoleToEVE(
 	th.devicesM.Unlock()
 	defer func() {
 		th.devicesM.Lock()
-		th.devices[devName].consoleInUse = false
+		if th.devices[devName] != nil {
+			th.devices[devName].consoleInUse = false
+		}
 		th.devicesM.Unlock()
 	}()
 

--- a/evetest/requirements.go
+++ b/evetest/requirements.go
@@ -151,9 +151,9 @@ type RequireEdgeDevice struct {
 
 	// Zero values mean that the test does not care about the particular resource size.
 	// None of these will be ever created with zero count - not even ethernet interfaces.
-	MinCPUs         uint8  // Default will be 4.
-	MinRAMInMB      uint32 // Default will be 8192 MB.
-	MinDiskSizeInMB uint32 // Default will be 28576 MB.
+	MinCPUs          uint8  // Default will be 4.
+	MinRAMInMiB      uint32 // Default will be 8 GiB (8192 MiB).
+	MinDiskSizeInMiB uint32 // Default will be 36 GiB (36864 MiB).
 
 	WithEVEVersion string
 	WithHypervisor Hypervisor

--- a/evetest/setup.go
+++ b/evetest/setup.go
@@ -124,9 +124,9 @@ func (th *TestHarness) prepareImageForEVEDevice(dev *deviceState) {
 		th.t.Fatalf("Invalid EVE image reference %v: %v", dev.imageRef, err)
 	}
 
-	diskSizeInMB := dev.requirement.MinDiskSizeInMB
-	if diskSizeInMB == 0 {
-		diskSizeInMB = constants.DefaultEVEDeviceDiskSizeInMB
+	diskSizeInMiB := dev.requirement.MinDiskSizeInMiB
+	if diskSizeInMiB == 0 {
+		diskSizeInMiB = constants.DefaultEVEDeviceDiskSizeInMiB
 	}
 
 	onboardKeyPEM, err := utils.ECDSAPrivateKeyToPEM(dev.onboardKey)
@@ -223,7 +223,7 @@ func (th *TestHarness) prepareImageForEVEDevice(dev *deviceState) {
 		DeviceName:    dev.name,
 		Image:         dev.imageRef,
 		MakeInstaller: dev.requirement.DeviceReusePolicy == CreateFromScratchWithInstaller,
-		DiskBytes:     uint64(diskSizeInMB) << 20,
+		DiskBytes:     uint64(diskSizeInMiB) << 20,
 		Config: &api.EveConfig{
 			ServerName:        fmt.Sprintf("%s:%d", GetControllerHostname(), GetControllerPort()),
 			SoftSerial:        dev.requirement.WithSoftSerial,
@@ -403,9 +403,9 @@ func (th *TestHarness) setupEVEDevices(
 		if cpus == 0 {
 			cpus = constants.DefaultEVEDeviceCPUs
 		}
-		memSizeInMB := dev.requirement.MinRAMInMB
-		if memSizeInMB == 0 {
-			memSizeInMB = constants.DefaultEVEDeviceRAMInMB
+		memSizeInMiB := dev.requirement.MinRAMInMiB
+		if memSizeInMiB == 0 {
+			memSizeInMiB = constants.DefaultEVEDeviceRAMInMiB
 		}
 		var interfaces []*api.EVEInterface
 		for i, port := range netModel.Ports {
@@ -420,7 +420,7 @@ func (th *TestHarness) setupEVEDevices(
 		dev.spec = &api.EVEDevice{
 			DeviceName:   dev.requirement.Name,
 			Cpus:         uint32(cpus),
-			MemoryBytes:  uint64(memSizeInMB) << 20,
+			MemoryBytes:  uint64(memSizeInMiB) << 20,
 			SerialNumber: dev.serial,
 			WithTpm:      dev.requirement.WithTPM,
 			Image:        dev.imageRef,
@@ -429,7 +429,14 @@ func (th *TestHarness) setupEVEDevices(
 		setupReq.Devices = append(setupReq.Devices, dev.spec)
 	}
 
-	ctx, cancel := context.WithTimeout(th.ctx, brokerSetupDevicesTimeout)
+	setupTimeout := brokerSetupDevicesTimeout
+	for _, dev := range devices {
+		if dev.requirement.DeviceReusePolicy == CreateFromScratchWithInstaller {
+			setupTimeout += constants.EVEInstallationTimeout
+			break
+		}
+	}
+	ctx, cancel := context.WithTimeout(th.ctx, setupTimeout)
 	th.log.Debugf("Submitting request to setup devices: %s", setupReq)
 	setupResp, err := th.brokerClient.SetupDevices(ctx, setupReq)
 	cancel()
@@ -990,8 +997,8 @@ func (th *TestHarness) maybeReuseDevices(
 		// Cannot reuse device if requirements changed.
 		prevReq := dev.requirement
 		equalReqs := newReq.MinCPUs == prevReq.MinCPUs &&
-			newReq.MinRAMInMB == prevReq.MinRAMInMB &&
-			newReq.MinDiskSizeInMB == prevReq.MinDiskSizeInMB &&
+			newReq.MinRAMInMiB == prevReq.MinRAMInMiB &&
+			newReq.MinDiskSizeInMiB == prevReq.MinDiskSizeInMiB &&
 			newReq.WithEVEVersion == prevReq.WithEVEVersion &&
 			newReq.WithHypervisor == prevReq.WithHypervisor &&
 			newReq.WithFilesystem == prevReq.WithFilesystem &&

--- a/evetest/tests/cluster/cluster_test.go
+++ b/evetest/tests/cluster/cluster_test.go
@@ -25,10 +25,6 @@ func clusterDeviceRequirements(devName string, withTPM bool) evetest.RequireEdge
 		Name:           devName,
 		WithTPM:        withTPM,
 		WithHypervisor: evetest.HypervisorKubevirt,
-		// The eve-kvm default (28576 MB) is too small for eve-k: system pods
-		// (k3s, KubeVirt, CDI, Longhorn) collectively fill the disk enough to
-		// trigger the "DiskPressure" node condition and cause pod evictions.
-		MinDiskSizeInMB: 36864,
 		// We want to test cluster creation.
 		DeviceReusePolicy: evetest.CreateFromScratchWithLiveImage,
 		WithFilesystem:    evetest.FilesystemZFS,
@@ -56,8 +52,7 @@ func clusterDeviceRequirements(devName string, withTPM bool) evetest.RequireEdge
 // --------------------
 //   - clusterDeviceRequirements (top of this file): WithHypervisor=Kubevirt,
 //     DeviceReusePolicy=CreateFromScratchWithLiveImage (we want to test
-//     fresh cluster formation), MinRAMInMB=8192, MinCPUs=4,
-//     MinDiskSizeInMB=24576, WithFilesystem=ZFS, plus grub options that
+//     fresh cluster formation), WithFilesystem=ZFS, plus grub options that
 //     cap dom0/eve/ctrd vcpus so cluster formation onboarding is fast.
 //   - SystemAdapter on eth0 (DHCP, mgmt+app, NetworkType=V4Only).
 //   - One Local NI "local-ni" (10.11.12.0/24, EnableFlowlog=true) and one
@@ -184,7 +179,7 @@ func TestSingleNodeCluster(test *testing.T) {
 			Tag:       "1.0",
 		},
 		CPUs:        1,
-		MemoryBytes: 500 * evetest.MB,
+		MemoryBytes: 500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",
@@ -395,7 +390,7 @@ func TestThreeNodesCluster(test *testing.T) {
 				Tag:       "1.0",
 			},
 			CPUs:        1,
-			MemoryBytes: 500 * evetest.MB,
+			MemoryBytes: 500 * evetest.MiB,
 			NetworkAdapters: []evetest.AppNetworkAdapter{
 				evetest.VirtualNetworkAdapter{
 					LogicalLabel:        "vif0",

--- a/evetest/tests/lps/network_test.go
+++ b/evetest/tests/lps/network_test.go
@@ -182,7 +182,7 @@ func TestNetworkLocalChanges(test *testing.T) {
 			Tag:       "1.0",
 		},
 		CPUs:        1,
-		MemoryBytes: 512 * evetest.MB,
+		MemoryBytes: 512 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",

--- a/evetest/tests/networking/acls_test.go
+++ b/evetest/tests/networking/acls_test.go
@@ -169,7 +169,7 @@ func TestLocalNetInstanceACLs(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",
@@ -204,7 +204,7 @@ func TestLocalNetInstanceACLs(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",
@@ -374,7 +374,7 @@ func TestLocalNetInstanceACLs(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",
@@ -578,7 +578,7 @@ func TestSwitchNetInstanceACLs(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",
@@ -606,7 +606,7 @@ func TestSwitchNetInstanceACLs(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",
@@ -751,7 +751,7 @@ func TestSwitchNetInstanceACLs(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",

--- a/evetest/tests/networking/bootstrap_test.go
+++ b/evetest/tests/networking/bootstrap_test.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	lastResortParamKey = "LAST_RESORT_ENABLED"
+	lastResortParamKey   = "LAST_RESORT_ENABLED"
+	useInstallerParamKey = "USE_INSTALLER"
 )
 
 var (
@@ -35,9 +36,23 @@ var (
 			Default: "false",
 		},
 	}
+
+	useInstallerParam = evetest.TestParameterDefinition{
+		Key:          useInstallerParamKey,
+		DefaultValue: false,
+		Description: evetest.TestParameterDescription{
+			Summary: "Use EVE installer instead of live image",
+			Default: "false",
+		},
+	}
 )
 
-func deviceRequirementsForBootstrap(devName string) evetest.RequireEdgeDevice {
+func deviceRequirementsForBootstrap(
+	devName string, useInstaller bool) evetest.RequireEdgeDevice {
+	reusePolicy := evetest.CreateFromScratchWithLiveImage
+	if useInstaller {
+		reusePolicy = evetest.CreateFromScratchWithInstaller
+	}
 	return evetest.RequireEdgeDevice{
 		Name:           devName,
 		WithHypervisor: evetest.HypervisorKVM,
@@ -49,7 +64,7 @@ func deviceRequirementsForBootstrap(devName string) evetest.RequireEdgeDevice {
 			"set_global hv_eve_cpu_settings \"eve_max_vcpus=3\"",
 			"set_global hv_ctrd_cpu_settings \"ctrd_max_vcpus=3\""},
 		// We start from scratch to test device connectivity bootstrapping.
-		DeviceReusePolicy: evetest.CreateFromScratchWithLiveImage,
+		DeviceReusePolicy: reusePolicy,
 	}
 }
 
@@ -112,14 +127,16 @@ func TestBootstrapWithLastResort(test *testing.T) {
 	// Define configurable parameters available for the test.
 	evetest.DefineTestParameters(
 		lastResortParam,
+		useInstallerParam,
 	)
 
 	// Get parameter values set for this test execution.
 	lastResortExplicitlyEnabled := evetest.GetTestParameter[bool](lastResortParamKey)
+	useInstaller := evetest.GetTestParameter[bool](useInstallerParamKey)
 
 	// Set up the test harness and specify the test prerequisites.
 	devName := "edge-dev"
-	requiredDevice := deviceRequirementsForBootstrap(devName)
+	requiredDevice := deviceRequirementsForBootstrap(devName, useInstaller)
 	requiredNetModel := evetest.RequireNetworkModel{
 		NetworkModel: netmodels.SingleEthWithDHCP,
 	}
@@ -242,10 +259,12 @@ func TestBootstrapWithStaticIP(test *testing.T) {
 	// Define configurable parameters available for the test.
 	evetest.DefineTestParameters(
 		useOverrideJSONParam,
+		useInstallerParam,
 	)
 
 	// Get parameter values set for this test execution.
 	useOverrideJSON := evetest.GetTestParameter[bool](useOverrideJSONParamKey)
+	useInstaller := evetest.GetTestParameter[bool](useInstallerParamKey)
 
 	// Build bootstrap configuration.
 	devName := "edge-dev"
@@ -270,7 +289,7 @@ func TestBootstrapWithStaticIP(test *testing.T) {
 		})
 
 	// Set up the test harness and specify test prerequisites.
-	requiredDevice := deviceRequirementsForBootstrap(devName)
+	requiredDevice := deviceRequirementsForBootstrap(devName, useInstaller)
 	if useOverrideJSON {
 		requiredDevice.WithInjectedNetworkOverride = &pillartypes.DevicePortConfig{
 			Version:      1,
@@ -449,11 +468,13 @@ func TestBootstrapWithProxy(test *testing.T) {
 	// Define configurable parameters available for the test.
 	evetest.DefineTestParameters(
 		useOverrideJSONParam,
+		useInstallerParam,
 		proxyConfigTypeParam,
 	)
 
 	// Get parameter values set for this test execution.
 	useOverrideJSON := evetest.GetTestParameter[bool](useOverrideJSONParamKey)
+	useInstaller := evetest.GetTestParameter[bool](useInstallerParamKey)
 	proxyConfigType := evetest.GetTestParameter[ProxyConfigType](proxyConfigTypeParamKey)
 
 	// Build bootstrap configuration.
@@ -504,7 +525,7 @@ func TestBootstrapWithProxy(test *testing.T) {
 		})
 
 	// Set up the test harness and specify test prerequisites.
-	requiredDevice := deviceRequirementsForBootstrap(devName)
+	requiredDevice := deviceRequirementsForBootstrap(devName, useInstaller)
 	if useOverrideJSON {
 		var proxyConfig pillartypes.ProxyConfig
 		switch proxyConfigType {
@@ -659,10 +680,12 @@ func TestBootstrapWithMgmtVLAN(test *testing.T) {
 	// Define configurable parameters available for the test.
 	evetest.DefineTestParameters(
 		useOverrideJSONParam,
+		useInstallerParam,
 	)
 
 	// Get parameter values set for this test execution.
 	useOverrideJSON := evetest.GetTestParameter[bool](useOverrideJSONParamKey)
+	useInstaller := evetest.GetTestParameter[bool](useInstallerParamKey)
 
 	// Build bootstrap configuration.
 	devName := "edge-dev"
@@ -688,7 +711,7 @@ func TestBootstrapWithMgmtVLAN(test *testing.T) {
 		})
 
 	// Set up the test harness and specify test prerequisites.
-	requiredDevice := deviceRequirementsForBootstrap(devName)
+	requiredDevice := deviceRequirementsForBootstrap(devName, useInstaller)
 	if useOverrideJSON {
 		requiredDevice.WithInjectedNetworkOverride = &pillartypes.DevicePortConfig{
 			Version:      1,
@@ -803,10 +826,12 @@ func TestBootstrapWithLACPBond(test *testing.T) {
 	// Define configurable parameters available for the test.
 	evetest.DefineTestParameters(
 		useOverrideJSONParam,
+		useInstallerParam,
 	)
 
 	// Get parameter values set for this test execution.
 	useOverrideJSON := evetest.GetTestParameter[bool](useOverrideJSONParamKey)
+	useInstaller := evetest.GetTestParameter[bool](useInstallerParamKey)
 
 	// Build bootstrap configuration with an LACP bond.
 	// With bootstrap config, EVE creates the bond at boot time, before
@@ -848,7 +873,7 @@ func TestBootstrapWithLACPBond(test *testing.T) {
 		})
 
 	// Set up the test harness and specify test prerequisites.
-	requiredDevice := deviceRequirementsForBootstrap(devName)
+	requiredDevice := deviceRequirementsForBootstrap(devName, useInstaller)
 	if useOverrideJSON {
 		requiredDevice.WithInjectedNetworkOverride = &pillartypes.DevicePortConfig{
 			Version:      1,

--- a/evetest/tests/networking/dns_test.go
+++ b/evetest/tests/networking/dns_test.go
@@ -347,7 +347,7 @@ func TestDNSFunctionality(test *testing.T) {
 			Tag:       "1.0",
 		},
 		CPUs:        1,
-		MemoryBytes: 500 * evetest.MB,
+		MemoryBytes: 500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",

--- a/evetest/tests/networking/failover_test.go
+++ b/evetest/tests/networking/failover_test.go
@@ -180,7 +180,7 @@ func TestPortFailover(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",

--- a/evetest/tests/networking/ipv6_test.go
+++ b/evetest/tests/networking/ipv6_test.go
@@ -293,7 +293,7 @@ func TestApplicationIPv6Connectivity(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",

--- a/evetest/tests/networking/netinst_test.go
+++ b/evetest/tests/networking/netinst_test.go
@@ -274,7 +274,7 @@ func TestLocalNI(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM, // PV does not work in xen, shim VM fails to start
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",
@@ -658,7 +658,7 @@ func TestSwitchNI(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM, // PV does not work in xen, shim VM fails to start
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",

--- a/evetest/tests/networking/routing_test.go
+++ b/evetest/tests/networking/routing_test.go
@@ -245,7 +245,7 @@ func TestPropagatedRoutes(test *testing.T) {
 		},
 		VirtualizationMode:  eveconfig.VmMode_HVM,
 		CPUs:                1,
-		MemoryBytes:         500 * evetest.MB,
+		MemoryBytes:         500 * evetest.MiB,
 		EnforceNetIntfOrder: true,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
@@ -620,7 +620,7 @@ func TestLocalNIWithMultiplePorts(test *testing.T) {
 		},
 		VirtualizationMode:  eveconfig.VmMode_HVM,
 		CPUs:                1,
-		MemoryBytes:         500 * evetest.MB,
+		MemoryBytes:         500 * evetest.MiB,
 		EnforceNetIntfOrder: true,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
@@ -1072,7 +1072,7 @@ func TestApplicationGateway(test *testing.T) {
 		Image:               appImage,
 		VirtualizationMode:  eveconfig.VmMode_HVM,
 		CPUs:                1,
-		MemoryBytes:         500 * evetest.MB,
+		MemoryBytes:         500 * evetest.MiB,
 		EnforceNetIntfOrder: true,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
@@ -1107,7 +1107,7 @@ func TestApplicationGateway(test *testing.T) {
 		Image:               appImage,
 		VirtualizationMode:  eveconfig.VmMode_HVM,
 		CPUs:                1,
-		MemoryBytes:         500 * evetest.MB,
+		MemoryBytes:         500 * evetest.MiB,
 		EnforceNetIntfOrder: true,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
@@ -1143,7 +1143,7 @@ func TestApplicationGateway(test *testing.T) {
 		Image:               appImage,
 		VirtualizationMode:  eveconfig.VmMode_HVM,
 		CPUs:                1,
-		MemoryBytes:         500 * evetest.MB,
+		MemoryBytes:         500 * evetest.MiB,
 		EnforceNetIntfOrder: true,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{

--- a/evetest/tests/networking/stp_test.go
+++ b/evetest/tests/networking/stp_test.go
@@ -213,7 +213,7 @@ func TestSwitchNIWithMultiplePorts(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM, // PV does not work in xen
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",

--- a/evetest/tests/networking/testsuite_test.go
+++ b/evetest/tests/networking/testsuite_test.go
@@ -59,6 +59,14 @@ func TestBootstrapSuite(test *testing.T) {
 						{Key: lastResortParamKey, Value: true},
 					},
 				},
+				// Add at least one bootstrap test exercising EVE installation.
+				{
+					Name: "TestBootstrapWithInstaller",
+					Parameters: []evetest.TestParameterValue{
+						{Key: lastResortParamKey, Value: false},
+						{Key: useInstallerParamKey, Value: true},
+					},
+				},
 			},
 		},
 		evetest.TestCase{

--- a/evetest/tests/networking/vlans_test.go
+++ b/evetest/tests/networking/vlans_test.go
@@ -207,7 +207,7 @@ func TestAccessVLANs(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters:    []evetest.AppNetworkAdapter{app1Vif},
 	}
 	app1UUID := devConfig.AddApplication(app1Config)
@@ -232,7 +232,7 @@ func TestAccessVLANs(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters:    []evetest.AppNetworkAdapter{app2Vif},
 	}
 	app2UUID := devConfig.AddApplication(app2Config)
@@ -733,7 +733,7 @@ func TestVLANSubinterfaces(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",
@@ -765,7 +765,7 @@ func TestVLANSubinterfaces(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",
@@ -1145,7 +1145,7 @@ func TestVLANSubinterfacesOnTopOfLAGs(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",
@@ -1178,7 +1178,7 @@ func TestVLANSubinterfacesOnTopOfLAGs(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",
@@ -1206,7 +1206,7 @@ func TestVLANSubinterfacesOnTopOfLAGs(test *testing.T) {
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
 		CPUs:               1,
-		MemoryBytes:        500 * evetest.MB,
+		MemoryBytes:        500 * evetest.MiB,
 		NetworkAdapters: []evetest.AppNetworkAdapter{
 			evetest.VirtualNetworkAdapter{
 				LogicalLabel:        "vif0",


### PR DESCRIPTION
# Description

The framework now supports a two-step installer boot flow when a test
requests `CreateFromScratchWithInstaller`: the broker boots an installer
VM that writes EVE onto a blank target disk, waits for it to power off,
then reconfigures the same VM's disk list (dropping the installer image)
and powers it on again as the real EVE device.
    
Reusing the same provider device across both phases preserves all
side-state -- swtpm directory, UEFI NVRAM, console port, and network
taps -- so the TPM key created during installation is still present
when EVE boots for the first time.
    
The `DeviceProvider` interface gains `ReconfigureDeviceDisks`, implemented
by both `QemuProvider` and `LibvirtProvider`. `QemuProvider` also gains a
`buildArgs()` helper that assembles the full QEMU command-line from the
current device spec; it is called by both `SetupDevice` and `ReconfigureDeviceDisks`.
    
Alongside this, the `DiskImage` struct (`Format` + `Path`) replaces the old
`ImageSpec`, `provider.DeviceSpec.Disks` carries a slice of disk images,
and `buildEVEImage` is refactored to use param/result structs
(`buildEVEImageParams` / `buildEVEImageResult`) for clarity.
    
Default disk size is raised from `~27.9 GiB` to `36 GiB` so that `/persist`
always stays above EVE's `4096 MiB` cleanup threshold regardless of image
type; this also eliminates the per-test override in the cluster suite.
    
All network bootstrap tests were given a new parameter `USE_INSTALLER`
so that it is possible to test bootstrapping with either the live or
the installer image. For example:

```    
EVETEST_USE_INSTALLER=true make evetest NAME=TestBootstrapWithStaticIP
```
## How to test and validate this PR

This is just a test framework enhancement. Not a user-facing change.
But if you still wish to test this, run any bootstrap test with `EVETEST_USE_INSTALLER` enabled.
For example:

```
make evetest-build-container
EVETEST_USE_INSTALLER=true make evetest NAME=TestBootstrapWithStaticIP
```

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.