### PR TITLE
Resolve container USER name for EVE-k volumes

### DIFF
--- a/pkg/pillar/cas/containerd.go
+++ b/pkg/pillar/cas/containerd.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -18,6 +19,7 @@ import (
 	containerderrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/oci"
 	snapshot "github.com/containerd/containerd/snapshots"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	v1types "github.com/google/go-containerregistry/pkg/v1/types"
@@ -27,6 +29,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/moby/sys/mountinfo"
+	"github.com/moby/sys/user"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
@@ -816,21 +819,66 @@ func (c *containerdCAS) prepareContainerRootDirForKubevirt(clientImageSpec *ocis
 		return err
 	}
 
-	// Userid and GID are same
-	ug := "0 0"
-	if user != "" {
-		uid, converr := strconv.Atoi(user)
-		if converr != nil {
-			return converr
-		}
-		ug = fmt.Sprintf("%d %d", uid, uid)
+	uid, gid, err := resolveUserGroup(GetRoofFsPath(rootPath), user)
+	if err != nil {
+		return fmt.Errorf("PrepareContainerRootDir: cannot resolve user %q: %w", user, err)
 	}
+	ug := fmt.Sprintf("%d %d", uid, gid)
 	if err := os.WriteFile(filepath.Join(rootPath, "ug"),
 		[]byte(ug), 0644); err != nil {
 		return err
 	}
 
 	return os.MkdirAll(filepath.Join(rootPath, "modules"), 0600)
+}
+
+// resolveUserGroup maps an OCI image Config.User string to numeric uid/gid.
+// User or group *names* are resolved against /etc/passwd and /etc/group in the
+// container's rootfs (rootfs must already be mounted). It accepts the same
+// forms as the OCI runtime and the HV=kvm/xen path (containerd's oci.WithUser):
+// "", "uid", "user", "uid:gid", "user:group", "uid:group", "user:gid". An empty
+// user yields 0/0. When only a numeric uid is given, gid defaults to that user's
+// primary group from /etc/passwd, falling back to 0 if the rootfs has no
+// matching entry.
+func resolveUserGroup(rootfs, userstr string) (uid, gid uint32, err error) {
+	if userstr == "" {
+		return 0, 0, nil
+	}
+	userPart, groupPart, hasGroup := strings.Cut(userstr, ":")
+
+	if v, aerr := strconv.Atoi(userPart); aerr == nil {
+		if v < 0 || v > math.MaxInt32 {
+			return 0, 0, fmt.Errorf("uid %q out of range", userPart)
+		}
+		uid = uint32(v)
+		// Default gid to the user's primary group; a missing rootfs entry
+		// is not an error for a numeric uid, matching oci.WithUserID.
+		if u, ferr := oci.UserFromPath(rootfs, func(u user.User) bool { return u.Uid == v }); ferr == nil {
+			gid = uint32(u.Gid)
+		}
+	} else {
+		u, ferr := oci.UserFromPath(rootfs, func(u user.User) bool { return u.Name == userPart })
+		if ferr != nil {
+			return 0, 0, ferr
+		}
+		uid, gid = uint32(u.Uid), uint32(u.Gid)
+	}
+
+	if hasGroup && groupPart != "" {
+		if v, aerr := strconv.Atoi(groupPart); aerr == nil {
+			if v < 0 || v > math.MaxInt32 {
+				return 0, 0, fmt.Errorf("gid %q out of range", groupPart)
+			}
+			gid = uint32(v)
+		} else {
+			g, ferr := oci.GIDFromPath(rootfs, func(g user.Group) bool { return g.Name == groupPart })
+			if ferr != nil {
+				return 0, 0, ferr
+			}
+			gid = g
+		}
+	}
+	return uid, gid, nil
 }
 
 // UnmountContainerRootDir unmounts container's rootPath

--- a/pkg/pillar/cas/containerd_test.go
+++ b/pkg/pillar/cas/containerd_test.go
@@ -125,3 +125,52 @@ func TestIngestBlobMissingFileNotInCAS(t *testing.T) {
 		t.Fatalf("expected IngestBlob to fail for a missing file not in CAS, got nil")
 	}
 }
+
+func TestResolveUserGroup(t *testing.T) {
+	rootfs := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(rootfs, "etc"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	passwd := "root:x:0:0:root:/root:/bin/bash\nzcli:x:1000:1000:Linux User:/home/zcli:/bin/bash\n"
+	group := "root:x:0:\nstaff:x:50:\nzcli:x:1000:\n"
+	if err := os.WriteFile(filepath.Join(rootfs, "etc", "passwd"), []byte(passwd), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rootfs, "etc", "group"), []byte(group), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		userstr  string
+		uid, gid uint32
+		wantErr  bool
+	}{
+		{userstr: "", uid: 0, gid: 0},
+		{userstr: "zcli", uid: 1000, gid: 1000},  // username resolved from /etc/passwd
+		{userstr: "1000", uid: 1000, gid: 1000},  // numeric uid; gid from passwd
+		{userstr: "1234", uid: 1234, gid: 0},     // uid absent from passwd; gid falls back to 0
+		{userstr: "1000:50", uid: 1000, gid: 50}, // numeric group overrides
+		{userstr: "zcli:staff", uid: 1000, gid: 50},
+		{userstr: "1000:staff", uid: 1000, gid: 50},
+		{userstr: "nobody", wantErr: true},
+		{userstr: "zcli:nogroup", wantErr: true},
+		{userstr: "2147483648", wantErr: true},      // uid > math.MaxInt32
+		{userstr: "1000:2147483648", wantErr: true}, // gid > math.MaxInt32
+	}
+	for _, tt := range tests {
+		uid, gid, err := resolveUserGroup(rootfs, tt.userstr)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("resolveUserGroup(%q): expected error, got uid=%d gid=%d", tt.userstr, uid, gid)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("resolveUserGroup(%q): unexpected error: %v", tt.userstr, err)
+			continue
+		}
+		if uid != tt.uid || gid != tt.gid {
+			t.Errorf("resolveUserGroup(%q) = %d/%d, want %d/%d", tt.userstr, uid, gid, tt.uid, tt.gid)
+		}
+	}
+}

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -142,7 +142,7 @@ require (
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/signal v0.7.0 // indirect
-	github.com/moby/sys/user v0.4.0 // indirect
+	github.com/moby/sys/user v0.4.0
 	github.com/moby/term v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect


### PR DESCRIPTION
# Description

A container app whose image declares a non-numeric `USER` (a username
rather than a numeric UID) fails to deploy on **EVE-k**. The app instance
stays in `CREATING_VOLUME` and the error surfaced to the controller is:

```
Error CreateVolume /persist/vault/volumes/<uuid>#0.container err: strconv.Atoi: parsing "zcli": invalid syntax
```

The kubevirt volume-preparation path (`prepareContainerRootDirForKubevirt`
in `pkg/pillar/cas/containerd.go`) read the OCI image's `Config.User` and
parsed it straight as an integer to build the `uid gid` (`ug`) file that
the runx/shim-VM init consumes. Any username-form `USER` therefore errored
out — even though it is perfectly valid OCI and already works on
EVE-kvm/xen, where the `pkg/pillar/containerd/oci.go` path delegates to
containerd's `oci.WithUser`, which resolves the name against the image's
`/etc/passwd`.

This PR resolves the user (and optional group) against the container
rootfs's `/etc/passwd` / `/etc/group`, matching the kvm/xen behavior. It
handles the `uid`, `user`, `uid:gid`, `user:group` (and mixed) forms and
derives the gid from the passwd entry instead of assuming `gid == uid`.

## How to test and validate this PR

Deploy a container app on an EVE-k device using an image whose Dockerfile
sets a non-numeric user, e.g. `USER zcli` where `zcli` maps to uid/gid
1000 in the image's `/etc/passwd` (`docker.io/zededa/zcli` is one such
image). Before this change the instance hangs in `CREATING_VOLUME` with
the `strconv.Atoi` error; after it, the volume is created and the app runs
as the resolved uid/gid. The same image already deploys on EVE-kvm.

Automated: `TestResolveUserGroup` in `pkg/pillar/cas/containerd_test.go`
covers the `zcli` username case, numeric `uid`/`uid:gid`, `user:group`,
and unknown-name errors.

## Changelog notes

Fix container apps failing to start on EVE-k when the image sets a
non-numeric user (e.g. `USER appuser`); the username is now resolved to
its uid/gid from the image, as it already was on EVE-kvm.

## PR Backports

EVE-k (kubevirt) is only usable in 17.0 and later, so this fix is only
relevant on 17.0.

- 17.0: To be backported.
- 16.0-stable: No, EVE-k is not usable before 17.0.
- 14.5-stable: No, EVE-k is not usable before 17.0.
- 13.4-stable: No, EVE-k is not usable before 17.0.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Note: verified on amd64 (the EVE-k `zcli` container reproduction and the
new unit test); arm64 not separately exercised, but the change is
architecture-independent.
