### PR TITLE
pubsub: size ReadWithMaxSize buffer to the file, not maxReadSize

### DIFF
--- a/pkg/pillar/utils/file/file.go
+++ b/pkg/pillar/utils/file/file.go
@@ -223,8 +223,17 @@ func ReadWithMaxSize(log *base.LogObject, filename string, maxReadSize int) ([]b
 		return nil, err
 	}
 	defer f.Close()
+	// Size the buffer to the file (capped at maxReadSize+1) instead of always
+	// allocating maxReadSize+1. pubsub-large stores each field of a large object
+	// as its own small file yet reads them with a 1 MiB maxReadSize, so a fixed
+	// max-sized buffer amplified every tiny-field read by orders of magnitude and,
+	// under DeviceNetworkStatus republish churn, drove the pillar cgroup to OOM.
+	bufSize := maxReadSize + 1
+	if fi, statErr := f.Stat(); statErr == nil && fi.Size() < int64(maxReadSize) {
+		bufSize = int(fi.Size()) + 1
+	}
 	r := bufio.NewReader(f)
-	content := make([]byte, maxReadSize+1)
+	content := make([]byte, bufSize)
 	n, err := r.Read(content)
 	if err != nil {
 		err = fmt.Errorf("ReadWithMaxSize %s failed: %v", filename, err)

--- a/pkg/pillar/utils/file/file_test.go
+++ b/pkg/pillar/utils/file/file_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReadWithMaxSize covers both the small-file path (content shorter than
+// maxReadSize, returned whole) and the too-large path (content longer than
+// maxReadSize, truncated with an error). The buffer is sized to the file for
+// the small case, but the returned content and truncation semantics must be
+// identical to allocating maxReadSize+1 in both cases.
+func TestReadWithMaxSize(t *testing.T) {
+	const maxReadSize = 100
+
+	tests := []struct {
+		name        string
+		fileSize    int
+		wantErr     bool
+		wantLen     int
+		wantContent bool // compare returned bytes against the written prefix
+	}{
+		{
+			name:        "smaller than maxReadSize",
+			fileSize:    50,
+			wantErr:     false,
+			wantLen:     50,
+			wantContent: true,
+		},
+		{
+			name:        "one below maxReadSize",
+			fileSize:    maxReadSize - 1,
+			wantErr:     false,
+			wantLen:     maxReadSize - 1,
+			wantContent: true,
+		},
+		{
+			name:        "larger than maxReadSize",
+			fileSize:    maxReadSize + 100,
+			wantErr:     true,
+			wantLen:     maxReadSize,
+			wantContent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make([]byte, tt.fileSize)
+			for i := range data {
+				data[i] = byte('a' + i%26)
+			}
+			filename := filepath.Join(t.TempDir(), "data")
+			if err := os.WriteFile(filename, data, 0644); err != nil {
+				t.Fatalf("WriteFile failed: %v", err)
+			}
+
+			content, err := ReadWithMaxSize(nil, filename, maxReadSize)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected truncation error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(content) != tt.wantLen {
+				t.Fatalf("got %d bytes, want %d", len(content), tt.wantLen)
+			}
+			if tt.wantContent && !bytes.Equal(content, data[:tt.wantLen]) {
+				t.Fatalf("returned content does not match file prefix")
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

I saw issues where DevicePortConfigList or DeviceNetworkStatus, which have lots of subscribers, cause lots of 1MB allocations due to churn resulting in a rapid set of updates. This PR reduces the burst memory allocation due to such bursts.

`ReadWithMaxSize` allocated a buffer of `maxReadSize+1` regardless of the
file's actual size. The pubsub "large" object mechanism stores each large
field of an object as its own separate file but reads them back with a 1 MiB
`maxReadSize`, so every tiny-field read allocated a full 1 MiB buffer. Under
frequent republishing of a large object (for example `DeviceNetworkStatus`,
whose subscribers each re-read the whole field tree on every publish) this
amplified the allocation rate by several orders of magnitude and put
significant, needless pressure on the pillar memory cgroup.

This change sizes the read buffer to the file (capped at `maxReadSize+1`)
instead of always allocating the maximum, cutting pubsub-large read
allocation for small fields from ~1 MiB to the field's real size.

## How to test and validate this PR

No behavioral change — the returned content is identical (the max-size cap
and truncation semantics are unchanged); only the buffer allocation shrinks.
Covered by the existing `pkg/pillar/utils/file` and `pkg/pillar/pubsub` tests.
The reduction is observable as lower `inuse`/allocation attributed to
`utils/file.ReadWithMaxSize` in a pillar heap profile while a large pubsub
object is being republished.

## Changelog notes

No user-facing changes (internal memory-efficiency fix).

## PR Backports

Efficiency fix, safe but not urgent to backport:

- 16.0-stable: Optional.
- 14.5-stable: Optional.
- 13.4-stable: Optional.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
