### PR TITLE
volumemgr: persist deferred content-tree deletes

### DIFF
--- a/pkg/pillar/base/logobjecttypes.go
+++ b/pkg/pillar/base/logobjecttypes.go
@@ -77,6 +77,8 @@ const (
 	ContentTreeConfigLogType LogObjectType = "contenttree_config"
 	// ContentTreeStatusLogType :
 	ContentTreeStatusLogType LogObjectType = "contenttree_status"
+	// DeferredContentDeleteStatusLogType :
+	DeferredContentDeleteStatusLogType LogObjectType = "deferred_content_delete_status"
 	// DevicePortConfig : object being logged
 	DevicePortConfigLogType LogObjectType = "deviceport_config"
 	// DevicePortConfigList :

--- a/pkg/pillar/cmd/volumemgr/blob.go
+++ b/pkg/pillar/cmd/volumemgr/blob.go
@@ -478,6 +478,16 @@ func unpublishBlobStatus(ctx *volumemgrContext, blobs ...*types.BlobStatus) {
 	errs := []error{}
 	for _, blob := range blobs {
 		key := blob.Sha256
+		// Keep blobs that an unexpired deferred-delete record protects, so they
+		// remain in CAS for reuse (e.g. across the EVE-kvm->EVE-k conversion)
+		// instead of being deleted then re-downloaded. Persist the (possibly
+		// decremented) RefCount rather than dropping it, so a later within-boot
+		// expiry sees the real count.
+		if blobDeferredProtected(ctx, blob.Sha256) {
+			log.Noticef("unpublishBlobStatus(%s): kept (refcount=%d), protected by deferred-delete record", key, blob.RefCount)
+			publishBlobStatus(ctx, blob)
+			continue
+		}
 		log.Functionf("unpublishBlobStatus(%s)", key)
 
 		// Drop references. Note that we never publish the resulting
@@ -622,6 +632,11 @@ func gcImagesFromCAS(ctx *volumemgrContext) {
 				}
 			}
 
+			// Keep images that an unexpired deferred-delete record protects.
+			if imageDeferredProtected(ctx, image) {
+				log.Noticef("gcImagesFromCAS: keeping image %s, protected by deferred-delete record", image)
+				continue
+			}
 			log.Functionf("gcImagesFromCAS: removing image %s from CAS since no ContentTreeStatus ref found", image)
 			if err := ctx.casClient.RemoveImage(image); err != nil {
 				log.Errorf("gcImagesFromCAS: Exception while removing image from CAS. %s", err)

--- a/pkg/pillar/cmd/volumemgr/deferredcontentdelete_test.go
+++ b/pkg/pillar/cmd/volumemgr/deferredcontentdelete_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+)
+
+// newDeferTestCtx returns a volumemgrContext with an in-memory
+// pubDeferredDelete publication for exercising the deferred-delete guards.
+func newDeferTestCtx(t *testing.T) *volumemgrContext {
+	t.Helper()
+	logger := logrus.StandardLogger()
+	log = base.NewSourceLogObject(logger, "test-volumemgr", 0)
+	ps := pubsub.New(&pubsub.EmptyDriver{}, logger, log)
+	pub, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.DeferredContentDeleteStatus{},
+	})
+	if err != nil {
+		t.Fatalf("NewPublication: %v", err)
+	}
+	return &volumemgrContext{pubDeferredDelete: pub}
+}
+
+func publishDefer(t *testing.T, ctx *volumemgrContext, refID string, blobs []string, expiry time.Time) types.DeferredContentDeleteStatus {
+	t.Helper()
+	id, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("uuid.NewV4: %v", err)
+	}
+	rec := types.DeferredContentDeleteStatus{
+		ContentID:   id,
+		ReferenceID: refID,
+		Blobs:       blobs,
+		DeleteTime:  expiry,
+	}
+	if err := ctx.pubDeferredDelete.Publish(rec.Key(), rec); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	refreshDeferredProtection(ctx)
+	return rec
+}
+
+func TestBlobDeferredProtected(t *testing.T) {
+	ctx := newDeferTestCtx(t)
+	future := time.Now().Add(time.Hour)
+	past := time.Now().Add(-time.Hour)
+
+	publishDefer(t, ctx, "ref-live", []string{"aaa", "bbb"}, future)
+	publishDefer(t, ctx, "ref-expired", []string{"ccc"}, past)
+
+	cases := map[string]bool{
+		"aaa": true,  // listed in an unexpired record
+		"bbb": true,  // listed in an unexpired record
+		"ccc": false, // only in an expired record -> not protected
+		"zzz": false, // not listed anywhere
+	}
+	for sha, want := range cases {
+		if got := blobDeferredProtected(ctx, sha); got != want {
+			t.Errorf("blobDeferredProtected(%q) = %v, want %v", sha, got, want)
+		}
+	}
+
+	if !imageDeferredProtected(ctx, "ref-live") {
+		t.Error("imageDeferredProtected(ref-live) = false, want true")
+	}
+	if imageDeferredProtected(ctx, "ref-expired") {
+		t.Error("imageDeferredProtected(ref-expired) = true, want false (expired)")
+	}
+	if imageDeferredProtected(ctx, "ref-missing") {
+		t.Error("imageDeferredProtected(ref-missing) = true, want false")
+	}
+}
+
+func TestCancelDeferredDelete(t *testing.T) {
+	ctx := newDeferTestCtx(t)
+	rec := publishDefer(t, ctx, "ref", []string{"sha-1"}, time.Now().Add(time.Hour))
+
+	if !blobDeferredProtected(ctx, "sha-1") {
+		t.Fatal("blob should be protected before cancel")
+	}
+	cancelDeferredDelete(ctx, rec.Key())
+	if blobDeferredProtected(ctx, "sha-1") {
+		t.Error("blob should not be protected after cancel")
+	}
+	if item, _ := ctx.pubDeferredDelete.Get(rec.Key()); item != nil {
+		t.Error("deferred-delete record should be gone after cancel")
+	}
+	// Cancelling a non-existent record must be a no-op (no panic).
+	missing, _ := uuid.NewV4()
+	cancelDeferredDelete(ctx, missing.String())
+}

--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -185,6 +185,9 @@ func populateDatastoreFields(ctx *volumemgrContext, config types.ContentTreeConf
 func createContentTreeStatus(ctx *volumemgrContext, config types.ContentTreeConfig) *types.ContentTreeStatus {
 
 	log.Functionf("createContentTreeStatus for %v", config.ContentID)
+	// If this content was pending a deferred delete, cancel it: the blobs kept
+	// in CAS are about to be reused rather than reaped at the deferral expiry.
+	cancelDeferredDelete(ctx, config.ContentID.String())
 	status := ctx.LookupContentTreeStatus(config.Key())
 	if status == nil {
 		status = &types.ContentTreeStatus{
@@ -298,50 +301,138 @@ func updateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus) {
 	log.Functionf("updateContentTree for %v Done", status.ContentID)
 }
 
-type timeAndContentTreeStatus struct {
-	deleteTime time.Time
-	status     *types.ContentTreeStatus
-}
-
-// deferredDelete has entries in time order
-var deferredDelete = make([]timeAndContentTreeStatus, 0)
-
-// deleteContentTree optionally delays the delete using the above slice
+// deleteContentTree optionally defers the delete, keeping the content's CAS
+// blobs and image for possible reuse (timer.defer.content.delete) instead of
+// deleting then re-downloading. The deferral is recorded in a Persistent
+// DeferredContentDeleteStatus, so it survives a reboot — in particular the
+// EVE-kvm->EVE-k boot-disk conversion, which deletes the running app before
+// repartitioning and reboots. While the record is unexpired, blobDeferredProtected
+// keeps the blobs in CAS even though no ContentTreeStatus references them; on
+// expiry checkDeferredDelete reaps them, and a re-created content tree cancels
+// the deferral and reuses them.
 func deleteContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus, deferContentDelete uint32) {
 	log.Functionf("deleteContentTree for %v", status.ContentID)
 
 	// Clean up in case it was never resolved
 	deleteResolveConfig(ctx, status.ResolveKey())
 
-	// If the content tree did not complete, or knob is at default of
-	// no defer, then delete. Otherwise honor defer time to to avoid
-	// delete then re-download
+	// If the content tree did not complete, or the knob is at the default of
+	// no defer, delete immediately.
 	if status.State < types.LOADED || deferContentDelete == 0 {
 		doDeleteContentTree(ctx, status)
-	} else {
-		expiry := time.Now().Add(time.Duration(deferContentDelete) * time.Second)
-		tc := timeAndContentTreeStatus{
-			deleteTime: expiry,
-			status:     status,
-		}
-		log.Noticef("Deferring delete of %s to %v",
-			status.Key(), expiry)
-		deferredDelete = append(deferredDelete, tc)
+		return
+	}
+
+	// Defer: publish a Persistent record naming the blobs and image to keep,
+	// then drop the live ContentTreeStatus and its blob references. The blobs
+	// stay in CAS at RefCount 0, protected by blobDeferredProtected, until the
+	// record expires or the content tree is re-created.
+	expiry := time.Now().Add(time.Duration(deferContentDelete) * time.Second)
+	rec := types.DeferredContentDeleteStatus{
+		ContentID:         status.ContentID,
+		GenerationCounter: status.GenerationCounter,
+		ReferenceID:       status.ReferenceID(),
+		Blobs:             append([]string{}, status.Blobs...),
+		DeleteTime:        expiry,
+	}
+	log.Noticef("Deferring delete of %s (%d blobs) to %v",
+		status.Key(), len(rec.Blobs), expiry)
+	if err := ctx.pubDeferredDelete.Publish(rec.Key(), rec); err != nil {
+		log.Errorf("deleteContentTree: publish deferred delete %s: %s", rec.Key(), err)
+	}
+	refreshDeferredProtection(ctx)
+
+	RemoveAllBlobsFromContentTreeStatus(ctx, status, status.Blobs...)
+	unpublishContentTreeStatus(ctx, status)
+}
+
+// cancelDeferredDelete drops any pending deferred delete for the given content
+// ID. Called when a content tree is (re-)created so its now-referenced blobs are
+// not reaped at the original expiry.
+func cancelDeferredDelete(ctx *volumemgrContext, key string) {
+	if item, _ := ctx.pubDeferredDelete.Get(key); item != nil {
+		log.Noticef("cancelDeferredDelete: content %s re-created, cancelling deferred delete", key)
+		ctx.pubDeferredDelete.Unpublish(key)
+		refreshDeferredProtection(ctx)
 	}
 }
 
+// refreshDeferredProtection rebuilds the cached sets of blob shas and image
+// references named by unexpired deferred-delete records. Callers of
+// blobDeferredProtected/imageDeferredProtected consult those sets, so this must
+// run whenever the pubDeferredDelete set changes (publish, cancel, expiry) to
+// keep the guards O(1) per lookup instead of scanning every record.
+func refreshDeferredProtection(ctx *volumemgrContext) {
+	now := time.Now()
+	blobs := make(map[string]bool)
+	images := make(map[string]bool)
+	for _, item := range ctx.pubDeferredDelete.GetAll() {
+		rec := item.(types.DeferredContentDeleteStatus)
+		if now.After(rec.DeleteTime) {
+			continue
+		}
+		for _, b := range rec.Blobs {
+			blobs[b] = true
+		}
+		images[rec.ReferenceID] = true
+	}
+	ctx.deferredProtectedBlobs = blobs
+	ctx.deferredProtectedImages = images
+}
+
+// blobDeferredProtected reports whether the blob sha is named by any unexpired
+// deferred-delete record, i.e. must be kept in CAS for possible reuse.
+func blobDeferredProtected(ctx *volumemgrContext, sha string) bool {
+	return ctx.deferredProtectedBlobs[sha]
+}
+
+// imageDeferredProtected reports whether the CAS image reference is named by any
+// unexpired deferred-delete record.
+func imageDeferredProtected(ctx *volumemgrContext, referenceID string) bool {
+	return ctx.deferredProtectedImages[referenceID]
+}
+
+// checkDeferredDelete performs the actual delete for every deferred-delete
+// record whose expiry has passed.
 func checkDeferredDelete(ctx *volumemgrContext) {
-	newDD := make([]timeAndContentTreeStatus, 0)
-	for _, tc := range deferredDelete {
-		if time.Now().After(tc.deleteTime) {
-			log.Noticef("Handling deferred delete of %s",
-				tc.status.Key())
-			doDeleteContentTree(ctx, tc.status)
-		} else {
-			newDD = append(newDD, tc)
+	now := time.Now()
+	for _, item := range ctx.pubDeferredDelete.GetAll() {
+		rec := item.(types.DeferredContentDeleteStatus)
+		if now.After(rec.DeleteTime) {
+			log.Noticef("Handling deferred delete of %s", rec.Key())
+			doDeferredContentDelete(ctx, rec)
 		}
 	}
-	deferredDelete = newDD
+}
+
+// doDeferredContentDelete reaps the blobs and image named by an expired
+// deferred-delete record and removes the record. Blobs that a re-created content
+// tree now references (RefCount != 0), or that another unexpired record still
+// protects, are left in place.
+func doDeferredContentDelete(ctx *volumemgrContext, rec types.DeferredContentDeleteStatus) {
+	// Drop the record first so its protection no longer applies to these blobs;
+	// any other unexpired record still protects shared blobs via unpublishBlobStatus.
+	ctx.pubDeferredDelete.Unpublish(rec.Key())
+	refreshDeferredProtection(ctx)
+
+	for _, sha := range rec.Blobs {
+		blob := ctx.LookupBlobStatus(sha)
+		if blob == nil {
+			// The blob is gone from CAS ahead of us (evicted or never
+			// recorded); nothing to unpublish. Any leftover CAS bytes are
+			// reaped by the next ordinary GC sweep.
+			log.Warnf("doDeferredContentDelete: blob %s of %s has no BlobStatus, skipping", sha, rec.Key())
+			continue
+		}
+		if blob.RefCount != 0 {
+			continue
+		}
+		unpublishBlobStatus(ctx, blob)
+	}
+	if err := ctx.casClient.RemoveImage(rec.ReferenceID); err != nil {
+		log.Errorf("doDeferredContentDelete: removing image %s: %s", rec.ReferenceID, err)
+	}
+	deleteLatchContentTreeHash(ctx, rec.ContentID, uint32(rec.GenerationCounter))
 }
 
 func doDeleteContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus) {

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -62,6 +62,7 @@ type volumemgrContext struct {
 	pubResolveConfig        pubsub.Publication
 	subContentTreeConfig    pubsub.Subscription
 	pubContentTreeStatus    pubsub.Publication
+	pubDeferredDelete       pubsub.Publication
 	subVolumeConfig         pubsub.Subscription
 	pubVolumeStatus         pubsub.Publication
 	subVolumeRefConfig      pubsub.Subscription
@@ -97,6 +98,14 @@ type volumemgrContext struct {
 	casClient cas.CAS
 
 	volumeConfigCreateDeferredMap map[string]*types.VolumeConfig
+
+	// deferredProtectedBlobs and deferredProtectedImages cache the blob shas
+	// and image references named by unexpired deferred-delete records, so the
+	// per-blob/per-image GC guards are O(1) lookups rather than a scan of every
+	// record. Rebuilt by refreshDeferredProtection whenever the pubDeferredDelete
+	// set changes.
+	deferredProtectedBlobs  map[string]bool
+	deferredProtectedImages map[string]bool
 
 	persistType types.PersistType
 
@@ -394,6 +403,22 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		log.Fatal(err)
 	}
 	ctx.pubContentTreeToHash = pubContentTreeToHash
+
+	// Persistent so a deferred content-tree delete survives a reboot (e.g. the
+	// EVE-kvm->EVE-k boot-disk conversion); the boot-time GC keeps the listed
+	// blobs/image until the deferral expires.
+	pubDeferredDelete, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName:  agentName,
+		Persistent: true,
+		TopicType:  types.DeferredContentDeleteStatus{},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.pubDeferredDelete = pubDeferredDelete
+	// Seed the protection cache from the records restored above, before any GC
+	// path consults it at boot.
+	refreshDeferredProtection(&ctx)
 
 	pubBlobStatus, err := ps.NewPublication(
 		pubsub.PublicationOptions{
@@ -700,6 +725,23 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	ctx.diskMetricsTickerHandle = <-diskMetricsTickerHandle
 
 	for {
+		// Apply any pending global config BEFORE servicing other subscriptions.
+		// When the controller raises timer.defer.content.delete and deletes an
+		// app in the same config update, the ConfigItemValueMap change and the
+		// ContentTreeConfig delete both arrive in our channels; Go select order
+		// is nondeterministic, so without this the delete can be handled while
+		// deferContentDelete is still 0, taking the IMMEDIATE branch in
+		// deleteContentTree and GC-ing the content's blobs the operator meant to
+		// retain (forcing a re-download on the next deploy). Draining the
+		// global-config channel first applies the new deferContentDelete before
+		// any delete in the same batch.
+		select {
+		case change := <-ctx.subGlobalConfig.MsgChan():
+			ctx.subGlobalConfig.ProcessChange(change)
+			continue
+		default:
+		}
+
 		select {
 		case change := <-ctx.subGlobalConfig.MsgChan():
 			ctx.subGlobalConfig.ProcessChange(change)

--- a/pkg/pillar/types/deferredcontentdeletetypes.go
+++ b/pkg/pillar/types/deferredcontentdeletetypes.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	uuid "github.com/satori/go.uuid"
+)
+
+// DeferredContentDeleteStatus records a content-tree delete that volumemgr has
+// deferred (timer.defer.content.delete) so the content's CAS blobs and image are
+// kept for possible reuse instead of being deleted and immediately
+// re-downloaded.
+//
+// It is published Persistent so the deferral survives a reboot — in particular
+// the EVE-kvm->EVE-k boot-disk conversion, which deletes the running app before
+// repartitioning and reboots. On the next boot volumemgr re-reads these records;
+// the boot-time GC keeps the listed blobs and image until DeleteTime, and the
+// actual delete happens at expiry (or is cancelled when the content tree is
+// re-created and reuses the still-present blobs).
+type DeferredContentDeleteStatus struct {
+	ContentID         uuid.UUID // also the publication key (matches ContentTreeStatus.Key())
+	GenerationCounter int64
+	ReferenceID       string    // CAS image reference to remove at expiry
+	Blobs             []string  // blob sha256 (lowercase, no "sha256:" prefix) to keep then reap
+	DeleteTime        time.Time // when the deferred delete becomes due
+}
+
+// Key is the ContentID, matching ContentTreeStatus.Key() so a re-created
+// content tree maps 1:1 to its pending deferred delete.
+func (status DeferredContentDeleteStatus) Key() string {
+	return status.ContentID.String()
+}
+
+// LogCreate :
+func (status DeferredContentDeleteStatus) LogCreate(logBase *base.LogObject) {
+	logObject := base.NewLogObject(logBase, base.DeferredContentDeleteStatusLogType, "",
+		status.ContentID, status.LogKey())
+	if logObject == nil {
+		return
+	}
+	logObject.CloneAndAddField("reference-id", status.ReferenceID).
+		AddField("blob-count-int64", len(status.Blobs)).
+		AddField("delete-time", status.DeleteTime.String()).
+		Noticef("Deferred content delete create")
+}
+
+// LogModify :
+func (status DeferredContentDeleteStatus) LogModify(logBase *base.LogObject, old interface{}) {
+	logObject := base.EnsureLogObject(logBase, base.DeferredContentDeleteStatusLogType, "",
+		status.ContentID, status.LogKey())
+	logObject.CloneAndAddField("reference-id", status.ReferenceID).
+		AddField("blob-count-int64", len(status.Blobs)).
+		AddField("delete-time", status.DeleteTime.String()).
+		Noticef("Deferred content delete modify")
+}
+
+// LogDelete :
+func (status DeferredContentDeleteStatus) LogDelete(logBase *base.LogObject) {
+	logObject := base.EnsureLogObject(logBase, base.DeferredContentDeleteStatusLogType, "",
+		status.ContentID, status.LogKey())
+	logObject.Noticef("Deferred content delete delete")
+	base.DeleteLogObject(logBase, status.LogKey())
+}
+
+// LogKey :
+func (status DeferredContentDeleteStatus) LogKey() string {
+	return string(base.DeferredContentDeleteStatusLogType) + "-" + status.Key()
+}


### PR DESCRIPTION
**Motivation:** a bug found while testing the kvm-to-k (EVE-kvm↔EVE-k) conversion — deferred content-tree deletes did not survive the conversion reboot. This fix makes timer.defer.content.delete more useful in general but required for the kvm-to-k tests which are being developed.

# Description

One way to both test and use the WIP EVE-kvm to EVE-k conversion without having
to re-download app images/containers is to ensure that the content tree is not
deleted (by setting the defer timer), delete the app instance, upgrade/convert
to EVE-k, then re-deploy the app instance. That assumes that the defer timer
works correctly even when there are delays and device reboots. This PR makes it
reliable in those conditions.

A content-tree delete deferred by `timer.defer.content.delete` keeps the
content's CAS blobs so a quick re-deploy reuses them instead of deleting and
re-downloading. That deferral was tracked only in memory plus the
still-published `ContentTreeStatus`, both lost on reboot. So when a reboot falls
inside the defer window — notably the EVE-kvm→EVE-k boot-disk conversion, which
deletes the running app before repartitioning and reboots — the blobs were
re-adopted unreferenced and the boot-time GC could reap them before the app was
redeployed, forcing a full re-download of an image whose bytes were still present
on the preserved `/persist`.

This records each deferred delete as a `Persistent` `DeferredContentDeleteStatus`
(content ID, image reference, blob list, expiry). It becomes the single source of
truth: the in-memory `deferredDelete` slice and the practice of leaving the
`ContentTreeStatus` published only to hold a RefCount are removed. While a record
is unexpired the blob and image GC reapers skip the listed content, so the blobs
survive the reboot regardless of GC-vs-redeploy timing; the redeploy re-creates
the content tree and reuses them. At expiry the record drives the delete, leaving
any blob that a live content tree now references.

**WIP / known follow-up:** `cancelDeferredDelete` keys on content ID, but a
redeploy is assigned a new content ID, so the original record is not cancelled
and lingers until its expiry (harmless — at expiry the now-referenced blobs are
skipped). Keying cancellation on the image reference / blob set would drop the
record promptly on redeploy.

## How to test and validate this PR

- Unit tests for the protection/cancel logic
  (`pkg/pillar/cmd/volumemgr/deferredcontentdelete_test.go`).
- Validated end-to-end under eden + swtpm across a kvm→k conversion: set
  `timer.defer.content.delete`, deploy an app, delete the app instance, convert
  to EVE-k (boot-disk repartition + reboot), then re-deploy the app. The
  `DeferredContentDeleteStatus` records survived the conversion reboot, the boot
  GC ran and the guards kept the blobs and image, and the app redeploy
  re-downloaded 0 bytes.

## Changelog notes

No user-facing changes.

## PR Backports

- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
