### PR TITLE
pkg/xen-tools: sanitize iGPU DBUF_CTL POWER_STATE to fix scanout corruption

### DIFF
--- a/docs/INTEL-IGPU-PASSTHROUGH.md
+++ b/docs/INTEL-IGPU-PASSTHROUGH.md
@@ -134,7 +134,7 @@ VfioIgdPkg builds `igd.rom`, an EFI Option ROM containing:
 
 ### Changes to QEMU's vfio-igd quirk
 
-The QEMU patches in `pkg/xen-tools` (patches 08–11) rework `hw/vfio/igd.c`:
+The QEMU patches in `pkg/xen-tools` (patches 08–11 and 15) rework `hw/vfio/igd.c`:
 
 **Patch 08 — igd_gen() backport**: upstream's `igd_gen()` returns correct generation
 numbers for Gen7 through Gen12 (Haswell through Raptor Lake).  The old function returned
@@ -171,6 +171,23 @@ Based on upstream QEMU commits:
   "vfio/igd: add new bar0 quirk to emulate BDSM mirror" by Corvin Köhne
 - [`f926baa0`](https://github.com/qemu/qemu/commit/f926baa03b7babb8291ea4c1cbeadaf224977dae)
   "vfio/igd: emulate BDSM in mmio bar0 for gen 6-10 devices" by Tomita Moeko
+
+**Patch 15 — DBUF_CTL POWER_STATE sanitize** (Gen9+): on some hosts the firmware
+POST modeset leaves the display data buffer (DBUF) powered, so the passed-through
+`DBUF_CTL` slice registers (S1..S4) read back `POWER_STATE` (bit30) = 1 while
+`POWER_REQUEST` (bit31) = 0 — a legitimate-but-inconsistent leftover (the device
+is not display-reset on assignment; `POWER_STATE` is a read-only status latch fed
+by the display power well, independent of the `POWER_REQUEST` input). The guest's
+Intel driver samples `POWER_STATE` to decide which DBUF slices are already
+enabled, sees the stale "powered" bit, and never issues `POWER_REQUEST`; DBUF
+then powers down, the plane FIFO underruns, and scanout is corrupted (vertical
+stripes) until a full modeset (e.g. a display sleep/wake) re-requests power. The
+quirk traps the `DBUF_CTL` slice registers (as many as the generation exposes) in BAR0 and clears `POWER_STATE` on read whenever
+`POWER_REQUEST` is not set, presenting a consistent register — the same approach
+Intel's own GVT device model uses (`gen9_dbuf_ctl_mmio_write`). The guest then
+issues the power request and the real power well brings DBUF up. Native Linux
+i915 does not hit this because it force-drives `POWER_REQUEST` at load regardless
+of the readout; the Windows driver trusts the readout.
 
 ---
 
@@ -290,6 +307,36 @@ BDB offset), and the BDB block list with recognised names. Useful for
 side-by-side comparison across host platforms (e.g. TGL vs RPL-P) when
 diagnosing GOP / connector init differences. Multiple dumps can be passed
 in one invocation; the decoder is read-only.
+
+### Debugging scanout corruption (iGPU MMIO register diff)
+
+Scanout corruption on a passed-through iGPU is usually a display-engine register
+left in a bad state. Because the device is bound to `vfio-pci` the host cannot
+read its BARs directly (the sysfs `resourceN` mmap is refused, and
+`/proc/<qemu>/mem` reads of the vfio BAR fault). Read the live MMIO through QEMU
+instead: `pmemsave` on the guest-physical BAR0 address dumps the register block
+to a file (QEMU maps the vfio BAR as a `ram_device` region). The helpers live in
+`tools/qemu/`:
+
+- `igpu-dump.py` — runs inside the `debug` container; snapshots the BAR0
+  display-register block (`0x40000..0x80000`) via QMP `pmemsave`.
+- `igpu-capture.sh` — from a workstation, captures two snapshots of the current
+  state and pulls them locally (set `NODE=root@<edge-node-ip>`).
+- `igpu-regdiff.py` — decodes and diffs two states, filtering volatile registers,
+  with a Gen12/RPL display-register name map.
+- `qmp.py` — minimal QMP/HMP helper (e.g. `info pci`, `xp`).
+
+Capture a corrupted state and a recovered state, then diff — the registers that
+differ are the prime suspects:
+
+```sh
+NODE=root@<edge-node-ip> tools/qemu/igpu-capture.sh bad     # while corrupted
+# ... recover (e.g. trigger a display sleep/wake) ...
+NODE=root@<edge-node-ip> tools/qemu/igpu-capture.sh good    # after recovery
+tools/qemu/igpu-regdiff.py --a igpu-dumps/bad*.bin --b igpu-dumps/good*.bin
+```
+
+This is how the DBUF_CTL `POWER_STATE` issue (patch 15) was found and verified.
 
 ---
 

--- a/pkg/xen-tools/patches-4.21.1/x86_64/15-vfio-igd-dbuf-ctl-sanitize.patch
+++ b/pkg/xen-tools/patches-4.21.1/x86_64/15-vfio-igd-dbuf-ctl-sanitize.patch
@@ -1,0 +1,162 @@
+From b40c1440cb2cddb14026cc2e90e6ca2199c26699 Mon Sep 17 00:00:00 2001
+From: Mikhail Malyshev <mike.malyshev@gmail.com>
+Date: Tue, 7 Jul 2026 16:09:55 +0000
+Subject: [PATCH] vfio/igd: sanitize DBUF_CTL POWER_STATE for iGPU passthrough
+
+On some hosts the firmware POST modeset leaves the display data buffer
+(DBUF) powered, so the passed-through iGPU's DBUF_CTL registers read
+back POWER_STATE=1 while POWER_REQUEST=0 -- an inconsistent leftover that
+never occurs under GVT, which emulates the register so POWER_STATE
+follows POWER_REQUEST.
+
+A guest display driver samples POWER_STATE to determine which DBUF
+slices are already enabled; seeing the stale "powered" bit it never
+issues POWER_REQUEST, so DBUF actually powers down, the plane FIFO
+underruns, and scanout is corrupted (vertical stripes) until a full
+modeset (e.g. a display sleep/wake) re-requests power.
+
+Present a consistent view like GVT: trap the DBUF_CTL slice registers
+(S1..S4, only as many as the generation exposes) in BAR0 and clear
+POWER_STATE on read whenever POWER_REQUEST is not set.  Writes pass
+straight through to the device.
+
+Signed-off-by: Mikhail Malyshev <mike.malyshev@gmail.com>
+---
+ hw/vfio/igd.c | 114 ++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 114 insertions(+)
+
+diff --git a/tools/qemu-xen/hw/vfio/igd.c b/tools/qemu-xen/hw/vfio/igd.c
+index fae1606e1d..8997611920 100644
+--- a/tools/qemu-xen/hw/vfio/igd.c
++++ b/tools/qemu-xen/hw/vfio/igd.c
+@@ -439,6 +439,94 @@ static const MemoryRegionOps igd_bdsm_mirror_ops = {
+ #define IGD_BDSM_GEN11 0xc0
+ #endif
+ 
++/*
++ * IGD BAR0 DBUF_CTL sanitize quirk.
++ *
++ * On hosts where the firmware POST modeset left the display engine powered,
++ * DBUF_CTL reads back POWER_STATE=1 while POWER_REQUEST=0 -- an inconsistent
++ * leftover that never occurs under GVT (which emulates the register so STATE
++ * follows REQUEST).  A passed-through guest driver samples POWER_STATE to
++ * decide which DBUF slices are already enabled, sees this stale "powered"
++ * bit, and therefore never issues POWER_REQUEST.  DBUF then powers down, the
++ * plane FIFO underruns, and scanout is corrupted until a full modeset (e.g.
++ * a display sleep/wake) re-requests power.
++ *
++ * Present a consistent view like GVT: intercept DBUF_CTL reads and clear
++ * POWER_STATE whenever POWER_REQUEST is not set.  Writes pass straight
++ * through to the device.
++ */
++#define IGD_DBUF_POWER_REQUEST  (1u << 31)
++#define IGD_DBUF_POWER_STATE    (1u << 30)
++
++/* DBUF_CTL slice registers within BAR0, in slice order (i915 numbers these
++ * S1..S4).  How many slices exist is generation-dependent, so only the first
++ * igd_dbuf_ctl_nslices(gen) entries are real DBUF_CTL registers on a given
++ * part; the rest are unrelated registers and must not be trapped. */
++static const uint32_t igd_dbuf_ctl_offsets[] = {
++    0x45008, /* S1 */ 0x44FE8, /* S2 */ 0x44300, /* S3 */ 0x44304, /* S4 */
++};
++
++/*
++ * DBUF slice count by generation, matching i915 dbuf.slice_mask:
++ * gen9/10 = 1 (S1), gen11 = 2 (S1-S2), gen12+ = 4 (S1-S4).
++ *
++ * Within gen12 the slice count is actually per-platform, not per-gen: ADL-P /
++ * RPL-P / DG2 expose 4 slices, but TGL / RKL / ADL-S have only 2.  We return 4
++ * for all gen12+ (igd_gen() can't distinguish them), so on a <4-slice gen12
++ * part S3/S4 (0x44300/0x44304) are over-trapped.  This is harmless in practice:
++ * the read handler only mutates a value when POWER_REQUEST=0 && POWER_STATE=1,
++ * which whatever register lives at those offsets is very unlikely to present.
++ * A fully-correct count would have to key off the PCI device ID.
++ */
++static int igd_dbuf_ctl_nslices(int gen)
++{
++    if (gen <= 10) {
++        return 1;
++    }
++    if (gen == 11) {
++        return 2;
++    }
++    return 4;
++}
++
++typedef struct IGDDbufCtlQuirk {
++    VFIOPCIDevice *vdev;
++    uint32_t bar_offset;    /* offset within BAR0 MMIO */
++    uint8_t bar;
++} IGDDbufCtlQuirk;
++
++static uint64_t igd_dbuf_ctl_read(void *opaque, hwaddr addr, unsigned size)
++{
++    IGDDbufCtlQuirk *q = opaque;
++    VFIOPCIDevice *vdev = q->vdev;
++    uint64_t val = vfio_region_read(&vdev->bars[q->bar].region,
++                                    addr + q->bar_offset, size);
++
++    if (size == 4 && !(val & IGD_DBUF_POWER_REQUEST) &&
++        (val & IGD_DBUF_POWER_STATE)) {
++        val &= ~(uint64_t)IGD_DBUF_POWER_STATE;
++        error_report_once("IGD quirk: DBUF_CTL@0x%x cleared stale "
++                          "POWER_STATE (POWER_REQUEST=0)", q->bar_offset);
++    }
++    return val;
++}
++
++static void igd_dbuf_ctl_write(void *opaque, hwaddr addr,
++                               uint64_t data, unsigned size)
++{
++    IGDDbufCtlQuirk *q = opaque;
++    VFIOPCIDevice *vdev = q->vdev;
++
++    vfio_region_write(&vdev->bars[q->bar].region,
++                      addr + q->bar_offset, data, size);
++}
++
++static const MemoryRegionOps igd_dbuf_ctl_ops = {
++    .read = igd_dbuf_ctl_read,
++    .write = igd_dbuf_ctl_write,
++    .endianness = DEVICE_LITTLE_ENDIAN,
++};
++
+ void vfio_probe_igd_bar0_quirk(VFIOPCIDevice *vdev, int nr)
+ {
+     IGDBdsmMirrorQuirk *mirror;
+@@ -488,6 +576,32 @@ void vfio_probe_igd_bar0_quirk(VFIOPCIDevice *vdev, int nr)
+                                         &quirk->mem[0], 1);
+ 
+     QLIST_INSERT_HEAD(&vdev->bars[nr].quirks, quirk, next);
++
++    /*
++     * DBUF_CTL sanitize quirk (gen9+): trap the DBUF_CTL slice registers so
++     * POWER_STATE is reported consistently with POWER_REQUEST (see
++     * igd_dbuf_ctl_read()).  Only trap slices that actually exist on this
++     * generation -- the remaining offsets are unrelated registers.
++     */
++    if (gen >= 9) {
++        int i, nslices = igd_dbuf_ctl_nslices(gen);
++
++        for (i = 0; i < nslices; i++) {
++            VFIOQuirk *dquirk = vfio_quirk_alloc(1);
++            IGDDbufCtlQuirk *dq = dquirk->data = g_malloc0(sizeof(*dq));
++
++            dq->vdev = vdev;
++            dq->bar = nr;
++            dq->bar_offset = igd_dbuf_ctl_offsets[i];
++            memory_region_init_io(&dquirk->mem[0], OBJECT(vdev),
++                                  &igd_dbuf_ctl_ops, dq,
++                                  "vfio-igd-dbuf-ctl-quirk", 4);
++            memory_region_add_subregion_overlap(vdev->bars[nr].region.mem,
++                                                igd_dbuf_ctl_offsets[i],
++                                                &dquirk->mem[0], 1);
++            QLIST_INSERT_HEAD(&vdev->bars[nr].quirks, dquirk, next);
++        }
++    }
+ }
+ 
+ void vfio_probe_igd_bar4_quirk(VFIOPCIDevice *vdev, int nr)
+-- 
+2.43.0
+

--- a/tools/qemu/igpu-capture.sh
+++ b/tools/qemu/igpu-capture.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# Capture two MMIO snapshots of the current iGPU state from an EVE node and pull
+# them to the workstation for local decode/diff with igpu-regdiff.py.
+#
+# Runs on the WORKSTATION. The reproducer state transition (corrupted screen ->
+# recover on sleep/wake) is driven manually; this just snapshots "right now".
+#
+#   tools/qemu/igpu-capture.sh A            # capture state A (e.g. corrupted)
+#   ... trigger sleep/wake so the screen recovers ...
+#   tools/qemu/igpu-capture.sh B            # capture state B (e.g. recovered)
+#   tools/qemu/igpu-regdiff.py --a igpu-dumps/A1*.bin igpu-dumps/A2*.bin \
+#                              --b igpu-dumps/B1*.bin igpu-dumps/B2*.bin
+#
+# Two samples per state let igpu-regdiff.py filter volatile registers.
+set -euo pipefail
+
+NODE=${NODE:?set NODE=root@<edge-node-ip>}
+KEY=${KEY:-$HOME/.ssh/id_rsa}
+LOCALDIR=${LOCALDIR:-igpu-dumps}
+DELAY=${DELAY:-0.5}
+LABEL=${1:?usage: igpu-capture.sh <label> (e.g. A or B)}
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# Ignore known_hosts: the node regenerates its host key on reboot, which the
+# reproducer does every cycle.
+SSHOPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -i "$KEY")
+SSH=(ssh "${SSHOPTS[@]}" "$NODE")
+SCP=(scp "${SSHOPTS[@]}")
+DUMP='python3 /persist/qemu-tools/igpu-dump.py'
+filt() { grep -viE 'deprecat|cgroup'; }
+run_dump() {  # $1=exec-id-suffix $2=label -> runs igpu-dump.py in debug ctr
+  "${SSH[@]}" "ctr -n services.linuxkit t exec --exec-id dbg-$1 debug $DUMP $2"
+}
+
+mkdir -p "$LOCALDIR"
+
+# Deploy/refresh on-node tools (idempotent; /persist survives reboots).
+"${SSH[@]}" 'mkdir -p /persist/qemu-tools/dumps'
+"${SCP[@]}" "$HERE/igpu-dump.py" "$NODE:/persist/qemu-tools/igpu-dump.py" >/dev/null
+
+for s in 1 2; do
+  out=$(run_dump "$LABEL$s-$$" "${LABEL}${s}" 2>&1 | filt)
+  echo "$out"
+  path=$(echo "$out" | awk '/^wrote /{print $2}')
+  [ -n "$path" ] || { echo "ERROR: no blob produced (iGPU asleep?)"; exit 1; }
+  "${SCP[@]}" "$NODE:$path" "$NODE:$path.json" "$LOCALDIR/" >/dev/null
+  echo "  -> $LOCALDIR/$(basename "$path")"
+  [ "$s" = 1 ] && sleep "$DELAY"
+done
+echo "captured state '$LABEL' into $LOCALDIR/"

--- a/tools/qemu/igpu-dump.py
+++ b/tools/qemu/igpu-dump.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Snapshot the passed-through Intel iGPU MMIO register block of a running EVE
+guest, by asking qemu (over QMP) to dump the guest-physical BAR0 range to a
+binary blob.
+
+Runs INSIDE the EVE `debug` container (which has python3 and sees the host's
+/run + /persist):
+
+    eve exec debug python3 /persist/qemu-tools/igpu-dump.py <label>
+
+Why QMP/pmemsave and not a host-side mmap: the iGPU is bound to vfio-pci, so the
+sysfs resourceN mmap is refused (EINVAL) and /proc/<qemu>/mem reads of the
+vfio BAR vma give EIO (VM_PFNMAP, no .access op). qemu itself holds the BAR
+mmap as a ram_device MemoryRegion, so `pmemsave` on the guest-physical BAR0
+address reads the live MMIO directly.
+
+The blob's byte offset i corresponds to BAR0 register offset RANGE_START + i,
+so blobs are directly comparable across snapshots (see igpu-regdiff.py).
+"""
+# Terse standalone diagnostic script: relax pylint style checks that
+# don't add value here.
+# pylint: disable=invalid-name,consider-using-f-string,missing-module-docstring,missing-class-docstring,missing-function-docstring,consider-using-with,unspecified-encoding,broad-exception-caught,multiple-imports,multiple-statements,too-many-locals,too-many-statements,unnecessary-lambda-assignment
+import socket, json, glob, sys, os, time, re, argparse
+
+IGPU_PCI_ID = "8086:a7a1"          # RPL-P Iris Xe (adjust per platform)
+# Display + power-well + DBUF + CDCLK + transcoder + pipe/plane/DDI/scaler.
+# Deliberately excludes GT/render (<0x40000, forcewake-gated, reads as 0 from
+# host) and the GTT (upper half of the 16MB BAR).
+DEFAULT_RANGE = (0x40000, 0x40000)  # start, length  -> 0x40000..0x80000
+
+def find_qmp_sock():
+    # Control "qmp" socket is free; "listener.qmp" is held by the monitor svc.
+    for pat in ("/hostfs/run/hypervisor/kvm/*/qmp",
+                "/run/hypervisor/kvm/*/qmp"):
+        g = glob.glob(pat)
+        if g:
+            return g[0]
+    return None
+
+class Qmp:
+    def __init__(self, path, timeout=15):
+        self.s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.s.settimeout(timeout)
+        self.s.connect(path)
+        self.f = self.s.makefile("rwb", buffering=0)
+        self._readline()                                # greeting ({"QMP":...})
+        self._send({"execute": "qmp_capabilities"})
+        self._recv()                                    # capabilities ack
+    def _send(self, obj):
+        self.f.write((json.dumps(obj) + "\n").encode())
+    def _readline(self):
+        line = self.f.readline()
+        return json.loads(line) if line else None
+    def _recv(self):
+        # Return the next command reply, skipping async events.
+        while True:
+            r = self._readline()
+            if r is None:
+                return None
+            if "return" in r or "error" in r:
+                return r
+    def hmp(self, cmd):
+        self._send({"execute": "human-monitor-command",
+                    "arguments": {"command-line": cmd}})
+        r = self._recv()
+        if r is None:
+            raise RuntimeError("no reply to: %s" % cmd)
+        if "error" in r:
+            raise RuntimeError("qmp error: %s" % r["error"])
+        return r["return"]
+    def close(self):
+        try: self.s.close()
+        except Exception: pass
+
+def find_bar0_base(q, pci_id):
+    """Parse `info pci` for the passthrough iGPU's guest-physical BAR0 base.
+    Must be rediscovered each run: OVMF can reassign it across reboots."""
+    out = q.hmp("info pci")
+    dev_re = re.compile(r"PCI device %s" % re.escape(pci_id))
+    bar0_re = re.compile(r"BAR0:.*at (0x[0-9a-fA-F]+)")
+    in_dev = False
+    for line in out.splitlines():
+        if dev_re.search(line):
+            in_dev = True
+            continue
+        if in_dev:
+            m = bar0_re.search(line)
+            if m:
+                base = int(m.group(1), 16)
+                if base == 0xffffffffffffffff:
+                    raise RuntimeError(
+                        "iGPU %s BAR0 is unmapped (0xff..ff): the device is "
+                        "asleep / memory decode disabled. Wake it and retry."
+                        % pci_id)
+                return base
+            if "device" in line and "function" in line:  # next device block
+                in_dev = False
+    raise RuntimeError("iGPU %s BAR0 not found in `info pci`" % pci_id)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("label", help="snapshot label, e.g. A1 / B1 / corrupted")
+    ap.add_argument("--pci-id", default=IGPU_PCI_ID)
+    ap.add_argument("--start", type=lambda x: int(x, 0), default=DEFAULT_RANGE[0])
+    ap.add_argument("--len", type=lambda x: int(x, 0), default=DEFAULT_RANGE[1])
+    ap.add_argument("--out-dir", default="/persist/qemu-tools/dumps")
+    args = ap.parse_args()
+
+    sock = find_qmp_sock()
+    if not sock:
+        sys.exit("no qmp socket found (guest running?)")
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    q = Qmp(sock)
+    try:
+        base = find_bar0_base(q, args.pci_id)
+        gpa = base + args.start
+        ts = time.strftime("%Y%m%d-%H%M%S")
+        blob = "%s/%s.%s.bin" % (args.out_dir, args.label, ts)
+        # qemu HMP parses the filename; a leading '/' is otherwise read as a
+        # division operator, so the path MUST be quoted.
+        ret = q.hmp('pmemsave 0x%x 0x%x "%s"' % (gpa, args.len, blob))
+        if ret.strip():  # pmemsave prints nothing on success; text == error
+            raise RuntimeError("pmemsave failed: %s" % ret.strip())
+        meta = {"label": args.label, "ts": ts, "pci_id": args.pci_id,
+                "bar0_base": base, "range_start": args.start,
+                "range_len": args.len, "blob": blob}
+        open(blob + ".json", "w").write(json.dumps(meta, indent=2))
+        sz = os.path.getsize(blob)
+        print("wrote %s (%d bytes)  BAR0_base=0x%x  covers 0x%x..0x%x"
+              % (blob, sz, base, args.start, args.start + args.len))
+    finally:
+        q.close()
+
+if __name__ == "__main__":
+    main()

--- a/tools/qemu/igpu-regdiff.py
+++ b/tools/qemu/igpu-regdiff.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Decode and diff Intel iGPU MMIO register blobs captured by igpu-dump.py.
+
+Runs LOCALLY on the workstation (never on the node): scp the .bin blobs off the
+node, then diff. Typical use compares a "corrupted" state (A) against a
+"recovered" state (B), each captured twice so volatile registers (scanline,
+frame counters, timestamps) can be filtered out automatically:
+
+    igpu-regdiff.py --a A1.bin A2.bin --b B1.bin B2.bin
+
+A register is reported only if it is *stable within* each state and *differs
+between* states -- those are the prime suspects for the corruption.
+
+A single blob per state also works (raw diff, no volatility filter):
+
+    igpu-regdiff.py --a A.bin --b B.bin
+
+Blob byte offset i maps to BAR0 register offset range_start + i. range_start is
+read from the blob's sidecar .json (written by igpu-dump.py), or override with
+--start.
+"""
+# Terse standalone diagnostic script: relax pylint style checks that
+# don't add value here.
+# pylint: disable=invalid-name,consider-using-f-string,missing-module-docstring,missing-class-docstring,missing-function-docstring,consider-using-with,unspecified-encoding,broad-exception-caught,multiple-imports,multiple-statements,too-many-locals,too-many-statements,unnecessary-lambda-assignment
+import argparse, json, os, struct, sys
+
+# --- Curated Gen12 (TGL/ADL/RPL) display register map, by absolute BAR offset.
+# Not exhaustive; unknown offsets are still reported, just without a name.
+def _build_regmap():
+    m = {}
+    # Power wells / DBUF / CDCLK / DC states
+    m[0x44fe8] = "DBUF_CTL_S2"
+    m[0x45008] = "DBUF_CTL_S1"
+    m[0x45400] = "PWR_WELL_CTL1_BIOS"
+    m[0x45404] = "PWR_WELL_CTL2_DRIVER"
+    m[0x45408] = "PWR_WELL_CTL3_KVMR"
+    m[0x4540c] = "PWR_WELL_CTL4_DEBUG"
+    m[0x45440] = "PWR_WELL_CTL_AUX1"
+    m[0x45444] = "PWR_WELL_CTL_AUX2"
+    m[0x45480] = "PWR_WELL_CTL_DDI1"
+    m[0x45484] = "PWR_WELL_CTL_DDI2"
+    m[0x45504] = "DC_STATE_EN"
+    m[0x46000] = "CDCLK_CTL"
+    m[0x46070] = "CDCLK_PLL_ENABLE"
+    m[0x46140] = "TRANS_CLK_SEL_A"
+    m[0x46144] = "TRANS_CLK_SEL_B"
+    # FBC
+    m[0x43208] = "FBC_CONTROL"
+    # Per-transcoder timing generator + DDI func ctl (A=0,B=1,C=2,D=3)
+    tnames = {0: "A", 1: "B", 2: "C", 3: "D"}
+    for t, nm in tnames.items():
+        b = 0x60000 + t * 0x1000
+        m[b + 0x00] = "TRANS_HTOTAL_%s" % nm
+        m[b + 0x04] = "TRANS_HBLANK_%s" % nm
+        m[b + 0x08] = "TRANS_HSYNC_%s" % nm
+        m[b + 0x0c] = "TRANS_VTOTAL_%s" % nm
+        m[b + 0x10] = "TRANS_VBLANK_%s" % nm
+        m[b + 0x14] = "TRANS_VSYNC_%s" % nm
+        m[b + 0x1c] = "PIPE_SRCSZ_%s" % nm
+        m[b + 0x28] = "TRANS_VSYNCSHIFT_%s" % nm
+        m[b + 0x30] = "TRANS_MULT_%s" % nm
+        m[b + 0x400] = "TRANS_DDI_FUNC_CTL_%s" % nm
+        m[b + 0x404] = "TRANS_DDI_FUNC_CTL2_%s" % nm
+        m[b + 0x410] = "TRANS_MSA_MISC_%s" % nm
+    # DDI buffer control (per DDI port a..e / TC)
+    for p in range(6):
+        m[0x64000 + p * 0x100] = "DDI_BUF_CTL_%d" % p
+        m[0x64040 + p * 0x100] = "DP_TP_CTL_%d" % p
+        m[0x64044 + p * 0x100] = "DP_TP_STATUS_%d" % p
+    # Per-pipe: pipe/cursor/plane/scaler (A=0,B=1,C=2,D=3)
+    for p, nm in tnames.items():
+        b = 0x70000 + p * 0x1000
+        m[b + 0x000] = "PIPE_DSL_%s" % nm            # scanline (volatile)
+        m[b + 0x008] = "TRANSCONF_%s" % nm           # enable=bit31 state=bit30
+        m[b + 0x024] = "PIPESTAT_%s" % nm            # status (partly volatile)
+        m[b + 0x028] = "PIPE_FRMTMSTMP_%s" % nm      # (volatile)
+        m[b + 0x030] = "PIPE_MISC_%s" % nm
+        m[b + 0x040] = "PIPE_FRMCNT_%s" % nm         # (volatile)
+        m[b + 0x044] = "PIPE_FLIPCNT_%s" % nm        # (volatile)
+        m[b + 0x080] = "CUR_CTL_%s" % nm
+        m[b + 0x084] = "CUR_BASE_%s" % nm
+        m[b + 0x088] = "CUR_POS_%s" % nm
+        # Universal plane 1 (primary)
+        m[b + 0x180] = "PLANE_CTL_1_%s" % nm         # enable=bit31, pixfmt, tiling
+        m[b + 0x188] = "PLANE_STRIDE_1_%s" % nm
+        m[b + 0x18c] = "PLANE_POS_1_%s" % nm
+        m[b + 0x190] = "PLANE_SIZE_1_%s" % nm
+        m[b + 0x19c] = "PLANE_SURF_1_%s" % nm        # surface base (arm)
+        m[b + 0x1a4] = "PLANE_OFFSET_1_%s" % nm
+        m[b + 0x1ac] = "PLANE_AUX_OFFSET_1_%s" % nm
+        m[b + 0x1cc] = "PLANE_COLOR_CTL_1_%s" % nm
+        m[b + 0x27c] = "PLANE_BUF_CFG_1_%s" % nm     # DBUF allocation
+        for lvl in range(8):
+            m[b + 0x240 + lvl * 4] = "PLANE_WM_1_%s_L%d" % (nm, lvl)
+        m[b + 0x268] = "PLANE_WM_TRANS_1_%s" % nm
+    # Pipe scalers (2 per pipe)
+    for p, nm in tnames.items():
+        sb = 0x68000 + p * 0x800
+        m[sb + 0x170] = "PS_WIN_POS_1_%s" % nm
+        m[sb + 0x174] = "PS_WIN_SZ_1_%s" % nm
+        m[sb + 0x180] = "PS_CTRL_1_%s" % nm
+    return m
+
+REGMAP = _build_regmap()
+
+def load(path):
+    data = open(path, "rb").read()
+    start = None
+    side = path + ".json"
+    if os.path.exists(side):
+        start = json.load(open(side)).get("range_start")
+    return data, start
+
+def as_dwords(data):
+    n = len(data) // 4
+    return struct.unpack_from("<%dI" % n, data, 0)
+
+def name(off):
+    return REGMAP.get(off, "")
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--a", nargs="+", required=True, help="state A blob(s)")
+    ap.add_argument("--b", nargs="+", required=True, help="state B blob(s)")
+    ap.add_argument("--start", type=lambda x: int(x, 0), default=None,
+                    help="BAR offset of blob byte 0 (else read from .json)")
+    ap.add_argument("--show-volatile", action="store_true",
+                    help="also list registers filtered out as volatile")
+    args = ap.parse_args()
+
+    a_blobs = [load(p) for p in args.a]
+    b_blobs = [load(p) for p in args.b]
+    start = args.start
+    if start is None:
+        for _, s in a_blobs + b_blobs:
+            if s is not None:
+                start = s; break
+    if start is None:
+        sys.exit("range_start unknown: pass --start or provide .json sidecars")
+
+    a = [as_dwords(d) for d, _ in a_blobs]
+    b = [as_dwords(d) for d, _ in b_blobs]
+    n = min(len(x) for x in a + b)
+
+    volatile, changed = [], []
+    for i in range(n):
+        av = [x[i] for x in a]
+        bv = [x[i] for x in b]
+        a_stable = len(set(av)) == 1
+        b_stable = len(set(bv)) == 1
+        if not (a_stable and b_stable):
+            if av[0] != bv[0] or not a_stable or not b_stable:
+                volatile.append(i)
+            continue
+        if av[0] != bv[0]:
+            changed.append(i)
+
+    off = lambda i: start + i * 4
+    print("# range 0x%x..0x%x  dwords=%d  A=%d blob(s)  B=%d blob(s)"
+          % (start, start + n * 4, n, len(a), len(b)))
+    print("# stable-diff registers (A != B, stable within each state): %d" % len(changed))
+    print("%-9s %-24s %-10s %-10s %s" % ("OFFSET", "NAME", "A", "B", "A^B"))
+    for i in changed:
+        print("0x%06x %-24s 0x%08x 0x%08x 0x%08x"
+              % (off(i), name(off(i)) or "?", a[0][i], b[0][i], a[0][i] ^ b[0][i]))
+    if args.show_volatile:
+        print("\n# volatile (filtered): %d" % len(volatile))
+        for i in volatile:
+            print("0x%06x %-24s A~%08x B~%08x"
+                  % (off(i), name(off(i)) or "?", a[0][i], b[0][i]))
+
+if __name__ == "__main__":
+    main()

--- a/tools/qemu/qmp.py
+++ b/tools/qemu/qmp.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# Minimal QMP client: connect, negotiate, run an HMP command, print reply.
+# Terse standalone diagnostic script: relax pylint style checks that
+# don't add value here.
+# pylint: disable=invalid-name,consider-using-f-string,missing-module-docstring,missing-class-docstring,missing-function-docstring,consider-using-with,unspecified-encoding,broad-exception-caught,multiple-imports,multiple-statements,too-many-locals,too-many-statements,unnecessary-lambda-assignment
+import socket, json, sys, glob
+
+def find_sock():
+    # Use the control "qmp" socket (free); "listener.qmp" is held by the monitor service.
+    g = glob.glob("/hostfs/run/hypervisor/kvm/*/qmp")
+    return g[0] if g else None
+
+def qmp(sock_path, hmp_cmd, timeout=10):
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.settimeout(timeout)
+    s.connect(sock_path)
+    f = s.makefile("rwb", buffering=0)
+    def recv():
+        line = f.readline()
+        return json.loads(line) if line else None
+    recv()  # greeting
+    f.write(b'{"execute":"qmp_capabilities"}\n')
+    recv()  # capabilities ack
+    cmd = {"execute": "human-monitor-command",
+           "arguments": {"command-line": hmp_cmd}}
+    f.write((json.dumps(cmd) + "\n").encode())
+    # read until we get a return/error object
+    while True:
+        r = recv()
+        if r is None:
+            break
+        if "return" in r or "error" in r:
+            print(r.get("return", r.get("error")))
+            break
+    s.close()
+
+if __name__ == "__main__":
+    sock = find_sock()
+    if not sock:
+        sys.exit("no listener.qmp socket found")
+    hmp = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else "info version"
+    qmp(sock, hmp)


### PR DESCRIPTION
# Description

Fixes first-boot scanout corruption (vertical stripes) on Intel iGPU passthrough (Gen9+, reproduced on Raptor Lake-P with a Windows guest).

On some hosts the firmware POST modeset leaves the display data buffer (DBUF) powered, so the passed-through iGPU's `DBUF_CTL_S0..S3` registers read back `POWER_STATE` (bit30) = 1 while `POWER_REQUEST` (bit31) = 0 — a legitimate but inconsistent leftover: the device is not display-reset on assignment, and `POWER_STATE` is a read-only status latch fed by the display power well, independent of the `POWER_REQUEST` input.

A guest display driver that samples `POWER_STATE` to decide which DBUF slices are already enabled (as the Intel driver does) sees the stale "powered" bit and never issues `POWER_REQUEST`. DBUF then powers down, the plane FIFO underruns, and scanout is corrupted until a full modeset (e.g. a display sleep/wake) re-requests power. Native i915 avoids this by force-driving `POWER_REQUEST` at load regardless of the readout; the Windows driver trusts the readout.

This adds a QEMU vfio-igd BAR0 quirk (`pkg/xen-tools` patch 15) that traps `DBUF_CTL_S0..S3` and clears `POWER_STATE` on read whenever `POWER_REQUEST` is not set, presenting a consistent register (`POWER_STATE` follows `POWER_REQUEST`) — the same approach Intel's own GVT device model uses (`gen9_dbuf_ctl_mmio_write`). The guest then issues the power request and the real power well brings DBUF up.

Also adds `tools/qemu/` helpers used to diagnose and verify this (read live iGPU MMIO via QMP `pmemsave` and diff a corrupted vs recovered state) and documents the quirk and the debugging workflow in `docs/INTEL-IGPU-PASSTHROUGH.md`.

## Upstream path on lore
https://lore.kernel.org/qemu-devel/20260717084942.1555442-1-mike.malyshev@gmail.com/T/#u

## How to test and validate this PR

On a device with an Intel iGPU (Gen9+) passed through to a guest OS that exhibits first-boot scanout corruption:

1. Build an image including this change and boot the guest with the iGPU passed through.
2. The guest display comes up clean on first boot (no vertical-stripe corruption), without needing a display sleep/wake.
3. Optional register check with the included tooling — `DBUF_CTL_S0..S3` read `0xc043c000` (POWER_REQUEST=1, POWER_STATE=1) instead of the corrupted `0x0043c000`:
   ```
   NODE=root@<edge-node-ip> tools/qemu/igpu-capture.sh state
   ```

## Changelog notes

Fixes first-boot scanout corruption on Intel iGPU (Gen9+) passthrough to a guest OS.

## PR Backports

- 16.0-stable: No — only affects setups with Intel iGPU passthrough.
- 14.5-stable: No — only affects setups with Intel iGPU passthrough.
- 13.4-stable: No — only affects setups with Intel iGPU passthrough.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device (N/A — Intel iGPU passthrough is x86-only)
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
