### PR TITLE
client: seams and unit tests for the onboarding loop

### DIFF
--- a/pkg/pillar/cmd/client/adapters.go
+++ b/pkg/pillar/cmd/client/adapters.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/utils"
+	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
+)
+
+// realControllerSender wraps *controllerconn.Client and satisfies controllerSender.
+type realControllerSender struct {
+	c *controllerconn.Client
+}
+
+func newRealControllerSender(c *controllerconn.Client) *realControllerSender {
+	return &realControllerSender{c: c}
+}
+
+func (r *realControllerSender) GetContextForAllIntfFunctions() (context.Context, context.CancelFunc) {
+	return r.c.GetContextForAllIntfFunctions()
+}
+
+func (r *realControllerSender) SendOnAllIntf(ctx context.Context, url string,
+	body *bytes.Buffer, opts controllerconn.RequestOptions) (controllerconn.SendRetval, error) {
+	return r.c.SendOnAllIntf(ctx, url, body, opts)
+}
+
+func (r *realControllerSender) RemoveAndVerifyAuthContainer(rv *controllerconn.SendRetval, skipVerify bool) error {
+	return r.c.RemoveAndVerifyAuthContainer(rv, skipVerify)
+}
+
+func (r *realControllerSender) VerifyProtoSigningCertChain(contents []byte) ([]byte, error) {
+	return r.c.VerifyProtoSigningCertChain(contents)
+}
+
+func (r *realControllerSender) StoreServerSigningCert(certBytes []byte) error {
+	return r.c.StoreServerSigningCert(certBytes)
+}
+
+func (r *realControllerSender) UpdateTLSProxyCerts() bool { return r.c.UpdateTLSProxyCerts() }
+
+func (r *realControllerSender) GetTLSConfig(clientCert *tls.Certificate) (*tls.Config, error) {
+	return r.c.GetTLSConfig(clientCert)
+}
+
+func (r *realControllerSender) TLSConfig() *tls.Config       { return r.c.TLSConfig }
+func (r *realControllerSender) SetTLSConfig(tc *tls.Config)  { r.c.TLSConfig = tc }
+func (r *realControllerSender) LedManagerDisabled() bool     { return r.c.NoLedManager }
+func (r *realControllerSender) SetLedManagerDisabled(b bool) { r.c.NoLedManager = b }
+func (r *realControllerSender) SetDeviceNetworkStatus(d *types.DeviceNetworkStatus) {
+	r.c.DeviceNetworkStatus = d
+}
+
+// realCertStore reads and writes the persistent controller-cert checkpoint.
+type realCertStore struct{ log *base.LogObject }
+
+func (r *realCertStore) Read(useBackup bool) ([]byte, error) {
+	b, _, err := persist.ReadControllerCerts(r.log, useBackup)
+	return b, err
+}
+
+func (r *realCertStore) MaybeSave(certBytes []byte) {
+	persist.MaybeSaveControllerCerts(r.log, certBytes)
+}
+
+// realLedNotifier proxies to ledmanager via utils.UpdateLedManagerConfig.
+type realLedNotifier struct{ log *base.LogObject }
+
+func (r *realLedNotifier) Update(pattern types.LedBlinkCount) {
+	utils.UpdateLedManagerConfig(r.log, pattern)
+}
+
+// nullLedNotifier discards all updates; used when LED suppression is needed
+// (currently during fetchCertChain so the cert prefetch does not look like
+// the device just came online).
+type nullLedNotifier struct{}
+
+func (nullLedNotifier) Update(pattern types.LedBlinkCount) {}
+
+// realHostnameSetter calls /bin/hostname via base.Exec.
+type realHostnameSetter struct{ log *base.LogObject }
+
+func (r *realHostnameSetter) Set(hostname string) error {
+	out, err := base.Exec(r.log, "/bin/hostname", hostname).CombinedOutput()
+	if err != nil {
+		r.log.Errorf("hostname command %s failed %s output %s", hostname, err, out)
+		return err
+	}
+	return nil
+}

--- a/pkg/pillar/cmd/client/certchain_test.go
+++ b/pkg/pillar/cmd/client/certchain_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"encoding/hex"
+	"testing"
+
+	zcert "github.com/lf-edge/eve-api/go/certs"
+	"google.golang.org/protobuf/proto"
+)
+
+func marshalCerts(t *testing.T, hashes ...[]byte) []byte {
+	t.Helper()
+	msg := &zcert.ZControllerCert{}
+	for _, h := range hashes {
+		msg.Certs = append(msg.Certs, &zcert.ZCert{CertHash: h})
+	}
+	b, err := proto.Marshal(msg)
+	if err != nil {
+		t.Fatalf("proto.Marshal: %v", err)
+	}
+	return b
+}
+
+func TestParseKeysFromControllerCerts(t *testing.T) {
+	h1 := []byte{0xab, 0xcd}
+	h2 := []byte{0xde, 0xad, 0xbe, 0xef}
+
+	t.Run("empty cert set", func(t *testing.T) {
+		keys, err := parseKeysFromControllerCerts(marshalCerts(t))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(keys) != 0 {
+			t.Errorf("keys = %v, want empty", keys)
+		}
+	})
+
+	t.Run("single cert", func(t *testing.T) {
+		keys, err := parseKeysFromControllerCerts(marshalCerts(t, h1))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(keys) != 1 || keys[0] != hex.EncodeToString(h1) {
+			t.Errorf("keys = %v, want [%s]", keys, hex.EncodeToString(h1))
+		}
+	})
+
+	t.Run("two certs preserve insertion order", func(t *testing.T) {
+		keys, err := parseKeysFromControllerCerts(marshalCerts(t, h1, h2))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []string{hex.EncodeToString(h1), hex.EncodeToString(h2)}
+		if len(keys) != 2 || keys[0] != want[0] || keys[1] != want[1] {
+			t.Errorf("keys = %v, want %v", keys, want)
+		}
+	})
+
+	t.Run("garbage bytes fail unmarshal", func(t *testing.T) {
+		_, err := parseKeysFromControllerCerts([]byte("not a protobuf"))
+		if err == nil {
+			t.Fatal("want error, got nil")
+		}
+	})
+}
+
+func TestCompareControllerCertBytes(t *testing.T) {
+	h1 := []byte{0xab, 0xcd}
+	h2 := []byte{0xde, 0xad}
+	h3 := []byte{0xbe, 0xef}
+
+	tests := []struct {
+		name        string
+		newBytes    []byte
+		prevBytes   []byte
+		wantChanged bool
+	}{
+		{
+			name:        "identical bytes",
+			newBytes:    marshalCerts(t, h1, h2),
+			prevBytes:   marshalCerts(t, h1, h2),
+			wantChanged: false,
+		},
+		{
+			name:        "same certs different order",
+			newBytes:    marshalCerts(t, h1, h2),
+			prevBytes:   marshalCerts(t, h2, h1),
+			wantChanged: false,
+		},
+		{
+			name:        "cert added",
+			newBytes:    marshalCerts(t, h1, h2, h3),
+			prevBytes:   marshalCerts(t, h1, h2),
+			wantChanged: true,
+		},
+		{
+			name:        "cert removed",
+			newBytes:    marshalCerts(t, h1),
+			prevBytes:   marshalCerts(t, h1, h2),
+			wantChanged: true,
+		},
+		{
+			name:        "cert swapped",
+			newBytes:    marshalCerts(t, h1, h3),
+			prevBytes:   marshalCerts(t, h1, h2),
+			wantChanged: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := compareControllerCertBytes(tc.newBytes, tc.prevBytes)
+			if got != tc.wantChanged {
+				t.Errorf("compareControllerCertBytes = %v, want %v", got, tc.wantChanged)
+			}
+		})
+	}
+}

--- a/pkg/pillar/cmd/client/client.go
+++ b/pkg/pillar/cmd/client/client.go
@@ -27,9 +27,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
-	"github.com/lf-edge/eve/pkg/pillar/utils"
 	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
-	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
@@ -40,12 +38,12 @@ const (
 	maxDelay    = time.Second * 600 // 10 minutes
 	uuidMaxWait = time.Second * 60  // 1 minute
 	// Time limits for event loop handlers
-	errorTime             = 3 * time.Minute
-	warningTime           = 40 * time.Second
-	bailOnHTTPErr         = false // For 4xx and 5xx HTTP errors we try other interfaces
-	withNetTrace          = false
-	uuidFileName          = types.PersistStatusDir + "/uuid"
-	hardwaremodelFileName = types.PersistStatusDir + "/hardwaremodel"
+	errorTime                    = 3 * time.Minute
+	warningTime                  = 40 * time.Second
+	bailOnHTTPErr                = false // For 4xx and 5xx HTTP errors we try other interfaces
+	withNetTrace                 = false
+	defaultUUIDFileName          = types.PersistStatusDir + "/uuid"
+	defaultHardwaremodelFileName = types.PersistStatusDir + "/hardwaremodel"
 )
 
 // Really a constant
@@ -68,8 +66,21 @@ type clientContext struct {
 	subGlobalConfig        pubsub.Subscription
 	globalConfig           *types.ConfigItemValueMap
 	getCertsTimer          *time.Timer
-	ctrlClient             *controllerconn.Client
 	agentMetrics           *controllerconn.AgentMetrics
+
+	// Seams. Production code wires real impls; tests inject fakes.
+	sender         controllerSender
+	certStore      certStore
+	led            ledNotifier
+	hostnameSetter hostnameSetter
+
+	// Runtime state previously held in package globals.
+	serverNameAndPort     string
+	onboardTLSConfig      *tls.Config
+	devtlsConfig          *tls.Config
+	uuidFileName          string
+	hardwaremodelFileName string
+
 	// cli options
 	operations    map[string]bool
 	maxRetriesPtr *int
@@ -94,11 +105,8 @@ func (ctxPtr *clientContext) ProcessAgentSpecificCLIFlags(flagSet *flag.FlagSet)
 }
 
 var (
-	serverNameAndPort string
-	onboardTLSConfig  *tls.Config
-	devtlsConfig      *tls.Config
-	logger            *logrus.Logger
-	log               *base.LogObject
+	logger *logrus.Logger
+	log    *base.LogObject
 )
 
 func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, arguments []string, baseDir string) int { //nolint:gocyclo
@@ -106,9 +114,14 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	log = logArg
 
 	clientCtx := clientContext{
-		deviceNetworkStatus: &types.DeviceNetworkStatus{},
-		globalConfig:        types.DefaultConfigItemValueMap(),
-		agentMetrics:        controllerconn.NewAgentMetrics(),
+		deviceNetworkStatus:   &types.DeviceNetworkStatus{},
+		globalConfig:          types.DefaultConfigItemValueMap(),
+		agentMetrics:          controllerconn.NewAgentMetrics(),
+		certStore:             &realCertStore{log: log},
+		led:                   &realLedNotifier{log: log},
+		hostnameSetter:        &realHostnameSetter{log: log},
+		uuidFileName:          defaultUUIDFileName,
+		hardwaremodelFileName: defaultHardwaremodelFileName,
 		operations: map[string]bool{
 			"selfRegister": false,
 			"getUuid":      false,
@@ -194,8 +207,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		DevSoftSerial:       hardware.GetSoftSerial(log),
 		AgentName:           agentName,
 	})
-
-	clientCtx.ctrlClient = ctrlClient
+	clientCtx.sender = newRealControllerSender(ctrlClient)
 	log.Functionf("Client Get Device Serial %s, Soft Serial %s", ctrlClient.DevSerial,
 		ctrlClient.DevSoftSerial)
 
@@ -215,7 +227,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	if err != nil {
 		log.Fatal(err)
 	}
-	serverNameAndPort = strings.TrimSpace(string(server))
+	clientCtx.serverNameAndPort = strings.TrimSpace(string(server))
 
 	var onboardCert tls.Certificate
 	var deviceCertPem []byte
@@ -228,7 +240,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		if err != nil {
 			log.Fatal(err)
 		}
-		onboardTLSConfig, err = ctrlClient.GetTLSConfig(&onboardCert)
+		clientCtx.onboardTLSConfig, err = clientCtx.sender.GetTLSConfig(&onboardCert)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -244,7 +256,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	if err != nil {
 		log.Fatal(err)
 	}
-	devtlsConfig, err = ctrlClient.GetTLSConfig(&deviceCert)
+	clientCtx.devtlsConfig, err = clientCtx.sender.GetTLSConfig(&deviceCert)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -278,32 +290,32 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		// try to fetch the server certs chain first
 		if !gotServerCerts {
 			// Set force so we re-download certs on each boot
-			gotServerCerts = fetchCertChain(ctrlClient, devtlsConfig, retryCount)
+			gotServerCerts = clientCtx.fetchCertChain(clientCtx.devtlsConfig, retryCount)
 			if !gotServerCerts {
 				log.Errorf("Failed to fetch certs from %s. Wrong URL?",
-					serverNameAndPort)
-				if !ctrlClient.NoLedManager {
-					utils.UpdateLedManagerConfig(log, types.LedBlinkInvalidControllerCert)
+					clientCtx.serverNameAndPort)
+				if !clientCtx.sender.LedManagerDisabled() {
+					clientCtx.led.Update(types.LedBlinkInvalidControllerCert)
 				}
 				return 0 // Try again later
 			}
 			log.Noticef("Fetched certs from %s",
-				serverNameAndPort)
+				clientCtx.serverNameAndPort)
 		}
 
 		if !gotRegister && clientCtx.operations["selfRegister"] {
-			done = selfRegister(ctrlClient, onboardTLSConfig, deviceCertPem, retryCount)
+			done = clientCtx.selfRegister(clientCtx.onboardTLSConfig, deviceCertPem, retryCount)
 			if done {
 				gotRegister = true
 				log.Noticef("Registered at %s",
-					serverNameAndPort)
+					clientCtx.serverNameAndPort)
 			} else {
 				log.Errorf("Failed to register at %s. Wrong URL? Not activated?",
-					serverNameAndPort)
+					clientCtx.serverNameAndPort)
 			}
 			if !done && clientCtx.operations["getUuid"] {
 				// Check if getUUid succeeds
-				done, devUUID, hardwaremodel = doGetUUID(&clientCtx, devtlsConfig, retryCount)
+				done, devUUID, hardwaremodel = clientCtx.doGetUUID(clientCtx.devtlsConfig, retryCount)
 				if done {
 					log.Noticef("getUUID succeeded; selfRegister no longer needed")
 					gotUUID = true
@@ -311,13 +323,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			}
 		}
 		if !gotUUID && clientCtx.operations["getUuid"] {
-			done, devUUID, hardwaremodel = doGetUUID(&clientCtx, devtlsConfig, retryCount)
+			done, devUUID, hardwaremodel = clientCtx.doGetUUID(clientCtx.devtlsConfig, retryCount)
 			if done {
 				log.Noticef("getUUID succeeded; selfRegister no longer needed")
 				gotUUID = true
 			} else {
 				log.Errorf("Failed to getUUID at %s. Wrong URL? Not activated?",
-					serverNameAndPort)
+					clientCtx.serverNameAndPort)
 			}
 		}
 		retryCount++
@@ -352,11 +364,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 				log.Warnf("/config/server changed from %s to %s",
 					server, nserver)
 				server = nserver
-				serverNameAndPort = strings.TrimSpace(string(server))
+				clientCtx.serverNameAndPort = strings.TrimSpace(string(server))
 				// Force a refresh
-				ok := fetchCertChain(ctrlClient, devtlsConfig, retryCount)
-				if !ok && !ctrlClient.NoLedManager {
-					utils.UpdateLedManagerConfig(log, types.LedBlinkInvalidControllerCert)
+				ok := clientCtx.fetchCertChain(clientCtx.devtlsConfig, retryCount)
+				if !ok && !clientCtx.sender.LedManagerDisabled() {
+					clientCtx.led.Update(types.LedBlinkInvalidControllerCert)
 				}
 				log.Noticef("get cert chain result %t", ok)
 			}
@@ -381,7 +393,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			// which did not have and use that checkpoint.
 			if clientCtx.networkState != types.DPCStateSuccess &&
 				clientCtx.operations["getUuid"] && oldUUID != nilUUID &&
-				haveControllerCertsCheckpoint() {
+				clientCtx.haveControllerCertsCheckpoint() {
 
 				log.Noticef("Already have a UUID %s; declaring success",
 					oldUUID.String())
@@ -391,9 +403,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 		case <-clientCtx.getCertsTimer.C:
 			// triggered by cert miss error in doGetUUID, so the TLS is device TLSConfig
-			ok := fetchCertChain(ctrlClient, devtlsConfig, retryCount)
-			if !ok && !ctrlClient.NoLedManager {
-				utils.UpdateLedManagerConfig(log, types.LedBlinkInvalidControllerCert)
+			ok := clientCtx.fetchCertChain(clientCtx.devtlsConfig, retryCount)
+			if !ok && !clientCtx.sender.LedManagerDisabled() {
+				clientCtx.led.Update(types.LedBlinkInvalidControllerCert)
 			}
 			log.Noticef("client timer get cert chain result %t", ok)
 
@@ -401,74 +413,8 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	// Post loop code
-	if devUUID != nilUUID {
-		var trigOnboardStatus types.OnboardingStatus
-		doWrite := true
-		if oldUUID != nilUUID {
-			if oldUUID != devUUID {
-				log.Functionf("Replacing existing UUID %s",
-					oldUUID.String())
-			} else {
-				log.Functionf("No change to UUID %s",
-					devUUID)
-				doWrite = false
-			}
-		} else {
-			log.Functionf("Got config with UUID %s", devUUID)
-		}
-		// Set the kernel hostname
-		cmd := "/bin/hostname"
-		cmdArgs := []string{devUUID.String()}
-		log.Noticef("Calling command %s %v", cmd, cmdArgs)
-		out, err := base.Exec(log, cmd, cmdArgs...).CombinedOutput()
-		if err != nil {
-			log.Errorf("hostname command %s failed %s output %s",
-				cmdArgs, err, out)
-		} else {
-			log.Noticef("Set hostname to %s", devUUID.String())
-		}
-		_, err = os.Stat(uuidFileName)
-		if err != nil {
-			doWrite = true
-		}
-		if doWrite {
-			b := []byte(fmt.Sprintf("%s\n", devUUID))
-			err = os.WriteFile(uuidFileName, b, 0644)
-			if err != nil {
-				log.Errorf("WriteFile %s failed: %v",
-					uuidFileName, err)
-			} else {
-				log.Noticef("Wrote UUID file %s", devUUID)
-			}
-		}
-		if hardwaremodel == "" {
-			hardwaremodel = oldHardwaremodel
-		}
-		if hardwaremodel == "" {
-			// Nothing from controller; use dmidecode etc
-			hardwaremodel = hardware.GetHardwareModelNoOverride(log)
-		}
-		// always publish the latest UUID and hardwaremode
-		trigOnboardStatus.DeviceUUID = devUUID
-		trigOnboardStatus.HardwareModel = hardwaremodel
 
-		pubOnboardStatus.Publish("global", trigOnboardStatus)
-		log.Functionf("client pub OnboardStatus")
-
-		if hardwaremodel != oldHardwaremodel {
-			// Write/update file for ledmanager
-			// Note that no CRLF
-			b := []byte(hardwaremodel)
-			err = os.WriteFile(hardwaremodelFileName, b, 0644)
-			if err != nil {
-				log.Errorf("WriteFile %s failed: %v",
-					hardwaremodelFileName, err)
-			} else {
-				log.Noticef("Wrote hardwaremodel %s", hardwaremodel)
-			}
-		}
-	}
+	clientCtx.finalizeOnboarding(devUUID, oldUUID, hardwaremodel, oldHardwaremodel, pubOnboardStatus)
 
 	err = clientCtx.agentMetrics.Publish(log, pub, "global")
 	if err != nil {
@@ -478,16 +424,86 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	return 0
 }
 
-// Post something without a return type.
+// finalizeOnboarding handles the post-loop side effects when Run() has
+// resolved a device UUID: setting the kernel hostname, writing the uuid and
+// hardwaremodel files, and publishing the OnboardingStatus. Returns immediately
+// when devUUID is the nil UUID (i.e. Run() exited without resolving one).
+func (ctx *clientContext) finalizeOnboarding(devUUID, oldUUID uuid.UUID,
+	hardwaremodel, oldHardwaremodel string, pubOnboardStatus pubsub.Publication) {
+	if devUUID == nilUUID {
+		return
+	}
+	var trigOnboardStatus types.OnboardingStatus
+	doWrite := true
+	if oldUUID != nilUUID {
+		if oldUUID != devUUID {
+			log.Functionf("Replacing existing UUID %s",
+				oldUUID.String())
+		} else {
+			log.Functionf("No change to UUID %s",
+				devUUID)
+			doWrite = false
+		}
+	} else {
+		log.Functionf("Got config with UUID %s", devUUID)
+	}
+	// Set the kernel hostname
+	log.Noticef("Calling /bin/hostname %s", devUUID.String())
+	if err := ctx.hostnameSetter.Set(devUUID.String()); err == nil {
+		log.Noticef("Set hostname to %s", devUUID.String())
+	}
+	if _, err := os.Stat(ctx.uuidFileName); err != nil {
+		doWrite = true
+	}
+	if doWrite {
+		b := []byte(fmt.Sprintf("%s\n", devUUID))
+		if err := os.WriteFile(ctx.uuidFileName, b, 0644); err != nil {
+			log.Errorf("WriteFile %s failed: %v",
+				ctx.uuidFileName, err)
+		} else {
+			log.Noticef("Wrote UUID file %s", devUUID)
+		}
+	}
+	if hardwaremodel == "" {
+		hardwaremodel = oldHardwaremodel
+	}
+	if hardwaremodel == "" {
+		// Nothing from controller; use dmidecode etc
+		hardwaremodel = hardware.GetHardwareModelNoOverride(log)
+	}
+	// always publish the latest UUID and hardwaremode
+	trigOnboardStatus.DeviceUUID = devUUID
+	trigOnboardStatus.HardwareModel = hardwaremodel
+
+	pubOnboardStatus.Publish("global", trigOnboardStatus)
+	log.Functionf("client pub OnboardStatus")
+
+	if hardwaremodel != oldHardwaremodel {
+		// Write/update file for ledmanager
+		// Note that no CRLF
+		b := []byte(hardwaremodel)
+		if err := os.WriteFile(ctx.hardwaremodelFileName, b, 0644); err != nil {
+			log.Errorf("WriteFile %s failed: %v",
+				ctx.hardwaremodelFileName, err)
+		} else {
+			log.Noticef("Wrote hardwaremodel %s", hardwaremodel)
+		}
+	}
+}
+
+// myPost posts a request to the controller and classifies the response
+// into a done/retry decision while emitting LED status updates via led.
+// led lets callers suppress LED updates for "internal" requests
+// (e.g. the cert prefetch in fetchCertChain) by passing a nullLedNotifier.
 // Returns true when done; false when retry.
-func myPost(ctrlClient *controllerconn.Client, tlsConfig *tls.Config,
+func (ctx *clientContext) myPost(led ledNotifier, tlsConfig *tls.Config,
 	requrl string, skipVerify bool, retryCount int,
 	b *bytes.Buffer) (done bool, rv controllerconn.SendRetval) {
 
-	ctrlClient.TLSConfig = tlsConfig
-	ctx, cancel := ctrlClient.GetContextForAllIntfFunctions()
+	ctx.sender.SetTLSConfig(tlsConfig)
+	sendCtx, cancel := ctx.sender.GetContextForAllIntfFunctions()
 	defer cancel()
-	rv, err := ctrlClient.SendOnAllIntf(ctx, requrl, b, controllerconn.RequestOptions{
+	rv, err := ctx.sender.SendOnAllIntf(sendCtx, requrl, b, controllerconn.RequestOptions{
 		WithNetTracing: withNetTrace,
 		NetTraceFolder: types.NetTraceFolder,
 		BailOnHTTPErr:  bailOnHTTPErr,
@@ -504,11 +520,7 @@ func myPost(ctrlClient *controllerconn.Client, tlsConfig *tls.Config,
 		case types.SenderStatusCertMiss:
 			log.Functionf("Controller certificate miss")
 		case types.SenderStatusNotFound:
-			if !ctrlClient.NoLedManager {
-				// Inform ledmanager about controller connectivity
-				utils.UpdateLedManagerConfig(log,
-					types.LedBlinkConnectedToController)
-			}
+			led.Update(types.LedBlinkConnectedToController)
 		default:
 			log.Error(err)
 		}
@@ -517,40 +529,23 @@ func myPost(ctrlClient *controllerconn.Client, tlsConfig *tls.Config,
 
 	switch rv.HTTPResp.StatusCode {
 	case http.StatusOK:
-		if !ctrlClient.NoLedManager {
-			// Inform ledmanager about existence in cloud
-			utils.UpdateLedManagerConfig(log, types.LedBlinkOnboarded)
-		}
+		led.Update(types.LedBlinkOnboarded)
 		log.Functionf("%s StatusOK", requrl)
 	case http.StatusCreated:
-		if !ctrlClient.NoLedManager {
-			// Inform ledmanager about existence in cloud
-			utils.UpdateLedManagerConfig(log, types.LedBlinkOnboarded)
-		}
+		led.Update(types.LedBlinkOnboarded)
 		log.Functionf("%s StatusCreated", requrl)
 	case http.StatusConflict:
-		if !ctrlClient.NoLedManager {
-			// Inform ledmanager about brokenness
-			utils.UpdateLedManagerConfig(log, types.LedBlinkOnboardingFailure)
-		}
+		led.Update(types.LedBlinkOnboardingFailure)
 		log.Errorf("%s StatusConflict", requrl)
 		// Retry until fixed
 		log.Errorf("%s", string(rv.RespContents))
 		return false, rv
 	case http.StatusNotFound, http.StatusUnauthorized, http.StatusNotModified:
 		// Caller needs to handle
-		if !ctrlClient.NoLedManager {
-			// Inform ledmanager about controller connectivity
-			utils.UpdateLedManagerConfig(log,
-				types.LedBlinkConnectedToController)
-		}
+		led.Update(types.LedBlinkConnectedToController)
 		return false, rv
 	default:
-		if !ctrlClient.NoLedManager {
-			// Inform ledmanager about controller connectivity
-			utils.UpdateLedManagerConfig(log,
-				types.LedBlinkConnectedToController)
-		}
+		led.Update(types.LedBlinkConnectedToController)
 		log.Errorf("%s statuscode %d %s",
 			requrl, rv.Status,
 			http.StatusText(rv.HTTPResp.StatusCode))
@@ -578,12 +573,9 @@ func myPost(ctrlClient *controllerconn.Client, tlsConfig *tls.Config,
 	if len(rv.RespContents) == 0 {
 		return true, rv
 	}
-	err = ctrlClient.RemoveAndVerifyAuthContainer(&rv, skipVerify)
+	err = ctx.sender.RemoveAndVerifyAuthContainer(&rv, skipVerify)
 	if err != nil {
-		if !ctrlClient.NoLedManager {
-			utils.UpdateLedManagerConfig(log,
-				types.LedBlinkInvalidAuthContainer)
-		}
+		led.Update(types.LedBlinkInvalidAuthContainer)
 		log.Errorf("RemoveAndVerifyAuthContainer failed: %s",
 			err)
 		return false, rv
@@ -591,8 +583,19 @@ func myPost(ctrlClient *controllerconn.Client, tlsConfig *tls.Config,
 	return true, rv
 }
 
-// Returns true when done; false when retry
-func selfRegister(ctrlClient *controllerconn.Client, tlsConfig *tls.Config, deviceCertPem []byte, retryCount int) bool {
+// activeLed returns the ledNotifier to use for caller-visible LED
+// transitions: the configured notifier when the sender has LED updates
+// enabled, otherwise a no-op.
+func (ctx *clientContext) activeLed() ledNotifier {
+	if ctx.sender.LedManagerDisabled() {
+		return nullLedNotifier{}
+	}
+	return ctx.led
+}
+
+// selfRegister sends a registration request and classifies the result.
+// Returns true when done; false when retry.
+func (ctx *clientContext) selfRegister(tlsConfig *tls.Config, deviceCertPem []byte, retryCount int) bool {
 	// XXX add option to get this from a file in /config + override
 	// logic
 	productSerial := hardware.GetProductSerial(log)
@@ -613,12 +616,11 @@ func selfRegister(ctrlClient *controllerconn.Client, tlsConfig *tls.Config, devi
 	}
 	// register URL does not include UUID string
 	requrl := controllerconn.URLPathString(
-		serverNameAndPort, nilUUID, "register")
-	done, rv := myPost(ctrlClient, tlsConfig, requrl, false, retryCount,
+		ctx.serverNameAndPort, nilUUID, "register")
+	done, rv := ctx.myPost(ctx.activeLed(), tlsConfig, requrl, false, retryCount,
 		bytes.NewBuffer(b))
 	if rv.HTTPResp != nil {
-		// Inform ledmanager about brokenness
-		if !ctrlClient.NoLedManager {
+		if !ctx.sender.LedManagerDisabled() {
 			// XXX zedcloud is not respecting the eve-api, fix this when zedcloud is updated.
 			// for now it returns:
 			// StatusBadRequest - if failed parse AuthContainer, verify signature or failed to unmarshal message.
@@ -630,11 +632,11 @@ func selfRegister(ctrlClient *controllerconn.Client, tlsConfig *tls.Config, devi
 			// https://github.com/lf-edge/eve-api/blob/main/APIv2.md#register
 			switch rv.HTTPResp.StatusCode {
 			case http.StatusBadRequest, http.StatusGatewayTimeout, http.StatusInternalServerError:
-				utils.UpdateLedManagerConfig(log, types.LedBlinkOnboardingFailure)
+				ctx.led.Update(types.LedBlinkOnboardingFailure)
 			case http.StatusForbidden:
-				utils.UpdateLedManagerConfig(log, types.LedBlinkOnboardingFailureNotFound)
+				ctx.led.Update(types.LedBlinkOnboardingFailureNotFound)
 			case http.StatusConflict, http.StatusNotModified:
-				utils.UpdateLedManagerConfig(log, types.LedBlinkOnboardingFailureConflict)
+				ctx.led.Update(types.LedBlinkOnboardingFailureConflict)
 			}
 		}
 		// Retry until fixed
@@ -647,19 +649,18 @@ func selfRegister(ctrlClient *controllerconn.Client, tlsConfig *tls.Config, devi
 	return done
 }
 
-// fetch V2 certs from cloud, return GotCloudCerts and ServerIsV1 boolean
-// if got certs, the chain is verified and then saved to /persist/checkpoint/controllercerts
-func fetchCertChain(ctrlClient *controllerconn.Client, tlsConfig *tls.Config, retryCount int) bool {
-	// certs API is and without UUID, use https
-	requrl := controllerconn.URLPathString(serverNameAndPort, nilUUID, "certs")
-	// Save and restore since we don't want the fetch of /certs to
-	// appear as if the device is onboarded.
-	savedNoLedManager := ctrlClient.NoLedManager
-	ctrlClient.NoLedManager = true
+// fetchCertChain pulls the V2 cert chain from the controller, verifies it,
+// and saves a checkpoint when the set of cert hashes differs from any
+// existing checkpoint. LED updates from the underlying request are
+// suppressed so the prefetch is not visible as "device just came online".
+// Returns true on success.
+func (ctx *clientContext) fetchCertChain(tlsConfig *tls.Config, retryCount int) bool {
+	requrl := controllerconn.URLPathString(ctx.serverNameAndPort, nilUUID, "certs")
+	savedNoLedManager := ctx.sender.LedManagerDisabled()
+	ctx.sender.SetLedManagerDisabled(true)
 
-	// currently there is no data included for the request, same as myGet()
-	done, rv := myPost(ctrlClient, tlsConfig, requrl, true, retryCount, nil)
-	ctrlClient.NoLedManager = savedNoLedManager
+	done, rv := ctx.myPost(nullLedNotifier{}, tlsConfig, requrl, true, retryCount, nil)
+	ctx.sender.SetLedManagerDisabled(savedNoLedManager)
 	if rv.HTTPResp != nil {
 		log.Functionf("client fetchCertChain done %v, resp-code %d, content len %d",
 			done, rv.HTTPResp.StatusCode, len(rv.RespContents))
@@ -669,12 +670,12 @@ func fetchCertChain(ctrlClient *controllerconn.Client, tlsConfig *tls.Config, re
 			rv.HTTPResp.StatusCode == http.StatusBadRequest {
 			// cloud server does not support V2 API
 			log.Functionf("client fetchCertChain: server %s does not support V2 API",
-				serverNameAndPort)
+				ctx.serverNameAndPort)
 			return false
 		}
 		// catch default return status, if not done, will return false later
 		log.Functionf("client fetchCertChain: server %s return status %s, done %v",
-			serverNameAndPort, rv.HTTPResp.Status, done)
+			ctx.serverNameAndPort, rv.HTTPResp.Status, done)
 	} else {
 		log.Functionf("client fetchCertChain done %v, resp null, content len %d",
 			done, len(rv.RespContents))
@@ -683,32 +684,30 @@ func fetchCertChain(ctrlClient *controllerconn.Client, tlsConfig *tls.Config, re
 		return false
 	}
 
-	ctrlClient.TLSConfig = tlsConfig
+	ctx.sender.SetTLSConfig(tlsConfig)
 	// verify the certificate chains down to the signing and ECDH leaves
-	signerCertBytes, err := ctrlClient.VerifyProtoSigningCertChain(rv.RespContents)
+	signerCertBytes, err := ctx.sender.VerifyProtoSigningCertChain(rv.RespContents)
 	if err != nil {
 		errStr := fmt.Sprintf("controller certificate signature verify fail, %v", err)
 		log.Errorln("fetchCertChain: " + errStr)
 		return false
 	}
 	// Save signer cert in the client object
-	err = ctrlClient.StoreServerSigningCert(signerCertBytes)
+	err = ctx.sender.StoreServerSigningCert(signerCertBytes)
 	if err != nil {
 		errStr := fmt.Sprintf("StoreServerSigningCert fail: %v", err)
 		log.Errorln("fetchCertChain: " + errStr)
 		return false // Try again to fetch and save
 	}
-	// Compare against the existing /persist/checkpoint/controllercerts
-	// to see if any certs were added or deleted. If so we write a new
-	// checkpoint. Since zedagent has not yet published ControllerCerts
-	// we compare against the checkpoint
-	// Note that it is not sufficient to compare the protobuf bytes
-	// since the controller might generate this from a golang map (with
-	// random order) thus we extract and compare they keys for
-	// the ControllerCert objects, which are the hashes of the certs.
+	// Compare against the existing checkpoint to see if any certs were
+	// added or deleted. If so we write a new checkpoint. Since zedagent
+	// has not yet published ControllerCerts we compare against the
+	// checkpoint. Note that it is not sufficient to compare the protobuf
+	// bytes since the controller might generate this from a golang map
+	// (with random order), so we extract and compare the CertHash keys.
 	changed := false
 	newCertChainBytes := rv.RespContents
-	prevCertChainBytes, _, _ := persist.ReadControllerCerts(log, false)
+	prevCertChainBytes, _ := ctx.certStore.Read(false)
 	if prevCertChainBytes == nil {
 		changed = true // Need to checkpoint
 	} else {
@@ -716,21 +715,19 @@ func fetchCertChain(ctrlClient *controllerconn.Client, tlsConfig *tls.Config, re
 			prevCertChainBytes)
 	}
 	if changed {
-		// This differs from last set of certs - save into /persist/checkpoint
-		persist.MaybeSaveControllerCerts(log, newCertChainBytes)
+		ctx.certStore.MaybeSave(newCertChainBytes)
 	}
 	log.Functionf("client fetchCertChain: ok")
 	return true
 }
 
-// Return true if we have a checkpoint file or a backup checkpoint file.
-func haveControllerCertsCheckpoint() bool {
-	certChainBytes, _, _ := persist.ReadControllerCerts(log, false)
-	if certChainBytes != nil {
+// haveControllerCertsCheckpoint reports whether either the primary or
+// backup controller-certs checkpoint exists on disk.
+func (ctx *clientContext) haveControllerCertsCheckpoint() bool {
+	if b, _ := ctx.certStore.Read(false); b != nil {
 		return true
 	}
-	certChainBytes, _, _ = persist.ReadControllerCerts(log, true)
-	if certChainBytes != nil {
+	if b, _ := ctx.certStore.Read(true); b != nil {
 		return true
 	}
 	return false
@@ -769,23 +766,23 @@ func compareControllerCertBytes(newCertChainBytes, prevCertChainBytes []byte) bo
 	return false
 }
 
-func doGetUUID(ctx *clientContext, tlsConfig *tls.Config,
+// doGetUUID asks the controller for the device UUID and, on success,
+// extracts the UUID and the controller-provided hardwaremodel override
+// (if any). Returns done=true on a parsed reply; on cert-miss errors
+// schedules a cert refetch on getCertsTimer.
+func (ctx *clientContext) doGetUUID(tlsConfig *tls.Config,
 	retryCount int) (bool, uuid.UUID, string) {
-	ctrlClient := ctx.ctrlClient
-
-	// get UUID does not have UUID string
 	requrl := controllerconn.URLPathString(
-		serverNameAndPort, nilUUID, "uuid")
+		ctx.serverNameAndPort, nilUUID, "uuid")
 	b, err := generateUUIDRequest()
 	if err != nil {
 		log.Errorln(err)
 		return false, nilUUID, ""
 	}
-	done, rv := myPost(ctrlClient, tlsConfig, requrl, false, retryCount,
+	done, rv := ctx.myPost(ctx.activeLed(), tlsConfig, requrl, false, retryCount,
 		bytes.NewBuffer(b))
 	if !done {
-		// This may be due to the cloud cert file is stale, since the hash does not match.
-		// acquire new cert chain.
+		// May be a stale cloud cert. Schedule a refetch.
 		if rv.Status == types.SenderStatusCertMiss {
 			ctx.getCertsTimer = time.NewTimer(time.Second)
 			log.Functionf("doGetUUID: Cert miss. Setup timer to acquire")
@@ -795,9 +792,8 @@ func doGetUUID(ctx *clientContext, tlsConfig *tls.Config,
 	log.Functionf("doGetUUID: client getUUID ok")
 	devUUID, hardwaremodel, err := parseUUIDResponse(rv.HTTPResp, rv.RespContents)
 	if err == nil {
-		// Inform ledmanager about config received from cloud
-		if !ctrlClient.NoLedManager {
-			utils.UpdateLedManagerConfig(log, types.LedBlinkOnboarded)
+		if !ctx.sender.LedManagerDisabled() {
+			ctx.led.Update(types.LedBlinkOnboarded)
 		}
 		// If successfully connected to the controller, log the peer certificates,
 		// can be used to detect if it's a MiTM proxy
@@ -900,17 +896,20 @@ func handleDNSImpl(ctxArg interface{}, key string,
 	}
 
 	// update proxy certs if configured
-	ctx.ctrlClient.DeviceNetworkStatus = &status
+	ctx.sender.SetDeviceNetworkStatus(&status)
 
 	// if there is proxy certs change, needs to update both
 	// onboard and device tlsconfig
-	ctx.ctrlClient.TLSConfig = devtlsConfig
-	updated := ctx.ctrlClient.UpdateTLSProxyCerts()
+	ctx.sender.SetTLSConfig(ctx.devtlsConfig)
+	updated := ctx.sender.UpdateTLSProxyCerts()
 	if updated {
-		if onboardTLSConfig != nil {
-			onboardTLSConfig.RootCAs = ctx.ctrlClient.TLSConfig.RootCAs
+		rootCAs := ctx.sender.TLSConfig().RootCAs
+		if ctx.onboardTLSConfig != nil {
+			ctx.onboardTLSConfig.RootCAs = rootCAs
 		}
-		devtlsConfig.RootCAs = ctx.ctrlClient.TLSConfig.RootCAs
+		if ctx.devtlsConfig != nil {
+			ctx.devtlsConfig.RootCAs = rootCAs
+		}
 		log.Functionf("handleDNSImpl: client rootCAs updated")
 	}
 

--- a/pkg/pillar/cmd/client/cliflags_test.go
+++ b/pkg/pillar/cmd/client/cliflags_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+// withFatalPanic installs a logger ExitFunc that panics rather than exiting,
+// so a test can drive log.Fatal paths and recover. Restored on test cleanup.
+func withFatalPanic(t *testing.T) {
+	t.Helper()
+	prev := logger.ExitFunc
+	logger.ExitFunc = func(int) { panic("log.Fatal called") }
+	t.Cleanup(func() { logger.ExitFunc = prev })
+}
+
+func newClientContextForFlags(ops map[string]bool) *clientContext {
+	return &clientContext{operations: ops}
+}
+
+func TestProcessAgentSpecificCLIFlags_KnownOps(t *testing.T) {
+	ctx := newClientContextForFlags(map[string]bool{
+		"selfRegister": false,
+		"getUuid":      false,
+	})
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	ctx.AddAgentSpecificCLIFlags(fs)
+	if err := fs.Parse([]string{"selfRegister", "getUuid"}); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	ctx.ProcessAgentSpecificCLIFlags(fs)
+
+	if !ctx.operations["selfRegister"] || !ctx.operations["getUuid"] {
+		t.Errorf("operations = %v, want both true", ctx.operations)
+	}
+}
+
+func TestProcessAgentSpecificCLIFlags_UnknownOpFatals(t *testing.T) {
+	if os.Getenv("CLIFLAGS_FATAL_CHILD") == "1" {
+		// reentrant subprocess path is unused; kept for documentation
+		return
+	}
+	withFatalPanic(t)
+	ctx := newClientContextForFlags(map[string]bool{
+		"selfRegister": false,
+	})
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	ctx.AddAgentSpecificCLIFlags(fs)
+	if err := fs.Parse([]string{"bogus"}); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected log.Fatal to be reached for unknown arg")
+		}
+	}()
+	ctx.ProcessAgentSpecificCLIFlags(fs)
+}

--- a/pkg/pillar/cmd/client/dogetuuid_test.go
+++ b/pkg/pillar/cmd/client/dogetuuid_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	eveuuid "github.com/lf-edge/eve-api/go/eveuuid"
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"google.golang.org/protobuf/proto"
+)
+
+func mustMarshalUUIDResponse(t *testing.T, msg *eveuuid.UuidResponse) []byte {
+	t.Helper()
+	b, err := proto.Marshal(msg)
+	if err != nil {
+		t.Fatalf("proto.Marshal: %v", err)
+	}
+	return b
+}
+
+func newDoGetUUIDCtx(sender *fakeControllerSender, led ledNotifier) *clientContext {
+	ctx := &clientContext{
+		sender:            sender,
+		led:               led,
+		serverNameAndPort: "test.example:8080",
+		getCertsTimer:     time.NewTimer(time.Hour),
+	}
+	ctx.getCertsTimer.Stop()
+	return ctx
+}
+
+func TestDoGetUUID_SuccessExtractsUUIDAndLEDs(t *testing.T) {
+	const goodUUID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	body := mustMarshalUUIDResponse(t, &eveuuid.UuidResponse{
+		Uuid:         goodUUID,
+		Manufacturer: "Dell",
+		ProductName:  "PowerEdge R740",
+	})
+	sender := &fakeControllerSender{sends: []sendResponse{
+		{rv: controllerconn.SendRetval{
+			HTTPResp:     httpResp(http.StatusOK, "application/x-proto-binary"),
+			RespContents: body,
+		}},
+	}}
+	led := &recordingLedNotifier{}
+	ctx := newDoGetUUIDCtx(sender, led)
+
+	done, devUUID, model := ctx.doGetUUID(&testTLSCfg, 0)
+	if !done {
+		t.Fatal("done = false, want true")
+	}
+	if devUUID.String() != goodUUID {
+		t.Errorf("devUUID = %s, want %s", devUUID, goodUUID)
+	}
+	if model != "Dell.PowerEdge R740" {
+		t.Errorf("model = %q, want %q", model, "Dell.PowerEdge R740")
+	}
+	// myPost emits Onboarded for 200; doGetUUID emits Onboarded again on parse success.
+	wantLed := []types.LedBlinkCount{types.LedBlinkOnboarded, types.LedBlinkOnboarded}
+	if !ledEqual(led.patterns, wantLed) {
+		t.Errorf("led = %v, want %v", led.patterns, wantLed)
+	}
+}
+
+func TestDoGetUUID_CertMissSchedulesTimer(t *testing.T) {
+	sender := &fakeControllerSender{sends: []sendResponse{
+		{rv: controllerconn.SendRetval{Status: types.SenderStatusCertMiss}, err: errors.New("cert miss")},
+	}}
+	led := &recordingLedNotifier{}
+	ctx := newDoGetUUIDCtx(sender, led)
+
+	done, _, _ := ctx.doGetUUID(&testTLSCfg, 0)
+	if done {
+		t.Error("done = true, want false on cert miss")
+	}
+	if ctx.getCertsTimer == nil {
+		t.Fatal("getCertsTimer = nil, want a re-armed timer")
+	}
+	select {
+	case <-ctx.getCertsTimer.C:
+	case <-time.After(2 * time.Second):
+		t.Fatal("getCertsTimer did not fire within 2s; was not re-armed by doGetUUID")
+	}
+}
+
+func TestDoGetUUID_ParseFailureReturnsFalse(t *testing.T) {
+	sender := &fakeControllerSender{sends: []sendResponse{
+		{rv: controllerconn.SendRetval{
+			HTTPResp:     httpResp(http.StatusOK, "application/x-proto-binary"),
+			RespContents: []byte("not a valid uuid response proto"),
+		}},
+	}}
+	led := &recordingLedNotifier{}
+	ctx := newDoGetUUIDCtx(sender, led)
+
+	done, _, _ := ctx.doGetUUID(&testTLSCfg, 0)
+	if done {
+		t.Error("done = true, want false on parse failure")
+	}
+}
+
+func TestDoGetUUID_NetworkErrorNoTimer(t *testing.T) {
+	sender := &fakeControllerSender{sends: []sendResponse{
+		{rv: controllerconn.SendRetval{Status: types.SenderStatusRefused}, err: errors.New("refused")},
+	}}
+	led := &recordingLedNotifier{}
+	ctx := newDoGetUUIDCtx(sender, led)
+
+	// Drain any pre-set timer to ensure the test observes a fresh state.
+	select {
+	case <-ctx.getCertsTimer.C:
+	default:
+	}
+	done, _, _ := ctx.doGetUUID(&testTLSCfg, 0)
+	if done {
+		t.Error("done = true, want false on network error")
+	}
+	// Timer must remain quiescent (no fresh re-arm on this code path).
+	select {
+	case <-ctx.getCertsTimer.C:
+		t.Error("getCertsTimer fired on non-CertMiss network error; should not have re-armed")
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/pkg/pillar/cmd/client/fakes_test.go
+++ b/pkg/pillar/cmd/client/fakes_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// fakeControllerSender satisfies controllerSender for unit tests. Each call
+// to SendOnAllIntf consumes the next queued response; queue exhaustion fails
+// the call so tests reliably catch unexpected requests.
+type fakeControllerSender struct {
+	// queued sends; first one consumed per SendOnAllIntf call.
+	sends []sendResponse
+	// canned verify outputs.
+	verifyChain     []byte
+	verifyChainErr  error
+	storeSigningErr error
+	updateProxyCert bool
+	// When updateProxyCert is true and proxyCertPool is non-nil, the fake
+	// installs the pool onto tlsConfig.RootCAs on UpdateTLSProxyCerts to
+	// mirror what the real *controllerconn.Client does.
+	proxyCertPool *x509.CertPool
+	// canned auth-container verify result.
+	authVerifyErr error
+
+	// recorded state
+	tlsConfig          *tls.Config
+	dns                *types.DeviceNetworkStatus
+	ledManagerDisabled bool
+	sentURLs           []string
+	sentBodies         [][]byte
+	storedSigningCert  []byte
+	authVerifyCalls    int
+}
+
+type sendResponse struct {
+	rv  controllerconn.SendRetval
+	err error
+}
+
+func (f *fakeControllerSender) GetContextForAllIntfFunctions() (context.Context, context.CancelFunc) {
+	return context.WithCancel(context.Background())
+}
+
+func (f *fakeControllerSender) SendOnAllIntf(_ context.Context, url string,
+	body *bytes.Buffer, _ controllerconn.RequestOptions) (controllerconn.SendRetval, error) {
+	f.sentURLs = append(f.sentURLs, url)
+	if body != nil {
+		f.sentBodies = append(f.sentBodies, append([]byte(nil), body.Bytes()...))
+	} else {
+		f.sentBodies = append(f.sentBodies, nil)
+	}
+	if len(f.sends) == 0 {
+		return controllerconn.SendRetval{}, fmt.Errorf("fakeControllerSender: no canned response for %s", url)
+	}
+	r := f.sends[0]
+	f.sends = f.sends[1:]
+	return r.rv, r.err
+}
+
+func (f *fakeControllerSender) RemoveAndVerifyAuthContainer(_ *controllerconn.SendRetval, _ bool) error {
+	f.authVerifyCalls++
+	return f.authVerifyErr
+}
+
+func (f *fakeControllerSender) VerifyProtoSigningCertChain(_ []byte) ([]byte, error) {
+	return f.verifyChain, f.verifyChainErr
+}
+
+func (f *fakeControllerSender) StoreServerSigningCert(b []byte) error {
+	f.storedSigningCert = append([]byte(nil), b...)
+	return f.storeSigningErr
+}
+
+func (f *fakeControllerSender) UpdateTLSProxyCerts() bool {
+	if f.updateProxyCert && f.tlsConfig != nil && f.proxyCertPool != nil {
+		f.tlsConfig.RootCAs = f.proxyCertPool
+	}
+	return f.updateProxyCert
+}
+
+func (f *fakeControllerSender) GetTLSConfig(_ *tls.Certificate) (*tls.Config, error) {
+	return &tls.Config{}, nil
+}
+
+func (f *fakeControllerSender) TLSConfig() *tls.Config                              { return f.tlsConfig }
+func (f *fakeControllerSender) SetTLSConfig(tc *tls.Config)                         { f.tlsConfig = tc }
+func (f *fakeControllerSender) SetDeviceNetworkStatus(d *types.DeviceNetworkStatus) { f.dns = d }
+func (f *fakeControllerSender) LedManagerDisabled() bool                            { return f.ledManagerDisabled }
+func (f *fakeControllerSender) SetLedManagerDisabled(b bool)                        { f.ledManagerDisabled = b }
+
+// fakeCertStore is an in-memory certStore.
+type fakeCertStore struct {
+	primary, backup []byte
+	saved           [][]byte
+}
+
+func (f *fakeCertStore) Read(useBackup bool) ([]byte, error) {
+	if useBackup {
+		return f.backup, nil
+	}
+	return f.primary, nil
+}
+
+func (f *fakeCertStore) MaybeSave(b []byte) {
+	f.saved = append(f.saved, append([]byte(nil), b...))
+}
+
+// recordingLedNotifier captures every Update call.
+type recordingLedNotifier struct {
+	patterns []types.LedBlinkCount
+}
+
+func (r *recordingLedNotifier) Update(p types.LedBlinkCount) {
+	r.patterns = append(r.patterns, p)
+}
+
+// fakeHostnameSetter records each Set call and returns an optional error.
+type fakeHostnameSetter struct {
+	calls []string
+	err   error
+}
+
+func (f *fakeHostnameSetter) Set(hostname string) error {
+	f.calls = append(f.calls, hostname)
+	return f.err
+}

--- a/pkg/pillar/cmd/client/fetchcertchain_test.go
+++ b/pkg/pillar/cmd/client/fetchcertchain_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func newFetchCtx(sender *fakeControllerSender, store *fakeCertStore) *clientContext {
+	return &clientContext{
+		sender:            sender,
+		certStore:         store,
+		led:               &recordingLedNotifier{},
+		serverNameAndPort: "test.example:8080",
+	}
+}
+
+// A valid (empty) cert chain proto marshals to zero bytes, which compares
+// equal to itself across calls — the only thing parseKeys cares about is
+// that proto.Unmarshal succeeds.
+var validCertBytes = []byte{}
+
+func TestFetchCertChain_ServerReturnsV1NotSupportedStatuses(t *testing.T) {
+	statuses := []int{
+		http.StatusNotFound,
+		http.StatusUnauthorized,
+		http.StatusNotImplemented,
+		http.StatusBadRequest,
+	}
+	for _, status := range statuses {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			sender := &fakeControllerSender{sends: []sendResponse{
+				{rv: controllerconn.SendRetval{HTTPResp: httpResp(status, "application/x-proto-binary")}},
+			}}
+			store := &fakeCertStore{}
+			ctx := newFetchCtx(sender, store)
+
+			ok := ctx.fetchCertChain(&testTLSCfg, 0)
+			if ok {
+				t.Errorf("fetchCertChain ok = true, want false on %s", http.StatusText(status))
+			}
+			if len(store.saved) != 0 {
+				t.Errorf("certStore.saved = %d entries, want 0", len(store.saved))
+			}
+		})
+	}
+}
+
+func TestFetchCertChain_VerifyChainFailureReturnsFalse(t *testing.T) {
+	sender := &fakeControllerSender{
+		sends: []sendResponse{
+			{rv: controllerconn.SendRetval{
+				HTTPResp:     httpResp(http.StatusOK, "application/x-proto-binary"),
+				RespContents: validCertBytes,
+			}},
+		},
+		verifyChainErr: errors.New("bad signature"),
+	}
+	store := &fakeCertStore{}
+	ctx := newFetchCtx(sender, store)
+
+	ok := ctx.fetchCertChain(&testTLSCfg, 0)
+	if ok {
+		t.Error("fetchCertChain ok = true, want false on verify failure")
+	}
+	if len(store.saved) != 0 {
+		t.Errorf("certStore.saved = %d, want 0", len(store.saved))
+	}
+}
+
+func TestFetchCertChain_StoreSigningFailureReturnsFalse(t *testing.T) {
+	sender := &fakeControllerSender{
+		sends: []sendResponse{
+			{rv: controllerconn.SendRetval{
+				HTTPResp:     httpResp(http.StatusOK, "application/x-proto-binary"),
+				RespContents: validCertBytes,
+			}},
+		},
+		verifyChain:     []byte("signer"),
+		storeSigningErr: errors.New("disk full"),
+	}
+	store := &fakeCertStore{}
+	ctx := newFetchCtx(sender, store)
+
+	if ok := ctx.fetchCertChain(&testTLSCfg, 0); ok {
+		t.Error("fetchCertChain ok = true, want false on StoreServerSigningCert failure")
+	}
+}
+
+func TestFetchCertChain_HappyPath_NoPreviousCheckpoint(t *testing.T) {
+	sender := &fakeControllerSender{
+		sends: []sendResponse{
+			{rv: controllerconn.SendRetval{
+				HTTPResp:     httpResp(http.StatusOK, "application/x-proto-binary"),
+				RespContents: validCertBytes,
+			}},
+		},
+		verifyChain: []byte("signer-cert"),
+	}
+	store := &fakeCertStore{}
+	ctx := newFetchCtx(sender, store)
+
+	if ok := ctx.fetchCertChain(&testTLSCfg, 0); !ok {
+		t.Fatal("fetchCertChain ok = false, want true on happy path")
+	}
+	if len(store.saved) != 1 {
+		t.Errorf("certStore.saved = %d, want 1 entry", len(store.saved))
+	}
+	if string(sender.storedSigningCert) != "signer-cert" {
+		t.Errorf("stored signing cert = %q, want %q", sender.storedSigningCert, "signer-cert")
+	}
+}
+
+func TestFetchCertChain_NoSaveWhenCheckpointMatches(t *testing.T) {
+	sender := &fakeControllerSender{
+		sends: []sendResponse{
+			{rv: controllerconn.SendRetval{
+				HTTPResp:     httpResp(http.StatusOK, "application/x-proto-binary"),
+				RespContents: validCertBytes,
+			}},
+		},
+		verifyChain: []byte("signer"),
+	}
+	store := &fakeCertStore{primary: validCertBytes}
+	ctx := newFetchCtx(sender, store)
+
+	if ok := ctx.fetchCertChain(&testTLSCfg, 0); !ok {
+		t.Fatal("fetchCertChain ok = false, want true when checkpoint matches")
+	}
+	if len(store.saved) != 0 {
+		t.Errorf("certStore.saved = %d, want no save when checkpoint matches", len(store.saved))
+	}
+}
+
+func TestFetchCertChain_LedSuppressionRestoredAfter(t *testing.T) {
+	sender := &fakeControllerSender{
+		sends: []sendResponse{
+			{rv: controllerconn.SendRetval{HTTPResp: httpResp(http.StatusNotFound, "application/x-proto-binary")}},
+		},
+	}
+	store := &fakeCertStore{}
+	ctx := newFetchCtx(sender, store)
+
+	// Caller starts with LED-manager enabled.
+	sender.SetLedManagerDisabled(false)
+	_ = ctx.fetchCertChain(&testTLSCfg, 0)
+	if sender.LedManagerDisabled() {
+		t.Error("LED-manager left disabled after fetchCertChain; should be restored")
+	}
+}
+
+func TestFetchCertChain_NetworkErrorReturnsFalse(t *testing.T) {
+	sender := &fakeControllerSender{sends: []sendResponse{
+		{rv: controllerconn.SendRetval{Status: types.SenderStatusRefused}, err: errors.New("net err")},
+	}}
+	store := &fakeCertStore{}
+	ctx := newFetchCtx(sender, store)
+
+	if ok := ctx.fetchCertChain(&testTLSCfg, 0); ok {
+		t.Error("fetchCertChain ok = true, want false on network error")
+	}
+}
+
+func TestHaveControllerCertsCheckpoint(t *testing.T) {
+	ctx := &clientContext{certStore: &fakeCertStore{}}
+	if ctx.haveControllerCertsCheckpoint() {
+		t.Error("want false on empty store")
+	}
+	ctx.certStore = &fakeCertStore{primary: []byte("x")}
+	if !ctx.haveControllerCertsCheckpoint() {
+		t.Error("want true when primary present")
+	}
+	ctx.certStore = &fakeCertStore{backup: []byte("x")}
+	if !ctx.haveControllerCertsCheckpoint() {
+		t.Error("want true when backup present")
+	}
+}

--- a/pkg/pillar/cmd/client/finalizeonboarding_test.go
+++ b/pkg/pillar/cmd/client/finalizeonboarding_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+)
+
+func newOnboardPublication(t *testing.T) pubsub.Publication {
+	t.Helper()
+	ps := pubsub.New(pubsub.NewMemoryDriver(), logrus.StandardLogger(), log)
+	pub, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: "client_test",
+		TopicType: types.OnboardingStatus{},
+	})
+	if err != nil {
+		t.Fatalf("NewPublication: %v", err)
+	}
+	return pub
+}
+
+func newFinalizeCtx(t *testing.T) (*clientContext, *fakeHostnameSetter, string) {
+	t.Helper()
+	dir := t.TempDir()
+	hs := &fakeHostnameSetter{}
+	ctx := &clientContext{
+		hostnameSetter:        hs,
+		uuidFileName:          filepath.Join(dir, "uuid"),
+		hardwaremodelFileName: filepath.Join(dir, "hardwaremodel"),
+	}
+	return ctx, hs, dir
+}
+
+func mustUUID(t *testing.T, s string) uuid.UUID {
+	t.Helper()
+	u, err := uuid.FromString(s)
+	if err != nil {
+		t.Fatalf("uuid.FromString(%s): %v", s, err)
+	}
+	return u
+}
+
+func TestFinalizeOnboarding_NilUUIDIsNoop(t *testing.T) {
+	ctx, hs, dir := newFinalizeCtx(t)
+	pub := newOnboardPublication(t)
+
+	ctx.finalizeOnboarding(nilUUID, nilUUID, "", "", pub)
+
+	if len(hs.calls) != 0 {
+		t.Errorf("hostname calls = %v, want 0 for nil UUID", hs.calls)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "uuid")); err == nil {
+		t.Error("uuid file written for nil UUID")
+	}
+}
+
+func TestFinalizeOnboarding_FirstOnboardWritesAllArtefacts(t *testing.T) {
+	const newUUID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	ctx, hs, dir := newFinalizeCtx(t)
+	pub := newOnboardPublication(t)
+
+	devUUID := mustUUID(t, newUUID)
+	ctx.finalizeOnboarding(devUUID, nilUUID, "Dell.PowerEdge R740", "", pub)
+
+	if len(hs.calls) != 1 || hs.calls[0] != newUUID {
+		t.Errorf("hostname calls = %v, want [%s]", hs.calls, newUUID)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "uuid"))
+	if err != nil {
+		t.Fatalf("read uuid file: %v", err)
+	}
+	if string(got) != newUUID+"\n" {
+		t.Errorf("uuid file = %q, want %q", got, newUUID+"\n")
+	}
+	gotModel, err := os.ReadFile(filepath.Join(dir, "hardwaremodel"))
+	if err != nil {
+		t.Fatalf("read hardwaremodel file: %v", err)
+	}
+	if string(gotModel) != "Dell.PowerEdge R740" {
+		t.Errorf("hardwaremodel file = %q", gotModel)
+	}
+	itm, err := pub.Get("global")
+	if err != nil {
+		t.Fatalf("pub.Get global: %v", err)
+	}
+	status := itm.(types.OnboardingStatus)
+	if status.DeviceUUID != devUUID {
+		t.Errorf("published UUID = %s, want %s", status.DeviceUUID, devUUID)
+	}
+	if status.HardwareModel != "Dell.PowerEdge R740" {
+		t.Errorf("published model = %q", status.HardwareModel)
+	}
+}
+
+func TestFinalizeOnboarding_UnchangedUUIDSkipsFileWriteWhenFileExists(t *testing.T) {
+	const goodUUID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	ctx, _, dir := newFinalizeCtx(t)
+	pub := newOnboardPublication(t)
+
+	// Pre-create the uuid file with stale contents to detect overwrite.
+	preExisting := []byte("stale\n")
+	if err := os.WriteFile(filepath.Join(dir, "uuid"), preExisting, 0644); err != nil {
+		t.Fatalf("seed uuid: %v", err)
+	}
+	// Allow filesystem timestamp granularity to register.
+	time.Sleep(20 * time.Millisecond)
+
+	devUUID := mustUUID(t, goodUUID)
+	ctx.finalizeOnboarding(devUUID, devUUID /* unchanged */, "", "", pub)
+
+	got, _ := os.ReadFile(filepath.Join(dir, "uuid"))
+	if string(got) != string(preExisting) {
+		t.Errorf("uuid file was overwritten: got %q, want unchanged %q", got, preExisting)
+	}
+}
+
+func TestFinalizeOnboarding_HardwaremodelUnchangedSkipsWrite(t *testing.T) {
+	const goodUUID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	ctx, _, dir := newFinalizeCtx(t)
+	pub := newOnboardPublication(t)
+
+	devUUID := mustUUID(t, goodUUID)
+	ctx.finalizeOnboarding(devUUID, devUUID, "Dell.X", "Dell.X" /* unchanged */, pub)
+
+	if _, err := os.Stat(filepath.Join(dir, "hardwaremodel")); err == nil {
+		t.Error("hardwaremodel file written when model unchanged")
+	}
+}
+
+func TestFinalizeOnboarding_HostnameSetterFailureDoesNotPanic(t *testing.T) {
+	const goodUUID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	ctx, hs, _ := newFinalizeCtx(t)
+	pub := newOnboardPublication(t)
+	hs.err = os.ErrPermission
+
+	devUUID := mustUUID(t, goodUUID)
+	ctx.finalizeOnboarding(devUUID, nilUUID, "Dell.X", "", pub)
+
+	// Despite the setter failing, OnboardingStatus must still be published.
+	if _, err := pub.Get("global"); err != nil {
+		t.Errorf("OnboardingStatus not published after hostname failure: %v", err)
+	}
+}

--- a/pkg/pillar/cmd/client/handlers_test.go
+++ b/pkg/pillar/cmd/client/handlers_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func newHandlerCtx(sender *fakeControllerSender) *clientContext {
+	return &clientContext{
+		sender:              sender,
+		deviceNetworkStatus: &types.DeviceNetworkStatus{},
+	}
+}
+
+func TestHandleDNSDelete_ResetsState(t *testing.T) {
+	ctx := newHandlerCtx(&fakeControllerSender{})
+	ctx.deviceNetworkStatus = &types.DeviceNetworkStatus{
+		State: types.DPCStateSuccess,
+	}
+	ctx.usableAddressCount = 5
+	ctx.networkState = types.DPCStateSuccess
+
+	handleDNSDelete(ctx, "global", types.DeviceNetworkStatus{})
+
+	if ctx.deviceNetworkStatus.State != types.DPCStateNone {
+		t.Errorf("state = %v, want zero (DPCStateNone)", ctx.deviceNetworkStatus.State)
+	}
+	if ctx.usableAddressCount != 0 {
+		t.Errorf("usableAddressCount = %d, want 0", ctx.usableAddressCount)
+	}
+}
+
+func TestHandleDNSDelete_IgnoresNonGlobalKey(t *testing.T) {
+	ctx := newHandlerCtx(&fakeControllerSender{})
+	ctx.deviceNetworkStatus = &types.DeviceNetworkStatus{State: types.DPCStateSuccess}
+	ctx.usableAddressCount = 5
+
+	handleDNSDelete(ctx, "other-key", types.DeviceNetworkStatus{})
+
+	if ctx.deviceNetworkStatus.State != types.DPCStateSuccess {
+		t.Error("state was reset for a non-global key")
+	}
+	if ctx.usableAddressCount != 5 {
+		t.Error("usableAddressCount was reset for a non-global key")
+	}
+}
+
+// dnsStatusWithAddrs builds a minimal DeviceNetworkStatus with the given
+// state and a single port carrying the provided non-link-local IPv4 addrs.
+// Each addr counts as one usable address.
+func dnsStatusWithAddrs(state types.DPCState, addrs ...string) types.DeviceNetworkStatus {
+	addrInfos := make([]types.AddrInfo, 0, len(addrs))
+	for _, a := range addrs {
+		addrInfos = append(addrInfos, types.AddrInfo{Addr: net.ParseIP(a)})
+	}
+	return types.DeviceNetworkStatus{
+		State: state,
+		Ports: []types.NetworkPortStatus{
+			{IfName: "eth0", IsMgmt: true, IsL3Port: true, AddrInfoList: addrInfos},
+		},
+	}
+}
+
+func TestHandleDNSImpl_StateAndAddressTransitions(t *testing.T) {
+	ctx := newHandlerCtx(&fakeControllerSender{})
+
+	// First update: no addresses, state PCIWait.
+	first := dnsStatusWithAddrs(types.DPCStatePCIWait)
+	handleDNSImpl(ctx, "global", first)
+	if ctx.networkState != types.DPCStatePCIWait {
+		t.Errorf("networkState = %v, want PCIWait", ctx.networkState)
+	}
+	if ctx.usableAddressCount != 0 {
+		t.Errorf("usableAddressCount = %d, want 0", ctx.usableAddressCount)
+	}
+
+	// Second update: same state, gain one address.
+	second := dnsStatusWithAddrs(types.DPCStatePCIWait, "10.0.0.1")
+	handleDNSImpl(ctx, "global", second)
+	if ctx.usableAddressCount != 1 {
+		t.Errorf("usableAddressCount = %d, want 1", ctx.usableAddressCount)
+	}
+
+	// Third update: state advances to Success, same one address.
+	third := dnsStatusWithAddrs(types.DPCStateSuccess, "10.0.0.1")
+	handleDNSImpl(ctx, "global", third)
+	if ctx.networkState != types.DPCStateSuccess {
+		t.Errorf("networkState = %v, want Success", ctx.networkState)
+	}
+	if ctx.usableAddressCount != 1 {
+		t.Errorf("usableAddressCount = %d, want 1 unchanged", ctx.usableAddressCount)
+	}
+
+	// Identical update returns early via MostlyEqual.
+	handleDNSImpl(ctx, "global", third)
+	if ctx.networkState != types.DPCStateSuccess {
+		t.Errorf("identical update changed state")
+	}
+}
+
+func TestHandleDNSImpl_IgnoresNonGlobalKey(t *testing.T) {
+	ctx := newHandlerCtx(&fakeControllerSender{})
+	original := *ctx.deviceNetworkStatus
+	handleDNSImpl(ctx, "other-key", dnsStatusWithAddrs(types.DPCStateSuccess, "10.0.0.1"))
+	if ctx.deviceNetworkStatus.State != original.State {
+		t.Error("non-global key altered state")
+	}
+}
+
+func TestHandleDNSImpl_ProxyCertsPropagatedToTLSConfigs(t *testing.T) {
+	pool := x509.NewCertPool()
+	sender := &fakeControllerSender{
+		updateProxyCert: true,
+		proxyCertPool:   pool,
+	}
+	ctx := newHandlerCtx(sender)
+	ctx.onboardTLSConfig = &tls.Config{}
+	ctx.devtlsConfig = &tls.Config{}
+
+	handleDNSImpl(ctx, "global", dnsStatusWithAddrs(types.DPCStateSuccess, "10.0.0.1"))
+
+	if ctx.onboardTLSConfig.RootCAs != pool {
+		t.Error("onboardTLSConfig.RootCAs not updated from sender")
+	}
+	if ctx.devtlsConfig.RootCAs != pool {
+		t.Error("devtlsConfig.RootCAs not updated from sender")
+	}
+	if sender.dns == nil {
+		t.Error("sender.SetDeviceNetworkStatus not called")
+	}
+}
+
+func TestHandleDNSCreateAndModify_DelegateToImpl(t *testing.T) {
+	ctx := newHandlerCtx(&fakeControllerSender{})
+	handleDNSCreate(ctx, "global", dnsStatusWithAddrs(types.DPCStateSuccess, "10.0.0.1"))
+	if ctx.networkState != types.DPCStateSuccess {
+		t.Errorf("after Create networkState = %v, want Success", ctx.networkState)
+	}
+	handleDNSModify(ctx, "global", dnsStatusWithAddrs(types.DPCStateFailWithIPAndDNS, "10.0.0.1"), nil)
+	if ctx.networkState != types.DPCStateFailWithIPAndDNS {
+		t.Errorf("after Modify networkState = %v, want FailWithIPAndDNS", ctx.networkState)
+	}
+}

--- a/pkg/pillar/cmd/client/interfaces.go
+++ b/pkg/pillar/cmd/client/interfaces.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// controllerSender is the slice of *controllerconn.Client used by cmd/client.
+// The real implementation wraps a *controllerconn.Client; tests inject a fake.
+type controllerSender interface {
+	GetContextForAllIntfFunctions() (context.Context, context.CancelFunc)
+	SendOnAllIntf(ctx context.Context, url string, body *bytes.Buffer,
+		opts controllerconn.RequestOptions) (controllerconn.SendRetval, error)
+	RemoveAndVerifyAuthContainer(rv *controllerconn.SendRetval, skipVerify bool) error
+	VerifyProtoSigningCertChain(contents []byte) ([]byte, error)
+	StoreServerSigningCert(certBytes []byte) error
+	UpdateTLSProxyCerts() bool
+	GetTLSConfig(clientCert *tls.Certificate) (*tls.Config, error)
+	TLSConfig() *tls.Config
+	SetTLSConfig(*tls.Config)
+	SetDeviceNetworkStatus(*types.DeviceNetworkStatus)
+	LedManagerDisabled() bool
+	SetLedManagerDisabled(bool)
+}
+
+// certStore wraps the on-disk controller-cert checkpoint store. Tests inject
+// an in-memory impl.
+type certStore interface {
+	Read(useBackup bool) ([]byte, error)
+	MaybeSave(certBytes []byte)
+}
+
+// ledNotifier abstracts ledmanager pattern updates so tests can record them.
+type ledNotifier interface {
+	Update(pattern types.LedBlinkCount)
+}
+
+// hostnameSetter abstracts the /bin/hostname call made after onboarding.
+type hostnameSetter interface {
+	Set(hostname string) error
+}

--- a/pkg/pillar/cmd/client/mypost_test.go
+++ b/pkg/pillar/cmd/client/mypost_test.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"bytes"
+	"crypto/tls"
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+var testTLSCfg = tls.Config{} //nolint:gochecknoglobals
+
+func httpResp(status int, contentType string) *http.Response {
+	r := &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     http.Header{},
+	}
+	if contentType != "" {
+		r.Header.Set("Content-Type", contentType)
+	}
+	return r
+}
+
+func newMyPostCtx(sender *fakeControllerSender) *clientContext {
+	return &clientContext{
+		sender:            sender,
+		serverNameAndPort: "test.example:8080",
+	}
+}
+
+func ledEqual(got, want []types.LedBlinkCount) bool {
+	if len(want) == 0 && len(got) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(got, want)
+}
+
+func TestMyPost_SendErrorClassification(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  types.SenderStatus
+		wantLed []types.LedBlinkCount
+	}{
+		{name: "upgrade", status: types.SenderStatusUpgrade},
+		{name: "refused", status: types.SenderStatusRefused},
+		{name: "cert invalid", status: types.SenderStatusCertInvalid},
+		{name: "cert miss", status: types.SenderStatusCertMiss},
+		{name: "not found emits connected", status: types.SenderStatusNotFound,
+			wantLed: []types.LedBlinkCount{types.LedBlinkConnectedToController}},
+		{name: "unknown sender status (default branch)", status: types.SenderStatusNone},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sender := &fakeControllerSender{sends: []sendResponse{
+				{rv: controllerconn.SendRetval{Status: tc.status}, err: errors.New("send failed")},
+			}}
+			led := &recordingLedNotifier{}
+			ctx := newMyPostCtx(sender)
+
+			done, _ := ctx.myPost(led, &testTLSCfg, "http://x/y", false, 0, bytes.NewBufferString(""))
+			if done {
+				t.Errorf("done = true, want false on send error")
+			}
+			if !ledEqual(led.patterns, tc.wantLed) {
+				t.Errorf("led = %v, want %v", led.patterns, tc.wantLed)
+			}
+		})
+	}
+}
+
+func TestMyPost_HTTPStatusBranches(t *testing.T) {
+	tests := []struct {
+		name      string
+		resp      *http.Response
+		body      []byte
+		wantDone  bool
+		wantLed   []types.LedBlinkCount
+		authError error
+	}{
+		{
+			name:     "200 with empty body",
+			resp:     httpResp(http.StatusOK, "application/x-proto-binary"),
+			wantDone: true,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkOnboarded},
+		},
+		{
+			name:     "201 Created with empty body",
+			resp:     httpResp(http.StatusCreated, "application/x-proto-binary"),
+			wantDone: true,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkOnboarded},
+		},
+		{
+			name:     "409 Conflict",
+			resp:     httpResp(http.StatusConflict, "application/x-proto-binary"),
+			wantDone: false,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkOnboardingFailure},
+		},
+		{
+			name:     "404 Not Found",
+			resp:     httpResp(http.StatusNotFound, "application/x-proto-binary"),
+			wantDone: false,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkConnectedToController},
+		},
+		{
+			name:     "401 Unauthorized",
+			resp:     httpResp(http.StatusUnauthorized, "application/x-proto-binary"),
+			wantDone: false,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkConnectedToController},
+		},
+		{
+			name:     "304 Not Modified",
+			resp:     httpResp(http.StatusNotModified, "application/x-proto-binary"),
+			wantDone: false,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkConnectedToController},
+		},
+		{
+			name:     "500 default branch",
+			resp:     httpResp(http.StatusInternalServerError, "application/x-proto-binary"),
+			wantDone: false,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkConnectedToController},
+		},
+		{
+			name:     "200 missing content-type",
+			resp:     httpResp(http.StatusOK, ""),
+			wantDone: false,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkOnboarded},
+		},
+		{
+			name:     "200 unparseable content-type",
+			resp:     httpResp(http.StatusOK, "garbage; ; ;"),
+			wantDone: false,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkOnboarded},
+		},
+		{
+			name:     "200 unsupported MIME",
+			resp:     httpResp(http.StatusOK, "text/html"),
+			wantDone: false,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkOnboarded},
+		},
+		{
+			name:     "200 with body and auth verify ok",
+			resp:     httpResp(http.StatusOK, "application/x-proto-binary"),
+			body:     []byte("payload"),
+			wantDone: true,
+			wantLed:  []types.LedBlinkCount{types.LedBlinkOnboarded},
+		},
+		{
+			name:      "200 with body and auth verify fails",
+			resp:      httpResp(http.StatusOK, "application/x-proto-binary"),
+			body:      []byte("payload"),
+			authError: errors.New("bad container"),
+			wantDone:  false,
+			wantLed:   []types.LedBlinkCount{types.LedBlinkOnboarded, types.LedBlinkInvalidAuthContainer},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sender := &fakeControllerSender{
+				sends: []sendResponse{
+					{rv: controllerconn.SendRetval{HTTPResp: tc.resp, RespContents: tc.body}},
+				},
+				authVerifyErr: tc.authError,
+			}
+			led := &recordingLedNotifier{}
+			ctx := newMyPostCtx(sender)
+
+			done, _ := ctx.myPost(led, &testTLSCfg, "http://x/y", false, 0, bytes.NewBufferString(""))
+			if done != tc.wantDone {
+				t.Errorf("done = %v, want %v", done, tc.wantDone)
+			}
+			if !ledEqual(led.patterns, tc.wantLed) {
+				t.Errorf("led = %v, want %v", led.patterns, tc.wantLed)
+			}
+			if tc.body != nil && tc.authError == nil && sender.authVerifyCalls != 1 {
+				t.Errorf("authVerifyCalls = %d, want 1", sender.authVerifyCalls)
+			}
+		})
+	}
+}

--- a/pkg/pillar/cmd/client/parseuuid_test.go
+++ b/pkg/pillar/cmd/client/parseuuid_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"testing"
+
+	eveuuid "github.com/lf-edge/eve-api/go/eveuuid"
+	uuid "github.com/satori/go.uuid"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestGenerateUUIDRequest_RoundTrip(t *testing.T) {
+	b, err := generateUUIDRequest()
+	if err != nil {
+		t.Fatalf("generateUUIDRequest: %v", err)
+	}
+	if b == nil {
+		t.Fatal("generateUUIDRequest returned nil bytes")
+	}
+	var req eveuuid.UuidRequest
+	if err := proto.Unmarshal(b, &req); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+}
+
+func TestParseUUIDResponse(t *testing.T) {
+	const goodUUID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+
+	marshal := func(t *testing.T, msg *eveuuid.UuidResponse) []byte {
+		t.Helper()
+		b, err := proto.Marshal(msg)
+		if err != nil {
+			t.Fatalf("proto.Marshal: %v", err)
+		}
+		return b
+	}
+
+	tests := []struct {
+		name         string
+		body         []byte
+		wantUUID     string
+		wantModel    string
+		wantParseErr bool
+		emptyModelOK bool // for cases where empty hardwaremodel is the expected result
+	}{
+		{
+			name: "valid with manufacturer and product",
+			body: marshal(t, &eveuuid.UuidResponse{
+				Uuid:         goodUUID,
+				Manufacturer: "Dell",
+				ProductName:  "PowerEdge R740",
+			}),
+			wantUUID:  goodUUID,
+			wantModel: "Dell.PowerEdge R740",
+		},
+		{
+			name: "valid without manufacturer/product gives empty model",
+			body: marshal(t, &eveuuid.UuidResponse{
+				Uuid: goodUUID,
+			}),
+			wantUUID:     goodUUID,
+			emptyModelOK: true,
+		},
+		{
+			name: "manufacturer only is not enough for a model",
+			body: marshal(t, &eveuuid.UuidResponse{
+				Uuid:         goodUUID,
+				Manufacturer: "Dell",
+			}),
+			wantUUID:     goodUUID,
+			emptyModelOK: true,
+		},
+		{
+			name: "uuid with surrounding whitespace is trimmed",
+			body: marshal(t, &eveuuid.UuidResponse{
+				Uuid: "  " + goodUUID + "\n",
+			}),
+			wantUUID:     goodUUID,
+			emptyModelOK: true,
+		},
+		{
+			name:         "invalid uuid string returns error",
+			body:         marshal(t, &eveuuid.UuidResponse{Uuid: "not-a-uuid"}),
+			wantParseErr: true,
+		},
+		{
+			name:         "garbage bytes fail proto unmarshal",
+			body:         []byte("not a protobuf"),
+			wantParseErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotUUID, gotModel, err := parseUUIDResponse(nil, tc.body)
+			if tc.wantParseErr {
+				if err == nil {
+					t.Fatalf("want error, got UUID=%s model=%q", gotUUID, gotModel)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			wantUUID, _ := uuid.FromString(tc.wantUUID)
+			if gotUUID != wantUUID {
+				t.Errorf("UUID = %s, want %s", gotUUID, wantUUID)
+			}
+			if tc.emptyModelOK {
+				if gotModel != "" {
+					t.Errorf("hardwaremodel = %q, want empty", gotModel)
+				}
+				return
+			}
+			if gotModel != tc.wantModel {
+				t.Errorf("hardwaremodel = %q, want %q", gotModel, tc.wantModel)
+			}
+		})
+	}
+}

--- a/pkg/pillar/cmd/client/selfregister_test.go
+++ b/pkg/pillar/cmd/client/selfregister_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func newSelfRegisterCtx(sender *fakeControllerSender, led ledNotifier) *clientContext {
+	return &clientContext{
+		sender:            sender,
+		led:               led,
+		serverNameAndPort: "test.example:8080",
+	}
+}
+
+// Note: selfRegister currently always returns done=false when myPost
+// produced any HTTP response (the `done = false` override at the end of
+// the HTTPResp != nil block). Success is declared later by doGetUUID.
+// These tests assert the LED pattern emitted for each status code; the
+// done value is exercised only on the no-response path.
+
+func TestSelfRegister_StatusCodeLEDPatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		wantLed []types.LedBlinkCount
+	}{
+		{
+			name:    "200 - onboarded only (no override branch)",
+			status:  http.StatusOK,
+			wantLed: []types.LedBlinkCount{types.LedBlinkOnboarded},
+		},
+		{
+			name:    "201 - onboarded only (no override branch)",
+			status:  http.StatusCreated,
+			wantLed: []types.LedBlinkCount{types.LedBlinkOnboarded},
+		},
+		{
+			name:    "400 - connected then onboarding failure",
+			status:  http.StatusBadRequest,
+			wantLed: []types.LedBlinkCount{types.LedBlinkConnectedToController, types.LedBlinkOnboardingFailure},
+		},
+		{
+			name:    "504 - connected then onboarding failure",
+			status:  http.StatusGatewayTimeout,
+			wantLed: []types.LedBlinkCount{types.LedBlinkConnectedToController, types.LedBlinkOnboardingFailure},
+		},
+		{
+			name:    "500 - connected then onboarding failure",
+			status:  http.StatusInternalServerError,
+			wantLed: []types.LedBlinkCount{types.LedBlinkConnectedToController, types.LedBlinkOnboardingFailure},
+		},
+		{
+			name:    "403 - connected then onboarding failure not found",
+			status:  http.StatusForbidden,
+			wantLed: []types.LedBlinkCount{types.LedBlinkConnectedToController, types.LedBlinkOnboardingFailureNotFound},
+		},
+		{
+			name:    "409 - onboarding failure then conflict",
+			status:  http.StatusConflict,
+			wantLed: []types.LedBlinkCount{types.LedBlinkOnboardingFailure, types.LedBlinkOnboardingFailureConflict},
+		},
+		{
+			name:    "304 - connected then conflict",
+			status:  http.StatusNotModified,
+			wantLed: []types.LedBlinkCount{types.LedBlinkConnectedToController, types.LedBlinkOnboardingFailureConflict},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sender := &fakeControllerSender{sends: []sendResponse{
+				{rv: controllerconn.SendRetval{HTTPResp: httpResp(tc.status, "application/x-proto-binary")}},
+			}}
+			led := &recordingLedNotifier{}
+			ctx := newSelfRegisterCtx(sender, led)
+
+			done := ctx.selfRegister(&testTLSCfg, []byte("device-cert-pem"), 0)
+			if done {
+				t.Errorf("done = true; selfRegister always returns false when an HTTP response is received")
+			}
+			if !ledEqual(led.patterns, tc.wantLed) {
+				t.Errorf("led = %v, want %v", led.patterns, tc.wantLed)
+			}
+		})
+	}
+}
+
+func TestSelfRegister_NetworkErrorNoLED(t *testing.T) {
+	sender := &fakeControllerSender{sends: []sendResponse{
+		{rv: controllerconn.SendRetval{Status: types.SenderStatusUpgrade}, err: errors.New("net err")},
+	}}
+	led := &recordingLedNotifier{}
+	ctx := newSelfRegisterCtx(sender, led)
+
+	done := ctx.selfRegister(&testTLSCfg, []byte("device-cert-pem"), 0)
+	if done {
+		t.Errorf("done = true, want false on network error")
+	}
+	if len(led.patterns) != 0 {
+		t.Errorf("led = %v, want no emissions when HTTPResp is nil", led.patterns)
+	}
+}
+
+func TestSelfRegister_LedManagerDisabled(t *testing.T) {
+	sender := &fakeControllerSender{
+		ledManagerDisabled: true,
+		sends: []sendResponse{
+			{rv: controllerconn.SendRetval{HTTPResp: httpResp(http.StatusBadRequest, "application/x-proto-binary")}},
+		},
+	}
+	led := &recordingLedNotifier{}
+	ctx := newSelfRegisterCtx(sender, led)
+
+	_ = ctx.selfRegister(&testTLSCfg, []byte("device-cert-pem"), 0)
+	if len(led.patterns) != 0 {
+		t.Errorf("led = %v, want no emissions when LED manager disabled", led.patterns)
+	}
+}

--- a/pkg/pillar/cmd/client/setup_test.go
+++ b/pkg/pillar/cmd/client/setup_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"os"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
+)
+
+func TestMain(m *testing.M) {
+	logger = logrus.StandardLogger()
+	logger.SetLevel(logrus.PanicLevel)
+	log = base.NewSourceLogObject(logger, "client_test", 0)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
# Description

Add unit-test coverage to `pkg/pillar/cmd/client` (zedclient), the agent that
drives device onboarding.

The onboarding loop was previously untestable in isolation: runtime state lived
in package globals and the loop called the controller, the on-disk cert
checkpoint, ledmanager, and `/bin/hostname` directly. The first commit moves that
state onto `clientContext` and fronts each runtime boundary with a small
interface, so tests can swap any seam. Production wiring is unchanged at the
behavior level.

The remaining commits add table-driven tests for the pure helpers (UUID parsing,
`/uuid` request generation, cert-set comparison, CLI validation) and for the
network- and side-effect-bearing parts of the loop via the new seams. Package
statement coverage goes from 0 to ~55%; the remaining gap is the top-level event
loop and adapter wiring, reached by Eden e2e tests separately.

No behavior change.

## How to test and validate this PR

Covered by automated Go unit tests:

```sh
cd pkg/pillar
go test -count=1 -cover ./cmd/client/
```

All tests pass and report ~55% statement coverage for the package (0% before
this PR). No runtime behavior changes, so onboarding on a real device is
unaffected.

## Changelog notes

No user-facing changes.

## PR Backports

- 16.0-stable: No, test-only/refactor with no user-facing change.
- 14.5-stable: No, test-only/refactor with no user-facing change.
- 13.4-stable: No, test-only/refactor with no user-facing change.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them: this is a test-only/refactor change with no runtime behavior
  change, verified by the Go unit tests above; no docs or on-device testing
  applies.
