### PR TITLE
Kernel update - [amd64-rt, amd64-generic, amd64-generic, arm64-generic, arm64-generic, arm64-nvidia-jp7, riscv64-generic]

### DIFF
--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -11,8 +11,8 @@ To quickly build a custom kernel for development (example shows disabling `MODUL
 git clone https://github.com/lf-edge/eve-kernel/
 cd eve-kernel
 
-# Checkout the branch you want to modify (example for amd64 v6.12.49)
-git checkout eve-kernel-amd64-v6.12.49-generic
+# Checkout the branch you want to modify (example for amd64 v6.12.96)
+git checkout eve-kernel-amd64-v6.12.96-generic
 
 # Generate base config (see "Kernel Config Flavors" section for other options: rt, hwe)
 make eve-core_defconfig
@@ -64,7 +64,7 @@ platform (`PLATFORM`).
 
 ### Current Kernel Versions
 
-- **amd64**: v6.12.49 (generic and rt platforms)
+- **amd64**: v6.12.96 (generic and rt platforms)
 - **arm64**:
   - v6.1.155 (generic)
   - v5.10.192 (nvidia-jp5)
@@ -83,7 +83,7 @@ Where `<FLAVOR>` corresponds to the EVE `PLATFORM` variable.
 
 Examples:
 
-- `eve-kernel-amd64-v6.12.49-generic` (PLATFORM=generic)
+- `eve-kernel-amd64-v6.12.96-generic` (PLATFORM=generic)
 - `eve-kernel-arm64-v5.10.192-nvidia-jp5` (PLATFORM=nvidia-jp5)
 - `eve-kernel-arm64-v5.15.136-nvidia-jp6` (PLATFORM=nvidia-jp6)
 - `eve-kernel-amd64-next` (next LTS development branch)
@@ -100,7 +100,7 @@ This file contains the specific commit hashes for each kernel branch that EVE us
 maps a combination of architecture, version, and flavor to a specific commit:
 
 ```makefile
-KERNEL_COMMIT_amd64_v6.12.49_generic = ef7ccc4d151c
+KERNEL_COMMIT_amd64_v6.12.96_generic = bfc617435842
 KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = b4464b03583e
 KERNEL_COMMIT_arm64_v6.1.155_generic = ece043d8b403
 KERNEL_COMMIT_riscv64_v6.1.112_generic = 18e1d313b90b
@@ -121,7 +121,7 @@ This file defines the kernel version selection logic based on architecture and p
 
 **Key Variables:**
 
-- `KERNEL_VERSION`: The kernel version (e.g., v6.12.49)
+- `KERNEL_VERSION`: The kernel version (e.g., v6.12.96)
 - `KERNEL_FLAVOR`: The kernel flavor matching the EVE `PLATFORM` (e.g., generic, nvidia-jp5, nvidia-jp6)
 - `KERNEL_CONFIG_FLAVOR`: Config variant (e.g., core, rt, hwe) - see detailed description below
 - `KERNEL_COMMIT`: The specific commit hash from kernel-commits.mk
@@ -148,7 +148,7 @@ This Python script automates the process of updating kernel commits in EVE.
 ./tools/update_kernel_commits.py
 
 # Update specific branch
-./tools/update_kernel_commits.py --branch eve-kernel-amd64-v6.12.49-generic
+./tools/update_kernel_commits.py --branch eve-kernel-amd64-v6.12.96-generic
 
 # Dry run to see what would change
 ./tools/update_kernel_commits.py --test
@@ -168,7 +168,7 @@ EVE's kernel repository uses a multi-branch strategy:
 
 These track specific stable kernel versions:
 
-- Example: `eve-kernel-amd64-v6.12.49-generic`
+- Example: `eve-kernel-amd64-v6.12.96-generic`
 - Based on upstream stable kernel releases
 - Receive backported fixes and EVE-specific patches
 - Used for production EVE releases
@@ -202,7 +202,7 @@ The appropriate branch is automatically selected based on:
 
 **⚠️ Important Distinction:** `KERNEL_FLAVOR` and `KERNEL_CONFIG_FLAVOR` are different concepts and can be confusing:
 
-- **`KERNEL_FLAVOR`** (also called just `FLAVOR` in branch names): Corresponds to the EVE `PLATFORM` variable and determines the kernel branch (e.g., generic, nvidia-jp5, nvidia-jp6). This is part of the branch name like `eve-kernel-amd64-v6.12.49-generic`.
+- **`KERNEL_FLAVOR`** (also called just `FLAVOR` in branch names): Corresponds to the EVE `PLATFORM` variable and determines the kernel branch (e.g., generic, nvidia-jp5, nvidia-jp6). This is part of the branch name like `eve-kernel-amd64-v6.12.96-generic`.
 - **`KERNEL_CONFIG_FLAVOR`**: Controls which configuration variant is used when building from a specific branch (e.g., core, rt, hwe). This is NOT part of the branch name but determines which defconfig file is used.
 
 The `KERNEL_CONFIG_FLAVOR` variable controls which kernel configuration variant to use. This allows
@@ -369,7 +369,7 @@ This must be done on the same machine where you built the kernel.
 
    ```bash
    cd /path/to/eve
-   ./tools/update_kernel_commits.py --branch eve-kernel-amd64-v6.12.49-generic
+   ./tools/update_kernel_commits.py --branch eve-kernel-amd64-v6.12.96-generic
    git add kernel-commits.mk
    git commit -F kernel-update-commit-message.txt
    ```

--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,7 +1,7 @@
 KERNEL_COMMIT_amd64_next_generic = a65e45508b45
-KERNEL_COMMIT_amd64_v6.12.49_generic = dcdba3ddf871
+KERNEL_COMMIT_amd64_v6.12.96_generic = bfc617435842
 KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = 2e0dcfd3260d
 KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 4929f15eda41
-KERNEL_COMMIT_arm64_v6.8.12_nvidia-jp7 = 452eaffef5ed
-KERNEL_COMMIT_arm64_v6.1.155_generic = 9fa67514972d
-KERNEL_COMMIT_riscv64_v6.1.112_generic = 30aa75d58cdd
+KERNEL_COMMIT_arm64_v6.1.155_generic = 417a12ac3d50
+KERNEL_COMMIT_arm64_v6.8.12_nvidia-jp7 = 7f5919c0eaef
+KERNEL_COMMIT_riscv64_v6.1.112_generic = bd5816893ca9

--- a/kernel-version.mk
+++ b/kernel-version.mk
@@ -35,7 +35,7 @@ ifeq (, $(filter $(PLATFORM), $(PLATFORMS_$(ZARCH))))
 endif
 
 ifeq ($(ZARCH), amd64)
-    KERNEL_VERSION=v6.12.49
+    KERNEL_VERSION=v6.12.96
     KERNEL_FLAVOR=generic
     ifeq ($(PLATFORM), rt)
         KERNEL_CONFIG_FLAVOR=rt


### PR DESCRIPTION
# Description

Update `kernel-commits.mk` to the latest commits of the `lf-edge/eve-kernel` branches, generated with `tools/update_kernel_commits.py`, and move amd64 to the new `eve-kernel-amd64-v6.12.96-generic` branch.

The arm64 and riscv64 pins pick up the same three changes:

- `KVM: x86: Fix shadow paging use-after-free due to unexpected role`
- `KVM: x86: Fix shadow paging use-after-free due to unexpected GFN`
- `Makefile.eve: make linuxkit tmp dir user-specific` (kernel build tooling; no runtime change)

amd64 instead moves from the `v6.12.49` to the `v6.12.96` eve-kernel branch, i.e. from upstream stable Linux 6.12.49 to 6.12.96 (47 point releases), and `kernel-version.mk` is bumped accordingly. Both KVM shadow-paging fixes are in upstream 6.12.96, as is the af_alg CVE-2026-31431 fix that `v6.12.49-generic` carried as a backport. The EVE patch stack (37 patches) was rebased onto the new tag unchanged, with one exception: `Makefile.eve: make linuxkit tmp dir user-specific` is not present on the new branch (build tooling only, no runtime effect). `docs/KERNEL.md` is updated to match, in a separate commit.

Updated pins used by this branch:

| eve-kernel branch | old | new |
| --- | --- | --- |
| `eve-kernel-amd64-v6.12.49-generic` → `eve-kernel-amd64-v6.12.96-generic` | `dcdba3ddf871` | `bfc617435842` |
| `eve-kernel-arm64-v6.1.155-generic` | `9fa67514972d` | `417a12ac3d50` |
| `eve-kernel-arm64-v6.8.12-nvidia-jp7` | `452eaffef5ed` | `7f5919c0eaef` |
| `eve-kernel-riscv64-v6.1.112-generic` | `30aa75d58cdd` | `bd5816893ca9` |

`amd64-next`, `nvidia-jp5` and `nvidia-jp6` pins are unchanged. The update also re-adds pins for eve-kernel branches that exist upstream but are not referenced by `kernel-version.mk` on master (`amd64-v6.1.111-rt`, `amd64-v6.1.177-generic`, `arm64-v6.1.112-generic`); these entries are inert for master builds. The inert amd64 6.1.x pin now tracks the new `v6.1.177` branch instead of `v6.1.112`. See the commit message for the full per-branch changelogs.

Docker Hub images for all new pins were verified to exist, including the amd64 `core` and `rt` config flavors.

## How to test and validate this PR

- The PR gate builds every supported `ZARCH`/`PLATFORM` combination against the new pins, which validates that the pinned kernel images are pullable and usable.
- Local validation: `make live && make run-live`; the device should boot normally and `uname -r` inside EVE reports a kernel version string containing the new short commit hash of the pinned kernel.
- The KVM shadow-paging fixes are exercised by deploying/booting any VM app instance; `make eden TEST_SMOKE=1` covers app-instance deployment end to end.

## Changelog notes

Kernel update for all supported platforms: the amd64 kernel moves to upstream stable Linux 6.12.96 (from 6.12.49), and arm64/riscv64 pick up two KVM x86 shadow-paging use-after-free fixes.

## PR Backports

- 17.0 (release branch): Yes — #6191
- 16.0-stable: Yes — #6183
- 14.5-stable: Yes — #6182
- 13.4-stable: Yes — #6181

The stable-branch PRs are not cherry-picks: the update script was re-run against each branch's own kernel set.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them: device testing is pending while this PR is in draft (CI + QA validation to follow); the `stable` label should be set as this update is mirrored to all current LTS branches.




