### PR TITLE
[16.0-stable] Kernel update - [amd64-rt, amd64-generic, amd64-generic, arm64-generic, arm64-generic, arm64-nvidia-jp7, riscv64-generic]

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,6 +1,6 @@
 KERNEL_COMMIT_amd64_next_generic = a65e45508b45
-KERNEL_COMMIT_amd64_v6.12.49_generic = 465d242734dc
+KERNEL_COMMIT_amd64_v6.12.96_generic = bfc617435842
 KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = 2e0dcfd3260d
 KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 4929f15eda41
-KERNEL_COMMIT_arm64_v6.1.155_generic = da7d6950689c
-KERNEL_COMMIT_riscv64_v6.1.112_generic = 30aa75d58cdd
+KERNEL_COMMIT_arm64_v6.1.155_generic = 417a12ac3d50
+KERNEL_COMMIT_riscv64_v6.1.112_generic = bd5816893ca9

--- a/kernel-version.mk
+++ b/kernel-version.mk
@@ -38,7 +38,7 @@ endif
 KERNEL_LTS_VERSION=next
 
 ifeq ($(ZARCH), amd64)
-    KERNEL_VERSION=v6.12.49
+    KERNEL_VERSION=v6.12.96
     KERNEL_FLAVOR=generic
     ifeq ($(PLATFORM), rt)
         KERNEL_CONFIG_FLAVOR=rt


### PR DESCRIPTION
# Description

Backport of #6180

Stable-branch counterpart of #6180 for `16.0-stable`. This is not a cherry-pick: `kernel-commits.mk` was re-generated with `tools/update_kernel_commits.py` against the kernel set used by this branch, and amd64 moves to the new `eve-kernel-amd64-v6.12.96-generic` branch (`kernel-version.mk` bumped from `v6.12.49` to `v6.12.96`).

Updated pins used by builds from this branch:

| eve-kernel branch | old | new | notable changes |
| --- | --- | --- | --- |
| `eve-kernel-amd64-v6.12.49-generic` → `eve-kernel-amd64-v6.12.96-generic` | `465d242734dc` | `bfc617435842` | upstream stable Linux 6.12.49 → 6.12.96, which already contains both KVM shadow-paging use-after-free fixes and the af_alg CVE-2026-31431 fix this branch carried as backports; the EVE patch stack was rebased onto 6.12.96 and keeps KVM emulation of guest access to disabled passthrough BARs (instead of -EFAULT) and the vfio BAR-resource setup change; the linuxkit tmpdir tooling fix is not on the new branch |
| `eve-kernel-arm64-v6.1.155-generic` | `da7d6950689c` | `417a12ac3d50` | 2x KVM shadow-paging use-after-free fixes; Raspberry Pi 5 enablement (NVMe configs, RP1 PWM driver, SPI, bcm2712-mip irqchip/PCI); linuxkit tmpdir tooling fix |
| `eve-kernel-riscv64-v6.1.112-generic` | `30aa75d58cdd` | `bd5816893ca9` | 2x KVM shadow-paging use-after-free fixes, linuxkit tmpdir tooling fix |

`amd64-next` (used for the `evaluation` platform HWE/LTS image), `nvidia-jp5` and `nvidia-jp6` pins are unchanged. A second commit then drops the four pins that no supported `ZARCH`/`PLATFORM` combination on this branch can select — `amd64-v6.1.111-rt` (rt is a config flavor here, not a branch flavor), `amd64-v6.1.177-generic` (amd64 builds v6.12.96), `arm64-v6.1.112-generic` (arm64 generic is v6.1.155) and `arm64-v6.8.12-nvidia-jp7` (no jp7 platform on this branch) — leaving `kernel-commits.mk` with only the six kernels this branch actually builds. Every supported ZARCH/PLATFORM combination still resolves to a defined pin. Full per-branch changelogs are in the commit message.

Docker Hub images for the new pins were verified to exist, including the amd64 `core`, `rt` and `hwe` config flavors.

## How to test and validate this PR

- The PR gate builds the supported `ZARCH`/`PLATFORM` combinations against the new pins, which validates that the pinned kernel images are pullable and usable.
- Local validation: `make live && make run-live`; the device should boot normally and `uname -r` inside EVE reports a kernel version string containing the new short commit hash of the pinned kernel.
- The KVM shadow-paging fixes are exercised by deploying/booting any VM app instance; `make eden TEST_SMOKE=1` covers app-instance deployment end to end. The disabled-BAR emulation fix matters for PCI passthrough of devices with disabled BARs (previously surfaced as guest crashes / -EFAULT).

## Changelog notes

Kernel update for amd64, arm64 and riscv64: the amd64 kernel moves to upstream stable Linux 6.12.96 (from 6.12.49), two KVM x86 shadow-paging use-after-free fixes, KVM now emulates guest access to disabled passthrough PCI BARs instead of failing, and Raspberry Pi 5 hardware enablement on arm64.

## PR Backports

Not applicable — this PR targets the `16.0-stable` branch (stable-branch counterpart of #6180).

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them: no documentation changes are needed for a kernel pin bump; device testing is pending while this PR is in draft (CI + QA validation to follow).



