### PR TITLE
usbmanager: stop self-parent assigngrp from OOMing pillar

### DIFF
--- a/pkg/pillar/cmd/usbmanager/ioBundleTree.go
+++ b/pkg/pillar/cmd/usbmanager/ioBundleTree.go
@@ -76,8 +76,14 @@ func (iobt ioBundleTree) groupParents(assigngrp string) []string {
 		return ret
 	}
 
+	visited := map[*ioBundlesElem]struct{}{}
 	ioBundleElem = ioBundleElem.parent
 	for ioBundleElem != nil {
+		if _, seen := visited[ioBundleElem]; seen {
+			// Cyclic parent chain; stop to avoid an unbounded loop.
+			break
+		}
+		visited[ioBundleElem] = struct{}{}
 		ret = append(ret, ioBundleElem.assignmentGroup)
 		ioBundleElem = ioBundleElem.parent
 	}
@@ -107,6 +113,11 @@ func (iobt ioBundleTree) groupDependendentsImpl(groups map[string]struct{}, ioBu
 	}
 
 	for _, childioBundlesElem := range ioBundlesElem.children {
+		if _, seen := groups[childioBundlesElem.assignmentGroup]; seen {
+			// Already visited this group; skip to avoid unbounded recursion on
+			// a cyclic parentassigngrp graph (e.g. a self-parent tree self-loop).
+			continue
+		}
 		groups[childioBundlesElem.assignmentGroup] = struct{}{}
 		iobt.groupDependendentsImpl(groups, childioBundlesElem)
 	}
@@ -150,6 +161,17 @@ func (iobt *ioBundleTree) removeIOBundle(ioBundle *types.IoBundle) {
 }
 
 func (iobt *ioBundleTree) addIOBundle(ioBundle *types.IoBundle) {
+	if ioBundle.AssignmentGroup != "" &&
+		ioBundle.AssignmentGroup == ioBundle.ParentAssignmentGroup {
+		// A group that is its own parent would build a self-referential tree node
+		// (children[grp] == self), which the dependents walk would recurse on
+		// forever. The circular-dependency check below cannot catch this because
+		// a group is never among its own descendants before it is inserted.
+		log.Warnf("ioBundle %s has parentassigngrp equal to its assigngrp %q; "+
+			"not adding to avoid a self-referential dependency", ioBundle.Phylabel,
+			ioBundle.AssignmentGroup)
+		return
+	}
 	dependents := iobt.groupDependendents(ioBundle.AssignmentGroup)
 	for _, dependee := range dependents {
 		if dependee == ioBundle.ParentAssignmentGroup {

--- a/pkg/pillar/cmd/usbmanager/ioBundleTree_test.go
+++ b/pkg/pillar/cmd/usbmanager/ioBundleTree_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -599,4 +600,61 @@ func TestAddIOBundleDeadlock(t *testing.T) {
 	iobt.addIOBundle(&ioBundles[0])
 	iobt.addIOBundle(&ioBundles[1])
 
+}
+
+// runsWithin runs fn and fails t if it does not return within d.
+func runsWithin(t *testing.T, d time.Duration, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		fn()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatalf("operation did not terminate within %v (unbounded recursion/loop?)", d)
+	}
+}
+
+// TestSelfParentAssigngrpRejected verifies that an ioBundle whose parentassigngrp
+// equals its own assigngrp is not added to the tree. Adding it would build a
+// self-referential node (children[grp] == self), and the dependents walk would
+// then recurse on it forever, growing the goroutine stack until the pillar
+// memory cgroup OOMs. The circular-dependency check in addIOBundle cannot catch
+// this because a group is never among its own descendants before insertion.
+func TestSelfParentAssigngrpRejected(t *testing.T) {
+	iobt := newIOBundleTree()
+	iobt.addIOBundle(&types.IoBundle{
+		Phylabel:              "phantom-parent",
+		AssignmentGroup:       "grpx",
+		ParentAssignmentGroup: "grpx",
+	})
+	if iobt.ioBundle("phantom-parent") != nil {
+		t.Fatal("self-parent ioBundle should have been rejected, but it was added")
+	}
+	if iobt.elementsByAssignmentGroup["grpx"] != nil {
+		t.Fatal("no tree element should exist for the rejected self-parent group")
+	}
+	runsWithin(t, 2*time.Second, func() { iobt.groupDependendents("grpx") })
+}
+
+// TestTreeWalksGuardCycles verifies the tree walks terminate even if a cyclic
+// tree slips past addIOBundle: a self-loop element is built by hand and both
+// walks must complete rather than recurse/loop forever.
+func TestTreeWalksGuardCycles(t *testing.T) {
+	iobt := newIOBundleTree()
+	loop := &ioBundlesElem{
+		ioBundlesMap:    map[string]*types.IoBundle{},
+		assignmentGroup: "loop",
+		children:        map[string]*ioBundlesElem{},
+	}
+	loop.children["loop"] = loop // self-loop in children
+	loop.parent = loop           // self-loop in parent chain
+	iobt.elementsByAssignmentGroup["loop"] = loop
+
+	runsWithin(t, 2*time.Second, func() {
+		iobt.groupDependendents("loop")
+		iobt.groupParents("loop")
+	})
 }


### PR DESCRIPTION
# Description

A device model can declare a PhysicalIO whose `parentassigngrp` equals its
own `assigngrp`. When usbmanager processes such a bundle it builds a
self-referential node in its internal ioBundle tree (the group becomes its
own child), and the dependents walk then recurses on that self-loop with no
visited guard. The goroutine stack grows without bound until the pillar
memory cgroup OOM-kills zedbox, and the watchdog reboots the device —
repeatedly, since the offending config is re-applied on every boot, leaving
the device stuck in a reboot loop and unmanageable.

The existing circular-dependency check in `addIOBundle` cannot catch a
self-parent, because a group is never among its own descendants before it is
inserted.

This change:

- rejects a self-parent bundle in `addIOBundle` so the self-referential node
  is never built;
- guards both tree walks (`groupDependendentsImpl` and `groupParents`) with a
  visited set, so any cyclic `parentassigngrp` graph that reaches them
  terminates instead of recursing/looping forever.

## How to test and validate this PR

Covered by unit tests in `pkg/pillar/cmd/usbmanager/ioBundleTree_test.go`
(`TestSelfParentAssigngrpRejected`, `TestTreeWalksGuardCycles`); the latter
builds a self-loop and asserts both walks return under a timeout — it hangs
without this fix.

End to end: push a device model with a PhysicalIO whose `parentassigngrp`
equals its `assigngrp`. On an unfixed build the device OOM-reboots within
~2 minutes and loops; with this fix the model is reported as an error
(`IOBundle cannot be its own parent`) and the device stays up with steady
memory.

## Changelog notes

Fixed a device reboot loop that could occur when the device model contained
an I/O adapter whose parent assignment group referred to itself.

## PR Backports

This is a device-management reboot-loop fix, and every current LTS branch is
affected:

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

`pkg/pillar/cmd/usbmanager/ioBundleTree.go` has not been touched since it was
added in 31b9c8eab (Dec 2023), so all four branches carry the file byte-identical
to master and the patch applies unmodified. Checked on each branch: without the
fix the self-loop walk stack-overflows, and with it the usbmanager package tests,
`go vet`, and `gofmt` are clean.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

