### PR TITLE
zfsmanager: don't publish ZVolStatus for zvol tree dirs

### DIFF
--- a/pkg/pillar/cmd/zfsmanager/zfsmanager.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsmanager.go
@@ -389,6 +389,15 @@ func deviceWatcherLoop(ctxPtr *zfsContext) {
 			// processing a remove event.
 		}
 		if event.Op&fsnotify.Create != 0 {
+			// Only the zvol device symlinks created by mdev carry a
+			// ZVolStatus. Intermediate directories under ZVolDevicePrefix
+			// (persist, vault, volumes) also raise Create events and are
+			// watched above, but publishing them yields bogus ZVolStatus
+			// entries, so skip anything that is not a symlink (mirrors the
+			// filter in processRecursive).
+			if fi, err := os.Lstat(fileName); err != nil || fi.Mode()&os.ModeSymlink == 0 {
+				continue
+			}
 			dataset := zfs.GetDatasetByDevice(fileName)
 			if dataset == "" {
 				log.Errorf("cannot determine dataset for device: %s", fileName)


### PR DESCRIPTION
# Description

Follow-up cleanup to the now-merged #6029 (zvol create event on purge).

The zfsmanager device watcher's create handler stored an event for every
path that appeared under `/dev/zvol`, including the intermediate directories
(`persist`, `vault`, `volumes`) that mdev creates alongside the zvol symlinks.
Those directories resolve on disk, so the reconcile step published a
`ZVolStatus` for each one. `volumemgr` matches `ZVolStatus` by exact dataset,
so the bogus entries never harmed anything, but they cluttered pubsub and the
logs and flapped on every purge.

This skips non-symlinks in the create handler, mirroring the symlink filter
already used by the startup walk (`processRecursive`). The directories are
still watched; only the spurious publish is dropped.

## How to test and validate this PR

On a ZFS-mode device, create and purge an app with a volume and watch
`zfsmanager`: there should no longer be `processed add`/`ZVolStatus` entries
for `/dev/zvol/persist`, `/dev/zvol/persist/vault`, or
`/dev/zvol/persist/vault/volumes`, only for the actual
`.../volumes/<uuid>.<gen>` device symlinks. Existing `cmd/zfsmanager` unit
tests still pass; behavior for real zvol devices is unchanged.

## Changelog notes

No user-facing changes.

## PR Backports

Not needed — cosmetic cleanup, no functional change.
