### PR TITLE
volumemgr: build-tagged fault injection for volume delete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,7 @@ endif
 
 # For all possible env variable that later can be handle by a Dockerfile as a build-arg-file of
 # a given package, we create a target of the form lk-extra-opt/<pkg-name>/<env-var-name>
-LK_POSSIBLE_PKG_PLUS_BUILD_ARGS := pillar/IMM_PROFILING pillar/ARTIFICIAL_LEAK pillar/COVER
+LK_POSSIBLE_PKG_PLUS_BUILD_ARGS := pillar/IMM_PROFILING pillar/ARTIFICIAL_LEAK pillar/COVER pillar/FAULT_INJECTION
 LK_POSSIBLE_BUILD_ARG_TARGETS := $(addprefix lk-extra-opt/,$(LK_POSSIBLE_PKG_PLUS_BUILD_ARGS))
 
 .PHONY: lk-extra-opt/%

--- a/Makefile
+++ b/Makefile
@@ -385,6 +385,13 @@ LK_POSSIBLE_BUILD_ARG_TARGETS := $(addprefix lk-extra-opt/,$(LK_POSSIBLE_PKG_PLU
 # It creates a file lk-build-arg-<env-var-name> in the package directory, so that it
 # 1) Can be picked up by the linuxkit build command as a --build-arg-file <file>
 # 2) Affects the package git hash, so the hash is unique for a given set of build args
+#
+# The variable is tested for being NON-EMPTY, not for the value y, so any value at
+# all turns the argument on: FAULT_INJECTION=n on the command line writes
+# FAULT_INJECTION=y into the build-arg file exactly as FAULT_INJECTION=y would.
+# Callers must therefore leave such a variable unset to disable it, and never pass
+# =n. The generated file is also untracked, so its presence dirties the tree and
+# adds -dirty to the package tag.
 lk-extra-opt/%: FORCE
 	$(eval LK_EXTRA_PKG_NAME := $(word 1,$(subst /, ,$*)))
 	$(eval LK_EXTRA_BUILD_ARG := $(word 2,$(subst /, ,$*)))

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -89,6 +89,8 @@ ARG IMM_PROFILING=n
 ENV IMM_PROFILING=${IMM_PROFILING}
 ARG ARTIFICIAL_LEAK=n
 ENV ARTIFICIAL_LEAK=${ARTIFICIAL_LEAK}
+ARG FAULT_INJECTION=n
+ENV FAULT_INJECTION=${FAULT_INJECTION}
 ARG COVER=n
 
 # we need zfs files during build
@@ -109,13 +111,14 @@ ARG GOPKGVERSION
 # make LK build args affect a layer, so value change will invalidate cache
 RUN echo "IMM_PROFILING: ${IMM_PROFILING}"
 RUN echo "ARTIFICIAL_LEAK: ${ARTIFICIAL_LEAK}"
+RUN echo "FAULT_INJECTION: ${FAULT_INJECTION}"
 RUN echo "COVER: ${COVER}"
 
 # hadolint ignore=DL4006
 RUN --mount=type=cache,target=/root/.cache/go-build echo "Running go vet" && make HV="$HV" vet && \
     echo "Running go fmt" && ERR="$(find . -name \*.go | grep -v /vendor/ | xargs gofmt -d -e -l -s)" && \
        if [ -n "$ERR" ] ; then printf 'go fmt Failed - ERR: %s' "$ERR" ; exit 1 ; fi && \
-       make ZARCH=${TARGETARCH} HV="$HV" DEV="$DEV" COVER="$COVER" RSTATS=$RSTATS RSTATS_ENDPOINT=$RSTATS_ENDPOINT RSTATS_TAG=$RSTATS_TAG IMM_PROFILING=$IMM_PROFILING ARTIFICIAL_LEAK=$ARTIFICIAL_LEAK DISTDIR=/final/opt/zededa/bin BUILD_VERSION=${GOPKGVERSION} build
+       make ZARCH=${TARGETARCH} HV="$HV" DEV="$DEV" COVER="$COVER" RSTATS=$RSTATS RSTATS_ENDPOINT=$RSTATS_ENDPOINT RSTATS_TAG=$RSTATS_TAG IMM_PROFILING=$IMM_PROFILING ARTIFICIAL_LEAK=$ARTIFICIAL_LEAK FAULT_INJECTION=$FAULT_INJECTION DISTDIR=/final/opt/zededa/bin BUILD_VERSION=${GOPKGVERSION} build
 
 # Generate the list of non-persistent pubsub topics from the sources being
 # built; upgradeconverter removes the matching directories under

--- a/pkg/pillar/Makefile
+++ b/pkg/pillar/Makefile
@@ -45,6 +45,9 @@ endif
 ifeq ($(COVER),y)
 	TAGS+=cover
 endif
+ifeq ($(FAULT_INJECTION),y)
+	TAGS+=faultinjection
+endif
 ifneq ($(TAGS),)
 	TAGS:=-tags "$(TAGS)"
 endif

--- a/pkg/pillar/kubeapi/faultinjection_volumedelete.go
+++ b/pkg/pillar/kubeapi/faultinjection_volumedelete.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k && faultinjection
+
+package kubeapi
+
+import (
+	"os"
+)
+
+// Fault-injection markers for the volume-delete path, mirroring the
+// file-existence idiom of DrainStatusFaultInjectionWait. This file is compiled
+// in only under the faultinjection build tag (FAULT_INJECTION=y), so production
+// images never carry it; the no-op variant in
+// faultinjection_volumedelete_disabled.go is used otherwise. When present, a
+// test creates a marker to make a delete fail at a chosen layer, then removes it
+// to observe recovery. Two markers target different layers so a test can pin
+// down which operation failed:
+//   - VolumeDestroyFaultPath makes volumeHandlerCSI.DestroyVolume fail for ANY
+//     volume, including replicated ones (which otherwise skip the PVC delete),
+//     so it exercises volumemgr's delete-retry loop directly.
+//   - DeletePVCFaultPath makes kubeapi.DeletePVC fail, reproducing a realistic
+//     k8s PVC-delete error on the non-replicated path.
+const (
+	VolumeDestroyFaultPath = "/tmp/VolumeDestroy_FaultInjection_Fail"
+	DeletePVCFaultPath     = "/tmp/DeletePVC_FaultInjection_Fail"
+)
+
+// VolumeDestroyFaultInjected reports whether the DestroyVolume fault marker is
+// present; while it is, DestroyVolume returns a synthetic error.
+func VolumeDestroyFaultInjected() bool {
+	_, err := os.Stat(VolumeDestroyFaultPath)
+	return err == nil
+}
+
+// DeletePVCFaultInjected reports whether the DeletePVC fault marker is present;
+// while it is, DeletePVC returns a synthetic error.
+func DeletePVCFaultInjected() bool {
+	_, err := os.Stat(DeletePVCFaultPath)
+	return err == nil
+}

--- a/pkg/pillar/kubeapi/faultinjection_volumedelete_disabled.go
+++ b/pkg/pillar/kubeapi/faultinjection_volumedelete_disabled.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k && !faultinjection
+
+package kubeapi
+
+// No-op variant used when the faultinjection build tag is absent (production
+// images). The real, file-existence-driven implementation lives in
+// faultinjection_volumedelete.go and is compiled in only under FAULT_INJECTION=y.
+// Callers invoke these unconditionally; here they always report "no fault", so
+// the delete-path fault branches are dead code the compiler drops.
+
+// VolumeDestroyFaultInjected always reports false in production builds.
+func VolumeDestroyFaultInjected() bool { return false }
+
+// DeletePVCFaultInjected always reports false in production builds.
+func DeletePVCFaultInjected() bool { return false }

--- a/pkg/pillar/kubeapi/vitoapiserver.go
+++ b/pkg/pillar/kubeapi/vitoapiserver.go
@@ -170,6 +170,13 @@ func checkLonghornSchedulable(nodeName string) error {
 
 // DeletePVC : deletes PVC of the given name.
 func DeletePVC(pvcName string, log *base.LogObject) error {
+	// Fault injection: while the marker file exists, fail the PVC delete to
+	// simulate a k8s-API-level delete failure. See DeletePVCFaultPath.
+	if DeletePVCFaultInjected() {
+		err := fmt.Errorf("fault-injected DeletePVC failure for %s", pvcName)
+		log.Warnf("%v", err)
+		return err
+	}
 	// Get the Kubernetes clientset
 	clientset, err := GetClientSet()
 	if err != nil {

--- a/pkg/pillar/volumehandlers/csihandler.go
+++ b/pkg/pillar/volumehandlers/csihandler.go
@@ -282,6 +282,15 @@ func (handler *volumeHandlerCSI) CreateVolume() (string, error) {
 func (handler *volumeHandlerCSI) DestroyVolume() (string, error) {
 	pvcName := handler.status.GetPVCName()
 	handler.log.Noticef("DestroyVolume called for PVC %s", pvcName)
+	// Fault injection: while the marker file exists, fail the destroy to
+	// simulate an unreachable owner node at delete time. Fires before the
+	// replicated skip so it can exercise the retry loop for replicated volumes
+	// too. See kubeapi.VolumeDestroyFaultPath.
+	if kubeapi.VolumeDestroyFaultInjected() {
+		err := fmt.Errorf("fault-injected DestroyVolume failure for PVC %s", pvcName)
+		handler.log.Warnf("DestroyVolume: %v", err)
+		return pvcName, err
+	}
 	// if this is a replicated volume, do not delete PVC on this node.
 	if !handler.status.IsReplicated {
 		err := kubeapi.DeletePVC(pvcName, handler.log)


### PR DESCRIPTION
# Description

Makes a volume destroy / PVC delete fail on demand so the volume-delete retry path (#6176) can be exercised end to end on a kubevirt/longhorn node — a scenario that is otherwise hard to arrange on a real cluster.

Two file-existence fault gates on the delete path, using the same marker idiom as `kubeapi.DrainStatusFaultInjectionWait`:

- `/tmp/VolumeDestroy_FaultInjection_Fail` fails `volumeHandlerCSI.DestroyVolume` **before** the replicated-volume skip, so it drives the retry loop for replicated Longhorn volumes too.
- `/tmp/DeletePVC_FaultInjection_Fail` fails `kubeapi.DeletePVC` on the non-replicated path.

Both are compiled in only under a new `faultinjection` build tag (`FAULT_INJECTION=y`); without it they resolve to no-op stubs returning false, so shipped images carry none of it. Wired through the linuxkit build-arg plumbing (top `Makefile`, pillar `Makefile`/`Dockerfile`).

This is test-only tooling that complements #6176; it is not required for the fix itself.

## PR dependencies

None. Pairs with the companion eden e2e test (lf-edge/eden#1217), which consumes these markers.

## How to test and validate this PR

Build an EVE-k image with the tag enabled:

```
make pkg/pillar HV=kubevirt FAULT_INJECTION=y   # or a full image build with FAULT_INJECTION=y
```

On a running kubevirt/longhorn EVE-k node, deploy an app with a volume and wait for the volume to reach the Created sub-state, then arm a fault and delete the app:

```
eve exec pillar touch /tmp/VolumeDestroy_FaultInjection_Fail
```

The volume destroy fails; with #6176 present the `VolumeStatus` stays published in the Deleting sub-state with an error and is re-driven off the gc tick. Removing the marker lets the next retry succeed and the volume is unpublished.

Automated: covered end to end by the companion eden suite (lf-edge/eden#1217). Validated on host EVE-k (master base): the retain→retry→recover and bounded give-up paths pass on an image built with this **and** #6176, and the recovery test **fails** on an image built with this but **without** #6176 — i.e. the test catches the pre-fix leak.

Without the `faultinjection` build tag the gates are no-op stubs, so a normal build is unaffected.

## Changelog notes

No user-facing changes (test-only tooling, compiled out of shipped images).

## PR Backports

- 16.0-stable: No (test tooling, backport only if #6176 is backported and needs e2e coverage there).
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
