### PR TITLE
Provide kmod userspace utilities to wwan container and main rootfs

### DIFF
--- a/pkg/udev/Dockerfile
+++ b/pkg/udev/Dockerfile
@@ -14,8 +14,16 @@ COPY etc/udev/rules.d/* /out/etc/udev/rules.d/
 RUN rm /out/usr/lib/udev/rules.d/*
 
 FROM scratch
+
 COPY --from=build /out/bin/udevadm /bin/
 COPY --from=build /out/sbin/udevd /sbin/
+COPY --from=build /out/bin/kmod /bin/
+COPY --from=build /out/sbin/depmod /sbin/
+COPY --from=build /out/sbin/insmod /sbin/
+COPY --from=build /out/sbin/lsmod /sbin/
+COPY --from=build /out/sbin/modinfo /sbin/
+COPY --from=build /out/sbin/modprobe /sbin/
+COPY --from=build /out/sbin/rmmod /sbin/
 COPY --from=build /out/usr/lib/udev /usr/lib/udev
 COPY --from=build /out/etc/udev /etc/udev
 COPY --from=build /out/etc/init.d/*  /etc/init.d/
@@ -23,6 +31,7 @@ COPY --from=build /out/usr/lib/libblkid.so.1 /lib/
 COPY --from=build /out/usr/lib/libkmod.so.2 /lib/
 COPY --from=build /out/usr/lib/libzstd.so.1 /usr/lib/
 COPY --from=build /out/usr/lib/liblzma.so.5 /usr/lib/
+COPY --from=build /out/usr/lib/libcrypto.so.3 /usr/lib/
 COPY --from=build /out/usr/lib/libz.so.1 /lib/
 COPY --from=build /out/usr/lib/libcrypto.so.3 /usr/lib
 

--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM lfedge/eve-alpine:39f46094f640424c345164420ed789afd8a4088b AS build
 ENV BUILD_PKGS meson ninja git libc-dev glib-dev make gcc udev dbus-dev libgudev-dev
-ENV PKGS alpine-baselayout dbus glib kmod-dev libgudev
+ENV PKGS alpine-baselayout dbus glib kmod kmod-dev libgudev
 RUN eve-alpine-deploy.sh
 
 ENV MM_VERSION=1.22.0


### PR DESCRIPTION
# Description

Several packages, such as dom0-ztools and wwan rely on init scripts to load modules. However, kmod tool is not installed in the main rootfs, so a limited version from busybox is used (without compression support) when a onboot service is executed. This PR installs the kmod userspace utilities from udev container, which is installed in the main rootfs in images/rootfs.yml.in file.

It also install the kmod for wwan container, which executes modprobe during startup of the container.

## How to test and validate this PR

1. `make live run-live`
2. Observe that there is no `Loading of unsigned module is rejected` message from kernel
3. Run `modinfo usbserial`, it should show the signature

```sh
# modinfo usbserial
filename:       /lib/modules/6.12.49-linuxkit-core-dcdba3ddf871/kernel/drivers/usb/serial/usbserial.ko.xz
license:        GPL v2
description:    USB Serial Driver core
author:         Greg Kroah-Hartman <gregkh@linuxfoundation.org>
depends:        
intree:         Y
name:           usbserial
retpoline:      Y
vermagic:       6.12.49-linuxkit-core-dcdba3ddf871 SMP preempt mod_unload 
sig_id:         PKCS#7
signer:         Build time autogenerated kernel key
sig_key:        21:C2:4F:02:A8:C9:DC:1A:6C:AD:92:E5:9D:EE:EC:8D:4E:1E:CE:21
sig_hashalgo:   sha256
signature:      49:84:D4:C9:62:42:F3:67:DB:AA:D6:CE:52:4F:C6:70:1E:79:74:15:
		A7:D2:9D:70:8E:AC:16:31:6D:4B:32:5F:36:B2:38:86:4C:F8:6A:03:
		67:90:60:B7:3B:4C:26:C3:4D:73:8D:2F:B6:38:ED:D7:89:EC:FA:D8:
		0E:F1:49:7E:95:79:39:84:49:4C:35:38:F4:E1:F9:10:4B:BB:28:E3:
		72:CB:2A:43:B0:BD:1F:1D:4B:0C:73:24:D5:91:16:94:F6:70:22:18:
		0E:57:81:48:4C:3D:EA:9F:B4:D3:74:C3:2A:AD:55:83:1E:33:E0:71:
		59:EA:0F:94:8B:15:F3:E8:5E:14:35:A3:87:1C:02:3F:C9:CC:91:DF:
		02:96:19:AD:99:F5:F9:ED:4F:71:0A:D4:9C:4D:5A:E7:16:FC:F0:57:
		D2:09:68:EA:39:D9:C5:91:D8:56:8B:C6:BA:18:61:7E:0F:E7:9C:9B:
		91:0A:4A:0B:40:38:37:50:7A:99:94:C8:6C:40:09:92:F5:03:CD:4B:
		53:02:28:A9:20:C8:16:8A:5C:E7:53:43:54:22:C0:80:71:69:EA:F0:
		47:3D:EE:AC:80:36:9E:CC:F0:2C:E6:9C:3F:52:9F:A7:96:61:E1:15:
		89:E1:FC:00:53:BC:CB:37:13:E1:CB:38:76:95:17:E8:1D:9E:9C:1C:
		48:74:DD:D7:48:20:F8:43:3A:AD:F8:AB:22:2D:12:A8:97:79:02:C9:
		A5:9A:DF:65:F1:B2:FE:10:F6:09:5B:AB:22:C6:76:1B:7E:64:F2:7A:
		78:56:4B:C1:E0:7B:5D:D3:83:9A:2E:9C:E4:71:69:B8:27:49:01:86:
		6A:C7:85:D9:D3:00:04:43:16:ED:18:1D:BB:8C:C4:A0:B9:38:7F:FA:
		B1:59:51:30:AD:36:2A:B9:0E:E2:1F:B7:54:09:56:66:C0:81:C4:D5:
		BD:E9:AC:53:72:4B:2F:51:D2:88:8F:56:34:C9:36:39:E1:F1:AD:24:
		AA:E8:44:5D:84:42:9C:68:8A:09:9D:8A:8D:96:57:E4:4B:07:71:01:
		99:60:F2:33:79:93:55:8F:F4:EA:2E:89:AF:15:DF:06:B1:63:66:CE:
		E5:60:60:46:3E:5B:DF:BB:92:BA:36:D6:C0:80:60:37:BA:BD:38:D5:
		D3:7B:EB:AF:99:B6:DE:B5:C1:B3:FD:C7:C0:9E:DC:15:E4:CD:D9:37:
		BF:56:1A:52:79:5D:10:21:9D:B2:46:71:40:83:2A:46:85:95:D5:0B:
		92:DE:47:26:3B:DD:D2:58:80:96:D1:69:CB:2D:A8:34:D0:DF:2E:12:
		2C:2A:DA:F3:34:BA:69:6F:E0:E0:1B:9D
```

## Changelog notes

None. This is on master.

## PR Backports

- [ ] 17.0

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.