### PR TITLE
Bump eve-libs to pick up x/crypto 0.52.0

### DIFF
--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.5.0
 	github.com/lf-edge/edge-containers v0.0.0-20260502192833-bdbe764faf59
 	github.com/lf-edge/eve-api/go v0.0.0-20260520095750-2a982d0b4ddb
-	github.com/lf-edge/eve-libs v0.0.0-20260623133124-1c3a4208858c
+	github.com/lf-edge/eve-libs v0.0.0-20260709031003-b4ce2d8fe509
 	github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d
 	github.com/lf-edge/go-qemu v0.0.0-20231121152149-4c467eda0c56
 	github.com/linuxkit/linuxkit/src/cmd/linuxkit v0.0.0-20240507172735-6d37353ca1ee

--- a/pkg/pillar/go.sum
+++ b/pkg/pillar/go.sum
@@ -499,8 +499,8 @@ github.com/lf-edge/edge-containers v0.0.0-20260502192833-bdbe764faf59 h1:fuyDqWU
 github.com/lf-edge/edge-containers v0.0.0-20260502192833-bdbe764faf59/go.mod h1:DoK51ifLgVh2GQ+IXTvmkhTuf8THijPCwYlNAbs2Nz0=
 github.com/lf-edge/eve-api/go v0.0.0-20260520095750-2a982d0b4ddb h1:KFvz8X8V/h6NpjkR6Ka24f1zh1Gvv988Jaz7SL2Z580=
 github.com/lf-edge/eve-api/go v0.0.0-20260520095750-2a982d0b4ddb/go.mod h1:6HxNA/qKJVEqwpuOFkcQ0h3QyotvAs/cjHLC961FPOY=
-github.com/lf-edge/eve-libs v0.0.0-20260623133124-1c3a4208858c h1:BIYA8Y4h0IwIKBTE45bkNVr1IR6FzjnIIoROxl/qULo=
-github.com/lf-edge/eve-libs v0.0.0-20260623133124-1c3a4208858c/go.mod h1:AfK4OlUgnJymZnPEuqzm7sJoCCtRgFhKtRU1kib+VBY=
+github.com/lf-edge/eve-libs v0.0.0-20260709031003-b4ce2d8fe509 h1:XF4/wbn0YSDxhnafSjfN6/t5AIA9KfOk4VgYsbfXXqI=
+github.com/lf-edge/eve-libs v0.0.0-20260709031003-b4ce2d8fe509/go.mod h1:gE8ZZCB1JM7TaXMma0yhLstMfHadLXTIOwVeJq1Jsds=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d h1:tUBb9M6u42LXwHAYHyh22wJeUUQlTpDkXwRXalpRqbo=
 github.com/lf-edge/eve/pkg/kube/cnirpc v0.0.0-20240315102754-0f6d1f182e0d/go.mod h1:Nn3juMJJ1G8dyHOebdZyS4jOB/fuxAd5fIajBaWjHr8=
 github.com/lf-edge/go-qemu v0.0.0-20231121152149-4c467eda0c56 h1:LmFp0jbNSwPLuxJA+nQ+mMQrQ53ESkvHP4CVMqR0zrY=

--- a/pkg/pillar/vendor/modules.txt
+++ b/pkg/pillar/vendor/modules.txt
@@ -882,7 +882,7 @@ github.com/lf-edge/eve-api/go/nestedappinstancemetrics
 github.com/lf-edge/eve-api/go/profile
 github.com/lf-edge/eve-api/go/proxy
 github.com/lf-edge/eve-api/go/register
-# github.com/lf-edge/eve-libs v0.0.0-20260623133124-1c3a4208858c
+# github.com/lf-edge/eve-libs v0.0.0-20260709031003-b4ce2d8fe509
 ## explicit; go 1.25.0
 github.com/lf-edge/eve-libs/depgraph
 github.com/lf-edge/eve-libs/nettrace


### PR DESCRIPTION
# Description

Update the pillar `github.com/lf-edge/eve-libs` dependency to the
current upstream tip. The new revision advances `golang.org/x/crypto`
from 0.51.0 to 0.52.0 (along with the `golang.org/x/net` and
`go-chi/chi` bumps eve-libs picked up in the same window). Pillar
already carried those direct dependencies at the newer versions, so
this re-pins eve-libs to keep the two modules aligned on the same
crypto/net baseline instead of leaving eve-libs a revision behind.

Diff is limited to `pkg/pillar/go.mod`, `go.sum`, and
`vendor/modules.txt` — the eve-libs changes in this range are
dependency bumps plus a test file, so there is no vendored source
change.

## How to test and validate this PR

Covered by the normal build: `make pkg/pillar` compiles cleanly with
the updated dependency. No behavioral change is expected.

## Changelog notes

No user-facing changes.

## PR Backports

- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
