### PR TITLE
kube: resync stale state on cluster DNID reassignment

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlecontent.go
+++ b/pkg/pillar/cmd/volumemgr/handlecontent.go
@@ -45,17 +45,33 @@ func handleContentTreeModify(ctxArg interface{}, key string,
 		log.Fatalf("Missing ContentTreeStatus for %s", config.Key())
 	}
 
+	// becomingLocal is true when a cluster DNID reassignment (e.g. node
+	// replacement) makes this node newly responsible for downloading the
+	// content: the existing status is parked at LOADED without ever having
+	// downloaded anything, so it must go through the same delete+recreate
+	// path as a content change to actually (re)enter the download pipeline.
+	becomingLocal := config.IsLocal && !oldConfig.IsLocal
+
 	// if the change is significant, i.e. the content has changed, then
 	// delete the whole content tree (incl blobs) and create a new one
 	// otherwise, just update the status and proceed normally
 	if config.RelativeURL != oldConfig.RelativeURL ||
 		config.Format != oldConfig.Format ||
-		config.ContentSha256 != oldConfig.ContentSha256 {
+		config.ContentSha256 != oldConfig.ContentSha256 ||
+		becomingLocal {
 
 		deleteContentTree(ctx, status, 0) // make sure the delete is immediate
 		status = createContentTreeStatus(ctx, config)
 	} else {
 		status.UpdateFromContentTreeConfig(config)
+		if config.IsLocal != status.IsLocal {
+			// Losing designation: no local content to reconcile here, just
+			// update the bookkeeping so future actions (e.g. Delete) target
+			// the node that is now actually responsible for this content.
+			log.Noticef("handleContentTreeModify(%s): IsLocal changed from %v to %v (DNID reassignment)",
+				config.Key(), status.IsLocal, config.IsLocal)
+			status.IsLocal = config.IsLocal
+		}
 	}
 
 	updateContentTree(ctx, status)

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -63,8 +63,26 @@ func handleVolumeModify(ctxArg interface{}, key string,
 				status.DisplayName, config.DisplayName, config.VolumeID)
 			status.DisplayName = config.DisplayName
 		}
+		needUpdateVol := false
+		if config.IsReplicated != status.IsReplicated {
+			// A cluster DNID reassignment (e.g. node replacement) changed
+			// which node owns this volume. Update the bookkeeping in place;
+			// the underlying PVC (if any) already exists cluster-wide via
+			// Longhorn, so no re-creation is needed here. doUpdateVol below
+			// re-evaluates so a genuinely-missing volume still gets created
+			// on the node that just became the owner.
+			log.Noticef("handleVolumeModify(%s): IsReplicated changed from %v to %v (DNID reassignment)",
+				config.Key(), status.IsReplicated, config.IsReplicated)
+			status.IsReplicated = config.IsReplicated
+			needUpdateVol = true
+		}
 		updateVolumeStatusRefCount(ctx, status)
 		publishVolumeStatus(ctx, status)
+		if needUpdateVol {
+			if changed, _ := doUpdateVol(ctx, status); changed {
+				publishVolumeStatus(ctx, status)
+			}
+		}
 		updateVolumeRefStatus(ctx, status)
 		if err := createOrUpdateAppDiskMetrics(ctx, agentName, status); err != nil {
 			log.Errorf("handleVolumeModify(%s): exception while publishing diskmetric. %s", key, err.Error())

--- a/pkg/pillar/cmd/volumemgr/handlevolume_test.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -49,4 +50,81 @@ func initStatusCtx(t *testing.T) volumemgrContext {
 	assert.Nil(t, err)
 	ctx.pubVolumeStatus = pubVolumeStatus
 	return ctx
+}
+
+// initVolumeModifyCtx builds on initStatusCtx with the additional
+// subscriptions/config handleVolumeModify's call chain (updateVolumeStatusRefCount,
+// doUpdateVol, updateVolumeRefStatus) touches, so handleVolumeModify can be
+// exercised directly instead of only its pubsub-facing helpers.
+func initVolumeModifyCtx(t *testing.T) volumemgrContext {
+	ctx := initStatusCtx(t)
+	ctx.globalConfig = types.DefaultConfigItemValueMap()
+	ctx.volumeConfigCreateDeferredMap = make(map[string]*types.VolumeConfig)
+
+	ps := pubsub.New(&pubsub.EmptyDriver{}, logrus.StandardLogger(), log)
+
+	subVolumeConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:   "zedagent",
+		MyAgentName: agentName,
+		TopicImpl:   types.VolumeConfig{},
+		Ctx:         &ctx,
+	})
+	assert.Nil(t, err)
+	ctx.subVolumeConfig = subVolumeConfig
+	subVolumeConfig.Activate()
+
+	subVolumeRefConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:   "zedmanager",
+		MyAgentName: agentName,
+		TopicImpl:   types.VolumeRefConfig{},
+		Ctx:         &ctx,
+	})
+	assert.Nil(t, err)
+	ctx.subVolumeRefConfig = subVolumeRefConfig
+	subVolumeRefConfig.Activate()
+
+	return ctx
+}
+
+// TestHandleVolumeModifyResyncsIsReplicated is a regression test for a cluster
+// (ENC) bug: when a "replace node" operation reassigns a volume's Designated
+// Node ID to this node, zedagent republishes VolumeConfig with IsReplicated
+// flipped to false, but handleVolumeModify never copied the new value onto
+// the already-existing VolumeStatus -- it stayed frozen at whatever value was
+// set when the status was first created. Since DestroyVolume() gates PVC
+// deletion on VolumeStatus.IsReplicated, a stale "true" meant the
+// newly-designated node silently skipped deleting the PVC on Delete.
+func TestHandleVolumeModifyResyncsIsReplicated(t *testing.T) {
+	ctx := initVolumeModifyCtx(t)
+
+	volumeID := uuid.Must(uuid.NewV4())
+	contentID := uuid.Must(uuid.NewV4())
+
+	// Simulate this node's pre-fix state: it was a replica (the volume's PVC
+	// lives on a different, designated node), already fully reconciled.
+	status := &types.VolumeStatus{
+		VolumeID:     volumeID,
+		ContentID:    contentID,
+		MaxVolSize:   1024,
+		State:        types.CREATED_VOLUME,
+		SubState:     types.VolumeSubStateCreated,
+		IsReplicated: true,
+	}
+	publishVolumeStatus(&ctx, status)
+
+	// Controller reassigns DNID to this node: same volume, same content,
+	// only IsReplicated flips to false.
+	config := types.VolumeConfig{
+		VolumeID:     volumeID,
+		ContentID:    contentID,
+		MaxVolSize:   1024,
+		IsReplicated: false,
+	}
+
+	handleVolumeModify(&ctx, config.Key(), config, types.VolumeConfig{})
+
+	got := ctx.LookupVolumeStatus(config.Key())
+	assert.NotNil(t, got)
+	assert.False(t, got.IsReplicated,
+		"VolumeStatus.IsReplicated must be resynced from VolumeConfig on modify, not frozen at creation time")
 }

--- a/pkg/pillar/cmd/zedkube/vmirsaffinity.go
+++ b/pkg/pillar/cmd/zedkube/vmirsaffinity.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package zedkube
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/hypervisor"
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kubevirt.io/client-go/kubecli"
+)
+
+// reconcileVMIRSAffinity corrects the node affinity recorded in an
+// AppInstance's VMI ReplicaSet when it no longer matches this node, but only
+// for apps whose cluster DNID is currently assigned to this node.
+//
+// The VMIRS's affinity is set once, by whichever node happens to create it
+// (see hypervisor.CreateReplicaVMIConfig), and is never revisited by that
+// creation path afterward. A cluster DNID reassignment (e.g. node
+// replacement) does not update it, so it can keep pointing at a node that no
+// longer runs (or never ran) this app.
+//
+// Gating on "am I the DNID node" -- rather than "am I the node currently
+// running this app" -- is deliberate: a temporary failover (e.g. the DNID
+// node reboots and the app runs elsewhere for a while, with DNID unchanged)
+// must NOT rewrite the affinity to the failover node, since the descheduler
+// (EnsureVMsDeschedulerAnnotated / RemovePodsViolatingNodeAffinity) relies on
+// the affinity still pointing at the true home node to move the app back
+// once it recovers. Only the actual DNID node ever corrects the affinity, and
+// it does so unconditionally on its own periodic check, independent of
+// whether it happens to be running the app right now.
+//
+// Patching only spec.template.spec.affinity does not disturb a VMI already
+// running: a ReplicaSet controller consults the template only when creating
+// a NEW replica to satisfy the desired count, never retroactively for a
+// replica already running.
+//
+// wdFunc is invoked once per app so the watchdog budget resets between
+// per-app API calls; see checkAppsFailover for the same pattern. Without it,
+// N apps each incurring a kubeAPITimeout-bounded Get+Update could together
+// exceed the agent's errorTime budget.
+func (z *zedkube) reconcileVMIRSAffinity(wdFunc func()) {
+	sub := z.subAppInstanceConfig
+	items := sub.GetAll()
+	if len(items) == 0 {
+		return
+	}
+	if !anyDesignatedVMI(items) {
+		// Nothing for this node to reconcile; skip the kubeconfig/client
+		// construction cost on this tick.
+		return
+	}
+
+	config, err := kubeapi.GetKubeConfig()
+	if err != nil {
+		log.Errorf("reconcileVMIRSAffinity: get kubeconfig: %v", err)
+		return
+	}
+	virtClient, err := kubecli.GetKubevirtClientFromRESTConfig(config)
+	if err != nil {
+		log.Errorf("reconcileVMIRSAffinity: kubevirt client: %v", err)
+		return
+	}
+
+	reconcileVMIRSAffinityWithClient(z.nodeName, virtClient, items, wdFunc)
+}
+
+// anyDesignatedVMI reports whether any item is a VMI-backed app for which
+// this node is the DNID, i.e. whether reconcileVMIRSAffinityWithClient would
+// do any real work for these items.
+func anyDesignatedVMI(items map[string]interface{}) bool {
+	for _, item := range items {
+		aiconfig := item.(types.AppInstanceConfig)
+		if aiconfig.IsDesignatedNodeID && aiconfig.FixedResources.VirtualizationMode != types.NOHYPER {
+			return true
+		}
+	}
+	return false
+}
+
+func reconcileVMIRSAffinityWithClient(nodeName string, virtClient kubecli.KubevirtClient,
+	items map[string]interface{}, wdFunc func()) {
+	for _, item := range items {
+		wdFunc()
+
+		aiconfig := item.(types.AppInstanceConfig)
+		if !aiconfig.IsDesignatedNodeID {
+			continue
+		}
+		if aiconfig.FixedResources.VirtualizationMode == types.NOHYPER {
+			// Native containers use a plain Kubernetes ReplicaSet/Pod
+			// template (CreateReplicaPodConfig), not a VMIRS.
+			continue
+		}
+
+		vmiRsName := base.GetAppKubeNameWithPurge(aiconfig.DisplayName,
+			aiconfig.UUIDandVersion.UUID, aiconfig.PurgeCmd.Counter+aiconfig.LocalPurgeCmd.Counter)
+
+		getCtx, getCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+		existing, err := virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).Get(getCtx, vmiRsName, metav1.GetOptions{})
+		getCancel()
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				log.Errorf("reconcileVMIRSAffinity: get vmirs %s: %v", vmiRsName, err)
+			}
+			// Not found: nothing to reconcile yet, Start() will create it
+			// with the correct affinity for whichever node activates it.
+			continue
+		}
+
+		desired := hypervisor.SetKubeAffinity(nodeName, aiconfig.AffinityType)
+		if reflect.DeepEqual(existing.Spec.Template.Spec.Affinity, desired) {
+			continue
+		}
+
+		existing.Spec.Template.Spec.Affinity = desired
+		updateCtx, updateCancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+		_, err = virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).Update(updateCtx, existing, metav1.UpdateOptions{})
+		updateCancel()
+		if err != nil {
+			log.Errorf("reconcileVMIRSAffinity: update vmirs %s affinity: %v", vmiRsName, err)
+			continue
+		}
+		log.Noticef("reconcileVMIRSAffinity: updated vmirs %s affinity to node %s (DNID reassignment)",
+			vmiRsName, nodeName)
+	}
+}

--- a/pkg/pillar/cmd/zedkube/vmirsaffinity_test.go
+++ b/pkg/pillar/cmd/zedkube/vmirsaffinity_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package zedkube
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/hypervisor"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	gomock "go.uber.org/mock/gomock"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	virtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+)
+
+const testNodeName = "this-node"
+
+func mkAppInstanceConfig(displayName string, isDesignated bool, virtMode types.VmMode) types.AppInstanceConfig {
+	return types.AppInstanceConfig{
+		UUIDandVersion:     types.UUIDandVersion{UUID: uuid.Must(uuid.NewV4())},
+		DisplayName:        displayName,
+		IsDesignatedNodeID: isDesignated,
+		AffinityType:       types.PreferredDuringScheduling,
+		FixedResources:     types.VmConfig{VirtualizationMode: virtMode},
+	}
+}
+
+func vmirsNameFor(aiconfig types.AppInstanceConfig) string {
+	return base.GetAppKubeNameWithPurge(aiconfig.DisplayName, aiconfig.UUIDandVersion.UUID,
+		aiconfig.PurgeCmd.Counter+aiconfig.LocalPurgeCmd.Counter)
+}
+
+func TestReconcileVMIRSAffinityWithClient_AlreadyCorrectSkipsUpdate(t *testing.T) {
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "test-zedkube", 0)
+
+	aiconfig := mkAppInstanceConfig("app1", true, types.PV)
+	name := vmirsNameFor(aiconfig)
+	correct := hypervisor.SetKubeAffinity(testNodeName, aiconfig.AffinityType)
+
+	ctrl := gomock.NewController(t)
+	mockClient := kubecli.NewMockKubevirtClient(ctrl)
+	mockRS := kubecli.NewMockReplicaSetInterface(ctrl)
+
+	mockClient.EXPECT().ReplicaSet(gomock.Any()).Return(mockRS)
+	mockRS.EXPECT().Get(gomock.Any(), name, metav1.GetOptions{}).Return(
+		&virtv1.VirtualMachineInstanceReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: virtv1.VirtualMachineInstanceReplicaSetSpec{
+				Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+					Spec: virtv1.VirtualMachineInstanceSpec{Affinity: correct},
+				},
+			},
+		}, nil)
+	// No Update expectation: gomock fails the test if Update is called.
+
+	wdCalls := 0
+	reconcileVMIRSAffinityWithClient(testNodeName, mockClient,
+		map[string]interface{}{aiconfig.Key(): aiconfig}, func() { wdCalls++ })
+
+	assert.Equal(t, 1, wdCalls)
+}
+
+func TestReconcileVMIRSAffinityWithClient_StaleUpdatesToThisNode(t *testing.T) {
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "test-zedkube", 0)
+
+	aiconfig := mkAppInstanceConfig("app2", true, types.PV)
+	name := vmirsNameFor(aiconfig)
+	stale := hypervisor.SetKubeAffinity("other-node", aiconfig.AffinityType)
+
+	ctrl := gomock.NewController(t)
+	mockClient := kubecli.NewMockKubevirtClient(ctrl)
+	mockRS := kubecli.NewMockReplicaSetInterface(ctrl)
+
+	mockClient.EXPECT().ReplicaSet(gomock.Any()).Return(mockRS).Times(2)
+	mockRS.EXPECT().Get(gomock.Any(), name, metav1.GetOptions{}).Return(
+		&virtv1.VirtualMachineInstanceReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: virtv1.VirtualMachineInstanceReplicaSetSpec{
+				Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+					Spec: virtv1.VirtualMachineInstanceSpec{Affinity: stale},
+				},
+			},
+		}, nil)
+	mockRS.EXPECT().Update(gomock.Any(), gomock.Any(), metav1.UpdateOptions{}).DoAndReturn(
+		func(_ context.Context, obj *virtv1.VirtualMachineInstanceReplicaSet, _ metav1.UpdateOptions) (*virtv1.VirtualMachineInstanceReplicaSet, error) {
+			assert.Equal(t, hypervisor.SetKubeAffinity(testNodeName, aiconfig.AffinityType), obj.Spec.Template.Spec.Affinity)
+			return obj, nil
+		})
+
+	reconcileVMIRSAffinityWithClient(testNodeName, mockClient,
+		map[string]interface{}{aiconfig.Key(): aiconfig}, func() {})
+}
+
+func TestReconcileVMIRSAffinityWithClient_NotFoundIsSwallowed(t *testing.T) {
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "test-zedkube", 0)
+
+	aiconfig := mkAppInstanceConfig("app3", true, types.PV)
+	name := vmirsNameFor(aiconfig)
+
+	ctrl := gomock.NewController(t)
+	mockClient := kubecli.NewMockKubevirtClient(ctrl)
+	mockRS := kubecli.NewMockReplicaSetInterface(ctrl)
+
+	mockClient.EXPECT().ReplicaSet(gomock.Any()).Return(mockRS)
+	mockRS.EXPECT().Get(gomock.Any(), name, metav1.GetOptions{}).Return(nil,
+		k8serrors.NewNotFound(schema.GroupResource{Resource: "virtualmachineinstancereplicasets"}, name))
+	// No Update expectation.
+
+	assert.NotPanics(t, func() {
+		reconcileVMIRSAffinityWithClient(testNodeName, mockClient,
+			map[string]interface{}{aiconfig.Key(): aiconfig}, func() {})
+	})
+}
+
+func TestReconcileVMIRSAffinityWithClient_SkipsNonDNIDAndNOHYPER(t *testing.T) {
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "test-zedkube", 0)
+
+	notDesignated := mkAppInstanceConfig("app4", false, types.PV)
+	nohyper := mkAppInstanceConfig("app5", true, types.NOHYPER)
+
+	ctrl := gomock.NewController(t)
+	mockClient := kubecli.NewMockKubevirtClient(ctrl)
+	// No ReplicaSet() expectation at all: gomock fails the test if it's called.
+
+	wdCalls := 0
+	reconcileVMIRSAffinityWithClient(testNodeName, mockClient,
+		map[string]interface{}{
+			notDesignated.Key(): notDesignated,
+			nohyper.Key():       nohyper,
+		}, func() { wdCalls++ })
+
+	assert.Equal(t, 2, wdCalls)
+}

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -737,6 +737,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			zedkubeCtx.checkStuckPendingVMI()
 			zedkubeWdUpdate()
 			zedkubeCtx.checkAppsStatus()
+			zedkubeCtx.reconcileVMIRSAffinity(zedkubeWdUpdate)
 			appStatusTimer = time.NewTimer(logcollectInterval * time.Second)
 
 		// Timer 3: cluster-wide stats and service health (leader-only, less frequent).

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -1454,6 +1454,20 @@ func handleModify(ctxArg interface{}, key string,
 	}
 
 	status.UUIDandVersion = config.UUIDandVersion
+	if config.IsDesignatedNodeID != status.IsDesignatedNodeID {
+		// A cluster DNID reassignment (e.g. node replacement) changed which
+		// node owns this app. Resync in place: publishAppInstanceStatus's
+		// fallback path (used when zedkube hasn't published ENClusterAppStatus
+		// for this app yet, e.g. right after the reassignment) trusts this
+		// field to decide whether this node should report status to the
+		// controller. Leaving it stale can mean no node reports during that
+		// window: the old node correctly stays quiet, and the newly
+		// designated node also stays quiet because it doesn't yet know it's
+		// the designated node.
+		log.Noticef("handleModify(%s): IsDesignatedNodeID changed from %v to %v (DNID reassignment)",
+			status.Key(), status.IsDesignatedNodeID, config.IsDesignatedNodeID)
+		status.IsDesignatedNodeID = config.IsDesignatedNodeID
+	}
 	publishAppInstanceStatus(ctx, status)
 
 	changed := doUpdate(ctx, config, status)

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -686,7 +686,7 @@ func (ctx kubevirtContext) CreateReplicaVMIConfig(domainName string, config type
 	}
 
 	// Set the affinity to this node the VMI is preferred to run on
-	affinity := setKubeAffinity(nodeName, config.AffinityType)
+	affinity := SetKubeAffinity(nodeName, config.AffinityType)
 
 	// Set tolerations to handle node conditions
 	tolerations := setKubeToleration(int64(tolerateSec))
@@ -1648,7 +1648,7 @@ func (ctx kubevirtContext) CreateReplicaPodConfig(domainName string, config type
 				},
 				Spec: k8sv1.PodSpec{
 					Tolerations: setKubeToleration(int64(tolerateSec)),
-					Affinity:    setKubeAffinity(nodeName, config.AffinityType),
+					Affinity:    SetKubeAffinity(nodeName, config.AffinityType),
 					Containers: []k8sv1.Container{
 						{
 							Name:            kubeName,
@@ -1745,7 +1745,12 @@ func (ctx kubevirtContext) CreateReplicaPodConfig(domainName string, config type
 	return nil
 }
 
-func setKubeAffinity(nodeName string, affinityType types.Affinity) *k8sv1.Affinity {
+// SetKubeAffinity builds the node affinity for a VMI/pod template that
+// prefers (or requires) scheduling onto nodeName. Exported so callers outside
+// this package (e.g. zedkube, which reconciles an already-existing VMIRS's
+// affinity after a cluster DNID reassignment) build the identical affinity
+// this package uses at creation time, rather than duplicating the logic.
+func SetKubeAffinity(nodeName string, affinityType types.Affinity) *k8sv1.Affinity {
 	matchExpressions := []k8sv1.NodeSelectorRequirement{
 		{
 			Key:      "kubernetes.io/hostname",


### PR DESCRIPTION

# Description

A "replace-node" operation reassigns an app's cluster Designated Node ID (DNID) to a different node, but several agents were only acting on the reassignment at creation time and never revisiting already-existing status:

- volumemgr: a content tree becoming local (IsLocal flip) never re-entered the download pipeline, and IsLocal/IsReplicated changes on existing ContentTree/Volume status were never resynced from config.
- zedmanager: AppInstanceStatus.IsDesignatedNodeID stayed frozen, which could leave no node reporting status to the controller across the reassignment window.
- zedkube: a VMIRS's node affinity is set once at creation and was never corrected afterward, so it could keep pointing at a stale node. Add a periodic reconciler, gated on "am I the DNID node" (not "am I currently running the app") so a temporary failover doesn't get its affinity rewritten.

Exports hypervisor.SetKubeAffinity so zedkube's reconciler builds the same affinity used at creation time instead of duplicating the logic.

## PR dependencies

## How to test and validate this PR

With the ENC running, node1, node2, node3, allocate an App onto some node as the DNID.
e.g. it's on node2, then replace the node2 w/ another device using 'replace node' operation.
Check the app, volume instance, content tree, to see if it is reassigned DNID onto a new node.
also very the VMI to see if the affinity for scheduling the node name has been reflected and updated.

## Changelog notes

kube: resync stale state on cluster DNID reassignment

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
