### PR TITLE
Include reserved ESP-B in the live image

### DIFF
--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -150,7 +150,7 @@ do_build_config() {
 }
 
 do_live() {
-  PART_SPEC="efi conf imga"
+  PART_SPEC="efi efi_b conf imga"
   # each live image is expected to have a soft serial number that
   # typically gets provisioned by an installer -- since we're
   # shortcutting the installer step here we need to generate it


### PR DESCRIPTION
# Description

The live image built by `pkg/eve/runme.sh`'s `do_live` laid down only
`efi`/`conf`/`imga` and omitted the reserved second EFI System Partition
(ESP-B) that an installer-produced disk carries. As a result a
live-booted device — including anything built through Eden's live-gen,
which just runs the `live` command on the EVE docker image — did not
match a freshly installed device and could not exercise ESP-B-present
behavior.

This adds `efi_b` to the live partition spec. `make-raw` places it at the
fixed GPT partition #7 with GUID `…30056`, type `ef00`, label
`"EFI System"`, and an empty FAT32 filesystem — byte-identical to what
the installer creates. ESP-B carries no payload today; it is a reserved
slot for future A/B EFI work.

## How to test and validate this PR

Build a live image and inspect its partition table:

```sh
make live            # or via Eden: eden setup builds the live image
sgdisk -p dist/<arch>/current/live.raw
```

The table should now contain partition #7 labeled `EFI System` with GUID
`ad6871ee-31f9-4cf3-9e09-6f7a25c30056`, type `ef00`, sized 2 GiB and
empty, in addition to the existing efi (#1), imga (#2), and conf (#4)
partitions. A live-booted device's on-disk layout should match a
fresh-installed device with respect to ESP-B.

## Changelog notes

No user-facing changes. The build-time live image now reserves the same
second EFI System Partition that an installer-produced disk already has.

## PR Backports

- 16.0-stable: No — reserved ESP-B is not present there.
- 14.5-stable: No — reserved ESP-B is not present there.
- 13.4-stable: No — reserved ESP-B is not present there.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — n/a, no doc change
- [ ] I've tested my PR on amd64 device — draft; validation pending
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
