### PR TITLE
kube: surface insufficient disk/memory for Longhorn

### DIFF
--- a/pkg/kube/longhorn-utils.sh
+++ b/pkg/kube/longhorn-utils.sh
@@ -10,12 +10,69 @@
 
 LONGHORN_VERSION=v1.9.1
 
+# Filesystem path Longhorn is told to use as its default disk (on /persist).
+LONGHORN_DISK_PATH="/persist/vault/volumes"
+
+# Resource floors below which Longhorn is unlikely to come up / schedule
+# replicas reliably. These drive the pre-flight warnings in
+# longhorn_preflight_check(); they are advisory (logged, not fatal).
+#   - Memory: Longhorn documents a 4 GiB per-node minimum, and that is for
+#     Longhorn alone - it runs alongside k3s and kubevirt here, so a node at
+#     the floor is already tight (https://longhorn.io/docs/1.9.1/best-practices/).
+#   - Storage: Longhorn refuses to schedule replicas once a disk drops below
+#     storageMinimalAvailablePercentage (default 25%) of its capacity. On a
+#     small /persist (e.g. a 32 GiB boot disk) EVE's own usage pushes available
+#     under that floor and no replica can be placed; a 64 GiB boot disk leaves
+#     enough headroom. We warn when the schedulable slice is below
+#     LONGHORN_MIN_SCHEDULABLE_GIB.
+LONGHORN_MIN_MEM_GIB=4
+LONGHORN_MIN_STORAGE_PCT=25
+LONGHORN_MIN_SCHEDULABLE_GIB=16
+
 # Used to gate logging only once in Longhorn_is_ready
 bootLhRdyComplete=""
+
+# longhorn_preflight_check warns (to the k3s install log) when node memory or the
+# schedulable space on the Longhorn default-disk path is below what Longhorn needs
+# to start and place replicas. Advisory only: it never fails the install (returns 0).
+longhorn_preflight_check() {
+    mem_kib=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo 2>/dev/null)
+    if [ -n "$mem_kib" ]; then
+        mem_gib=$((mem_kib / 1024 / 1024))
+        if [ "$mem_gib" -lt "$LONGHORN_MIN_MEM_GIB" ]; then
+            logmsg "WARNING: node has ${mem_gib} GiB RAM; Longhorn needs at least ${LONGHORN_MIN_MEM_GIB} GiB per node (and more running alongside k3s/kubevirt). Longhorn may fail to start reliably; provision more memory."
+        fi
+    else
+        logmsg "WARNING: could not read MemTotal from /proc/meminfo; skipping Longhorn memory pre-flight check"
+    fi
+
+    disk_path="$LONGHORN_DISK_PATH"
+    [ -d "$disk_path" ] || disk_path="/persist"
+    # -P guarantees single-line POSIX output, so columns are fixed: 2=total, 4=available.
+    # shellcheck disable=SC2046 # intentional split of df's two-number output
+    set -- $(df -kP "$disk_path" 2>/dev/null | awk 'NR==2 {print $2, $4}')
+    if [ "$#" -eq 2 ]; then
+        total_kib=$1
+        avail_kib=$2
+        total_gib=$((total_kib / 1024 / 1024))
+        avail_gib=$((avail_kib / 1024 / 1024))
+        reserve_kib=$((total_kib * LONGHORN_MIN_STORAGE_PCT / 100))
+        sched_kib=$((avail_kib - reserve_kib))
+        [ "$sched_kib" -lt 0 ] && sched_kib=0
+        sched_gib=$((sched_kib / 1024 / 1024))
+        if [ "$sched_gib" -lt "$LONGHORN_MIN_SCHEDULABLE_GIB" ]; then
+            logmsg "WARNING: Longhorn default disk ${disk_path} has ${avail_gib} GiB free of ${total_gib} GiB; after the ${LONGHORN_MIN_STORAGE_PCT}% Longhorn reserve only ~${sched_gib} GiB is schedulable (< ${LONGHORN_MIN_SCHEDULABLE_GIB} GiB). Replicas may fail to schedule; a 64 GiB boot disk is recommended for EVE-k."
+        fi
+    else
+        logmsg "WARNING: could not read df output for ${disk_path}; skipping Longhorn storage pre-flight check"
+    fi
+    return 0
+}
 
 longhorn_install() {
     node_name=$1
     logmsg "Installing longhorn version ${LONGHORN_VERSION}"
+    longhorn_preflight_check
     apply_longhorn_disk_config "$node_name"
     lhCfgPath=/etc/lh-cfg-${LONGHORN_VERSION}.yaml
     if ! grep -q 'create-default-disk-labeled-nodes: true' "$lhCfgPath"; then
@@ -200,7 +257,7 @@ Longhorn_is_ready() {
 apply_longhorn_disk_config() {
         node=$1
         kubectl label node "$node" node.longhorn.io/create-default-disk='config'
-        kubectl annotate node "$node" node.longhorn.io/default-disks-config='[ { "path":"/persist/vault/volumes", "allowScheduling":true }]'
+        kubectl annotate node "$node" node.longhorn.io/default-disks-config="[ { \"path\":\"${LONGHORN_DISK_PATH}\", \"allowScheduling\":true }]"
 }
 
 check_overwrite_nsmounter() {

--- a/pkg/pillar/kubeapi/longhorninfo.go
+++ b/pkg/pillar/kubeapi/longhorninfo.go
@@ -456,6 +456,45 @@ func getDsServiceStatus(ds appsv1.DaemonSet) (time.Time, types.ServiceStatus) {
 	return latestTime, types.ServiceStatusDegraded
 }
 
+// longhornStorageUnschedulable reports whether any Longhorn node has a disk
+// whose "Schedulable" condition is False. Longhorn flips that condition to
+// False (reason "DiskPressure") once a disk's available space falls below its
+// storage-minimal-available floor - the state a too-small /persist reaches on
+// EVE-k, where the longhorn-manager pods stay Ready but no replica can be
+// placed. The returned string (node/disk/reason) is for logging only; it is
+// not propagated in KubeStorageInfo.
+func longhornStorageUnschedulable() (bool, string) {
+	config, err := GetKubeConfig()
+	if err != nil {
+		return false, ""
+	}
+	lhClient, err := versioned.NewForConfig(config)
+	if err != nil {
+		return false, ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer cancel()
+	nodes, err := lhClient.LonghornV1beta2().Nodes(longhornNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, ""
+	}
+	for _, node := range nodes.Items {
+		for diskName, ds := range node.Status.DiskStatus {
+			if ds == nil {
+				continue
+			}
+			for _, cond := range ds.Conditions {
+				if cond.Type == lhv1beta2.DiskConditionTypeSchedulable &&
+					cond.Status == lhv1beta2.ConditionStatusFalse {
+					return true, fmt.Sprintf("node %s disk %s unschedulable: %s",
+						node.ObjectMeta.Name, diskName, cond.Reason)
+				}
+			}
+		}
+	}
+	return false, ""
+}
+
 // PopulateKSI retrieve cluster-wide PVC health data which
 // will be sent out to the controller as info messages
 func PopulateKSI() (types.KubeStorageInfo, error) {
@@ -487,6 +526,13 @@ func PopulateKSI() (types.KubeStorageInfo, error) {
 		healthTime, dsStat := getDsServiceStatus(ds)
 		ksi.Health = min(ksi.Health, dsStat)
 		ksi.TransitionTime = healthTime
+	}
+
+	// The daemonset check above only sees pod readiness; an unschedulable disk
+	// (too-small /persist) leaves pods Ready but no replica placeable, so fold
+	// that into the reported health.
+	if unschedulable, _ := longhornStorageUnschedulable(); unschedulable {
+		ksi.Health = min(ksi.Health, types.ServiceStatusDegraded)
 	}
 
 	pvcs, err := clientset.CoreV1().PersistentVolumeClaims(EVEKubeNameSpace).List(context.Background(), metav1.ListOptions{})


### PR DESCRIPTION
**Motivation:** found while testing kvm-to-k on EVE-k — insufficient disk/memory for Longhorn silently wedged cluster bring-up; surfacing it (health Degraded + warning) is needed to diagnose and validate the EVE-k side of the conversion in testing.

## Motivation

On EVE-k the fixed boot-disk partitions (ESP + IMGA/IMGB + …) consume
~22 GiB, so a 32 GiB disk leaves `/persist` too small for Longhorn.
After Longhorn's 2 GiB reserve and its 25% minimal-available floor
there is effectively no schedulable space, so replicas never place —
first boot and app deploys become **extremely slow or fail outright**,
today with no clear signal pointing at disk size. EVE-k needs a 64 GiB
disk. These changes make that condition observable instead of silent.

## Changes

- **`pkg/kube/longhorn-utils.sh`**: a pre-flight check at Longhorn
  install time logs an actionable warning to the k3s install log when
  node RAM is below Longhorn's documented 4 GiB per-node minimum, or
  when the default disk has too little schedulable space after the 25%
  reserve. Advisory only — it never fails the install.

- **`pkg/pillar/kubeapi/longhorninfo.go`**: `KubeStorageInfo.Health`
  was derived only from longhorn-manager pod readiness, so a too-small
  `/persist` (pods Ready, disk `Schedulable=False`) still reported
  Healthy. It now also inspects the Longhorn node-disk `Schedulable`
  condition and degrades health to `Degraded` when a disk is
  unschedulable, so the disk-too-small state surfaces in the cluster
  storage health reported to the controller (and is assertable from
  eden tests) instead of appearing Healthy.

## How to test and validate this PR

- `gofmt`/`go vet` clean; `pkg/pillar/kubeapi` builds under the kubevirt tag.
- E2E under eden (EVE-k): boot an EVE-k node on a 32 GiB disk — too small
  for Longhorn after its 2 GiB reserve and 25% minimal-available floor — and
  confirm the reported `KubeStorageInfo.Health` is now `Degraded`. Before
  this change it stayed `Healthy` because longhorn-manager pods were Ready
  even though the node disk was `Schedulable=False`. Repeat on a 64 GiB disk
  and confirm health is not degraded.
- Confirm the k3s install log carries the advisory warning when node RAM is
  below Longhorn's 4 GiB per-node minimum or the default disk has too little
  schedulable space, and that the warning never fails the install.

## Changelog notes

EVE-k cluster storage health is now reported as Degraded (rather than
Healthy) when a node's disk is too small for Longhorn to schedule replicas,
and an advisory warning is logged at Longhorn install time when node RAM or
schedulable disk space is below Longhorn's documented minimums.

## PR Backports

- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
