### PR TITLE
github/workflows: Switch Claude model to Opus 4.8

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -54,7 +54,7 @@ jobs:
           classify_inline_comments: false
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-            --model claude-sonnet-4-6
+            --model claude-opus-4-8
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}


### PR DESCRIPTION
# Description

With more complex models already available (or to be available, like fable), it doesn't make much sense to continue to use old sonnet, let's bump to latest version of Opus.

## How to test and validate this PR

Run Claude PR review workflow.

## Changelog notes

None.

## PR Backports

No backports.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.