### PR TITLE
eve-k: disable apiserver watch cache on multi-node clusters

### DIFF
--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -93,6 +93,7 @@ COPY registration-utils.sh /usr/bin/
 COPY all-kube-events.sh /usr/bin/
 COPY lib/* /usr/bin/kube/
 COPY cfg-manifests/03-enc-disable-local-path.yaml /etc/kube/
+COPY cfg-manifests/04-multinode-watch-cache.yaml /etc/kube/
 
 # kubevirt yaml files are patched files and will be removed later, look at cluster-init.sh
 COPY multus-daemonset.yaml /etc

--- a/pkg/kube/cfg-manifests/04-multinode-watch-cache.yaml
+++ b/pkg/kube/cfg-manifests/04-multinode-watch-cache.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+# Multi-node clusters only (installed by cluster-init.sh via
+# provision_cluster_config_file, which runs only in edge-node-cluster mode).
+#
+# Disable the kube-apiserver in-memory watch cache so every LIST/WATCH is served
+# straight from etcd. During k3s/etcd churn (the single-node -> multi-node
+# transition, and any later leader election such as a node failover) a
+# transiently-behind watch cache can serve a reconnecting informer a successful
+# but incomplete stream, silently dropping a window of events. With the CoreDNS
+# kubernetes plugin's resync disabled (resyncPeriod = 0) those lost Service
+# events are never re-listed, so Services created in that window stay permanently
+# NXDOMAIN and app deployment (CDI upload) fails. Serving from etcd removes that
+# stale-serve path: a reconnect either resumes cleanly or gets an honest
+# "410 Gone" that forces a re-LIST.
+#
+# The "+" suffix appends to the kube-apiserver-arg list from the base
+# /etc/rancher/k3s/config.yaml rather than replacing it.
+#
+# Cost of disabling the cache on these constrained edge nodes was benchmarked and
+# found negligible at realistic load (no measurable CPU or app-deploy-time impact,
+# slightly lower apiserver memory; only more etcd LIST traffic that etcd absorbs).
+kube-apiserver-arg+:
+  - "watch-cache=false"

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -1169,6 +1169,9 @@ EOF
             logmsg "possible unhandled cluster type $cluster_type in (provision_cluster_config_file)"
     fi
 
+    # Multi-node only; rationale is in 04-multinode-watch-cache.yaml.
+    cp "${KUBE_MANIFESTS_SRC_DIR}/${K3S_CONFIG_FILE_WATCH_CACHE}" "${K3S_CONFIG_DIR}/${K3S_CONFIG_FILE_WATCH_CACHE}"
+
     # we have 2 conditions, one is we are the bootstrap node or not, the other is we are
     # the first time configure k3s cluster or not. If both are true, then we need bootstrap config
     # otherwise, we just need normal server config to join the existing cluster

--- a/pkg/kube/lib/config.sh
+++ b/pkg/kube/lib/config.sh
@@ -23,6 +23,9 @@ K3S_CLUSTER_CONFIG_FILE="${K3S_CONFIG_DIR}/01-clusterconfig.yaml"
 # 02-nodename skipped, defined in cluster-utils.sh
 # shellcheck disable=SC2034
 K3S_CONFIG_FILE_DISABLE_LOCAL_PATH="03-enc-disable-local-path.yaml"
+# Disables the apiserver watch cache; installed on multi-node clusters only.
+# shellcheck disable=SC2034
+K3S_CONFIG_FILE_WATCH_CACHE="04-multinode-watch-cache.yaml"
 # shellcheck disable=SC2034
 K3S_USER_OVERRIDE_CONFIG_SRC="/persist/vault/k3s-user-override.yaml"
 # shellcheck disable=SC2034


### PR DESCRIPTION
# Description

Fixes #6113.

Please see the issue description :arrow_up: .

**Fix:** run the k3s apiserver with `--kube-apiserver-arg=watch-cache=false` on
multi-node clusters. With no cache, every LIST/WATCH is a consistent etcd read, so the
stale-serve path cannot form: a reconnect either resumes cleanly or gets an honest
`410 → re-LIST`. It is a *standing* fix — covers the initial transition and every
future failover, with no timing/retry logic.

Implementation mirrors the existing `03-enc-disable-local-path.yaml` pattern: a new
`config.yaml.d` drop-in (`04-multinode-watch-cache.yaml`) that appends `watch-cache=false`
to `kube-apiserver-arg` (the `+` suffix appends rather than replacing the base args),
installed by `cluster-init.sh` only in `edge-node-cluster` mode. Single-node keeps the
cache. Because `config.yaml.d` is rebuilt every boot and this drop-in is only written in
cluster mode, a cluster→single-node transition drops it automatically — no cleanup code
needed (same lifecycle as the existing cluster drop-ins).

### Control-plane cost

Since removing the cache might hurt performance I did some benchmarking on a standard cluster as it's provided by evetest: 3 nodes (4 vCPU / 8 GB, embedded etcd on ZFS).

At realistic (unsaturated) load, equal apiserver uptime:

| edge-dev1, ~14 LIST/s | cache ON | cache OFF |
|---|---|---|
| node CPU | 73.8% | 73.4% |
| apiserver LIST p99 | 67 ms | 48 ms |
| etcd read p99 (list) | 24 ms | 25 ms |
| apiserver RSS | 749 MB | 704 MB |
| APF 429s | none | none |

Real app rollout (20 app bundles, all 3 apiservers flipped):

| cluster aggregate | cache ON | cache OFF |
|---|---|---|
| deploy time (submit→ready) | 17 s | 16 s |
| avg node CPU | 32% | 31% |
| apiserver LIST p99 | 25 ms | 96 ms |
| APF 429s | none | none |

Net: no measurable CPU cost, no app-deploy slowdown, slightly *lower* apiserver memory;
the only real change is more etcd LIST traffic (~35×, from a tiny absolute base) that
etcd absorbs with flat read latency. The one dimension that grows is LIST p99, which
scales with cluster object count (still sub-100 ms here).

## How to test and validate this PR

- I found the bug just by running evetest's `TestThreeNodesCluster` a bunch of times.

An automated evetest regression test (`TestClusterCoreDNSWatch`) is being validated
separately and will follow.

## Changelog notes

Fix EVE-K clusters intermittently failing app deployment after multi-node cluster
formation or node failover due to stale CoreDNS Service records.

## PR Backports

- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR