### PR TITLE
tools: run repo-root dev scripts from a git worktree

### DIFF
--- a/tools/bump_dockerfiles.pl
+++ b/tools/bump_dockerfiles.pl
@@ -5,7 +5,9 @@
 
 use 5.12.0;
 
--d ".git" or die "Please run from the root directory of the repository";
+# .git is a directory in a plain checkout but a file in a git worktree; -e
+# matches both, and .git only exists at the repository/worktree root.
+-e ".git" or die "Please run from the root directory of the repository";
 
 say "Be aware of the two shortcomings of this tool:";
 say "1. pkg/eve/Dockerfile.in is not bumped";

--- a/tools/mini-yetus.sh
+++ b/tools/mini-yetus.sh
@@ -54,8 +54,9 @@ shift $((OPTIND -1))
 
 echo "[+] Running mini-yetus"
 
-# check if we are in the root of the repository
-if [ ! -d .git ]; then
+# check if we are in the root of the repository (works for a plain checkout,
+# where .git is a directory, and for a git worktree, where .git is a file)
+if [ "$(git rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)" ]; then
     echo "[!] Error: This script must be run from the root of the EVE repository."
     exit 1
 fi


### PR DESCRIPTION
# Description

`tools/mini-yetus.sh` and `tools/bump_dockerfiles.pl` guard against being run outside the repository root by testing for a `.git` **directory**. That fails inside a **git worktree**, where `.git` is a file (a gitdir pointer) rather than a directory, so both scripts abort with "must be run from the root of the repository" even when run from the worktree root.

Fix both in a worktree-aware way:
- `mini-yetus.sh`: compare `git rev-parse --show-toplevel` against the current directory.
- `bump_dockerfiles.pl`: test `-e .git` (matches both a directory and a file) instead of `-d .git`.

Both resolve correctly for a plain checkout and a linked worktree.

## How to test and validate this PR

- From a plain checkout root: `make mini-yetus` and `./tools/bump_dockerfiles.pl` run as before.
- From a `git worktree add`'ed worktree root: both now run instead of erroring out.

## Changelog notes

No user-facing changes (developer tooling only).

## PR Backports

- 16.0-stable: No — developer tooling, not shipped.
- 14.5-stable: No — developer tooling, not shipped.
- 13.4-stable: No — developer tooling, not shipped.

## Checklist

- [x] I've provided a proper description
- [x] I've written the test verification instructions
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them (dev-only tooling; no device/doc impact).
