### PR TITLE
evetest: add PhysicalIO device config builder

### DIFF
--- a/evetest/devconfig.go
+++ b/evetest/devconfig.go
@@ -442,6 +442,12 @@ type NetworkAdapterConfig struct {
 	Usage         evecommon.PhyIoMemberUsage
 	PNAC          PNAC
 
+	// AssignmentGroup overrides the PhysicalIO assignment group. Defaults to
+	// LogicalLabel when empty.
+	AssignmentGroup string
+	// ParentAssignmentGroup sets the parent assignment group (empty if none).
+	ParentAssignmentGroup string
+
 	// AllowLocalModifications enables the Local Profile Server (LPS) to modify
 	// the network configuration of this adapter.
 	AllowLocalModifications bool
@@ -488,13 +494,69 @@ func (config NetworkAdapterConfig) toPhysicalIOProto() *eveconfig.PhysicalIO {
 	default:
 		phyIoType = evecommon.PhyIoType_PhyIoNetEth
 	}
+	assigngrp := config.AssignmentGroup
+	if assigngrp == "" {
+		assigngrp = config.LogicalLabel
+	}
 	return &eveconfig.PhysicalIO{
-		Ptype:        phyIoType,
-		Logicallabel: config.LogicalLabel,
-		Assigngrp:    config.LogicalLabel,
-		Phylabel:     config.PhysicalLabel,
-		Phyaddrs:     physAddrs,
-		Usage:        config.Usage,
+		Ptype:           phyIoType,
+		Logicallabel:    config.LogicalLabel,
+		Assigngrp:       assigngrp,
+		Parentassigngrp: config.ParentAssignmentGroup,
+		Phylabel:        config.PhysicalLabel,
+		Phyaddrs:        physAddrs,
+		Usage:           config.Usage,
+	}
+}
+
+// PhysicalIOConfig represents a raw PhysicalIO (assignable I/O) device in the
+// device model. Use it for non-network devices and for deliberately
+// inconsistent device models that AddNetworkAdapter cannot express (a specific
+// Ptype, a phantom device at a chosen PCI address, a custom assignment group,
+// etc.). A given logical label is owned by exactly one of AddNetworkAdapter or
+// AddPhysicalIO.
+type PhysicalIOConfig struct {
+	LogicalLabel  string
+	PhysicalLabel string
+	Type          evecommon.PhyIoType
+	// AssignmentGroup defaults to LogicalLabel when empty.
+	AssignmentGroup       string
+	ParentAssignmentGroup string
+	Usage                 evecommon.PhyIoMemberUsage
+	// Physical addresses; every non-empty field is written into Phyaddrs.
+	PCIAddress    string
+	USBAddress    string
+	InterfaceName string
+	Serial        string
+}
+
+// toPhysicalIOProto returns the EVE protobuf PhysicalIO for this device.
+func (config PhysicalIOConfig) toPhysicalIOProto() *eveconfig.PhysicalIO {
+	physAddrs := map[string]string{}
+	if config.PCIAddress != "" {
+		physAddrs["pcilong"] = config.PCIAddress
+	}
+	if config.USBAddress != "" {
+		physAddrs["usbaddr"] = config.USBAddress
+	}
+	if config.InterfaceName != "" {
+		physAddrs["ifname"] = config.InterfaceName
+	}
+	if config.Serial != "" {
+		physAddrs["serial"] = config.Serial
+	}
+	assigngrp := config.AssignmentGroup
+	if assigngrp == "" {
+		assigngrp = config.LogicalLabel
+	}
+	return &eveconfig.PhysicalIO{
+		Ptype:           config.Type,
+		Logicallabel:    config.LogicalLabel,
+		Assigngrp:       assigngrp,
+		Parentassigngrp: config.ParentAssignmentGroup,
+		Phylabel:        config.PhysicalLabel,
+		Phyaddrs:        physAddrs,
+		Usage:           config.Usage,
 	}
 }
 
@@ -1625,6 +1687,12 @@ func (dc *EdgeDeviceConfig) AddNetworkAdapter(config NetworkAdapterConfig) {
 				"by a bond adapter", config.LogicalLabel)
 		}
 	}
+	for _, physIO := range dc.DeviceIoList {
+		if physIO.Logicallabel == config.LogicalLabel {
+			dc.th.t.Fatalf("Network adapter logical label %q is already in use "+
+				"by an I/O device", config.LogicalLabel)
+		}
+	}
 	dc.checkAdapterNetwork(config)
 	dc.DeviceIoList = append(dc.DeviceIoList, config.toPhysicalIOProto())
 	if config.PNAC.Enable {
@@ -1632,6 +1700,44 @@ func (dc *EdgeDeviceConfig) AddNetworkAdapter(config NetworkAdapterConfig) {
 	}
 	if config.NetworkUUID != NilUUID {
 		dc.SystemAdapterList = append(dc.SystemAdapterList, config.toSystemAdapterProto())
+	}
+}
+
+// AddPhysicalIO adds a raw PhysicalIO (assignable I/O) device to the device
+// configuration. Use it for non-network devices and for device-model
+// inconsistencies that AddNetworkAdapter cannot express. A given logical label
+// is owned by exactly one of AddNetworkAdapter or AddPhysicalIO.
+func (dc *EdgeDeviceConfig) AddPhysicalIO(config PhysicalIOConfig) {
+	dc.checkIOLogicalLabelFree(config.LogicalLabel)
+	dc.DeviceIoList = append(dc.DeviceIoList, config.toPhysicalIOProto())
+}
+
+// checkIOLogicalLabelFree fails the test if logicalLabel is already used by any
+// I/O device, system adapter, VLAN or bond adapter.
+func (dc *EdgeDeviceConfig) checkIOLogicalLabelFree(logicalLabel string) {
+	for _, physIO := range dc.DeviceIoList {
+		if physIO.Logicallabel == logicalLabel {
+			dc.th.t.Fatalf("I/O device with logical label %q already exists",
+				logicalLabel)
+		}
+	}
+	for _, adapter := range dc.SystemAdapterList {
+		if adapter.Name == logicalLabel {
+			dc.th.t.Fatalf("logical label %q is already in use by a system adapter",
+				logicalLabel)
+		}
+	}
+	for _, vlan := range dc.Vlans {
+		if vlan.Logicallabel == logicalLabel {
+			dc.th.t.Fatalf("logical label %q is already in use by a VLAN adapter",
+				logicalLabel)
+		}
+	}
+	for _, bond := range dc.Bonds {
+		if bond.Logicallabel == logicalLabel {
+			dc.th.t.Fatalf("logical label %q is already in use by a bond adapter",
+				logicalLabel)
+		}
 	}
 }
 

--- a/evetest/testing.go
+++ b/evetest/testing.go
@@ -76,6 +76,10 @@ func (t *T) fail(msg string, now bool) {
 	t.th.testM.Lock()
 	if t.th.test.failedCh != nil {
 		close(t.th.test.failedCh)
+		// Clear so a re-entrant fail() does not close it again. This happens
+		// when a Fatal triggers cleanup (Close -> checkRebootCounts) that
+		// itself reports an error.
+		t.th.test.failedCh = nil
 	}
 	t.th.testM.Unlock()
 


### PR DESCRIPTION
# Description

Extends the evetest device-config builder so tests can express assignable
I/O devices and deliberately inconsistent device models.

Before this change, a `PhysicalIO` entry could only be produced as a side
effect of `AddNetworkAdapter`, which always derives a network `Ptype` and
hardwires the assignment group to the logical label. There was no way to add a
non-network assignable device (audio, USB, ...) or to model a device-model
inconsistency (a phantom device at a chosen PCI address, a custom or parent
assignment group).

This adds:

- **`PhysicalIOConfig` + `AddPhysicalIO`** — a builder for a raw assignable I/O
  device: `Type` (any `PhyIoType`), `AssignmentGroup`, `ParentAssignmentGroup`,
  `Usage`, and physical addresses (`PCIAddress`, `USBAddress`, `InterfaceName`,
  `Serial`).
- **`AssignmentGroup` / `ParentAssignmentGroup` on `NetworkAdapterConfig`** —
  the assignment group now defaults to the logical label but can be overridden,
  and a parent assignment group can be set.

A given logical label is owned by exactly one of `AddNetworkAdapter` or
`AddPhysicalIO`; using the same label through both fails the test, so the
resulting `DeviceIoList` is independent of call order.

This is test-framework tooling only; it changes no EVE runtime behavior. It is
the prerequisite for upcoming domainmgr assignable-adapter error-reporting
tests, which need to inject these device-model inconsistencies.

## How to test and validate this PR

Framework-only change, validated by compiling the framework and the existing
tests that consume it (from `evetest/`):

```sh
GOWORK=off go build .
GOWORK=off go vet ./tests/...
GOWORK=off go build ./tests/...
```

All pass. No behavioral test is applicable until a test uses `AddPhysicalIO`
(added in the follow-up PR).

## Changelog notes

None — internal test framework only; no user-visible or on-device change.

## PR Backports

Not applicable — test tooling, not shipped in any release image.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — N/A, godoc on the new types/methods
- [x] I've tested my PR on amd64 device — framework compiles; consumed by follow-up tests
- [ ] I've tested my PR on arm64 device — N/A, host-arch-independent builder code
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
