### PR TITLE
pillar/dpcmanager: fix data race in TestDPCWithAssignedInterface

### DIFF
--- a/pkg/pillar/dpcmanager/dpcmanager_test.go
+++ b/pkg/pillar/dpcmanager/dpcmanager_test.go
@@ -2188,12 +2188,16 @@ func TestDPCWithAssignedInterface(test *testing.T) {
 	t.Expect(dpcList[0].LastError).To(Equal("port eth1 in PCIBack is used by ccf4c2f8-1d0f-4b44-b55a-220f7a138f6d"))
 
 	// eth1 was released from the application but it is still in PCIBack.
-	aa.IoBundleList[1].UsedByUUID = uuid.UUID{}
+	// Build a fresh AA instead of mutating the list already handed over to
+	// DpcManager; the manager reads it from its own goroutine, so mutating
+	// the shared backing array here would be a data race.
+	aa = makeAA(selectedIntfs{eth0: true, eth1: true})
+	aa.IoBundleList[1].IsPCIBack = true
 	dpcManager.UpdateAA(aa)
 	t.Eventually(dpcStateCb(0)).Should(Equal(types.DPCStatePCIWait))
 
 	// Finally the eth1 is released from PCIBack.
-	aa.IoBundleList[1].IsPCIBack = false
+	aa = makeAA(selectedIntfs{eth0: true, eth1: true})
 	dpcManager.UpdateAA(aa)
 	eth1 := mockEth1()
 	networkMonitor.AddOrUpdateInterface(eth1)


### PR DESCRIPTION
# Description

I'm observing more race errors on `make test`, like this: https://github.com/lf-edge/eve/actions/runs/29025222934/job/86142944414#step:5:3188

This PR provides the fix:

The test passed an AssignableAdapters to DpcManager.UpdateAA and then mutated aa.IoBundleList entries in place afterwards. Since the list shares its backing array with the caller and the manager reads it from its own goroutine (updateDNS -> LookupIoBundleLogicallabel), this was a data race that intermittently failed the -race coverage run.

Build a fresh AssignableAdapters for each state change instead of mutating the list already handed over to the manager, matching the pattern already used by the sibling dpcmanager tests and by production (nim supplies a freshly deserialized AA on every update).

## How to test and validate this PR

It's already covered by `make test`, so our `Go Tests` and `coverage` workflows.

## Changelog notes

None.

## PR Backports

So far I just observed on master, so no backports.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.