### PR TITLE
[16.0-stable] assets.yml: compress large assets with zstd

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -125,6 +125,16 @@ jobs:
             docker export --output assets/collected_sources.tar eve_sources
             docker rm eve_sources
           fi
+      - name: Compress large assets with zstd
+        # installer.raw, live.raw, and collected_sources.tar can exceed the
+        # GitHub release asset size limit (2 GiB). These compress extremely
+        # well (raw disk images typically 5-20x for sparse regions), keeping
+        # them well under the limit and reducing transfer time.
+        run: |
+          for file in assets/*.raw assets/collected_sources.tar; do
+            [ -e "$file" ] || continue
+            zstd -T0 --rm -q "$file"
+          done
       - name: Rename, create SHA256 checksums and upload files
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           for file in assets/*.raw assets/collected_sources.tar; do
             [ -e "$file" ] || continue
-            zstd -T0 --rm -q "$file"
+            zstd -T0 --rm -q --long=30 "$file"
           done
       - name: Rename, create SHA256 checksums and upload files
         env:


### PR DESCRIPTION
Backport of #5907, #5990

- #5907 — GHA: add arm64 kubevirt and nvidia-jp7 build/publish coverage
- #5990 — assets.yml: improve compression for EVE evaluation artifacts

# Description

Backports the `assets.yml` artifact-compression work to `16.0-stable`.
`installer.raw`, `live.raw`, and the eve-sources export can exceed
GitHub's 2 GiB release-asset limit; these commits compress them with
zstd (long-range mode, `--long=30`) before upload, rename the sources
export to `collected_sources.tar`, and make the upload loop fail the job
on a failed upload.

From #5907 only the single relevant commit was cherry-picked
(`assets.yml: compress large assets with zstd and fix sources export`);
the rest of that PR (arm64 kubevirt / nvidia-jp7 coverage) is not part of
this backport. Both commits cherry-picked cleanly with no conflicts.

## How to test and validate this PR

See original PRs.

## Changelog notes

See original PRs.

## Checklist

- [x] This is a backport; the original PRs are referenced above with
  `#NUMBER` links and the title follows the `[16.0-stable]` template.

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.