### PR TITLE
pkg/kube: allow debugging-user exec in all but system namespaces

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -251,7 +251,10 @@ config_cluster_roles() {
         cp "$user_yaml_path" /run/.kube/k3s/user.yaml
 
         # apply kubernetes and kubevirt roles and binding to debugging-user
-        kubectl apply -f /etc/debuguser-role-binding.yaml
+        if ! kubectl apply -f /etc/debuguser-role-binding.yaml; then
+                logmsg "Failed to apply debuguser-role-binding.yaml"
+                return 1
+        fi
         touch /var/lib/debuguser-initialized
 }
 

--- a/pkg/kube/debuguser-role-binding.yaml
+++ b/pkg/kube/debuguser-role-binding.yaml
@@ -106,26 +106,64 @@ subjects:
     kind: User
     name: debugging-user
 ---
+# Allow debugging-user to exec/attach/port-forward into pods cluster-wide. Access to
+# infrastructure namespaces is then denied by the ValidatingAdmissionPolicy below, so the
+# net effect is "allowed in every namespace except the system ones". RBAC is allow-only and
+# cannot express such an exclusion on its own; the dynamic set of user/ZKS namespaces makes a
+# per-namespace allow-list impractical, so a deny-list on the small fixed set of system
+# namespaces is used instead.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: debugging-exec-role
-  namespace: eve-kube-app
 rules:
   - apiGroups: [""]
-    resources: ['pods/exec']
+    resources: ['pods/exec', 'pods/attach', 'pods/portforward']
     verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: debugging-exec-role-binding
-  namespace: eve-kube-app
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: debugging-exec-role
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: debugging-user
+---
+# Deny exec/attach/port-forward by debugging-user in infrastructure namespaces. These are
+# CONNECT operations on pod subresources, so they pass through admission control and can be
+# blocked declaratively here (read access, which is not admission-controlled, is unaffected and
+# stays cluster-wide). The policy is scoped to debugging-user so system components (kubevirt,
+# longhorn, descheduler, etc.) that exec into these namespaces are not affected.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: debugging-user-deny-system-ns-exec
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CONNECT"]
+        resources: ["pods/exec", "pods/attach", "pods/portforward"]
+  matchConditions:
+    - name: only-debugging-user
+      expression: "request.userInfo.username == 'debugging-user'"
+  validations:
+    - expression: >-
+        !(request.namespace in ['kube-system','kube-public','kube-node-lease',
+        'kubevirt','cdi','longhorn-system','zks-fleet-system','cattle-system'])
+      message: "exec/attach/port-forward by debugging-user is not permitted in system namespaces"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: debugging-user-deny-system-ns-exec-binding
+spec:
+  policyName: debugging-user-deny-system-ns-exec
+  validationActions: ["Deny"]

--- a/pkg/kube/debuguser-role-binding.yaml
+++ b/pkg/kube/debuguser-role-binding.yaml
@@ -157,7 +157,8 @@ spec:
   validations:
     - expression: >-
         !(request.namespace in ['kube-system','kube-public','kube-node-lease',
-        'kubevirt','cdi','longhorn-system','zks-fleet-system','cattle-system'])
+        'kubevirt','cdi','longhorn-system','zks-fleet-system',
+        'zks-system','zks-impersonation-system'])
       message: "exec/attach/port-forward by debugging-user is not permitted in system namespaces"
 ---
 apiVersion: admissionregistration.k8s.io/v1


### PR DESCRIPTION
# Description

To support native-Kubernetes mode where users own arbitrary namespaces, broaden the debugging-user's exec access from the single eve-kube-app namespace to cluster-wide, then exclude infrastructure namespaces.

The namespace-scoped exec Role/RoleBinding is replaced with a cluster-wide ClusterRole/ClusterRoleBinding covering pods/exec, pods/attach and pods/portforward. Since RBAC is allow-only, a ValidatingAdmissionPolicy (scoped to debugging-user, fail-closed) denies these CONNECT operations in system namespaces: kube-system, kube-public, kube-node-lease, kubevirt, cdi, longhorn-system, zks-fleet-system and cattle-system. Read access is unchanged (stays cluster-wide).

## PR dependencies

## How to test and validate this PR

Configure the edge-node cluster in native-kubernetes mode, and deploy some pods to user's namespace,
and verify using edgeview w/ tcp/kube, remote kubectl exec operations works on those pods.

## Changelog notes

pkg/kube: allow debugging-user exec in all but system namespaces

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.


