### PR TITLE
Fix TestResolvConfEqual

### DIFF
--- a/pkg/pillar/dpcreconciler/genericitems/items_test.go
+++ b/pkg/pillar/dpcreconciler/genericitems/items_test.go
@@ -92,11 +92,9 @@ func TestResolvConfDependencies(t *testing.T) {
 }
 
 func TestResolvConfEqual(t *testing.T) {
-	dns1 := net.ParseIP("8.8.8.8")
-	dns2 := net.ParseIP("1.1.1.1")
-	r1 := ResolvConf{DNSServers: map[string][]net.IP{"eth0": {dns1}}}
-	r2Same := ResolvConf{DNSServers: map[string][]net.IP{"eth0": {dns1}}}
-	r3Diff := ResolvConf{DNSServers: map[string][]net.IP{"eth0": {dns2}}}
+	r1 := ResolvConf{SearchDomains: []string{"local", "test"}}
+	r2Same := ResolvConf{SearchDomains: []string{"test", "local"}}
+	r3Diff := ResolvConf{SearchDomains: []string{"local"}}
 	r4Empty := ResolvConf{}
 	tests := []struct {
 		name  string
@@ -105,7 +103,7 @@ func TestResolvConfEqual(t *testing.T) {
 		want  bool
 	}{
 		{"identical", r1, r2Same, true},
-		{"different IP", r1, r3Diff, false},
+		{"different search domains", r1, r3Diff, false},
 		{"both empty", r4Empty, r4Empty, true},
 		{"one empty", r1, r4Empty, false},
 		{"wrong type", r1, NetIO{}, false},


### PR DESCRIPTION
# Description

The `ResolvConf` item was modified in commit 2e739c88ea51 (`Fix DNS resolution for management ports via mgmt dnsmasq`). As a result, [recently merged](https://github.com/lf-edge/eve/pull/5901) `TestResolvConfEqual` started to fail to even build. This commit updates the test to reflect the current content of the `ResolvConf` item.

## How to test and validate this PR

- try to build pillar
- run unit test `TestResolvConfEqual`.

## Changelog notes

No user-facing changes

## PR Backports

Not to be backported (this test is only on master)

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.