### PR TITLE
downloader: apply datastore custom certs when resolving OCI

### DIFF
--- a/pkg/pillar/cmd/downloader/download.go
+++ b/pkg/pillar/cmd/downloader/download.go
@@ -168,6 +168,15 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 	}
 	defer dEndPoint.Close()
 
+	if len(certs) > 0 {
+		log.Functionf("%s: Set trusted certs", trType)
+		err = dEndPoint.WithTrustedCerts(certs)
+		if err != nil {
+			log.Errorf("Set trusted certificates failed: %s", err)
+			return "", cancel, tracedReq, err
+		}
+	}
+
 	// Configure the network client.
 	err = dEndPoint.WithSrcIP(ipSrc)
 	if err != nil {
@@ -178,14 +187,6 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 		// With other (currently supported) datastore types this call will not fail.
 		log.Errorf("Set source IP failed: %s", err)
 		err = nil
-	}
-	if len(certs) > 0 {
-		log.Functionf("%s: Set trusted certs", trType)
-		err = dEndPoint.WithTrustedCerts(certs)
-		if err != nil {
-			log.Errorf("Set trusted certificates failed: %s", err)
-			return "", cancel, tracedReq, err
-		}
 	}
 	// check for proxies on the selected management port interface
 	proxyLookupURL := controllerconn.IntfLookupProxyCfg(log, &ctx.deviceNetworkStatus, ifname, downloadURL, trType)
@@ -369,7 +370,7 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 // interfaces or IP addresses.
 func objectMetadata(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 	syncOp zedUpload.SyncOpType, downloadURL, netTraceFolder string,
-	auth *zedUpload.AuthInput, dpath, region string, ifname string,
+	auth *zedUpload.AuthInput, dpath, region string, certs [][]byte, ifname string,
 	ipSrc net.IP, filename string, receiveChan chan<- CancelChannel) (string, bool, error) {
 
 	// create Endpoint
@@ -389,6 +390,13 @@ func objectMetadata(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 	}
 	defer dEndPoint.Close()
 
+	if len(certs) > 0 {
+		log.Functionf("%s: Set trusted certs", trType)
+		if err := dEndPoint.WithTrustedCerts(certs); err != nil {
+			log.Errorf("Set trusted certificates failed: %s", err)
+			return sha256, cancel, err
+		}
+	}
 	// Configure the network client.
 	dEndPoint.WithSrcIP(ipSrc)
 	// check for proxies on the selected management port interface

--- a/pkg/pillar/cmd/downloader/resolveconfig.go
+++ b/pkg/pillar/cmd/downloader/resolveconfig.go
@@ -269,7 +269,7 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig,
 			ipSrc, ifname, dsCtx.TransportMethod)
 
 		sha256, cancelled, err = objectMetadata(ctx, trType, syncOp, serverURL, types.NetTraceFolder, auth,
-			dsCtx.Dpath, dsCtx.Region,
+			dsCtx.Dpath, dsCtx.Region, dst.DsCertPEM,
 			ifname, ipSrc, remoteName, receiveChan)
 		if err != nil {
 			if cancelled {


### PR DESCRIPTION
# Description

When resolving an OCI image tag to its sha256 digest, the downloader opened the
registry endpoint without the datastore's trusted certificates. Registries
fronted by a private or self-signed CA therefore failed TLS verification during
tag resolution, even though the actual image download succeeded — the download
path already installs the certs via `WithTrustedCerts`.

This PR threads the datastore's `DsCertPEM` through `objectMetadata` and applies
it to the endpoint when present, using the same error handling and logging as
the download path, so OCI tag resolution honours datastore custom certificates.

## PR dependencies

None.

## How to test and validate this PR

This is a bug fix; to confirm the issue is resolved:

1. Stand up an OCI registry fronted by a private or self-signed CA, and create a
   datastore config that supplies that CA certificate (`DsCertPEM`).
2. Deploy an app instance / content tree that references an image by **tag**
   (not by digest), so the downloader runs tag→digest resolution.
3. Before this change: tag resolution fails with a TLS certificate verification
   error, even though a by-digest download from the same registry succeeds.
   After this change: resolution succeeds using the datastore's custom certs.


## Changelog notes

Fixed OCI image download with custom tls certificate.

## PR Backports

The same gap exists in all current LTS branches — `objectMetadata` does not
receive the datastore certs there, while the image-download path already passes
`dst.DsCertPEM` — so the fix applies to each:

- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — not needed; internal bug fix with no user-facing API/config change
- [X] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device 
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't

🤖 Generated with [Claude Code](https://claude.com/claude-code)
