### PR TITLE
evetest: add EVE upgrade testing support

### DIFF
--- a/evetest/Makefile
+++ b/evetest/Makefile
@@ -62,12 +62,20 @@ endif
 	$(eval BROKER_IMAGE_MOUNT :=)
 	$(eval BROKER_IMAGE_ENV :=)
 	$(eval BROKER_PROXY_CA_MOUNT :=)
+	@# Always mount the evetest data directory so that Docker bind-mounts issued
+	@# from inside the container (e.g. rootfs extraction for upgrades) resolve
+	@# correctly on the host.
+	$(eval EVETEST_HOME_DIR := $(HOME)/.evetest)
+	$(eval EVETEST_HOME_MOUNT := -v $(EVETEST_HOME_DIR):$(EVETEST_HOME_DIR))
+	@mkdir -p $(EVETEST_HOME_DIR)
 ifndef EVETEST_BROKER_ADDRESS
 	@# Broker runs inside the container; it stores per-VM disk images on the
 	@# host. Default to <home-dir>/.evetest because /tmp is usually on the small
 	@# root partition (or tmpfs) and quickly fills up with three-node clusters.
-	$(eval IMAGE_DIR := $(or $(EVETEST_BROKER_IMAGE_DIR),$(HOME)/.evetest))
-	$(eval BROKER_IMAGE_MOUNT := -v $(IMAGE_DIR):$(IMAGE_DIR))
+	$(eval IMAGE_DIR := $(or $(EVETEST_BROKER_IMAGE_DIR),$(EVETEST_HOME_DIR)))
+	@# Only add a broker image mount when the image dir differs from EVETEST_HOME_DIR
+	@# to avoid a duplicate bind-mount error.
+	$(eval BROKER_IMAGE_MOUNT := $(if $(filter-out $(EVETEST_HOME_DIR),$(IMAGE_DIR)),-v $(IMAGE_DIR):$(IMAGE_DIR),))
 	$(eval BROKER_IMAGE_ENV := -e EVETEST_BROKER_IMAGE_DIR=$(IMAGE_DIR))
 ifneq ($(EVETEST_BROKER_PROXY_CA_CHAIN),)
 	$(eval BROKER_PROXY_CA_MOUNT := -v $(EVETEST_BROKER_PROXY_CA_CHAIN):/etc/evetest/proxy/ca-chain.pem:ro)
@@ -127,6 +135,7 @@ endif
 		--device=/dev/net/tun \
 		$(KVM_DEVICE) \
 		$(ARTIFACTS_MOUNT) \
+		$(EVETEST_HOME_MOUNT) \
 		$(BROKER_IMAGE_MOUNT) \
 		$(BROKER_PROXY_CA_MOUNT) \
 		$(GO_CACHE_MOUNT) \
@@ -136,6 +145,7 @@ endif
 		$(BROKER_IMAGE_ENV) \
 		$(GO_CACHE_ENV) \
 		-e EVETEST_NAME=$(EVETEST_NAME) \
+		-e EVETEST_HOME=$(EVETEST_HOME_DIR) \
 		-e EVETEST_HOST_UID=$(EVETEST_HOST_UID) \
 		-e EVETEST_HOST_GID=$(EVETEST_HOST_GID) \
 		$(EVETEST_ORG)/evetest:$(EVETEST_VERSION)-adam-$(EVETEST_ADAM_VERSION)

--- a/evetest/cmd/list-tests/main.go
+++ b/evetest/cmd/list-tests/main.go
@@ -29,6 +29,7 @@ import (
 type paramInfo struct {
 	key           string
 	defValue      string // from Description.Default
+	hasDefault    bool   // true when Description.Default was explicitly set (even if "")
 	allowedValues string // from Description.AllowedValues (e.g. "kvm|xen|kubevirt")
 	typeHint      string // inferred from DefaultValue literal: "bool", "string", "int", …
 }
@@ -69,6 +70,7 @@ type testInfo struct {
 type pkgContext struct {
 	constValues  map[string]string // string const name → string value (for key resolution)
 	constStrings map[string]string // const name → String() return value (for variant display)
+	allConsts    map[string]string // all simple const name → literal value (for variant display)
 	varParams    map[string]paramInfo
 }
 
@@ -81,7 +83,7 @@ func main() {
 	// Parse the evetest framework package (parent of testsDir) to discover
 	// all functions that return TestParameterDefinition.
 	evetestDir := filepath.Dir(testsDir)
-	paramFuncs := buildParamFuncs(evetestDir)
+	paramFuncs, evetestConstValues := buildParamFuncs(evetestDir)
 
 	// Group _test.go files by directory (= Go package).
 	dirFiles := map[string][]string{}
@@ -116,6 +118,11 @@ func main() {
 		}
 
 		ctx := buildPkgContext(parsedFiles)
+		// Inject evetest package string constants with "evetest." prefix so that
+		// SelectorExpr references like evetest.DiskSizeMiBParameterKey are resolved.
+		for k, v := range evetestConstValues {
+			ctx.constValues["evetest."+k] = v
+		}
 
 		for _, f := range parsedFiles {
 			for _, decl := range f.Decls {
@@ -203,8 +210,12 @@ func formatParams(params []paramInfo) string {
 		case pi.typeHint != "":
 			annotation = "(" + pi.typeHint + ")"
 		}
-		if pi.defValue != "" {
-			parts[i] = key + annotation + ", default: " + pi.defValue
+		if pi.hasDefault {
+			displayDefault := pi.defValue
+			if displayDefault == "" {
+				displayDefault = `""`
+			}
+			parts[i] = key + annotation + ", default: " + displayDefault
 		} else {
 			parts[i] = key + annotation
 		}
@@ -231,15 +242,16 @@ func buildPkgContext(files []*ast.File) pkgContext {
 	ctx := pkgContext{
 		constValues:  map[string]string{},
 		constStrings: map[string]string{},
+		allConsts:    map[string]string{},
 		varParams:    map[string]paramInfo{},
 	}
 
-	// Pass 1: collect string const values.
+	// Pass 1: collect const values (package-level and function-local).
 	for _, f := range files {
-		for _, decl := range f.Decls {
-			gd, ok := decl.(*ast.GenDecl)
+		ast.Inspect(f, func(n ast.Node) bool {
+			gd, ok := n.(*ast.GenDecl)
 			if !ok || gd.Tok != token.CONST {
-				continue
+				return true
 			}
 			for _, spec := range gd.Specs {
 				vs, ok := spec.(*ast.ValueSpec)
@@ -247,15 +259,21 @@ func buildPkgContext(files []*ast.File) pkgContext {
 					continue
 				}
 				for i, name := range vs.Names {
-					if i < len(vs.Values) {
-						lit, ok := vs.Values[i].(*ast.BasicLit)
-						if ok && lit.Kind == token.STRING {
-							ctx.constValues[name.Name] = unquote(lit.Value)
-						}
+					if i >= len(vs.Values) {
+						continue
+					}
+					// String consts go into constValues (used for key resolution).
+					if lit, ok := vs.Values[i].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+						ctx.constValues[name.Name] = unquote(lit.Value)
+					}
+					// All simple literal consts go into allConsts (used for display).
+					if v, ok := extractConstLiteralValue(vs.Values[i]); ok {
+						ctx.allConsts[name.Name] = v
 					}
 				}
 			}
-		}
+			return true
+		})
 	}
 
 	// Pass 2: parse String() methods to get human-readable const representations.
@@ -351,11 +369,12 @@ func returnsSingleString(fd *ast.FuncDecl) bool {
 
 // buildParamFuncs parses the non-test Go source files in sourceDir and returns
 // a map from function name to the paramInfo it produces for every function
-// whose sole return type is TestParameterDefinition.
-func buildParamFuncs(sourceDir string) map[string]paramInfo {
+// whose sole return type is TestParameterDefinition, plus the package's string
+// constant map (used by callers to resolve evetest.XxxKey references).
+func buildParamFuncs(sourceDir string) (map[string]paramInfo, map[string]string) {
 	entries, err := os.ReadDir(sourceDir)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 	fset := token.NewFileSet()
 	var files []*ast.File
@@ -395,7 +414,7 @@ func buildParamFuncs(sourceDir string) map[string]paramInfo {
 			})
 		}
 	}
-	return result
+	return result, ctx.constValues
 }
 
 // returnsParamDef reports whether fd's sole return value is TestParameterDefinition.
@@ -474,6 +493,7 @@ func extractParamDefLit(expr ast.Expr, ctx pkgContext) (paramInfo, bool) {
 		return paramInfo{}, false
 	}
 	var key, defValue, allowedValues, typeHint string
+	var hasDefault bool
 	for _, elt := range comp.Elts {
 		kv, ok := elt.(*ast.KeyValueExpr)
 		if !ok {
@@ -505,6 +525,7 @@ func extractParamDefLit(expr ast.Expr, ctx pkgContext) (paramInfo, bool) {
 				switch descField.Name {
 				case "Default":
 					defValue = resolveStringExpr(descKV.Value, ctx)
+					hasDefault = true
 				case "AllowedValues":
 					allowedValues = resolveStringExpr(descKV.Value, ctx)
 				}
@@ -515,7 +536,7 @@ func extractParamDefLit(expr ast.Expr, ctx pkgContext) (paramInfo, bool) {
 		return paramInfo{}, false
 	}
 	return paramInfo{
-		key: key, defValue: defValue,
+		key: key, defValue: defValue, hasDefault: hasDefault,
 		allowedValues: allowedValues, typeHint: typeHint,
 	}, true
 }
@@ -553,7 +574,7 @@ func isParamDefType(expr ast.Expr) bool {
 }
 
 // resolveStringExpr extracts a string value from an expression expected to be
-// a string constant (literal or named const).
+// a string constant (literal or named const, possibly from another package).
 func resolveStringExpr(expr ast.Expr, ctx pkgContext) string {
 	switch e := expr.(type) {
 	case *ast.BasicLit:
@@ -563,6 +584,12 @@ func resolveStringExpr(expr ast.Expr, ctx pkgContext) string {
 	case *ast.Ident:
 		if v, ok := ctx.constValues[e.Name]; ok {
 			return v
+		}
+	case *ast.SelectorExpr:
+		if pkg, ok := e.X.(*ast.Ident); ok {
+			if v, ok := ctx.constValues[pkg.Name+"."+e.Sel.Name]; ok {
+				return v
+			}
 		}
 	}
 	return ""
@@ -710,6 +737,9 @@ func resolveDisplayValue(expr ast.Expr, ctx pkgContext) string {
 		if s, ok := ctx.constStrings[id.Name]; ok {
 			return s
 		}
+		if s, ok := ctx.allConsts[id.Name]; ok {
+			return s
+		}
 		return id.Name
 	}
 	switch e := expr.(type) {
@@ -723,8 +753,42 @@ func resolveDisplayValue(expr ast.Expr, ctx pkgContext) string {
 			return s
 		}
 		return e.Sel.Name
+	case *ast.CallExpr:
+		// Handle inline type conversions like uint32(20480).
+		if len(e.Args) == 1 {
+			if v, ok := extractConstLiteralValue(e.Args[0]); ok {
+				return v
+			}
+		}
 	}
 	return "?"
+}
+
+// extractConstLiteralValue returns the display string for a simple constant
+// initializer expression (string/numeric literal, bool ident, or a single-arg
+// type-conversion call such as uint32(20480)).
+func extractConstLiteralValue(expr ast.Expr) (string, bool) {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		if e.Kind == token.STRING {
+			return unquote(e.Value), true
+		}
+		return e.Value, true
+	case *ast.Ident:
+		if e.Name == "true" || e.Name == "false" {
+			return e.Name, true
+		}
+	case *ast.CallExpr:
+		if len(e.Args) == 1 {
+			if inner, ok := e.Args[0].(*ast.BasicLit); ok {
+				if inner.Kind == token.STRING {
+					return unquote(inner.Value), true
+				}
+				return inner.Value, true
+			}
+		}
+	}
+	return "", false
 }
 
 func unquote(s string) string {

--- a/evetest/constants/config.go
+++ b/evetest/constants/config.go
@@ -77,6 +77,14 @@ const (
 	// This is read by the evetest container.
 	EVERepoEnv = "EVE_REPO"
 
+	// HomeDirEnv specifies the evetest data directory on the host ($HOME/.evetest).
+	// It is passed by the Makefile as EVETEST_HOME=$(HOME)/.evetest and must be
+	// bind-mounted into the container at the same path so that Docker bind-mounts
+	// issued from inside the container (e.g. for rootfs extraction) resolve
+	// correctly on the host.
+	// This is read by the evetest container.
+	HomeDirEnv = "HOME"
+
 	// PreferredArchEnv specifies the preferred CPU architecture for EVE devices.
 	// Accepted values: "amd64", "arm64" (case-insensitive).
 	// The framework will use this architecture if the broker supports it;

--- a/evetest/devconfig.go
+++ b/evetest/devconfig.go
@@ -1759,6 +1759,9 @@ func (dc *EdgeDeviceConfig) setDefaultConfigProperties() {
 		{Key: string(pillartypes.LocationCloudInterval), Value: "300"},
 		{Key: string(pillartypes.AllowLogFastupload), Value: "true"},
 		{Key: string(pillartypes.DownloadRetryTime), Value: "60"},
+
+		// Reduce the post-upgrade testing period so upgrades complete faster in tests.
+		{Key: string(pillartypes.MintimeUpdateSuccess), Value: "60"},
 	}
 
 	// Do not overwrite test-defined values.
@@ -2307,5 +2310,40 @@ func (dc *EdgeDeviceConfig) DeleteSCEPProfile(profileName string) {
 	}
 	if !found {
 		dc.th.t.Fatalf("SCEP profile with name %q was not found", profileName)
+	}
+}
+
+// SetBaseOS configures an EVE OS upgrade from the given image storage source.
+// shortVersion is the full EVE short version string (e.g. "12.1.0-kvm-amd64")
+// that EVE will report in ZInfoDevSW.ShortVersion after the upgrade.
+// Calling this again on the same config replaces the previously set BaseOS entry.
+func (dc *EdgeDeviceConfig) SetBaseOS(storage ApplicationImageStorage, shortVersion string) {
+	// Remove content tree and datastores from any previous SetBaseOS call.
+	if dc.Baseos != nil {
+		prevContentTreeUUID := dc.Baseos.ContentTreeUuid
+		var prevDsUUIDs []string
+		dc.ContentInfo = generics.FilterList(dc.ContentInfo,
+			func(ct *eveconfig.ContentTree) bool {
+				if ct.Uuid == prevContentTreeUUID {
+					prevDsUUIDs = ct.DsIdsList
+					return false
+				}
+				return true
+			})
+		dc.Datastores = generics.FilterList(dc.Datastores,
+			func(ds *eveconfig.DatastoreConfig) bool {
+				return !generics.ContainsItem(prevDsUUIDs, ds.Id)
+			})
+	}
+	contentTreeUUID := dc.th.newUUID("baseos content tree")
+	datastoreUUID := dc.th.newUUID("baseos datastore")
+	contentTree, dsConfig := storage.toProto(dc.th, dc.log, dc.DeviceName,
+		contentTreeUUID, datastoreUUID, "eve baseos")
+	dc.ContentInfo = append(dc.ContentInfo, contentTree)
+	dc.Datastores = append(dc.Datastores, dsConfig)
+	dc.Baseos = &eveconfig.BaseOS{
+		ContentTreeUuid: contentTreeUUID.String(),
+		Activate:        true,
+		BaseOsVersion:   shortVersion,
 	}
 }

--- a/evetest/edgedevice.go
+++ b/evetest/edgedevice.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -22,6 +23,7 @@ import (
 	evemetrics "github.com/lf-edge/eve-api/go/metrics"
 	api "github.com/lf-edge/eve/evetest/grpcapi/go"
 	"github.com/lf-edge/eve/evetest/logger"
+	"github.com/lf-edge/eve/evetest/utils"
 	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
 	uuid "github.com/satori/go.uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -349,10 +351,227 @@ func (d *EdgeDevice) GetDeviceIPAddress(netAdapterLogicalLabel string) []net.IP 
 }
 
 // UpgradeEVE upgrades the EVE OS to the specified version and optionally
-// waits until the upgrade completes.
-func (d *EdgeDevice) UpgradeEVE(eveVersion string, waitUntilUpgraded bool) {
-	// TODO (do not forget to log progress)
-	d.th.t.Fatalf("UpgradeEVE is not implemented")
+// waits until the upgrade completes or reverts.
+// When expectRevert is true, the upgrade is expected to fail and EVE to revert
+// to the previous version -- the function then waits for the target version to
+// show a FAILED status instead of waiting for it to become active.
+// A reverted upgrade causes two reboots (one to try the new version, one to
+// revert), so the expected reboot count is incremented accordingly.
+func (d *EdgeDevice) UpgradeEVE(targetEVEVersion string, targetEVEHypervisor Hypervisor,
+	waitUntilUpgraded bool, expectRevert bool) {
+
+	// Read current device arch (set during Setup).
+	d.th.devicesM.Lock()
+	devState, found := d.th.devices[d.devName]
+	if !found {
+		d.th.devicesM.Unlock()
+		d.th.t.Fatalf("Unknown device %q", d.devName)
+	}
+	currentImageRef := devState.imageRef
+	d.th.devicesM.Unlock()
+
+	targetImageRef := &api.ImageRef{
+		Repo:       currentImageRef.Repo,
+		Version:    targetEVEVersion,
+		Hypervisor: targetEVEHypervisor.toAPIType(),
+		Arch:       currentImageRef.Arch,
+	}
+	imageName, err := utils.EVEDockerImageName(targetImageRef)
+	if err != nil {
+		d.th.t.Fatalf("Invalid target image ref: %v", err)
+	}
+	d.th.log.Infof("Pulling EVE image %s", imageName)
+
+	ctx, cancel := context.WithTimeout(d.th.ctx, eveImagePullTimeout)
+	defer cancel()
+
+	logger := d.th.log.WithField("component", "upgrade")
+	err = utils.PullDockerImage(ctx, logger, imageName)
+	if err != nil {
+		d.th.t.Fatalf("Failed to pull EVE image %s: %v", imageName, err)
+	}
+
+	archStr := "amd64"
+	if currentImageRef.Arch == api.ArchType_ARCH_ARM64 {
+		archStr = "arm64"
+	}
+	platform := "linux/" + archStr
+
+	// Get the actual short version string from the image.
+	versionOut, err := utils.RunDockerCommand(
+		ctx, logger, imageName, "version", nil, platform)
+	if err != nil {
+		d.th.t.Fatalf("Failed to get version from image %s: %v",
+			imageName, err)
+	}
+	shortVersion := strings.TrimSpace(versionOut)
+	d.th.log.Debugf("Target EVE short version is %q", shortVersion)
+
+	// Extract rootfs (cache by short version to avoid re-extraction on reuse).
+	rootfsFilename := "rootfs-" + shortVersion + ".img"
+	rootfsPath := filepath.Join(d.th.imgServerDir, rootfsFilename)
+	if _, statErr := os.Stat(rootfsPath); os.IsNotExist(statErr) {
+		d.th.log.Infof("Extracting EVE rootfs from %s", imageName)
+		_, err = utils.RunDockerCommand(ctx, logger, imageName,
+			"-f raw rootfs",
+			map[string]string{"/out": d.th.imgServerDir},
+			platform)
+		if err != nil {
+			d.th.t.Fatalf("Failed to extract EVE rootfs from %s: %v",
+				imageName, err)
+		}
+		defaultOut := filepath.Join(d.th.imgServerDir, "rootfs.img")
+		if renErr := os.Rename(defaultOut, rootfsPath); renErr != nil {
+			d.th.t.Fatalf("Failed to rename EVE rootfs: %v", renErr)
+		}
+	} else {
+		d.th.log.Infof("Reusing cached rootfs %s", rootfsFilename)
+	}
+
+	sha256hex, fileSize, err := utils.FileHashAndSize(rootfsPath)
+	if err != nil {
+		d.th.t.Fatalf("UpgradeEVE: failed to hash rootfs %s: %v", rootfsPath, err)
+	}
+
+	// Build upgrade device config from a clone of the current config.
+	config := d.GetConfig()
+	config.SetBaseOS(HTTPStorage{
+		ImageFormat:       eveconfig.Format_RAW,
+		ImageSHA256:       sha256hex,
+		MaxDownloadBytes:  uint64(fileSize),
+		ImageRelativePath: rootfsFilename,
+		ServerAddress:     GetImageServerIPv4().String(),
+		ServerPort:        GetImageServerPort(),
+	}, shortVersion)
+
+	d.th.log.Infof("Applying EVE upgrade config (target=%s)", shortVersion)
+	// A successful upgrade reboots once; a reverted upgrade reboots twice
+	// (once to try the new version, once to revert to the previous one).
+	d.th.incExpectedRebootCount(d.devName)
+	if expectRevert {
+		d.th.incExpectedRebootCount(d.devName)
+	}
+	d.th.devicesM.Lock()
+	d.th.devices[d.devName].wasUpgraded = true
+	d.th.devicesM.Unlock()
+	d.ApplyConfig(config, false, false)
+
+	if waitUntilUpgraded {
+		if expectRevert {
+			d.waitForRevert(shortVersion)
+		} else {
+			d.waitForUpgrade(shortVersion)
+		}
+	}
+}
+
+// waitForUpgrade blocks until the device's SwList contains an entry for
+// targetShortVersion with PartitionState=="active", or fatals on failure/timeout.
+func (d *EdgeDevice) waitForUpgrade(targetShortVersion string) {
+	d.th.log.Infof("Waiting for device %q to upgrade to %s",
+		d.devName, targetShortVersion)
+	devUUID := d.getDevUUID()
+
+	infoCh := make(chan *eveinfo.ZInfoMsg, 20)
+	unsub, err := d.th.adamClient.SubscribeToDeviceInfoMsgs(devUUID,
+		func(msg *eveinfo.ZInfoMsg) bool {
+			return msg.GetZtype() == eveinfo.ZInfoTypes_ZiDevice
+		},
+		infoCh)
+	if err != nil {
+		d.th.t.Fatalf("Failed to subscribe to info messages: %v", err)
+	}
+	defer unsub()
+
+	ctx, cancel := context.WithTimeout(d.th.ctx, eveUpgradeTimeout)
+	defer cancel()
+
+	var lastLoggedState, lastLoggedStatus string
+	for {
+		select {
+		case msg, ok := <-infoCh:
+			if !ok {
+				d.th.t.Fatalf("Device info subscription closed unexpectedly")
+			}
+			for _, sw := range msg.GetDinfo().GetSwList() {
+				if sw.GetShortVersion() != targetShortVersion {
+					continue
+				}
+				if sw.GetUserStatus() == eveinfo.BaseOsStatus_FAILED {
+					d.th.t.Fatalf("EVE upgrade to %s failed: %s",
+						targetShortVersion, sw.GetSubStatusStr())
+				}
+				if sw.GetPartitionState() == "active" {
+					d.th.log.Infof("Device %q successfully upgraded to %s",
+						d.devName, targetShortVersion)
+					return
+				}
+				state := sw.GetPartitionState()
+				status := sw.GetUserStatus().String()
+				if state != lastLoggedState || status != lastLoggedStatus {
+					d.th.log.Infof("EVE upgrade in progress for device %s "+
+						"(state=%s, status=%s)", d.devName, state, status)
+					lastLoggedState, lastLoggedStatus = state, status
+				}
+			}
+		case <-ctx.Done():
+			d.th.t.Fatalf("Timed out waiting for device %q to upgrade to %s",
+				d.devName, targetShortVersion)
+		}
+	}
+}
+
+// waitForRevert blocks until the device's SwList shows the target version with
+// a FAILED status (indicating EVE rejected it and reverted to the previous version),
+// or fatals on timeout.
+func (d *EdgeDevice) waitForRevert(targetShortVersion string) {
+	d.th.log.Infof("Waiting for device %q to revert from failed upgrade to %s",
+		d.devName, targetShortVersion)
+	devUUID := d.getDevUUID()
+
+	infoCh := make(chan *eveinfo.ZInfoMsg, 20)
+	unsub, err := d.th.adamClient.SubscribeToDeviceInfoMsgs(devUUID,
+		func(msg *eveinfo.ZInfoMsg) bool {
+			return msg.GetZtype() == eveinfo.ZInfoTypes_ZiDevice
+		},
+		infoCh)
+	if err != nil {
+		d.th.t.Fatalf("Failed to subscribe to info messages: %v", err)
+	}
+	defer unsub()
+
+	ctx, cancel := context.WithTimeout(d.th.ctx, eveUpgradeTimeout)
+	defer cancel()
+
+	var lastLoggedState, lastLoggedStatus string
+	for {
+		select {
+		case msg, ok := <-infoCh:
+			if !ok {
+				d.th.t.Fatalf("Device info subscription closed unexpectedly")
+			}
+			for _, sw := range msg.GetDinfo().GetSwList() {
+				if sw.GetShortVersion() != targetShortVersion {
+					continue
+				}
+				if sw.GetUserStatus() == eveinfo.BaseOsStatus_FAILED {
+					d.th.log.Infof("Device %q successfully reverted from %s: %s",
+						d.devName, targetShortVersion, sw.GetSubStatusStr())
+					return
+				}
+				state := sw.GetPartitionState()
+				status := sw.GetUserStatus().String()
+				if state != lastLoggedState || status != lastLoggedStatus {
+					d.th.log.Infof("Upgrade revert in progress (state=%s, status=%s)",
+						state, status)
+					lastLoggedState, lastLoggedStatus = state, status
+				}
+			}
+		case <-ctx.Done():
+			d.th.t.Fatalf("Timed out waiting for device %q to revert from upgrade to %s",
+				d.devName, targetShortVersion)
+		}
+	}
 }
 
 // RequestReboot requests a device reboot via configuration and optionally

--- a/evetest/harness.go
+++ b/evetest/harness.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -125,10 +126,19 @@ const (
 
 	// If download progress does not advance for this long, WaitUntilAppIsRunning fails.
 	downloadStalledTimeout = time.Minute
+
+	// Timeout for pulling an EVE docker image and extracting its rootfs.
+	eveImagePullTimeout = 15 * time.Minute
+
+	// Timeout for an EVE device to complete an OS upgrade (download, install, reboot,
+	// complete the testing period, and mark the new partition as active).
+	eveUpgradeTimeout = 20 * time.Minute
 )
 
 const (
 	controllerIntfName = "controller"
+	imgServerIntfName  = "img-server"
+	imgServerPort      = 80
 
 	sdnTunName = "sdn-tun"
 	sdnTunMTU  = 1500
@@ -153,6 +163,8 @@ var (
 
 	controllerIPv4 = net.ParseIP("245.245.245.245").To4()
 	controllerIPv6 = net.ParseIP("fd24:1ac2:e355::1").To16()
+
+	imgServerIPv4 = net.ParseIP("244.244.244.244").To4()
 )
 
 const (
@@ -206,6 +218,10 @@ type TestHarness struct {
 	// Controller
 	adamClient   *controller.AdamClient
 	adamStatusCh chan controller.AdamState
+
+	// Image server (HTTP file server serving EVE and app images).
+	imgServerListener net.Listener
+	imgServerDir      string // temp dir under $HOME/.evetest; removed in Close()
 
 	// SDN
 	sdnConn   *grpc.ClientConn
@@ -323,6 +339,10 @@ type deviceState struct {
 	lastBootTime        time.Time
 	rebootCount         int
 	expectedRebootCount int
+
+	// wasUpgraded is set to true once UpgradeEVE has applied an upgrade config.
+	// Upgraded devices must not be reused across tests.
+	wasUpgraded bool
 }
 
 // Global test harness instance.
@@ -504,6 +524,37 @@ func Init(t *testing.T) *T {
 	th.wg.Add(1)
 	go th.processDeviceStateEvents()
 
+	// Create the HTTP image server on a dedicated dummy interface.
+	// The serving directory is a temp dir under EVETEST_HOME (= $HOME/.evetest on the
+	// host), which is bind-mounted at the same path inside the container so that
+	// Docker bind-mounts issued via RunDockerCommand resolve correctly on the host.
+	imgCacheParent := viper.GetString(constants.HomeDirEnv)
+	if err = os.MkdirAll(imgCacheParent, 0755); err != nil {
+		th.t.Fatalf("failed to create image cache parent dir: %v", err)
+	}
+	th.imgServerDir, err = os.MkdirTemp(imgCacheParent, "img-cache-")
+	if err != nil {
+		th.t.Fatalf("failed to create image server directory: %v", err)
+	}
+	imgServerIPNets := []net.IPNet{
+		{IP: GetImageServerIPv4(), Mask: net.CIDRMask(32, 32)},
+	}
+	err = utils.CreateDummyInterface(imgServerIntfName, imgServerIPNets)
+	if err != nil {
+		th.t.Fatalf("failed to create image server interface: %v", err)
+	}
+	imgListenAddr := net.JoinHostPort(imgServerIPv4.String(), strconv.Itoa(imgServerPort))
+	th.imgServerListener, err = net.Listen("tcp", imgListenAddr)
+	if err != nil {
+		th.t.Fatalf("failed to listen on image server address %s: %v", imgListenAddr, err)
+	}
+	go func() {
+		mux := http.NewServeMux()
+		mux.Handle("/", http.FileServer(http.Dir(th.imgServerDir)))
+		_ = http.Serve(th.imgServerListener, mux)
+	}()
+	th.log.Infof("Image server listening on http://%s/ (serving %s)", imgListenAddr, th.imgServerDir)
+
 	// Create broker client.
 	brokerAddr := viper.GetString(constants.BrokerAddressEnv)
 	if brokerAddr == "" {
@@ -645,6 +696,18 @@ func Close() error {
 		th.log.Warnf("Failed to close broker connection: %v", err)
 	} else {
 		th.log.Infof("Closed broker connection")
+	}
+
+	// Stop the image server and remove its cache directory.
+	if th.imgServerListener != nil {
+		if err := th.imgServerListener.Close(); err != nil {
+			th.log.Warnf("Failed to close image server listener: %v", err)
+		}
+	}
+	if th.imgServerDir != "" {
+		if err := os.RemoveAll(th.imgServerDir); err != nil {
+			th.log.Warnf("Failed to remove image cache dir %s: %v", th.imgServerDir, err)
+		}
 	}
 
 	// Stop the Adam controller.
@@ -1007,6 +1070,16 @@ func GetControllerIPv4() net.IP {
 // associated with the container's default IPv6 route, if present.
 func GetControllerIPv6() net.IP {
 	return controllerIPv6
+}
+
+// GetImageServerIPv4 returns the IPv4 address of the HTTP image server.
+func GetImageServerIPv4() net.IP {
+	return imgServerIPv4
+}
+
+// GetImageServerPort returns the port of the HTTP image server.
+func GetImageServerPort() uint16 {
+	return imgServerPort
 }
 
 // GetSrcIPv4ForInternetAccess returns the first non-link-local IPv4 address

--- a/evetest/requirements.go
+++ b/evetest/requirements.go
@@ -62,6 +62,21 @@ func (h *Hypervisor) FromString(s string) error {
 	return nil
 }
 
+// toAPIType converts a Hypervisor to the corresponding api.HypervisorType.
+// Defaults to HV_KVM for HypervisorUndefined.
+func (h Hypervisor) toAPIType() api.HypervisorType {
+	switch h {
+	case HypervisorKVM, HypervisorUndefined:
+		return api.HypervisorType_HV_KVM
+	case HypervisorXen:
+		return api.HypervisorType_HV_XEN
+	case HypervisorKubevirt:
+		return api.HypervisorType_HV_KUBEVIRT
+	default:
+		return api.HypervisorType_HV_KVM
+	}
+}
+
 // Filesystem identifies the filesystem type required or detected on an EVE device.
 type Filesystem int
 

--- a/evetest/setup.go
+++ b/evetest/setup.go
@@ -472,6 +472,10 @@ func (th *TestHarness) openTunnelToSDN() {
 						DstNetwork: GetControllerIPv6().String() + "/128",
 						Gateway:    sdnTunContainerIPv6.String(),
 					},
+					{
+						DstNetwork: GetImageServerIPv4().String() + "/32",
+						Gateway:    sdnTunContainerIPv4.String(),
+					},
 				},
 			},
 		},
@@ -978,6 +982,12 @@ func (th *TestHarness) maybeReuseDevices(
 
 		dev, devFound := th.devices[devName]
 		if !devFound {
+			th.devicesM.Unlock()
+			return false
+		}
+		if dev.wasUpgraded {
+			// EVE was upgraded on this device; the running version no longer
+			// matches the original requirement, so reuse is not safe.
 			th.devicesM.Unlock()
 			return false
 		}

--- a/evetest/testparam.go
+++ b/evetest/testparam.go
@@ -236,6 +236,55 @@ func GetHypervisorParameterValue() Hypervisor {
 	return GetTestParameter[Hypervisor](HypervisorParameterKey)
 }
 
+// EVEVersionParameterKey is the key used for the EVE version parameter.
+// This is the EVETEST_EVE_VERSION environment variable, which defaults to the
+// HEAD of the checked-out EVE repo when not set (determined by the evetest
+// Makefile).
+// Most tests do not need to explicitly use this parameter and will automatically
+// get EVE device(s) running the version defined by the EVETEST_EVE_VERSION variable.
+// Only needed when a test must start from a different EVE version and then later
+// upgrade to the version selected by EVETEST_EVE_VERSION, or when a test suite
+// needs to override the EVE version for a specific sub-test variant.
+const EVEVersionParameterKey = "EVE_VERSION"
+
+// EVEVersionParameter is a predefined TestParameterDefinition for the EVE version.
+func EVEVersionParameter() TestParameterDefinition {
+	return TestParameterDefinition{
+		Key:          EVEVersionParameterKey,
+		DefaultValue: "",
+		Description: TestParameterDescription{
+			Summary: "EVE version to run on the device (e.g. \"16.0.0-lts\")",
+			Default: "HEAD of the checked-out EVE repo (determined by the evetest Makefile)",
+		},
+	}
+}
+
+// GetEVEVersionParameterValue returns the value set for the EVE version parameter.
+func GetEVEVersionParameterValue() string {
+	return GetTestParameter[string](EVEVersionParameterKey)
+}
+
+// DiskSizeMiBParameterKey is the key used for the DiskSizeMiB parameter.
+const DiskSizeMiBParameterKey = "DISK_SIZE_MB"
+
+// DiskSizeMiBParameter is a predefined TestParameterDefinition for the device disk size.
+// A value of 0 means the framework default (36864 MiB) is used.
+func DiskSizeMiBParameter() TestParameterDefinition {
+	return TestParameterDefinition{
+		Key:          DiskSizeMiBParameterKey,
+		DefaultValue: uint32(0),
+		Description: TestParameterDescription{
+			Summary: "Device disk size in MiB",
+			Default: "0 (use framework default 36864 MiB)",
+		},
+	}
+}
+
+// GetDiskSizeMiBParameterValue returns the value set for the DiskSizeMiB parameter.
+func GetDiskSizeMiBParameterValue() uint32 {
+	return GetTestParameter[uint32](DiskSizeMiBParameterKey)
+}
+
 // SkipIfHypervisorKubevirt skips the current test if the resolved HYPERVISOR
 // parameter is HypervisorKubevirt. Kubevirt is only supported by tests under
 // `evetest/tests/cluster`; non-cluster tests should call this helper right

--- a/evetest/tests/upgrade/testsuite_test.go
+++ b/evetest/tests/upgrade/testsuite_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade_test
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve/evetest"
+)
+
+// TestUpgradeSuite runs TestEVEUpgrade across multiple hypervisor combinations
+// and disk sizes.
+// IMPORTANT: In this test suite, it is assumed that the tested EVE version
+// (selected by the variable EVETEST_EVE_VERSION) is at least 17.0.0
+// and therefore uses the 2 * 10GB partition layout.
+func TestUpgradeSuite(test *testing.T) {
+	evetest.Init(test)
+	defer evetest.Close()
+
+	const (
+		// 16.0.0-lts has small enough partitions to boot on smallDiskSizeMiB.
+		// The target EVE version (>= 17.0.0) requires larger partitions, so the
+		// upgrade fails and EVE reverts -- which is what the *WithSmallDisk variants
+		// are designed to test.
+		initialEVEVersionForKVM = "16.0.0-lts"
+
+		// EVE-K (k3s/kubevirt-based EVE) is officially supported starting from 17.0.0.
+		// TODO: strip the rc suffix once 17.0.0 is released.
+		initialEVEVersionForKubevirt = "17.0.0-rc2"
+
+		// Enough for the pre-10GB partition layout, but not enough for EVE 17.0.0+,
+		// which is why *WithSmallDisk variants expect revert.
+		smallDiskSizeMiB = uint32(20480) // 20 GiB
+	)
+
+	// Define configurable parameters available for the test suite.
+	evetest.DefineTestParameters(
+		evetest.TPMParameter(),
+	)
+
+	evetest.RunTestSuite(
+		evetest.TestCase{
+			Test: TestEVEUpgrade,
+			// Target EVE version is common to all variants: set via EVETEST_EVE_VERSION.
+			Variants: []evetest.TestVariant{
+				{
+					Name: "TestEVEUpgradeKVMtoKVM",
+					Parameters: []evetest.TestParameterValue{
+						// Initial
+						{Key: initialEVEVersionParamKey, Value: initialEVEVersionForKVM},
+						{Key: initialHypervisorParamKey, Value: evetest.HypervisorKVM},
+						// Target
+						{Key: evetest.HypervisorParameterKey, Value: evetest.HypervisorKVM},
+					},
+				},
+				{
+					Name: "TestEVEUpgradeKubevirtToKubevirt",
+					Parameters: []evetest.TestParameterValue{
+						// Initial
+						{Key: initialEVEVersionParamKey, Value: initialEVEVersionForKubevirt},
+						{Key: initialHypervisorParamKey, Value: evetest.HypervisorKubevirt},
+						// Target
+						{Key: evetest.HypervisorParameterKey, Value: evetest.HypervisorKubevirt},
+					},
+				},
+				{
+					Name: "TestEVEUpgradeKVMtoKubevirt",
+					Parameters: []evetest.TestParameterValue{
+						// Initial
+						{Key: initialEVEVersionParamKey, Value: initialEVEVersionForKVM},
+						{Key: initialHypervisorParamKey, Value: evetest.HypervisorKVM},
+						// Target
+						{Key: evetest.HypervisorParameterKey, Value: evetest.HypervisorKubevirt},
+					},
+				},
+				{
+					Name: "TestEVEUpgradeKVMtoKVMWithSmallDisk",
+					Parameters: []evetest.TestParameterValue{
+						// Initial
+						{Key: initialEVEVersionParamKey, Value: initialEVEVersionForKVM},
+						{Key: initialHypervisorParamKey, Value: evetest.HypervisorKVM},
+						// Target
+						{Key: evetest.HypervisorParameterKey, Value: evetest.HypervisorKVM},
+						// Extra params
+						{Key: evetest.DiskSizeMiBParameterKey, Value: smallDiskSizeMiB},
+						// Expect upgrade to fail
+						{Key: expectRevertParamKey, Value: true},
+					},
+				},
+				{
+					Name: "TestEVEUpgradeKVMtoKubevirtWithSmallDisk",
+					Parameters: []evetest.TestParameterValue{
+						// Initial
+						{Key: initialEVEVersionParamKey, Value: initialEVEVersionForKVM},
+						{Key: initialHypervisorParamKey, Value: evetest.HypervisorKVM},
+						// Target
+						{Key: evetest.HypervisorParameterKey, Value: evetest.HypervisorKubevirt},
+						// Extra params
+						{Key: evetest.DiskSizeMiBParameterKey, Value: smallDiskSizeMiB},
+						// Expect upgrade to fail
+						{Key: expectRevertParamKey, Value: true},
+					},
+				},
+			},
+		},
+	)
+}

--- a/evetest/tests/upgrade/upgrade_test.go
+++ b/evetest/tests/upgrade/upgrade_test.go
@@ -1,0 +1,262 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	eveconfig "github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve-api/go/evecommon"
+	eveinfo "github.com/lf-edge/eve-api/go/info"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/constants"
+	"github.com/lf-edge/eve/evetest/matchers"
+	"github.com/lf-edge/eve/evetest/netmodels"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+const (
+	initialEVEVersionParamKey = "INITIAL_EVE_VERSION"
+	initialHypervisorParamKey = "INITIAL_HYPERVISOR"
+	expectRevertParamKey     = "EXPECT_REVERT"
+
+	appSSHUser     = "root"
+	appSSHPassword = "testpassword"
+	appSSHFwdPort  = 2222
+)
+
+// TestEVEUpgrade performs an end-to-end upgrade from an initial EVE version to a
+// target version. It deploys a container application before the upgrade, runs
+// the upgrade (which causes one reboot), and then verifies that the application
+// is still healthy under the new EVE version.
+//
+// The device boots on the initial version (EVETEST_INITIAL_EVE_VERSION +
+// EVETEST_INITIAL_HYPERVISOR) and is upgraded to the target version
+// (EVETEST_EVE_VERSION + EVETEST_HYPERVISOR). This way the standard EVETEST_EVE_VERSION
+// variable always refers to the version being tested, which is the upgrade target.
+//
+// Parameters:
+//   - EVE_VERSION: target EVE version to upgrade to (default is the current HEAD
+//     of the checked-out EVE repo)
+//   - HYPERVISOR: target hypervisor for the upgraded EVE (default: kvm)
+//   - INITIAL_EVE_VERSION: initial EVE version the device starts on (required,
+//     e.g. "16.0.0-lts")
+//   - INITIAL_HYPERVISOR: initial hypervisor for the starting device (default: kvm)
+//   - DISK_SIZE_MB: device disk size in MiB (0 = framework default 36864 MiB)
+//   - EXPECT_REVERT: if true, the upgrade is expected to fail and EVE to revert
+//     to the previous version (default: false)
+//
+// A container app (evetest-ubuntu-ctr) is deployed before the upgrade and verified
+// to be healthy both before and after the upgrade (or revert).
+func TestEVEUpgrade(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	// Define configurable parameters available for the test.
+	evetest.DefineTestParameters(
+		evetest.EVEVersionParameter(),
+		evetest.HypervisorParameter(),
+		evetest.TPMParameter(),
+		evetest.DiskSizeMiBParameter(),
+		evetest.TestParameterDefinition{
+			Key:          initialEVEVersionParamKey,
+			DefaultValue: "16.0.0-lts",
+			Description: evetest.TestParameterDescription{
+				Summary: "EVE version to upgrade from (the pre-upgrade initial version)",
+				Default: "16.0.0-lts",
+			},
+		},
+		evetest.TestParameterDefinition{
+			Key:          initialHypervisorParamKey,
+			DefaultValue: evetest.HypervisorKVM,
+			Description: evetest.TestParameterDescription{
+				Summary:       "Hypervisor used by the initial (pre-upgrade) EVE version",
+				Default:       "kvm",
+				AllowedValues: "kvm|xen|kubevirt",
+			},
+		},
+		evetest.TestParameterDefinition{
+			Key:          expectRevertParamKey,
+			DefaultValue: false,
+			Description: evetest.TestParameterDescription{
+				Summary: "Expect the upgrade to fail and EVE to revert to the previous version",
+				Default: "false",
+			},
+		},
+	)
+
+	// Get parameter values set for this test execution.
+	withTPM := evetest.GetTPMParameterValue()
+	diskSizeMiB := evetest.GetDiskSizeMiBParameterValue()
+	initialVersion := evetest.GetTestParameter[string](initialEVEVersionParamKey)
+	if initialVersion == "" {
+		evetestT.Fatalf("%s%s is required for TestEVEUpgrade",
+			constants.EnvPrefix, initialEVEVersionParamKey)
+	}
+	initialHypervisor := evetest.GetTestParameter[evetest.Hypervisor](initialHypervisorParamKey)
+	targetVersion := evetest.GetEVEVersionParameterValue()
+	targetHypervisor := evetest.GetHypervisorParameterValue()
+	expectRevert := evetest.GetTestParameter[bool](expectRevertParamKey)
+
+	const devName = "edge-dev"
+	evetest.Setup(
+		evetest.RequireEdgeDevice{
+			Name:              devName,
+			WithEVEVersion:    initialVersion,
+			WithHypervisor:    initialHypervisor,
+			WithTPM:           withTPM,
+			MinDiskSizeInMiB:  diskSizeMiB,
+			DeviceReusePolicy: evetest.CreateFromScratchWithInstaller,
+		},
+		evetest.RequireNetworkModel{NetworkModel: netmodels.SingleEthWithDHCP},
+	)
+	device := evetest.GetEdgeDevice(devName)
+
+	// Apply initial device config: management adapter only.
+	// For kubevirt, the NI and app are added only after the cluster is ready.
+	devConfig := evetest.NewEdgeDeviceConfig(devName)
+	networkUUID := devConfig.AddNetwork(evetest.DHCPNetworkConfig{
+		NetworkType: evecommon.NetworkType_V4,
+	})
+	devConfig.AddNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  "eth0",
+		PhysicalLabel: "eth0",
+		InterfaceName: "eth0",
+		NetworkUUID:   networkUUID,
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+	})
+
+	const nodeReadyCond = eveinfo.KubeNodeConditionType_KUBE_NODE_CONDITION_TYPE_READY
+	isK3sReady := func(info *eveinfo.ZInfoKubeCluster) bool {
+		if info == nil || len(info.Nodes) != 1 {
+			return false
+		}
+		if info.Storage.Health != eveinfo.ServiceStatus_SERVICE_STATUS_HEALTHY {
+			return false
+		}
+		for _, cond := range info.Nodes[0].GetConditions() {
+			if cond.GetType() == nodeReadyCond {
+				return cond.GetSet()
+			}
+		}
+		return false
+	}
+
+	if initialHypervisor == evetest.HypervisorKubevirt {
+		clusterUpdates, stopClusterWatch := device.WatchClusterInfo()
+		defer stopClusterWatch()
+		device.ApplyConfig(devConfig, true, true)
+
+		t.Eventually(clusterUpdates, 20*time.Minute).Should(Receive(
+			matchers.SatisfyPredicate("K3s node is ready", isK3sReady)))
+		evetest.Checkpoint("k3s-ready")
+	}
+
+	niUUID := devConfig.AddNetworkInstance(evetest.LocalNetworkInstanceConfig{
+		DisplayName: "local-ni",
+		Port:        "eth0",
+		Subnet:      evetest.IPSubnet("10.11.12.0/24"),
+		DHCPRange: types.IPRange{
+			Start: evetest.IPAddress("10.11.12.2"),
+			End:   evetest.IPAddress("10.11.12.254"),
+		},
+		Gateway: evetest.IPAddress("10.11.12.1"),
+		MTU:     1500,
+	})
+	appUUID := devConfig.AddApplication(evetest.ApplicationInstanceConfig{
+		DisplayName: "upgrade-test-app",
+		Activate:    true,
+		Image: evetest.DockerContainer{
+			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			Tag:       "1.0",
+		},
+		VirtualizationMode: eveconfig.VmMode_HVM,
+		CPUs:               1,
+		MemoryBytes:        500 * evetest.MiB,
+		NetworkAdapters: []evetest.AppNetworkAdapter{
+			evetest.VirtualNetworkAdapter{
+				LogicalLabel:        "vif0",
+				NetworkInstanceUUID: niUUID,
+				PortFwdRules: []evetest.PortFwdRule{
+					{
+						Protocol:     evetest.NetworkProtocolTCP,
+						EdgeNodePort: appSSHFwdPort,
+						AppPort:      22,
+					},
+				},
+				ACLAllowRules: []evetest.ACLAllowRule{
+					{
+						Protocol:     evetest.NetworkProtocolAny,
+						RemoteSubnet: evetest.IPSubnet("0.0.0.0/0"),
+					},
+				},
+			},
+		},
+	})
+	device.ApplyConfig(devConfig, false, false)
+
+	device.WaitUntilAppIsRunning(appUUID, 5*time.Minute)
+
+	// Verify the app is reachable before the upgrade.
+	appAuth := evetest.UsernamePasswordAuth{Username: appSSHUser, Password: appSSHPassword}
+	sshTimeout := 20 * time.Second
+	log := evetest.Logger()
+	log.Infof("Verifying app is reachable before upgrade")
+	t.Eventually(func(t Gomega) {
+		out, _, err := device.RunShellScriptInsideApp(
+			appUUID, appAuth, "hostname", sshTimeout, 0)
+		t.Expect(err).NotTo(HaveOccurred())
+		t.Expect(strings.TrimSpace(out)).To(Equal(appUUID.String()))
+	}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+	evetest.Checkpoint("pre-upgrade")
+
+	device.UpgradeEVE(targetVersion, targetHypervisor, true, expectRevert)
+
+	if expectRevert {
+		evetest.Checkpoint("upgrade-reverted")
+	} else {
+		evetest.Checkpoint("upgrade-complete")
+	}
+
+	// If the EVE version now running uses Kubevirt, wait for K3s to be ready
+	// before checking the app. Check the last published cluster info first --
+	// the cluster may have already become ready during UpgradeEVE.
+	activeHypervisor := targetHypervisor
+	if expectRevert {
+		activeHypervisor = initialHypervisor
+	}
+	if activeHypervisor == evetest.HypervisorKubevirt {
+		if !isK3sReady(device.GetClusterInfo()) {
+			clusterUpdates, stopClusterWatch := device.WatchClusterInfo()
+			defer stopClusterWatch()
+			t.Eventually(clusterUpdates, 20*time.Minute).Should(Receive(
+				matchers.SatisfyPredicate("K3s node is ready", isK3sReady)))
+		}
+		evetest.Checkpoint("k3s-ready-post-upgrade")
+	}
+
+	// Verify the app comes back up and is still reachable (under the new EVE
+	// version on success, or back under the original version after a revert).
+	device.WaitUntilAppIsRunning(appUUID, 5*time.Minute)
+	log.Infof("Verifying app is reachable after upgrade")
+	t.Eventually(func(t Gomega) {
+		out, _, err := device.RunShellScriptInsideApp(
+			appUUID, appAuth, "hostname", sshTimeout, 0)
+		t.Expect(err).NotTo(HaveOccurred())
+		t.Expect(strings.TrimSpace(out)).To(Equal(appUUID.String()))
+	}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+	if expectRevert {
+		evetest.Checkpoint("post-revert-verified")
+	} else {
+		evetest.Checkpoint("post-upgrade-verified")
+	}
+}

--- a/evetest/utils/files.go
+++ b/evetest/utils/files.go
@@ -4,6 +4,8 @@
 package utils
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/fs"
@@ -70,6 +72,21 @@ func CopyFile(src string, dst string) (err error) {
 	}
 	err = out.Sync()
 	return
+}
+
+// FileHashAndSize computes the SHA-256 hex digest and byte size of the file at path.
+func FileHashAndSize(path string) (sha256hex string, size int64, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", 0, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	n, err := io.Copy(h, f)
+	if err != nil {
+		return "", 0, err
+	}
+	return hex.EncodeToString(h.Sum(nil)), n, nil
 }
 
 // CopyFolder from source to destination


### PR DESCRIPTION
# Description

Adds end-to-end EVE upgrade testing to the evetest framework.

Framework additions:
- HTTP image server serving rootfs images to EVE devices from the evetest container.
- `EdgeDeviceConfig.SetBaseOS` to configure an EVE OS upgrade.
- `EdgeDevice.UpgradeEVE` to pull the target EVE image, push the upgrade config, and wait for the upgrade or revert to complete.

Upgrade test (`tests/upgrade`):
- `TestEVEUpgrade`: deploys a container app, upgrades EVE from an initial version (`EVETEST_INITIAL_EVE_VERSION`) to the tested target (`EVETEST_EVE_VERSION`), and verifies the app is still reachable after the upgrade or revert.
- `TestUpgradeSuite`: covers KVM→KVM, Kubevirt→Kubevirt, KVM→Kubevirt, and small-disk (expected revert) variants.

Also improves list-tests to correctly resolve cross-package parameter key constants, numeric typed constants, and explicitly empty default values.

## How to test and validate this PR

This is just a test framework enhancement. Not a user-facing change.
But if you still wish to test this, run `TestEVEUpgrade`.
For example:

```
make evetest-build-container
EVETEST_INITIAL_EVE_VERSION=17.0.0-rc2 \
EVETEST_EVE_VERSION=<your-target-EVE-version> \
make evetest NAME=TestEVEUpgrade
```

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.