### PR TITLE
docs: bootstrap VLAN must stay up for OS updates

### DIFF
--- a/docs/DEVICE-CONNECTIVITY.md
+++ b/docs/DEVICE-CONNECTIVITY.md
@@ -771,6 +771,23 @@ EVE publishes the following information to the controller:
   EAPOL-Start and EAPOL-Logoff frames, EAP-Request/Response frames, and counts of invalid
   or malformed frames.
 
+### Availability during EVE-OS updates
+
+On networks that gate management access with 802.1X, the non-authenticated
+(bootstrap) VLAN described above must remain available not only for initial
+enrollment but also across EVE-OS updates. An update changes the measured-boot
+PCR values, so the device's TPM can no longer locally unseal the vault key: the
+device must reach the controller to complete remote attestation and receive the
+encrypted backup key before it can unlock the vault (see
+[Encrypted Data Store](SECURITY-ARCHITECTURE.md#encrypted-data-store)). Because
+the 802.1X client certificate's private key is itself kept in the vault, the
+port cannot be authenticated until *after* the vault is unlocked — so this
+controller round-trip depends entirely on the bootstrap VLAN, exactly as during
+first enrollment. If the network does not give unauthenticated EVE devices
+connectivity to the controller, a device that reboots into an updated image
+cannot complete attestation, cannot unlock its vault, and loses controller
+connectivity until the network is reconfigured.
+
 ## Air-Gap Mode
 
 Air-Gap mode allows a device to operate without connectivity to the main controller,


### PR DESCRIPTION
# Description

Documentation only. Adds a short note to the 802.1X / SCEP section of
`docs/DEVICE-CONNECTIVITY.md` clarifying that the non-authenticated (bootstrap)
VLAN must remain available across EVE-OS updates, not just for initial
enrollment.

An update changes the measured-boot PCRs, so the vault key can only be recovered
through a controller round-trip (remote attestation + encrypted backup key, per
`SECURITY-ARCHITECTURE.md`). Because the 802.1X client private key is itself kept
in the vault, the port cannot be authenticated until after the vault is unlocked
— so that round-trip must go over the bootstrap VLAN. Without unauthenticated
controller connectivity, a device rebooting into an updated image cannot unlock
its vault.

No code changes.

## How to test and validate this PR

Docs only — render and review the changed section in `docs/DEVICE-CONNECTIVITY.md`.

## Changelog notes

No user-facing changes (documentation only).

## PR Backports

- 16.0-stable: No — documentation only.
- 14.5-stable: No — documentation only.
- 13.4-stable: No — documentation only.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device (N/A — docs only)
- [ ] I've tested my PR on arm64 device (N/A — docs only)
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
