### PR TITLE
persist,zedagent: create controllercerts.bak and lastconfig.bak on first save

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -1038,6 +1038,15 @@ func getLatestConfig(getconfigCtx *getconfigContext, iteration int,
 
 func saveReceivedProtoMessage(contents []byte) {
 	persist.SaveConfig(log, "lastconfig", contents)
+	// Ensure a lastconfig.bak fallback exists from the very first save.
+	// Otherwise it is only created by backupSavedConfig() after
+	// MintimeUpdateSuccess, so a /persist recreate or corruption before then
+	// leaves no known-good config to fall back to (the restore path keeps a
+	// truncated/corrupt lastconfig, since it has no per-type validator).
+	// backupSavedConfig() still refreshes it as the proven-good rollback copy.
+	if !persist.ExistsSavedConfig(log, "lastconfig.bak") {
+		persist.CloneContentAndTimes(log, "lastconfig", "lastconfig.bak")
+	}
 }
 
 // This is called after types.MintimeUpdateSuccess

--- a/pkg/pillar/utils/persist/checkpoint.go
+++ b/pkg/pillar/utils/persist/checkpoint.go
@@ -106,13 +106,18 @@ func ExistsSavedConfig(log *base.LogObject, filename string) bool {
 // MaybeSaveControllerCerts saves a checkpoint of a verified chain
 // of controller certificates if it differs from the currently saved chain.
 // If so, the previous controllercerts file is moved to controllercerts.bak
-// without changing its modification time.
+// without changing its modification time. On the very first save there is no
+// previous file to move, so it additionally creates controllercerts.bak from
+// the saved file when none exists yet (this also backfills devices installed
+// before a backup was kept). That way ReadControllerCerts always has a fallback
+// if the primary is later truncated or corrupted.
 // Since the order of the certs in the protobuf encoded contents can differ
 // even though the certs are the same, the caller needs to verify that
 // there was an actual change. This function does a basic bytes.Equal to
 // handle any other spurious calls.
 func MaybeSaveControllerCerts(log *base.LogObject, contents []byte) {
 	filename := "controllercerts"
+	backupname := filename + ".bak"
 	oldContents, ts, err := ReadSavedConfig(log, filename)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -121,6 +126,11 @@ func MaybeSaveControllerCerts(log *base.LogObject, contents []byte) {
 	} else {
 		if bytes.Equal(oldContents, contents) {
 			log.Functionf("MaybeSaveControllerCerts: same content as saved at %v", ts)
+			// Backfill the backup if it is missing (e.g. certs unchanged
+			// since an install that predated keeping controllercerts.bak).
+			if !ExistsSavedConfig(log, backupname) {
+				CloneContentAndTimes(log, filename, backupname)
+			}
 			return
 		}
 	}
@@ -130,6 +140,12 @@ func MaybeSaveControllerCerts(log *base.LogObject, contents []byte) {
 		// Can occur if no space in filesystem
 		log.Errorf("MaybeSaveControllerCerts failed: %s", err)
 		return
+	}
+	// On the first save WriteRenameWithBackup had no prior controllercerts to
+	// move to controllercerts.bak, so create the backup from the just-written
+	// file.
+	if !ExistsSavedConfig(log, backupname) {
+		CloneContentAndTimes(log, filename, backupname)
 	}
 	log.Notice("MaybeSaveControllerCerts updated the certs")
 }


### PR DESCRIPTION
# Description

**Motivation:** discovered while testing the in-field EVE-kvm ↔ EVE-k boot-disk
conversion. After a `/persist` recreate/restore the device relies on the
`/persist/checkpoint` files (and their `.bak` fallbacks) to come back up, offline
included. Two of those `.bak` fallbacks are not created early enough on a freshly
installed device, so a corruption/recreate in that window has nothing to fall back
to.

This ensures both are created from the first save when missing:

- **`controllercerts.bak`** — `MaybeSaveControllerCerts` relies on
  `WriteRenameWithBackup`, which moves the *previous* `controllercerts` to
  `.bak`; on the first save there is nothing to move, so no backup is created.
- **`lastconfig.bak`** — only created by `backupSavedConfig()` after
  `MintimeUpdateSuccess` (the config-rollback known-good), so early there is no
  backup. `restore`'s `needsRestore` has no per-type validator for the checkpoint
  config and keeps a truncated/corrupt `lastconfig`, so a recreate before that
  timer would leave no good config to fall back to.

Both fixes create the `.bak` from the just-written file only when none exists yet,
and backfill devices installed before a backup was kept. Existing behavior is
unchanged once a `.bak` exists: `WriteRenameWithBackup` still rolls the previous
certs into `controllercerts.bak`, and `backupSavedConfig()` still refreshes
`lastconfig.bak` as the proven-good rollback copy after `MintimeUpdateSuccess`.

## PR dependencies

None — independent, based on `master`.

## How to test and validate this PR

Automated: exercised by the kvm→k restore eden tests (lf-edge/eden#1203) —
`update_eve_image_kvm_to_k_f9_persist_restore` (full `/persist` wipe) and
`update_eve_image_kvm_to_k_f11_truncate_restore` (partial truncation), which rely
on these `.bak` fallbacks / restored checkpoints for offline recovery.

Manual:
1. Install/onboard a device so it fetches config and controller certs.
2. Immediately (before `timer.test.baseimage.update` elapses) confirm both
   backups already exist:
   `eve exec pillar ls -l /persist/checkpoint/controllercerts.bak /persist/checkpoint/lastconfig.bak`
   (before this change they are absent on a fresh device until later).
3. Truncate/corrupt the primary `controllercerts` / `lastconfig`, reboot, and
   confirm the device recovers using the `.bak` copies.

## Changelog notes

No user-facing changes (internal robustness: always keep `controllercerts.bak`
and `lastconfig.bak` fallbacks for the checkpoint files).

## PR Backports

- 16.0-stable: No — minor robustness fix motivated by the 17.0 kvm→k conversion
  work; can be backported on request.
- 14.5-stable: No — same reason.
- 13.4-stable: No — same reason.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (updated the relevant doc comments; no external docs affected)
- [ ] I've tested my PR on amd64 device — build + `go vet` pass; on-device validation via the F9/F11 eden tests once images are rebuilt with both commits
- [ ] I've tested my PR on arm64 device — arch-independent (pure Go, no arch-specific paths)
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
