### PR TITLE
zedagent: heal corrupt checkpoint from its backup

### DIFF
--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -43,6 +43,36 @@ type cipherContext struct {
 
 var controllerCertHash []byte
 
+// isControllerCertsDecodable reports whether the checkpointed controller certs file
+// (e.g. "controllercerts") decodes structurally as a ZControllerCert. Chain
+// verification is intentionally skipped, so this distinguishes a
+// corrupt/truncated/missing file (returns false) from an intact file that
+// merely fails verification -- for example an expired but well-formed signing
+// chain (returns true). Only the former is safe to restore from a backup.
+func isControllerCertsDecodable(filename string) bool {
+	contents, _, err := persist.ReadSavedConfig(log, filename)
+	if err != nil || len(contents) == 0 {
+		return false
+	}
+	return proto.Unmarshal(contents, &zcert.ZControllerCert{}) == nil
+}
+
+// maybeHealControllerCertsFromBackup restores controllercerts from
+// controllercerts.bak when the primary is corrupt (does not decode) but the
+// backup is good. Without this a later cert update would move the corrupt
+// primary onto the good backup (WriteRenameWithBackup in
+// MaybeSaveControllerCerts), leaving no valid controller certs to fall back to.
+func maybeHealControllerCertsFromBackup() {
+	if isControllerCertsDecodable("controllercerts") {
+		return // primary intact (or only fails verification); leave it
+	}
+	if !isControllerCertsDecodable("controllercerts.bak") {
+		return // no good backup to restore from
+	}
+	log.Warnf("Restoring corrupt controllercerts from controllercerts.bak")
+	persist.CloneContentAndTimes(log, "controllercerts.bak", "controllercerts")
+}
+
 // parse and update controller certs
 // Returns true if there was a change to the set of certs.
 func parsePublishControllerCerts(ctx *zedagentContext, contents []byte) (changed bool, err error) {

--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -803,6 +803,7 @@ func requestConfigByURL(getconfigCtx *getconfigContext, url string,
 			// can be used to enable the local keyboard etc for
 			// debugging purposes.
 			confName := "lastconfig"
+			fellBackToBackup := false
 			if !ctx.bootReason.StartWithSavedConfig() {
 				log.Warnf("Use backup config due to boot reason %s",
 					ctx.bootReason.String())
@@ -820,6 +821,7 @@ func requestConfigByURL(getconfigCtx *getconfigContext, url string,
 				log.Errorf("getconfig %s: %v", confName, err)
 				if confName == "lastconfig" {
 					confName = "lastconfig.bak"
+					fellBackToBackup = true
 					continue
 				}
 				return invalidConfig, rv.TracedReqs
@@ -827,6 +829,19 @@ func requestConfigByURL(getconfigCtx *getconfigContext, url string,
 			if config != nil {
 				log.Noticef("Using saved config %s dated %s",
 					confName, ts.Format(time.RFC3339Nano))
+
+				// We fell back to lastconfig.bak and it is valid. If the
+				// primary lastconfig is corrupt (does not decode), restore it
+				// from the backup so a later backupSavedConfig() does not clone
+				// the corrupt primary over the good backup, which would leave
+				// no valid config to fall back to on the next boot. Only a
+				// decode failure counts as corruption: a primary that decodes
+				// but failed verification (e.g. controllercerts not loaded yet)
+				// is intact and must be left alone.
+				if fellBackToBackup && !isSavedConfigDecodable(ctrlClient, "lastconfig") {
+					log.Warnf("Restoring corrupt lastconfig from lastconfig.bak")
+					persist.CloneContentAndTimes(log, "lastconfig.bak", "lastconfig")
+				}
 
 				cfgRetval := inhaleDeviceConfig(getconfigCtx, config, savedConfig)
 				if cfgRetval != configOK {
@@ -1080,6 +1095,28 @@ func saveSentHardwareInventoryProtoMessage(contents []byte) {
 // XXX for debug we track these
 func saveSentAppInfoProtoMessage(contents []byte) {
 	persist.SaveConfig(log, "lastappinfo", contents)
+}
+
+// isSavedConfigDecodable reports whether the checkpointed config file (e.g.
+// "lastconfig") decodes structurally: the auth envelope unmarshals and its
+// payload unmarshals as a ConfigResponse. Verification is intentionally
+// skipped, so this distinguishes a corrupt/truncated/missing file (returns
+// false) from an intact file that merely fails verification -- for example
+// when controllercerts are not loaded yet, or the signing chain has expired
+// (returns true). Only the former is safe to restore from a backup.
+func isSavedConfigDecodable(ctrlClient *controllerconn.Client, filename string) bool {
+	contents, _, err := persist.ReadSavedConfig(log, filename)
+	if err != nil || len(contents) == 0 {
+		return false
+	}
+	sendRV := controllerconn.SendRetval{RespContents: contents}
+	if err := ctrlClient.RemoveAndVerifyAuthContainer(&sendRV, true); err != nil {
+		return false
+	}
+	if err := proto.Unmarshal(sendRV.RespContents, &zconfig.ConfigResponse{}); err != nil {
+		return false
+	}
+	return true
 }
 
 // If the file exists then read the config, and return is modify time

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -658,6 +658,10 @@ func initializeControllerCerts(ctx *zedagentContext, ctrlClient *controllerconn.
 	if ctrlClient == nil {
 		log.Fatal("nil ctrlClient in initializeControllerCerts")
 	}
+	// If the primary controllercerts is corrupt but controllercerts.bak is
+	// good, restore the primary first, so a later cert update does not move
+	// the corrupt primary onto the good backup (see the helper for details).
+	maybeHealControllerCertsFromBackup()
 	useBackup := false
 	err := ctrlClient.LoadSavedServerSigningCert(useBackup)
 	certChainBytes := ctrlClient.GetCertChainBytes()


### PR DESCRIPTION
# Description

Follow-on to #6122. After a partial `/persist` corruption the primary
`lastconfig` / `controllercerts` checkpoint can fail to decode. zedagent already
falls back to the `.bak` copy but leaves the corrupt primary on disk, and a
later backup then overwrites the good `.bak` with it: `backupSavedConfig()`
clones `lastconfig` once the config is proven good, and `MaybeSaveControllerCerts`
moves the current `controllercerts` aside on the next cert update. Both copies
end up corrupt, leaving the device with nothing to fall back to on the next boot.

This restores the primary from its `.bak` as soon as the fallback read succeeds,
so the primary is valid again before any backup runs. The heal is gated on a
structural decode — a plain protobuf unmarshal with verification skipped — so a
truncated/garbage file is repaired while an intact-but-unverifiable file
(controllercerts not loaded yet, or an expired-but-well-formed signing chain)
is left untouched.

## PR dependencies

Builds on #6122 (creates `controllercerts.bak` / `lastconfig.bak` on first save).
Based on `master`.

## How to test and validate this PR

Automated: exercised by the kvm→k restore eden test
`update_eve_image_kvm_to_k_f11_truncate_restore` (lf-edge/eden#1203), which
truncates the checkpoint files on-device (keeping the `.bak`s), reboots offline,
and asserts recovery. Before this change the truncated `lastconfig` was cloned
over its good `.bak` after `MintimeUpdateSuccess`, leaving both copies corrupt
(test FAIL). With it, the `.bak` stays intact and the primary is healed —
validated on a locally-built amd64 image: post-restore `lastconfig` and
`lastconfig.bak` are both the full 2760 bytes, WiFi creds decrypt from the
restored ecdh, and the test PASSes.

Manual:
1. Onboard a device; wait for `controllercerts.bak` / `lastconfig.bak` to exist.
2. Truncate `/persist/checkpoint/lastconfig` (and `controllercerts`), reboot
   offline.
3. Confirm the device heals the primary from its `.bak` and the `.bak` is not
   overwritten with the truncated content.

## Changelog notes

No user-facing changes (internal robustness: repair a corrupt checkpoint from its
`.bak` before it can overwrite the good backup).

## PR Backports

- 16.0-stable: No — robustness fix motivated by the 17.0 kvm→k conversion work;
  can be backported on request.
- 14.5-stable: No — same reason.
- 13.4-stable: No — same reason.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (doc comments on the new helpers; no external docs affected)
- [x] I've tested my PR on amd64 device — validated via the F11 eden restore test on a locally-built amd64 image
- [ ] I've tested my PR on arm64 device — arch-independent (pure Go, no arch-specific paths)
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
