### PR TITLE
[14.5-stable] Kernel update - [amd64-generic, amd64-generic, arm64-generic, arm64-generic, arm64-nvidia-jp7, riscv64-generic]

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,6 +1,6 @@
 KERNEL_COMMIT_amd64_v6.1.111_rt = c708a17493f1
-KERNEL_COMMIT_amd64_v6.1.112_generic = e724ce36605c
+KERNEL_COMMIT_amd64_v6.1.177_generic = 66072f59c883
 KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = 2e0dcfd3260d
 KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 4929f15eda41
-KERNEL_COMMIT_arm64_v6.1.112_generic = ffedeff9b67d
-KERNEL_COMMIT_riscv64_v6.1.112_generic = 30aa75d58cdd
+KERNEL_COMMIT_arm64_v6.1.112_generic = 20eaad6e15a1
+KERNEL_COMMIT_riscv64_v6.1.112_generic = bd5816893ca9

--- a/kernel-version.mk
+++ b/kernel-version.mk
@@ -34,7 +34,7 @@ ifeq ($(ZARCH), amd64)
         KERNEL_VERSION=v6.1.111
     else
         KERNEL_FLAVOR=generic
-        KERNEL_VERSION=v6.1.112
+        KERNEL_VERSION=v6.1.177
     endif
 else ifeq ($(ZARCH), arm64)
     ifeq (, $(findstring nvidia,$(PLATFORM)))


### PR DESCRIPTION
# Description

Backport of #6180

Stable-branch counterpart of #6180 for `14.5-stable`. This is not a cherry-pick: `kernel-commits.mk` was re-generated with `tools/update_kernel_commits.py` against the kernel set used by this branch.

Updated pins used by builds from this branch:

| eve-kernel branch | old | new | notable changes |
| --- | --- | --- | --- |
| `eve-kernel-amd64-v6.1.112-generic` → `eve-kernel-amd64-v6.1.177-generic` | `e724ce36605c` | `66072f59c883` | amd64 generic moves to upstream stable Linux 6.1.177 (from 6.1.112, 65 point releases) and `kernel-version.mk` is bumped to match; 6.1.177 already carries both KVM shadow-paging use-after-free fixes, the af_alg CVE-2026-31431 fix and the `iommu/vt-d` perfmon revert that this branch backported, and the EVE patch stack is otherwise unchanged (linuxkit tmpdir tooling fix included) |
| `eve-kernel-arm64-v6.1.112-generic` | `ffedeff9b67d` | `20eaad6e15a1` | 2x KVM shadow-paging use-after-free fixes, linuxkit tmpdir tooling fix |
| `eve-kernel-riscv64-v6.1.112-generic` | `30aa75d58cdd` | `bd5816893ca9` | 2x KVM shadow-paging use-after-free fixes, linuxkit tmpdir tooling fix |

`amd64-v6.1.111-rt`, `nvidia-jp5` and `nvidia-jp6` pins are unchanged (the af_alg CVE-2026-31431 fix already shipped to this branch via #5940). The update also adds pins for eve-kernel branches consumed by newer EVE releases (`amd64-v6.12.96-generic`, `arm64-v6.1.155-generic`, `arm64-v6.8.12-nvidia-jp7`); these entries are inert on this branch. arm64 and riscv64 stay on `v6.1.112`: no `v6.1.177` branch exists for those architectures. Full per-branch changelogs are in the commit message.

## How to test and validate this PR

- The PR gate builds the supported `ZARCH`/`PLATFORM` combinations against the new pins, which validates that the pinned kernel images are pullable and usable.
- Local validation: `make live && make run-live`; the device should boot normally and `uname -r` inside EVE reports a kernel version string containing the new short commit hash of the pinned kernel.
- The KVM shadow-paging fixes are exercised by deploying/booting any VM app instance; `make eden TEST_SMOKE=1` covers app-instance deployment end to end.

## Changelog notes

Kernel update for amd64, arm64 and riscv64: the amd64 generic kernel moves to upstream stable Linux 6.1.177 (from 6.1.112), and all architectures pick up two KVM x86 shadow-paging use-after-free fixes.

## PR Backports

Not applicable — this PR targets the `14.5-stable` branch (stable-branch counterpart of #6180).

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them: no documentation changes are needed for a kernel pin bump; device testing is pending while this PR is in draft (CI + QA validation to follow).


