### PR TITLE
[16.0-stable] zedagent: fall back to /config/authorized_keys when GlobalConfig is missing

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -322,50 +322,63 @@ func indicateInvalidBootstrapConfig(getconfigCtx *getconfigContext) {
 	getconfigCtx.ledBlinkCount = types.LedBlinkInvalidBootstrapConfig
 }
 
-// Load /config/GlobalConfig/ json file with ConfigItemValueMap provided that:
-//   - the file exists
+// loadGlobalConfig loads /config/GlobalConfig and/or
+// /config/authorized_keys at boot. Precedence:
+//   - GlobalConfig present: authoritative, even with empty
+//     debug.enable.ssh; authorized_keys is ignored.
+//   - GlobalConfig missing: fall back to authorized_keys as the
+//     bootstrap-SSH source on un-onboarded devices.
+//   - Neither present: nothing to load.
 //
-// Note that we need to re-load on each boot since the loaded file content
-// is not persisted anywhere in /persist. Once the device has been onboarded
-// and we have a /persist/checkpoint/lastconfig this file is ignored (by the caller).
-//
-// The function will only load the ConfigItemValueMap items into
-// zedagentCtx,globalConfig. The caller is responsible for publishing those
-// if this returns true
+// Returns true iff zedagentCtx.globalConfig was overwritten; the
+// caller publishes it in that case. Re-runs on every boot; content
+// is not persisted to /persist. Once /persist/checkpoint/lastconfig
+// exists the caller skips this.
 func loadGlobalConfig(getconfigCtx *getconfigContext) bool {
-	//  Check if global config has been already loaded.
-	if !fileutils.FileExists(log, types.ImportGlobalConfigFile) {
-		// No /config/GlobalConfig/ file to read
+	return loadGlobalConfigImpl(getconfigCtx, types.ImportGlobalConfigFile, types.BaseAuthorizedKeysFile)
+}
+
+// loadGlobalConfigImpl is the testable core of loadGlobalConfig
+// with explicit file paths.
+func loadGlobalConfigImpl(getconfigCtx *getconfigContext, globalConfigFile, authorizedKeysFile string) bool {
+	globalConfigExists := fileutils.FileExists(log, globalConfigFile)
+	authKeysExists := fileutils.FileExists(log, authorizedKeysFile)
+	if !globalConfigExists && !authKeysExists {
 		return false
 	}
 
 	// Start with defaults for this EVE version
 	newConfigPtr := types.DefaultConfigItemValueMap()
-	// Load file content.
-	contents, err := os.ReadFile(types.ImportGlobalConfigFile)
-	if err != nil {
-		log.Errorf("Failed to read global config: %v", err)
-		return false
+
+	if globalConfigExists {
+		contents, err := os.ReadFile(globalConfigFile)
+		if err != nil {
+			log.Errorf("Failed to read global config: %v", err)
+			return false
+		}
+		var config types.ConfigItemValueMap
+		if err := json.Unmarshal(contents, &config); err != nil {
+			log.Errorf("Could not unmarshall data in file %s: %s",
+				globalConfigFile, err)
+			return false
+		}
+		log.Noticef("/config/GlobalConfig contains: %v", config)
+		newConfigPtr.UpdateItemValues(&config)
+		if authKeysExists {
+			log.Noticef("Ignoring %s: GlobalConfig is authoritative",
+				authorizedKeysFile)
+		}
+	} else {
+		// Bootstrap-SSH path: only authorized_keys, no GlobalConfig.
+		keyData, keyDataValid := readAuthorizedKeys(authorizedKeysFile)
+		if len(keyData) == 0 || !keyDataValid {
+			return false
+		}
+		log.Noticef("Loaded bootstrap SSH keys from %s: %v",
+			authorizedKeysFile, keyData)
+		newConfigPtr.SetGlobalValueString(types.SSHAuthorizedKeys, keyData)
 	}
 
-	var config types.ConfigItemValueMap
-	err = json.Unmarshal(contents, &config)
-	if err != nil {
-		log.Errorf("Could not unmarshall data in file %s: %s",
-			types.ImportGlobalConfigFile, err)
-		return false
-	}
-	log.Noticef("/config/GlobalConfig contains: %v", config)
-	newConfigPtr.UpdateItemValues(&config)
-
-	keyData, keyDataValid := readAuthorizedKeys(types.BaseAuthorizedKeysFile)
-	doAuthorizedKeys := (len(keyData) != 0 && keyDataValid)
-	if doAuthorizedKeys {
-		log.Noticef("Found the key data in %s: %v",
-			types.BaseAuthorizedKeysFile, keyData)
-		newConfigPtr.SetGlobalValueString(types.SSHAuthorizedKeys,
-			keyData)
-	}
 	getconfigCtx.zedagentCtx.globalConfig = *newConfigPtr
 	return true
 }

--- a/pkg/pillar/cmd/zedagent/handleconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zedagent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/onsi/gomega"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// ---- loadGlobalConfigImpl tests ----
+
+const testSSHKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKey test@example.com"
+
+func TestLoadGlobalConfigBothMissing(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctx := initGetConfigCtx(g)
+
+	dir := t.TempDir()
+	result := loadGlobalConfigImpl(ctx,
+		filepath.Join(dir, "global.json"),
+		filepath.Join(dir, "authorized_keys"))
+	g.Expect(result).To(gomega.BeFalse())
+}
+
+func TestLoadGlobalConfigSuccess(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctx := initGetConfigCtx(g)
+
+	dir := t.TempDir()
+
+	// Write a GlobalConfig JSON that sets a recognisable value.
+	cfg := types.DefaultConfigItemValueMap()
+	cfg.SetGlobalValueInt(types.ConfigInterval, 42)
+	data, err := json.Marshal(cfg)
+	g.Expect(err).To(gomega.BeNil())
+
+	globalFile := filepath.Join(dir, "global.json")
+	g.Expect(os.WriteFile(globalFile, data, 0644)).To(gomega.Succeed())
+
+	result := loadGlobalConfigImpl(ctx, globalFile, filepath.Join(dir, "no_keys"))
+	g.Expect(result).To(gomega.BeTrue())
+	g.Expect(ctx.zedagentCtx.globalConfig.GlobalValueInt(types.ConfigInterval)).
+		To(gomega.Equal(uint32(42)))
+}
+
+// TestLoadGlobalConfigPrefersGlobalOverAuthKeys: when GlobalConfig
+// exists, its (possibly empty) debug.enable.ssh wins over the
+// authorized_keys file. Uses a non-default ConfigInterval value as a
+// fingerprint so the test would fail if the bootstrap branch were
+// silently taken instead.
+func TestLoadGlobalConfigPrefersGlobalOverAuthKeys(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctx := initGetConfigCtx(g)
+
+	dir := t.TempDir()
+
+	// GlobalConfig with EMPTY debug.enable.ssh AND a non-default
+	// ConfigInterval — the latter is the fingerprint that the
+	// GlobalConfig branch ran (bootstrap branch would leave it
+	// at the default).
+	cfg := types.DefaultConfigItemValueMap()
+	cfg.SetGlobalValueString(types.SSHAuthorizedKeys, "")
+	cfg.SetGlobalValueInt(types.ConfigInterval, 17)
+	data, err := json.Marshal(cfg)
+	g.Expect(err).To(gomega.BeNil())
+
+	globalFile := filepath.Join(dir, "global.json")
+	authKeysFile := filepath.Join(dir, "authorized_keys")
+	g.Expect(os.WriteFile(globalFile, data, 0644)).To(gomega.Succeed())
+	g.Expect(os.WriteFile(authKeysFile, []byte(testSSHKey+"\n"), 0644)).To(gomega.Succeed())
+
+	result := loadGlobalConfigImpl(ctx, globalFile, authKeysFile)
+	g.Expect(result).To(gomega.BeTrue())
+	g.Expect(ctx.zedagentCtx.globalConfig.GlobalValueString(types.SSHAuthorizedKeys)).
+		To(gomega.Equal(""))
+	g.Expect(ctx.zedagentCtx.globalConfig.GlobalValueInt(types.ConfigInterval)).
+		To(gomega.Equal(uint32(17)))
+}
+
+// TestLoadGlobalConfigBootstrapFromAuthorizedKeys: no GlobalConfig
+// on /config, only authorized_keys. Synthesizes a default
+// ConfigItemValueMap with debug.enable.ssh set to the file content.
+func TestLoadGlobalConfigBootstrapFromAuthorizedKeys(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctx := initGetConfigCtx(g)
+
+	dir := t.TempDir()
+	globalFile := filepath.Join(dir, "global.json") // intentionally absent
+	authKeysFile := filepath.Join(dir, "authorized_keys")
+	g.Expect(os.WriteFile(authKeysFile, []byte(testSSHKey+"\n"), 0644)).To(gomega.Succeed())
+
+	result := loadGlobalConfigImpl(ctx, globalFile, authKeysFile)
+	g.Expect(result).To(gomega.BeTrue())
+	g.Expect(ctx.zedagentCtx.globalConfig.GlobalValueString(types.SSHAuthorizedKeys)).
+		To(gomega.Equal(testSSHKey))
+}
+
+// TestLoadGlobalConfigBootstrapEmptyAuthKeys: empty authorized_keys
+// with no GlobalConfig must not publish a default ConfigItemValueMap.
+func TestLoadGlobalConfigBootstrapEmptyAuthKeys(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctx := initGetConfigCtx(g)
+
+	dir := t.TempDir()
+	globalFile := filepath.Join(dir, "global.json") // intentionally absent
+	authKeysFile := filepath.Join(dir, "authorized_keys")
+	g.Expect(os.WriteFile(authKeysFile, []byte(""), 0644)).To(gomega.Succeed())
+
+	result := loadGlobalConfigImpl(ctx, globalFile, authKeysFile)
+	g.Expect(result).To(gomega.BeFalse())
+}
+
+func TestLoadGlobalConfigMalformedJSON(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctx := initGetConfigCtx(g)
+
+	dir := t.TempDir()
+	globalFile := filepath.Join(dir, "global.json")
+	g.Expect(os.WriteFile(globalFile, []byte("{not valid json}"), 0644)).To(gomega.Succeed())
+
+	result := loadGlobalConfigImpl(ctx, globalFile, filepath.Join(dir, "no_keys"))
+	g.Expect(result).To(gomega.BeFalse())
+}


### PR DESCRIPTION
# Description

Backport of #6039

## How to test and validate this PR

Six unit tests covering the precedence matrix (all in `pkg/pillar/cmd/zedagent/handleconfig_test.go`):

- `TestLoadGlobalConfigBothMissing` — both files absent → false
- `TestLoadGlobalConfigSuccess` — GlobalConfig only → true, fields loaded
- `TestLoadGlobalConfigPrefersGlobalOverAuthKeys` — both present, empty `debug.enable.ssh` in GlobalConfig → empty SSH wins, ConfigInterval intact
- `TestLoadGlobalConfigBootstrapFromAuthorizedKeys` — authorized_keys only (the regression scenario) → keys loaded
- `TestLoadGlobalConfigBootstrapEmptyAuthKeys` — empty authorized_keys, no GlobalConfig → false
- `TestLoadGlobalConfigMalformedJSON` — GlobalConfig malformed → false

Manual verification:

- Fresh device with `/config/authorized_keys` and NO `/config/GlobalConfig`: confirm `iptables -L INPUT | grep dpt:ssh` shows ACCEPT (not REJECT), and SSH connects on port 22 (or 2222 via qemu host-forward).
- Device with `/config/GlobalConfig` setting `debug.enable.ssh=""` AND a populated `/config/authorized_keys`: confirm SSH remains rejected — precedence is preserved.

## Changelog notes

Restore pre-PR-#5584 behaviour: devices with `/config/authorized_keys` but no `/config/GlobalConfig` regain operator SSH access before the device has been onboarded to a controller. Devices where `/config/GlobalConfig` explicitly sets `debug.enable.ssh=""` continue to deny SSH (precedence is preserved).

## PR Backports

N/A — this is a backport PR.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs:

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.