### PR TITLE
evetpm: refuse to seal the vault key against all-zero firmware PCRs (defense in depth)

### DIFF
--- a/pkg/pillar/evetpm/tpm.go
+++ b/pkg/pillar/evetpm/tpm.go
@@ -89,6 +89,9 @@ const (
 	PCRIndexMax = 15
 	// PCRIndexSRTM is the PCR index for Static Root of Trust for Measurement
 	PCRIndexSRTM = 0
+	// PCRIndexBootManagerCode is the PCR index for the boot manager/OS loader
+	// binary (EVE's GRUB), measured by firmware per the TCG PC Client profile.
+	PCRIndexBootManagerCode = 4
 	// PCRIndexGPT is the PCR index for GPT partition table and boot manager configuration
 	PCRIndexGPT = 5
 	// PCRIndexOS is the PCR index for defined by the OS or user.
@@ -134,6 +137,14 @@ var (
 		}
 		return tpm2.PCRSelection{Hash: tpm2.AlgSHA256, PCRs: pcrs}
 	}()
+
+	// criticalFirmwarePCRs are the firmware-owned SHA-256 PCRs that must carry a
+	// genuine measurement for the measured-boot chain to be anchored: PCR 0 (firmware
+	// / S-CRTM version) and PCR 4 (the boot manager measurement of the launched
+	// bootloader, EVE's GRUB). If either is left at its all-zero reset value, firmware
+	// did no SHA-256 measured boot, so the value is forgeable by any code that runs
+	// after ExitBootServices, defeating the seal.
+	criticalFirmwarePCRs = []int{PCRIndexSRTM, PCRIndexBootManagerCode}
 
 	// TpmDevicePath is the TPM device file path, it is not a constant due to
 	// test usage.
@@ -1228,6 +1239,17 @@ func unsealDiskKeyLegacy(pcrSel tpm2.PCRSelection) ([]byte, error) {
 // protect the key on the CPU-TPM bus. Otherwise, it falls back to the
 // legacy unencrypted seal path.
 func SealDiskKey(log *base.LogObject, key []byte, pcrSel tpm2.PCRSelection) error {
+	// Never seal to firmware anchor PCRs that were left at their all-zero
+	// reset value. An all-zero PCR 0 or 4 means firmware did not extend the
+	// SHA-256 bank, so the value is forgeable by any code running after
+	// ExitBootServices (EVE's GRUB is unsigned) and the seal would provide
+	// no tamper protection.
+	if zeroed, err := unextendedCriticalPCRs(); err != nil {
+		return fmt.Errorf("checking firmware PCRs before sealing: %w", err)
+	} else if len(zeroed) > 0 {
+		return fmt.Errorf("refusing to seal disk key: firmware anchor PCR(s) %v are all-zero in the SHA-256 bank, measured-boot chain is not anchored (TPM Carte Blanche attack)", zeroed)
+	}
+
 	if tpmSupportsAES128CFB() {
 		log.Noticef("TPM supports AES-128-CFB, sealing with parameter encryption")
 		if err := sealDiskKeyEncrypted(log, key, pcrSel); err != nil {
@@ -1443,6 +1465,33 @@ func pcrBankSHA256EnabledHelper() bool {
 	//test is by reading PCR index 0 from SHA256 bank
 	_, err = tpm2.ReadPCR(rw, 0, tpm2.AlgSHA256)
 	return err == nil
+}
+
+// unextendedCriticalPCRs reads the critical firmware PCRs (criticalFirmwarePCRs)
+// from the SHA-256 bank and returns those still at their all-zero reset value.
+// An all-zero firmware PCR means firmware never extended the SHA-256 bank for it,
+// so the value can be reproduced (forged) by any code that runs after
+// ExitBootServices. Sealing to such a PCR provides no tamper protection
+// (TPM Carte Blanche attack).
+func unextendedCriticalPCRs() ([]int, error) {
+	rw, err := tpm2.OpenTPM(TpmDevicePath)
+	if err != nil {
+		return nil, err
+	}
+	defer rw.Close()
+
+	zero := make([]byte, sha256.Size)
+	zeroed := make([]int, 0, len(criticalFirmwarePCRs))
+	for _, idx := range criticalFirmwarePCRs {
+		val, err := tpm2.ReadPCR(rw, idx, tpm2.AlgSHA256)
+		if err != nil {
+			return nil, fmt.Errorf("reading PCR %d from SHA-256 bank: %w", idx, err)
+		}
+		if bytes.Equal(val, zero) {
+			zeroed = append(zeroed, idx)
+		}
+	}
+	return zeroed, nil
 }
 
 func backupCopiedMeasurementLogs() error {

--- a/pkg/pillar/evetpm/tpm_test.go
+++ b/pkg/pillar/evetpm/tpm_test.go
@@ -79,11 +79,67 @@ func TestDriveSessionKey(t *testing.T) {
 	}
 }
 
+// extendFirmwareAnchorPCRs extends the firmware anchor PCRs (criticalFirmwarePCRs,
+// i.e. 0 and 4) in the SHA-256 bank so SealDiskKey's TPM Carte Blanche guard is
+// satisfied, mimicking a platform where firmware measured the boot chain. Safe to
+// call more than once.
+func extendFirmwareAnchorPCRs(t *testing.T) {
+	t.Helper()
+	rw, err := tpm2.OpenTPM(TpmDevicePath)
+	if err != nil {
+		t.Fatalf("OpenTPM failed with err: %v", err)
+	}
+	defer rw.Close()
+
+	val := bytes.Repeat([]byte{0xA5}, sha256.Size)
+	for _, pcr := range criticalFirmwarePCRs {
+		if err := tpm2.PCRExtend(rw, tpmutil.Handle(pcr), tpm2.AlgSHA256, val, ""); err != nil {
+			t.Fatalf("Failed to extend firmware anchor PCR %d: %v", pcr, err)
+		}
+	}
+}
+
+func TestSealRefusesunextendedCriticalPCRs(t *testing.T) {
+	if !SimTpmAvailable() {
+		t.Skip("TPM is not available, skipping the test.")
+	}
+
+	// This refusal path only holds on a fresh TPM where the firmware anchor PCRs
+	// are still all-zero. Standard PCRs cannot be reset without a TPM restart, so
+	// if a prior test already extended them, skip rather than fail.
+	zeroed, err := unextendedCriticalPCRs()
+	if err != nil {
+		t.Fatalf("unextendedCriticalPCRs failed with err: %v", err)
+	}
+	if len(zeroed) == 0 {
+		t.Skip("firmware anchor PCRs already extended by a prior test; refusal path needs fresh PCRs")
+	}
+
+	// With all-zero firmware anchor PCRs, SealDiskKey must refuse to seal.
+	if err := SealDiskKey(logger, []byte("secret"), DefaultDiskKeySealingPCRs); err == nil {
+		t.Fatalf("SealDiskKey should refuse to seal against all-zero firmware PCRs, got nil")
+	}
+
+	// After extending the anchors, the guard is satisfied and sealing succeeds.
+	extendFirmwareAnchorPCRs(t)
+	if remaining, err := unextendedCriticalPCRs(); err != nil {
+		t.Fatalf("unextendedCriticalPCRs failed with err: %v", err)
+	} else if len(remaining) != 0 {
+		t.Fatalf("expected no all-zero firmware PCRs after extending, got %v", remaining)
+	}
+	if err := SealDiskKey(logger, []byte("secret"), DefaultDiskKeySealingPCRs); err != nil {
+		t.Fatalf("SealDiskKey failed after extending firmware anchor PCRs: %v", err)
+	}
+}
+
 func TestSealUnseal(t *testing.T) {
 	_, err := os.Stat(TpmDevicePath)
 	if err != nil {
 		t.Skip("TPM is not available, skipping the test.")
 	}
+
+	// firmware anchor PCRs must be extended or SealDiskKey refuses (TPM Carte Blanche attack)
+	extendFirmwareAnchorPCRs(t)
 
 	dataToSeal := []byte("secret")
 	if err := SealDiskKey(logger, dataToSeal, DefaultDiskKeySealingPCRs); err != nil {
@@ -110,6 +166,9 @@ func TestSealUnsealMismatchReport(t *testing.T) {
 		t.Fatalf("OpenTPM failed with err: %v", err)
 	}
 	defer rw.Close()
+
+	// firmware anchor PCRs must be extended or SealDiskKey refuses (TPM Carte Blanche attack)
+	extendFirmwareAnchorPCRs(t)
 
 	dataToSeal := []byte("secret")
 	if err := SealDiskKey(logger, dataToSeal, DefaultDiskKeySealingPCRs); err != nil {
@@ -141,6 +200,9 @@ func TestSealUnsealTpmEventLogCollect(t *testing.T) {
 		t.Fatalf("OpenTPM failed with err: %v", err)
 	}
 	defer rw.Close()
+
+	// firmware anchor PCRs must be extended or SealDiskKey refuses (TPM Carte Blanche attack)
+	extendFirmwareAnchorPCRs(t)
 
 	// this should write tpm event log to measurementLogSealSuccess file
 	dataToSeal := []byte("secret")


### PR DESCRIPTION
# Description

Harden SealDiskKey against the TPM Carte Blanche attack: firmware that
enables the SHA-256 PCR bank but never extends it leaves PCRs 0 and 4 at their
all-zero reset value. Because PCRs are extend-only from a known start, any
code running after ExitBootServices can extend those PCRs to arbitrary
values and replay a legitimate boot. As EVE ships an unsigned GRUB, an
attacker with local access can then swap the bootloader, replay the
expected PCR 8/9/13/14 measurements, and unseal the vault, with no network
or controller involvement.

Before sealing, read the firmware anchor PCRs (0 = firmware/S-CRTM version,
4 = boot manager/bootloader binary) from the SHA-256 bank and refuse to
seal if any is all-zero, so the disk key is never bound to a policy that
provides no tamper protection.

This is defense-in-depth on the EVE side. The primary fix belongs in
platform firmware, which must genuinely extend the SHA-256 bank for PCRs
0-4 and never leave them unmeasured.

Add TestSealRefusesUnextendedFirmwarePCRs covering both the refusal on
all-zero anchors and successful sealing once they carry measurements, and
extend the anchor PCRs in the existing SealDiskKey tests so they exercise a
realistic anchored boot state.

## PR dependencies

None.

## How to test and validate this PR

Unit test.

## Changelog notes

None.

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 16.0-stable
- 14.5-stable
- 13.4-stable

For example, if this PR fixes a bug in a feature that was introduced in 14.5,
you can write:

```text
- 16.0-stable: To be backported.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
