### PR TITLE
dpcreconciler: drop alternativeMAC

### DIFF
--- a/pkg/pillar/dpcreconciler/linuxitems/adapter.go
+++ b/pkg/pillar/dpcreconciler/linuxitems/adapter.go
@@ -184,34 +184,27 @@ func (c *AdapterConfigurator) Create(ctx context.Context, item depgraph.Item) er
 		c.Log.Error(err)
 		return err
 	}
-	// Make sure the ethernet interface is DOWN before renaming
-	// and changing the MAC address, otherwise we get error
-	// `Device or resource busy`.
+	// Make sure the ethernet interface is DOWN before renaming,
+	// otherwise we get error `Device or resource busy`.
 	if err := netlink.LinkSetDown(link); err != nil {
 		err = fmt.Errorf("netlink.LinkSetDown(%s) failed: %v",
 			adapter.IfName, err)
 		c.Log.Error(err)
 		return err
 	}
-	// Get MAC address and create the alternate with the group bit toggled.
+	// Save the physical port's MAC; the ethN bridge is given the same
+	// address below.
 	macAddr := link.Attrs().HardwareAddr
-	altMacAddr := c.alternativeMAC(link.Attrs().HardwareAddr)
-	if len(altMacAddr) != 0 {
-		// Toggle MAC address - set to altMacAddr
-		if err := netlink.LinkSetHardwareAddr(link, altMacAddr); err != nil {
-			err = fmt.Errorf("netlink.LinkSetHardwareAddr(%s, %s) failed: %v",
-				adapter.IfName, altMacAddr, err)
-			c.Log.Error(err)
-			return err
-		}
-	}
 	if err := types.IfRename(c.Log, adapter.IfName, kernIfname); err != nil {
 		err = fmt.Errorf("IfRename(%s, %s) failed: %v",
 			adapter.IfName, kernIfname, err)
 		c.Log.Error(err)
 		return err
 	}
-	// Create bridge and name it ethN, use macAddr.
+	// Create the bridge, name it ethN, and give it the same MAC as the
+	// underlying port (now renamed kethN). Sharing the address is safe:
+	// NIM assigns IP config — including the IPv6 link-local — only to the
+	// ethN bridge, never to kethN, so the two never collide on the link.
 	attrs := netlink.NewLinkAttrs()
 	attrs.Name = adapter.IfName
 	attrs.HardwareAddr = macAddr
@@ -309,17 +302,6 @@ func (c *AdapterConfigurator) updateAdapterStaticIPs(link netlink.Link,
 	return nil
 }
 
-// Create alternate MAC address with the group bit toggled.
-func (c *AdapterConfigurator) alternativeMAC(mac net.HardwareAddr) net.HardwareAddr {
-	var altMacAddr net.HardwareAddr
-	if len(mac) != 0 {
-		altMacAddr = make([]byte, len(mac))
-		copy(altMacAddr, mac)
-		altMacAddr[0] = altMacAddr[0] ^ 2
-	}
-	return altMacAddr
-}
-
 // Modify is able to update the MTU attribute and the set of static IPs.
 func (c *AdapterConfigurator) Modify(_ context.Context, oldItem, newItem depgraph.Item) (err error) {
 	oldAdapter, isAdapter := oldItem.(Adapter)
@@ -390,24 +372,13 @@ func (c *AdapterConfigurator) Delete(ctx context.Context, item depgraph.Item) er
 		c.Log.Error(err)
 		return err
 	}
-	// Make sure the ethernet interface is DOWN before renaming
-	// and changing the MAC address, otherwise we get error
-	// `Device or resource busy`.
+	// Make sure the ethernet interface is DOWN before renaming,
+	// otherwise we get error `Device or resource busy`.
 	if err := netlink.LinkSetDown(kernLink); err != nil {
 		err = fmt.Errorf("netlink.LinkSetDown(%s) failed: %v",
 			kernIfname, err)
 		c.Log.Error(err)
 		return err
-	}
-	// Toggle MAC address of the interface back to the original.
-	altMacAddr := c.alternativeMAC(kernLink.Attrs().HardwareAddr)
-	if len(altMacAddr) != 0 {
-		if err := netlink.LinkSetHardwareAddr(kernLink, altMacAddr); err != nil {
-			err = fmt.Errorf("netlink.LinkSetHardwareAddr(%s, %s) failed: %v",
-				kernIfname, altMacAddr, err)
-			c.Log.Error(err)
-			return err
-		}
 	}
 	// Rename the interface back to the original name.
 	if err := types.IfRename(c.Log, kernIfname, adapter.IfName); err != nil {


### PR DESCRIPTION
# Description

In EVE-OS we rename eth<N> to keth<N> and then create a bridge on top of that called eth<N> in order to allow transparent deployment of switch network instances on any Ethernet port, including management ports.
As part of doing that we have been setting a different MAC address on keth<N> (toggle the local bit) so that eth<N> can use the hardware MAC address. This can apparently be dectected as the system having two MAC addresses which can trigger certain security software, and it turns out that there is no issue in assigning the same MAC address to eth<N> and keth<N>.

The implementation of this change is as follows:
`alternativeMAC` and both of its call sites are removed. The physical port
renamed to `kethN` keeps its original MAC and shares it with the `ethN`
bridge, which is assigned that same address.

Sharing the address is safe: NIM enables and configures IP only on the
managed `ethN` bridges, not on the underlying `kethN` ports, so `kethN`
carries no IPv6 link-local address and there is no link-local collision
between the two. The Linux bridge FDB also tolerates a duplicate local
address by design (`fdb_add_local`: "it is okay to have multiple ports
with same address").

## How to test and validate this PR

Bring up an EVE device (or eden/QEMU) with at least one Ethernet port and
confirm networking still comes up: the `ethN` bridge takes the port's MAC,
the port is renamed to `kethN` and enslaved, and connectivity to the
controller is unaffected. Both `ethN` and `kethN` now carry the same MAC;
verify there is no IPv6 link-local on `kethN` and no FDB error in dmesg.

Tested by deploying a switch NI on eth0 and verifying that the switch NI and the management traffic on eth0 both work.

## Changelog notes

No user-facing changes.

## PR Backports

- 17.0: Yes.
- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [X] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
