### PR TITLE
zedagent: guard volume config parsing against nil app and volume refs

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlevolume.go
+++ b/pkg/pillar/cmd/zedagent/handlevolume.go
@@ -55,9 +55,9 @@ func parseVolumeConfig(ctx *getconfigContext,
 		var cfgVolume *zconfig.Volume
 		for _, cfgVolume = range cfgVolumeList {
 			// Search by UUID and (remote) Generation counter, ignore local gen. counter.
-			if cfgVolume.Uuid == uuid {
+			if cfgVolume.GetUuid() == uuid {
 				foundVolume = true
-				sameGenCounter = cfgVolume.GenerationCount == genCounter
+				sameGenCounter = cfgVolume.GetGenerationCount() == genCounter
 				break
 			}
 		}
@@ -121,8 +121,21 @@ func parseVolumeConfig(ctx *getconfigContext,
 		// Looks for NOHYPER type in VirtualizationMode.
 		appInstanceList := config.GetApps()
 		for _, ai := range appInstanceList {
+			if ai == nil {
+				log.Notice("ignoring empty app instance in config")
+				continue
+			}
+			if ai.Fixedresources == nil {
+				log.Noticef("ignoring app (%s / %+v) without Fixedresources set", ai.Displayname, ai.Uuidandversion)
+				continue
+			}
+
 			if ai.Fixedresources.VirtualizationMode == zconfig.VmMode_NOHYPER {
 				for _, vr := range ai.VolumeRefList {
+					if vr == nil {
+						log.Noticef("ignoring empty volume reference of %s / %+v", ai.Displayname, ai.Uuidandversion)
+						continue
+					}
 					if vr.Uuid == volumeConfig.VolumeID.String() && volumeConfig.ContentID != uuid.Nil {
 						volumeConfig.IsNativeContainer = true
 						// Native containers are downloaded to every node, so set isreplciated to false
@@ -157,9 +170,9 @@ func checkVolumeHasNoAppReferences(ctx *getconfigContext, cfgVolume *zconfig.Vol
 
 	appInstanceList := devConfig.GetApps()
 	for _, el := range appInstanceList {
-		for _, vr := range el.VolumeRefList {
-			if vr.Uuid == cfgVolume.GetUuid() &&
-				vr.GenerationCount == cfgVolume.GenerationCount {
+		for _, vr := range el.GetVolumeRefList() {
+			if vr.GetUuid() == cfgVolume.GetUuid() &&
+				vr.GetGenerationCount() == cfgVolume.GetGenerationCount() {
 				return false
 			}
 		}


### PR DESCRIPTION
# Description

`parseVolumeConfig` and `checkVolumeHasNoAppReferences` dereferenced
`AppInstanceConfig`, `VolumeRef` and `Volume` pointers directly while
iterating the device configuration. A config carrying nil/empty app
instances, volume references or volumes (e.g. `{"apps":[null]}` or
`{"volumeRefList":[null]}`) therefore crashed `zedagent` with a nil pointer
dereference during parsing — found by `FuzzParseConfig`.

This PR:

- guards the `NOHYPER` native-container scan against nil app instances, apps
  without `Fixedresources`, and nil volume references; and
- switches the volume lookup loops (`parseVolumeConfig`'s delete scan and
  `checkVolumeHasNoAppReferences`) to the nil-safe protobuf getters,

so malformed config entries are skipped instead of panicking the agent.

A nil `Fixedresources` can never be `NOHYPER` (its zero value is `PV`), so
skipping such entries is behaviorally identical to the existing no-match path
for well-formed configurations.

## How to test and validate this PR

Automated (no hardware required):

- `make -C pkg/pillar test` runs `FuzzParseConfig`, which drives `parseConfig`
  — and therefore `parseVolumeConfig` and `checkVolumeHasNoAppReferences` —
  with malformed `EdgeDevConfig` JSON.
- Before this change, the seed `{"apps":[{},{}], ... ,"volumes":[{},{}], ...}`
  panicked at `ai.Fixedresources.VirtualizationMode`. With the fix the parser
  skips the empty entries and returns normally.
- Additional inputs that must no longer panic:
  - `{"apps":[null]}`
  - `{"volumes":[{}],"apps":[{"volumeRefList":[null]}]}`

The fuzz testdata:
```
christoph@ponyhof ~/p/e/p/p/c/zedagent (fix_handlevolume_crash)> cat testdata/fuzz/FuzzParseConfig/d9f4c9804c96dee7 
go test fuzz v1
string("{\"id\":{},\"apps\":[{},{}],\"tores\":[],\"base\":[],\"reboot\":{},\"backup\":{},\"\x82onfigItems\":[{}],\"ciemAdapuerLis\x96\":[],\"deviceIoList\":[],\"manufacturer\":\"\",\"productmaNe\":\"\",\"networ:Instances\":[],\"systile_cpherContexts\":[],\"conventInfo\":[],\"volumes\":[{},{}],\"scep_profile_confighash\":\"\",\"maintenance_mode\":false,\"controller_epoch\":0,\"baseos\":{},\"global_profile\":\"\",\"local_profile_server\":\"\",\"profile_server_token\":\"\",\"vlans\":[],\"bonds\":[],\"edgeview\":{},\"disks\":{},\"shutdown\":{},\"device_name\":\"\",\"project_name\":\"\",\"project_id\":\"\",\"enterprise_name\":\"\",\"enterprise_id\":\"\",\"con{ig_tiKKmestamp\":{},\"loc_config\":{},\"patchEnvelopes\":[],\"cluster\":{},\"pnacs\":[],\"controllercerts\":[]}")
byte('ã')
```

## Changelog notes

Fixed a `zedagent` crash (nil pointer dereference) when parsing a device
configuration that contained empty or malformed app-instance or volume
entries.

## PR Backports

- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation — N/A: bug fix, no documentation impact
- [x] I've tested my PR on amd64 device — not run on hardware; covered by the `FuzzParseConfig` unit/fuzz tests
- [ ] I've tested my PR on arm64 device — not run on hardware; the parsing code is architecture-independent
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR — to be set via the GitHub UI

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
