### PR TITLE
zfs: report zvol provisioned size (volsize) in volume metrics

### DIFF
--- a/evetest/devconfig.go
+++ b/evetest/devconfig.go
@@ -2378,6 +2378,37 @@ func (dc *EdgeDeviceConfig) DeleteApplication(appUUID uuid.UUID) {
 	}
 }
 
+// AddBlankVolume adds a standalone empty (VCOT_BLANK) volume of the requested
+// size to the device configuration and returns its UUID.
+//
+// A blank volume is created by volumemgr as an empty block device of the given
+// size, with no content downloaded into it and no application reference
+// required (volumemgr creates standalone volumes; see the
+// VolumeConfig.HasNoAppReferences handling in volumemgr). On a device whose
+// /persist is ZFS, a non-container, non-ISO volume is backed by a ZFS zvol
+// whose "volsize" property equals sizeBytes (rounded up to the ZFS
+// volblocksize). That volsize is the provisioned size volumemgr reports in
+// AppDiskMetric.ProvisionedBytes, which zedagent surfaces to the controller as
+// ZMetricVolume.TotalBytes and VolumeResources.MaxSizeBytes.
+//
+// The volume is created in clear text so that it does not depend on the vault
+// being unlocked, keeping the volume-creation path independent of vault
+// readiness.
+func (dc *EdgeDeviceConfig) AddBlankVolume(
+	displayName string, sizeBytes uint64) uuid.UUID {
+	volumeUUID := dc.th.newUUID("blank volume")
+	dc.Volumes = append(dc.Volumes, &eveconfig.Volume{
+		Uuid: volumeUUID.String(),
+		Origin: &eveconfig.VolumeContentOrigin{
+			Type: eveconfig.VolumeContentOriginType_VCOT_BLANK,
+		},
+		Maxsizebytes: int64(sizeBytes),
+		DisplayName:  displayName,
+		ClearText:    true,
+	})
+	return volumeUUID
+}
+
 // SetLPS configures the Local Profile Server (LPS) settings for the device.
 func (dc *EdgeDeviceConfig) SetLPS(config LPSConfig) {
 	dc.GlobalProfile = config.GlobalProfile

--- a/evetest/tests/storage/zvol_provisioned_size_test.go
+++ b/evetest/tests/storage/zvol_provisioned_size_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package storage_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	"github.com/lf-edge/eve-api/go/evecommon"
+	eveinfo "github.com/lf-edge/eve-api/go/info"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/matchers"
+	"github.com/lf-edge/eve/evetest/netmodels"
+	pillartypes "github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// TestZVolProvisionedSizeReported verifies that a ZFS zvol-backed volume reports
+// its provisioned size (the zvol "volsize"), rather than 0, in the disk metrics.
+//
+// Regression context
+// ------------------
+// zfs.fillImgInfo() populated ImgInfo.ActualSize (from "usedbydataset") but
+// never set ImgInfo.VirtualSize. volumeHandlerZVol.GetVolumeDetails() returns
+// VirtualSize as the volume's max size, so every zvol reported a provisioned
+// size of 0: volumemgr's AppDiskMetric.ProvisionedBytes was 0, and hence the
+// controller-visible ZMetricVolume.TotalBytes and VolumeResources.MaxSizeBytes
+// were 0 too -- even though the zvol has a non-zero volsize. The fix reads the
+// zvol "volsize" property into VirtualSize.
+//
+// Scenario
+// --------
+// The test is intentionally minimal and hermetic: it does NOT deploy an
+// application and does NOT write any data. The bug is about the *provisioned*
+// (allotted) size, which is fixed at volume-creation time and independent of
+// usage, so a standalone empty block-device volume is sufficient to exercise
+// it. volumemgr creates standalone (app-unreferenced) volumes on its own, so no
+// application is needed to trigger creation.
+//
+// Requires a KVM device whose /persist is ZFS: a non-container, non-ISO volume
+// is only backed by a zvol when /persist is ZFS. On EXT4 there is no zvol and
+// the code path under test does not run, so the test skips.
+//
+// Phases
+// ------
+//  1. Set up a KVM + ZFS device with a single DHCP mgmt port.
+//  2. Apply a config that declares one standalone empty 1 GiB block-device
+//     volume (no app, no network instance).
+//  3. Wait for volumemgr to create the volume (state CREATED_VOLUME) and,
+//     once its disk metrics have been (re)computed, assert the provisioned
+//     size is the zvol volsize (== 1 GiB), not 0. This is checked both via
+//     the controller-visible EVE API (ZInfoVolume/ZMetricVolume) and via
+//     volumemgr's own AppDiskMetric pubsub object.
+func TestZVolProvisionedSizeReported(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	// A 1 GiB volume is an exact multiple of the ZFS volblocksize (16 KiB), so
+	// the resulting zvol volsize -- and therefore the reported provisioned size
+	// -- is exactly 1 GiB with no block-size rounding.
+	const blankVolumeSize = 1 * evetest.GiB
+
+	// Set up a KVM device with ZFS persist. ZFS is required: only then is the
+	// blank RAW volume backed by a zvol (see VolumeStatus.UseZVolDisk).
+	devName := "edge-dev"
+	evetest.Setup(
+		evetest.RequireEdgeDevice{
+			Name:              devName,
+			WithHypervisor:    evetest.HypervisorKVM,
+			WithFilesystem:    evetest.FilesystemZFS,
+			DeviceReusePolicy: evetest.ResetDeviceConfig,
+		},
+		evetest.RequireNetworkModel{
+			NetworkModel: netmodels.SingleEthWithDHCP,
+		},
+	)
+	device := evetest.GetEdgeDevice(devName)
+	evetest.Checkpoint("setup-done")
+
+	// Build the device config: keep the mgmt port (so the device stays
+	// reachable) and add a single standalone empty block-device volume.
+	// Shorten the disk-scan and metric report intervals to their minimum so the
+	// provisioned size is (re)computed and reported to the controller quickly.
+	devConfig := evetest.NewEdgeDeviceConfig(devName)
+	cfgProps := pillartypes.NewConfigItemValueMap()
+	cfgProps.SetGlobalValueInt(pillartypes.DiskScanMetricInterval, 5)
+	cfgProps.SetGlobalValueInt(pillartypes.MetricInterval, 5)
+	devConfig.SetConfigProperties(cfgProps)
+	dhcpNet := devConfig.AddNetwork(evetest.DHCPNetworkConfig{
+		NetworkType: evecommon.NetworkType_V4Only,
+	})
+	devConfig.AddNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  "ethernet0",
+		PhysicalLabel: "eth0",
+		InterfaceName: "eth0",
+		NetworkUUID:   dhcpNet,
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+	})
+	volUUID := devConfig.AddBlankVolume("zvol-provisioned-test", blankVolumeSize)
+
+	volInfoUpdates, stopVolInfoWatch := device.WatchVolumeInfo(volUUID)
+	defer stopVolInfoWatch()
+	device.ApplyConfig(devConfig, true, true)
+	evetest.Checkpoint("blank-volume-config-applied")
+
+	// Wait for the volume to be created. CREATED_VOLUME is the volume-equivalent
+	// of ONLINE; by this point volumemgr has created the zvol and knows its
+	// volsize. Resources.MaxSizeBytes is VolumeResources, derived from the same
+	// AppDiskMetric.ProvisionedBytes the fix corrects.
+	timeout := 3 * time.Minute
+	var volInfo *eveinfo.ZInfoVolume
+	t.Eventually(volInfoUpdates, timeout).Should(Receive(matchers.SatisfyPredicate(
+		"Volume is created with a non-zero provisioned (max) size",
+		func(info *eveinfo.ZInfoVolume) bool {
+			volInfo = info
+			return info.GetState() == eveinfo.ZSwState_CREATED_VOLUME &&
+				info.GetResources().GetMaxSizeBytes() > 0
+		})))
+	evetest.Checkpoint("blank-volume-created")
+
+	// EVE API (info): the volume resources max size is the provisioned size.
+	t.Expect(volInfo.GetResources().GetMaxSizeBytes()).To(
+		BeNumerically("~", uint64(blankVolumeSize), evetest.MiB),
+		"ZInfoVolume.Resources.MaxSizeBytes should be the zvol volsize (~1 GiB), was 0 before the fix")
+
+	// EVE API (metrics): ZMetricVolume.TotalBytes mirrors ProvisionedBytes.
+	// Metrics are reported periodically, so poll until the volume appears.
+	t.Eventually(func() uint64 {
+		vm := device.GetVolumeMetrics(volUUID)
+		if vm == nil {
+			return 0
+		}
+		return vm.GetTotalBytes()
+	}, timeout, 5*time.Second).Should(
+		BeNumerically("~", uint64(blankVolumeSize), evetest.MiB),
+		"ZMetricVolume.TotalBytes should be the zvol volsize (~1 GiB), was 0 before the fix")
+
+	// volumemgr pubsub object: AppDiskMetric.ProvisionedBytes is the value the
+	// fix populates. The zvol device path embeds the volume UUID, so match on
+	// it. Poll because volumemgr recomputes disk metrics on its own interval.
+	t.Eventually(func() uint64 {
+		for _, m := range evetest.ReadAllPublications[pillartypes.AppDiskMetric](
+			device, "volumemgr", false) {
+			if strings.Contains(m.DiskPath, volUUID.String()) {
+				return m.ProvisionedBytes
+			}
+		}
+		return 0
+	}, timeout, 5*time.Second).Should(
+		BeNumerically("~", uint64(blankVolumeSize), evetest.MiB),
+		"volumemgr AppDiskMetric.ProvisionedBytes should be the zvol volsize (~1 GiB), was 0 before the fix")
+}

--- a/pkg/pillar/zfs/zfs.go
+++ b/pkg/pillar/zfs/zfs.go
@@ -432,6 +432,15 @@ func fillImgInfo(dataset libzfs.Dataset, datasetFullName string, imgInfo *types.
 	if err != nil {
 		return fmt.Errorf("GetZFSVolumeInfo: failed to parse Usedbydataset: %s", err)
 	}
+	// Provisioned size for zvol volumes comes from the "volsize" property.
+	// Filesystem datasets have no volsize (value "-"), so this is best-effort:
+	// on any error or non-numeric value we leave VirtualSize at 0 rather than
+	// failing, to avoid dropping non-volume datasets in GetAllZFSVolumeInfo.
+	if propVolSize, verr := dataset.GetProperty(libzfs.DatasetPropVolsize); verr == nil {
+		if volSize, perr := strconv.ParseUint(propVolSize.Value, 10, 64); perr == nil {
+			imgInfo.VirtualSize = volSize
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Description

fillImgInfo() populated ImgInfo.ActualSize (from the zfs "usedbydataset"
property) but never set ImgInfo.VirtualSize. volumeHandlerZVol's
GetVolumeDetails() returns imgInfo.VirtualSize as the volume's max size,
so every ZFS zvol reported a provisioned size of 0: AppDiskMetric
ProvisionedBytes was 0, and volume resource MaxSizeBytes was 0, for all
zvol-backed volumes -- even though the zvol has a non-zero volsize
(e.g. `zfs get volsize` reports 5G while ProvisionedBytes was 0).

Read the "volsize" property and set VirtualSize from it. This is
best-effort: fillImgInfo also runs on every dataset via
GetAllZFSVolumeInfo (including filesystem datasets and the pool root,
which have no volsize), so a missing or non-numeric value leaves
VirtualSize at 0 rather than returning an error, to avoid dropping
non-volume datasets from the results.

Add an evetest regression test (TestZVolProvisionedSizeReported) on a
KVM + ZFS device. It declares a single standalone empty block-device
(VCOT_BLANK) volume -- no application, no image download, no data I/O,
since the provisioned size is fixed at zvol creation and independent of
usage -- then waits for volumemgr to create it and asserts the reported
provisioned size is the zvol volsize (~1 GiB), not 0, at all three
layers: ZInfoVolume.Resources.MaxSizeBytes, ZMetricVolume.TotalBytes,
and volumemgr's AppDiskMetric.ProvisionedBytes pubsub object. This also
adds the EdgeDeviceConfig.AddBlankVolume builder, since evetest
previously had no way to declare an empty block-device volume.


## PR dependencies

None

## How to test and validate this PR

- build this pr (make ZARCH=amd64 pkgs eve)
- run new evetest exercising the AppDiskMetric path on a zfs persist HV=kvm system:
```
cd evetest
make build-container
cd ../
EVETEST_EVE_VERSION=0.0.0-pr-6154-d80e69ac EVETEST_PAUSE_ON_FAILURE=true make evetest NAME=TestZVolProvisionedSizeReported
```

## Changelog notes

Report provisioned/virtual size for ZFS persist AppDiskMetrics

## PR Backports

```text
- 17.0-stable: Yes
- 16.0-stable: Yes
- 14.5-stable: Yes
- 13.4-stable: No, as the feature is not available there.
```

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
