### PR TITLE
pkg/pillar/cas: make IngestBlob idempotent when the verified file is gone

### DIFF
--- a/pkg/pillar/cas/containerd.go
+++ b/pkg/pillar/cas/containerd.go
@@ -268,16 +268,30 @@ func (c *containerdCAS) IngestBlob(ctx context.Context, blobs ...types.BlobStatu
 			logrus.Error(err.Error())
 			return loadedBlobs, err
 		case blobFile != "":
-			fileReader, err := os.Open(blobFile)
-			if err != nil {
+			fileReader, openErr := os.Open(blobFile)
+			if openErr != nil {
+				// The verified file may have been deleted by the verifier:
+				// when two content trees share a layer blob, the first tree to
+				// finish loading it into CAS drops the last verifier reference,
+				// which deletes the shared verified file. That deletion only
+				// happens after the blob has been committed to CAS, so a missing
+				// file here means the blob is already present and this ingest is
+				// a no-op. Treat it as a successful (idempotent) load instead of
+				// failing the sibling tree's deployment.
+				if c.CheckBlobExists(sha) {
+					logrus.Infof("IngestBlob(%s): blob file %s missing but blob already present in CAS, treating as loaded",
+						blob.Sha256, blobFile)
+					blob.State = types.LOADED
+					loadedBlobs = append(loadedBlobs, blob)
+					continue
+				}
 				err = fmt.Errorf("IngestBlob(%s): could not open blob file for reading at %s: %+s",
-					blob.Sha256, blobFile, err.Error())
+					blob.Sha256, blobFile, openErr.Error())
 				logrus.Error(err.Error())
 				return loadedBlobs, err
 			}
 			defer fileReader.Close()
 			contentReader = fileReader
-			defer fileReader.Close()
 		default:
 			contentReader = bytes.NewReader(blob.Content)
 		}

--- a/pkg/pillar/cas/containerd_test.go
+++ b/pkg/pillar/cas/containerd_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cas
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/containerd"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// newTestContainerdCAS connects to the host containerd. These tests exercise
+// the real content store, so they only run on systems that have a functional
+// containerd and are skipped otherwise (same convention as containerd/oci_test.go).
+func newTestContainerdCAS(t *testing.T) *containerdCAS {
+	t.Helper()
+	client, err := containerd.NewContainerdClient(false)
+	if err != nil {
+		t.Skipf("test must be run on a system with a functional containerd: %v", err)
+	}
+	return &containerdCAS{ctrdClient: client}
+}
+
+func leafBlob(sha string, data []byte, path string) types.BlobStatus {
+	return types.BlobStatus{
+		Sha256: sha,
+		Size:   uint64(len(data)),
+		Path:   path,
+		// State must be < LOADED, otherwise IngestBlob short-circuits before
+		// ever opening the file, which is the path under test here.
+		State:     types.VERIFIED,
+		MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+	}
+}
+
+// TestIngestBlobMissingFileAlreadyInCAS verifies that IngestBlob is idempotent
+// when the verified blob file is gone but the blob is already in the content
+// store. A layer blob shared by multiple content trees is backed by a single
+// verified file that is removed once the blob has been committed to the content
+// store; a content tree that ingests the same blob afterwards finds the file
+// missing. Since the content is already present, IngestBlob must report the
+// blob as loaded rather than fail.
+func TestIngestBlobMissingFileAlreadyInCAS(t *testing.T) {
+	c := newTestContainerdCAS(t)
+	// Registered first so it runs last (t.Cleanup is LIFO): the blob removal
+	// below must run while the client is still open.
+	t.Cleanup(func() { _ = c.CloseClient() })
+
+	data := []byte("shared layer blob contents")
+	sum := sha256.Sum256(data)
+	blobSha := hex.EncodeToString(sum[:])
+	blobHash := fmt.Sprintf("sha256:%s", blobSha)
+
+	blobPath := filepath.Join(t.TempDir(), "verified-blob")
+	if err := os.WriteFile(blobPath, data, 0644); err != nil {
+		t.Fatalf("failed to write blob file: %v", err)
+	}
+	t.Cleanup(func() { _ = c.RemoveBlob(blobHash) })
+
+	// A single lease keeps the blob referenced (and out of containerd GC) across
+	// both ingests, mirroring the image reference that holds it in production.
+	ctx, deleteLease, err := c.ctrdClient.CtrNewUserServicesCtxWithLease()
+	if err != nil {
+		t.Fatalf("failed to create lease context: %v", err)
+	}
+	defer deleteLease()
+
+	// First load: ingests the blob into CAS from the verified file.
+	loaded, err := c.IngestBlob(ctx, leafBlob(blobSha, data, blobPath))
+	if err != nil {
+		t.Fatalf("first IngestBlob failed: %v", err)
+	}
+	if len(loaded) != 1 || loaded[0].State != types.LOADED {
+		t.Fatalf("expected blob LOADED after first ingest, got %+v", loaded)
+	}
+	if !c.CheckBlobExists(blobHash) {
+		t.Fatalf("blob %s not present in CAS after first ingest", blobHash)
+	}
+
+	// Simulate the verifier deleting the shared verified file once the first
+	// tree finished loading it.
+	if err := os.Remove(blobPath); err != nil {
+		t.Fatalf("failed to remove blob file: %v", err)
+	}
+
+	// Second load from a fresh BlobStatus whose file is now gone. The blob is
+	// already in CAS, so this must succeed.
+	loaded2, err := c.IngestBlob(ctx, leafBlob(blobSha, data, blobPath))
+	if err != nil {
+		t.Fatalf("second IngestBlob failed although the blob is already present in CAS: %v", err)
+	}
+	if len(loaded2) != 1 || loaded2[0].State != types.LOADED {
+		t.Fatalf("expected blob LOADED on second ingest, got %+v", loaded2)
+	}
+}
+
+// TestIngestBlobMissingFileNotInCAS verifies the fallback does not swallow
+// genuine errors: a missing file for a blob that is NOT in CAS must still fail.
+func TestIngestBlobMissingFileNotInCAS(t *testing.T) {
+	c := newTestContainerdCAS(t)
+	defer c.CloseClient()
+
+	// A sha that is not present in CAS, paired with a non-existent file.
+	data := []byte("blob that was never ingested")
+	sum := sha256.Sum256(data)
+	blobSha := hex.EncodeToString(sum[:])
+	if c.CheckBlobExists(fmt.Sprintf("sha256:%s", blobSha)) {
+		t.Skipf("unexpected: blob %s already present in CAS", blobSha)
+	}
+
+	ctx, deleteLease, err := c.ctrdClient.CtrNewUserServicesCtxWithLease()
+	if err != nil {
+		t.Fatalf("failed to create lease context: %v", err)
+	}
+	defer deleteLease()
+
+	missingPath := filepath.Join(t.TempDir(), "does-not-exist")
+	if _, err := c.IngestBlob(ctx, leafBlob(blobSha, data, missingPath)); err == nil {
+		t.Fatalf("expected IngestBlob to fail for a missing file not in CAS, got nil")
+	}
+}


### PR DESCRIPTION
# Description

`IngestBlob` in `pkg/pillar/cas` opens a blob's verified file directly and fails the entire ingest if that file is missing. When several container images share a layer blob (same SHA256), the blob is deduplicated into a single verified file that is removed once the blob has been committed to the containerd content store and the last reference to the verified copy is released.

If two images that share such a layer are deployed at the same time, their content trees load the blob concurrently. After the first one finishes and the shared verified file is removed, the second content tree's `IngestBlob` can still be opening that file and fails with `could not open blob file ... no such file or directory`, leaving its application unable to start.

Because the verified file is only removed after the blob is already in the content store, a missing file at that point means the content is present. This change makes `IngestBlob` check the content store on open failure: if the blob already exists, it is marked loaded and ingest continues, making repeated ingests of the same content idempotent.

## How to test and validate this PR

This is a timing-dependent race between two concurrent content-tree loads of a shared layer, so it is not guaranteed to reproduce on every attempt.

1. Build two *different* container images that share one or more layers — e.g. both built `FROM` the same base, so they share the base layers but have distinct manifests:

   ```dockerfile
   # image-a
   FROM docker.io/library/ubuntu:24.04
   RUN echo "app-a" > /etc/app-id
   CMD ["sleep", "infinity"]
   ```

   ```dockerfile
   # image-b
   FROM docker.io/library/ubuntu:24.04
   RUN echo "app-b" > /etc/app-id
   CMD ["sleep", "infinity"]
   ```

   Push both to a registry.
2. On a freshly installed device (so the shared layers aren't already cached), deploy both images as two applications **at the same time**.
3. Confirm both applications reach RUNNING. Without this change, one of them can get stuck loading with `could not open blob file ... no such file or directory` for the shared layer.

## Changelog notes

Fixed a race that could leave a container application stuck during deployment when multiple images sharing the same image layer were deployed at the same time.

## PR Backports

- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — n/a, no doc changes
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
