### PR TITLE
eve-k: use stable :latest tag for eve-external-boot-image in VMIRSes

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -443,6 +443,16 @@ external_boot_image_import() {
                 logmsg "re-tag external-boot-image failed"
                 return 1
         fi
+        # --force is required: the image store is persistent (root=/persist/vault/containerd
+        # per config-k3s.toml), so :latest already exists (pointing at the previous
+        # version) on every upgrade after the first. Without --force, containerd's
+        # image tag returns AlreadyExists and this import fails; the inspecti guard
+        # above would then early-return on the next boot, leaving :latest stuck on the
+        # old image permanently.
+        if ! /var/lib/k3s/bin/k3s ctr -a /run/containerd-user/containerd.sock image tag --force "$eve_external_boot_img" "${eve_external_boot_img_name}:latest"; then
+                logmsg "re-tag external-boot-image as latest failed"
+                return 1
+        fi
         logmsg "Successfully installed external-boot-image $import_name_tag as $eve_external_boot_img"
 
         # Clean up old eve-external-boot-image versions that don't match current release
@@ -459,7 +469,7 @@ cleanup_old_external_boot_images() {
         logmsg "Cleaning up old external-boot-image versions, keeping tag: $current_tag"
 
         # List all images and filter for eve-external-boot-image
-        old_images=$(/var/lib/k3s/bin/k3s ctr -a /run/containerd-user/containerd.sock images list -q | grep "^${img_name}:" | grep -v ":${current_tag}$")
+        old_images=$(/var/lib/k3s/bin/k3s ctr -a /run/containerd-user/containerd.sock images list -q | grep "^${img_name}:" | grep -v ":${current_tag}$" | grep -v ":latest$")
 
         if [ -z "$old_images" ]; then
                 logmsg "No old external-boot-image versions to clean up"

--- a/pkg/pillar/cmd/zedkube/bootimgmigrate.go
+++ b/pkg/pillar/cmd/zedkube/bootimgmigrate.go
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package zedkube
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	ctrd "github.com/containerd/containerd"
+	ctrdnamespaces "github.com/containerd/containerd/namespaces"
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sapitypes "k8s.io/apimachinery/pkg/types"
+	virtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+)
+
+const (
+	extBootImgBase   = "docker.io/lfedge/eve-external-boot-image:"
+	extBootImgLatest = extBootImgBase + "latest"
+	k3sCtrdSock      = "/run/containerd-user/containerd.sock"
+	k3sCtrdNamespace = "k8s.io"
+	ctrdCheckTimeout = 5 * time.Second
+)
+
+type bootImgMigrateState int
+
+const (
+	bootImgStateWaitReady bootImgMigrateState = iota // wait for image + KubeVirt (order-independent)
+	bootImgStateMigrate                              // patch local VMIRSes
+	bootImgStateDone                                 // stable final state
+)
+
+func (s bootImgMigrateState) String() string {
+	switch s {
+	case bootImgStateWaitReady:
+		return "WaitReady"
+	case bootImgStateMigrate:
+		return "Migrate"
+	case bootImgStateDone:
+		return "Done"
+	default:
+		return "Unknown"
+	}
+}
+
+// bootImgMigrator is a one-shot state machine that migrates VMIRSes on this
+// node from versioned eve-external-boot-image tags to :latest.  It runs in the
+// zedkube timer loop until it reaches Done.
+//
+// State transitions:
+//
+//	WaitReady → Migrate → Done
+//
+// WaitReady: poll (independently, in any order) until eve-external-boot-image:latest
+//
+//	is present in k3s containerd AND the KubeVirt CR reports Available.
+//	imageReady and kubeVirtReady are cached once true so each condition is
+//	only re-checked until it first succeeds.  nodeName must also be known
+//	(non-empty) before we leave this state: the migration is scoped by
+//	affinity == nodeName, so advancing with an empty nodeName would skip
+//	every VMIRS and latch to Done having migrated nothing.
+//
+// Migrate: patch all local VMIRSes (affinity hostname == nodeName) that still
+//
+//	reference a versioned tag, then force-delete their VMIs still running a
+//	versioned tag so the ReplicaSet recreates them from the patched template
+//	(patching a VMIRS template does not roll its existing VMIs).  Retried until
+//	no local VMIRS template and no local VMI reference a versioned tag.
+//
+// Done: nothing left to do.
+//
+// Timing note: this migration races the descheduler (descheduler.go).  In a
+// rolling upgrade the descheduler on the just-upgraded (designated) node can
+// evict an app from a surviving node and reschedule it here before this machine
+// patches the VMIRS.  The new pod then fails with ErrImageNeverPull because its
+// versioned tag was deleted by cleanup_old_external_boot_images.  The Migrate
+// step recovers this deterministically by deleting the stale VMI itself (see
+// deleteStaleBootImgVMIs) rather than depending on checkStuckPendingVMI, whose
+// bounded force-delete budget can be exhausted recreating old-tag VMIs while
+// this machine is still in WaitReady waiting for KubeVirt to report Available.
+// To keep the exposure window small, step() collapses WaitReady → Migrate into
+// a single tick once both readiness conditions are met, rather than spending a
+// tick per transition.
+type bootImgMigrator struct {
+	state         bootImgMigrateState
+	imageReady    bool
+	kubeVirtReady bool
+}
+
+// isDone reports whether the migrator has reached its terminal state, so the
+// caller can skip building a kubevirt client (and re-reading kubeconfig) on
+// every tick once there is no work left.
+func (m *bootImgMigrator) isDone() bool {
+	return m.state == bootImgStateDone
+}
+
+// step advances the state machine as far as it can in one tick, stopping when a
+// state makes no further progress (waiting on an external condition or a retry).
+// Called from the zedkube event loop; virtClient is injected so callers can
+// supply a fake for testing.
+func (m *bootImgMigrator) step(nodeName, namespace string, virtClient kubecli.KubevirtClient) {
+	for {
+		prev := m.state
+		switch m.state {
+		case bootImgStateWaitReady:
+			// Scope the migration to this node by affinity, so nodeName must be
+			// known first; an empty nodeName means EdgeNodeInfo has not been
+			// received yet, so stay put rather than advance and skip everything.
+			if nodeName == "" {
+				return
+			}
+			if !m.imageReady {
+				m.imageReady = extBootImgLatestPresent()
+			}
+			if !m.kubeVirtReady {
+				m.kubeVirtReady = kubeVirtCondAvailable(virtClient)
+			}
+			if m.imageReady && m.kubeVirtReady {
+				log.Noticef("bootImgMigrate: %s -> Migrate", prev)
+				m.state = bootImgStateMigrate
+			}
+
+		case bootImgStateMigrate:
+			done, err := migrateLocalVMIRSBootImages(nodeName, namespace, virtClient)
+			if err != nil {
+				log.Warnf("bootImgMigrate: migration error (will retry): %v", err)
+				return
+			}
+			if done {
+				log.Noticef("bootImgMigrate: %s -> Done", prev)
+				m.state = bootImgStateDone
+			}
+
+		case bootImgStateDone:
+			return
+		}
+		if m.state == prev {
+			// No progress this tick; wait for the next one.
+			return
+		}
+	}
+}
+
+// extBootImgLatestPresent returns true if eve-external-boot-image:latest is
+// present in the k3s containerd image store (namespace k8s.io).
+func extBootImgLatestPresent() bool {
+	client, err := ctrd.New(k3sCtrdSock, ctrd.WithTimeout(ctrdCheckTimeout))
+	if err != nil {
+		return false
+	}
+	defer client.Close()
+	ctx := ctrdnamespaces.WithNamespace(context.Background(), k3sCtrdNamespace)
+	_, err = client.ImageService().Get(ctx, extBootImgLatest)
+	return err == nil
+}
+
+// kubeVirtCondAvailable returns true when the KubeVirt CR reports the
+// KubeVirtConditionAvailable condition as True.
+func kubeVirtCondAvailable(virtClient kubecli.KubevirtClient) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer cancel()
+	kv, err := virtClient.KubeVirt("kubevirt").Get(ctx, "kubevirt", metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+	for _, cond := range kv.Status.Conditions {
+		if cond.Type == virtv1.KubeVirtConditionAvailable && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// migrateLocalVMIRSBootImages patches VMIRSes whose node affinity names this
+// node and whose KernelBoot image is a versioned (non-:latest) external-boot
+// image, then deletes any of their VMIs still running a versioned tag so the
+// ReplicaSet recreates them from the migrated template.  Returns (true, nil)
+// when no local VMIRS template and no local VMI reference a versioned tag any
+// more (or there were none).  Returns (false, nil) if a patch failed or a stale
+// VMI was (re)deleted this call; the caller should retry.
+func migrateLocalVMIRSBootImages(nodeName, namespace string, virtClient kubecli.KubevirtClient) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer cancel()
+	list, err := virtClient.ReplicaSet(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	patch := []byte(`{"spec":{"template":{"spec":{"domain":{"firmware":{"kernelBoot":{"container":{"image":"` +
+		extBootImgLatest + `"}}}}}}}}`)
+
+	// localVMIRS collects the names of every VMIRS scheduled to this node so we
+	// can find and replace their stale VMIs below.  Membership is not
+	// conditional on patching: a VMIRS whose template is already :latest can
+	// still own a VMI that predates the migration.
+	localVMIRS := make(map[string]struct{})
+	anyFailed := false
+	for i := range list.Items {
+		vmirs := &list.Items[i]
+		if vmirsAffinityNode(vmirs) != nodeName {
+			continue
+		}
+		localVMIRS[vmirs.Name] = struct{}{}
+		tmpl := vmirs.Spec.Template
+		if tmpl == nil ||
+			tmpl.Spec.Domain.Firmware == nil ||
+			tmpl.Spec.Domain.Firmware.KernelBoot == nil ||
+			tmpl.Spec.Domain.Firmware.KernelBoot.Container == nil {
+			continue
+		}
+		img := tmpl.Spec.Domain.Firmware.KernelBoot.Container.Image
+		if img == extBootImgLatest || !strings.HasPrefix(img, extBootImgBase) {
+			continue
+		}
+		log.Noticef("bootImgMigrate: VMIRS %s: %s -> %s", vmirs.Name, img, extBootImgLatest)
+		patchCtx, patchCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+		_, merr := virtClient.ReplicaSet(namespace).Patch(
+			patchCtx, vmirs.Name, k8sapitypes.MergePatchType, patch, metav1.PatchOptions{})
+		patchCancel()
+		if merr != nil {
+			log.Warnf("bootImgMigrate: patch VMIRS %s: %v", vmirs.Name, merr)
+			anyFailed = true
+		}
+	}
+
+	// Patching the VMIRS template does not roll existing VMIs: KubeVirt keeps a
+	// VMI on the template it was created from, so a VMI created from the old
+	// (versioned) tag stays wedged in ErrImageNeverPull because that tag was
+	// pruned by cluster-init's cleanup_old_external_boot_images on upgrade.
+	// Delete those stale VMIs so the ReplicaSet recreates them from the now
+	// :latest template.  We cannot rely on checkStuckPendingVMI for this: its
+	// force-delete budget (pendingVMIMaxDeletes) can be exhausted recreating
+	// old-tag VMIs while this migrator is still blocked in WaitReady waiting for
+	// KubeVirt to report Available.
+	staleVMIs, derr := deleteStaleBootImgVMIs(namespace, localVMIRS, virtClient)
+	if derr != nil {
+		return false, derr
+	}
+
+	// Stay out of Done while a stale VMI was just (re)deleted: next tick
+	// re-checks until the ReplicaSet has recreated it from :latest.
+	return !anyFailed && !staleVMIs, nil
+}
+
+// deleteStaleBootImgVMIs force-deletes VMIs owned by one of the given (local)
+// VMIRSes whose KernelBoot image still references a versioned external-boot tag,
+// so the owning ReplicaSet recreates them from the migrated :latest template.
+// Returns true if any such VMI was found (and a delete attempted) this call, so
+// the caller keeps retrying until none remain.  A VMI recreated from the
+// migrated template carries :latest and is skipped, so this self-terminates.
+func deleteStaleBootImgVMIs(namespace string, localVMIRS map[string]struct{}, virtClient kubecli.KubevirtClient) (bool, error) {
+	if len(localVMIRS) == 0 {
+		return false, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer cancel()
+	vmiList, err := virtClient.VirtualMachineInstance(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+	anyStale := false
+	for i := range vmiList.Items {
+		vmi := &vmiList.Items[i]
+		if len(vmi.OwnerReferences) == 0 {
+			continue
+		}
+		if _, ok := localVMIRS[vmi.OwnerReferences[0].Name]; !ok {
+			continue
+		}
+		fw := vmi.Spec.Domain.Firmware
+		if fw == nil || fw.KernelBoot == nil || fw.KernelBoot.Container == nil {
+			continue
+		}
+		img := fw.KernelBoot.Container.Image
+		if img == extBootImgLatest || !strings.HasPrefix(img, extBootImgBase) {
+			continue
+		}
+		anyStale = true
+		log.Noticef("bootImgMigrate: VMI %s references stale %s; force-deleting so ReplicaSet recreates from %s",
+			vmi.Name, img, extBootImgLatest)
+		if err := kubeapi.TryFastDeleteVmi(log, virtClient, vmi.Name); err != nil {
+			log.Warnf("bootImgMigrate: delete stale VMI %s: %v", vmi.Name, err)
+		}
+	}
+	return anyStale, nil
+}
+
+// vmirsAffinityNode extracts the kubernetes.io/hostname value from the EVE-set
+// node affinity in a VMIRS template spec.  EVE encodes the owner node via
+// setKubeAffinity using either preferredDuringSchedulingIgnoredDuringExecution
+// or requiredDuringSchedulingIgnoredDuringExecution.  Returns "" if neither is
+// present or the hostname matchExpression is absent.
+func vmirsAffinityNode(vmirs *virtv1.VirtualMachineInstanceReplicaSet) string {
+	if vmirs.Spec.Template == nil {
+		return ""
+	}
+	aff := vmirs.Spec.Template.Spec.Affinity
+	if aff == nil || aff.NodeAffinity == nil {
+		return ""
+	}
+	na := aff.NodeAffinity
+	for _, pref := range na.PreferredDuringSchedulingIgnoredDuringExecution {
+		for _, expr := range pref.Preference.MatchExpressions {
+			if expr.Key == "kubernetes.io/hostname" && len(expr.Values) > 0 {
+				return expr.Values[0]
+			}
+		}
+	}
+	if req := na.RequiredDuringSchedulingIgnoredDuringExecution; req != nil {
+		for _, term := range req.NodeSelectorTerms {
+			for _, expr := range term.MatchExpressions {
+				if expr.Key == "kubernetes.io/hostname" && len(expr.Values) > 0 {
+					return expr.Values[0]
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/pillar/cmd/zedkube/bootimgmigrate_test.go
+++ b/pkg/pillar/cmd/zedkube/bootimgmigrate_test.go
@@ -1,0 +1,526 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package zedkube
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
+	gomock "go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	virtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+)
+
+func TestMain(m *testing.M) {
+	l := logrus.New()
+	l.SetLevel(logrus.DebugLevel)
+	log = base.NewSourceLogObject(l, "test", 0)
+	os.Exit(m.Run())
+}
+
+// --- helpers -----------------------------------------------------------------
+
+const (
+	testNode = "node-a"
+	testNS   = "eve-kube-app"
+)
+
+// vmirsPreferred builds a VMIRS with the standard EVE preferred-scheduling
+// node affinity and a KernelBoot container image.
+func vmirsPreferred(nodeName, image string) virtv1.VirtualMachineInstanceReplicaSet {
+	return virtv1.VirtualMachineInstanceReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "vmirs-" + nodeName},
+		Spec: virtv1.VirtualMachineInstanceReplicaSetSpec{
+			Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: virtv1.VirtualMachineInstanceSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+								{
+									Preference: corev1.NodeSelectorTerm{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{Key: "kubernetes.io/hostname", Values: []string{nodeName}},
+										},
+									},
+								},
+							},
+						},
+					},
+					Domain: virtv1.DomainSpec{
+						Firmware: &virtv1.Firmware{
+							KernelBoot: &virtv1.KernelBoot{
+								Container: &virtv1.KernelBootContainer{Image: image},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// vmirsRequired builds a VMIRS with required-scheduling node affinity.
+func vmirsRequired(nodeName, image string) virtv1.VirtualMachineInstanceReplicaSet {
+	return virtv1.VirtualMachineInstanceReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "vmirs-req-" + nodeName},
+		Spec: virtv1.VirtualMachineInstanceReplicaSetSpec{
+			Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: virtv1.VirtualMachineInstanceSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{Key: "kubernetes.io/hostname", Values: []string{nodeName}},
+										},
+									},
+								},
+							},
+						},
+					},
+					Domain: virtv1.DomainSpec{
+						Firmware: &virtv1.Firmware{
+							KernelBoot: &virtv1.KernelBoot{
+								Container: &virtv1.KernelBootContainer{Image: image},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func mockClientWithRS(ctrl *gomock.Controller, ns string) (*kubecli.MockKubevirtClient, *kubecli.MockReplicaSetInterface) {
+	mc := kubecli.NewMockKubevirtClient(ctrl)
+	mrs := kubecli.NewMockReplicaSetInterface(ctrl)
+	mc.EXPECT().ReplicaSet(ns).Return(mrs).AnyTimes()
+	return mc, mrs
+}
+
+// expectVMIList wires VirtualMachineInstance(ns) and a single List returning the
+// given VMIs. migrateLocalVMIRSBootImages lists VMIs (to replace stale ones)
+// whenever at least one VMIRS is scheduled to this node.
+func expectVMIList(ctrl *gomock.Controller, mc *kubecli.MockKubevirtClient, ns string,
+	items []virtv1.VirtualMachineInstance) *kubecli.MockVirtualMachineInstanceInterface {
+	mvmi := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
+	mc.EXPECT().VirtualMachineInstance(ns).Return(mvmi).AnyTimes()
+	mvmi.EXPECT().List(gomock.Any(), metav1.ListOptions{}).Return(
+		&virtv1.VirtualMachineInstanceList{Items: items}, nil)
+	return mvmi
+}
+
+// vmiOwnedBy builds a VMI owned by vmirsName with a KernelBoot container image.
+func vmiOwnedBy(name, vmirsName, image string) virtv1.VirtualMachineInstance {
+	return virtv1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       testNS,
+			OwnerReferences: []metav1.OwnerReference{{Name: vmirsName}},
+		},
+		Spec: virtv1.VirtualMachineInstanceSpec{
+			Domain: virtv1.DomainSpec{
+				Firmware: &virtv1.Firmware{
+					KernelBoot: &virtv1.KernelBoot{
+						Container: &virtv1.KernelBootContainer{Image: image},
+					},
+				},
+			},
+		},
+	}
+}
+
+// --- vmirsAffinityNode -------------------------------------------------------
+
+func TestVMIRSAffinityNode_Preferred(t *testing.T) {
+	v := vmirsPreferred("node-a", extBootImgLatest)
+	if got := vmirsAffinityNode(&v); got != "node-a" {
+		t.Fatalf("got %q, want node-a", got)
+	}
+}
+
+func TestVMIRSAffinityNode_Required(t *testing.T) {
+	v := vmirsRequired("node-b", extBootImgLatest)
+	if got := vmirsAffinityNode(&v); got != "node-b" {
+		t.Fatalf("got %q, want node-b", got)
+	}
+}
+
+func TestVMIRSAffinityNode_NoAffinity(t *testing.T) {
+	v := virtv1.VirtualMachineInstanceReplicaSet{
+		Spec: virtv1.VirtualMachineInstanceReplicaSetSpec{
+			Template: &virtv1.VirtualMachineInstanceTemplateSpec{},
+		},
+	}
+	if got := vmirsAffinityNode(&v); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}
+
+func TestVMIRSAffinityNode_NilTemplate(t *testing.T) {
+	v := virtv1.VirtualMachineInstanceReplicaSet{}
+	if got := vmirsAffinityNode(&v); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}
+
+// --- kubeVirtCondAvailable ---------------------------------------------------
+
+func TestKubeVirtCondAvailable_True(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mc := kubecli.NewMockKubevirtClient(ctrl)
+	mkv := kubecli.NewMockKubeVirtInterface(ctrl)
+	mc.EXPECT().KubeVirt("kubevirt").Return(mkv)
+	mkv.EXPECT().Get(gomock.Any(), "kubevirt", metav1.GetOptions{}).Return(&virtv1.KubeVirt{
+		Status: virtv1.KubeVirtStatus{
+			Conditions: []virtv1.KubeVirtCondition{
+				{Type: virtv1.KubeVirtConditionAvailable, Status: corev1.ConditionTrue},
+			},
+		},
+	}, nil)
+	if !kubeVirtCondAvailable(mc) {
+		t.Fatal("expected true")
+	}
+}
+
+func TestKubeVirtCondAvailable_ConditionFalse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mc := kubecli.NewMockKubevirtClient(ctrl)
+	mkv := kubecli.NewMockKubeVirtInterface(ctrl)
+	mc.EXPECT().KubeVirt("kubevirt").Return(mkv)
+	mkv.EXPECT().Get(gomock.Any(), "kubevirt", metav1.GetOptions{}).Return(&virtv1.KubeVirt{
+		Status: virtv1.KubeVirtStatus{
+			Conditions: []virtv1.KubeVirtCondition{
+				{Type: virtv1.KubeVirtConditionAvailable, Status: corev1.ConditionFalse},
+			},
+		},
+	}, nil)
+	if kubeVirtCondAvailable(mc) {
+		t.Fatal("expected false")
+	}
+}
+
+func TestKubeVirtCondAvailable_GetError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mc := kubecli.NewMockKubevirtClient(ctrl)
+	mkv := kubecli.NewMockKubeVirtInterface(ctrl)
+	mc.EXPECT().KubeVirt("kubevirt").Return(mkv)
+	mkv.EXPECT().Get(gomock.Any(), "kubevirt", metav1.GetOptions{}).Return(nil, errors.New("not found"))
+	if kubeVirtCondAvailable(mc) {
+		t.Fatal("expected false on Get error")
+	}
+}
+
+// --- migrateLocalVMIRSBootImages ---------------------------------------------
+
+func TestMigrateLocalVMIRS_AlreadyLatest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mc, mrs := mockClientWithRS(ctrl, testNS)
+	v := vmirsPreferred(testNode, extBootImgLatest)
+	mrs.EXPECT().List(gomock.Any(), metav1.ListOptions{}).Return(
+		&virtv1.VirtualMachineInstanceReplicaSetList{Items: []virtv1.VirtualMachineInstanceReplicaSet{v}}, nil)
+	// No Patch expectation — gomock fails on unexpected calls.
+	expectVMIList(ctrl, mc, testNS, nil)
+	done, err := migrateLocalVMIRSBootImages(testNode, testNS, mc)
+	if err != nil || !done {
+		t.Fatalf("got done=%v err=%v, want done=true err=nil", done, err)
+	}
+}
+
+func TestMigrateLocalVMIRS_AffinityMismatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mc, mrs := mockClientWithRS(ctrl, testNS)
+	v := vmirsPreferred("other-node", "docker.io/lfedge/eve-external-boot-image:1.2.3")
+	mrs.EXPECT().List(gomock.Any(), metav1.ListOptions{}).Return(
+		&virtv1.VirtualMachineInstanceReplicaSetList{Items: []virtv1.VirtualMachineInstanceReplicaSet{v}}, nil)
+	// VMIRS scheduled to other-node: not local, so no VMI list is expected.
+	done, err := migrateLocalVMIRSBootImages(testNode, testNS, mc)
+	if err != nil || !done {
+		t.Fatalf("got done=%v err=%v, want done=true err=nil", done, err)
+	}
+}
+
+func TestMigrateLocalVMIRS_NoKernelBoot(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mc, mrs := mockClientWithRS(ctrl, testNS)
+	v := virtv1.VirtualMachineInstanceReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "vmirs-no-kb"},
+		Spec: virtv1.VirtualMachineInstanceReplicaSetSpec{
+			Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: virtv1.VirtualMachineInstanceSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+								{Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{
+									{Key: "kubernetes.io/hostname", Values: []string{testNode}},
+								}}},
+							},
+						},
+					},
+					Domain: virtv1.DomainSpec{}, // no Firmware/KernelBoot
+				},
+			},
+		},
+	}
+	mrs.EXPECT().List(gomock.Any(), metav1.ListOptions{}).Return(
+		&virtv1.VirtualMachineInstanceReplicaSetList{Items: []virtv1.VirtualMachineInstanceReplicaSet{v}}, nil)
+	expectVMIList(ctrl, mc, testNS, nil)
+	done, err := migrateLocalVMIRSBootImages(testNode, testNS, mc)
+	if err != nil || !done {
+		t.Fatalf("got done=%v err=%v, want done=true err=nil", done, err)
+	}
+}
+
+func TestMigrateLocalVMIRS_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mc, mrs := mockClientWithRS(ctrl, testNS)
+	v := vmirsPreferred(testNode, "docker.io/lfedge/eve-external-boot-image:1.2.3")
+	mrs.EXPECT().List(gomock.Any(), metav1.ListOptions{}).Return(
+		&virtv1.VirtualMachineInstanceReplicaSetList{Items: []virtv1.VirtualMachineInstanceReplicaSet{v}}, nil)
+	mrs.EXPECT().Patch(gomock.Any(), v.Name, gomock.Any(), gomock.Any(), gomock.Any()).Return(&v, nil)
+	expectVMIList(ctrl, mc, testNS, nil)
+	done, err := migrateLocalVMIRSBootImages(testNode, testNS, mc)
+	if err != nil || !done {
+		t.Fatalf("got done=%v err=%v, want done=true err=nil", done, err)
+	}
+}
+
+func TestMigrateLocalVMIRS_RequiredAffinitySuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mc, mrs := mockClientWithRS(ctrl, testNS)
+	v := vmirsRequired(testNode, "docker.io/lfedge/eve-external-boot-image:1.2.3")
+	mrs.EXPECT().List(gomock.Any(), metav1.ListOptions{}).Return(
+		&virtv1.VirtualMachineInstanceReplicaSetList{Items: []virtv1.VirtualMachineInstanceReplicaSet{v}}, nil)
+	mrs.EXPECT().Patch(gomock.Any(), v.Name, gomock.Any(), gomock.Any(), gomock.Any()).Return(&v, nil)
+	expectVMIList(ctrl, mc, testNS, nil)
+	done, err := migrateLocalVMIRSBootImages(testNode, testNS, mc)
+	if err != nil || !done {
+		t.Fatalf("got done=%v err=%v, want done=true err=nil", done, err)
+	}
+}
+
+func TestMigrateLocalVMIRS_PatchFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mc, mrs := mockClientWithRS(ctrl, testNS)
+	v := vmirsPreferred(testNode, "docker.io/lfedge/eve-external-boot-image:1.2.3")
+	mrs.EXPECT().List(gomock.Any(), metav1.ListOptions{}).Return(
+		&virtv1.VirtualMachineInstanceReplicaSetList{Items: []virtv1.VirtualMachineInstanceReplicaSet{v}}, nil)
+	mrs.EXPECT().Patch(gomock.Any(), v.Name, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("conflict"))
+	// Stale-VMI sweep still runs after a failed patch; no stale VMIs here.
+	expectVMIList(ctrl, mc, testNS, nil)
+	done, err := migrateLocalVMIRSBootImages(testNode, testNS, mc)
+	if err != nil || done {
+		t.Fatalf("got done=%v err=%v, want done=false err=nil", done, err)
+	}
+}
+
+func TestMigrateLocalVMIRS_ListError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mc, mrs := mockClientWithRS(ctrl, testNS)
+	mrs.EXPECT().List(gomock.Any(), metav1.ListOptions{}).Return(nil, errors.New("api unavailable"))
+	_, err := migrateLocalVMIRSBootImages(testNode, testNS, mc)
+	if err == nil {
+		t.Fatal("expected error from List failure")
+	}
+}
+
+// --- deleteStaleBootImgVMIs (via migrateLocalVMIRSBootImages) ----------------
+
+// A VMIRS template already migrated to :latest, but one of its VMIs still runs a
+// versioned tag (patching the template does not roll existing VMIs). The stale
+// VMI must be force-deleted so the ReplicaSet recreates it, and migration must
+// not report done until then.
+func TestMigrateLocalVMIRS_DeletesStaleVMI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mc, mrs := mockClientWithRS(ctrl, testNS)
+	v := vmirsPreferred(testNode, extBootImgLatest)
+	mrs.EXPECT().List(gomock.Any(), metav1.ListOptions{}).Return(
+		&virtv1.VirtualMachineInstanceReplicaSetList{Items: []virtv1.VirtualMachineInstanceReplicaSet{v}}, nil)
+	// No Patch — template is already :latest.
+
+	stale := vmiOwnedBy("vmi-old", v.Name, "docker.io/lfedge/eve-external-boot-image:1.2.3")
+	mvmi := expectVMIList(ctrl, mc, testNS, []virtv1.VirtualMachineInstance{stale})
+	// TryFastDeleteVmi: Get, then clear-finalizers Update, then Delete.
+	mvmi.EXPECT().Get(gomock.Any(), "vmi-old", metav1.GetOptions{}).Return(&stale, nil)
+	mvmi.EXPECT().Update(gomock.Any(), gomock.Any(), metav1.UpdateOptions{}).Return(&stale, nil)
+	mvmi.EXPECT().Delete(gomock.Any(), "vmi-old", gomock.Any()).Return(nil)
+
+	done, err := migrateLocalVMIRSBootImages(testNode, testNS, mc)
+	if err != nil || done {
+		t.Fatalf("got done=%v err=%v, want done=false err=nil", done, err)
+	}
+}
+
+// A VMI already recreated from the migrated template (:latest) must be left
+// alone, and migration reports done.
+func TestMigrateLocalVMIRS_LeavesMigratedVMI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mc, mrs := mockClientWithRS(ctrl, testNS)
+	v := vmirsPreferred(testNode, extBootImgLatest)
+	mrs.EXPECT().List(gomock.Any(), metav1.ListOptions{}).Return(
+		&virtv1.VirtualMachineInstanceReplicaSetList{Items: []virtv1.VirtualMachineInstanceReplicaSet{v}}, nil)
+	fresh := vmiOwnedBy("vmi-new", v.Name, extBootImgLatest)
+	// List returns only a :latest VMI; no Get/Update/Delete expected.
+	expectVMIList(ctrl, mc, testNS, []virtv1.VirtualMachineInstance{fresh})
+
+	done, err := migrateLocalVMIRSBootImages(testNode, testNS, mc)
+	if err != nil || !done {
+		t.Fatalf("got done=%v err=%v, want done=true err=nil", done, err)
+	}
+}
+
+// A stale VMI owned by a VMIRS on another node must not be touched.
+func TestMigrateLocalVMIRS_IgnoresForeignVMI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mc, mrs := mockClientWithRS(ctrl, testNS)
+	v := vmirsPreferred(testNode, extBootImgLatest)
+	mrs.EXPECT().List(gomock.Any(), metav1.ListOptions{}).Return(
+		&virtv1.VirtualMachineInstanceReplicaSetList{Items: []virtv1.VirtualMachineInstanceReplicaSet{v}}, nil)
+	// Stale VMI, but owned by a VMIRS not scheduled to this node.
+	foreign := vmiOwnedBy("vmi-foreign", "vmirs-other-node", "docker.io/lfedge/eve-external-boot-image:1.2.3")
+	expectVMIList(ctrl, mc, testNS, []virtv1.VirtualMachineInstance{foreign})
+
+	done, err := migrateLocalVMIRSBootImages(testNode, testNS, mc)
+	if err != nil || !done {
+		t.Fatalf("got done=%v err=%v, want done=true err=nil", done, err)
+	}
+}
+
+// A VMI list failure surfaces as an error so the caller retries.
+func TestMigrateLocalVMIRS_VMIListError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mc, mrs := mockClientWithRS(ctrl, testNS)
+	v := vmirsPreferred(testNode, extBootImgLatest)
+	mrs.EXPECT().List(gomock.Any(), metav1.ListOptions{}).Return(
+		&virtv1.VirtualMachineInstanceReplicaSetList{Items: []virtv1.VirtualMachineInstanceReplicaSet{v}}, nil)
+	mvmi := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
+	mc.EXPECT().VirtualMachineInstance(testNS).Return(mvmi).AnyTimes()
+	mvmi.EXPECT().List(gomock.Any(), metav1.ListOptions{}).Return(nil, errors.New("api unavailable"))
+
+	_, err := migrateLocalVMIRSBootImages(testNode, testNS, mc)
+	if err == nil {
+		t.Fatal("expected error from VMI List failure")
+	}
+}
+
+// --- bootImgMigrator.step ----------------------------------------------------
+
+// kvClientAlwaysFalse returns a mock KubevirtClient whose KubeVirt.Get reports
+// Available=False, keeping the migrator in WaitReady.
+func kvClientAlwaysFalse(ctrl *gomock.Controller) kubecli.KubevirtClient {
+	mc := kubecli.NewMockKubevirtClient(ctrl)
+	mkv := kubecli.NewMockKubeVirtInterface(ctrl)
+	mc.EXPECT().KubeVirt("kubevirt").Return(mkv).AnyTimes()
+	mkv.EXPECT().Get(gomock.Any(), "kubevirt", metav1.GetOptions{}).Return(&virtv1.KubeVirt{}, nil).AnyTimes()
+	return mc
+}
+
+func TestBootImgMigratorStep_WaitReadyNeitherReady(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	// extBootImgLatestPresent() will return false (no real containerd socket in tests).
+	// kubeVirtCondAvailable returns false.
+	m := bootImgMigrator{}
+	m.step(testNode, testNS, kvClientAlwaysFalse(ctrl))
+	if m.state != bootImgStateWaitReady {
+		t.Fatalf("state=%v, want WaitReady", m.state)
+	}
+}
+
+func TestBootImgMigratorStep_WaitReadyKubeVirtNotReady(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	// Simulate image already confirmed ready from a prior tick.
+	m := bootImgMigrator{imageReady: true}
+	m.step(testNode, testNS, kvClientAlwaysFalse(ctrl))
+	if m.state != bootImgStateWaitReady {
+		t.Fatalf("state=%v, want WaitReady", m.state)
+	}
+}
+
+func TestBootImgMigratorStep_EmptyNodeNameStaysWaitReady(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	// nodeName unknown (EdgeNodeInfo not yet received): must not advance, even
+	// with image already confirmed ready, or it would latch to Done having
+	// skipped every VMIRS. No KubeVirt/ReplicaSet calls are expected.
+	mc := kubecli.NewMockKubevirtClient(ctrl)
+	m := bootImgMigrator{imageReady: true}
+	m.step("", testNS, mc)
+	if m.state != bootImgStateWaitReady {
+		t.Fatalf("state=%v, want WaitReady", m.state)
+	}
+}
+
+func TestBootImgMigratorStep_WaitReadyBothReady_CollapsesToDone(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	// When both readiness conditions are met, step() collapses
+	// WaitReady → Migrate → Done in a single tick (empty VMIRS list, nothing to
+	// patch) rather than spending a tick per transition. This keeps the window
+	// where the descheduler could reschedule an app onto this node before the
+	// VMIRS is patched as small as possible.
+	mc := kubecli.NewMockKubevirtClient(ctrl)
+	mkv := kubecli.NewMockKubeVirtInterface(ctrl)
+	mrs := kubecli.NewMockReplicaSetInterface(ctrl)
+	mc.EXPECT().KubeVirt("kubevirt").Return(mkv).AnyTimes()
+	mkv.EXPECT().Get(gomock.Any(), "kubevirt", metav1.GetOptions{}).Return(&virtv1.KubeVirt{
+		Status: virtv1.KubeVirtStatus{Conditions: []virtv1.KubeVirtCondition{
+			{Type: virtv1.KubeVirtConditionAvailable, Status: corev1.ConditionTrue},
+		}},
+	}, nil).AnyTimes()
+	mc.EXPECT().ReplicaSet(testNS).Return(mrs).AnyTimes()
+	mrs.EXPECT().List(gomock.Any(), metav1.ListOptions{}).Return(
+		&virtv1.VirtualMachineInstanceReplicaSetList{}, nil)
+
+	m := bootImgMigrator{imageReady: true}
+	m.step(testNode, testNS, mc)
+	if m.state != bootImgStateDone {
+		t.Fatalf("state=%v, want Done", m.state)
+	}
+}
+
+func TestBootImgMigratorStep_MigrateNothingToDo(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mc, mrs := mockClientWithRS(ctrl, testNS)
+	mrs.EXPECT().List(gomock.Any(), metav1.ListOptions{}).Return(
+		&virtv1.VirtualMachineInstanceReplicaSetList{}, nil)
+
+	m := bootImgMigrator{state: bootImgStateMigrate}
+	m.step(testNode, testNS, mc)
+	if m.state != bootImgStateDone {
+		t.Fatalf("state=%v, want Done", m.state)
+	}
+}
+
+func TestBootImgMigratorStep_MigratePatchFails_StaysMigrate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mc, mrs := mockClientWithRS(ctrl, testNS)
+	v := vmirsPreferred(testNode, "docker.io/lfedge/eve-external-boot-image:1.2.3")
+	mrs.EXPECT().List(gomock.Any(), metav1.ListOptions{}).Return(
+		&virtv1.VirtualMachineInstanceReplicaSetList{Items: []virtv1.VirtualMachineInstanceReplicaSet{v}}, nil)
+	mrs.EXPECT().Patch(gomock.Any(), v.Name, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("conflict"))
+	expectVMIList(ctrl, mc, testNS, nil)
+
+	m := bootImgMigrator{state: bootImgStateMigrate}
+	m.step(testNode, testNS, mc)
+	if m.state != bootImgStateMigrate {
+		t.Fatalf("state=%v, want Migrate", m.state)
+	}
+}
+
+func TestBootImgMigratorStep_DoneIsNoop(t *testing.T) {
+	// No mock expectations — any unexpected call fails the test.
+	ctrl := gomock.NewController(t)
+	mc := kubecli.NewMockKubevirtClient(ctrl)
+	m := bootImgMigrator{state: bootImgStateDone}
+	m.step(testNode, testNS, mc)
+	if m.state != bootImgStateDone {
+		t.Fatalf("state=%v, want Done", m.state)
+	}
+}

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -161,6 +161,11 @@ type zedkube struct {
 	// conflict, avoiding spurious pubsub publishes (pubsub uses deep equality).
 	// Also used by collectLBPoolStatus to surface per-node conflicts on non-bootstrap nodes.
 	lbConflictError types.ErrorDescription
+
+	// bootImgMigrator advances the one-shot state machine that patches existing
+	// VMIRSes from versioned eve-external-boot-image tags to :latest after a
+	// baseOS upgrade.  Zero value starts in the WaitReady state.
+	bootImgMigrator bootImgMigrator
 }
 
 func inlineUsage() int {
@@ -764,7 +769,15 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 				}
 			}
 			zedkubeCtx.applyLonghornNodeDrainPolicy()
-
+			// Skip once migration is complete so we don't rebuild a kubevirt
+			// client (and re-read kubeconfig) every tick for a no-op.
+			if !zedkubeCtx.bootImgMigrator.isDone() {
+				if virtClient, err := getVirtClient(); err != nil {
+					log.Warnf("bootImgMigrate: get virtClient: %v", err)
+				} else {
+					zedkubeCtx.bootImgMigrator.step(zedkubeCtx.nodeName, kubeapi.EVEKubeNameSpace, virtClient)
+				}
+			}
 			kubeCfgTimer = time.NewTimer(kubeCfgInterval * time.Second)
 
 		// Timer 5: leader-only safety-net re-evaluation of the stale-master

--- a/pkg/pillar/docs/zedkube.md
+++ b/pkg/pillar/docs/zedkube.md
@@ -15,7 +15,7 @@ WebSocket protocol onto a local TCP port.
 Two independent paths trigger this proxy:
 
 | | **Remote Console** | **Edgeview VNC** |
-|---|---|---|
+| --- | --- | --- |
 | Initiator | zedkube (`runAppVNC`) | edgeview (`setAndStartProxyTCP`) |
 | Trigger | `AppInstanceConfig.RemoteConsole=true` | TCP command `appUUID:4822` |
 | Client | Guacamole (controller UI) | edgeview TCP relay |
@@ -113,6 +113,86 @@ This collection is specific for the kubernetes status and stats. Although EVE ha
 ### Handle Domain Apps Status in domainmgr
 
 When the application is launched and managed in KubeVirt mode, the Kubernetes cluster is provisioned for this application, being a VMI (Virtual Machine Instance) replicaSet object or a Pod replicaSet object. It uses a declarative approach to manage the desired state of the applications. The configurations are saved in the Kubernetes database for the Kubernetes controller to use to ensure the objects eventually achieve the correct state if possible. Any particular VMI/Pod state of a domain may not be in working condition at the time when EVE domainmgr checks. In the domainmgr code running in KubeVirt mode, if it can not contact the Kubernetes API server to query about the application, or if the application itself has not be started yet in the cluster, the kubervirt.go will return the 'Unknown' status back. It will keep a 'Unknown' status starting timestamp per application. If the 'Unknown' status lasts longer then 5 minutes, the status functions in kubevirt.go will return 'Halting' status back to domainmgr. The timestamp will be cleared once it can get the application status from the kubernetes.
+
+## External Boot Image Migration
+
+### Background
+
+A container application in KubeVirt mode runs as a "container shim VMI": a
+`VirtualMachineInstanceReplicaSet` (VMIRS) whose `Firmware.KernelBoot.Container`
+points at the `eve-external-boot-image`, an EVE-bundled image supplying the
+kernel and initrd for the guest. That image is imported into the k3s containerd
+store by `external_boot_image_import` in `pkg/kube/cluster-init.sh` and is never
+pulled from a registry — the pod spec uses `ImagePullPolicy: PullNever`, so the
+tag must already exist locally.
+
+Historically each VMIRS embedded the *versioned* tag
+(`eve-external-boot-image:<eve-version>`, read from `/run/eve-release` at VMIRS
+creation). On a baseOS upgrade this broke: `cluster-init.sh` imports the new
+version and `cleanup_old_external_boot_images` deletes the previous version's
+tag. The VMIRS survives in etcd across the reboot, still referencing the deleted
+tag; `domainmgr`'s `Start()` sees `IsAlreadyExists` and leaves it unchanged. Any
+new virt-launcher pod (restart, failover, or failback) then fails permanently
+with `ErrImageNeverPull`.
+
+### Fix: stable `:latest` tag + one-time migration
+
+The image lifecycle (versioned tags) is decoupled from the VMIRS reference
+(stable tag):
+
+- `cluster-init.sh` tags each imported image as both `:<eve-version>` **and**
+  `:latest` (with `ctr image tag --force`, since `:latest` already exists from
+  the previous version — the image store is persistent under
+  `/persist/vault/containerd`), and excludes `:latest` from cleanup.
+- `hypervisor/kubevirt.go` (`CreateReplicaVMIConfig`) references `:latest`, so
+  newly created VMIRSes never embed a version-specific tag.
+- `zedkube`'s `bootImgMigrator` (`bootimgmigrate.go`) patches VMIRSes created by
+  older EVE that still hold a versioned tag.
+
+### `bootImgMigrator` state machine
+
+Driven once per `kubeCfgTimer` tick (60s) from the zedkube event loop until it
+reaches `Done`, after which the loop skips it (`isDone()`).
+
+| State | Behaviour |
+| --- | --- |
+| `WaitReady` | Poll — independently, in any order — until `eve-external-boot-image:latest` is present in k3s containerd **and** the KubeVirt CR reports `Available`. Also requires `nodeName` (from `EdgeNodeInfo`) to be known; advancing with an empty `nodeName` would skip every VMIRS. Each condition is cached once true. |
+| `Migrate` | List VMIRSes and patch (JSON merge patch) those whose `kubernetes.io/hostname` node affinity matches this node and whose boot image is still a versioned tag, setting it to `:latest`; then force-delete any of their VMIs still running a versioned tag so the ReplicaSet recreates them from the patched template (patching a VMIRS template does **not** roll its existing VMIs). Retried until no local VMIRS template and no local VMI reference a versioned tag. |
+| `Done` | Terminal; nothing left to do. |
+
+Once both readiness conditions are met, `step()` collapses
+`WaitReady → Migrate → Done` within a single tick rather than one transition per
+tick, to minimise the race window described below.
+
+### Node scoping and the descheduler race
+
+The migration is scoped to VMIRSes whose affinity names the local node. The
+affinity encodes the app's *designated node* (see [failover.md](failover.md)),
+and the descheduler only pulls an app back to its designated node — so the node
+running this migrator is exactly the node onto which its matching VMIRSes will be
+(re)scheduled, and the node that holds the freshly imported `:latest`. Patching
+another node's VMIRS would be unsafe mid-upgrade, since that node may not yet
+have imported `:latest`.
+
+This migration races the descheduler. In a rolling upgrade the just-upgraded
+designated node can evict an app from a surviving node and reschedule it here
+before the VMIRS is patched; the new pod then hits `ErrImageNeverPull`. The
+`Migrate` step recovers this deterministically: after patching a VMIRS it also
+force-deletes that VMIRS's VMIs still on a versioned tag, so the ReplicaSet
+recreates them from the `:latest` template. Patching the template alone is not
+enough — KubeVirt keeps an existing VMI on the template it was created from, so
+the stale VMI must be deleted for the new image to take effect.
+
+This replaces an earlier design that relied on `checkStuckPendingVMI`
+(`pendingvmi.go`) to force-delete the stuck VMI. That backstop is unreliable
+here: its force-delete budget (`pendingVMIMaxDeletes`) can be exhausted
+recreating old-tag VMIs while the migrator is still in `WaitReady` waiting for
+KubeVirt to report `Available`, after which the counter never resets (the VMI
+never reaches `Running`) and the app stays wedged indefinitely. Note also that
+`ErrImageNeverPull` is not in `podHasContainerError`'s reason set; that path
+caught the stuck pod only via the `PodPending`-phase branch of
+`virtLauncherPodIsActiveOnNode`. `checkStuckPendingVMI` remains a general
+backstop for stuck VMIs, but the boot-image migration no longer depends on it.
 
 ## Kubernetes Node Draining
 

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -508,12 +508,13 @@ func (ctx kubevirtContext) CreateReplicaVMIConfig(domainName string, config type
 				// Include both tty0 (video) and ttyS0 (serial) consoles so that logs are captured
 				// by kubevirt's guest-console-log container
 				kernelArgs := "console=tty0 console=ttyS0 root=/dev/vda dhcp=1 rootfstype=ext4"
-				eveRelease, err := os.ReadFile("/run/eve-release")
-				if err != nil {
-					return logError("Failed to fetch eve-release %v", err)
-				}
-				tag := strings.TrimRight(string(eveRelease), "\n")
-				scratchImage := "docker.io/lfedge/eve-external-boot-image:" + tag
+				// :latest is a local k3s-containerd tag (re)created by cluster-init.sh
+				// each boot, never a registry pull (imagePullPolicy: Never below). Keep
+				// :latest, not a versioned tag: those are pruned on upgrade and wedge.
+				// If image is not yet available early in boot the virt-launcher pod
+				// will show ErrImageNeverPull and kubelet will retry until
+				// pkg/kube imports the image.
+				scratchImage := "docker.io/lfedge/eve-external-boot-image:latest"
 				kernelPath := "/kernel"
 				initrdPath := "/runx-initrd"
 
@@ -2243,9 +2244,12 @@ func addKernelBootContainer(spec *v1.VirtualMachineInstanceSpec, image, kernelAr
 	spec.Domain.Firmware.KernelBoot = &v1.KernelBoot{
 		KernelArgs: kernelArgs,
 		Container: &v1.KernelBootContainer{
-			Image:           image,
-			KernelPath:      kernelPath,
-			InitrdPath:      initrdPath,
+			Image:      image,
+			KernelPath: kernelPath,
+			InitrdPath: initrdPath,
+			// Must stay PullNever: the image is provisioned locally by
+			// cluster-init.sh. Any other policy makes a :latest image pull
+			// from docker.io, which must never happen.
 			ImagePullPolicy: k8sv1.PullNever,
 		},
 	}


### PR DESCRIPTION
## Description

Container-as-VM VMIRSes were embedding a versioned eve-external-boot-image
tag (e.g. :1.2.3) that gets deleted by cluster-init.sh cleanup on every
baseOS upgrade, permanently breaking virt-launcher pod scheduling on
upgraded nodes (ErrImageNeverPull, ImagePullPolicy: PullNever).

Fix by decoupling image lifecycle from VMIRS references:

- cluster-init.sh: tag the imported image as both :VERSION and :latest,
  and exclude :latest from cleanup_old_external_boot_images so it survives
  across upgrades. The :latest re-tag uses `ctr image tag --force`: the
  image store is persistent (/persist/vault/containerd), so :latest
  already exists from the prior version and a plain tag would fail with
  AlreadyExists — which, combined with the inspecti early-return guard,
  would leave :latest stuck on the old image permanently.

- kubevirt.go CreateReplicaVMIConfig: use :latest instead of reading
  /run/eve-release, so new VMIRSes never embed a version-specific tag.

- zedkube bootImgMigrator (new): one-shot state machine
  (WaitReady → Migrate → Done) that migrates existing VMIRSes still
  referencing a versioned tag. WaitReady polls independently for both
  eve-external-boot-image:latest in k3s containerd and the KubeVirt CR
  Available condition, and requires nodeName to be known before advancing
  (an empty nodeName would skip every VMIRS and latch to Done). Scoped to
  VMIRSes whose kubernetes.io/hostname node affinity matches the local
  node, so each node only patches its own apps. Once complete the event
  loop skips it (isDone) to avoid rebuilding a kubevirt client every tick.

  Patching the VMIRS template is necessary but not sufficient: KubeVirt
  keeps an existing VMI on the template it was created from, so a VMI
  created from the old (versioned) tag stays wedged in ErrImageNeverPull
  after its tag is pruned on upgrade. The Migrate step therefore also
  force-deletes (deleteStaleBootImgVMIs) any VMI owned by a local VMIRS
  that still references a versioned tag, so the ReplicaSet recreates it
  from the now-:latest template. Migration only reaches Done once no local
  VMIRS template and no local VMI reference a versioned tag; a stale VMI
  keeps the machine in Migrate, retried each tick until the recreated VMI
  carries :latest (which self-terminates the sweep).

  This also handles the descheduler race in a rolling upgrade, where an
  app can be rescheduled onto the upgraded node before its VMIRS is
  patched. step() collapses WaitReady → Migrate into a single tick to
  shrink that window. Recovery is deterministic via the migrator's own
  stale-VMI delete; it does not depend on checkStuckPendingVMI, whose
  bounded force-delete budget (pendingVMIMaxDeletes) can be exhausted
  recreating old-tag VMIs while the migrator is still in WaitReady waiting
  for KubeVirt to report Available — after which its counter never resets
  (the VMI never reaches Running) and the app stays wedged indefinitely.
  checkStuckPendingVMI remains a general backstop for stuck VMIs.

Also documents the migration in docs/zedkube.md and normalizes a
pre-existing markdown table separator in the same file.

## PR dependencies

None

## How to test and validate this PR

- deploy HV=k eve node and a container app instance on a release before this change
- update eve baseos
- confirm app instance starts
- use kubectl to wait for vmirs, vmi, and virt-launcher pod to show updated kernel boot container 

```
[kube] root@e20a0bd7-ffdc-4f45-aa1c-ea658dc110f0:/$ kubectl -n eve-kube-app describe pod | grep external
    Image:         docker.io/lfedge/eve-external-boot-image:latest
    Image:         docker.io/lfedge/eve-external-boot-image:latest
  Normal   Pulled                  23m                kubelet                  Container image "docker.io/lfedge/eve-external-boot-image:latest" already present on machine
  Normal   Pulled                  23m                kubelet                  Container image "docker.io/lfedge/eve-external-boot-image:latest" already present on machine
[kube] root@e20a0bd7-ffdc-4f45-aa1c-ea658dc110f0:/$ kubectl -n eve-kube-app describe vmi | grep external
          Image:              docker.io/lfedge/eve-external-boot-image:latest
[kube] root@e20a0bd7-ffdc-4f45-aa1c-ea658dc110f0:/$ kubectl -n eve-kube-app describe vmirs | grep external
              Image:              docker.io/lfedge/eve-external-boot-image:latest
```

## Changelog notes

fix: container app instances should use latest tag of external-boot-image to enable app start across eve base-os image updates.

## PR Backports

- 17.0-stable: yes
- 16.0-stable: No
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
