### PR TITLE
Kernel update - [arm64-generic]

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -3,5 +3,5 @@ KERNEL_COMMIT_amd64_v6.12.49_generic = dcdba3ddf871
 KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = 2e0dcfd3260d
 KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 4929f15eda41
 KERNEL_COMMIT_arm64_v6.8.12_nvidia-jp7 = 452eaffef5ed
-KERNEL_COMMIT_arm64_v6.1.155_generic = da7d6950689c
+KERNEL_COMMIT_arm64_v6.1.155_generic = 88e6efd1067a
 KERNEL_COMMIT_riscv64_v6.1.112_generic = 30aa75d58cdd


### PR DESCRIPTION
# Description

This commit changes:
eve-kernel-arm64-v6.1.155-generic
    88e6efd1067a: drivers: pwm: Add RP1 PWM driver
    f68bd17c4668: arm64: configs: enable SPI support for Raspberry Pi 5
    8ed723972af2: irqchip/bcm2712-mip, PCI: brcmstb: support upstream brcm,bcm2712-mip binding

This PR is needed for the upcoming fixes for Raspberry Pi. The RPi firmware will be updated, so we need some changes in our drivers. Apart from that, SPI support is also enabled for RPi 5, which will allow support TPM.

## How to test and validate this PR

It's covered by current tests.

## Changelog notes

None (it will be mentioned on upcoming Raspberry Pi fixes)

## PR Backports

Raspberry Pi is broken on master, so no need to backport.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.