### PR TITLE
evetest: make EVE-k cluster test filesystem configurable (ext4 default)

### DIFF
--- a/evetest/README.md
+++ b/evetest/README.md
@@ -209,7 +209,7 @@ evetest.RequireEdgeDevice{
     Name:              "dev1",          // logical name to reference the device
     MinCPUs:           4,               // default: 4
     MinRAMInMiB:       8192,            // default: 8 GiB
-    MinDiskSizeInMiB:  36864,           // default: 36 GiB
+    MinDiskSizeInMiB:  65536,           // default: 64 GiB
     WithHypervisor:    evetest.HypervisorKVM,
     WithFilesystem:    evetest.FilesystemZFS,
     WithTPM:           true,

--- a/evetest/requirements.go
+++ b/evetest/requirements.go
@@ -168,7 +168,7 @@ type RequireEdgeDevice struct {
 	// None of these will be ever created with zero count - not even ethernet interfaces.
 	MinCPUs          uint8  // Default will be 4.
 	MinRAMInMiB      uint32 // Default will be 8 GiB (8192 MiB).
-	MinDiskSizeInMiB uint32 // Default will be 36 GiB (36864 MiB).
+	MinDiskSizeInMiB uint32 // Default will be 64 GiB (65536 MiB).
 
 	WithEVEVersion string
 	WithHypervisor Hypervisor

--- a/evetest/testparam.go
+++ b/evetest/testparam.go
@@ -268,14 +268,14 @@ func GetEVEVersionParameterValue() string {
 const DiskSizeMiBParameterKey = "DISK_SIZE_MB"
 
 // DiskSizeMiBParameter is a predefined TestParameterDefinition for the device disk size.
-// A value of 0 means the framework default (36864 MiB) is used.
+// A value of 0 means the framework default (65536 MiB) is used.
 func DiskSizeMiBParameter() TestParameterDefinition {
 	return TestParameterDefinition{
 		Key:          DiskSizeMiBParameterKey,
 		DefaultValue: uint32(0),
 		Description: TestParameterDescription{
 			Summary: "Device disk size in MiB",
-			Default: "0 (use framework default 36864 MiB)",
+			Default: "0 (use framework default 65536 MiB)",
 		},
 	}
 }

--- a/evetest/tests/cluster/cluster_test.go
+++ b/evetest/tests/cluster/cluster_test.go
@@ -20,14 +20,21 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
-func clusterDeviceRequirements(devName string, withTPM bool) evetest.RequireEdgeDevice {
+func clusterDeviceRequirements(
+	devName string, withTPM bool, filesystem evetest.Filesystem) evetest.RequireEdgeDevice {
 	return evetest.RequireEdgeDevice{
 		Name:           devName,
 		WithTPM:        withTPM,
 		WithHypervisor: evetest.HypervisorKubevirt,
 		// We want to test cluster creation.
 		DeviceReusePolicy: evetest.CreateFromScratchWithLiveImage,
-		WithFilesystem:    evetest.FilesystemZFS,
+		// Filesystem is configurable via the FILESYSTEM parameter and defaults
+		// to ext4. EVE-k formation is fsync-heavy (k3s/etcd WAL, Longhorn/CDI/
+		// KubeVirt image extraction); ZFS's synchronous ZIL commit adds enough
+		// fsync latency to crash-loop the in-process apiserver during the
+		// single->multi-node etcd transition, whereas ext4 stays healthy. Kept
+		// configurable because a lot of EVE-k behaves differently per filesystem.
+		WithFilesystem: filesystem,
 		WithGrubOptions: []string{
 			// Application performance is not a primary concern; instead, we focus
 			// on minimizing device onboarding time and accelerating cluster formation.
@@ -52,8 +59,9 @@ func clusterDeviceRequirements(devName string, withTPM bool) evetest.RequireEdge
 // --------------------
 //   - clusterDeviceRequirements (top of this file): WithHypervisor=Kubevirt,
 //     DeviceReusePolicy=CreateFromScratchWithLiveImage (we want to test
-//     fresh cluster formation), WithFilesystem=ZFS, plus grub options that
-//     cap dom0/eve/ctrd vcpus so cluster formation onboarding is fast.
+//     fresh cluster formation), default ext4 (changeable via the FILESYSTEM
+//     parameter), plus grub options that cap dom0/eve/ctrd vcpus so
+//     cluster formation is fast.
 //   - SystemAdapter on eth0 (DHCP, mgmt+app, NetworkType=V4Only).
 //   - One Local NI "local-ni" (10.11.12.0/24, EnableFlowlog=true) and one
 //     container app with default-allow + port-fwd 2222->22.
@@ -61,6 +69,7 @@ func clusterDeviceRequirements(devName string, withTPM bool) evetest.RequireEdge
 // Test parameters
 // ---------------
 //   - TPM (bool) via evetest.TPMParameter().
+//   - FILESYSTEM (ext4|zfs, defaults to ext4) via evetest.FilesystemParameter().
 //
 // Phases
 // ------
@@ -95,14 +104,16 @@ func TestSingleNodeCluster(test *testing.T) {
 	// Define configurable parameters available for the test.
 	evetest.DefineTestParameters(
 		evetest.TPMParameter(),
+		evetest.FilesystemParameter(),
 	)
 
 	// Get parameter values set for this test execution.
 	withTPM := evetest.GetTPMParameterValue()
+	filesystem := evetest.GetFilesystemParameterValue()
 
 	// Set up the test harness and specify the test prerequisites.
 	devName := "edge-dev"
-	requiredDevice := clusterDeviceRequirements(devName, withTPM)
+	requiredDevice := clusterDeviceRequirements(devName, withTPM, filesystem)
 	requiredNetModel := evetest.RequireNetworkModel{
 		NetworkModel: netmodels.SingleEthWithDHCP,
 	}
@@ -252,7 +263,8 @@ func TestSingleNodeCluster(test *testing.T) {
 // --------------------
 //   - Three RequireEdgeDevice entries built via clusterDeviceRequirements
 //     (same params as TestSingleNodeCluster: Kubevirt, fresh image,
-//     ZFS, 8 GB RAM, 4 vCPUs, vcpu-cap grub options).
+//     ext4 by default / configurable via FILESYSTEM, 8 GB RAM, 4 vCPUs,
+//     vcpu-cap grub options).
 //   - ClusterConfig (evetest.NewEdgeClusterConfig) with three
 //     ClusterNode entries: each device gets a distinct ClusterIP from
 //     10.244.244.0/24 (.2, .3, .4) on ClusterInterface="ethernet1".
@@ -267,6 +279,7 @@ func TestSingleNodeCluster(test *testing.T) {
 // Test parameters
 // ---------------
 //   - TPM via evetest.TPMParameter().
+//   - FILESYSTEM (ext4|zfs, defaults to ext4) via evetest.FilesystemParameter().
 //
 // Phases
 // ------
@@ -298,17 +311,19 @@ func TestThreeNodesCluster(test *testing.T) {
 	// Define configurable parameters available for the test.
 	evetest.DefineTestParameters(
 		evetest.TPMParameter(),
+		evetest.FilesystemParameter(),
 	)
 
 	// Get parameter values set for this test execution.
 	withTPM := evetest.GetTPMParameterValue()
+	filesystem := evetest.GetFilesystemParameterValue()
 
 	// Set up the test harness and specify the test prerequisites.
 	var requiredDevices [3]evetest.Requirement
 	var devName [3]string
 	for i := 0; i < 3; i++ {
 		devName[i] = fmt.Sprintf("edge-dev%d", i+1)
-		requiredDevices[i] = clusterDeviceRequirements(devName[i], withTPM)
+		requiredDevices[i] = clusterDeviceRequirements(devName[i], withTPM, filesystem)
 	}
 
 	requiredNetModel := evetest.RequireNetworkModel{

--- a/evetest/tests/upgrade/upgrade_test.go
+++ b/evetest/tests/upgrade/upgrade_test.go
@@ -48,7 +48,7 @@ const (
 //   - INITIAL_EVE_VERSION: initial EVE version the device starts on (required,
 //     e.g. "16.0.0-lts")
 //   - INITIAL_HYPERVISOR: initial hypervisor for the starting device (default: kvm)
-//   - DISK_SIZE_MB: device disk size in MiB (0 = framework default 36864 MiB)
+//   - DISK_SIZE_MB: device disk size in MiB (0 = framework default 65536 MiB)
 //   - EXPECT_REVERT: if true, the upgrade is expected to fail and EVE to revert
 //     to the previous version (default: false)
 //


### PR DESCRIPTION
# Description

The evetest EVE-k cluster tests (`evetest/tests/cluster/cluster_test.go`)
hard-coded a ZFS `/persist`. ZFS crash-loops the EVE-k control plane during
cluster formation: its synchronous ZIL commit adds heavy fsync latency, and
formation is fsync-heavy on many small files (k3s/etcd WAL, Longhorn/CDI/
KubeVirt image extraction). During the single→multi-node etcd transition this
starves the in-process apiserver's etcd ops, readiness checks time out, k3s
restarts it in a loop, and the cluster never converges (Longhorn nodes
deregister, CDI uploads fail, pinned apps hang in "Init"). On ext4 the
apiservers stay healthy through the transition.

This drops the hard-coded filesystem and instead exposes it through the
existing `FILESYSTEM` test parameter (`evetest.FilesystemParameter`),
defaulting to **ext4**, on both `TestSingleNodeCluster` and
`TestThreeNodesCluster`. Making ext4 the default fixes the crash-loop, while
`FILESYSTEM=zfs` keeps an easy way to run the eve-k tests on ZFS when needed
(a lot of eve-k behaves differently depending on the filesystem).

ext4 needs the larger boot disk (it has no ZFS lz4 compression, and EVE-k's
Longhorn preflight reserves 25% and needs ≥16 GiB schedulable) — the
framework already defaults devices to a 64 GiB boot disk
(`DefaultEVEDeviceDiskSizeInMiB`), so no explicit disk size is set here.

The ZFS-specific storage test (`TestVaultZvolTrimReclaimsBlocks`) deliberately
tests ZFS and is left unchanged.

A second commit also corrects stale documentation that still stated the old
36 GiB device disk-size default — the framework default is now 64 GiB
(`DefaultEVEDeviceDiskSizeInMiB = 65536`) — in `requirements.go`,
`testparam.go`, `tests/upgrade/upgrade_test.go` and the README.

## How to test and validate this PR

Test-only change. Run the EVE-k cluster tests against an EVE-k image, e.g.:

```
make evetest NAME=TestThreeNodesCluster                    # default: ext4
FILESYSTEM=zfs make evetest NAME=TestThreeNodesCluster     # opt back into ZFS
```

The ext4 default was validated end-to-end on a distributed evetest broker:
the three-node cluster forms, storage reports healthy, and a deployed app
reaches RUNNING with the port-forward `hostname` and outbound
`curl "Hello world!"` smoke checks passing. The previous hard-coded-ZFS
configuration failed cluster formation.

## Changelog notes

No user-facing changes (test infrastructure only).

## PR Backports

- 16.0-stable: No, evetest cluster tests are test-infra only.
- 14.5-stable: No, evetest cluster tests are test-infra only.
- 13.4-stable: No, evetest cluster tests are test-infra only.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — N/A, test-only change
- [x] I've tested my PR on amd64 device — validated via evetest on amd64
- [ ] I've tested my PR on arm64 device — N/A, EVE-k cluster tests run on amd64
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
