### PR TITLE
mgmtproxy: improve image-pull throughput with io.Copy relay

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -1385,6 +1385,17 @@ patch_cdi_proxy_config() {
         local proxy_url="${MGMTPROXY_CNI0_URL}"
         # noProxy is a comma-separated string per the CDI ImportProxy API
         local no_proxy="10.42.0.0/16,10.43.0.0/16,127.0.0.0/8,localhost,.svc,.cluster.local,169.254.0.0/16"
+        # Skip (and stay silent) when the CDI CR already carries the desired
+        # importProxy config. This function is called on every main-loop
+        # iteration (~16s) for upgrade/reset recovery, so logging or patching
+        # unconditionally would spam k3s-install.log and issue a pointless
+        # kubectl patch each time. Only act when something actually differs.
+        local cur_proxy cur_no_proxy
+        cur_proxy=$(kubectl get cdi cdi -o jsonpath='{.spec.config.importProxy.HTTPSProxy}' 2>/dev/null)
+        cur_no_proxy=$(kubectl get cdi cdi -o jsonpath='{.spec.config.importProxy.noProxy}' 2>/dev/null)
+        if [ "${cur_proxy}" = "${proxy_url}" ] && [ "${cur_no_proxy}" = "${no_proxy}" ]; then
+                return 0
+        fi
         logmsg "patch_cdi_proxy_config: HTTPSProxy=${proxy_url}"
         kubectl patch cdi cdi --type merge -p \
                 "{\"spec\":{\"config\":{\"importProxy\":{\"HTTPSProxy\":\"${proxy_url}\",\"noProxy\":\"${no_proxy}\"}}}}"

--- a/pkg/pillar/cmd/mgmtproxy/README.md
+++ b/pkg/pillar/cmd/mgmtproxy/README.md
@@ -451,6 +451,49 @@ If `/healthz` shows the proxy choosing a port that NIM marks `LastError`,
 it's a fallback after `WithoutFailed` was empty — usually transient, but
 worth investigating if persistent.
 
+## Throughput tuning
+
+The proxy is a plain TCP relay (CONNECT — it never terminates TLS), so per-stream
+throughput is bounded by the usual TCP bandwidth-delay product: `window / RTT`. Image
+pulls go to internet registries (quay.io, ghcr, github) at tens of ms RTT, so a small
+receive window throttles a large layer badly — e.g. a ~32 KiB window over a ~90 ms path
+caps a single stream near 0.35 MB/s regardless of available bandwidth.
+
+The relay copies each direction with `io.Copy`. Between two `*net.TCPConn` that takes the
+kernel `splice()` zero-copy path: payload moves socket→pipe→socket without a userspace
+buffer, and the kernel keeps draining the receive socket promptly. That prompt drain is
+what lets Linux TCP receive-window autotuning grow the advertised window toward its ceiling
+`net.ipv4.tcp_rmem[2]` (~6 MiB by default) instead of leaving it pinned small — the lever
+for image-pull throughput on high-RTT paths.
+
+Because `splice()` keeps the payload in-kernel, the tunnel's idle watchdog cannot watch a
+per-write signal; it polls each socket's `TCP_INFO.tcpi_bytes_received` (every
+`idleTimeout/4`) and closes the tunnel once the combined count has not advanced for a full
+`idleTimeout` (so the close fires between `idleTimeout` and `idleTimeout + idleTimeout/4`
+after the last observed progress). If a connection is not a TCP socket (e.g. in tests),
+idle enforcement is skipped rather than risking a false close of an active tunnel.
+
+To diagnose a slow pull, confirm it is actually the proxy and not the client's own
+pipeline (containerd TLS-decrypt + decompress + disk): pull the **same** object both
+ways and compare —
+
+```sh
+curl -o /dev/null https://<object>                              # direct baseline
+curl -o /dev/null --proxy http://127.0.0.1:5443 https://<object> # via mgmtproxy
+```
+
+If the via-proxy rate trails the direct rate, inspect the upstream socket while a pull
+runs and read the real window/RTT instead of guessing:
+
+```sh
+ss -tinp 'dport = :443'   # watch rwnd / cwnd / Recv-Q on the mgmtproxy→registry socket
+```
+
+A small `rwnd` with `Recv-Q` *not* full points at the receive-window ceiling (the
+buffers above are the lever). A full `Recv-Q` points at downstream backpressure
+(containerd not draining the loopback side fast enough) — bigger upstream buffers won't
+help that; look at the client side.
+
 ## Known v1 limitations / follow-ups
 
 - **Stale `NO_PROXY` on cluster-node-IP change.** Containerd does not reload

--- a/pkg/pillar/cmd/mgmtproxy/mgmtproxy_test.go
+++ b/pkg/pillar/cmd/mgmtproxy/mgmtproxy_test.go
@@ -9,10 +9,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -321,47 +323,6 @@ func TestProxyHandlerHealthz(t *testing.T) {
 	}
 }
 
-// --- copyAndSignal ---------------------------------------------------------
-
-func TestCopyAndSignal(t *testing.T) {
-	src := strings.NewReader("hello mgmtproxy tunnel")
-	var dst strings.Builder
-	activity := make(chan struct{}, 4)
-
-	n := copyAndSignal(&dst, src, activity)
-	if int(n) != len("hello mgmtproxy tunnel") {
-		t.Errorf("copied %d bytes, want %d", n, len("hello mgmtproxy tunnel"))
-	}
-	if dst.String() != "hello mgmtproxy tunnel" {
-		t.Errorf("dst = %q, want the source string", dst.String())
-	}
-	select {
-	case <-activity:
-		// expected: at least one activity poke for the single read.
-	default:
-		t.Error("expected an activity signal after a non-empty copy")
-	}
-}
-
-// errAfterWriter fails the write after recording how many bytes it accepted,
-// so we can assert copyAndSignal returns the best-effort partial total.
-type errAfterWriter struct{ accepted int }
-
-func (w *errAfterWriter) Write(p []byte) (int, error) {
-	w.accepted = len(p)
-	return len(p), errors.New("write error")
-}
-
-func TestCopyAndSignalWriteError(t *testing.T) {
-	src := strings.NewReader("partial payload")
-	w := &errAfterWriter{}
-	activity := make(chan struct{}, 4)
-	n := copyAndSignal(w, src, activity)
-	if int(n) != w.accepted {
-		t.Errorf("returned %d, want best-effort %d", n, w.accepted)
-	}
-}
-
 // --- dialCostAware (network-free paths) ------------------------------------
 
 func TestDialCostAwareNoMgmtInterfaces(t *testing.T) {
@@ -447,6 +408,105 @@ func TestDialCostAwareOrdersByCost(t *testing.T) {
 			t.Errorf("attempt[%d] = %s, want %s (cost order)", i, attempts[i].IfName, want)
 		}
 	}
+}
+
+// --- idleWatchdog ----------------------------------------------------------
+
+// tcpConnPair returns the two ends of a single loopback TCP connection. Real
+// TCP sockets are required (not net.Pipe) so the watchdog's TCP_INFO read works.
+func tcpConnPair(t *testing.T) (net.Conn, net.Conn) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	type res struct {
+		c   net.Conn
+		err error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		c, err := ln.Accept()
+		ch <- res{c, err}
+	}()
+	c1, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	r := <-ch
+	if r.err != nil {
+		t.Fatalf("accept: %v", r.err)
+	}
+	return c1, r.c
+}
+
+// TestIdleWatchdogClosesStalledTunnel: with no bytes ever received on either
+// socket, the watchdog must flip idleClosed and close the conns after timeout.
+func TestIdleWatchdogClosesStalledTunnel(t *testing.T) {
+	c1, c2 := tcpConnPair(t)
+	defer c1.Close()
+	defer c2.Close()
+
+	var idleClosed atomic.Bool
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		idleWatchdog(ctx, &idleClosed, 300*time.Millisecond, c1, c2)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("watchdog did not close a stalled tunnel within 3s")
+	}
+	if !idleClosed.Load() {
+		t.Error("idleClosed = false, want true for a stalled tunnel")
+	}
+}
+
+// TestIdleWatchdogKeepsActiveTunnelOpen: a tunnel that keeps receiving bytes
+// must not be closed, even past several timeout windows.
+func TestIdleWatchdogKeepsActiveTunnelOpen(t *testing.T) {
+	c1, c2 := tcpConnPair(t)
+	defer c1.Close()
+	defer c2.Close()
+	// Drain c2 so writes never block on a full window.
+	go io.Copy(io.Discard, c2)
+
+	var idleClosed atomic.Bool
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		idleWatchdog(ctx, &idleClosed, 300*time.Millisecond, c1, c2)
+		close(done)
+	}()
+
+	// Keep traffic flowing on the c1→c2 leg for ~3 timeout windows.
+	stop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				_, _ = c1.Write([]byte("x"))
+			}
+		}
+	}()
+
+	time.Sleep(900 * time.Millisecond)
+	if idleClosed.Load() {
+		t.Error("idleClosed = true, want false for an active tunnel")
+	}
+	close(stop)
+	cancel()
+	<-done
 }
 
 // --- tunnel ----------------------------------------------------------------

--- a/pkg/pillar/cmd/mgmtproxy/proxy.go
+++ b/pkg/pillar/cmd/mgmtproxy/proxy.go
@@ -14,9 +14,11 @@ import (
 	"net/http"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	"golang.org/x/sys/unix"
 )
 
 // newProxyHandler returns the http.Handler installed on the loopback listener.
@@ -184,30 +186,36 @@ func handleConnect(ctx *mgmtProxyContext, w http.ResponseWriter, req *http.Reque
 // tunnel performs a bidirectional copy with an idle timeout and accounts
 // bytes per direction. On close it logs a single Functionf line with the
 // totals — visible if operators bump the level to debug a specific pull.
+//
+// The copy is io.Copy in each direction: between two *net.TCPConn it takes the
+// kernel splice() zero-copy path, so payload never round-trips through a
+// userspace buffer. splice keeps draining the receive socket promptly, which
+// is what keeps TCP receive-window autotuning growing the window toward the
+// kernel ceiling (tcp_rmem[2], ~6 MiB by default) — the lever for image-pull
+// throughput on high-RTT internet paths (see README.md).
 func tunnel(ctx *mgmtProxyContext, target, ifName string, a, b net.Conn, dialStart time.Time) {
 	idleCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	activity := make(chan struct{}, 4)
 	idleClosed := atomic.Bool{}
-	go idleWatchdog(idleCtx, &idleClosed, activity, a, b)
+	go idleWatchdog(idleCtx, &idleClosed, idleTimeout, a, b)
 
 	var wg sync.WaitGroup
-	var bytesA2B, bytesB2A uint64
+	var bytesA2B, bytesB2A int64
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		bytesA2B = copyAndSignal(b, a, activity)
+		bytesA2B = copyTunnel(b, a)
 		_ = a.Close()
 	}()
 	go func() {
 		defer wg.Done()
-		bytesB2A = copyAndSignal(a, b, activity)
+		bytesB2A = copyTunnel(a, b)
 		_ = b.Close()
 	}()
 	wg.Wait()
-	ctx.stats.bytesUp.Add(bytesA2B)
-	ctx.stats.bytesDown.Add(bytesB2A)
+	ctx.stats.bytesUp.Add(uint64(bytesA2B))
+	ctx.stats.bytesDown.Add(uint64(bytesB2A))
 	if idleClosed.Load() {
 		ctx.stats.tunnelIdleClosed.Add(1)
 	}
@@ -220,64 +228,109 @@ func tunnel(ctx *mgmtProxyContext, target, ifName string, a, b net.Conn, dialSta
 	// /healthz tunnelIdleClosed counter and the bytes=0 in edgeview tell
 	// the rest of the story without double-counting.
 	ctx.agentMetrics.RecordSuccess(log, ifName, target,
-		int64(bytesA2B), int64(bytesB2A), durationMs, false)
+		bytesA2B, bytesB2A, durationMs, false)
 	log.Functionf("mgmtproxy: tunnel %s via %s closed: up=%d down=%d duration=%v idle=%v",
 		target, ifName, bytesA2B, bytesB2A,
 		time.Duration(durationMs)*time.Millisecond, idleClosed.Load())
 }
 
-// copyAndSignal copies src→dst and pokes the activity channel periodically so
-// the idle watchdog can tell the tunnel from a stalled one. Returns total
-// bytes copied (best-effort — partial writes on error still counted).
-func copyAndSignal(dst io.Writer, src io.Reader, activity chan<- struct{}) uint64 {
-	buf := make([]byte, 32*1024)
-	var total uint64
-	for {
-		n, err := src.Read(buf)
-		if n > 0 {
-			w, werr := dst.Write(buf[:n])
-			total += uint64(w)
-			if werr != nil {
-				return total
-			}
-			select {
-			case activity <- struct{}{}:
-			default:
-			}
-		}
-		if err != nil {
-			if !errors.Is(err, io.EOF) && !errors.Is(err, net.ErrClosed) {
-				log.Tracef("mgmtproxy: tunnel read: %v", err)
-			}
-			return total
-		}
+// copyTunnel copies src→dst for one direction of the tunnel and returns the
+// number of bytes copied. Between two *net.TCPConn io.Copy takes the kernel
+// splice() zero-copy path. EOF and the errors that fire when the peer half is
+// closed during teardown (net.ErrClosed) are the normal way a tunnel ends; any
+// other error is logged at Trace as a debugging signal (matching the prior
+// manual copy loop) without failing the relay.
+func copyTunnel(dst io.Writer, src io.Reader) int64 {
+	n, err := io.Copy(dst, src)
+	if err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, io.EOF) {
+		log.Tracef("mgmtproxy: tunnel copy: %v", err)
 	}
+	return n
 }
 
+// idleWatchdog closes the tunnel connections if no payload bytes are received
+// on either socket for timeout. The splice() path in tunnel never surfaces
+// per-chunk progress to userspace, so instead of a per-write activity signal we
+// poll each socket's TCP_INFO.tcpi_bytes_received and close once the combined
+// count has not advanced for a full timeout. The poll runs every timeout/4, so
+// the actual close fires between timeout and timeout+timeout/4 after the last
+// observed progress.
+//
+// If neither connection exposes TCP_INFO (e.g. a non-TCP conn in tests), idle
+// enforcement is skipped rather than risking a false close of an active tunnel.
 func idleWatchdog(ctx context.Context, idleClosed *atomic.Bool,
-	activity <-chan struct{}, conns ...net.Conn) {
+	timeout time.Duration, conns ...net.Conn) {
 
-	timer := time.NewTimer(idleTimeout)
-	defer timer.Stop()
+	interval := timeout / 4
+	if interval <= 0 {
+		interval = time.Millisecond
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var lastBytes uint64
+	lastChange := time.Now()
+	seenBytes := false
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-activity:
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
+		case <-ticker.C:
+			var total uint64
+			readable := 0
+			for _, c := range conns {
+				if n, ok := tcpBytesReceived(c); ok {
+					total += n
+					readable++
 				}
 			}
-			timer.Reset(idleTimeout)
-		case <-timer.C:
-			log.Warnf("mgmtproxy: tunnel idle for %v, closing", idleTimeout)
-			idleClosed.Store(true)
-			for _, c := range conns {
-				_ = c.Close()
+			if readable == 0 {
+				// Can't observe progress on these conns; don't risk
+				// closing a tunnel that may well be active.
+				lastChange = time.Now()
+				continue
 			}
-			return
+			if !seenBytes || total != lastBytes {
+				seenBytes = true
+				lastBytes = total
+				lastChange = time.Now()
+				continue
+			}
+			if time.Since(lastChange) >= timeout {
+				log.Warnf("mgmtproxy: tunnel idle for %v, closing", timeout)
+				idleClosed.Store(true)
+				for _, c := range conns {
+					_ = c.Close()
+				}
+				return
+			}
 		}
 	}
+}
+
+// tcpBytesReceived returns the cumulative payload bytes the kernel has received
+// on conn's socket (TCP_INFO.tcpi_bytes_received). ok is false if conn is not a
+// TCP socket or the counter can't be read — callers treat that as "unknown",
+// never as "idle".
+func tcpBytesReceived(conn net.Conn) (uint64, bool) {
+	sc, ok := conn.(syscall.Conn)
+	if !ok {
+		return 0, false
+	}
+	raw, err := sc.SyscallConn()
+	if err != nil {
+		return 0, false
+	}
+	var bytes uint64
+	var got bool
+	if cerr := raw.Control(func(fd uintptr) {
+		info, gerr := unix.GetsockoptTCPInfo(int(fd), unix.IPPROTO_TCP, unix.TCP_INFO)
+		if gerr == nil {
+			bytes = info.Bytes_received
+			got = true
+		}
+	}); cerr != nil {
+		return 0, false
+	}
+	return bytes, got
 }


### PR DESCRIPTION
# Description

The CONNECT relay copied each direction with a 32 KiB buffer. Over the high-RTT internet paths used for container image pulls (quay.io, ghcr.io, github), that left per-stream throughput limited by a small TCP receive window, well below available bandwidth: a 32 KiB read pins the kernel's receive-window autotuning estimate low, so the window never grows.

This PR relays each direction with `io.Copy` instead. Between two `*net.TCPConn` that takes the kernel `splice()` zero-copy path, which drains the receive socket promptly and lets TCP receive-window autotuning grow the window toward its ceiling (`net.ipv4.tcp_rmem[2]`, ~6 MiB by default) — the actual lever for throughput.

It does **not** set `SO_RCVBUF`/`SO_SNDBUF` on the upstream socket. An explicit `setsockopt` disables receive-window autotuning for that socket (the kernel sets `SOCK_RCVBUF_LOCK`) and is clamped to `net.core.rmem_max` (~208 KiB default, which EVE does not raise), capping the window far below what autotuning reaches on its own. An earlier version of this PR did set a 2 MiB `SO_RCVBUF`/`SO_SNDBUF`; that was dropped as counterproductive on a stock host.

Because `splice()` keeps payload in-kernel, the idle watchdog can no longer observe a per-write activity signal; it polls each socket's `TCP_INFO.tcpi_bytes_received` and closes the tunnel once the combined count has not advanced for a full `idleTimeout`, treating "can't read TCP_INFO" as unknown (never as idle) so it won't false-close an active tunnel.

Also suppresses noisy logging from the CDI mgmtproxy integration: `patch_cdi_proxy_config()` runs on every cluster-init main-loop iteration (~16s) and previously re-issued the `kubectl patch` (and logged it) unconditionally; it now reads the current CDI `importProxy` config and only patches/logs when it actually differs, matching the check-then-act pattern of `setup_cni0_proxy_ip()`.

## PR dependencies

## How to test and validate this PR

Install the eve-k image from scratch and measure the time for all k3s components to initialize, comparing against a direct (no-proxy) install of the same images.

Measured on an eve-k device — a full cold install (k3s + kubevirt/cdi + longhorn) through the proxy matched a direct install to within run-to-run noise:

| Phase | Direct Δ | Proxy Δ | Proxy − Direct |
|---|---|---|---|
| k3s download+unpack | 10s | 11s | +1s |
| kubevirt + cdi | 121s | 131s | +10s |
| longhorn | 732s | 739s | +7s |
| descheduler | 0s | 0s | 0s |
| final settle → END | 27s | 28s | +1s |
| **Total** | **890s (14m50s)** | **909s (15m09s)** | **+19s (≈2.1%)** |

## Changelog notes

mgmtproxy: improve image-pull throughput with io.Copy relay

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
