### PR TITLE
[17.0] volumemgr,kubeapi: defer+retry app volumes until EVE-k cluster storage is ready

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -726,7 +726,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			WaitForKubevirt: waitForKubevirtFlag,
 		}
 		for {
-			err = kubeapi.WaitForKubernetes(agentName, ps, stillRunning, kubeOpts)
+			err = kubeapi.WaitForKubernetes(agentName, ps, stillRunning, domainCtx.nodeName, kubeOpts)
 			if err == nil {
 				break
 			}

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -91,7 +91,7 @@ func handleVolumeDelete(ctxArg interface{}, key string,
 		}
 		updateVolumeStatusRefCount(ctx, status)
 		maybeDeleteVolume(ctx, status)
-		maybeSpaceAvailable(ctx)
+		reevaluatePendingVolumes(ctx)
 	}
 	log.Functionf("handleVolumeDelete(%s) Done", key)
 }
@@ -321,8 +321,11 @@ func maybeDeleteVolume(ctx *volumemgrContext, status *types.VolumeStatus) {
 	log.Functionf("maybeDeleteVolume for %v Done", status.Key())
 }
 
-// maybeSpaceAvailable iterates over VolumeStatus and call doUpdateVol if state is less than CREATING_VOLUME
-func maybeSpaceAvailable(ctx *volumemgrContext) {
+// reevaluatePendingVolumes re-drives every VolumeStatus still below
+// CREATING_VOLUME through doUpdateVol. It is called whenever something may have
+// unblocked a deferred volume -- disk space freeing up, or EVE-k cluster storage
+// (longhorn/CDI) becoming ready.
+func reevaluatePendingVolumes(ctx *volumemgrContext) {
 	for _, s := range ctx.pubVolumeStatus.GetAll() {
 		status := s.(types.VolumeStatus)
 		if status.State >= types.CREATING_VOLUME {
@@ -336,7 +339,7 @@ func maybeSpaceAvailable(ctx *volumemgrContext) {
 			publishVolumeStatus(ctx, &status)
 			updateVolumeRefStatus(ctx, &status)
 			if err := createOrUpdateAppDiskMetrics(ctx, agentName, &status); err != nil {
-				log.Errorf("maybeSpaceAvailable(%s): exception while publishing diskmetric. %s", status.Key(), err.Error())
+				log.Errorf("reevaluatePendingVolumes(%s): exception while publishing diskmetric. %s", status.Key(), err.Error())
 			}
 		}
 	}

--- a/pkg/pillar/cmd/volumemgr/handlevolumeref.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolumeref.go
@@ -124,7 +124,7 @@ func handleVolumeRefDelete(ctxArg interface{}, key string,
 		publishVolumeStatus(ctx, vs)
 		updateVolumeRefStatus(ctx, vs)
 		maybeDeleteVolume(ctx, vs)
-		maybeSpaceAvailable(ctx)
+		reevaluatePendingVolumes(ctx)
 	}
 	log.Functionf("handleVolumeRefDelete(%s) Done", key)
 }

--- a/pkg/pillar/cmd/volumemgr/handlework.go
+++ b/pkg/pillar/cmd/volumemgr/handlework.go
@@ -292,7 +292,7 @@ func processVolumeWorkResult(ctxPtr interface{}, res worker.WorkResult) error {
 		log.Functionf("processVolumeWorkResult for %v, VolumeStatus found", d.status.Key())
 		updateVolumeStatusRefCount(ctx, status)
 		maybeDeleteVolume(ctx, status)
-		maybeSpaceAvailable(ctx)
+		reevaluatePendingVolumes(ctx)
 	}
 	return nil
 }

--- a/pkg/pillar/cmd/volumemgr/retryclustervolume.go
+++ b/pkg/pillar/cmd/volumemgr/retryclustervolume.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
 // Cache for the EVE-k cluster-storage readiness probe (single-threaded volumemgr
@@ -18,6 +19,43 @@ var (
 )
 
 const clusterStorageProbeTTL = 15 * time.Second
+
+// maxClusterVolumeRetries bounds how many times a parked volume is re-driven after
+// a transient cluster-storage failure. Each retry re-runs RolloutDiskToPVC (which
+// can block for minutes), so this caps a misclassified or un-typeable failure at a
+// finite number of attempts instead of looping every gc tick forever; once the
+// budget is spent the volume is left in a terminal error for the operator to see.
+const maxClusterVolumeRetries = 12
+
+// clusterVolumeRetryAction is what retryFailedClusterVolumeCreate should do with a
+// single VolumeStatus. Split out as a pure function so the bounded-retry boundary is
+// unit-testable without pubsub/worker wiring.
+type clusterVolumeRetryAction int
+
+const (
+	cvSkip    clusterVolumeRetryAction = iota // not a parked transient cluster-volume failure
+	cvRedrive                                 // clear the error and re-drive the create
+	cvGiveUp                                  // retry budget spent; leave a terminal error
+)
+
+// clusterVolumeRetryActionFor decides, from a VolumeStatus alone, whether the retry
+// should skip it, re-drive it, or give up. A volume is a retry candidate only while
+// parked in CREATING_VOLUME/PrepareDone with an error kubeapi classified transient;
+// once it has been re-driven maxClusterVolumeRetries times it is given up so a
+// persistent failure surfaces terminally instead of looping every gc tick.
+func clusterVolumeRetryActionFor(status *types.VolumeStatus) clusterVolumeRetryAction {
+	if status.State != types.CREATING_VOLUME ||
+		status.SubState != types.VolumeSubStatePrepareDone {
+		return cvSkip
+	}
+	if !status.HasError() || !status.ClusterStorageTransientErr {
+		return cvSkip
+	}
+	if status.ClusterStorageRetryCount >= maxClusterVolumeRetries {
+		return cvGiveUp
+	}
+	return cvRedrive
+}
 
 // clusterStorageReady reports whether EVE-k longhorn+CDI are ready to create app
 // volumes, caching the kube-API probe. The volume-create path calls this so
@@ -37,4 +75,48 @@ func clusterStorageReady(ctx *volumemgrContext) bool {
 	clusterStorageReadyCheckAt = time.Now()
 	clusterStorageReadyCache = kubeapi.ClusterStorageReadyForVolumes(log, ctx.nodeName)
 	return clusterStorageReadyCache
+}
+
+// retryFailedClusterVolumeCreate re-drives volumes parked in a CREATING_VOLUME
+// error that kubeapi classified as a transient EVE-k cluster-storage failure
+// (longhorn/CDI/k8s-API not ready yet, common right after a kvm->k conversion).
+// It clears the error and resubmits the create work; if the create fails again
+// the error is set anew, so this self-throttles to at most one retry per gc
+// tick. Called from the periodic gc handler.
+func retryFailedClusterVolumeCreate(ctx *volumemgrContext) {
+	if !ctx.hvTypeKube {
+		// PVC/longhorn/CDI volume creation only happens on EVE-k.
+		return
+	}
+	// Until the cluster storage stack is back, a retry would just re-run a
+	// RolloutDiskToPVC that blocks for minutes and re-fails, wasting a worker
+	// slot; wait for readiness before re-driving.
+	if !clusterStorageReady(ctx) {
+		return
+	}
+	for _, st := range ctx.pubVolumeStatus.GetAll() {
+		status := st.(types.VolumeStatus)
+		switch clusterVolumeRetryActionFor(&status) {
+		case cvSkip:
+			continue
+		case cvGiveUp:
+			// Leave the volume parked in its error; clearing the transient verdict
+			// makes it no longer eligible here, so a persistent failure surfaces to
+			// the operator instead of looping forever.
+			log.Errorf("retryFailedClusterVolumeCreate: giving up on volume %s (%s) "+
+				"after %d retries; leaving terminal error: %s",
+				status.Key(), status.DisplayName, status.ClusterStorageRetryCount, status.Error)
+			status.ClusterStorageTransientErr = false
+			publishVolumeStatus(ctx, &status)
+		case cvRedrive:
+			status.ClusterStorageRetryCount++
+			log.Noticef("retryFailedClusterVolumeCreate: retrying volume %s (%s) "+
+				"(attempt %d/%d) after transient cluster-storage error: %s",
+				status.Key(), status.DisplayName, status.ClusterStorageRetryCount,
+				maxClusterVolumeRetries, status.Error)
+			status.ClearErrorWithSource()
+			publishVolumeStatus(ctx, &status)
+			AddWorkCreate(ctx, &status)
+		}
+	}
 }

--- a/pkg/pillar/cmd/volumemgr/retryclustervolume.go
+++ b/pkg/pillar/cmd/volumemgr/retryclustervolume.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+)
+
+// Cache for the EVE-k cluster-storage readiness probe (single-threaded volumemgr
+// main loop, so no lock needed). Once ready it stays ready (longhorn/CDI don't
+// un-deploy); while not ready we re-probe at most every clusterStorageProbeTTL.
+var (
+	clusterStorageReadyCache   bool
+	clusterStorageReadyCheckAt time.Time
+)
+
+const clusterStorageProbeTTL = 15 * time.Second
+
+// clusterStorageReady reports whether EVE-k longhorn+CDI are ready to create app
+// volumes, caching the kube-API probe. The volume-create path calls this so
+// volumemgr DEFERS (quietly, no error) until the cluster storage stack is up,
+// instead of attempting and failing (storageclass-not-found / no-upload-pod-
+// annotation) then relying on the error-retry. Always true off EVE-k.
+func clusterStorageReady(ctx *volumemgrContext) bool {
+	if !ctx.hvTypeKube {
+		return true
+	}
+	if clusterStorageReadyCache {
+		return true
+	}
+	if time.Since(clusterStorageReadyCheckAt) < clusterStorageProbeTTL {
+		return false
+	}
+	clusterStorageReadyCheckAt = time.Now()
+	clusterStorageReadyCache = kubeapi.ClusterStorageReadyForVolumes(log, ctx.nodeName)
+	return clusterStorageReadyCache
+}

--- a/pkg/pillar/cmd/volumemgr/retryclustervolume_test.go
+++ b/pkg/pillar/cmd/volumemgr/retryclustervolume_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// parkedTransientVolume builds a VolumeStatus in the state the cluster-volume retry
+// treats as a candidate: CREATING_VOLUME/PrepareDone, a recorded error, and a
+// transient verdict, with the given number of prior re-drives.
+func parkedTransientVolume(retryCount int) types.VolumeStatus {
+	vs := types.VolumeStatus{
+		State:                      types.CREATING_VOLUME,
+		SubState:                   types.VolumeSubStatePrepareDone,
+		ClusterStorageTransientErr: true,
+		ClusterStorageRetryCount:   retryCount,
+	}
+	vs.SetErrorWithSource("RolloutDiskToPVC attempts to upload image failed",
+		types.VolumeStatus{}, time.Now())
+	return vs
+}
+
+// TestClusterVolumeRetryActionFor pins the bounded-retry boundary: a parked transient
+// volume is re-driven until it has been retried maxClusterVolumeRetries times, after
+// which the retry gives up (leaving a terminal error) instead of looping every gc
+// tick forever. Anything that is not a parked transient cluster-volume failure is
+// skipped.
+func TestClusterVolumeRetryActionFor(t *testing.T) {
+	// Under the cap: re-drive.
+	for _, n := range []int{0, 1, maxClusterVolumeRetries - 1} {
+		vs := parkedTransientVolume(n)
+		if got := clusterVolumeRetryActionFor(&vs); got != cvRedrive {
+			t.Errorf("retryCount=%d: got %d, want cvRedrive(%d)", n, got, cvRedrive)
+		}
+	}
+	// At or beyond the cap: give up (terminal), no more re-drives.
+	for _, n := range []int{maxClusterVolumeRetries, maxClusterVolumeRetries + 5} {
+		vs := parkedTransientVolume(n)
+		if got := clusterVolumeRetryActionFor(&vs); got != cvGiveUp {
+			t.Errorf("retryCount=%d: got %d, want cvGiveUp(%d)", n, got, cvGiveUp)
+		}
+	}
+	// Not a retry candidate: skip.
+	skips := map[string]func(*types.VolumeStatus){
+		"no error":       func(v *types.VolumeStatus) { v.ClearErrorWithSource() },
+		"not transient":  func(v *types.VolumeStatus) { v.ClusterStorageTransientErr = false },
+		"wrong state":    func(v *types.VolumeStatus) { v.State = types.CREATED_VOLUME },
+		"wrong substate": func(v *types.VolumeStatus) { v.SubState = types.VolumeSubStateCreated },
+	}
+	for name, mutate := range skips {
+		vs := parkedTransientVolume(0)
+		mutate(&vs)
+		if got := clusterVolumeRetryActionFor(&vs); got != cvSkip {
+			t.Errorf("%s: got %d, want cvSkip(%d)", name, got, cvSkip)
+		}
+	}
+}

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	zconfig "github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils"
 	"github.com/lf-edge/eve/pkg/pillar/volumehandlers"
@@ -749,12 +750,18 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 			if vr.Error != nil {
 				log.Errorf("doUpdate: Error received from the volume worker %v",
 					vr.Error)
+				// Record whether kubeapi classified this as a transient EVE-k
+				// cluster-storage failure, so retryFailedClusterVolumeCreate can
+				// re-drive only those once storage is ready.
+				status.ClusterStorageTransientErr = kubeapi.IsTransient(vr.Error)
 				status.SetErrorWithSource(vr.Error.Error(),
 					types.VolumeStatus{}, vr.ErrorTime)
 				changed = true
 				return changed, false
 			} else if status.IsErrorSource(types.VolumeStatus{}) {
 				log.Functionf("doUpdateContentTree: Clearing volume error %s", status.Error)
+				status.ClusterStorageTransientErr = false
+				status.ClusterStorageRetryCount = 0
 				status.ClearErrorWithSource()
 				changed = true
 			}

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -575,6 +575,10 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 				}
 				return changed, false
 			}
+			if ctx.hvTypeKube && !clusterStorageReady(ctx) {
+				log.Noticef("doUpdateVol(%s): deferring blank volume create until cluster storage (longhorn/CDI) ready", status.Key())
+				return changed, false
+			}
 			status.State = types.CREATING_VOLUME
 			status.ReferenceName = "" //set empty for blank volume
 			status.ContentFormat = blankVolumeFormat
@@ -649,6 +653,10 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 				return changed, false
 			}
 
+			if ctx.hvTypeKube && !clusterStorageReady(ctx) {
+				log.Noticef("doUpdateVol(%s): deferring volume create until cluster storage (longhorn/CDI) ready", status.Key())
+				return changed, false
+			}
 			status.State = types.CREATING_VOLUME
 			// first blob is always the root
 			if len(ctStatus.Blobs) < 1 {

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -106,6 +106,10 @@ type volumemgrContext struct {
 
 	// EVE 'k' mode
 	hvTypeKube bool
+	// nodeName is this device's Kubernetes node name (EVE-k), derived from
+	// EdgeNodeInfo.DeviceName; passed to the kubeapi readiness helpers instead of
+	// relying on os.Hostname().
+	nodeName string
 }
 
 func (ctxPtr *volumemgrContext) lookupVolumeStatusByUUID(id string) *types.VolumeStatus {
@@ -122,6 +126,11 @@ func (ctxPtr *volumemgrContext) lookupVolumeStatusByUUID(id string) *types.Volum
 
 func (ctxPtr *volumemgrContext) GetCasClient() cas.CAS {
 	return ctxPtr.casClient
+}
+
+// GetNodeName returns this device's Kubernetes node name (EVE-k), or "" off EVE-k.
+func (ctxPtr *volumemgrContext) GetNodeName() string {
+	return ctxPtr.nodeName
 }
 
 // AddAgentSpecificCLIFlags adds CLI options
@@ -284,12 +293,22 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			}
 		}
 
+		// Resolve this node's Kubernetes node name from EdgeNodeInfo.DeviceName,
+		// used by the kubeapi readiness helpers instead of os.Hostname(). Proceed
+		// with an empty name on timeout; the readiness gate simply stays deferred.
+		nodeName, err := wait.WaitForNodeName(ps, log, agentName,
+			warningTime, errorTime, 60*time.Second)
+		if err != nil {
+			log.Warnf("volumemgr: %v", err)
+		}
+		ctx.nodeName = nodeName
+
 		// Assume single node: where kubevirt is running
 		waitForLhFlag := true
 		if encc.Valid && encc.ClusterType != types.ClusterTypeReplicatedStorage {
 			waitForLhFlag = false
 		}
-		err := kubeapi.WaitForKubernetes(agentName, ps, stillRunning,
+		err = kubeapi.WaitForKubernetes(agentName, ps, stillRunning, ctx.nodeName,
 			kubeapi.WaitForKubernetesOptions{
 				WaitForLonghorn: waitForLhFlag,
 			})
@@ -298,7 +317,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		} else {
 			log.Noticef("volumemgr run: kubernetes node ready, longhorn ready")
 		}
-
 	}
 
 	if ctx.persistType == types.PersistZFS {

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -317,6 +317,39 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		} else {
 			log.Noticef("volumemgr run: kubernetes node ready, longhorn ready")
 		}
+
+		// Then block until cluster storage (Longhorn + CDI) can actually serve a
+		// volume, using the same readiness predicate the per-volume gate uses
+		// (kubeapi.ClusterStorageReadyForVolumes via clusterStorageReady). Bounded
+		// so a cluster that never converges cannot wedge volumemgr; any volume
+		// requested afterwards still defers and retries through the gate.
+		//
+		// PROVISIONAL: this up-front wait and the per-volume defer/retry gate
+		// deliberately coexist so we can observe how often the gate/retry fires
+		// after this wait has passed. Once we decide whether the retry earns its
+		// keep, drop one of the two so a volume is gated in a single place.
+		storageDeadline := time.NewTimer(20 * time.Minute)
+		storageReady := false
+	storageWait:
+		for {
+			if clusterStorageReady(&ctx) {
+				storageReady = true
+				break
+			}
+			select {
+			case <-storageDeadline.C:
+				break storageWait
+			case <-stillRunning.C:
+				ps.StillRunning(agentName, warningTime, errorTime)
+			}
+		}
+		storageDeadline.Stop()
+		if storageReady {
+			log.Noticef("volumemgr run: cluster storage (longhorn+CDI) ready")
+		} else {
+			log.Warnf("volumemgr run: timeout waiting for cluster storage; " +
+				"volumes will defer and retry")
+		}
 	}
 
 	if ctx.persistType == types.PersistZFS {

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -764,6 +764,13 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 				gcUnusedInitObjects(&ctx)
 				ctx.initGced = true
 			}
+			// Re-drive volumes deferred pre-create waiting on EVE-k cluster
+			// storage readiness so they proceed once longhorn/CDI come up. Only
+			// EVE-k defers here; on other HVs the disk-space deferral is already
+			// re-driven by the event-driven callers, so skip the periodic pass.
+			if ctx.hvTypeKube {
+				reevaluatePendingVolumes(&ctx)
+			}
 			ps.CheckMaxTimeTopic(agentName, "gc", start,
 				warningTime, errorTime)
 

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -797,6 +797,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 				gcUnusedInitObjects(&ctx)
 				ctx.initGced = true
 			}
+			// Re-drive volumes parked in a transient EVE-k cluster-storage
+			// error (longhorn/CDI not ready yet, common right after a kvm->k
+			// conversion) so they recover once the cluster is up.
+			retryFailedClusterVolumeCreate(&ctx)
 			// Re-drive volumes deferred pre-create waiting on EVE-k cluster
 			// storage readiness so they proceed once longhorn/CDI come up. Only
 			// EVE-k defers here; on other HVs the disk-space deferral is already

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -663,7 +663,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	zedkubeCtx.subAssignableAdapters = subAssignableAdapters
 	subAssignableAdapters.Activate()
 
-	err = kubeapi.WaitForKubernetes(agentName, ps, stillRunning,
+	err = kubeapi.WaitForKubernetes(agentName, ps, stillRunning, zedkubeCtx.nodeName,
 		kubeapi.WaitForKubernetesOptions{},
 		// Make sure we keep ClusterIPIsReady up to date while we wait
 		// for Kubernetes to come up.

--- a/pkg/pillar/kubeapi/cdiupload.go
+++ b/pkg/pillar/kubeapi/cdiupload.go
@@ -77,3 +77,20 @@ func cdiUploadIsComplete(log *base.LogObject, pvc *corev1.PersistentVolumeClaim)
 	}
 	return true
 }
+
+// IsPVCUploadComplete reports whether the CDI image upload into the named PVC has
+// finished. A non-nil error means the PVC could not be queried; callers should
+// treat that as "not known complete". Used after a reboot that left a PVC behind
+// to decide whether the upload still needs to be re-driven against it.
+func IsPVCUploadComplete(pvcName string, log *base.LogObject) (bool, error) {
+	clientset, err := GetClientSet()
+	if err != nil {
+		return false, fmt.Errorf("failed to get clientset: %v", err)
+	}
+	pvc, err := clientset.CoreV1().PersistentVolumeClaims(EVEKubeNameSpace).
+		Get(context.Background(), pvcName, metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to get PVC %s: %v", pvcName, err)
+	}
+	return cdiUploadIsComplete(log, pvc), nil
+}

--- a/pkg/pillar/kubeapi/errors.go
+++ b/pkg/pillar/kubeapi/errors.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package kubeapi
+
+import "errors"
+
+// TransientError marks a cluster-storage failure that is expected to clear once
+// the EVE-k storage stack (the k3s API server, Longhorn and CDI) has finished
+// coming up -- e.g. during a freshly installed node's first boot or the minutes
+// after a kvm->k conversion. Callers use IsTransient to decide whether a parked
+// volume-create is worth re-driving; a permanent failure must not be retried in
+// a loop. The verdict is recorded at the point the typed Kubernetes error is
+// still available, because it is lost once the error is flattened to a string
+// across the volumemgr worker boundary.
+//
+// This type and IsTransient are build-tag-free so volumemgr can consult the
+// verdict on every hypervisor; the classification that produces a TransientError
+// (asTransient/transientf) is EVE-k only and lives in the k-tagged file.
+type TransientError struct {
+	Err error
+}
+
+// Error implements the error interface.
+func (e *TransientError) Error() string { return e.Err.Error() }
+
+// Unwrap lets errors.Is/errors.As reach the wrapped error.
+func (e *TransientError) Unwrap() error { return e.Err }
+
+// IsTransient reports whether err, or anything it wraps, was classified as a
+// transient cluster-storage failure. Safe on a nil error (returns false). On
+// non-EVE-k builds nothing produces a TransientError, so it always returns false.
+func IsTransient(err error) bool {
+	var t *TransientError
+	return errors.As(err, &t)
+}

--- a/pkg/pillar/kubeapi/errors_k.go
+++ b/pkg/pillar/kubeapi/errors_k.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package kubeapi
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// transientf builds a TransientError from a formatted message. Use it for
+// failure modes that carry no typed Kubernetes error to classify -- the
+// cluster-storage stack's own "not ready yet" diagnostics (virtctl/CDI upload,
+// Longhorn engine not deployed) -- so the transient verdict is stated explicitly
+// by the code rather than re-derived from message text downstream.
+func transientf(format string, args ...interface{}) error {
+	return &TransientError{Err: fmt.Errorf(format, args...)}
+}
+
+// asTransient classifies a Kubernetes client-go error and wraps it in a
+// TransientError when it is retryable, or returns err unchanged when it is
+// permanent. Classification is by typed error (or a net.Error for a request
+// that never reached the API server), never by message text, so it does not
+// break on a Kubernetes version bump. Returns nil for a nil error.
+func asTransient(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case k8serrors.IsAlreadyExists(err),
+		k8serrors.IsInvalid(err),
+		k8serrors.IsBadRequest(err),
+		k8serrors.IsForbidden(err),
+		k8serrors.IsUnauthorized(err):
+		// Permanent: reissuing the same request cannot succeed.
+		return err
+	case k8serrors.IsNotFound(err),
+		k8serrors.IsTimeout(err),
+		k8serrors.IsServerTimeout(err),
+		k8serrors.IsTooManyRequests(err),
+		k8serrors.IsServiceUnavailable(err),
+		k8serrors.IsInternalError(err):
+		// Transient: a storageclass/CRD/service not registered yet, or the
+		// API server briefly unavailable while the cluster comes up.
+		return &TransientError{Err: err}
+	}
+	// Not a typed API-status error: a dial/connection failure before the
+	// request reached the API server (k3s still starting) shows up as a
+	// net.Error, which is also transient.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return &TransientError{Err: err}
+	}
+	return err
+}

--- a/pkg/pillar/kubeapi/errors_test.go
+++ b/pkg/pillar/kubeapi/errors_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package kubeapi
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var pvcGR = schema.GroupResource{Group: "", Resource: "persistentvolumeclaims"}
+
+// TestAsTransientClassification checks that asTransient marks retryable
+// cluster-storage failures transient and leaves permanent ones alone, driven by
+// the typed Kubernetes error rather than message text.
+func TestAsTransientClassification(t *testing.T) {
+	tests := []struct {
+		name          string
+		err           error
+		wantTransient bool
+	}{
+		{"nil", nil, false},
+		{"already-exists permanent", k8serrors.NewAlreadyExists(pvcGR, "p"), false},
+		{"bad-request permanent", k8serrors.NewBadRequest("nope"), false},
+		{"conflict unclassified permanent", k8serrors.NewConflict(pvcGR, "p", errors.New("x")), false},
+		{"plain error permanent", errors.New("some local failure"), false},
+		{"not-found transient", k8serrors.NewNotFound(pvcGR, "p"), true},
+		{"service-unavailable transient", k8serrors.NewServiceUnavailable("cdi down"), true},
+		{"internal transient", k8serrors.NewInternalError(errors.New("boom")), true},
+		{"timeout transient", k8serrors.NewTimeoutError("slow", 1), true},
+		{"too-many-requests transient", k8serrors.NewTooManyRequestsError("busy"), true},
+		{"net dial error transient", &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsTransient(asTransient(tc.err))
+			if got != tc.wantTransient {
+				t.Errorf("IsTransient(asTransient(%v)) = %v, want %v", tc.err, got, tc.wantTransient)
+			}
+		})
+	}
+}
+
+// TestIsTransientThroughWrap verifies the verdict survives an additional
+// fmt.Errorf %w wrap (as happens when csihandler wraps the kubeapi error before
+// it crosses the worker boundary), and that wrapping a permanent error does not
+// flip it to transient.
+func TestIsTransientThroughWrap(t *testing.T) {
+	transient := asTransient(k8serrors.NewServiceUnavailable("cdi down"))
+	wrapped := fmt.Errorf("Error converting disk to PVC p: %w", transient)
+	if !IsTransient(wrapped) {
+		t.Errorf("wrapped transient error not detected as transient")
+	}
+
+	permanent := asTransient(k8serrors.NewBadRequest("nope"))
+	wrappedPerm := fmt.Errorf("Error converting disk to PVC p: %w", permanent)
+	if IsTransient(wrappedPerm) {
+		t.Errorf("wrapped permanent error wrongly detected as transient")
+	}
+}
+
+// TestTransientf checks the explicit-diagnostic constructor yields a transient
+// error carrying the formatted message.
+func TestTransientf(t *testing.T) {
+	err := transientf("PVC Upload for pvc:%s attempts to upload image failed, no upload pod annotation", "p")
+	if !IsTransient(err) {
+		t.Errorf("transientf did not produce a transient error")
+	}
+	want := "PVC Upload for pvc:p attempts to upload image failed, no upload pod annotation"
+	if err.Error() != want {
+		t.Errorf("transientf message = %q, want %q", err.Error(), want)
+	}
+}

--- a/pkg/pillar/kubeapi/kubeapi.go
+++ b/pkg/pillar/kubeapi/kubeapi.go
@@ -178,7 +178,7 @@ type WaitForKubernetesOptions struct {
 // The caller supplies ClusterType in opts; this function does not create any
 // pubsub subscriptions.
 func WaitForKubernetes(agentName string, ps *pubsub.PubSub, stillRunning *time.Ticker,
-	opts WaitForKubernetesOptions, alsoWatch ...pubsub.ChannelWatch) (err error) {
+	nodeName string, opts WaitForKubernetesOptions, alsoWatch ...pubsub.ChannelWatch) (err error) {
 
 	var watches []pubsub.ChannelWatch
 	stillRunningWatch := pubsub.ChannelWatch{
@@ -226,18 +226,14 @@ func WaitForKubernetes(agentName string, ps *pubsub.PubSub, stillRunning *time.T
 		return err
 	}
 
-	devUUID, err := os.Hostname()
-	if err != nil {
-		return err
-	}
-
 	// Wait for the node to be Ready and for any optional components declared by opts.
+	// nodeName is the caller-supplied EVE-k node name (from EdgeNodeInfo.DeviceName),
+	// not os.Hostname().
 	var nodeReadyErr error
 	doneCh := make(chan struct{}, 1)
 	go func() {
 		nodeReadyErr = wait.PollImmediate(time.Second, time.Minute*20, func() (bool, error) {
-			hostname, err := waitForNodeReady(client, devUUID)
-			if err != nil {
+			if err := nodeReadyByName(client, nodeName); err != nil {
 				return false, nil
 			}
 			if opts.WaitForKubevirt {
@@ -246,7 +242,7 @@ func WaitForKubernetes(agentName string, ps *pubsub.PubSub, stillRunning *time.T
 				}
 			}
 			if opts.WaitForLonghorn {
-				if err := checkLonghornReady(client, hostname); err != nil {
+				if err := checkLonghornReady(client, nodeName); err != nil {
 					return false, nil
 				}
 			}
@@ -327,17 +323,24 @@ func checkLonghornReady(client kubernetes.Interface, nodeName string) error {
 	return nil
 }
 
+// nodeReadyByName confirms this device's Kubernetes node object exists. nodeName is the
+// EVE-k node name derived from EdgeNodeInfo.DeviceName (supplied by the caller) — the name
+// k3s registered the node under — NOT os.Hostname() (the device UUID). Looking the node up
+// by name avoids the node-uuid label indirection, which wedged the old lookup when a
+// device's UUID changed and the label went stale.
+func nodeReadyByName(client kubernetes.Interface, nodeName string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer cancel()
+	_, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	return err
+}
+
 // WaitForLonghornReady blocks until all required Longhorn daemonsets are running
 // and ready on this node, or until ctx is cancelled. It is safe to call from a
 // worker goroutine; it never touches pubsub or the watchdog.
 // All setup steps (kubeconfig, client, node name lookup) are retried inside the
 // loop so that a slow k3s start after a reboot is handled transparently.
-func WaitForLonghornReady(ctx context.Context, log *base.LogObject) error {
-	devUUID, err := os.Hostname()
-	if err != nil {
-		return fmt.Errorf("WaitForLonghornReady: hostname: %v", err)
-	}
-
+func WaitForLonghornReady(ctx context.Context, log *base.LogObject, nodeName string) error {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
@@ -358,10 +361,7 @@ func WaitForLonghornReady(ctx context.Context, log *base.LogObject) error {
 				log.Noticef("WaitForLonghornReady: client error: %v", err)
 				continue
 			}
-			// Resolve the k3s node name from the device UUID label — the OS hostname
-			// is the device UUID, not the Kubernetes node name used in pod field selectors.
-			nodeName, err := waitForNodeReady(client, devUUID)
-			if err != nil {
+			if err := nodeReadyByName(client, nodeName); err != nil {
 				log.Noticef("WaitForLonghornReady: node not ready: %v", err)
 				continue
 			}
@@ -392,25 +392,6 @@ func waitForKubevirtReady(kubeConfig *rest.Config) error {
 		}
 	}
 	return fmt.Errorf("KubeVirt CR not yet Available")
-}
-
-func waitForNodeReady(client *kubernetes.Clientset, devUUID string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
-	defer cancel()
-	labelSelector := metav1.LabelSelector{
-		MatchLabels: map[string]string{"node-uuid": devUUID},
-	}
-	options := metav1.ListOptions{
-		LabelSelector: metav1.FormatLabelSelector(&labelSelector),
-	}
-	nodes, err := client.CoreV1().Nodes().List(ctx, options)
-	if err != nil {
-		return "", err
-	}
-	for _, node := range nodes.Items {
-		return node.Name, nil
-	}
-	return "", fmt.Errorf("node not found by label uuid %s", devUUID)
 }
 
 // WaitForPVCReady : Loop until PVC is ready for timeout

--- a/pkg/pillar/kubeapi/nokube.go
+++ b/pkg/pillar/kubeapi/nokube.go
@@ -22,7 +22,7 @@ type WaitForKubernetesOptions struct {
 }
 
 // WaitForKubernetes in this file is just stub for non EVE-k builds.
-func WaitForKubernetes(string, *pubsub.PubSub, *time.Ticker, WaitForKubernetesOptions,
+func WaitForKubernetes(string, *pubsub.PubSub, *time.Ticker, string, WaitForKubernetesOptions,
 	...pubsub.ChannelWatch) error {
 	panic("WaitForKubernetes is not built")
 }
@@ -75,7 +75,7 @@ func EnsureVMsDeschedulerAnnotated(*base.LogObject) error {
 }
 
 // WaitForLonghornReady is a stub for non EVE-k builds.
-func WaitForLonghornReady(ctx context.Context, log *base.LogObject) error {
+func WaitForLonghornReady(ctx context.Context, log *base.LogObject, nodeName string) error {
 	return nil
 }
 

--- a/pkg/pillar/kubeapi/nokube.go
+++ b/pkg/pillar/kubeapi/nokube.go
@@ -69,6 +69,11 @@ func GetStorageClassForReplicaCount(count int) string {
 	return ""
 }
 
+// ClusterStorageReadyForVolumes is a stub for non EVE-k builds (no cluster storage).
+func ClusterStorageReadyForVolumes(*base.LogObject, string) bool {
+	return true
+}
+
 // EnsureVMsDeschedulerAnnotated is a stub for non EVE-k builds.
 func EnsureVMsDeschedulerAnnotated(*base.LogObject) error {
 	return nil

--- a/pkg/pillar/kubeapi/vitoapiserver.go
+++ b/pkg/pillar/kubeapi/vitoapiserver.go
@@ -17,6 +17,8 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/diskmetrics"
 	"github.com/lf-edge/eve/pkg/pillar/types"
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,6 +52,110 @@ func CreatePVC(pvcName string, size uint64, log *base.LogObject, storageClass st
 
 	log.Noticef("Created PVC: %s\n", result.ObjectMeta.Name)
 	return nil
+}
+
+// cdiControlPlaneDeployments are the CDI Deployments (namespace "cdi") that must
+// each have an available replica before a CDI image upload can succeed.
+var cdiControlPlaneDeployments = []string{"cdi-apiserver", "cdi-deployment", "cdi-uploadproxy"}
+
+// ClusterStorageReadyForVolumes reports whether the EVE-k cluster storage stack is
+// ready to create app volumes: the `longhorn` StorageClass exists and the Longhorn
+// control-plane daemonsets are running on this node, the CDI upload proxy Service
+// has a ClusterIP, and the CDI control-plane Deployments (cdi-apiserver,
+// cdi-deployment, cdi-uploadproxy) each have at least one available replica.
+// Callers use this to DEFER volume creation quietly until longhorn/CDI are
+// up -- which can take tens of minutes whenever an app volume is requested while the
+// EVE-k cluster is still coming up: on a freshly installed node's first boot when the
+// controller's EdgeDevConfig already contains the app instance, or in the minutes
+// after a kvm->k conversion. Without the gate these attempts fail with "storageclass
+// not found" / "no upload pod annotation" / RolloutDiskToPVC "attempts to upload
+// image failed".
+//
+// The uploadproxy ClusterIP is assigned at Service creation, well before the CDI
+// pods are Ready and before CDI can create/annotate a per-PVC upload pod, so the
+// Service check alone is necessary but NOT sufficient; the Deployment-availability
+// check closes that gap so RolloutDiskToPVC's upload is not attempted prematurely.
+// Best-effort: any API error or missing/unavailable component => not ready (false).
+// nodeName is this device's Kubernetes node name (derived by the caller from
+// EdgeNodeInfo.DeviceName), used for the per-node Longhorn checks below — not
+// os.Hostname().
+func ClusterStorageReadyForVolumes(log *base.LogObject, nodeName string) bool {
+	clientset, err := GetClientSet()
+	if err != nil {
+		log.Functionf("ClusterStorageReadyForVolumes: no clientset yet: %v", err)
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer cancel()
+	if _, err := clientset.StorageV1().StorageClasses().
+		Get(ctx, VolumeCSIClusterStorageClass, metav1.GetOptions{}); err != nil {
+		log.Functionf("ClusterStorageReadyForVolumes: StorageClass %s not ready: %v",
+			VolumeCSIClusterStorageClass, err)
+		return false
+	}
+	// The StorageClass can exist before Longhorn's control plane is running, so
+	// also require the Longhorn daemonsets to be ready on this node.
+	if err := checkLonghornReady(clientset, nodeName); err != nil {
+		log.Functionf("ClusterStorageReadyForVolumes: longhorn not ready: %v", err)
+		return false
+	}
+	// Daemonsets Running is necessary but not sufficient: Longhorn refuses to
+	// schedule replicas -- leaving a new volume unattachable -- unless at least one
+	// disk on this node reports Schedulable=True.
+	if err := checkLonghornSchedulable(nodeName); err != nil {
+		log.Functionf("ClusterStorageReadyForVolumes: %v", err)
+		return false
+	}
+	svc, err := clientset.CoreV1().Services("cdi").
+		Get(ctx, "cdi-uploadproxy", metav1.GetOptions{})
+	if err != nil || svc.Spec.ClusterIP == "" {
+		log.Functionf("ClusterStorageReadyForVolumes: cdi-uploadproxy Service not ready: %v", err)
+		return false
+	}
+	// A ClusterIP alone does not mean CDI can serve an upload: require the CDI
+	// control-plane Deployments to each have an available replica so the upload
+	// pod can be created and annotated before RolloutDiskToPVC attempts the upload.
+	for _, dep := range cdiControlPlaneDeployments {
+		d, err := clientset.AppsV1().Deployments("cdi").Get(ctx, dep, metav1.GetOptions{})
+		if err != nil || d.Status.AvailableReplicas < 1 {
+			log.Functionf("ClusterStorageReadyForVolumes: CDI deployment %s not available yet: %v",
+				dep, err)
+			return false
+		}
+	}
+	return true
+}
+
+// checkLonghornSchedulable returns nil if at least one Longhorn disk on nodeName
+// reports Schedulable=True. Longhorn refuses to schedule replicas -- leaving a new
+// volume unattachable -- when every disk is below storage-minimal-available-percentage
+// (e.g. a nearly-full /persist), so this is the per-node disk-schedulable signal, not
+// just the daemonsets. Shared by ClusterStorageReadyForVolumes and the node descheduler
+// readiness check.
+func checkLonghornSchedulable(nodeName string) error {
+	config, err := GetKubeConfig()
+	if err != nil {
+		return fmt.Errorf("no kubeconfig yet: %w", err)
+	}
+	lhClient, err := lhclientset.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("longhorn client: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer cancel()
+	lhNode, err := lhClient.LonghornV1beta2().Nodes("longhorn-system").Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("longhorn node %s not ready: %w", nodeName, err)
+	}
+	for _, ds := range lhNode.Status.DiskStatus {
+		for _, cond := range ds.Conditions {
+			if cond.Type == lhv1beta2.DiskConditionTypeSchedulable &&
+				cond.Status == lhv1beta2.ConditionStatusTrue {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("longhorn node %s has no schedulable disk", nodeName)
 }
 
 // DeletePVC : deletes PVC of the given name.

--- a/pkg/pillar/kubeapi/vitoapiserver.go
+++ b/pkg/pillar/kubeapi/vitoapiserver.go
@@ -20,6 +20,7 @@ import (
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	lhclientset "github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -45,7 +46,16 @@ func CreatePVC(pvcName string, size uint64, log *base.LogObject, storageClass st
 	result, err := clientset.CoreV1().PersistentVolumeClaims(pvc.Namespace).
 		Create(context.Background(), pvc, metav1.CreateOptions{})
 	if err != nil {
-		err = fmt.Errorf("failed to CreatePVC %s: %v", pvcName, err)
+		if k8serrors.IsAlreadyExists(err) {
+			// Idempotent: a prior attempt (e.g. one that created the PVC but
+			// then failed at the CDI upload because the cluster was not ready)
+			// already left this PVC. Treat it as success so a retry proceeds to
+			// the image upload against the existing PVC (RolloutDiskToPVC then
+			// uses --no-create) instead of dying here with AlreadyExists.
+			log.Noticef("CreatePVC: PVC %s already exists, reusing it", pvcName)
+			return nil
+		}
+		err = asTransient(fmt.Errorf("failed to CreatePVC %s: %w", pvcName, err))
 		log.Error(err)
 		return err
 	}
@@ -326,30 +336,36 @@ func RolloutDiskToPVC(ctx context.Context, log *base.LogObject, exists bool,
 	// Get the Kubernetes clientset
 	clientset, err := GetClientSet()
 	if err != nil {
-		err = fmt.Errorf("failed to get clientset %v", err)
+		err = transientf("failed to get clientset %v", err)
 		log.Error(err)
 		return err
 	}
 
 	var service *corev1.Service
-	// Get the Service from Kubernetes API.
-	i := 5
-	for {
+	// Fetch the cdi-uploadproxy Service, retrying a bounded number of times while
+	// the cluster API is briefly unreachable. Honor ctx (not context.Background())
+	// so a volume-config delete (createCancel) aborts a stuck create instead of
+	// pinning the worker, and cap the attempts so any persistent error returns
+	// rather than spinning forever. The transient return is safe because the outer
+	// retryFailedClusterVolumeCreate is itself bounded.
+	const svcMaxRetries = 5
+	for i := 0; ; i++ {
 		service, err = clientset.CoreV1().Services("cdi").
-			Get(context.Background(), "cdi-uploadproxy", metav1.GetOptions{})
-
-		if err != nil {
-			if strings.Contains(err.Error(), "dial tcp 127.0.0.1:6443") && i <= 0 {
-				err = fmt.Errorf("failed to get Service cdi/cdi-uploadproxy: %v\n", err)
-				log.Error(err)
-				return err
-			}
-			time.Sleep(10 * time.Second)
-			log.Noticef("RolloutDiskToPVC loop (%d), wait for 10 sec, err %v", i, err)
-		} else {
+			Get(ctx, "cdi-uploadproxy", metav1.GetOptions{})
+		if err == nil {
 			break
 		}
-		i = i - 1
+		if i >= svcMaxRetries {
+			err = transientf("failed to get Service cdi/cdi-uploadproxy after %d tries: %v", i, err)
+			log.Error(err)
+			return err
+		}
+		log.Noticef("RolloutDiskToPVC: get cdi-uploadproxy Service failed (try %d/%d), retry in 10s: %v", i, svcMaxRetries, err)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(10 * time.Second):
+		}
 	}
 
 	// Get the ClusterIP of the Service.
@@ -382,7 +398,7 @@ func RolloutDiskToPVC(ctx context.Context, log *base.LogObject, exists bool,
 	if !exists {
 		err = CreatePVC(pvcName, pvcSize, log, storageClass)
 		if err != nil {
-			err = fmt.Errorf("Error creating PVC %s", pvcName)
+			err = fmt.Errorf("Error creating PVC %s: %w", pvcName, err)
 			log.Error(err)
 			return err
 		}
@@ -464,7 +480,7 @@ func RolloutDiskToPVC(ctx context.Context, log *base.LogObject, exists bool,
 		err = waitForPVCUploadComplete(ctx, pvcName, log)
 		waitCdiAnnotationDuration := time.Since(waitCdiAnnotationStart)
 		if err != nil {
-			err = fmt.Errorf("RolloutDiskToPVC: error wait for PVC %v", err)
+			err = transientf("RolloutDiskToPVC: error wait for PVC %v", err)
 			log.Error(err)
 			return err
 		}
@@ -483,34 +499,41 @@ func RolloutDiskToPVC(ctx context.Context, log *base.LogObject, exists bool,
 	// 1. Use the PVC as our starting point to diagnose, we have it's name
 	pvc, err := PVCGet(pvcName, log)
 	if err != nil {
-		return fmt.Errorf("PVC Upload for pvc:%s attempts to upload image failed, pvc not created", pvcName)
+		return transientf("PVC Upload for pvc:%s attempts to upload image failed, pvc not created", pvcName)
 	}
 	pvName := pvc.Spec.VolumeName
 	// 2. Check if the uploader marked its annotation on the pvc
 	cdiUploadPodName, exists := pvc.ObjectMeta.Annotations["cdi.kubevirt.io/storage.uploadPodName"]
 	if !exists {
-		return fmt.Errorf("PVC Upload for pvc:%s attempts to upload image failed, no upload pod annotation", pvcName)
+		return transientf("PVC Upload for pvc:%s attempts to upload image failed, no upload pod annotation", pvcName)
 	}
 	// 3. Did the uploader get created?
 	pod, err := PODGet(cdiUploadPodName, log)
 	if err != nil {
-		return fmt.Errorf("PVC Upload for pvc:%s attempts to upload image failed, upload pod:%s does not exist", pvcName, cdiUploadPodName)
+		return transientf("PVC Upload for pvc:%s attempts to upload image failed, upload pod:%s does not exist", pvcName, cdiUploadPodName)
 	}
 	uploadNodeName := pod.Spec.NodeName
 	// 4. Did the PVC claim get a backing pv?
 	lhVol, err := lhVolGet(pvName)
 	if err != nil {
-		return fmt.Errorf("PVC Upload for pvc:%s attempts to upload image failed, pv:%s does not exist", pvcName, pvName)
+		return transientf("PVC Upload for pvc:%s attempts to upload image failed, pv:%s does not exist", pvcName, pvName)
 	}
 	lhVolEi := lhVol.Status.CurrentImage
 	// 5. Does the backing vol have an engine? Is that engine deployed on the node where the uploader is?
 	deployed, err := lhEiDeployedOnNode(lhVolEi, uploadNodeName)
 	if !deployed {
-		return fmt.Errorf("PVC Upload for pvc:%s attempts to upload image failed, engine not deployed on node:%s %v", pvcName, uploadNodeName, err)
+		return transientf("PVC Upload for pvc:%s attempts to upload image failed, engine not deployed on node:%s %v", pvcName, uploadNodeName, err)
 	}
 
-	// Fallback to generic failure message
-	return fmt.Errorf("RolloutDiskToPVC pvc:%s attempts to upload image failed", pvcName)
+	// The upload failed after every attempt for a reason none of the diagnostics
+	// above pinned down. Keep it transient: a sustained upload-proxy / CDI outage
+	// with otherwise-healthy infra lands here and IS recoverable once it clears, so
+	// classifying it permanent would strand a retryable volume. The forever-loop a
+	// genuinely permanent failure (e.g. an unusable image) would otherwise cause is
+	// bounded not here but by retryFailedClusterVolumeCreate's maxClusterVolumeRetries
+	// cap, which parks the volume in a terminal error after a finite number of
+	// re-drives -- so this stays transient and the bound provides the escape hatch.
+	return transientf("RolloutDiskToPVC pvc:%s attempts to upload image failed", pvcName)
 }
 
 // GetPVFromPVC : Returns volume name (PV) from the PVC name

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -143,6 +143,18 @@ type VolumeStatus struct {
 	// We find that info from NOHYPER flag set in appinstance.
 	IsNativeContainer bool
 
+	// ClusterStorageTransientErr is set when the current volume-create Error came
+	// from the EVE-k cluster storage stack (Longhorn/CDI/k8s API) while it was
+	// still coming up, and is therefore worth retrying once it is ready. Set from
+	// the typed kubeapi verdict when the error is recorded; false on other HVs.
+	ClusterStorageTransientErr bool
+
+	// ClusterStorageRetryCount counts how many times retryFailedClusterVolumeCreate
+	// has re-driven this volume after a transient cluster-storage failure. It bounds
+	// the retry so an un-typeable or misclassified failure cannot loop forever;
+	// reset to 0 when the volume-create succeeds.
+	ClusterStorageRetryCount int
+
 	ErrorAndTimeWithSource
 }
 

--- a/pkg/pillar/utils/wait/waitfor.go
+++ b/pkg/pillar/utils/wait/waitfor.go
@@ -4,6 +4,8 @@
 package wait
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	info "github.com/lf-edge/eve-api/go/info"
@@ -146,4 +148,95 @@ func handleOnboardStatusImpl(ctxArg interface{}, key string,
 	}
 	ctx.Status = status
 	ctx.Initialized = true
+}
+
+// NodeNameFromDeviceName converts an EdgeNodeInfo.DeviceName into the Kubernetes
+// node name that k3s registers this node under: lower-cased with underscores
+// replaced by hyphens. This normalization must match the one in cluster-utils.sh;
+// keep them in sync.
+func NodeNameFromDeviceName(deviceName string) string {
+	return strings.ReplaceAll(strings.ToLower(deviceName), "_", "-")
+}
+
+// nodeNameContext carries the resolved node name out of the EdgeNodeInfo handlers.
+type nodeNameContext struct {
+	nodeName string
+	found    bool
+}
+
+// WaitForNodeName waits for zedagent to publish an EdgeNodeInfo with a non-empty
+// DeviceName and returns the derived Kubernetes node name (see NodeNameFromDeviceName).
+// If timeout > 0 it returns an error should the name not arrive within that window;
+// timeout == 0 waits indefinitely. The watchdog is kicked throughout.
+//
+// TODO: domainmgr and zedkube still resolve the node name with their own
+// EdgeNodeInfo subscriptions and copies of the DeviceName normalization; convert
+// them to this helper so the derivation lives in one place.
+//
+//revive:disable-next-line:exported // WaitFor* naming matches WaitForVault/WaitForOnboarded in this package
+func WaitForNodeName(ps *pubsub.PubSub, log *base.LogObject, agentName string,
+	warningTime, errorTime, timeout time.Duration) (string, error) {
+
+	nctx := &nodeNameContext{}
+	sub, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "zedagent",
+		MyAgentName:   agentName,
+		TopicImpl:     types.EdgeNodeInfo{},
+		Activate:      false,
+		Ctx:           nctx,
+		CreateHandler: handleEdgeNodeInfoCreate,
+		ModifyHandler: handleEdgeNodeInfoModify,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		return "", err
+	}
+	sub.Activate()
+	defer sub.Close()
+
+	// Run a periodic timer so we always update StillRunning
+	stillRunning := time.NewTicker(25 * time.Second)
+	defer stillRunning.Stop()
+	ps.StillRunning(agentName, warningTime, errorTime)
+
+	var timeoutCh <-chan time.Time
+	if timeout > 0 {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		timeoutCh = timer.C
+	}
+
+	for !nctx.found {
+		log.Functionf("Waiting for EdgeNodeInfo DeviceName")
+		select {
+		case change := <-sub.MsgChan():
+			sub.ProcessChange(change)
+		case <-timeoutCh:
+			return "", fmt.Errorf("timeout waiting for EdgeNodeInfo DeviceName")
+		case <-stillRunning.C:
+		}
+		ps.StillRunning(agentName, warningTime, errorTime)
+	}
+	return nctx.nodeName, nil
+}
+
+func handleEdgeNodeInfoCreate(ctxArg interface{}, key string, statusArg interface{}) {
+	handleEdgeNodeInfoImpl(ctxArg, statusArg)
+}
+
+func handleEdgeNodeInfoModify(ctxArg interface{}, key string, statusArg interface{}, _ interface{}) {
+	handleEdgeNodeInfoImpl(ctxArg, statusArg)
+}
+
+func handleEdgeNodeInfoImpl(ctxArg interface{}, statusArg interface{}) {
+	ctx := ctxArg.(*nodeNameContext)
+	enInfo := statusArg.(types.EdgeNodeInfo)
+	if enInfo.DeviceName == "" {
+		return
+	}
+	if nodeName := NodeNameFromDeviceName(enInfo.DeviceName); nodeName != "" {
+		ctx.nodeName = nodeName
+		ctx.found = true
+	}
 }

--- a/pkg/pillar/volumehandlers/commonhandler_test.go
+++ b/pkg/pillar/volumehandlers/commonhandler_test.go
@@ -42,6 +42,10 @@ func (m *mockVolumeMgr) GetCasClient() cas.CAS {
 	return nil
 }
 
+func (m *mockVolumeMgr) GetNodeName() string {
+	return ""
+}
+
 func newTestLog(t *testing.T) *base.LogObject {
 	t.Helper()
 	logger := logrus.New()

--- a/pkg/pillar/volumehandlers/csihandler.go
+++ b/pkg/pillar/volumehandlers/csihandler.go
@@ -154,11 +154,23 @@ func (handler *volumeHandlerCSI) CreateVolume() (string, error) {
 	handler.log.Noticef("CreateVolume called for PVC %s size %v", pvcName, pvcSize)
 
 	// Guard against re-creation on reboot: if the PVC already exists (created in a
-	// prior boot where VolumeStatus was not persisted as CREATED_VOLUME), skip the
-	// entire create path — the content is already in place.
+	// prior boot where VolumeStatus was not persisted as CREATED_VOLUME) the
+	// content is normally already in place. The exception is a prior attempt that
+	// created the PVC but did not finish the CDI image upload (e.g. the cluster
+	// was still coming up): fall through and re-drive the upload against the
+	// existing PVC rather than declaring the volume done with no data.
+	pvcExists := false
 	if found, err := kubeapi.FindPVC(pvcName, handler.log); err == nil && found {
-		handler.log.Noticef("CreateVolume: PVC %s already exists, skipping creation", pvcName)
-		return pvcName, nil
+		pvcExists = true
+		if handler.status.ReferenceName == "" {
+			handler.log.Noticef("CreateVolume: PVC %s already exists, skipping creation", pvcName)
+			return pvcName, nil
+		}
+		if uploaded, uerr := kubeapi.IsPVCUploadComplete(pvcName, handler.log); uerr == nil && uploaded {
+			handler.log.Noticef("CreateVolume: PVC %s already exists and upload complete, skipping creation", pvcName)
+			return pvcName, nil
+		}
+		handler.log.Noticef("CreateVolume: PVC %s exists but upload not complete, re-driving upload", pvcName)
 	}
 
 	repCount, err := kubeapi.GetSupportedReplicaCountForCluster()
@@ -220,7 +232,7 @@ func (handler *volumeHandlerCSI) CreateVolume() (string, error) {
 			}
 
 			// Convert to PVC
-			pvcerr := kubeapi.RolloutDiskToPVC(createContext, handler.log, false, rawImgFile, pvcName, false, pvcSize, storageClassName)
+			pvcerr := kubeapi.RolloutDiskToPVC(createContext, handler.log, pvcExists, rawImgFile, pvcName, false, pvcSize, storageClassName)
 
 			// Since we succeeded or failed to create PVC above, no point in keeping the rawImgFile.
 			// Delete it to save space.
@@ -231,10 +243,10 @@ func (handler *volumeHandlerCSI) CreateVolume() (string, error) {
 			}
 
 			if pvcerr != nil {
-				errStr := fmt.Sprintf("Error converting %s to PVC %s: %v",
+				err := fmt.Errorf("Error converting %s to PVC %s: %w",
 					rawImgFile, pvcName, pvcerr)
-				handler.log.Error(errStr)
-				return pvcName, errors.New(errStr)
+				handler.log.Error(err)
+				return pvcName, err
 			}
 		} else {
 			qcowFile, err := handler.getVolumeFilePath()
@@ -245,21 +257,21 @@ func (handler *volumeHandlerCSI) CreateVolume() (string, error) {
 				return pvcName, errors.New(errStr)
 			}
 			// Convert qcow2 to PVC
-			err = kubeapi.RolloutDiskToPVC(createContext, handler.log, false, qcowFile, pvcName, false, pvcSize, storageClassName)
+			err = kubeapi.RolloutDiskToPVC(createContext, handler.log, pvcExists, qcowFile, pvcName, false, pvcSize, storageClassName)
 
 			if err != nil {
-				errStr := fmt.Sprintf("Error converting %s to PVC %s: %v",
+				err = fmt.Errorf("Error converting %s to PVC %s: %w",
 					qcowFile, pvcName, err)
-				handler.log.Error(errStr)
-				return pvcName, errors.New(errStr)
+				handler.log.Error(err)
+				return pvcName, err
 			}
 		}
 	} else {
 		err := kubeapi.CreatePVC(pvcName, pvcSize, handler.log, storageClassName)
 		if err != nil {
-			errStr := fmt.Sprintf("Error creating PVC %s", pvcName)
-			handler.log.Error(errStr)
-			return "", errors.New(errStr)
+			err = fmt.Errorf("Error creating PVC %s: %w", pvcName, err)
+			handler.log.Error(err)
+			return "", err
 		}
 	}
 

--- a/pkg/pillar/volumehandlers/csihandler.go
+++ b/pkg/pillar/volumehandlers/csihandler.go
@@ -90,7 +90,7 @@ func (handler *volumeHandlerCSI) PrepareVolume() error {
 		}
 	}()
 
-	return kubeapi.WaitForLonghornReady(ctx, handler.log)
+	return kubeapi.WaitForLonghornReady(ctx, handler.log, handler.volumeManager.GetNodeName())
 }
 
 func (handler *volumeHandlerCSI) HandlePrepared() (bool, error) {

--- a/pkg/pillar/volumehandlers/handlers.go
+++ b/pkg/pillar/volumehandlers/handlers.go
@@ -51,6 +51,9 @@ type VolumeMgr interface {
 	LookupZVolStatusByDataset(dataset string) *types.ZVolStatus
 	GetCapabilities() *types.Capabilities
 	GetCasClient() cas.CAS
+	// GetNodeName returns this device's Kubernetes node name (EVE-k), derived from
+	// EdgeNodeInfo.DeviceName. Empty off EVE-k.
+	GetNodeName() string
 }
 
 func useVhost(log *base.LogObject, volumeManager VolumeMgr) bool {


### PR DESCRIPTION
Backport of #6121.

On EVE-k an app volume can be requested before the cluster storage stack
(k3s + Longhorn + CDI) is up — whenever the app instance is already in the
EdgeDevConfig while the cluster is still coming up. Two common triggers are a
freshly installed EVE-k node's first boot with an app already in its config, and
the minutes after a kvm→k conversion. In that window volume creation was
attempted prematurely and failed (storageclass-not-found, "no upload pod
annotation", RolloutDiskToPVC upload failures), sometimes leaving the volume
parked in a permanent error with no further attempts. Separately, the EVE-k
readiness checks identified this node from `os.Hostname()` (the device UUID),
which does not work when k3s registers the node under the controller-assigned
device name, and wedged the Kubernetes-readiness wait (and therefore domainmgr)
indefinitely if the device UUID ever diverged from the `node-uuid` label.

This makes app-volume creation defer quietly and retry until cluster storage can
actually serve it — up to a bounded number of attempts so a genuinely permanent
failure still surfaces — and identifies the node by its Kubernetes node name
(derived from the controller-assigned device name) so the readiness checks work
on named devices and no longer wedge when the device UUID changes. Included in
17.0 per the `next-17.0.0-rc` label on the original PR.

Cherry-picked from master with `git cherry-pick -x` (the 8 commits of #6121,
`56bd06f0`…`3d35218e`). Applied with no conflicts; the combined diff is identical
to #6121.

## How to test and validate this PR

1. Create a device in the controller and specify an app instance to deploy on it.
2. Install EVE-k on that device and let it onboard to the controller.
3. Confirm the volume and app instance converge to RUNNING. This takes at least
   10 minutes, often 30, due to the time to download, install and initialize the
   k3s, CDI and Longhorn packages.

The transient-vs-permanent retry boundary is unit-tested directly
(`clusterVolumeRetryActionFor` in volumemgr and the kubeapi error classifier).

## Changelog notes

On EVE-k, app volumes requested before the cluster storage stack (k3s / Longhorn
/ CDI) is ready are now deferred and retried until storage is available, instead
of failing and leaving the volume parked in a permanent error; this covers a
freshly installed EVE-k node's first boot. The EVE-k cluster-readiness checks now
identify the node by its Kubernetes node name (from the controller-assigned
device name) rather than the OS hostname, so they work on named devices and no
longer wedge when the device UUID changes.

## PR Backports

- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [x] I've written the test verification instructions
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
