### PR TITLE
build-tools: fix dockerized Go builder to match eve-alpine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
 
 # you are not supposed to tweak these variables -- they are effectively R/O
 HV_DEFAULT=kvm
-GOVER ?= 1.24.1
+GOVER ?= 1.25.11
 PKGBASE=github.com/lf-edge/eve
 GOMODULE=$(PKGBASE)/pkg/pillar
 GOTREE=$(CURDIR)/pkg/pillar

--- a/build-tools/src/scripts/Dockerfile
+++ b/build-tools/src/scripts/Dockerfile
@@ -1,5 +1,8 @@
-ARG GOVER=1.20.1
-FROM golang:${GOVER}-alpine
+ARG GOVER=1.25.11
+# Pin the Alpine minor version to match eve-alpine (3.22) so this builder tracks
+# the same toolchain/libc as the real EVE build; the unpinned golang:*-alpine
+# tag floats to whatever Alpine is newest.
+FROM golang:${GOVER}-alpine3.22
 ARG USER
 ARG GROUP
 ARG UID
@@ -23,7 +26,7 @@ RUN echo "${USER} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USER}
 # coreutils's uname -o breaks above url generation.
 # hadolint ignore=DL3018
 RUN apk add --no-cache coreutils
-ENV ZFS_VERSION=2.3.3
+ENV ZFS_VERSION=2.3.6
 ENV ZFS_COMMIT=zfs-${ZFS_VERSION}
 ENV ZFS_REPO=https://github.com/openzfs/zfs
 
@@ -64,3 +67,7 @@ RUN mv /go/bin/* /usr/bin
 ENV HOME /home/${USER}
 ENV GOFLAGS=-mod=vendor
 ENV GO111MODULE=on
+# go-libzfs pulls in the OpenZFS libspl headers, which still call the glibc
+# LFS64 symbols fstat64/stat64. musl (>=1.2.4) dropped those, so remap them to
+# the plain 64-bit fstat/stat -- same as pkg/pillar/Dockerfile.
+ENV CGO_CFLAGS="-Dfstat64=fstat -Dstat64=stat"


### PR DESCRIPTION
# Description

The `eve-build-<user>` image (`build-tools/src/scripts/Dockerfile`) backs every
`DOCKER_GO` target — `make shell`, `make test`, `make pillar-vet`, `make pillar-fmt`,
`make pillar-build`. It had drifted from the real EVE build environment
(`eve-alpine`) and could no longer build pillar:

- **Go version.** Go was pinned to 1.24.1, but pillar and other `go.mod` files now
  require `go 1.25.0` (`toolchain go1.25.11`). With `GOTOOLCHAIN=local`, every
  `DOCKER_GO` target failed immediately with
  `go.mod requires go >= 1.25.0 (running go 1.24.1)`. Bump `GOVER` to `1.25.11`.
- **Alpine pin.** The base used the floating `golang:${GOVER}-alpine` tag, which now
  resolves to a newer Alpine than `eve-alpine`. Pin `alpine3.22` so the builder
  tracks eve-alpine's Alpine/libc.
- **ZFS version.** OpenZFS was built from 2.3.3 while the shipping `dom0-ztools`
  package is on 2.3.6. Align the builder with 2.3.6.
- **go-libzfs cgo.** `go-libzfs` pulls in the OpenZFS `libspl` headers, which still
  reference the glibc LFS64 symbols `fstat64`/`stat64`. musl (>= 1.2.4) dropped
  those, so cgo compilation failed. Set `CGO_CFLAGS="-Dfstat64=fstat -Dstat64=stat"`
  — the same remap `pkg/pillar/Dockerfile` already uses.

## How to test and validate this PR

On a clean checkout:

```
make pillar-vet HV=kvm
```

Before this change it fails with `go.mod requires go >= 1.25.0`; once Go alone is
bumped it then fails compiling `go-libzfs` (`fstat64`/`struct stat64`). With all of
the above the builder image rebuilds and `go vet ./...` on pillar completes clean.
`make shell` and `make test` use the same image.

## Changelog notes

No user-facing changes (developer build tooling only).

## PR Backports

- 16.0-stable: No — `pkg/pillar/go.mod` there requires `go 1.24.0`, already satisfied by the existing `GOVER 1.24.1`.
- 14.5-stable: No — same, `go.mod` requires `go 1.24.0`.
- 13.4-stable: No — `go.mod` requires `go 1.23.0`.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them. This is a change to the dockerized Go build image only; it does not
  run on the device, so the amd64/arm64 device-test boxes do not apply.
