### PR TITLE
github/workflows: Setup git permissions inside Yetus container

### DIFF
--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -31,11 +31,20 @@ jobs:
           git diff upstream/${{ github.base_ref }}...HEAD > ${{ github.workspace }}/pr.patch
           # Get back to upstream master so patch can be applied
           git checkout upstream/master
+          git submodule update --init --recursive
+
+      - name: Prepare gitconfig for container
+        run: |
+          cat > /tmp/gitconfig <<'EOF'
+          [safe]
+              directory = *
+          EOF
 
       - name: Yetus
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
+            -v /tmp/gitconfig:/etc/gitconfig \
             lfedge/eve-yetus:0.15.1-eve-2 \
             test-patch \
             --basedir=/workspace/src \


### PR DESCRIPTION
# Description

With the introduction of evetest, we now have submodules in our source tree. This makes codespell plugin trying to initialize submodules and let to the following error:

```
Initializing git submodules...
fatal: detected dubious ownership in repository at '/workspace/src/evetest/grpcapi/eve-api' To add an exception for this directory, call:

	git config --global --add safe.directory /workspace/src/evetest/grpcapi/eve-api
fatal: Unable to find current revision in submodule path 'evetest/grpcapi/eve-api'
```

In this case /workspace is the mount point inside the container running Yetus, mounted from the current source directory (from a different user ID). This commit fixes this issue by adding the safe.directory git option to all directories within the container through a config file prepared in advance and mount inside the container at /etc/gitconfig. It also initializes submodules after checkout upstream/master because codespell plugin is initializing them as well.


## How to test and validate this PR

Run Yetus GH workflow.

## Changelog notes

None.

## PR Backports

- [x] 17.0

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.