### PR TITLE
verifier: reject malformed content sha256 to prevent path traversal

### DIFF
--- a/pkg/pillar/cmd/verifier/lib/verifier.go
+++ b/pkg/pillar/cmd/verifier/lib/verifier.go
@@ -19,6 +19,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/lf-edge/eve/pkg/pillar/utils"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
@@ -79,7 +80,11 @@ func (v *Verifier) MarkObjectAsVerifying(
 	tmpID uuid.UUID) (int64, string, error) {
 
 	verifierDirname := v.GetVerifierDir()
-	pendingFilename, verifierFilename, _ := v.ImageVerifierFilenames(location, digest, tmpID.String(), mediaType)
+	pendingFilename, verifierFilename, _, err := v.ImageVerifierFilenames(location, digest, tmpID.String(), mediaType)
+	if err != nil {
+		v.logger.Error(err)
+		return 0, "", err
+	}
 
 	// Move to verifier directory which is RO
 	// XXX should have dom0 do this and/or have RO mounts
@@ -124,7 +129,10 @@ func (v *Verifier) MarkObjectAsVerifying(
 func (v *Verifier) MarkObjectAsVerified(location, digest, mediaType string, tmpID uuid.UUID) (string, error) {
 
 	verifiedDirname := v.GetVerifiedDir()
-	_, verifierFilename, verifiedFilename := v.ImageVerifierFilenames(location, digest, tmpID.String(), mediaType)
+	_, verifierFilename, verifiedFilename, err := v.ImageVerifierFilenames(location, digest, tmpID.String(), mediaType)
+	if err != nil {
+		return "", err
+	}
 	// Move directory from DownloadDirname/verifier to
 	// DownloadDirname/verified
 	// XXX should have dom0 do this and/or have RO mounts
@@ -167,11 +175,22 @@ func (v *Verifier) MarkObjectAsVerified(location, digest, mediaType string, tmpI
 // lost during a reboot. We need that information to be persistent and survive reboot,
 // so we can reconstruct it. Hence, we preserve it in the filename. It is PathEscape'd
 // so it is filename-safe.
-func (v *Verifier) ImageVerifierFilenames(infile, sha256, tmpID, mediaType string) (string, string, string) {
+//
+// The sha256 digest is controller-provided and becomes part of the on-disk
+// filename. Unlike mediaType it is not escaped, so a crafted value such as
+// "../../../persist/secret" would, after path.Join cleans it, escape the
+// verifier/verified directories and let a downloaded blob be written outside
+// the intended tree (path traversal). To prevent that, reject any digest that
+// is not a strict 64-character hex SHA-256.
+func (v *Verifier) ImageVerifierFilenames(infile, sha256, tmpID, mediaType string) (string, string, string, error) {
+	if !utils.IsValidSHA256(sha256) {
+		return "", "", "", fmt.Errorf(
+			"invalid sha256 %q: must be 64 hexadecimal characters", sha256)
+	}
 	verifierDirname, verifiedDirname := v.GetVerifierDir(), v.GetVerifiedDir()
 	// Handle names which are paths
 	mediaTypeSafe := url.PathEscape(mediaType)
 	verifierFilename := strings.Join([]string{tmpID, sha256, mediaTypeSafe}, ".")
 	verifiedFilename := strings.Join([]string{sha256, mediaTypeSafe}, ".")
-	return infile, path.Join(verifierDirname, verifierFilename), path.Join(verifiedDirname, verifiedFilename)
+	return infile, path.Join(verifierDirname, verifierFilename), path.Join(verifiedDirname, verifiedFilename), nil
 }

--- a/pkg/pillar/cmd/verifier/lib/verifier_test.go
+++ b/pkg/pillar/cmd/verifier/lib/verifier_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package verifier
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
+)
+
+// escapesDir reports whether resolved is outside dir (i.e. path traversal).
+func escapesDir(dir, resolved string) bool {
+	rel, err := filepath.Rel(dir, resolved)
+	if err != nil {
+		return true
+	}
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// TestImageVerifierFilenamesRejectsInvalidSha256 verifies that ImageVerifierFilenames
+// rejects a controller-supplied sha256 that is not a strict 64-character hex digest.
+// The digest is joined (unescaped) into the on-disk verifier/verified filenames, so a
+// crafted value with parent-directory segments would, after path.Join cleaned it,
+// resolve outside the verifier tree (path traversal). A valid digest must be accepted
+// and stay contained.
+func TestImageVerifierFilenamesRejectsInvalidSha256(t *testing.T) {
+	log := base.NewSourceLogObject(logrus.StandardLogger(), "verifier_test", 0)
+	v, err := NewVerifier(t.TempDir(), log)
+	if err != nil {
+		t.Fatalf("NewVerifier failed: %v", err)
+	}
+
+	mediaType := "application/vnd.oci.image.manifest.v1+json"
+	badDigests := []string{
+		"../../../../../../persist/secret", // traversal into a sibling of the verifier dir
+		"../../../pwned",                   // traversal, fewer segments
+		"..",
+		"foo/bar",
+		"",
+		"9f86d081884c7d659a2feaa0c55ad015", // too short (32 hex chars)
+		"zzzz6d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",  // non-hex
+		"9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08ff", // too long (66)
+	}
+	for _, bad := range badDigests {
+		if _, _, _, err := v.ImageVerifierFilenames("infile", bad, "tmpID", mediaType); err == nil {
+			t.Errorf("ImageVerifierFilenames accepted invalid sha256 %q, expected error", bad)
+		}
+	}
+
+	// A valid digest must be accepted and stay inside the verifier/verified dirs.
+	goodDigest := "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+	_, verifierFilename, verifiedFilename, err := v.ImageVerifierFilenames(
+		"infile", goodDigest, "tmpID", mediaType)
+	if err != nil {
+		t.Fatalf("ImageVerifierFilenames rejected valid sha256: %v", err)
+	}
+	if escapesDir(v.GetVerifierDir(), verifierFilename) {
+		t.Errorf("verifierFilename %q escaped verifier dir %q",
+			verifierFilename, v.GetVerifierDir())
+	}
+	if escapesDir(v.GetVerifiedDir(), verifiedFilename) {
+		t.Errorf("verifiedFilename %q escaped verified dir %q",
+			verifiedFilename, v.GetVerifiedDir())
+	}
+}

--- a/pkg/pillar/cmd/verifier/pubsub/handlers_test.go
+++ b/pkg/pillar/cmd/verifier/pubsub/handlers_test.go
@@ -16,7 +16,7 @@ func TestMediaTypeInStatusFromVerifiedFilename(t *testing.T) {
 	log := base.NewSourceLogObject(logrus.StandardLogger(), "verifier_test", 0)
 	mediaType := "application/vnd.docker.distribution.manifest.v2+json"
 	tmpID := "tempID"
-	sha256 := "dummySha256"
+	sha256 := "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
 	infile := "dummyFile"
 	dummyPath := t.TempDir()
 	v, err := verifier.NewVerifier(dummyPath, log)
@@ -24,7 +24,10 @@ func TestMediaTypeInStatusFromVerifiedFilename(t *testing.T) {
 		t.Fatalf("Error creating verifier: %v", err)
 	}
 
-	_, _, verifiedFilename := v.ImageVerifierFilenames(infile, sha256, tmpID, mediaType)
+	_, _, verifiedFilename, err := v.ImageVerifierFilenames(infile, sha256, tmpID, mediaType)
+	if err != nil {
+		t.Fatalf("ImageVerifierFilenames failed: %v", err)
+	}
 	status := verifyImageStatusFromVerifiedImageFile(verifiedFilename, 12345, dummyPath, log)
 
 	if status == nil {

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -27,6 +27,20 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 	changed := false
 	addedBlobs := []string{}
 
+	// The content sha256 (controller-supplied via ContentTreeConfig, or later
+	// resolved from an OCI tag) becomes part of the on-disk filenames used by the
+	// downloader and verifier. Reject a malformed digest here, before it is used to
+	// build any path, and surface it through the status so the controller learns why
+	// the content tree failed instead of the request being dropped silently. An empty
+	// digest is allowed: an OCI tag that has not yet been resolved to a digest.
+	if status.ContentSha256 != "" && !utils.IsValidSHA256(status.ContentSha256) {
+		err := fmt.Sprintf("doUpdateContentTree(%s) name %s: malformed content sha256 %q: must be 64 hexadecimal characters",
+			status.Key(), status.DisplayName, status.ContentSha256)
+		log.Error(err)
+		status.SetErrorDescription(types.ErrorDescription{Error: err})
+		return true, false
+	}
+
 	if status.State < types.VERIFIED {
 		if !status.AllDatastoresResolved {
 			log.Functionf("contentTreeStatus(%s) does not have a datastore type yet, deferring", status.ContentID)

--- a/pkg/pillar/cmd/volumemgr/updatestatus_test.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/sirupsen/logrus"
+)
+
+// TestDoUpdateContentTreeRejectsMalformedSha256 verifies that a content tree whose
+// (controller-supplied) sha256 is not a strict 64-hex digest is failed with an error
+// set on its ContentTreeStatus, rather than being processed. That error is what the
+// controller sees reported back (PublishContentInfoToZedCloud copies it into
+// ZInfoContentTree.Err), so a malformed digest is signalled instead of silently
+// dropped. It also prevents the crafted digest from ever reaching the downloader /
+// verifier, where it would otherwise be joined into on-disk paths (path traversal).
+func TestDoUpdateContentTreeRejectsMalformedSha256(t *testing.T) {
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "test-volumemgr", 0)
+	ctx := &volumemgrContext{}
+
+	// A malformed digest must be rejected with an error on the status; the top-of-
+	// function guard returns before any pubsub/ctx access, so a bare context is enough.
+	bad := []string{
+		"../../../../../../persist/secret",
+		"..",
+		"foo/bar",
+		"not-hex",
+		"9f86d081884c7d659a2feaa0c55ad015", // too short
+	}
+	for _, sha := range bad {
+		status := &types.ContentTreeStatus{
+			ContentSha256: sha,
+			DisplayName:   "test",
+			State:         types.INITIAL,
+		}
+		changed, _ := doUpdateContentTree(ctx, status)
+		if !changed {
+			t.Errorf("doUpdateContentTree(%q) reported no change, expected error set", sha)
+		}
+		if !status.HasError() {
+			t.Errorf("doUpdateContentTree(%q) did not set an error on the status", sha)
+		}
+	}
+
+	// An empty sha256 (unresolved OCI tag) must NOT be rejected by this guard.
+	emptyStatus := &types.ContentTreeStatus{
+		ContentSha256:         "",
+		DisplayName:           "test-empty",
+		State:                 types.INITIAL,
+		AllDatastoresResolved: false, // defers further processing, so we only exercise the guard
+	}
+	doUpdateContentTree(ctx, emptyStatus)
+	if emptyStatus.HasError() {
+		t.Errorf("doUpdateContentTree set an error for an empty (unresolved) sha256: %s",
+			emptyStatus.Error)
+	}
+}

--- a/pkg/pillar/utils/sha.go
+++ b/pkg/pillar/utils/sha.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import "regexp"
+
+// sha256Regexp matches a valid SHA-256 digest: exactly 64 hexadecimal characters.
+var sha256Regexp = regexp.MustCompile(`^[0-9a-fA-F]{64}$`)
+
+// IsValidSHA256 reports whether s is a syntactically valid SHA-256 digest, i.e.
+// exactly 64 hexadecimal characters. It does not verify that the digest matches
+// any content; it only guards against malformed values (e.g. controller-supplied
+// digests that contain path separators or "..") before they are used to build
+// file paths or looked up as content-addressable identifiers.
+func IsValidSHA256(s string) bool {
+	return sha256Regexp.MatchString(s)
+}

--- a/pkg/pillar/utils/sha_test.go
+++ b/pkg/pillar/utils/sha_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import "testing"
+
+func TestIsValidSHA256(t *testing.T) {
+	valid := []string{
+		"9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+		"E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855", // upper-case hex
+	}
+	for _, s := range valid {
+		if !IsValidSHA256(s) {
+			t.Errorf("IsValidSHA256(%q) = false, want true", s)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"..",
+		"foo/bar",
+		"../../../../../../persist/secret", // path traversal
+		"9f86d081884c7d659a2feaa0c55ad015", // too short (32)
+		"9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08f", // too long (65)
+		"zzzz6d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", // non-hex
+		"sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0", // prefixed
+	}
+	for _, s := range invalid {
+		if IsValidSHA256(s) {
+			t.Errorf("IsValidSHA256(%q) = true, want false", s)
+		}
+	}
+}


### PR DESCRIPTION
# Description

The `verifier` builds the on-disk verifier/verified filenames for a blob by
joining the content digest into the path:
`path.Join(verifierDir, tmpID "." sha256 "." mediaType)`. The `mediaType` is
`url.PathEscape`'d and `tmpID` is an internally-generated UUID, but the `sha256`
segment — which originates from the controller-supplied
`ContentTreeConfig.ContentSha256` and is only lower-cased on the way in — was
used verbatim. A crafted digest containing parent-directory segments (e.g.
`../../../persist/secret`) survives `path.Join`'s cleaning and resolves to a
location outside the verifier directory. Because the verifier then `os.Rename`s
the downloaded blob to that path (before the hash is even checked), a controller
able to set that field could write/overwrite files outside the intended tree —
a path traversal in a device-management component.

This PR fixes it in three small commits:

1. **utils: add `IsValidSHA256`** — a shared helper that reports whether a string
   is a syntactically valid 64-character hex SHA-256. There is no such helper in
   the standard library, so it is added once instead of duplicating the regex.
2. **verifier: reject non-hex sha256** — `ImageVerifierFilenames` validates the
   digest with `IsValidSHA256` before it is ever used to build a path and now
   returns an error; `MarkObjectAsVerifying`/`MarkObjectAsVerified` propagate it,
   so `handleCreate` marks the image as failed instead of writing out of tree.
3. **volumemgr: fail content tree on malformed sha256 and report it** —
   `doUpdateContentTree` (the content-tree state machine) rejects a non-empty,
   malformed digest before any blob is created or path is built, sets an error on
   the `ContentTreeStatus`, and stops processing. `PublishContentInfoToZedCloud`
   already copies that error into the `ZInfoContentTree` report, so the controller
   is told the content tree is malformed rather than the config being dropped
   silently. An empty digest is still allowed (an unresolved OCI tag).

## How to test and validate this PR

Covered by unit tests. From `pkg/pillar`:

```sh
go test ./utils/ ./cmd/verifier/... ./cmd/volumemgr/
```

- `TestIsValidSHA256` — accepts valid 64-hex digests (upper/lower), rejects
  empty, wrong-length, non-hex, prefixed, and traversal strings.
- `TestImageVerifierFilenamesRejectsInvalidSha256` — the real
  `ImageVerifierFilenames` rejects traversal and otherwise malformed digests,
  and a valid digest stays contained within the verifier/verified dirs.
- `TestDoUpdateContentTreeRejectsMalformedSha256` — a content tree with a
  malformed digest gets an error set on its `ContentTreeStatus` (which is what is
  reported to the controller), while an empty digest is not rejected.

End-to-end: push a `ContentTree` whose sha256 is not a 64-hex string; the content
tree fails with a clear error surfaced to the controller, and no blob is written
outside the verifier directory.

## Changelog notes

Security: a controller-supplied content image digest that is not a valid SHA-256
is now rejected instead of being used to construct on-disk paths, closing a
path-traversal where a downloaded blob could be written outside the verifier
directory. Malformed digests are reported back on the content tree's status.

## PR Backports

- 17.0: Backported in #6207.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — n/a, no doc-facing behavior change
- [ ] I've tested my PR on amd64 device — covered by unit tests; not run on a device
- [ ] I've tested my PR on arm64 device — covered by unit tests; not run on a device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

