### PR TITLE
[14.5-stable] Backport #6086: downloader: apply datastore custom certs when resolving OCI

### DIFF
--- a/pkg/pillar/cmd/downloader/download.go
+++ b/pkg/pillar/cmd/downloader/download.go
@@ -89,6 +89,15 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 	}
 	defer dEndPoint.Close()
 
+	if len(certs) > 0 {
+		log.Functionf("%s: Set trusted certs", trType)
+		err = dEndPoint.WithTrustedCerts(certs)
+		if err != nil {
+			log.Errorf("Set trusted certificates failed: %s", err)
+			return "", cancel, tracedReq, err
+		}
+	}
+
 	// Configure the network client.
 	err = dEndPoint.WithSrcIP(ipSrc)
 	if err != nil {
@@ -99,14 +108,6 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 		// With other (currently supported) datastore types this call will not fail.
 		log.Errorf("Set source IP failed: %s", err)
 		err = nil
-	}
-	if len(certs) > 0 {
-		log.Functionf("%s: Set trusted certs", trType)
-		err = dEndPoint.WithTrustedCerts(certs)
-		if err != nil {
-			log.Errorf("Set trusted certificates failed: %s", err)
-			return "", cancel, tracedReq, err
-		}
 	}
 	// check for proxies on the selected management port interface
 	proxyLookupURL := controllerconn.IntfLookupProxyCfg(log, &ctx.deviceNetworkStatus, ifname, downloadURL, trType)
@@ -290,7 +291,7 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 // interfaces or IP addresses.
 func objectMetadata(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 	syncOp zedUpload.SyncOpType, downloadURL string,
-	auth *zedUpload.AuthInput, dpath, region string, ifname string,
+	auth *zedUpload.AuthInput, dpath, region string, certs [][]byte, ifname string,
 	ipSrc net.IP, filename string, receiveChan chan<- CancelChannel) (string, bool, error) {
 
 	// create Endpoint
@@ -310,6 +311,13 @@ func objectMetadata(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 	}
 	defer dEndPoint.Close()
 
+	if len(certs) > 0 {
+		log.Functionf("%s: Set trusted certs", trType)
+		if err := dEndPoint.WithTrustedCerts(certs); err != nil {
+			log.Errorf("Set trusted certificates failed: %s", err)
+			return sha256, cancel, err
+		}
+	}
 	// Configure the network client.
 	dEndPoint.WithSrcIP(ipSrc)
 	// check for proxies on the selected management port interface

--- a/pkg/pillar/cmd/downloader/resolveconfig.go
+++ b/pkg/pillar/cmd/downloader/resolveconfig.go
@@ -269,7 +269,7 @@ func resolveTagsToHash(ctx *downloaderContext, rc types.ResolveConfig,
 			ipSrc, ifname, dsCtx.TransportMethod)
 
 		sha256, cancelled, err = objectMetadata(ctx, trType, syncOp, serverURL, auth,
-			dsCtx.Dpath, dsCtx.Region,
+			dsCtx.Dpath, dsCtx.Region, dst.DsCertPEM,
 			ifname, ipSrc, remoteName, receiveChan)
 		if err != nil {
 			if cancelled {


### PR DESCRIPTION
## Description

Backport of #6086 to `14.5-stable`.

When resolving an OCI image tag to its sha256 digest, the downloader opened the
registry endpoint without the datastore's trusted certificates. Registries
fronted by a private or self-signed CA therefore failed TLS verification during
tag resolution, even though the actual image download succeeded — the download
path already installs the certs via `WithTrustedCerts`.

This threads the datastore's `DsCertPEM` through `objectMetadata` and applies it
to the endpoint when present, using the same error handling and logging as the
download path, so OCI tag resolution honours datastore custom certificates.

Cherry-picked from `cc187d6fc9a65b71cac59b9ea49df7b0e4780952` (the squash-merge
of #6086 on `master`).

## PR dependencies

None.

## PR Backports

The cherry-pick required manual conflict resolution in `download.go` and
`resolveconfig.go`: this branch predates the `netTraceFolder` parameter that
`master` added to `objectMetadata`, so only the new `certs [][]byte` parameter
(and the matching `dst.DsCertPEM` argument at the call site) were threaded into
the existing signature/call on this branch. The substantive change is identical
to #6086. (`dst.DsCertPEM` is already passed to `download()` on this branch, so
the threaded type matches.)

## Changelog notes

Fixed OCI image download with custom tls certificate.

## How to test and validate this PR

1. Stand up an OCI registry fronted by a private or self-signed CA, and create a
   datastore config that supplies that CA certificate (`DsCertPEM`).
2. Deploy an app instance / content tree that references an image by **tag**
   (not by digest), so the downloader runs tag→digest resolution.
3. Before this change: tag resolution fails with a TLS certificate verification
   error, even though a by-digest download from the same registry succeeds.
   After this change: resolution succeeds using the datastore's custom certs.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — not needed; internal bug fix with no user-facing API/config change
- [ ] I've tested my PR on amd64 device — backport; the change was verified on `master` in #6086
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
