### PR TITLE
evetest: move images to lfedge, add CI publishing, fix multi-arch builds

### DIFF
--- a/.github/workflows/publish-evetest.yml
+++ b/.github/workflows/publish-evetest.yml
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+name: Publish Evetest
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - "master"
+    paths:
+      - "evetest/**"
+      # tests/, netmodels/ and matchers/ are not baked into the evetest
+      # container image -- they are bind-mounted at runtime from the checked
+      # out eve repo, so changes here don't require rebuilding/republishing.
+      - "!evetest/tests/**"
+      - "!evetest/netmodels/**"
+      - "!evetest/matchers/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  # ════════════════════════════════════════════════════════════════════════
+  # Build and push every evetest image (multi-arch: amd64 + arm64), one
+  # matrix entry per image, in parallel.
+  # ════════════════════════════════════════════════════════════════════════
+  publish:
+    if: github.event.repository.full_name == 'lf-edge/eve'
+    runs-on: zededa-ubuntu-2204
+    timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: sdn
+            dir: evetest/sdn
+            target: build
+            needs_linuxkit: true
+          - name: evetest
+            dir: evetest
+            target: build-container
+            needs_linuxkit: false
+          - name: broker
+            dir: evetest
+            target: build-broker-container
+            needs_linuxkit: false
+          - name: testapps
+            dir: evetest/testapps
+            target: build
+            needs_linuxkit: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Ensure linuxkit is available
+        if: matrix.needs_linuxkit
+        run: |
+          if command -v linuxkit >/dev/null 2>&1; then
+            echo "LINUXKIT=$(command -v linuxkit)" >> "$GITHUB_ENV"
+          else
+            make build-tools
+            echo "LINUXKIT=$(pwd)/build-tools/bin/linuxkit" >> "$GITHUB_ENV"
+          fi
+      - name: Login to Docker Hub
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        with:
+          username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+          password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+      - name: Build and push ${{ matrix.name }} image
+        working-directory: ${{ matrix.dir }}
+        run: |
+          make ${{ matrix.target }} DOCKER_TARGET=push \
+            DOCKER_PLATFORM=linux/amd64,linux/arm64
+      - name: Clean
+        if: ${{ always() }}
+        run: |
+          docker system prune -f -a --volumes
+          rm -rf ~/.linuxkit

--- a/evetest/Dockerfile.broker
+++ b/evetest/Dockerfile.broker
@@ -6,20 +6,44 @@ ARG GOLANG_VERSION=1.25
 
 ###########################
 # Build stage
+# Runs natively on the build host using --platform=$BUILDPLATFORM so that Go
+# executes without QEMU emulation. CGO (and therefore the libvirt provider)
+# is only enabled when the target arch matches the build host's own arch
+# (native build): a real amd64 or arm64 dev machine building its own arch
+# gets a full CGO-enabled binary with libvirt support, since the native gcc/
+# libvirt-dev installed below actually matches what's being linked. Cross-
+# compiling (e.g. building an arm64 image from an amd64 host) would need
+# a foreign cross toolchain plus foreign libvirt headers, which isn't worth
+# maintaining now that Proxmox (not libvirt) is our primary distributed-mode
+# provider -- so a cross-build instead sets CGO_ENABLED=0 and falls back to
+# the libvirt provider's stub (see broker/provider/libvirt_stub.go), the
+# same mechanism Dockerfile.evetest already relies on for its own
+# CGO_ENABLED=0 build. The proxmox and qemu providers are unaffected and
+# fully supported in every case.
 ###########################
-FROM golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION} AS builder
+# hadolint ignore=DL3029
+FROM --platform=$BUILDPLATFORM golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION} AS builder
 
 # Set build-time "version" variable.
 ARG EVETEST_VERSION=dev
 ENV EVETEST_VERSION=${EVETEST_VERSION}
 
+ARG TARGETOS
+ARG TARGETARCH
+ARG BUILDARCH
+
 # Set up working directory and GOBIN
 WORKDIR /broker
 ENV GOBIN=/go/bin
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
 # Use the pre-downloaded module cache; ignore vendor/ even if it appears in the build context.
 ENV GOFLAGS="-mod=readonly"
 
-# Install build dependencies
+# Install build dependencies. gcc/musl-dev/pkgconfig/libvirt-dev only end up
+# actually used when CGO is enabled below (native build); installing them
+# unconditionally keeps this Dockerfile simple, and they match the build
+# host's own arch either way since this stage is pinned to $BUILDPLATFORM.
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
     make \
@@ -36,8 +60,12 @@ RUN go mod download
 # Copy source code and build the broker
 COPY . .
 
-# Run Makefile target to install evetest-broker
-RUN make _install-broker
+# Run Makefile target to install evetest-broker. CGO_ENABLED=1 (full libvirt
+# support) when building for the host's own native arch; CGO_ENABLED=0
+# (libvirt provider excluded, see broker/provider/libvirt_stub.go) for any
+# cross-build to a different target arch.
+RUN if [ "$TARGETARCH" = "$BUILDARCH" ]; then export CGO_ENABLED=1; else export CGO_ENABLED=0; fi && \
+    make _install-broker
 
 ###########################
 # Runtime image

--- a/evetest/Makefile
+++ b/evetest/Makefile
@@ -7,7 +7,7 @@ EVETEST_ORG ?= lfedge
 EVETEST_ADAM_VERSION ?= 0.0.75
 EVETEST_ADAM_REPO ?= lfedge/adam
 
-EVETEST_IMAGE := $(EVETEST_ORG)/evetest:$(EVETEST_VERSION)-adam-$(EVETEST_ADAM_VERSION)
+EVETEST_IMAGE := $(EVETEST_ORG)/evetest:$(EVETEST_VERSION)
 EVETEST_API_PORT ?= 50021
 
 PROTOC_VERSION ?= 31.1
@@ -53,7 +53,7 @@ ifndef EVETEST_EVE_VERSION
 	)))
 	$(eval EVE_VERSION_ENV := -e EVETEST_EVE_VERSION=$(EVETEST_EVE_VERSION))
 endif
-	@echo "Running evetest $(EVETEST_NAME) for EVE $(EVETEST_EVE_VERSION) with evetest image version $(EVETEST_VERSION)-adam-$(EVETEST_ADAM_VERSION)..."
+	@echo "Running evetest $(EVETEST_NAME) for EVE $(EVETEST_EVE_VERSION) with evetest image version $(EVETEST_VERSION) (adam $(EVETEST_ADAM_VERSION))..."
 	$(eval ENV_VARS := $(shell env | grep '^EVETEST_' | grep -v '^EVETEST_NAME=' | sed 's/^/-e /'))
 	$(eval ARTIFACTS_MOUNT :=)
 ifneq ($(EVETEST_COLLECT_ARTIFACTS),)
@@ -148,7 +148,7 @@ endif
 		-e EVETEST_HOME=$(EVETEST_HOME_DIR) \
 		-e EVETEST_HOST_UID=$(EVETEST_HOST_UID) \
 		-e EVETEST_HOST_GID=$(EVETEST_HOST_GID) \
-		$(EVETEST_ORG)/evetest:$(EVETEST_VERSION)-adam-$(EVETEST_ADAM_VERSION)
+		$(EVETEST_IMAGE)
 
 ensure-evetest-image:
 	@if ! docker image inspect $(EVETEST_IMAGE) >/dev/null 2>&1; then \
@@ -194,7 +194,7 @@ build-container:
 		--build-arg EVETEST_VERSION=$(EVETEST_VERSION) \
 		--build-arg EVETEST_ADAM_REPO=$(EVETEST_ADAM_REPO) \
 		--build-arg EVETEST_ADAM_VERSION=$(EVETEST_ADAM_VERSION) \
-		-t $(EVETEST_ORG)/evetest:$(EVETEST_VERSION)-adam-$(EVETEST_ADAM_VERSION) \
+		-t $(EVETEST_IMAGE) \
 		-f Dockerfile.evetest .
 
 build-test-apps:

--- a/evetest/Makefile
+++ b/evetest/Makefile
@@ -198,10 +198,7 @@ build-container:
 		-f Dockerfile.evetest .
 
 build-test-apps:
-	@for app in testapps/*/; do \
-		echo "Building $$app..."; \
-		$(MAKE) -C $$app build || exit 1; \
-	done
+	@$(MAKE) -C testapps build
 
 build-broker-container:
 	@echo "Building Docker image $(EVETEST_ORG)/evetest-broker:$(EVETEST_VERSION)"

--- a/evetest/README.md
+++ b/evetest/README.md
@@ -750,8 +750,18 @@ same terminal session beforehand.
 |----------|-------------|---------|
 | `EVETEST_ORG` | Docker Hub organization for evetest and evetest-broker images | `lfedge` |
 | `EVETEST_EVE_REPO` | EVE image repository | `lfedge/eve` |
-| `EVETEST_ADAM_VERSION` | Adam controller version | `0.0.75` |
-| `EVETEST_SDN_VERSION` | SDN emulator version | `v0.0.1` |
+| `EVETEST_ADAM_VERSION` | Adam controller version *(build-time only, see note below)* | `0.0.75` |
+| `EVETEST_SDN_VERSION` | SDN emulator version | `1.0` |
+
+> **`EVETEST_ADAM_VERSION` requires evetest container rebuild.** Unlike the other
+> variables above, Adam's binary is baked into the evetest image at build time
+> (`Dockerfile.evetest` copies it in from `lfedge/adam:$EVETEST_ADAM_VERSION`);
+> the evetest image tag is just `evetest:<EVETEST_VERSION>`, so it does not encode
+> which Adam version is inside. Setting `EVETEST_ADAM_VERSION` as a runtime environment
+> variable before `make evetest` has **no effect** on which Adam binary actually runs.
+> To test against a different (e.g. custom-built) Adam version, rebuild the image first:
+> `make build-container EVETEST_ADAM_VERSION=<version>`, then run tests as usual
+> against that locally-built image.
 
 ### Broker Variables (for distributed mode)
 

--- a/evetest/README.md
+++ b/evetest/README.md
@@ -909,7 +909,14 @@ The broker currently supports the following **device providers**:
 - **QEMU** — direct QEMU invocation, used in all-in-one mode
 - **libvirt** — uses libvirt APIs, used in distributed mode; the broker runs as a
   container on the hypervisor host (see `make libvirt-setup-broker-user` /
-  `make libvirt-run-broker-container` above)
+  `make libvirt-run-broker-container` above). Requires CGO, which is only
+  enabled for a **native** broker build (build host arch == target arch) --
+  building `make build-broker-container` directly on an amd64 or arm64 host
+  gets full libvirt support either way. The **published** arm64 broker image
+  is *cross-compiled* from an amd64 CI runner, so it is built with
+  `CGO_ENABLED=0` and falls back to a stub that returns an error if the
+  libvirt provider is selected (see the note on `make build-broker-container`
+  below)
 - **proxmox** — uses the Proxmox VE REST API, used in distributed mode; the broker
   itself runs inside a VM on the Proxmox host, set up end to end by the installer in
   [deploy/proxmox/README.md](deploy/proxmox/README.md)
@@ -960,7 +967,7 @@ and the framework subscribes to Adam's data streams to keep device state up to d
 | `make list-tests` | List all available tests and test suites with their configurable parameters |
 | `make evetest` | Run a test (requires `NAME=...`) |
 | `make build-container` | Build the evetest container; set `DOCKER_PLATFORM=linux/<arch>` to cross-compile for a different architecture (Go build stage runs natively on the host, no QEMU emulation); use `DOCKER_TARGET=push` to publish to a registry instead of loading locally |
-| `make build-broker-container` | Build broker Docker image only; set `DOCKER_PLATFORM=linux/<arch>` to build for a different architecture (the builder runs under QEMU emulation since the broker requires CGO for libvirt); use `DOCKER_TARGET=push` to publish to a registry instead of loading locally |
+| `make build-broker-container` | Build broker Docker image only; set `DOCKER_PLATFORM=linux/<arch>` to cross-compile for a different architecture (Go build stage runs natively on the host, no QEMU emulation); CGO (and therefore the libvirt provider) is only enabled when `DOCKER_PLATFORM` matches the build host's own arch -- e.g. building on an arm64 host with the default `DOCKER_PLATFORM` gets full libvirt support, but cross-compiling to a *different* arch than the host (as CI does to publish the arm64 image from an amd64 runner) sets `CGO_ENABLED=0` and drops libvirt (qemu and proxmox providers are unaffected either way); use `DOCKER_TARGET=push` to publish to a registry instead of loading locally |
 | `make build-sdn-container` | Build SDN VM container (requires linuxkit, with the `LINUXKIT` variable pointing to the binary); set `DOCKER_PLATFORM=linux/<arch>` to cross-compile for a different architecture (Go build stage runs natively on the host, no QEMU emulation); use `DOCKER_TARGET=push` to publish to a registry instead of loading locally |
 | `make build-test-apps` | Build all test apps under `testapps/` by invoking each app's `build` target; supports the same `DOCKER_PLATFORM`, `DOCKER_TARGET`, and `EVETEST_ORG` variables |
 | `make install-cli` | Install the `evetest` CLI binary |

--- a/evetest/VERSION
+++ b/evetest/VERSION
@@ -1,2 +1,2 @@
 # Evetest version. Increment this manually whenever changes are made to the evetest framework.
-v0.0.1
+1.0

--- a/evetest/constants/config.go
+++ b/evetest/constants/config.go
@@ -273,14 +273,13 @@ const (
 	DefaultAdamRepo = "lfedge/adam"
 
 	// DefaultSDNRepo is the default SDN image repository.
-	// TODO: change to lfedge once the repo is created
-	DefaultSDNRepo = "milan4zededa/evetest-sdn"
+	DefaultSDNRepo = "lfedge/evetest-sdn"
 
 	// DefaultAdamVersion specifies the Adam version to use by default.
 	DefaultAdamVersion = "0.0.75"
 
 	// DefaultSDNVersion specifies the SDN version to use by default.
-	DefaultSDNVersion = "v0.0.1"
+	DefaultSDNVersion = "1.0"
 
 	// DefaultSDNUplinkIPv4Subnet species the IPv4 subnet used for SDN uplink
 	// interfaces by default.

--- a/evetest/deploy/proxmox/README.md
+++ b/evetest/deploy/proxmox/README.md
@@ -123,7 +123,7 @@ token), so the installer always prompts you interactively for that account's pas
 (masked, never accepted as a flag, never touching shell history). The password/URL/etc.
 are written into the broker VM's `/etc/evetest/broker.env`. The broker container image
 tag is **baked into the installer** from `evetest/VERSION` at assembly time (e.g.
-`lfedge/evetest-broker:v0.0.1`); override with `--broker-image`.
+`lfedge/evetest-broker:1.0`); override with `--broker-image`.
 
 ### Stable LAN IP across reinstalls
 

--- a/evetest/deploy/proxmox/installer.sh.tmpl
+++ b/evetest/deploy/proxmox/installer.sh.tmpl
@@ -53,9 +53,8 @@ LAN_BRIDGE="vmbr0"
 BROKER_LAN_MAC=""
 UPLINK_VNET="evu"
 # @@VERSION@@ is replaced with evetest/VERSION when the installer is assembled
-# (make proxmox-broker-installer), e.g. lfedge/evetest-broker:v0.0.1.
-# TODO: Replace the image repository with lfedge once it has been created.
-BROKER_IMAGE="milan4zededa/evetest-broker:@@VERSION@@"
+# (make proxmox-broker-installer), e.g. lfedge/evetest-broker:1.0.
+BROKER_IMAGE="lfedge/evetest-broker:@@VERSION@@"
 BROKER_VM_CORES="4"
 BROKER_VM_MEMORY="8192"
 BROKER_VM_DISK="64"          # GiB; hosts all the pulled/cached Docker images

--- a/evetest/sdn/VERSION
+++ b/evetest/sdn/VERSION
@@ -1,2 +1,2 @@
 # Evetest-SDN version. Increment this manually whenever changes are made to evetest/sdn/vm.
-v0.0.1
+1.0

--- a/evetest/testapps/Makefile
+++ b/evetest/testapps/Makefile
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Builds (and, with DOCKER_TARGET=push, pushes) every test app under this
+# directory by invoking each subdirectory's own "build" target. Adding a new
+# test app is picked up here -- and by .github/workflows/publish-evetest.yml,
+# which just calls this Makefile -- automatically, with no changes needed in
+# either place. See README.md in this directory for how to add one.
+
+build:
+	@for dir in */; do \
+		app=$${dir%/}; \
+		[ -f "$$app/Makefile" ] || continue; \
+		echo "Building $$app..."; \
+		$(MAKE) -C "$$app" build || exit 1; \
+	done

--- a/evetest/testapps/README.md
+++ b/evetest/testapps/README.md
@@ -1,0 +1,48 @@
+# Test Applications
+
+Applications deployed as EVE app workloads by evetest tests. Every app here today
+is a container image, but this directory may also hold VM app sources in the
+future -- the only requirement is that each subdirectory's `Makefile` expose
+a `build` target (see below). Some of these apps are also useful as
+general-purpose EVE workloads outside of evetest, not just as test fixtures.
+
+## Adding a new test app
+
+Create a new subdirectory here with its own `Makefile` exposing a `build`
+target. For a container app, add a `Dockerfile` and a `Makefile` modeled on
+an existing one (`ubuntu-ctr/Makefile` or `lps/Makefile`), following this
+convention:
+
+  ```makefile
+  EVETEST_ORG ?= lfedge
+  IMAGE = $(EVETEST_ORG)/evetest-<name>
+  # Update VERSION whenever there is a change made to this app.
+  VERSION ?= 1.0
+
+  DOCKER_TARGET ?= load
+  DOCKER_PLATFORM ?= $(shell uname -s | tr '[A-Z]' '[a-z]')/$(subst aarch64,arm64,$(subst x86_64,amd64,$(shell uname -m)))
+
+  build:
+      docker buildx build \
+          --$(DOCKER_TARGET) \
+          --platform $(DOCKER_PLATFORM) \
+          -t $(IMAGE):$(VERSION) .
+  ```
+
+That's it -- no other file needs to change. `testapps/Makefile`'s `build`
+target iterates every subdirectory here and runs its `build` target, so a new
+app is automatically picked up by:
+
+- `make build-test-apps` (from `evetest/`, for local builds), and
+- `.github/workflows/publish-evetest.yml` (for publishing to Docker Hub on
+  every push to `master`), which just invokes `make build` here with
+  `DOCKER_TARGET=push DOCKER_PLATFORM=linux/amd64,linux/arm64`.
+
+Bump `VERSION` in your app's own `Makefile` whenever you change it -- each
+app is versioned and published independently.
+
+## Referencing a test app image in a test
+
+Use `lfedge/evetest-<name>:<version>` as the `ImageName` (see existing tests
+under `evetest/tests/` for examples with `ImageName: "lfedge/evetest-ubuntu-ctr"`
+or `"lfedge/evetest-lps"`).

--- a/evetest/testapps/lps/Dockerfile
+++ b/evetest/testapps/lps/Dockerfile
@@ -1,8 +1,10 @@
 # Copyright (c) 2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+ARG GOLANG_VERSION=1.25
+
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM golang:1.24 AS build
+FROM --platform=$BUILDPLATFORM golang:${GOLANG_VERSION} AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/evetest/testapps/lps/Makefile
+++ b/evetest/testapps/lps/Makefile
@@ -1,8 +1,7 @@
 # Copyright (c) 2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# TODO: temporary, change to lfedge
-EVETEST_ORG ?= milan4zededa
+EVETEST_ORG ?= lfedge
 IMAGE = $(EVETEST_ORG)/evetest-lps
 # Update VERSION whenever there is a change made to this app.
 VERSION ?= 1.0

--- a/evetest/testapps/lps/README.md
+++ b/evetest/testapps/lps/README.md
@@ -176,9 +176,9 @@ card's inputs are disabled and a notice replaces the editable area.
 ## Building and Pushing
 
 ```bash
-make build            # builds docker image
-make push             # builds and pushes to Docker Hub
-REPO=myrepo make push # use a different Docker Hub repository
+make build                                       # build and load the image locally
+make build DOCKER_TARGET=push                    # build and push to Docker Hub
+make build EVETEST_ORG=myorg DOCKER_TARGET=push  # push to a different Docker Hub org
 ```
 
 ## Command-line Flags

--- a/evetest/testapps/ubuntu-ctr/Makefile
+++ b/evetest/testapps/ubuntu-ctr/Makefile
@@ -1,8 +1,7 @@
 # Copyright (c) 2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# TODO: temporary, change to lfedge
-EVETEST_ORG ?= milan4zededa
+EVETEST_ORG ?= lfedge
 IMAGE = $(EVETEST_ORG)/evetest-ubuntu-ctr
 # Update VERSION whenever there is a change made to this app.
 VERSION ?= 1.0

--- a/evetest/tests/cluster/cluster_test.go
+++ b/evetest/tests/cluster/cluster_test.go
@@ -175,7 +175,7 @@ func TestSingleNodeCluster(test *testing.T) {
 		DisplayName: "container-app",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		CPUs:        1,
@@ -274,7 +274,7 @@ func TestSingleNodeCluster(test *testing.T) {
 //     with a 30-min budget. K3s must form across the three nodes via the
 //     dedicated cluster network.
 //  2. app-config-is-submitted: add a Local NI + a container app
-//     (milan4zededa/evetest-ubuntu-ctr:1.0) as a
+//     (lfedge/evetest-ubuntu-ctr:1.0) as a
 //     ClusterApplicationInstanceConfig with
 //     DesignatedNodeName=devName[0] and Affinity=PREFERRED -- the
 //     scheduler should prefer node 1 but is allowed to pick a different
@@ -386,7 +386,7 @@ func TestThreeNodesCluster(test *testing.T) {
 			DisplayName: "container-app",
 			Activate:    true,
 			Image: evetest.DockerContainer{
-				ImageName: "milan4zededa/evetest-ubuntu-ctr",
+				ImageName: "lfedge/evetest-ubuntu-ctr",
 				Tag:       "1.0",
 			},
 			CPUs:        1,

--- a/evetest/tests/lps/network_test.go
+++ b/evetest/tests/lps/network_test.go
@@ -54,7 +54,7 @@ const (
 //   - SystemAdapter for eth1 (DHCP, mgmt+app) with
 //     AllowLocalModifications=true.
 //   - Local NI "local-ni" (10.11.12.0/24, MTU=1500) on eth0.
-//   - LPS application "lps-app" (milan4zededa/evetest-lps:1.0) on the NI
+//   - LPS application "lps-app" (lfedge/evetest-lps:1.0) on the NI
 //     with two port-fwd rules:
 //   - 2222->22 for the test framework to drive curl-against-LPS commands
 //     via SSH inside the app,
@@ -177,7 +177,7 @@ func TestNetworkLocalChanges(test *testing.T) {
 		DisplayName: "lps-app",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-lps",
+			ImageName: "lfedge/evetest-lps",
 			Tag:       "1.0",
 		},
 		CPUs:        1,

--- a/evetest/tests/networking/acls_test.go
+++ b/evetest/tests/networking/acls_test.go
@@ -40,7 +40,7 @@ const enableFlowlogParamKey = "ENABLE_FLOWLOG"
 // ------
 //  1. Setup: one Local NI ("local-ni") on ethernet0, subnet 10.11.12.0/24,
 //     EnableFlowlog controlled by the ENABLE_FLOWLOG parameter.
-//     Two container apps (milan4zededa/evetest-ubuntu-ctr:1.0) deployed on the
+//     Two container apps (lfedge/evetest-ubuntu-ctr:1.0) deployed on the
 //     same NI, each with a fixed MAC, an SSH port-forward (2222->22 and 2223->22),
 //     and distinct ACL rule sets:
 //     - acl-app-1: allow FQDN "http-server.test", allow FQDN netmodels.LongFQDN,
@@ -164,7 +164,7 @@ func TestLocalNetInstanceACLs(test *testing.T) {
 		DisplayName: "acl-app-1",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
@@ -199,7 +199,7 @@ func TestLocalNetInstanceACLs(test *testing.T) {
 		DisplayName: "acl-app-2",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
@@ -369,7 +369,7 @@ func TestLocalNetInstanceACLs(test *testing.T) {
 		DisplayName: "acl-app-1",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
@@ -458,7 +458,7 @@ func TestLocalNetInstanceACLs(test *testing.T) {
 // Phases
 // ------
 //  1. Setup: one Switch NI ("switch-ni") on ethernet0.
-//     Two container apps (milan4zededa/evetest-ubuntu-ctr:1.0) bridged into the same
+//     Two container apps (lfedge/evetest-ubuntu-ctr:1.0) bridged into the same
 //     SDN L2 segment (172.20.20.0/24), each with a fixed MAC and distinct ACL rules:
 //     - acl-app-1: allow TCP to 10.17.17.25/32 (http-server) on port 80; allow TCP
 //     from 172.20.20.1/32 to cover inbound SSH. The SDN SNAT's connections from
@@ -573,7 +573,7 @@ func TestSwitchNetInstanceACLs(test *testing.T) {
 		DisplayName: "acl-app-1",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
@@ -601,7 +601,7 @@ func TestSwitchNetInstanceACLs(test *testing.T) {
 		DisplayName: "acl-app-2",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
@@ -746,7 +746,7 @@ func TestSwitchNetInstanceACLs(test *testing.T) {
 		DisplayName: "acl-app-1",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,

--- a/evetest/tests/networking/datastore_test.go
+++ b/evetest/tests/networking/datastore_test.go
@@ -77,7 +77,7 @@ import "testing"
 //     environment variables (test parameters). Skip the test if the parameters
 //     are not set, rather than failing -- these tests should be opt-in.
 //
-//   - For container registries: use a small public image. milan4zededa/evetest-*
+//   - For container registries: use a small public image. lfedge/evetest-*
 //     test images are already used elsewhere; reuse the smallest one.
 //
 // TestHTTPDatastore validates that EVE can download a content tree served over
@@ -198,7 +198,7 @@ func TestAzureDatastore(test *testing.T) {
 // public registry (Docker Hub by default).
 //
 // Recommended image: a small, fixed-tag image already used by other evetest
-// tests, e.g. milan4zededa/evetest-ubuntu-ctr:1.0 or an even smaller test
+// tests, e.g. lfedge/evetest-ubuntu-ctr:1.0 or an even smaller test
 // image (busybox). Keep the tag pinned to avoid reproducibility regressions
 // when the registry mutates :latest.
 //

--- a/evetest/tests/networking/dns_test.go
+++ b/evetest/tests/networking/dns_test.go
@@ -85,7 +85,7 @@ import (
 //     fall back to the previous DPC (CurrentIndex == 1, new DPC lastError
 //     non-empty).
 //  4. Per-NI DNS isolation: creates a Local NI ("local-ni") on ethernet1
-//     and deploys a container app (milan4zededa/evetest-ubuntu-ctr:1.0)
+//     and deploys a container app (lfedge/evetest-ubuntu-ctr:1.0)
 //     with port-forward 2222->22. From inside the app:
 //     - nslookup <controller>: resolves to the controller IP.
 //     - nslookup http-server1.test: succeeds (all ethernet1 DNS servers
@@ -483,7 +483,7 @@ func TestDNSFunctionality(test *testing.T) {
 		DisplayName: "dns-test-app",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		CPUs:        1,

--- a/evetest/tests/networking/failover_test.go
+++ b/evetest/tests/networking/failover_test.go
@@ -175,7 +175,7 @@ func TestPortFailover(test *testing.T) {
 		DisplayName: "failover-app",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,

--- a/evetest/tests/networking/ipv6_test.go
+++ b/evetest/tests/networking/ipv6_test.go
@@ -199,7 +199,7 @@ func TestDeviceIPv6Connectivity(test *testing.T) {
 // ------
 //  1. Apply DHCPNetworkConfig{V6Only} on ethernet0 (mgmt+app). Add a Switch
 //     NI ("switch-ni-v6") on ethernet0 with MTU=1500. Deploy container app
-//     (milan4zededa/evetest-ubuntu-ctr:1.0, VmMode_HVM) on the switch NI
+//     (lfedge/evetest-ubuntu-ctr:1.0, VmMode_HVM) on the switch NI
 //     with a fixed MAC and an allow-all IPv6 ACL (::/0).
 //     WaitUntilAppIsRunning.
 //  2. Watch app info: the VIF eventually reports at least one global-unicast
@@ -291,7 +291,7 @@ func TestApplicationIPv6Connectivity(test *testing.T) {
 		DisplayName: "container-app",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,

--- a/evetest/tests/networking/netinst_test.go
+++ b/evetest/tests/networking/netinst_test.go
@@ -57,7 +57,7 @@ import (
 //  3. NI delete: assert the state returns to ZNETINST_STATE_UNSPECIFIED.
 //  4. NI + app: recreate the NI (subnet 10.11.12.0/24 again, this time
 //     EnableFlowlog=true) and deploy a container app
-//     (milan4zededa/evetest-ubuntu-ctr:1.0) with a single
+//     (lfedge/evetest-ubuntu-ctr:1.0) with a single
 //     VirtualNetworkAdapter on the NI, a fixed MAC 02:16:3e:00:00:01, a
 //     port-fwd 2222->22 ACE, and an allow-all ACL. VirtualizationMode=HVM
 //     (PV does not work on Xen because the shim VM fails to start there).
@@ -269,7 +269,7 @@ func TestLocalNI(test *testing.T) {
 		DisplayName: "container-app",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM, // PV does not work in xen, shim VM fails to start
@@ -468,7 +468,7 @@ func TestLocalNI(test *testing.T) {
 //     bridge, MTU=2000.
 //  3. NI delete: state returns to ZNETINST_STATE_UNSPECIFIED.
 //  4. NI + app: recreate the NI on ethernet0 and deploy a container app
-//     (milan4zededa/evetest-ubuntu-ctr:1.0) with one VirtualNetworkAdapter
+//     (lfedge/evetest-ubuntu-ctr:1.0) with one VirtualNetworkAdapter
 //     on the NI, fixed MAC 02:16:3e:00:00:01, allow-all ACL.
 //     VirtualizationMode=HVM (same Xen-PV caveat as TestLocalNI).
 //     WaitUntilAppIsRunning, then assert:
@@ -653,7 +653,7 @@ func TestSwitchNI(test *testing.T) {
 		DisplayName: "container-app",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM, // PV does not work in xen, shim VM fails to start

--- a/evetest/tests/networking/ntp_test.go
+++ b/evetest/tests/networking/ntp_test.go
@@ -131,7 +131,7 @@ func TestDeviceNTPConfig(test *testing.T) {
 //     entry pointing to "ntp-local-ni". The NI's dnsmasq must merge port
 //     NTP servers and the NI NTP server and advertise the union to apps.
 //   - One container app on the NI (default-allow + port-fwd 2222->22).
-//     Use the existing milan4zededa/evetest-ubuntu-ctr image; it ships
+//     Use the existing lfedge/evetest-ubuntu-ctr image; it ships
 //     with chronyd which will sync against whatever DHCP delivers.
 //
 // Assertions

--- a/evetest/tests/networking/passthrough_test.go
+++ b/evetest/tests/networking/passthrough_test.go
@@ -55,7 +55,7 @@ import "testing"
 //     wraps containers in a shim VM for isolation (see APP-CONNECTIVITY.md
 //     "Virtual network interfaces" and "Container App VIF MTU"), so the
 //     shim VM is the passthrough target and the container inside it sees
-//     the NIC directly. The existing milan4zededa/evetest-ubuntu-ctr
+//     the NIC directly. The existing lfedge/evetest-ubuntu-ctr
 //     image used by TestLocalNI / TestSwitchNI is therefore suitable
 //     here too; using it avoids pulling a separate cloud image.
 //   - Optionally a Local NI on eth0 and a virtual VIF for the app, so the
@@ -81,7 +81,7 @@ import "testing"
 //     accept any name and instead match by MAC or by the order in
 //     which it appears after the mgmt interface).
 //     b) Acquire an IP from the SDN-side DHCP server for the eth1
-//     network. With the milan4zededa/evetest-ubuntu-ctr image the
+//     network. With the lfedge/evetest-ubuntu-ctr image the
 //     shim VM's init script runs DHCP on every recognized interface
 //     by default, so the address should be present as soon as the
 //     link appears; in a VM cloud image variant, run `dhclient

--- a/evetest/tests/networking/routing_test.go
+++ b/evetest/tests/networking/routing_test.go
@@ -70,7 +70,7 @@ import (
 //     the NI bridge IP 10.50.1.1 when advertising via DHCP option 121).
 //     - ni-eth2 (10.50.2.0/24, bridge 10.50.2.1): PropagateConnectedRoutes=false,
 //     static route 10.22.22.0/24 via 10.50.2.1.
-//     One container app (milan4zededa/evetest-ubuntu-ctr:1.0) with three
+//     One container app (lfedge/evetest-ubuntu-ctr:1.0) with three
 //     VIFs (vif0..vif2), one per NI, EnforceNetIntfOrder=true for
 //     deterministic vif-to-interface mapping inside the app, default-allow
 //     ACL on each VIF, and a TCP 2222->22 port-forward on vif0.
@@ -240,7 +240,7 @@ func TestPropagatedRoutes(test *testing.T) {
 		DisplayName: "multi-ni-app",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		VirtualizationMode:  eveconfig.VmMode_HVM,
@@ -453,7 +453,7 @@ func TestPropagatedRoutes(test *testing.T) {
 //     NI: 0.0.0.0/0 via label "internet" with gateway ping (GwPingMaxCost=5,
 //     PreferLowerCost=true); 10.88.88.0/24 via label "httpserver" with TCP
 //     probe to 10.88.88.70:80 (PreferLowerCost=true). One container app
-//     (milan4zededa/evetest-ubuntu-ctr:1.0) with a VIF on the NI, a TCP
+//     (lfedge/evetest-ubuntu-ctr:1.0) with a VIF on the NI, a TCP
 //     2222->22 port-forward scoped to shared label "portfwd" (eth3 lacks
 //     "portfwd" and does not forward), and a default-allow ACL.
 //  2. Initial routing: WatchNetworkInstanceInfo waits until the NI is ONLINE
@@ -615,7 +615,7 @@ func TestLocalNIWithMultiplePorts(test *testing.T) {
 		DisplayName: "multi-port-app",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		VirtualizationMode:  eveconfig.VmMode_HVM,
@@ -882,7 +882,7 @@ func findRoute(routes []*eveinfo.IPRoute, dst string) *eveinfo.IPRoute {
 //     10.21.21.0/24 via 172.28.1.2, DNSServers=[10.16.16.25]); airgap2
 //     (Local, no uplink, 172.28.2.0/24, StaticRoute 0.0.0.0/0 via 172.28.2.2,
 //     DNSServers=[172.28.2.1], StaticDNSEntries=[http-server-2.test, http-server-1.test]).
-//     Three container apps (milan4zededa/evetest-ubuntu-ctr:1.0) with
+//     Three container apps (lfedge/evetest-ubuntu-ctr:1.0) with
 //     default-allow ACLs: app-gw (3 VIFs: vif0→ni-eth1 MAC 02:16:3e:01:00:00,
 //     vif1→airgap1 static 172.28.1.2, vif2→airgap2 static 172.28.2.2);
 //     app-client1 (2 VIFs: vif0→ni-eth0 portfwd 2222→22, vif1→airgap1 static
@@ -1051,7 +1051,7 @@ func TestApplicationGateway(test *testing.T) {
 	)
 
 	appImage := evetest.DockerContainer{
-		ImageName: "milan4zededa/evetest-ubuntu-ctr",
+		ImageName: "lfedge/evetest-ubuntu-ctr",
 		Tag:       "1.0",
 	}
 

--- a/evetest/tests/networking/stp_test.go
+++ b/evetest/tests/networking/stp_test.go
@@ -83,7 +83,7 @@ import (
 //   - Switch NI "switch-ni" with Port="switch-ports" (resolves to ethernet1,
 //     ethernet2, ethernet3). BPDU enabled for ethernet3 by referencing
 //     the "edge-port" label.
-//   - One container app (milan4zededa/evetest-ubuntu-ctr:1.0) with one VIF
+//   - One container app (lfedge/evetest-ubuntu-ctr:1.0) with one VIF
 //     on the NI and allow-all ACL. The SDN router on bridge1 provides DHCP,
 //     so the app obtains an IP from 10.51.0.0/24.
 //
@@ -208,7 +208,7 @@ func TestSwitchNIWithMultiplePorts(test *testing.T) {
 		DisplayName: "container-app",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM, // PV does not work in xen

--- a/evetest/tests/networking/vlans_test.go
+++ b/evetest/tests/networking/vlans_test.go
@@ -74,7 +74,7 @@ import (
 //     ethernet2 → VLAN 100 (access port, PVID 100), ethernet3 → VLAN 200
 //     (access port, PVID 200). ethernet1 has no VlanAccessPort entry and acts
 //     as the trunk (carries both VLANs tagged toward the SDN router).
-//   - Two container apps (milan4zededa/evetest-ubuntu-ctr:1.0):
+//   - Two container apps (lfedge/evetest-ubuntu-ctr:1.0):
 //     app1 with AccessVLAN=100, app2 with AccessVLAN=200, each with an
 //     allow-all ACL.
 //
@@ -202,7 +202,7 @@ func TestAccessVLANs(test *testing.T) {
 		DisplayName: "vlan100-app",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
@@ -227,7 +227,7 @@ func TestAccessVLANs(test *testing.T) {
 		DisplayName: "vlan200-app",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,
@@ -535,7 +535,7 @@ func TestAccessVLANs(test *testing.T) {
 //     the NI gateway port 2222 → app port 22.
 //   - NI2 (Local, 10.50.77.0/24) on ethernet0. SSH into app2 is forwarded
 //     from the NI gateway port 2223 → app port 22.
-//   - Two container apps (milan4zededa/evetest-ubuntu-ctr:1.0): app1 on NI1,
+//   - Two container apps (lfedge/evetest-ubuntu-ctr:1.0): app1 on NI1,
 //     app2 on NI2, each with an allow-all ACL.
 //
 // Bootstrap note
@@ -692,7 +692,7 @@ func TestVLANSubinterfaces(test *testing.T) {
 	// Phase 2: Application connectivity
 	// -----------------------------------------------------------------------
 
-	const appImage = "milan4zededa/evetest-ubuntu-ctr"
+	const appImage = "lfedge/evetest-ubuntu-ctr"
 	const appTag = "1.0"
 	appAuth := evetest.UsernamePasswordAuth{
 		Username: "root",
@@ -1103,7 +1103,7 @@ func TestVLANSubinterfacesOnTopOfLAGs(test *testing.T) {
 	// Phase 2: Application connectivity
 	// -----------------------------------------------------------------------
 
-	const appImage = "milan4zededa/evetest-ubuntu-ctr"
+	const appImage = "lfedge/evetest-ubuntu-ctr"
 	const appTag = "1.0"
 	appAuth := evetest.UsernamePasswordAuth{
 		Username: "root",

--- a/evetest/tests/upgrade/upgrade_test.go
+++ b/evetest/tests/upgrade/upgrade_test.go
@@ -174,7 +174,7 @@ func TestEVEUpgrade(test *testing.T) {
 		DisplayName: "upgrade-test-app",
 		Activate:    true,
 		Image: evetest.DockerContainer{
-			ImageName: "milan4zededa/evetest-ubuntu-ctr",
+			ImageName: "lfedge/evetest-ubuntu-ctr",
 			Tag:       "1.0",
 		},
 		VirtualizationMode: eveconfig.VmMode_HVM,


### PR DESCRIPTION
# Description

- Move evetest's SDN/evetest/broker/test-app Docker Hub image references from
  the maintainer's personal `milan4zededa` account to the `lfedge` org, now
  that [those repos exist there](https://hub.docker.com/u/lfedge?page=1&search=evetest).
- Simplify evetest/sdn versioning to plain `X.Y` (starting at `1.0`, dropping
  the `v` prefix, third component, and the redundant `-adam-<version>` tag
  suffix on the evetest image).
- Add `.github/workflows/publish-evetest.yml`: builds and pushes all five
  evetest images (SDN, evetest, broker, ubuntu-ctr, lps test app), multi-arch
  amd64+arm64, on push to `master` when their respective paths change.
- Fix `Dockerfile.broker` to properly cross-compile (CGO/libvirt enabled only
  for native-arch builds, falling back to the libvirt provider's stub for
  cross-builds) instead of relying on slow full QEMU emulation.
- Bump `testapps/lps`'s Dockerfile to Go 1.25 to match its `go.mod` (found
  while validating these multi-arch builds).

## PR dependencies

List all dependencies of this PR (when applicable, otherwise remove this
section).

## How to test and validate this PR

1. After merge, open the `Actions` tab and confirm the `Publish Evetest`
   workflow ran and all five `publish (...)` matrix jobs (`sdn`, `evetest`,
   `broker`, `testapp-ubuntu-ctr`, `testapp-lps`) completed successfully.
2. On Docker Hub, confirm each of the following was updated with a `1.0` tag
   and is multi-arch (`docker buildx imagetools inspect <image>:1.0` should
   list both `linux/amd64` and `linux/arm64`):
   - `lfedge/evetest-sdn`
   - `lfedge/evetest`
   - `lfedge/evetest-broker`
   - `lfedge/evetest-ubuntu-ctr`
   - `lfedge/evetest-lps`
3. Pull the published `lfedge/evetest-broker:1.0` arm64 image and confirm it
   still runs with the `qemu`/`proxmox` providers, and that selecting the
   `libvirt` provider fails with a clear error:
    ```
    level=fatal msg="Failed to create libvirt device provider: libvirt provider is not available: binary was built without CGO support"
    ```
4. From a clean checkout, run `make evetest NAME=<some quick test>` to confirm
   the newly published images pull and run end to end.

## Changelog notes

No user-facing changes (test infrastructure only).

## PR Backports

Not to be backported.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
