### PR TITLE
[17.0] pkg/xen-tools: recover from disabled-BAR mmap SIGBUS as Unsupported Request

### DIFF
--- a/pkg/xen-tools/patches-4.21.1/10-bridge-helper-support.patch
+++ b/pkg/xen-tools/patches-4.21.1/10-bridge-helper-support.patch
@@ -1,8 +1,8 @@
 diff --git a/tools/qemu-xen/net/tap.c b/tools/qemu-xen/net/tap.c
-index 1bf085d..1887c4a 100644
+index 3f90022c0b..3defed22a7 100644
 --- a/tools/qemu-xen/net/tap.c
 +++ b/tools/qemu-xen/net/tap.c
-@@ -63,7 +63,7 @@ typedef struct TAPState {
+@@ -64,7 +64,7 @@ typedef struct TAPState {
      Notifier exit;
  } TAPState;
  
@@ -11,7 +11,7 @@ index 1bf085d..1887c4a 100644
                            int fd, Error **errp);
  
  static void tap_send(void *opaque);
-@@ -323,7 +323,7 @@ static void tap_exit_notify(Notifier *notifier, void *data)
+@@ -279,7 +279,7 @@ static void tap_exit_notify(Notifier *notifier, void *data)
      Error *err = NULL;
  
      if (s->down_script[0]) {
@@ -20,8 +20,8 @@ index 1bf085d..1887c4a 100644
          if (err) {
              error_report_err(err);
          }
-@@ -431,7 +431,7 @@ static TAPState *net_tap_fd_init(NetClientState *peer,
-     return s;
+@@ -403,7 +403,7 @@ static void close_all_fds_after_fork(int excluded_fd)
+     qemu_close_all_open_fd(skip_fd, nskip);
  }
  
 -static void launch_script(const char *setup_script, const char *ifname,
@@ -29,7 +29,7 @@ index 1bf085d..1887c4a 100644
                            int fd, Error **errp)
  {
      int pid, status;
-@@ -456,6 +456,7 @@ static void launch_script(const char *setup_script, const char *ifname,
+@@ -422,6 +422,7 @@ static void launch_script(const char *setup_script, const char *ifname,
          parg = args;
          *parg++ = (char *)setup_script;
          *parg++ = (char *)ifname;
@@ -37,7 +37,7 @@ index 1bf085d..1887c4a 100644
          *parg = NULL;
          execv(setup_script, args);
          _exit(1);
-@@ -648,8 +649,8 @@ int net_init_bridge(const Netdev *netdev, const char *name,
+@@ -608,8 +609,8 @@ int net_init_bridge(const Netdev *netdev, const char *name,
  }
  
  static int net_tap_init(const NetdevTapOptions *tap, int *vnet_hdr,
@@ -48,7 +48,7 @@ index 1bf085d..1887c4a 100644
  {
      Error *err = NULL;
      int fd, vnet_hdr_required;
-@@ -671,7 +672,7 @@ static int net_tap_init(const NetdevTapOptions *tap, int *vnet_hdr,
+@@ -631,7 +632,7 @@ static int net_tap_init(const NetdevTapOptions *tap, int *vnet_hdr,
      if (setup_script &&
          setup_script[0] != '\0' &&
          strcmp(setup_script, "no") != 0) {
@@ -57,9 +57,9 @@ index 1bf085d..1887c4a 100644
          if (err) {
              error_propagate(errp, err);
              close(fd);
-@@ -1003,8 +1004,14 @@ free_fail:
+@@ -951,8 +952,14 @@ free_fail:
          }
-
+ 
          for (i = 0; i < queues; i++) {
 -            fd = net_tap_init(tap, &vnet_hdr, i >= 1 ? "no" : script,
 -                              ifname, sizeof ifname, queues > 1, errp);

--- a/pkg/xen-tools/patches-4.21.1/20-return_zero_close_if_special_file.patch
+++ b/pkg/xen-tools/patches-4.21.1/20-return_zero_close_if_special_file.patch
@@ -3,10 +3,10 @@ Date: Mon, 19 Sep 2024 11:20:00 +0530
 Subject: [PATCH] 20-return_zero_close_if_special_file.patch removes a CVE fix
 
 diff --git a/tools/qemu-xen/fsdev/virtfs-proxy-helper.c b/tools/qemu-xen/fsdev/virtfs-proxy-helper.c
-index d9511f4..657b632 100644
+index 144aaf585a..7b14944f9b 100644
 --- a/tools/qemu-xen/fsdev/virtfs-proxy-helper.c
 +++ b/tools/qemu-xen/fsdev/virtfs-proxy-helper.c
-@@ -354,10 +354,6 @@ static int open_regular(const char *pathname, int flags, mode_t mode)
+@@ -359,10 +359,6 @@ static int open_regular(const char *pathname, int flags, mode_t mode)
          return fd;
      }
  
@@ -18,7 +18,7 @@ index d9511f4..657b632 100644
  }
  
 diff --git a/tools/qemu-xen/hw/9pfs/9p-util.h b/tools/qemu-xen/hw/9pfs/9p-util.h
-index df1b583..b8ce93f 100644
+index 51c94b0116..204514f35f 100644
 --- a/tools/qemu-xen/hw/9pfs/9p-util.h
 +++ b/tools/qemu-xen/hw/9pfs/9p-util.h
 @@ -111,38 +111,6 @@ static inline void close_preserve_errno(int fd)

--- a/pkg/xen-tools/patches-4.21.1/25-qemu--qemu-options.hx-describe-hub-chardev-and-aggregation.patch
+++ b/pkg/xen-tools/patches-4.21.1/25-qemu--qemu-options.hx-describe-hub-chardev-and-aggregation.patch
@@ -20,10 +20,10 @@ Message-ID: <20250123085327.965501-5-r.peniaev@gmail.com>
  1 file changed, 45 insertions(+), 4 deletions(-)
 
 diff --git a/tools/qemu-xen/qemu-options.hx b/tools/qemu-xen/qemu-options.hx
-index d19bf533d696..ec0090dfe229 100644
+index d94e2cbbae..3b8be4b15a 100644
 --- a/tools/qemu-xen/qemu-options.hx
 +++ b/tools/qemu-xen/qemu-options.hx
-@@ -3733,7 +3733,7 @@ SRST
+@@ -3782,7 +3782,7 @@ SRST
  The general form of a character device option is:
  
  ``-chardev backend,id=id[,mux=on|off][,options]``
@@ -32,7 +32,7 @@ index d19bf533d696..ec0090dfe229 100644
      ``vc``, ``ringbuf``, ``file``, ``pipe``, ``console``, ``serial``,
      ``pty``, ``stdio``, ``braille``, ``parallel``,
      ``spicevmc``, ``spiceport``. The specific backend will determine the
-@@ -3790,9 +3790,10 @@ The general form of a character device option is:
+@@ -3839,9 +3839,10 @@ The general form of a character device option is:
      the QEMU monitor, and ``-nographic`` also multiplexes the console
      and the monitor to stdio.
  
@@ -46,7 +46,7 @@ index d19bf533d696..ec0090dfe229 100644
  
      Every backend supports the ``logfile`` option, which supplies the
      path to a file to record all data transmitted via the backend. The
-@@ -3892,6 +3893,46 @@ The available backends are:
+@@ -3941,6 +3942,46 @@ The available backends are:
      Forward QEMU's emulated msmouse events to the guest. ``msmouse``
      does not take any options.
  
@@ -93,6 +93,3 @@ index d19bf533d696..ec0090dfe229 100644
  ``-chardev vc,id=id[[,width=width][,height=height]][[,cols=cols][,rows=rows]]``
      Connect to a QEMU text console. ``vc`` may optionally be given a
      specific size.
--- 
-2.43.0
-

--- a/pkg/xen-tools/patches-4.21.1/x86_64/10-vfio-igd-bar0-bdsm-mirror.patch
+++ b/pkg/xen-tools/patches-4.21.1/x86_64/10-vfio-igd-bar0-bdsm-mirror.patch
@@ -23,10 +23,10 @@ Signed-off-by: Mikhail Malyshev <mike.malyshev@gmail.com>
  3 files changed, 83 insertions(+)
 
 diff --git a/tools/qemu-xen/hw/vfio/igd.c b/tools/qemu-xen/hw/vfio/igd.c
-index d320d032a7..79420c9c7d 100644
+index 3b52c471fc..5a1b1471de 100644
 --- a/tools/qemu-xen/hw/vfio/igd.c
 +++ b/tools/qemu-xen/hw/vfio/igd.c
-@@ -365,6 +365,92 @@ static const MemoryRegionOps vfio_igd_index_quirk = {
+@@ -378,6 +378,92 @@ static const MemoryRegionOps vfio_igd_index_quirk = {
      .endianness = DEVICE_LITTLE_ENDIAN,
  };
  
@@ -143,6 +143,3 @@ index bf67df2fbc..5ad090a229 100644
  void vfio_probe_igd_bar4_quirk(VFIOPCIDevice *vdev, int nr);
  
  extern const PropertyInfo qdev_prop_nv_gpudirect_clique;
--- 
-2.43.0
-

--- a/pkg/xen-tools/patches-4.21.1/x86_64/11-vfio-igd-diagnostic-logging.patch
+++ b/pkg/xen-tools/patches-4.21.1/x86_64/11-vfio-igd-diagnostic-logging.patch
@@ -14,10 +14,10 @@ Signed-off-by: Mikhail Malyshev <mike.malyshev@gmail.com>
  1 file changed, 40 insertions(+), 8 deletions(-)
 
 diff --git a/tools/qemu-xen/hw/vfio/igd.c b/tools/qemu-xen/hw/vfio/igd.c
-index 79420c9c7d..02361f9167 100644
+index 5a1b1471de..9ad1ad0717 100644
 --- a/tools/qemu-xen/hw/vfio/igd.c
 +++ b/tools/qemu-xen/hw/vfio/igd.c
-@@ -388,11 +388,15 @@ static uint64_t igd_bdsm_mirror_read(void *opaque, hwaddr addr, unsigned size)
+@@ -401,11 +401,15 @@ static uint64_t igd_bdsm_mirror_read(void *opaque, hwaddr addr, unsigned size)
      VFIOPCIDevice *vdev = mirror->vdev;
  
      /* Read and discard from real hardware in case it has side effects */
@@ -38,7 +38,7 @@ index 79420c9c7d..02361f9167 100644
  }
  
  static void igd_bdsm_mirror_write(void *opaque, hwaddr addr,
-@@ -401,6 +405,9 @@ static void igd_bdsm_mirror_write(void *opaque, hwaddr addr,
+@@ -414,6 +418,9 @@ static void igd_bdsm_mirror_write(void *opaque, hwaddr addr,
      IGDBdsmMirrorQuirk *mirror = opaque;
      VFIOPCIDevice *vdev = mirror->vdev;
  
@@ -48,7 +48,7 @@ index 79420c9c7d..02361f9167 100644
      vfio_pci_write_config(&vdev->pdev,
                            mirror->config_offset + addr, data, size);
  }
-@@ -436,6 +443,24 @@ void vfio_probe_igd_bar0_quirk(VFIOPCIDevice *vdev, int nr)
+@@ -454,6 +461,24 @@ void vfio_probe_igd_bar0_quirk(VFIOPCIDevice *vdev, int nr)
      mirror->bar_offset = IGD_BDSM_MMIO_OFFSET;
      mirror->config_offset = (gen < 11) ? IGD_BDSM : IGD_BDSM_GEN11;
  
@@ -73,7 +73,7 @@ index 79420c9c7d..02361f9167 100644
      memory_region_init_io(&quirk->mem[0], OBJECT(vdev), &igd_bdsm_mirror_ops,
                            mirror, "vfio-igd-bdsm-quirk",
                            (gen < 11) ? 4 : 8);
-@@ -523,6 +548,8 @@ void vfio_probe_igd_bar4_quirk(VFIOPCIDevice *vdev, int nr)
+@@ -654,6 +679,8 @@ void vfio_probe_igd_bar4_quirk(VFIOPCIDevice *vdev, int nr)
          return;
      }
  
@@ -82,7 +82,7 @@ index 79420c9c7d..02361f9167 100644
      /*
       * Check whether we have all the vfio device specific regions to
       * support legacy mode (added in Linux v4.6).  If not, bail.
-@@ -678,9 +705,14 @@ void vfio_probe_igd_bar4_quirk(VFIOPCIDevice *vdev, int nr)
+@@ -792,9 +819,14 @@ void vfio_probe_igd_bar4_quirk(VFIOPCIDevice *vdev, int nr)
                       vdev->vbasedev.name);
      }
  
@@ -100,6 +100,3 @@ index 79420c9c7d..02361f9167 100644
      }
  
      if (pwrite(vdev->vbasedev.fd, &cmd_orig, sizeof(cmd_orig),
--- 
-2.43.0
-

--- a/pkg/xen-tools/patches-4.21.1/x86_64/12-vfio-igd-opregion-dump.patch
+++ b/pkg/xen-tools/patches-4.21.1/x86_64/12-vfio-igd-opregion-dump.patch
@@ -34,7 +34,7 @@ Signed-off-by: Mikhail Malyshev <mike.malyshev@gmail.com>
  1 file changed, 57 insertions(+)
 
 diff --git a/tools/qemu-xen/hw/vfio/igd.c b/tools/qemu-xen/hw/vfio/igd.c
-index 02361f9167..2bca066ce6 100644
+index 9ad1ad0717..fae1606e1d 100644
 --- a/tools/qemu-xen/hw/vfio/igd.c
 +++ b/tools/qemu-xen/hw/vfio/igd.c
 @@ -16,6 +16,7 @@
@@ -45,9 +45,9 @@ index 02361f9167..2bca066ce6 100644
  #include "pci.h"
  #include "trace.h"
  
-@@ -583,6 +584,62 @@ void vfio_probe_igd_bar4_quirk(VFIOPCIDevice *vdev, int nr)
- 
-     gmch = vfio_pci_read_config(&vdev->pdev, IGD_GMCH, 4);
+@@ -581,6 +582,62 @@ void vfio_probe_igd_bar4_quirk(VFIOPCIDevice *vdev, int nr)
+     pci_set_long(vdev->pdev.wmask + IGD_GMCH, 0);
+     pci_set_long(vdev->emulated_config_bits + IGD_GMCH, ~0);
  
 +    /*
 +     * Diagnostic: dump the host iGPU's OpRegion to a per-domain file
@@ -106,8 +106,5 @@ index 02361f9167..2bca066ce6 100644
 +    }
 +
      /*
-      * If IGD VGA Disable is clear (expected) and VGA is not already enabled,
-      * try to enable it.  Probably shouldn't be using legacy mode without VGA,
--- 
-2.43.0
-
+      * BDSM is read-write, emulated.  Initialize to 0 here (before the BDF
+      * and LPC bridge checks) so that:

--- a/pkg/xen-tools/patches-4.21.1/x86_64/16-vfio-pci-disabled-bar-sigbus-ur.patch
+++ b/pkg/xen-tools/patches-4.21.1/x86_64/16-vfio-pci-disabled-bar-sigbus-ur.patch
@@ -1,0 +1,261 @@
+From b3e4cd12c04834e31b51ae292efc84c12e53f7cb Mon Sep 17 00:00:00 2001
+From: Mikhail Malyshev <mikem@zededa.com>
+Date: Thu, 16 Jul 2026 10:37:36 +0000
+Subject: [PATCH] hw/vfio: recover from disabled-BAR mmap SIGBUS as Unsupported
+ Request
+
+A guest that clears PCI_COMMAND.MEM on a passed-through device makes vfio-pci
+invalidate the device's BAR mmaps in the kernel: any access to them then faults
+with BUS_ADRERR. A vCPU MMIO access that races the resulting BAR teardown can
+reach memory_region_ram_device_{read,write}() against a mmap the kernel has
+already invalidated and take SIGBUS, which qemu turns into a fatal abort of the
+whole VM.
+
+On real hardware an access to a BAR whose memory decode is disabled is answered
+by the PCIe layer with an Unsupported Request: reads return all-ones, writes are
+dropped, and the instruction completes. Emulate that instead of aborting.
+
+Record each ram_device mmap host range as it is (un)mapped, arm a per-thread
+sigsetjmp checkpoint around the raw load/store in the ram_device ops, and have
+the SIGBUS handler longjmp back to it when a non-MCE fault address falls in one
+of those ranges. Mirrors the SIGBUS-recovery idiom already used by
+qemu_prealloc_mem(). MCE and non-vfio SIGBUS are unaffected.
+
+Notes:
+- A compiler barrier() brackets the guarded load/store so the ram_device_active
+  guard is ordered around the faulting access rather than depending on codegen.
+- Overflowing the mmap range table warns rather than silently leaving a range
+  untracked (which would reintroduce the abort).
+- sigsetjmp saves the signal mask (an rt_sigprocmask per trapped access); it
+  cannot be dropped without leaving SIGBUS blocked after siglongjmp, so it is a
+  deliberate cost on the trapped-MMIO slow path only, never the EPT fast path.
+
+Signed-off-by: Mikhail Malyshev <mikem@zededa.com>
+---
+ hw/vfio/helpers.c     |   5 ++
+ include/exec/memory.h |  10 ++++
+ system/cpus.c         |   8 +++
+ system/memory.c       | 125 +++++++++++++++++++++++++++++++++++++++++-
+ 4 files changed, 147 insertions(+), 1 deletion(-)
+
+diff --git a/tools/qemu-xen/hw/vfio/helpers.c b/tools/qemu-xen/hw/vfio/helpers.c
+index ea15c79db0a..b0cc13ab89a 100644
+--- a/tools/qemu-xen/hw/vfio/helpers.c
++++ b/tools/qemu-xen/hw/vfio/helpers.c
+@@ -388,6 +388,7 @@ static void vfio_subregion_unmap(VFIORegion *region, int index)
+                             region->mmaps[index].offset +
+                             region->mmaps[index].size - 1);
+     memory_region_del_subregion(region->mem, &region->mmaps[index].mem);
++    memory_region_ram_device_del_range(region->mmaps[index].mmap);
+     munmap(region->mmaps[index].mmap, region->mmaps[index].size);
+     object_unparent(OBJECT(&region->mmaps[index].mem));
+     region->mmaps[index].mmap = NULL;
+@@ -435,6 +436,9 @@ int vfio_region_mmap(VFIORegion *region)
+                                           memory_region_owner(region->mem),
+                                           name, region->mmaps[i].size,
+                                           region->mmaps[i].mmap);
++        /* track the mmap host range for disabled-BAR SIGBUS -> UR recovery */
++        memory_region_ram_device_add_range(region->mmaps[i].mmap,
++                                           region->mmaps[i].size);
+         g_free(name);
+         memory_region_add_subregion(region->mem, region->mmaps[i].offset,
+                                     &region->mmaps[i].mem);
+@@ -490,6 +494,7 @@ void vfio_region_finalize(VFIORegion *region)
+ 
+     for (i = 0; i < region->nr_mmaps; i++) {
+         if (region->mmaps[i].mmap) {
++            memory_region_ram_device_del_range(region->mmaps[i].mmap);
+             munmap(region->mmaps[i].mmap, region->mmaps[i].size);
+             object_unparent(OBJECT(&region->mmaps[i].mem));
+         }
+diff --git a/tools/qemu-xen/include/exec/memory.h b/tools/qemu-xen/include/exec/memory.h
+index 296fd068c0b..9a27fc7f786 100644
+--- a/tools/qemu-xen/include/exec/memory.h
++++ b/tools/qemu-xen/include/exec/memory.h
+@@ -1461,6 +1461,16 @@ void memory_region_init_ram_device_ptr(MemoryRegion *mr,
+                                        uint64_t size,
+                                        void *ptr);
+ 
++/*
++ * vfio disabled-BAR SIGBUS recovery (see system/memory.c). vfio registers each
++ * BAR mmap host range so a racing MMIO into a just-invalidated mmap can be
++ * completed as an Unsupported Request instead of aborting qemu.
++ */
++void memory_region_ram_device_add_range(void *host, size_t size);
++void memory_region_ram_device_del_range(void *host);
++/* called from the SIGBUS handler; longjmps (no return) when it recovers */
++bool memory_region_ram_device_on_sigbus(void *addr);
++
+ /**
+  * memory_region_init_alias: Initialize a memory region that aliases all or a
+  *                           part of another memory region.
+diff --git a/tools/qemu-xen/system/cpus.c b/tools/qemu-xen/system/cpus.c
+index 1c818ff6828..1b4a66a3c4c 100644
+--- a/tools/qemu-xen/system/cpus.c
++++ b/tools/qemu-xen/system/cpus.c
+@@ -371,6 +371,14 @@ static void sigbus_reraise(void)
+ static void sigbus_handler(int n, siginfo_t *siginfo, void *ctx)
+ {
+     if (siginfo->si_code != BUS_MCEERR_AO && siginfo->si_code != BUS_MCEERR_AR) {
++        /*
++         * Not an MCE. If this is a racing MMIO into a passed-through vfio BAR
++         * whose PCI_COMMAND.MEM was just cleared (mmap invalidated by the
++         * kernel), complete it as an Unsupported Request instead of aborting.
++         * memory_region_ram_device_on_sigbus() longjmps back into the
++         * ram_device access and does not return when it recovers.
++         */
++        memory_region_ram_device_on_sigbus(siginfo->si_addr);
+         sigbus_reraise();
+     }
+ 
+diff --git a/tools/qemu-xen/system/memory.c b/tools/qemu-xen/system/memory.c
+index 5e6eb459d5d..48d1bbca4f9 100644
+--- a/tools/qemu-xen/system/memory.c
++++ b/tools/qemu-xen/system/memory.c
+@@ -1335,11 +1335,125 @@ const MemoryRegionOps unassigned_mem_ops = {
+     .endianness = DEVICE_NATIVE_ENDIAN,
+ };
+ 
++/*
++ * vfio passthrough disabled-BAR SIGBUS recovery.
++ *
++ * When a guest clears PCI_COMMAND.MEM on a passed-through device, vfio-pci in
++ * the kernel invalidates the BAR's mmap: any access faults with BUS_ADRERR. A
++ * vCPU MMIO access that races the teardown reaches the ram_device ops below
++ * against the just-invalidated mmap and takes SIGBUS, which qemu would turn
++ * into an abort. On real hardware an access to a MEM=0 BAR is answered with an
++ * Unsupported Request (reads return all-ones, writes are dropped).
++ *
++ * Recover to those semantics: record each ram_device mmap host range, arm a
++ * sigsetjmp checkpoint around the raw load/store, and let the SIGBUS handler
++ * (system/cpus.c) longjmp back here when the fault address is one of our
++ * ranges. Same idiom as qemu_prealloc_mem() in util/oslib-posix.c.
++ */
++typedef struct RamDeviceRange {
++    uintptr_t start;
++    uintptr_t end;
++} RamDeviceRange;
++#define RAM_DEVICE_MAX_RANGES 64
++static RamDeviceRange ram_device_ranges[RAM_DEVICE_MAX_RANGES];
++/*
++ * Mutated only from the vfio mmap/munmap paths (device (un)realize), which run
++ * under the BQL; read locklessly from the SIGBUS handler on the faulting vCPU
++ * thread. The range set is tied to the device mmap lifecycle, not to the
++ * MEM-toggle path that triggers the fault, so a fault never races an add/del
++ * of its own range. (If a non-BQL ram_device dispatch or vfio unmap path were
++ * ever added, this swap-remove would need to become atomic.)
++ */
++static int ram_device_nranges;
++
++void memory_region_ram_device_add_range(void *host, size_t size)
++{
++    if (!host) {
++        return;
++    }
++    if (ram_device_nranges >= RAM_DEVICE_MAX_RANGES) {
++        /*
++         * Don't drop it silently: an untracked mmap reintroduces the fatal
++         * abort this recovery prevents, so make the failure mode observable.
++         */
++        warn_report("ram_device SIGBUS recovery: range table full (%d); host %p "
++                    "(0x%zx) left untracked, a racing MMIO to it while its BAR "
++                    "is disabled would abort qemu", RAM_DEVICE_MAX_RANGES,
++                    host, size);
++        return;
++    }
++    ram_device_ranges[ram_device_nranges].start = (uintptr_t)host;
++    ram_device_ranges[ram_device_nranges].end = (uintptr_t)host + size;
++    ram_device_nranges++;
++}
++
++void memory_region_ram_device_del_range(void *host)
++{
++    int i;
++    for (i = 0; i < ram_device_nranges; i++) {
++        if (ram_device_ranges[i].start == (uintptr_t)host) {
++            ram_device_ranges[i] = ram_device_ranges[--ram_device_nranges];
++            return;
++        }
++    }
++}
++
++static bool ram_device_addr_known(uintptr_t addr)
++{
++    int i, n = ram_device_nranges; /* snapshot for the lockless signal-context read */
++
++    for (i = 0; i < n; i++) {
++        if (addr >= ram_device_ranges[i].start &&
++            addr < ram_device_ranges[i].end) {
++            return true;
++        }
++    }
++    return false;
++}
++
++/* per-thread checkpoint, armed around the raw mmap access below */
++static __thread sigjmp_buf ram_device_env;
++static __thread volatile sig_atomic_t ram_device_active;
++
++/*
++ * Called from the SIGBUS handler on the faulting thread. If a ram_device
++ * access is in flight on this thread and the fault hit one of our mmap ranges,
++ * jump back to the checkpoint (does not return); otherwise return false.
++ */
++bool memory_region_ram_device_on_sigbus(void *addr)
++{
++    if (ram_device_active && ram_device_addr_known((uintptr_t)addr)) {
++        siglongjmp(ram_device_env, 1);
++    }
++    return false;
++}
++
+ static uint64_t memory_region_ram_device_read(void *opaque,
+                                               hwaddr addr, unsigned size)
+ {
+     MemoryRegion *mr = opaque;
+-    uint64_t data = ldn_he_p(mr->ram_block->host + addr, size);
++    uint64_t data;
++
++    /*
++     * sigsetjmp(env, 1) saves the signal mask (an rt_sigprocmask on glibc) on
++     * every trapped ram_device access. It can't be dropped: siglongjmp out of
++     * the SIGBUS handler must restore the mask or SIGBUS stays blocked on the
++     * thread. This is a deliberate per-access cost, incurred only on the
++     * trapped-MMIO slow path (quirked/sub-page BARs, teardown), never on the
++     * EPT fast path.
++     */
++    if (sigsetjmp(ram_device_env, 1)) {
++        /* mmap faulted (BUS_ADRERR): BAR MEM disabled -> Unsupported Request */
++        ram_device_active = 0;
++        data = (size >= 8) ? ~(uint64_t)0 : (((uint64_t)1 << (size * 8)) - 1);
++        trace_memory_region_ram_device_read(get_cpu_index(), mr, addr, data, size);
++        return data;
++    }
++    ram_device_active = 1;
++    barrier(); /* the guard must be set before the faulting load, reset after */
++    data = ldn_he_p(mr->ram_block->host + addr, size);
++    barrier();
++    ram_device_active = 0;
+ 
+     trace_memory_region_ram_device_read(get_cpu_index(), mr, addr, data, size);
+ 
+@@ -1353,7 +1467,16 @@ static void memory_region_ram_device_write(void *opaque, hwaddr addr,
+ 
+     trace_memory_region_ram_device_write(get_cpu_index(), mr, addr, data, size);
+ 
++    if (sigsetjmp(ram_device_env, 1)) {
++        /* mmap faulted (BUS_ADRERR): BAR MEM disabled -> drop write (UR) */
++        ram_device_active = 0;
++        return;
++    }
++    ram_device_active = 1;
++    barrier(); /* the guard must be set before the faulting store, reset after */
+     stn_he_p(mr->ram_block->host + addr, size, data);
++    barrier();
++    ram_device_active = 0;
+ }
+ 
+ static const MemoryRegionOps ram_device_mem_ops = {
+-- 
+2.43.0
+


### PR DESCRIPTION
# Description

Backport of #6171 to the 17.0 release branch.

On PCI passthrough, when a guest clears `PCI_COMMAND.MEM` on a passed-through
device, vfio-pci in the kernel invalidates the device's BAR mmaps; any access
to them then faults with `BUS_ADRERR`. A vCPU MMIO access that races the
resulting BAR teardown can reach qemu's `ram_device` read/write handlers
against a mmap the kernel has already invalidated and take SIGBUS, which qemu
turns into a fatal abort of the whole VM.

On real hardware such an access to a BAR whose memory decode is disabled is
answered by the PCIe layer with an Unsupported Request: reads return all-ones,
writes are dropped, and the instruction completes normally. This change
emulates that instead of aborting, via a per-thread `sigsetjmp` checkpoint
around the raw load/store in the `ram_device` ops plus a SIGBUS-handler
`siglongjmp` when a non-MCE fault falls in a recorded vfio mmap range. MCE and
non-vfio SIGBUS handling are unaffected. Implemented as a qemu-xen patch under
`pkg/xen-tools/patches-4.21.1/`.

Cherry-picked cleanly (no conflicts) from the two commits that landed on
master; the combined diff is byte-identical to what merged there. The 17.0
branch already carries the Xen 4.21.1 / qemu-xen 9.1.0 patch stack these
changes touch.

## How to test and validate this PR

On a device with an Intel iGPU passed through to a VM, drive `PCI_COMMAND.MEM`
toggles from inside the guest while other vCPUs hammer BAR0 MMIO (FORCEWAKE).
Without the change qemu aborts with SIGBUS (domain crashes, exit 135) within
~1s; with the change the guest survives the toggles (the racing MMIO is
completed as UR). Validated upstream on an amd64 Raptor-Lake device: 20/20 runs
survive with the patch vs 100% crash without it.

## Changelog notes

Fix a VM crash on PCI passthrough: a guest disabling a device's memory decode
while another vCPU accesses the BAR could abort qemu with SIGBUS. Such racing
accesses are now completed as Unsupported Requests instead.

## PR Backports

- 16.0-stable: No — depends on the Xen 4.21.1 / qemu-xen 9.1.0 patch stack; the patched code paths are not present on stable branches.
- 14.5-stable: No — same reason.
- 13.4-stable: No — same reason.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs:

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
