### PR TITLE
Fix pillar go routine leaks

### DIFF
--- a/pkg/pillar/base/execwrapper.go
+++ b/pkg/pillar/base/execwrapper.go
@@ -79,8 +79,10 @@ func (c *Command) execCommand() ([]byte, error) {
 		return nil, fmt.Errorf("execCommand(%v): error while starting command: %s", c.command.Args, err.Error())
 	}
 
-	// Use a channel to signal completion so we can use a select statement
-	done := make(chan error)
+	// Use a channel to signal completion so we can use a select statement.
+	// Buffered so the Wait() goroutine can always deliver its result and exit,
+	// even if execCommand already returned via the ctx-cancel or timeout branch.
+	done := make(chan error, 1)
 	go func() { done <- c.command.Wait() }()
 	stillRunning := time.NewTicker(25 * time.Second)
 	defer stillRunning.Stop()

--- a/pkg/pillar/cmd/monitor/ipc_server.go
+++ b/pkg/pillar/cmd/monitor/ipc_server.go
@@ -71,6 +71,7 @@ type ipcMessage struct {
 
 type monitorIPCServer struct {
 	codec *framed.ReadWriteCloser
+	conn  net.Conn // current client connection (used to tear down on replace)
 	// dataReady chan bool
 	ctx *monitor
 	sync.Mutex
@@ -90,38 +91,41 @@ func (s *monitorIPCServer) c() chan bool {
 }
 
 func (s *monitorIPCServer) handleConnection(conn net.Conn) {
-	s.Lock()
-	defer s.Unlock()
 	// the format of the frame is length + data
 	// where the length is 32 bit unsigned integer
-	s.codec = framed.NewReadWriteCloser(conn)
-	s.codec.EnableBigFrames()
+	codec := framed.NewReadWriteCloser(conn)
+	codec.EnableBigFrames()
+
+	s.Lock()
+	// Only one client is expected at a time. Close any previous connection so
+	// its reader goroutine (blocked in ReadFrame) exits instead of leaking.
+	if s.conn != nil {
+		s.conn.Close()
+	}
+	s.conn = conn
+	s.codec = codec
+	s.Unlock()
 
 	go func() {
-		defer s.close()
-		s.run()
+		defer conn.Close()
+		s.run(codec)
 	}()
 
 	// notify the monitor that the client is connected
 	s.ctx.clientConnected <- true
 }
 
-// close the server
-func (s *monitorIPCServer) close() {
-	s.codec.Close()
-}
-
 // main loop
-func (s *monitorIPCServer) run() {
+func (s *monitorIPCServer) run(codec *framed.ReadWriteCloser) {
 	// we never exit from the loop until the connection is closed
 	// other errors are logged and we continue
 	for {
 		// read request
-		req, err := s.readRequest()
+		req, err := s.readRequest(codec)
 		if err != nil {
 			log.Warnf("Error reading request: %v", err)
-			// exit if EOF
-			if errors.Is(err, io.EOF) {
+			// exit if the connection is closed (EOF) or torn down.
+			if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
 				return
 			}
 			continue
@@ -141,8 +145,8 @@ func (s *monitorIPCServer) run() {
 }
 
 // read request
-func (s *monitorIPCServer) readRequest() (*request, error) {
-	frame, err := s.codec.ReadFrame()
+func (s *monitorIPCServer) readRequest(codec *framed.ReadWriteCloser) (*request, error) {
+	frame, err := codec.ReadFrame()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pillar/cmd/zedrouter/appcontainer.go
+++ b/pkg/pillar/cmd/zedrouter/appcontainer.go
@@ -177,6 +177,8 @@ func (z *zedrouter) getAppContainerStats(cli *client.Client,
 		}
 
 		acStats, err := z.processAppContainerStats(stats, container, startTime)
+		// Close the stats body to release its connection and read goroutine.
+		stats.Body.Close()
 		if err != nil {
 			z.log.Errorf("getAppContainerStats: process stats for %s, error %v\n",
 				container.Names[0], err)
@@ -261,6 +263,8 @@ func (z *zedrouter) getAppContainerLogs(status types.AppNetworkStatus,
 		}
 
 		stdcopy.StdCopy(&buf, &buf, io.LimitReader(out, 100000))
+		// Close the log stream so its connection and read goroutine are freed.
+		out.Close()
 		logLines := strings.Split(buf.String(), "\n")
 		numlogs += len(logLines)
 		z.log.Tracef("getAppContainerLogs: container %s, lasttime %s, lines %d",
@@ -354,6 +358,7 @@ func (z *zedrouter) getIotEdgeMetricsAndLogs(status types.AppNetworkStatus,
 			err)
 		return
 	}
+	defer cli.Close()
 	*acNum += len(containers)
 
 	// collect container stats, and publish to zedclient

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -529,10 +529,13 @@ func (client *Client) CtrLogIOCreator(domainName string) cio.Creator {
 	pipeStdout, err := os.OpenFile(stdoutFile, os.O_WRONLY, 0)
 	if err != nil {
 		logrus.Errorf("CtrLogIOCreator: Error opening file %s with: %s", stdoutFile, err)
+		// Release the reader goroutine so it doesn't leak waiting for a writer.
+		unblockFifoReader(stdoutFile)
 	}
 	pipeStderr, err := os.OpenFile(stderrFile, os.O_WRONLY, 0)
 	if err != nil {
 		logrus.Errorf("CtrLogIOCreator: Error opening file %s with: %s", stderrFile, err)
+		unblockFifoReader(stderrFile)
 	}
 
 	// Create a fake stdin, so we won't break any interactive application

--- a/pkg/pillar/containerd/logging.go
+++ b/pkg/pillar/containerd/logging.go
@@ -114,6 +114,22 @@ func (r *remoteLog) Path(n string) string {
 	return path
 }
 
+// unblockFifoReader releases the reader goroutine started by remoteLog.Path,
+// which sits in a blocking O_RDONLY open until a writer opens the FIFO. The
+// intended writer is the container task, with CtrLogIOCreator opening the write
+// end as well. If that write-end open fails and the task never opens the FIFO
+// either, the reader goroutine would block forever and leak. Opening the FIFO
+// O_RDWR never blocks and completes the reader's pending open; closing it then
+// lets the reader observe EOF (no remaining writers) and exit cleanly.
+func unblockFifoReader(path string) {
+	fd, err := syscall.Open(path, syscall.O_RDWR|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		logrus.Errorf("unblockFifoReader: unable to open %s: %v", path, err)
+		return
+	}
+	syscall.Close(fd)
+}
+
 // Open a log file for the named service.
 func (r *remoteLog) Open(n string) (io.WriteCloser, error) {
 	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)

--- a/pkg/pillar/containerd/logging.go
+++ b/pkg/pillar/containerd/logging.go
@@ -1,4 +1,4 @@
-// This file is drived from the code available in linuxkit project under Apache License v2
+// This file is derived from the code available in linuxkit project under Apache License v2
 //    https://github.com/linuxkit/linuxkit/blob/master/pkg/init/cmd/service/logging.go
 
 package containerd

--- a/pkg/pillar/controllerconn/wstunnelclient.go
+++ b/pkg/pillar/controllerconn/wstunnelclient.go
@@ -49,6 +49,9 @@ type WSConnection struct {
 	ws              *websocket.Conn // websocket connection
 	tun             *WSTunnelClient // link back to tunnel
 	localConnection net.Conn        // connection to local relay
+	// done is closed when this connection is torn down, signalling
+	// per-connection goroutines (e.g. processResponses) to exit.
+	done chan struct{}
 }
 
 var wsWriterMutex sync.Mutex // mutex to allow a single goroutine to send a response at a time
@@ -71,12 +74,7 @@ func InitializeTunnelClient(log *base.LogObject, serverNameAndPort string, local
 // Start triggers workflow to establish the websocket
 // session with remote tunnel server
 func (t *WSTunnelClient) Start() {
-	log := t.log
-	log.Functionf("Creating %s at %s", "func", agentlog.GetMyStack())
-	go func() {
-		t.startSession()
-		<-make(chan struct{}, 0)
-	}()
+	t.startSession()
 }
 
 // TestConnection validates the configured parameters for correctness
@@ -186,7 +184,7 @@ func (t *WSTunnelClient) startSession() error {
 				}
 				t.retryOnFailCount++
 			} else {
-				t.conn = &WSConnection{ws: ws, tun: t}
+				t.conn = &WSConnection{ws: ws, tun: t, done: make(chan struct{})}
 				// Safety setting
 				ws.SetReadLimit(100 * 1024 * 1024)
 				// Request Loop
@@ -195,15 +193,14 @@ func (t *WSTunnelClient) startSession() error {
 				t.conn.handleRequests()
 				t.Connected = false
 			}
-			// check whether we need to exit
+			// Throttle reconnects, but return (not break) on Stop() so we
+			// exit the loop rather than just the select.
 			select {
 			case <-t.exitChan:
-				break
-			default: // non-blocking receive
+				timer.Stop()
+				return
+			case <-timer.C:
 			}
-
-			// ensure we don't open connections too rapidly,
-			<-timer.C
 		}
 	}()
 
@@ -213,7 +210,10 @@ func (t *WSTunnelClient) startSession() error {
 // Stop tunnel client
 func (t *WSTunnelClient) Stop() {
 	t.log.Function("Shutting down WS tunnel client and exiting.")
-	t.exitChan <- struct{}{}
+	// Close (not send) so every goroutine waiting on exitChan is released;
+	// a single send would wake only one. Stop() runs at most once per
+	// instance, so the close can't happen twice.
+	close(t.exitChan)
 }
 
 // handleRequests reads a request from the socket, then forks
@@ -263,6 +263,12 @@ func (wsc *WSConnection) handleRequests() {
 			log.Tracef("[id=%d] Encountered WS request to process with no payload", id)
 		}
 
+	}
+	// Connection is dead: signal per-connection goroutines to exit and drop
+	// the local relay connection so its fd isn't leaked.
+	close(wsc.done)
+	if wsc.localConnection != nil {
+		wsc.localConnection.Close()
 	}
 	// delay a few seconds to allow for writes to drain and then force-close the socket
 	log.Functionf("Creating %s at %s", "func", agentlog.GetMyStack())
@@ -420,7 +426,18 @@ func (wsc *WSConnection) processResponses() {
 
 	var id int64
 	ticker := time.NewTicker(100 * time.Millisecond)
-	for range ticker.C {
+	defer ticker.Stop()
+	for {
+		// Exit when this connection is torn down (wsc.done) or the tunnel is
+		// stopped (exitChan); return rather than break to leave the loop.
+		select {
+		case <-wsc.done:
+			return
+		case <-wsc.tun.exitChan:
+			return
+		case <-ticker.C:
+		}
+
 		responseBuffer := make([]byte, 524288)
 		wsc.localConnection.SetReadDeadline(time.Now().Add(90 * time.Millisecond))
 		num, _ := wsc.localConnection.Read(responseBuffer)
@@ -430,13 +447,6 @@ func (wsc *WSConnection) processResponses() {
 
 			wsc.writeResponseMessage(id, bytes.NewBuffer(response))
 			id++
-		}
-
-		// check whether we need to exit
-		select {
-		case <-wsc.tun.exitChan:
-			break
-		default: // non-blocking receive
 		}
 	}
 }

--- a/pkg/pillar/hardware/leds.go
+++ b/pkg/pillar/hardware/leds.go
@@ -359,29 +359,38 @@ func maxLEDBrightness(log *base.LogObject, ledName string) []byte {
 	return []byte("1")
 }
 
+// startBlink creates the stop/ack channels and launches the blink goroutine.
+// The channels are created here (synchronously, in the caller's goroutine)
+// rather than inside executeBlinkLoop so that ctx.BlinkSendStop/BlinkRecvStop
+// are guaranteed to be set as soon as this returns. The ledmanager handler
+// decides whether to stop a running blink loop by checking
+// ctx.BlinkSendStop != nil; if those fields were only set asynchronously from
+// within the goroutine, two closely-spaced updates could both observe them as
+// nil, spawn two blink goroutines, and leak one of them on the unbuffered
+// BlinkRecvStop send (also risking a send on a closed channel).
+func startBlink(log *base.LogObject, ctx *BlinkContext, color string, leds []string) {
+	// sendStop is closed by the sender to request a stop; recvStop is used by
+	// the receiver to acknowledge.
+	sendStop := make(chan string, 1)
+	recvStop := make(chan string)
+	ctx.BlinkSendStop = sendStop
+	ctx.BlinkRecvStop = recvStop
+	go executeBlinkLoop(log, color, leds, sendStop, recvStop)
+}
+
 // Execute blink forever until there is a message to stop
-func executeBlinkLoop(log *base.LogObject, ctx *BlinkContext, color string, leds []string) {
+func executeBlinkLoop(log *base.LogObject, color string, leds []string,
+	sendStop, recvStop chan string) {
 
 	log.Functionf("Started blink thread for color %s", color)
-	// Both of these channels are created here. This routine is considered as a receiver.
-	// But closing of these channels happens as follows:
-	// blinkSendStop will be closed by the sender and that signal is received by this routine to exit the loop
-	// blinkRecvStop will be closed by the sender after this routine sends done message.
-	ctx.BlinkRecvStop = make(chan string)
-	ctx.BlinkSendStop = make(chan string, 1)
-	var ok, valid bool
 	for {
-
 		select {
-		case _, valid = <-ctx.BlinkSendStop:
-			ok = true
+		case _, valid := <-sendStop:
+			if !valid { // channel closed -> stop requested
+				recvStop <- "done"
+				return
+			}
 		default:
-			ok = false
-		}
-
-		if ok && !valid { // This channel was closed
-			ctx.BlinkRecvStop <- "done"
-			return
 		}
 
 		switch color {
@@ -398,16 +407,11 @@ func executeBlinkLoop(log *base.LogObject, ctx *BlinkContext, color string, leds
 			doLedAction(log, leds[0], true) // Green on
 			time.Sleep(200 * time.Millisecond)
 		default:
-			log.Noticef("Unsupported Color")
-			close(ctx.BlinkRecvStop)
-			close(ctx.BlinkSendStop)
-			ctx.BlinkRecvStop = nil
-			ctx.BlinkSendStop = nil
+			// Only Orange and Green are ever started blinking, so unreachable.
+			log.Noticef("Unsupported blink color %s", color)
 			return
 		}
-
 	}
-
 }
 
 // ExecuteAppStatusDisplayFunc sets the appStatusArgs
@@ -421,14 +425,14 @@ func ExecuteAppStatusDisplayFunc(log *base.LogObject, ctx *BlinkContext, appStat
 		doLedAction(log, appStatusArgs[0], true) // Green on
 		doLedAction(log, appStatusArgs[1], true) // Red on
 		if blink == true {
-			go executeBlinkLoop(log, ctx, "Orange", appStatusArgs)
+			startBlink(log, ctx, "Orange", appStatusArgs)
 		}
 
 	case "Green": // Green can blink or solid
 		doLedAction(log, appStatusArgs[1], false) // Red off
 		doLedAction(log, appStatusArgs[0], true)  // Green on
 		if blink == true {
-			go executeBlinkLoop(log, ctx, "Green", appStatusArgs)
+			startBlink(log, ctx, "Green", appStatusArgs)
 		}
 	default: // Turn off both red and green
 		doLedAction(log, appStatusArgs[0], false)

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -2334,7 +2334,9 @@ func makeRequestAsync(client *http.Client, endpoint, id string, rChan chan<- vtp
 }
 
 func makeRequest(client *http.Client, wk *procutils.WatchdogKicker, endpoint, id string) (body string, err error) {
-	rChan := make(chan vtpmRequestResult)
+	// Buffered so makeRequestAsync can always deliver its result and exit,
+	// even after this function returns via the timeout branch below.
+	rChan := make(chan vtpmRequestResult, 1)
 	go makeRequestAsync(client, endpoint, id, rChan)
 
 	startTime := time.Now()


### PR DESCRIPTION
# Description

This PR fixes a set of **goroutine leaks** found across `pkg/pillar`. In each case goroutines could accumulate over the device's lifetime (per exec, per vTPM request, per remote-console reconnect, per stats-collection cycle, per app-status change, per IPC reconnect, per container-log setup, or per boot event), which over time wastes memory and file descriptors and, on the device-management agents, can eventually threaten stability.

Each fix is a separate commit:

- **base/execwrapper**: the `Wait()` goroutine sent its result on an unbuffered channel that the timeout/cancel branches abandon, blocking it forever on every timed-out or cancelled `Exec`. Buffered the channel.
- **hypervisor/kvm**: `makeRequestAsync` sent on an unbuffered channel abandoned by `makeRequest` after its timeout, leaking a goroutine per timed-out vTPM request. Buffered the channel.
- **controllerconn (WS tunnel client)**: fixed several leaks that accumulated on every remote-console enable/reconnect cycle — a permanently parked `Start()` goroutine, a `Stop()` that only woke one of several waiters, two `break`-inside-`select` bugs that never broke their loops, an unstopped ticker, and a `processResponses` goroutine with no per-connection exit.
- **zedrouter**: the IoT-Edge app-stats collector created a fresh docker client every cycle and never closed it or the `ContainerStats`/`ContainerLogs` response bodies, leaking connections and their net/http goroutines. Close them.
- **hardware/leds**: the blink loop published its stop channels asynchronously from inside the goroutine, so two closely-spaced app-status updates could spawn two blink goroutines and orphan one (also risking a send on a closed channel). Create the channels synchronously before launching the goroutine.
- **monitor (IPC server)**: connections shared a single codec and the reader had no exit when a client went idle or was replaced, leaking a goroutine per reconnect. Use a per-connection codec, tear down the previous connection, and exit on EOF/closed.
- **containerd**: the log-FIFO reader goroutine blocks in a blocking `O_RDONLY` open until a writer appears; if the writer open failed it blocked forever. Release the reader when the write end fails to open.
- **zedkube**: the boot-up uncordon watcher was guarded by a flag set only from inside the watcher, so a burst of `EdgeNodeInfo` updates could launch several watchers (and race on the flag). Set the guard synchronously before spawning.

## How to test and validate this PR

These are hard to exercise directly on hardware; validation is primarily via review and existing unit tests. Suggested checks:

- **Unit tests / build**: `make -C pkg/pillar test` and `make -C pkg/pillar vet` pass. Affected packages (`base`, `hypervisor`, `controllerconn`, `zedrouter`, `hardware`, `monitor`, `containerd`, `zedkube`) build and their existing tests pass locally (including the `kubevirt` build tag for `zedkube`).
- **Goroutine-count observation** (optional, on a running device): capture `/persist/agentdebug/*/sigusr1` (or the agent's stack dump) or the goroutine count exposed by the agents before/after exercising the relevant flow, and confirm it no longer grows:
  - *controllerconn*: repeatedly enable/disable remote console on an app instance and let the websocket reconnect; goroutine count should return to baseline.
  - *zedrouter*: deploy an IoT-Edge app with `GetStatsIPAddr` set and let stats collection run for many cycles; connection/goroutine count should stay flat.
  - *monitor*: connect and disconnect the TUI to `/run/monitor.sock` repeatedly.
  - *base/execwrapper* & *hypervisor*: force exec/vTPM-request timeouts and confirm no accumulation.
- No new automated tests were added (the fixes are lifecycle corrections in existing code paths).

## Changelog notes

Fixed several goroutine leaks in EVE device services that could slowly consume memory and file descriptors over long uptimes; improves long-term stability. No user-facing behavior changes.

## PR Backports

These are latent bugs present in the affected code on the stable branches; the leaks are low-rate but long-lived, so backporting is reasonable where the code exists. Please confirm per branch:

```text
- 17.0: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported (for the fixes whose code is present there).
- 13.4-stable: To be backported (for the fixes whose code is present there).
```

(Add the `stable` label if these are accepted for backport.)

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — N/A (bug fixes, no doc changes)
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
