### PR TITLE
zedmanager: defer apps only while hi-pri apps boot

### DIFF
--- a/pkg/pillar/activeapp/activeapp.go
+++ b/pkg/pillar/activeapp/activeapp.go
@@ -43,11 +43,16 @@ func DelLocalAppActiveFile(log *base.LogObject, appUUID string) {
 
 // LoadActiveAppInstanceUUIDs reads all JSON files from the specified directory,
 // extracts the UUID from each filename (by removing the ".json" extension),
-// and returns a slice of UUIDs.
+// and returns a slice of UUIDs. A missing directory is not an error: it is the
+// normal state before any app instance has become active, and is reported as an
+// empty list.
 func LoadActiveAppInstanceUUIDs(log *base.LogObject) ([]string, error) {
 	// Read all directory entries using os.ReadDir.
 	entries, err := os.ReadDir(types.LocalActiveAppConfigDir)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/pkg/pillar/cmd/zedmanager/boot_priority_failure_test.go
+++ b/pkg/pillar/cmd/zedmanager/boot_priority_failure_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2025-2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zedmanager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+// This test is deliberately written against countRunningAppsForUUIDs and the
+// startup-timeout condition only, so the same source compiles and runs on both
+// the unmodified master tree and this change. It documents that a high-priority
+// app that fails to boot does not count as running, and that low-priority apps
+// are therefore released by the startup timeout rather than blocked forever.
+
+const failedHighPriApp = "6ba7b810-9dad-11d1-80b4-00c04fd430f1"
+
+// newBootPriorityContext builds a zedmanagerContext whose subAppInstanceStatus
+// is a memory-backed subscription populated with the given app states.
+func newBootPriorityContext(t *testing.T, states map[string]types.SwState, delayBaseTime time.Time) *zedmanagerContext {
+	t.Helper()
+	logger := logrus.StandardLogger()
+	log = base.NewSourceLogObject(logger, agentName, 0)
+	ps := pubsub.New(pubsub.NewMemoryDriver(), logger, log)
+
+	pub, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.AppInstanceStatus{},
+	})
+	assert.NoError(t, err)
+	for u, state := range states {
+		id, err := uuid.FromString(u)
+		assert.NoError(t, err)
+		status := types.AppInstanceStatus{
+			UUIDandVersion: types.UUIDandVersion{UUID: id, Version: "1"},
+			State:          state,
+		}
+		assert.NoError(t, pub.Publish(status.Key(), status))
+	}
+	sub, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:  agentName,
+		TopicImpl:  types.AppInstanceStatus{},
+		Persistent: true,
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, sub.Activate())
+
+	return &zedmanagerContext{
+		subAppInstanceStatus: sub,
+		delayBaseTime:        delayBaseTime,
+	}
+}
+
+// releaseLowPriority mirrors the low-priority release condition: release once
+// all high-priority apps are running, or the startup window has expired. On
+// master this is the condition inside checkLowPriorityApps; on this change the
+// equivalent is !highPriorityAppsPending.
+func releaseLowPriority(ctx *zedmanagerContext, active map[string]struct{}) bool {
+	running := countRunningAppsForUUIDs(ctx, active)
+	return running >= uint(len(active)) ||
+		time.Now().After(ctx.delayBaseTime.Add(waitForAppsToStartTimeout))
+}
+
+// TestFailedHighPriorityAppDoesNotBlockForever models an app that was active
+// before the reboot (high priority) and had an app-direct adapter, eth2, which
+// is gone after the reboot. DomainStatus for it never reaches a running state,
+// so it stays in a failed/non-running state. Low-priority apps must not be held
+// forever: the startup timeout releases them.
+func TestFailedHighPriorityAppDoesNotBlockForever(t *testing.T) {
+	active := map[string]struct{}{failedHighPriApp: {}}
+
+	// A failed high-priority app can settle in different non-running states
+	// depending on where boot failed (device model died -> BROKEN; never got
+	// far enough to boot because the adapter is missing -> INSTALLED).
+	for _, failState := range []types.SwState{types.BROKEN, types.INSTALLED} {
+		t.Run(failState.String(), func(t *testing.T) {
+			// Startup window still open: the app is not running and the timeout
+			// has not passed, so low-priority apps stay held.
+			ctxOpen := newBootPriorityContext(t,
+				map[string]types.SwState{failedHighPriApp: failState}, time.Now())
+			assert.Equal(t, uint(0), countRunningAppsForUUIDs(ctxOpen, active),
+				"a failed high-priority app must not count as running")
+			assert.False(t, releaseLowPriority(ctxOpen, active),
+				"low-priority apps stay held while the startup window is open")
+
+			// Startup window expired: low-priority apps are released even though
+			// the high-priority app never started - i.e. not blocked forever.
+			ctxExpired := newBootPriorityContext(t,
+				map[string]types.SwState{failedHighPriApp: failState},
+				time.Now().Add(-2*waitForAppsToStartTimeout))
+			assert.True(t, releaseLowPriority(ctxExpired, active),
+				"low-priority apps are released once the startup window expires")
+		})
+	}
+}

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/lf-edge/eve/pkg/pillar/activeapp"
 	"github.com/lf-edge/eve/pkg/pillar/hypervisor"
 	uuid "github.com/satori/go.uuid"
 
@@ -187,23 +186,12 @@ func doUpdate(ctx *zedmanagerContext,
 		}
 	}
 
-	// Check if the App is low priority.
-	// Load the UUIDs of the apps that were previously (before the reboot) in the ACTIVE state.
-	var hasPriority bool
-	activeAppsUUIDs, err := activeapp.LoadActiveAppInstanceUUIDs(log)
-	if err != nil {
-		log.Warningf("checkLowPriorityApps: failed to load active app instance UUIDs: %v", err)
-		activeAppsUUIDs = []string{} // Fallback to an empty list
-	}
-	// Check if the app is in the active list
-	log.Functionf("Processing AppInstanceConfig for app with UUID: %s", config.UUIDandVersion.UUID.String())
-	for _, uuid := range activeAppsUUIDs {
-		log.Functionf("active app instance UUID: %s", uuid)
-		if uuid == config.UUIDandVersion.UUID.String() {
-			hasPriority = true
-		}
-	}
-	if !hasPriority && !status.NoBootPriority {
+	// An app that was not active before the reboot is low-priority, but it is
+	// only held back while high-priority apps are still coming up. Outside that
+	// window (steady state, or no high-priority apps at all) it starts at once.
+	activeMap := loadActiveAppInstanceMap()
+	_, hasPriority := activeMap[config.UUIDandVersion.UUID.String()]
+	if !hasPriority && !status.NoBootPriority && highPriorityAppsPending(ctx, activeMap) {
 		log.Functionf("low priority app %s", uuidStr)
 		status.NoBootPriority = true
 		return true

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -71,6 +71,10 @@ type zedmanagerContext struct {
 	currentTotalMemoryMB      uint64
 	// The time from which the configured applications delays should be counted
 	delayBaseTime time.Time
+	// priorityStartTimer fires once, waitForAppsToStartTimeout after
+	// delayBaseTime, to release low-priority apps even if the high-priority
+	// apps never reach a running state (e.g. they failed to start).
+	priorityStartTimer *time.Timer
 	// cli options
 	// hypervisorPtr is the name of the hypervisor to use
 	hypervisorPtr      *string
@@ -452,7 +456,15 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	// The ticker that triggers a check for the applications in the START_DELAYED state
 	delayedStartTicker := time.NewTicker(1 * time.Second)
-	priorityStartTicker := time.NewTicker(5 * time.Second)
+
+	// Low-priority apps are released by an event: either a high-priority app
+	// reaching a running state (observed via subAppInstanceStatus below) or the
+	// priorityStartTimer expiring. Create it stopped; it is armed when
+	// delayBaseTime is first set in handleZedAgentStatusImpl.
+	ctx.priorityStartTimer = time.NewTimer(waitForAppsToStartTimeout)
+	if !ctx.priorityStartTimer.Stop() {
+		<-ctx.priorityStartTimer.C
+	}
 
 	log.Functionf("Handling all inputs")
 	for {
@@ -483,6 +495,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 		case change := <-subAppInstanceStatus.MsgChan():
 			subAppInstanceStatus.ProcessChange(change)
+			// A high-priority app may have just reached a running state; this
+			// is the point where subAppInstanceStatus reflects it, so re-check
+			// whether low-priority apps can now be released.
+			checkLowPriorityApps(&ctx)
 
 		case change := <-subVolumesSnapshotStatus.MsgChan():
 			subVolumesSnapshotStatus.ProcessChange(change)
@@ -510,7 +526,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		case <-delayedStartTicker.C:
 			checkDelayedStartApps(&ctx)
 
-		case <-priorityStartTicker.C:
+		case <-ctx.priorityStartTimer.C:
 			checkLowPriorityApps(&ctx)
 		case <-stillRunning.C:
 		}
@@ -627,6 +643,18 @@ func highPriorityAppsPending(ctx *zedmanagerContext, activeMap map[string]struct
 	return countRunningAppsForUUIDs(ctx, activeMap) < uint(len(activeMap))
 }
 
+// hasPendingLowPriorityApps reports whether any app instance is currently held
+// back waiting for high-priority apps. It is a cheap guard so the release check
+// can be driven by status-change events without doing real work on every one.
+func hasPendingLowPriorityApps(ctx *zedmanagerContext) bool {
+	for _, s := range ctx.subAppInstanceStatus.GetAll() {
+		if s.(types.AppInstanceStatus).NoBootPriority {
+			return true
+		}
+	}
+	return false
+}
+
 // loadActiveAppInstanceMap returns the set of app instance UUIDs that were
 // active before the last reboot. A load failure is treated as an empty set.
 func loadActiveAppInstanceMap() map[string]struct{} {
@@ -646,6 +674,9 @@ func loadActiveAppInstanceMap() map[string]struct{} {
 // If all the High priority apps are running or the timeout has expired, then
 // we can start the Low priority apps.
 func checkLowPriorityApps(ctx *zedmanagerContext) {
+	if !hasPendingLowPriorityApps(ctx) {
+		return
+	}
 	activeMap := loadActiveAppInstanceMap()
 	log.Functionf("check low priority apps: %v", activeMap)
 	if highPriorityAppsPending(ctx, activeMap) {
@@ -1730,6 +1761,11 @@ func handleZedAgentStatusImpl(ctxArg interface{}, key string,
 	if status.ConfigGetStatus == types.ConfigGetSuccess || status.ConfigGetStatus == types.ConfigGetReadSaved {
 		if ctxPtr.delayBaseTime.IsZero() {
 			ctxPtr.delayBaseTime = time.Now()
+			// Arm the fallback that releases low-priority apps once the
+			// startup window closes. The extra margin keeps the timer from
+			// firing a hair before highPriorityAppsPending sees the deadline
+			// as passed, which would leave apps held with no further wakeup.
+			ctxPtr.priorityStartTimer.Reset(waitForAppsToStartTimeout + time.Second)
 		}
 	}
 

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -612,35 +612,56 @@ func checkDelayedStartApps(ctx *zedmanagerContext) {
 	}
 }
 
+// highPriorityAppsPending reports whether any high-priority app instance (one
+// that was active before the last reboot, listed in activeMap) has yet to reach
+// a running state while the post-boot startup window is still open. Low-priority
+// apps are held back only while this holds, so that high-priority apps get
+// resources first; once it returns false there is nothing left to wait for.
+func highPriorityAppsPending(ctx *zedmanagerContext, activeMap map[string]struct{}) bool {
+	if len(activeMap) == 0 {
+		return false
+	}
+	if time.Now().After(ctx.delayBaseTime.Add(waitForAppsToStartTimeout)) {
+		return false
+	}
+	return countRunningAppsForUUIDs(ctx, activeMap) < uint(len(activeMap))
+}
+
+// loadActiveAppInstanceMap returns the set of app instance UUIDs that were
+// active before the last reboot. A load failure is treated as an empty set.
+func loadActiveAppInstanceMap() map[string]struct{} {
+	activeAppsUUIDs, err := activeapp.LoadActiveAppInstanceUUIDs(log)
+	if err != nil {
+		log.Warningf("loadActiveAppInstanceMap: failed to load active app instance UUIDs: %v", err)
+	}
+	activeMap := make(map[string]struct{}, len(activeAppsUUIDs))
+	for _, uuid := range activeAppsUUIDs {
+		activeMap[uuid] = struct{}{}
+	}
+	return activeMap
+}
+
 // Handle the applications in Low Priority state ready to be started.
 // Get the list of the Apps in High priority state and check if they are running.
 // If all the High priority apps are running or the timeout has expired, then
 // we can start the Low priority apps.
 func checkLowPriorityApps(ctx *zedmanagerContext) {
-	activeAppsUUIDs, err := activeapp.LoadActiveAppInstanceUUIDs(log)
-	if err != nil {
-		log.Warningf("checkLowPriorityApps: failed to load active app instance UUIDs: %v", err)
-		activeAppsUUIDs = []string{} // Fallback to an empty list
-	}
-	activeMap := make(map[string]struct{})
-	for _, uuid := range activeAppsUUIDs {
-		activeMap[uuid] = struct{}{}
-	}
+	activeMap := loadActiveAppInstanceMap()
 	log.Functionf("check low priority apps: %v", activeMap)
-	runningCount := countRunningAppsForUUIDs(ctx, activeMap)
-	if runningCount >= uint(len(activeMap)) || time.Now().After(ctx.delayBaseTime.Add(waitForAppsToStartTimeout)) {
-		configs := ctx.subAppInstanceConfig.GetAll()
-		for _, c := range configs {
-			config := c.(types.AppInstanceConfig)
-			if localConfig := lookupLocalAppInstanceConfig(ctx, config.Key()); localConfig != nil {
-				config = *localConfig
-			}
-			status := lookupAppInstanceStatus(ctx, config.Key())
-			if status != nil && status.NoBootPriority {
-				doUpdate(ctx, config, status)
-				status.NoBootPriority = false
-				publishAppInstanceStatus(ctx, status)
-			}
+	if highPriorityAppsPending(ctx, activeMap) {
+		return
+	}
+	configs := ctx.subAppInstanceConfig.GetAll()
+	for _, c := range configs {
+		config := c.(types.AppInstanceConfig)
+		if localConfig := lookupLocalAppInstanceConfig(ctx, config.Key()); localConfig != nil {
+			config = *localConfig
+		}
+		status := lookupAppInstanceStatus(ctx, config.Key())
+		if status != nil && status.NoBootPriority {
+			doUpdate(ctx, config, status)
+			status.NoBootPriority = false
+			publishAppInstanceStatus(ctx, status)
 		}
 	}
 }

--- a/pkg/pillar/cmd/zedmanager/zedmanager_test.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2025-2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zedmanager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+// appStatus is a minimal AppInstanceStatus fixture: a UUID and a SwState are all
+// highPriorityAppsPending / countRunningAppsForUUIDs look at.
+type appStatus struct {
+	uuid  string
+	state types.SwState
+}
+
+// newPendingTestContext builds a zedmanagerContext whose subAppInstanceStatus is
+// backed by an in-process memory driver populated with the given statuses.
+func newPendingTestContext(t *testing.T, statuses []appStatus, delayBaseTime time.Time) *zedmanagerContext {
+	t.Helper()
+	logger := logrus.StandardLogger()
+	log = base.NewSourceLogObject(logger, agentName, 0)
+	ps := pubsub.New(pubsub.NewMemoryDriver(), logger, log)
+
+	pub, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.AppInstanceStatus{},
+	})
+	assert.NoError(t, err)
+	for _, s := range statuses {
+		u, err := uuid.FromString(s.uuid)
+		assert.NoError(t, err)
+		status := types.AppInstanceStatus{
+			UUIDandVersion: types.UUIDandVersion{UUID: u, Version: "1"},
+			State:          s.state,
+		}
+		assert.NoError(t, pub.Publish(status.Key(), status))
+	}
+
+	// Persistent makes Activate populate the subscription from the shared store
+	// synchronously, so GetAll reflects the published statuses without pumping
+	// the change channel.
+	sub, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:  agentName,
+		TopicImpl:  types.AppInstanceStatus{},
+		Persistent: true,
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, sub.Activate())
+
+	return &zedmanagerContext{
+		subAppInstanceStatus: sub,
+		delayBaseTime:        delayBaseTime,
+	}
+}
+
+func activeSet(uuids ...string) map[string]struct{} {
+	m := make(map[string]struct{}, len(uuids))
+	for _, u := range uuids {
+		m[u] = struct{}{}
+	}
+	return m
+}
+
+const (
+	appA = "6ba7b810-9dad-11d1-80b4-00c04fd430a1"
+	appB = "6ba7b810-9dad-11d1-80b4-00c04fd430a2"
+)
+
+// TestHighPriorityAppsPending checks when low-priority apps are held back.
+// The decisive property for a failed high-priority app is that error/terminal
+// states (e.g. BROKEN) do not count as running, so a high-priority app that
+// never reaches RUNNING keeps low-priority apps waiting only until the startup
+// window expires — after which they are released regardless.
+func TestHighPriorityAppsPending(t *testing.T) {
+	// A delayBaseTime of now leaves the startup window open; a time older than
+	// the timeout has it already expired.
+	windowOpen := time.Now()
+	windowExpired := time.Now().Add(-2 * waitForAppsToStartTimeout)
+
+	tests := []struct {
+		name          string
+		statuses      []appStatus
+		active        map[string]struct{}
+		delayBaseTime time.Time
+		wantPending   bool
+	}{
+		{
+			name:          "no high-priority apps",
+			statuses:      []appStatus{{appA, types.RUNNING}},
+			active:        activeSet(),
+			delayBaseTime: windowOpen,
+			wantPending:   false,
+		},
+		{
+			name:          "all high-priority apps running",
+			statuses:      []appStatus{{appA, types.RUNNING}, {appB, types.BOOTING}},
+			active:        activeSet(appA, appB),
+			delayBaseTime: windowOpen,
+			wantPending:   false,
+		},
+		{
+			name:          "one high-priority app not yet started",
+			statuses:      []appStatus{{appA, types.RUNNING}, {appB, types.INSTALLED}},
+			active:        activeSet(appA, appB),
+			delayBaseTime: windowOpen,
+			wantPending:   true,
+		},
+		{
+			name:          "window expired releases despite pending app",
+			statuses:      []appStatus{{appA, types.RUNNING}, {appB, types.INSTALLED}},
+			active:        activeSet(appA, appB),
+			delayBaseTime: windowExpired,
+			wantPending:   false,
+		},
+		{
+			name:          "failed high-priority app holds until window open",
+			statuses:      []appStatus{{appA, types.BROKEN}},
+			active:        activeSet(appA),
+			delayBaseTime: windowOpen,
+			wantPending:   true,
+		},
+		{
+			name:          "failed high-priority app released after window",
+			statuses:      []appStatus{{appA, types.BROKEN}},
+			active:        activeSet(appA),
+			delayBaseTime: windowExpired,
+			wantPending:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newPendingTestContext(t, tt.statuses, tt.delayBaseTime)
+			assert.Equal(t, tt.wantPending, highPriorityAppsPending(ctx, tt.active))
+		})
+	}
+}


### PR DESCRIPTION
# Description

I got fed up by Claude Code spending 15 minutes being distracted by the Warning-level logs caused by this so I asked for a fix. 

An app instance that was not active before the last reboot is treated as low
priority and held back until the previously-active (high-priority) apps have
started. Two problems with how this worked:

1. The deferral was applied unconditionally — **every** app deployed after boot
   was marked `NoBootPriority` and only released on the next poll, adding start
   latency even when no high-priority app was still coming up. It also logged a
   warning every 5 seconds whenever `/persist/vault/active-app-instance-config`
   did not yet exist (the normal state before any app has ever been active, or
   before the vault is mounted).
2. The release ran as a 5-second poll for the life of the device, even though it
   only has work to do during the post-boot startup window.

**First commit** — deferral now applies only while there are high-priority apps
that have not yet reached a running state and the startup window is still open;
outside that window, or with no high-priority apps, an app starts immediately. A
missing active-app directory is treated as an empty set instead of an error,
removing the periodic warning. The hold/release decision is shared between the
release path and the per-app update path so they cannot drift.

**Second commit** — the 5-second poll is replaced by events: a re-check whenever
an app instance status changes (when a high-priority app reaching a running
state becomes visible) plus a single timer armed for the startup timeout. A
cheap guard skips the check unless an app is actually held back, so status
changes cost almost nothing in steady state.

A high-priority app that fails and never reaches a running state — e.g. one that
was active before the reboot with an app-direct adapter (say `eth2`) that is now
absent, so its `DomainStatus` ends in a failed state — does not satisfy the
wait. It is never counted as running, so the event path alone would hold
low-priority apps indefinitely; the timer releases them once the startup window
(`waitForAppsToStartTimeout`, 5 min) closes.

`NoBootPriority` is internal to zedmanager and not reported to the controller,
so the change has no external effect.

## Recommendation on the two commits

Commit 1 is the one we should land at a minimum: it removes the log noise (the every-5-second warning about the missing active-app directory). Commit 2 is not required for that, but seems worth taking too — it avoids delaying the boot of newly deployed app instances and removes the periodic, mostly-unneeded polling work.

## How to test and validate this PR

Two unit tests in `pkg/pillar/cmd/zedmanager`:

- `TestHighPriorityAppsPending` drives the hold/release decision through a
  memory-backed pubsub subscription: no high-priority apps, all running, one
  still starting, window expired, and a failed (BROKEN) high-priority app.
- `TestFailedHighPriorityAppDoesNotBlockForever` models the missing-adapter
  case (high-priority app ends in BROKEN/INSTALLED, never running) and asserts
  it is not counted as running and that low-priority apps are released once the
  startup window expires. It is written to compile and pass on both master and
  this branch, confirming the "not blocked forever" property in both.

Manual: on a device that has never had an active app, confirm zedmanager no
longer logs `failed to load active app instance UUIDs` every 5 seconds, and that
an app deployed in steady state moves toward RUNNING without an extra hold.

## Changelog notes

None. Internal log-noise and startup-latency fix with no user-facing change.

## PR Backports

Not needed — log/performance fix with no user-visible behavior change.

- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [x] I've written the test verification instructions

