### PR TITLE
pkg/apparmor: fix vector profile for newer-kernel AppArmor mediation

### DIFF
--- a/pkg/apparmor/profiles/usr.bin.vector
+++ b/pkg/apparmor/profiles/usr.bin.vector
@@ -3,15 +3,29 @@
 
 #include <tunables/global>
 
-profile vector /usr/bin/vector {
+# attach_disconnected: vector runs in its own mount/network namespace, so the
+# sink sockets below (bound by newlogd in the host namespace) resolve as a
+# "disconnected path" during AppArmor mediation. Without this flag such paths
+# are reported relative, never match the absolute rules, and are denied.
+profile vector /usr/bin/vector flags=(attach_disconnected) {
     #include <abstractions/base>
+
+    # the prometheus_exporter sink opens a TCP listener; kernels with af_unix /
+    # network_v9 mediation mediate inet socket creation, so it must be granted.
+    network inet stream,
+    network inet6 stream,
 
     # allow access to vector's config and buffers
     owner /persist/vector/** rwk,
 
-    # allow to access the sockets to communicate with newlogd
+    # sockets used to communicate with newlogd. vector binds the *source*
+    # sockets (create only -> w). vector connect()s to the *sink* sockets; a
+    # unix stream connect is mediated as "wr" on kernels with af_unix mediation,
+    # so those need rw.
     owner /run/devKeep_source.sock w,
     owner /run/devUpload_source.sock w,
+    owner /run/devKeep_sink.sock rw,
+    owner /run/devUpload_sink.sock rw,
 
     # allow to inspect it's own state / environment
     owner /proc/*/cgroup r,


### PR DESCRIPTION
# Description

AppArmor profiles are compiled against the feature set the running kernel
advertises under `/sys/kernel/security/apparmor/features/`. Newer kernels turn
on finer-grained mediation — `af_unix` socket mediation and the `network_v9`
policy ABI — that older kernels don't expose. On such a kernel the *unchanged*
`vector` profile is recompiled to mediate operations that were previously
unmediated, so access that used to be implicitly allowed now defaults to deny
and the `vector` log-processing agent crash-loops.

## Affected kernel versions

Fine-grained `af_unix` socket mediation (and the `network_v9` policy ABI)
landed in mainline Linux **6.14**, so this becomes relevant once EVE runs on a
**>= 6.14** kernel. EVE's current release kernels — `6.1.x`, `6.8.x`
(nvidia-jp7), `6.12.x` (generic) — are all below that and do **not** advertise
these mediation features, so the profile change is a no-op there. It was
observed on a device running a `6.17.x` kernel. The change is therefore safe to
merge now and is purely forward-looking for the kernel bump.

Two things break:

- `vector`'s socket sinks `connect()` to `newlogd`'s `/run/dev*_sink.sock`
  sockets. That connect is now mediated as a file `wr` access, but the profile
  only granted the `*_source.sock` paths. On top of that, `vector` runs in its
  own mount/network namespace, so the sink sockets (bound by `newlogd` in the
  host namespace) resolve as a **disconnected path** during mediation —
  reported as a relative name that never matches an absolute rule unless the
  profile is flagged `attach_disconnected`.
- the `prometheus_exporter` sink's TCP listener fails to bind because inet
  socket creation is now mediated and the profile declared no `network` rule.

Observed on the device as a ~60s crash loop with:

```
apparmor="DENIED" operation="connect" class="file"
  info="Failed name lookup - disconnected path" name="run/devUpload_sink.sock"
apparmor="DENIED" operation="create" class="net" family="inet" sock_type="stream"
```

This adds exactly what `vector` needs:

1. `flags=(attach_disconnected)` — so the cross-namespace sink-socket paths get
   a matchable absolute name.
2. `network inet stream,` / `network inet6 stream,` — for the prometheus
   exporter's TCP listener.
3. `rw` on the two `*_sink.sock` paths — a unix stream `connect()` is mediated
   as `wr`. The `*_source.sock` paths stay create-only (`w`), since `vector`
   only needs to bind them.

The change is a no-op on kernels without `af_unix`/`network_v9` mediation
(the added rules simply aren't exercised), so it is safe on current release
kernels and forward-compatible for a kernel bump.

## How to test and validate this PR

On a device whose kernel advertises `af_unix` mediation (check
`cat /sys/kernel/security/apparmor/features/network/af_unix`):

Before the fix, `logread | grep vector` shows `vector` restarting on a loop
with `Permission denied` on `/run/dev*_sink.sock` and on the prometheus TCP
bind, and `dmesg | grep -i 'apparmor.*DENIED'` shows the denials above.

With the fixed profile in place:

- `vector` stays up (no restart loop); `logread | grep vector` shows
  `Healthcheck passed`, `Vector has started`, and
  `Building HTTP server address=127.0.0.1:8889` with no permission errors.
- `dmesg | grep -i 'apparmor.*DENIED'` shows no new denials for `profile="vector"`.

This was validated live by reloading the patched profile with
`apparmor_parser -r` on a running arm64 device with a >=6.14 kernel: the crash
loop stopped immediately and `vector` connected to `newlogd`'s sockets and
bound the exporter.

## Changelog notes

None. Fixes a crash loop of the internal `vector` logging agent that only
occurs on kernels with AppArmor `af_unix`/`network_v9` mediation; no behavior
change on current release kernels.

## PR Backports

- 16.0-stable: No. The bug only manifests on kernels with af_unix/network_v9 mediation, which this branch does not ship.
- 14.5-stable: No. The vector package does not exist on this branch.
- 13.4-stable: No. The vector package does not exist on this branch.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (not applicable — no doc change)
- [ ] I've tested my PR on amd64 device (not applicable — bug is kernel-mediation specific; validated on arm64)
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
