### PR TITLE
hypervisor: build QMP commands with json.Marshal to prevent injection

### DIFF
--- a/pkg/pillar/hypervisor/qmp.go
+++ b/pkg/pillar/hypervisor/qmp.go
@@ -91,28 +91,62 @@ func execQuit(socket string) error {
 	return err
 }
 
+// qmpCommand mirrors the wire format of a QMP command. Marshalling it with
+// encoding/json guarantees that string arguments (VNC passwords, device ids,
+// etc.) are properly escaped, so a value containing a quote or backslash can
+// never break out of the JSON and inject additional arguments or commands.
+type qmpCommand struct {
+	Execute   string      `json:"execute"`
+	Arguments interface{} `json:"arguments,omitempty"`
+}
+
+// buildQMPCommand marshals a QMP command with the given arguments into valid,
+// properly escaped JSON. Pass nil arguments for commands that take none.
+func buildQMPCommand(execute string, arguments interface{}) ([]byte, error) {
+	cmd, err := json.Marshal(qmpCommand{Execute: execute, Arguments: arguments})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal QMP command %q: %w", execute, err)
+	}
+	return cmd, nil
+}
+
 func execVNCPassword(socket string, password string) error {
-	vncSetPwd := fmt.Sprintf(`{ "execute": "change-vnc-password", "arguments": { "password": "%s" } }`, password)
-	// But log this:
-	cmd := `{ "execute": "change-vnc-password", "arguments": { "password": <redacted> } }`
-	logrus.Debugf("executing QMP command: %s", cmd)
-	_, err := execRawCmd(socket, vncSetPwd, true)
+	vncSetPwd, err := buildQMPCommand("change-vnc-password",
+		map[string]string{"password": password})
+	if err != nil {
+		return err
+	}
+	// Never log the password itself.
+	logrus.Debugf(`executing QMP command: { "execute": "change-vnc-password", "arguments": { "password": <redacted> } }`)
+	_, err = execRawCmd(socket, string(vncSetPwd), true)
 	return err
 }
 
 // QmpExecDeviceDelete removes a device
 func QmpExecDeviceDelete(socket, id string) error {
-	qmpString := fmt.Sprintf(`{ "execute": "device_del", "arguments": { "id": "%s"}}`, id)
+	qmpString, err := buildQMPCommand("device_del",
+		map[string]string{"id": id})
+	if err != nil {
+		return err
+	}
 	logrus.Debugf("executing QMP command: %s", qmpString)
-	_, err := execRawCmd(socket, qmpString, true)
+	_, err = execRawCmd(socket, string(qmpString), true)
 	return err
 }
 
 // QmpExecDeviceAdd adds a usb device via busnum/devnum
 func QmpExecDeviceAdd(socket, id string, busnum, devnum uint16) error {
-	qmpString := fmt.Sprintf(`{ "execute": "device_add", "arguments": { "driver": "usb-host", "hostbus": %d, "hostaddr": %d, "id": "%s"} }`, busnum, devnum, id)
+	qmpString, err := buildQMPCommand("device_add", map[string]interface{}{
+		"driver":   "usb-host",
+		"hostbus":  busnum,
+		"hostaddr": devnum,
+		"id":       id,
+	})
+	if err != nil {
+		return err
+	}
 	logrus.Debugf("executing QMP command: %s", qmpString)
-	_, err := execRawCmd(socket, qmpString, true)
+	_, err = execRawCmd(socket, string(qmpString), true)
 	return err
 }
 

--- a/pkg/pillar/hypervisor/qmp_test.go
+++ b/pkg/pillar/hypervisor/qmp_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package hypervisor
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// TestBuildQMPCommandValidJSON ensures buildQMPCommand always produces valid,
+// parseable JSON, even for argument values that contain characters which are
+// special in JSON (quotes, backslashes) or which attempt to break out of the
+// string and inject additional QMP arguments/commands (EV-2614).
+func TestBuildQMPCommandValidJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		password string
+	}{
+		{"simple", "s3cr3t"},
+		{"empty", ""},
+		{"double_quote", `foo"bar`},
+		{"backslash", `foo\bar`},
+		{"injection_attempt", `x" } }, { "execute": "quit" `},
+		{"injection_extra_arg", `x", "protocol": "vnc`},
+		{"newline_and_unicode", "a\nb\té"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := buildQMPCommand("change-vnc-password",
+				map[string]string{"password": tt.password})
+			if err != nil {
+				t.Fatalf("buildQMPCommand returned error: %v", err)
+			}
+
+			// The output must be a single, well-formed JSON object.
+			var parsed struct {
+				Execute   string `json:"execute"`
+				Arguments struct {
+					Password string `json:"password"`
+				} `json:"arguments"`
+			}
+			dec := json.NewDecoder(bytes.NewReader(raw))
+			dec.DisallowUnknownFields()
+			if err := dec.Decode(&parsed); err != nil {
+				t.Fatalf("output is not valid JSON: %v (raw: %s)", err, raw)
+			}
+			// Ensure there is no trailing content (e.g. an injected second
+			// command) after the first JSON object.
+			if dec.More() {
+				t.Fatalf("unexpected trailing content after JSON object (raw: %s)", raw)
+			}
+
+			if parsed.Execute != "change-vnc-password" {
+				t.Errorf("execute = %q, want change-vnc-password", parsed.Execute)
+			}
+			// The password must round-trip exactly, i.e. it stays confined to
+			// the password field and is not interpreted as structure.
+			if parsed.Arguments.Password != tt.password {
+				t.Errorf("password round-trip mismatch:\n got: %q\nwant: %q",
+					parsed.Arguments.Password, tt.password)
+			}
+		})
+	}
+}
+
+// TestBuildQMPCommandNoArguments verifies that a command without arguments does
+// not emit an empty "arguments" field.
+func TestBuildQMPCommandNoArguments(t *testing.T) {
+	raw, err := buildQMPCommand("cont", nil)
+	if err != nil {
+		t.Fatalf("buildQMPCommand returned error: %v", err)
+	}
+	if got, want := string(raw), `{"execute":"cont"}`; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
# Description

execVNCPassword built the change-vnc-password QMP command with fmt.Sprintf, interpolating the controller-supplied VNC password directly into a JSON string literal without any escaping. A password containing a double-quote or backslash produced 

malformed JSON, and a crafted value could close the password string early and inject additional QMP arguments or commands onto the running VM's monitor socket.

Introduce a qmpCommand struct plus a buildQMPCommand helper that marshals commands (and their arguments) with encoding/json, which always escapes special characters so argument values stay confined to their field. Convert execVNCPassword and the sibling QmpExecDeviceDelete / QmpExecDeviceAdd helpers (which interpolated an id string with the same pattern) to use it.

Add qmp_test.go covering quote/backslash/newline and explicit injection payloads, asserting the output is a single well-formed JSON object with no trailing content and that the value round-trips exactly.

## How to test and validate this PR

Covered by the introduced QMP tests.

## Changelog notes

hypervisor: fix QMP command injection via unescaped VNC password/device-id.

## PR Backports

This requires API access and authorization, so I'd defer the backport to all other branches. But it can be discussed.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.