### PR TITLE
pillar: use wait helper for k8s node name

### DIFF
--- a/pkg/kube/cluster-utils.sh
+++ b/pkg/kube/cluster-utils.sh
@@ -281,7 +281,9 @@ check_and_remove_excessive_k3s_logs() {
     fi
 }
 
-# kubernetes's name must be lower case and '-' instead of '_'
+# Convert a device name to its Kubernetes node name: lower case with '_'
+# replaced by '-'. Must match NodeNameFromDeviceName in
+# pkg/pillar/utils/wait/waitfor.go; keep them in sync.
 convert_to_k8s_compatible() {
         echo "$1" | tr '[:upper:]_' '[:lower:]-'
 }

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -119,7 +119,6 @@ type domainContext struct {
 	pubDomainStatus        pubsub.Publication
 	subGlobalConfig        pubsub.Subscription
 	subZFSPoolStatus       pubsub.Subscription
-	subEdgeNodeInfo        pubsub.Subscription
 	pubAssignableAdapters  pubsub.Publication
 	pubDomainMetric        pubsub.Publication
 	pubHostMemory          pubsub.Publication
@@ -471,24 +470,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	domainCtx.subZFSPoolStatus = subZFSPoolStatus
 
-	// Look for edge node info
-	subEdgeNodeInfo, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:   "zedagent",
-		MyAgentName: agentName,
-		TopicImpl:   types.EdgeNodeInfo{},
-		Persistent:  false,
-		Activate:    false,
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	domainCtx.subEdgeNodeInfo = subEdgeNodeInfo
-	_ = subEdgeNodeInfo.Activate()
-
-	// Wait for ConfigIntemValueMap and EdgeNodeInfo (if kube)
-	edgenodeInfoInitialized := false
-	for !domainCtx.GCComplete || (domainCtx.hvTypeKube && !edgenodeInfoInitialized) {
-		log.Noticef("waiting for GCComplete and EdgeNodeInfo")
+	// Wait for ConfigItemValueMap
+	for !domainCtx.GCComplete {
+		log.Noticef("waiting for GCComplete")
 		select {
 		case change := <-subGlobalConfig.MsgChan():
 			subGlobalConfig.ProcessChange(change)
@@ -496,15 +480,22 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		case <-domainCtx.publishTicker.C:
 			publishProcessesHandler(&domainCtx)
 
-		case change := <-subEdgeNodeInfo.MsgChan():
-			subEdgeNodeInfo.ProcessChange(change)
-			edgenodeInfoInitialized = domainCtx.checkAndSaveEdgeNodeInfo()
-
 		case <-stillRunning.C:
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
 	log.Noticef("processed GCComplete")
+
+	// The Kubernetes node name is derived from EdgeNodeInfo, which is static
+	// for the lifetime of a boot; resolve it once up front.
+	if domainCtx.hvTypeKube {
+		domainCtx.nodeName, err = wait.WaitForNodeName(ps, log, agentName,
+			warningTime, errorTime, 0)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Noticef("Got nodeName %s", domainCtx.nodeName)
+	}
 
 	if !domainCtx.setInitialUsbAccess {
 		log.Functionf("GCComplete but not setInitialUsbAccess => first boot")
@@ -587,9 +578,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 		case change := <-subZFSPoolStatus.MsgChan():
 			subZFSPoolStatus.ProcessChange(change)
-
-		case change := <-subEdgeNodeInfo.MsgChan():
-			subEdgeNodeInfo.ProcessChange(change)
 
 		case <-domainCtx.publishTicker.C:
 			publishProcessesHandler(&domainCtx)
@@ -816,9 +804,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 		case change := <-subPhysicalIOAdapter.MsgChan():
 			subPhysicalIOAdapter.ProcessChange(change)
-
-		case change := <-subEdgeNodeInfo.MsgChan():
-			subEdgeNodeInfo.ProcessChange(change)
 
 		case <-domainCtx.publishTicker.C:
 			start := time.Now()
@@ -4463,25 +4448,6 @@ func lookupCapabilities(ctx *domainContext) (*types.Capabilities, error) {
 		log.Fatalf("Unexpected type from pubCapabilities: %T", c)
 	}
 	return &capabilities, nil
-}
-
-// checkAndSaveEdgeNodeInfo checks if the device name is set in the EdgeNodeInfo
-// it returns true if we got the valid EdgeNodeInfo update
-func (ctx *domainContext) checkAndSaveEdgeNodeInfo() bool {
-	items := ctx.subEdgeNodeInfo.GetAll()
-	if len(items) > 0 {
-		for _, item := range items {
-			enInfo := item.(types.EdgeNodeInfo)
-			if enInfo.DeviceName != "" {
-				log.Noticef("checkAndSaveEdgeNodeInfo: found devicename %s", enInfo.DeviceName)
-				ctx.nodeName = strings.ReplaceAll(strings.ToLower(enInfo.DeviceName), "_", "-")
-				if ctx.nodeName != "" {
-					return true
-				}
-			}
-		}
-	}
-	return false
 }
 
 func getDmiSystemInfo(dmi *types.DmiSystemInfo) {

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	utils "github.com/lf-edge/eve/pkg/pillar/utils/file"
+	"github.com/lf-edge/eve/pkg/pillar/utils/wait"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
@@ -73,7 +74,6 @@ type zedkube struct {
 	subGlobalConfig          pubsub.Subscription
 	subDeviceNetworkStatus   pubsub.Subscription
 	subEdgeNodeClusterConfig pubsub.Subscription
-	subEdgeNodeInfo          pubsub.Subscription
 	subZedAgentStatus        pubsub.Subscription
 
 	subControllerCert    pubsub.Subscription
@@ -465,20 +465,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	zedkubeCtx.pubCipherMetrics = pubCipherMetrics
 
-	// Look for edge node info
-	subEdgeNodeInfo, err := ps.NewSubscription(pubsub.SubscriptionOptions{
-		AgentName:   "zedagent",
-		MyAgentName: agentName,
-		TopicImpl:   types.EdgeNodeInfo{},
-		Persistent:  false,
-		Activate:    false,
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	zedkubeCtx.subEdgeNodeInfo = subEdgeNodeInfo
-	subEdgeNodeInfo.Activate()
-
 	// start the leader election
 	zedkubeCtx.electionNotifyCh = make(chan struct{}, 1)
 	go zedkubeCtx.handleLeaderElection()
@@ -573,17 +559,34 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	log.Noticef("Got EdgeNodeClusterConfig")
 
-	// Wait for the certs and nodeInfo needed to decrypt the cluster token and for other
+	// The Kubernetes node name and node UUID are derived from EdgeNodeInfo, which
+	// is static for the lifetime of a boot; resolve it once up front.
+	enInfo, err := wait.WaitForEdgeNodeInfo(ps, log, agentName, warningTime, errorTime, 0)
+	if err != nil {
+		log.Fatal(err)
+	}
+	zedkubeCtx.nodeName = wait.NodeNameFromDeviceName(enInfo.DeviceName)
+	zedkubeCtx.nodeuuid = enInfo.DeviceID.String()
+	log.Noticef("zedkube run: got nodeName %s nodeuuid %s",
+		zedkubeCtx.nodeName, zedkubeCtx.nodeuuid)
+	// Re-enable the local node and apply the longhorn disk reservation now that
+	// our identity is known.
+	if !zedkubeCtx.onBootUncordonCheckComplete {
+		go nodeOnBootHealthStatusWatcher(&zedkubeCtx)
+	}
+	zedkubeCtx.applyLonghornDiskReserved()
+
+	// Wait for the certs needed to decrypt the cluster token and for other
 	// operations. We wait after ENCC so we can gate specifically on the ECDH cert required
 	// for decryption, rather than accepting any controller cert.
 	needECDHCert := zedkubeCtx.clusterConfig.CipherToken.IsCipher &&
 		zedkubeCtx.clusterConfig.CipherToken.CipherContext != nil
-	var edgenodeCertInitialized, edgenodeInfoInitialized bool
+	var edgenodeCertInitialized bool
 	ecdhCertInitialized := !needECDHCert
-	for !edgenodeCertInitialized || !edgenodeInfoInitialized || !ecdhCertInitialized {
+	for !edgenodeCertInitialized || !ecdhCertInitialized {
 		log.Noticef("zedkube run: waiting for edgenode cert (initialized=%t), "+
-			"edgenode info (initialized=%t), ecdh cert (initialized=%t)",
-			edgenodeCertInitialized, edgenodeInfoInitialized, ecdhCertInitialized)
+			"ecdh cert (initialized=%t)",
+			edgenodeCertInitialized, ecdhCertInitialized)
 		select {
 		case change := <-subControllerCert.MsgChan():
 			subControllerCert.ProcessChange(change)
@@ -599,10 +602,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			if len(subEdgeNodeCert.GetAll()) > 0 {
 				edgenodeCertInitialized = true
 			}
-
-		case change := <-subEdgeNodeInfo.MsgChan():
-			subEdgeNodeInfo.ProcessChange(change)
-			edgenodeInfoInitialized = zedkubeCtx.checkAndSaveEdgeNodeInfo()
 
 		case <-stillRunning.C:
 		}
@@ -676,7 +675,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	// Launch the VMI descheduler watcher once kubernetes is ready. GlobalConfig
 	// (which sets OnBoot) is processed as early as the ENCC wait loop above, so
 	// pubKubeConfig already reflects the operator's intent by the time we reach
-	// here. nodeName is also guaranteed set — the EdgeNodeInfo init loop completed
+	// here. nodeName is also guaranteed set — WaitForEdgeNodeInfo completed
 	// before WaitForKubernetes.
 	//
 	// NOTE: if the operator enables types.KubernetesVmiDescheduleEvents after
@@ -793,9 +792,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			subEdgeNodeCert.ProcessChange(change)
 			// Additional edgenode cert updates
 			zedkubeCtx.applyCertsChange("edgenode")
-
-		case change := <-subEdgeNodeInfo.MsgChan():
-			subEdgeNodeInfo.ProcessChange(change)
 
 		case change := <-subZedAgentStatus.MsgChan():
 			subZedAgentStatus.ProcessChange(change)
@@ -1192,32 +1188,6 @@ func handleZedAgentStatusDelete(ctxArg interface{}, key string,
 	statusArg interface{}) {
 	// do nothing
 	log.Functionf("handleZedAgentStatusDelete(%s) done", key)
-}
-
-// checkAndSaveEdgeNodeInfo checks if the device name is set in the EdgeNodeInfo
-// it returns true if we got the valid EdgeNodeInfo update
-func (z *zedkube) checkAndSaveEdgeNodeInfo() bool {
-	items := z.subEdgeNodeInfo.GetAll()
-	if len(items) > 0 {
-		for _, item := range items {
-			enInfo := item.(types.EdgeNodeInfo)
-			if enInfo.DeviceName != "" {
-				log.Noticef("checkAndSaveEdgeNodeInfo: found devicename %s", enInfo.DeviceName)
-				z.nodeName = strings.ReplaceAll(strings.ToLower(enInfo.DeviceName), "_", "-")
-				z.nodeuuid = enInfo.DeviceID.String()
-				if z.nodeName != "" && z.nodeuuid != "" {
-					//Re-enable local node
-					if !z.onBootUncordonCheckComplete {
-						go nodeOnBootHealthStatusWatcher(z)
-					}
-
-					z.applyLonghornDiskReserved()
-					return true
-				}
-			}
-		}
-	}
-	return false
 }
 
 // It may be a while until the node is ready to be uncordoned

--- a/pkg/pillar/utils/wait/waitfor.go
+++ b/pkg/pillar/utils/wait/waitfor.go
@@ -170,6 +170,8 @@ type edgeNodeInfoContext struct {
 // long-lived subscription to react to later updates. If timeout > 0 it returns
 // an error should the info not arrive within that window; timeout == 0 waits
 // indefinitely. The watchdog is kicked throughout.
+//
+//revive:disable-next-line:exported // WaitFor* naming matches WaitForVault/WaitForOnboarded in this package
 func WaitForEdgeNodeInfo(ps *pubsub.PubSub, log *base.LogObject, agentName string,
 	warningTime, errorTime, timeout time.Duration) (types.EdgeNodeInfo, error) {
 

--- a/pkg/pillar/utils/wait/waitfor.go
+++ b/pkg/pillar/utils/wait/waitfor.go
@@ -152,32 +152,28 @@ func handleOnboardStatusImpl(ctxArg interface{}, key string,
 
 // NodeNameFromDeviceName converts an EdgeNodeInfo.DeviceName into the Kubernetes
 // node name that k3s registers this node under: lower-cased with underscores
-// replaced by hyphens. This normalization must match the one in cluster-utils.sh;
-// keep them in sync.
+// replaced by hyphens. This normalization must match convert_to_k8s_compatible
+// in pkg/kube/cluster-utils.sh; keep them in sync.
 func NodeNameFromDeviceName(deviceName string) string {
 	return strings.ReplaceAll(strings.ToLower(deviceName), "_", "-")
 }
 
-// nodeNameContext carries the resolved node name out of the EdgeNodeInfo handlers.
-type nodeNameContext struct {
-	nodeName string
-	found    bool
+// edgeNodeInfoContext carries the resolved EdgeNodeInfo out of the handlers.
+type edgeNodeInfoContext struct {
+	info  types.EdgeNodeInfo
+	found bool
 }
 
-// WaitForNodeName waits for zedagent to publish an EdgeNodeInfo with a non-empty
-// DeviceName and returns the derived Kubernetes node name (see NodeNameFromDeviceName).
-// If timeout > 0 it returns an error should the name not arrive within that window;
-// timeout == 0 waits indefinitely. The watchdog is kicked throughout.
-//
-// TODO: domainmgr and zedkube still resolve the node name with their own
-// EdgeNodeInfo subscriptions and copies of the DeviceName normalization; convert
-// them to this helper so the derivation lives in one place.
-//
-//revive:disable-next-line:exported // WaitFor* naming matches WaitForVault/WaitForOnboarded in this package
-func WaitForNodeName(ps *pubsub.PubSub, log *base.LogObject, agentName string,
-	warningTime, errorTime, timeout time.Duration) (string, error) {
+// WaitForEdgeNodeInfo waits for zedagent to publish an EdgeNodeInfo with a
+// non-empty DeviceName and returns it. EdgeNodeInfo is static for the lifetime
+// of a boot, so a single up-front wait is enough; callers need not keep a
+// long-lived subscription to react to later updates. If timeout > 0 it returns
+// an error should the info not arrive within that window; timeout == 0 waits
+// indefinitely. The watchdog is kicked throughout.
+func WaitForEdgeNodeInfo(ps *pubsub.PubSub, log *base.LogObject, agentName string,
+	warningTime, errorTime, timeout time.Duration) (types.EdgeNodeInfo, error) {
 
-	nctx := &nodeNameContext{}
+	nctx := &edgeNodeInfoContext{}
 	sub, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedagent",
 		MyAgentName:   agentName,
@@ -190,7 +186,7 @@ func WaitForNodeName(ps *pubsub.PubSub, log *base.LogObject, agentName string,
 		ErrorTime:     errorTime,
 	})
 	if err != nil {
-		return "", err
+		return types.EdgeNodeInfo{}, err
 	}
 	sub.Activate()
 	defer sub.Close()
@@ -213,12 +209,27 @@ func WaitForNodeName(ps *pubsub.PubSub, log *base.LogObject, agentName string,
 		case change := <-sub.MsgChan():
 			sub.ProcessChange(change)
 		case <-timeoutCh:
-			return "", fmt.Errorf("timeout waiting for EdgeNodeInfo DeviceName")
+			return types.EdgeNodeInfo{}, fmt.Errorf("timeout waiting for EdgeNodeInfo DeviceName")
 		case <-stillRunning.C:
 		}
 		ps.StillRunning(agentName, warningTime, errorTime)
 	}
-	return nctx.nodeName, nil
+	return nctx.info, nil
+}
+
+// WaitForNodeName waits for a non-empty EdgeNodeInfo.DeviceName and returns the
+// derived Kubernetes node name (see NodeNameFromDeviceName). Timeout and watchdog
+// semantics match WaitForEdgeNodeInfo.
+//
+//revive:disable-next-line:exported // WaitFor* naming matches WaitForVault/WaitForOnboarded in this package
+func WaitForNodeName(ps *pubsub.PubSub, log *base.LogObject, agentName string,
+	warningTime, errorTime, timeout time.Duration) (string, error) {
+
+	enInfo, err := WaitForEdgeNodeInfo(ps, log, agentName, warningTime, errorTime, timeout)
+	if err != nil {
+		return "", err
+	}
+	return NodeNameFromDeviceName(enInfo.DeviceName), nil
 }
 
 func handleEdgeNodeInfoCreate(ctxArg interface{}, key string, statusArg interface{}) {
@@ -230,13 +241,11 @@ func handleEdgeNodeInfoModify(ctxArg interface{}, key string, statusArg interfac
 }
 
 func handleEdgeNodeInfoImpl(ctxArg interface{}, statusArg interface{}) {
-	ctx := ctxArg.(*nodeNameContext)
+	ctx := ctxArg.(*edgeNodeInfoContext)
 	enInfo := statusArg.(types.EdgeNodeInfo)
 	if enInfo.DeviceName == "" {
 		return
 	}
-	if nodeName := NodeNameFromDeviceName(enInfo.DeviceName); nodeName != "" {
-		ctx.nodeName = nodeName
-		ctx.found = true
-	}
+	ctx.info = enInfo
+	ctx.found = true
 }


### PR DESCRIPTION
# Description

Follow-up cleanup to #6121, which added the `WaitForNodeName` /
`NodeNameFromDeviceName` helpers in `utils/wait` and left a TODO to convert the
remaining open-coders.

`domainmgr` and `zedkube` each opened their own `EdgeNodeInfo` subscription,
open-coded the `DeviceName` → Kubernetes-node-name normalization
(`strings.ReplaceAll(strings.ToLower(name), "_", "-")`), and then kept the
subscription alive in their run loops without ever re-deriving the name.
`EdgeNodeInfo` is static for the lifetime of a boot, so the long-lived
subscription is unnecessary — a single up-front wait yields everything.

Both agents now resolve the node name once via the shared helpers:

- `domainmgr` uses `WaitForNodeName`.
- `zedkube` uses the new `WaitForEdgeNodeInfo`, which returns the whole
  `types.EdgeNodeInfo` so zedkube also gets the `DeviceID` (node UUID) it uses
  for its k8s `node-uuid` lookups, and still fires its on-boot side effects
  (uncordon watcher, Longhorn disk reservation).

The derivation now lives in exactly one Go location, `NodeNameFromDeviceName`.
Its shell twin `convert_to_k8s_compatible` (`cluster-utils.sh`, used for the
k3s node name and the Longhorn node name) can't import Go, so the two are now
cross-referenced by name in both directions to keep them in sync.

No functional change intended — same node name/UUID resolution, same startup
gating, just consolidated.

## How to test and validate this PR

- `make -C pkg/pillar` builds and `go vet` pass for both the default and
  `HV=k` (`-tags k`) tag sets; the change is compile-validated for the
  kubevirt build that actually exercises this code.
- End-to-end: bring up an EVE-k device/cluster and confirm `domainmgr` and
  `zedkube` reach steady state — the node registers under the derived name,
  and node-scoped operations (cordon/drain, Longhorn disk reservation) work as
  before.

Validated on a live amd64 EVE-k device (this branch, `HV=k`, under eden/QEMU):
`domainmgr` logged `Got nodeName <uuid>`, `zedkube` logged
`got nodeName <uuid> nodeuuid <uuid>` (both name and UUID from the single
`WaitForEdgeNodeInfo` struct), no `checkAndSaveEdgeNodeInfo` lines remained, and
k3s registered the node `Ready`/`control-plane` under that derived name.

## Changelog notes

None (internal refactor; no user-facing changes).

## PR Backports

- 16.0-stable: No — internal cleanup, not a fix.
- 14.5-stable: No — internal cleanup, not a fix.
- 13.4-stable: No — internal cleanup, not a fix.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Validated on amd64 EVE-k (see the results under "How to test" above). arm64 not
exercised; this is an architecture-independent Go refactor of the agent startup
path, also compile- and vet-validated for the default and `HV=k` tag sets.
