### PR TITLE
pillar/cloudconfig: fix path-traversal in WriteFile containment check

### DIFF
--- a/pkg/pillar/utils/cloudconfig/cloudconfig.go
+++ b/pkg/pillar/utils/cloudconfig/cloudconfig.go
@@ -74,8 +74,11 @@ func WriteFile(log *base.LogObject, file WritableFile, rootPath string) error {
 	mode := os.FileMode(perm)
 
 	writePath := filepath.Join(rootPath, file.Path)
-	// sanitize path
-	if !strings.HasPrefix(filepath.Clean(writePath), rootPath) {
+	// Reject any write that escapes rootPath. filepath.Rel expresses the
+	// resolved writePath relative to rootPath: a contained path yields a
+	// normal subpath, while an escape yields ".." or a "../"-prefixed result.
+	rel, err := filepath.Rel(rootPath, writePath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 		return fmt.Errorf("detected possible attempt to write file outside of root path. invalid path %s", file.Path)
 	}
 

--- a/pkg/pillar/utils/cloudconfig/cloudconfig_test.go
+++ b/pkg/pillar/utils/cloudconfig/cloudconfig_test.go
@@ -17,11 +17,20 @@ func TestCloudConfig(t *testing.T) {
 
 	log := base.NewSourceLogObject(logrus.StandardLogger(), "cloudconfig", 0)
 	// create a temporary directory to write files to
-	rootPath, err := os.MkdirTemp("", "cloudconfig_test")
+	baseDir, err := os.MkdirTemp("", "cloudconfig_test")
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %v", err)
 	}
-	t.Cleanup(func() { os.RemoveAll(rootPath) })
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
+
+	// Mirror cas.GetRoofFsPath, whose filepath.Join drops the trailing
+	// separator so rootPath ends in a bare "rootfs" component. This lets the
+	// "sibling directory traversal" case below exercise the prefix bypass: a
+	// sibling such as "rootfs_evil" shares "rootfs" as a leading string.
+	rootPath := filepath.Join(baseDir, "rootfs")
+	if err := os.MkdirAll(rootPath, 0755); err != nil {
+		t.Fatalf("failed to create root path: %v", err)
+	}
 
 	// define the test cases
 	testCases := []struct {
@@ -135,6 +144,21 @@ write_files:
 			expected: []cloudconfig.WritableFile{},
 			errParse: nil,
 			errWrite: fmt.Errorf("detected possible attempt to write file outside of root path. invalid path %s", "../../etc/passwd"),
+		},
+		{
+			// A sibling directory that merely shares a leading string with
+			// rootPath (e.g. "rootfs" vs "rootfs_evil") is still outside it
+			// and must be rejected.
+			name: "sibling directory traversal",
+			input: `#cloud-config
+write_files:
+- path: ../rootfs_evil/etc/profile.d/x.sh
+  content: cHduZWQK
+  permissions: "0644"
+  encoding: b64`,
+			expected: []cloudconfig.WritableFile{},
+			errParse: nil,
+			errWrite: fmt.Errorf("detected possible attempt to write file outside of root path. invalid path %s", "../rootfs_evil/etc/profile.d/x.sh"),
 		},
 		{
 			name: "gzip encoding",


### PR DESCRIPTION
# Description

`WriteFile` guarded against writes escaping the target container rootfs with
`strings.HasPrefix(filepath.Clean(writePath), rootPath)`. Because `rootPath`
comes from `cas.GetRoofFsPath`, whose `filepath.Join` strips the trailing
separator (e.g. `.../<uuid>/rootfs`), a crafted `write_files` entry such as
`../rootfs_evil/etc/profile.d/x.sh` resolves to a sibling directory that
shares the string prefix `.../rootfs` and therefore passed the check. A
malicious cloud-init config could thus write and chmod attacker-controlled
files outside the intended container rootfs.

This replaces the prefix check with a strict containment test based on
`filepath.Rel`, which rejects any resolved path equal to `..` or starting with
`../` while still accepting the root itself and normal subpaths.

## How to test and validate this PR

Covered by an automated unit test. Run:

```sh
make -C pkg/pillar test
# or, natively for a tight loop:
go test ./utils/cloudconfig/ -run TestCloudConfig -v
```

The `TestCloudConfig/sibling_directory_traversal` case builds a `rootPath`
ending in a bare `rootfs` component (mirroring `cas.GetRoofFsPath`) and feeds a
`write_files` path of `../rootfs_evil/...`. It fails against the old
`strings.HasPrefix` check and passes with the fix.

## Changelog notes

Security fix: a controller-supplied cloud-init `write_files` entry can no
longer write files outside an app container's rootfs via a sibling directory
that shares a name prefix with the rootfs path.

## PR Backports

- 17.0: Backported in #6212.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

(The vulnerable code also exists on 12.0-stable, but that branch is outside the
current LTS set, so it is not being backported.)

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them. This is a self-contained path-containment fix in a pure utility
  function, fully exercised by a unit test, so per-arch device testing is not
  applicable.
