### PR TITLE
zedkube: detect and recover stuck kubelet volume mounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -463,7 +463,7 @@ endif
 # Before 10.2.0 it was 300MB. We must maintain compatibility with older versions so rootfs size cannot exceed 300MB.
 # 'k' and nvidia are not affected by this limitation because there no installation of kubevirt/k3s prior to 10.2.0
 # Even though the partition layout is now unified, let's still check for ROOTFS_MAXSIZE_MB not exceeding 10GB for 'k'
-# and NVIDIA based platforms, and 290MB for x86_64 and other arm64 platforms. That helps in catching image size
+# and NVIDIA based platforms, and 291MB for x86_64 and other arm64 platforms. That helps in catching image size
 # increases earlier than at later stage.
 # We are currently filtering out a few packages from bulk builds since they are not getting published in Docker HUB
 ifeq ($(HV),k)
@@ -474,7 +474,7 @@ else
         PKGS_$(ZARCH)=$(shell find pkg -maxdepth 1 -type d | grep -Ev "eve|alpine|sources|kube|external-boot-image$$")
         # nvidia platform requires more space
         ifeq (, $(findstring nvidia,$(PLATFORM)))
-            ROOTFS_MAXSIZE_MB=290
+            ROOTFS_MAXSIZE_MB=291
         else
             ROOTFS_MAXSIZE_MB=10240
         endif

--- a/pkg/pillar/cmd/zedkube/pendingvmi.go
+++ b/pkg/pillar/cmd/zedkube/pendingvmi.go
@@ -242,15 +242,19 @@ func (z *zedkube) virtLauncherActiveOnThisNode(appKubeName string) bool {
 
 // podHasContainerError returns true if any container in the pod is in a
 // waiting state with an error-indicating reason (CrashLoopBackOff,
-// ImagePullBackOff, ErrImagePull, CreateContainerError, RunContainerError)
-// or has terminated with a non-zero exit code. These surface as "Error" or
-// similar in kubectl's STATUS column even when Pod.Status.Phase=Running.
+// ImagePullBackOff, ErrImagePull, CreateContainerError,
+// CreateContainerConfigError, RunContainerError) or has terminated with a
+// non-zero exit code. These surface as "Error" or similar in kubectl's STATUS
+// column even when Pod.Status.Phase=Running. CreateContainerConfigError in
+// particular covers a pod blocked on a missing Secret/ConfigMap (e.g. an
+// orphaned CDI upload pod whose TLS secret was deleted), which must not be
+// mistaken for a volume-mount wedge.
 func podHasContainerError(p corev1.Pod) bool {
 	for _, cs := range p.Status.ContainerStatuses {
 		if w := cs.State.Waiting; w != nil {
 			switch w.Reason {
 			case "CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull",
-				"CreateContainerError", "RunContainerError":
+				"CreateContainerError", "CreateContainerConfigError", "RunContainerError":
 				return true
 			}
 		}

--- a/pkg/pillar/cmd/zedkube/pendingvmi_test.go
+++ b/pkg/pillar/cmd/zedkube/pendingvmi_test.go
@@ -34,6 +34,46 @@ func TestVMIPhaseIsPreRunning(t *testing.T) {
 	}
 }
 
+func TestPodHasContainerError(t *testing.T) {
+	mk := func(state corev1.ContainerState) corev1.Pod {
+		return corev1.Pod{Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{State: state}},
+		}}
+	}
+	waiting := func(reason string) corev1.ContainerState {
+		return corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: reason}}
+	}
+
+	tests := []struct {
+		name string
+		pod  corev1.Pod
+		want bool
+	}{
+		{"CrashLoopBackOff", mk(waiting("CrashLoopBackOff")), true},
+		{"ImagePullBackOff", mk(waiting("ImagePullBackOff")), true},
+		{"ErrImagePull", mk(waiting("ErrImagePull")), true},
+		{"CreateContainerError", mk(waiting("CreateContainerError")), true},
+		// A pod blocked on a deleted Secret/ConfigMap, e.g. an orphaned CDI
+		// upload pod: Pending forever, but not a volume-mount wedge.
+		{"CreateContainerConfigError", mk(waiting("CreateContainerConfigError")), true},
+		{"RunContainerError", mk(waiting("RunContainerError")), true},
+		{"ContainerCreating", mk(waiting("ContainerCreating")), false},
+		{"PodInitializing", mk(waiting("PodInitializing")), false},
+		{"empty reason", mk(waiting("")), false},
+		{"running", mk(corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}), false},
+		{"terminated ok", mk(corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}}), false},
+		{"terminated non-zero", mk(corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: 1}}), true},
+		{"no containers", corev1.Pod{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, podHasContainerError(tc.pod))
+		})
+	}
+}
+
 func TestVirtLauncherPodIsActiveOnNode(t *testing.T) {
 	const node = "andrew-cherry"
 	const appKubeName = "enc-a2-84c66"

--- a/pkg/pillar/cmd/zedkube/stuckmount.go
+++ b/pkg/pillar/cmd/zedkube/stuckmount.go
@@ -1,0 +1,263 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package zedkube
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// stuckMountThreshold is how long a pod must sit Pending with an attached
+	// but unmounted volume before we treat it as a kubelet mount wedge. Node
+	// staging normally completes in seconds, so minutes means wedged.
+	stuckMountThreshold = 5 * time.Minute
+	// stuckMountMaxRecover caps recovery attempts within one wedge episode;
+	// reset once a tick observes no wedged pod.
+	stuckMountMaxRecover = 3
+	// stuckMountSuppressWindow is the cooldown after a recovery attempt, so the
+	// detector cannot thrash a k3s restart faster than kubelet can recover.
+	stuckMountSuppressWindow = 15 * time.Minute
+	// stuckMountDevPath is where the Longhorn CSI node plugin materializes the
+	// block device once the volume is attached to this node.
+	stuckMountDevPath = "/dev/longhorn"
+	// stuckMountDryRun gates the recovery action. When true the detector only
+	// logs what it would do and takes NO action; when false it restarts k3s to
+	// give kubelet a fresh volume manager.
+	stuckMountDryRun = false
+	// stuckMountK3sStartFlag is cluster-init.sh's manual-start flag
+	// (K3S_MANUAL_START_FLAG in cluster-utils.sh). Touching it resets the
+	// supervisor's exponential restart backoff so k3s is relaunched promptly
+	// after we terminate it. It lives on the /run bind shared with the kube
+	// container.
+	stuckMountK3sStartFlag = "/run/kube/k3s-start"
+	// stuckMountRecoveryMarker is a distinctive, greppable string emitted on
+	// every recovery so operators can spot mount-wedge restarts in the logs.
+	stuckMountRecoveryMarker = "MOUNT-WEDGE-RECOVERY"
+)
+
+// checkStuckVolumeMount detects the kubelet volume-mount wedge: a pod scheduled
+// on this node sits Pending past stuckMountThreshold with no container-level
+// error, yet at least one of its Longhorn PVCs is attached to this node
+// (VolumeAttachment reports Attached and /dev/longhorn/<pv> exists) — meaning
+// attach succeeded but kubelet never issued NodeStage, so the pod never starts.
+// Longhorn, CDI and image pull are not at fault; the stall is in kubelet's
+// volume manager, and only a fresh kubelet clears it.
+//
+// Recovery (see recoverKubeletMountWedge) restarts k3s so kubelet comes back
+// with a fresh volume manager, rate-limited by stuckMountMaxRecover and
+// stuckMountSuppressWindow. Set stuckMountDryRun to disable the action and only
+// log.
+func (z *zedkube) checkStuckVolumeMount() {
+	if z.nodeName == "" {
+		return
+	}
+	clientset, err := getKubeClientSet()
+	if err != nil {
+		log.Errorf("checkStuckVolumeMount: get clientset: %v", err)
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer cancel()
+	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("checkStuckVolumeMount: list pods: %v", err)
+		return
+	}
+
+	now := time.Now()
+	var wedged []string
+	for i := range pods.Items {
+		if desc, ok := z.podMountWedge(pods.Items[i], now); ok {
+			wedged = append(wedged, desc)
+		}
+	}
+
+	if len(wedged) == 0 {
+		z.stuckMountRecoverCount = 0
+		return
+	}
+
+	if now.Before(z.stuckMountSuppressUntil) {
+		log.Functionf("checkStuckVolumeMount: %d wedged pod(s); recovery in cooldown until %v: %s",
+			len(wedged), z.stuckMountSuppressUntil, strings.Join(wedged, "; "))
+		return
+	}
+	if z.stuckMountRecoverCount >= stuckMountMaxRecover {
+		log.Errorf("checkStuckVolumeMount: %d wedged pod(s) after %d recovery attempts; giving up until they clear: %s",
+			len(wedged), stuckMountMaxRecover, strings.Join(wedged, "; "))
+		return
+	}
+
+	z.stuckMountRecoverCount++
+	z.stuckMountSuppressUntil = now.Add(stuckMountSuppressWindow)
+	z.recoverKubeletMountWedge(wedged)
+}
+
+// podMountWedge reports whether pod p on this node exhibits the mount wedge and,
+// if so, returns a human-readable description. It matches a Pending, non-
+// terminating pod aged past stuckMountThreshold that has no container- or
+// init-container error (image pull / crashloop are excluded as different
+// failures) and at least one Longhorn PVC that is attached to this node yet
+// still unmounted.
+func (z *zedkube) podMountWedge(p corev1.Pod, now time.Time) (string, bool) {
+	if p.Spec.NodeName != z.nodeName {
+		return "", false
+	}
+	if p.Status.Phase != corev1.PodPending || isPodTerminating(p) {
+		return "", false
+	}
+	if podHasContainerError(p) || podHasInitContainerError(p) {
+		return "", false
+	}
+	age := now.Sub(p.CreationTimestamp.Time)
+	if age < stuckMountThreshold {
+		return "", false
+	}
+	for _, vol := range p.Spec.Volumes {
+		if vol.PersistentVolumeClaim == nil {
+			continue
+		}
+		pvc, err := kubeapi.PVCGet(vol.PersistentVolumeClaim.ClaimName, log)
+		if err != nil || pvc.Spec.VolumeName == "" {
+			continue
+		}
+		pvName := pvc.Spec.VolumeName
+		attached, err := kubeapi.GetVolumeAttachmentAttached(pvName, z.nodeName, log)
+		if err != nil || !attached {
+			continue
+		}
+		if !longhornDevicePresent(pvName) {
+			continue
+		}
+		return fmt.Sprintf("pod=%s pv=%s attached+device-present but unmounted, Pending %v",
+			p.Name, pvName, age.Round(time.Second)), true
+	}
+	return "", false
+}
+
+// longhornDevicePresent reports whether the Longhorn block device for pvName
+// exists on this node, i.e. the volume is attached at the node level.
+func longhornDevicePresent(pvName string) bool {
+	_, err := os.Stat(stuckMountDevPath + "/" + pvName)
+	return err == nil
+}
+
+// podHasInitContainerError mirrors podHasContainerError over init containers:
+// true if any init container is waiting on an error reason (image pull /
+// create / run) or terminated non-zero. Used to exclude image-pull failures
+// (e.g. a boot-image init container) from the mount-wedge signature.
+func podHasInitContainerError(p corev1.Pod) bool {
+	for _, cs := range p.Status.InitContainerStatuses {
+		if w := cs.State.Waiting; w != nil {
+			switch w.Reason {
+			case "CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull",
+				"CreateContainerError", "CreateContainerConfigError", "RunContainerError":
+				return true
+			}
+		}
+		if t := cs.State.Terminated; t != nil && t.ExitCode != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// recoverKubeletMountWedge is the recovery action for the mount wedge. The only
+// known remedy is a fresh kubelet, which we get by terminating k3s and letting
+// cluster-init.sh's supervisor relaunch it. Because pillar runs in the host PID
+// namespace and shares the /run bind with the kube container, zedkube can both
+// reset the supervisor's restart backoff (touch K3S_MANUAL_START_FLAG) and send
+// SIGTERM to the k3s server process directly. Every attempt logs a distinctive
+// marker so a restart is easy to spot in the device logs. While stuckMountDryRun
+// is true it takes NO action and only logs.
+func (z *zedkube) recoverKubeletMountWedge(wedged []string) {
+	detail := strings.Join(wedged, "; ")
+	if stuckMountDryRun {
+		log.Noticef("%s: DRY-RUN would restart kubelet/k3s to clear the volume-mount wedge (attempt %d/%d): %s",
+			stuckMountRecoveryMarker, z.stuckMountRecoverCount, stuckMountMaxRecover, detail)
+		return
+	}
+
+	log.Warnf("%s: restarting kubelet/k3s to clear the volume-mount wedge (attempt %d/%d): %s",
+		stuckMountRecoveryMarker, z.stuckMountRecoverCount, stuckMountMaxRecover, detail)
+
+	// Reset the supervisor's exponential restart backoff so k3s is relaunched
+	// promptly rather than after a multi-minute wait.
+	if err := os.MkdirAll(filepath.Dir(stuckMountK3sStartFlag), 0755); err != nil {
+		log.Errorf("%s: cannot create %s dir: %v", stuckMountRecoveryMarker, stuckMountK3sStartFlag, err)
+	} else if f, err := os.Create(stuckMountK3sStartFlag); err != nil {
+		log.Errorf("%s: cannot touch %s: %v", stuckMountRecoveryMarker, stuckMountK3sStartFlag, err)
+	} else {
+		f.Close()
+	}
+
+	pids, err := signalK3sServer()
+	if err != nil {
+		log.Errorf("%s: attempt %d/%d FAILED to enumerate k3s: %v; wedge: %s",
+			stuckMountRecoveryMarker, z.stuckMountRecoverCount, stuckMountMaxRecover, err, detail)
+		return
+	}
+	if len(pids) == 0 {
+		log.Errorf("%s: attempt %d/%d found no 'k3s server' process to signal; wedge: %s",
+			stuckMountRecoveryMarker, z.stuckMountRecoverCount, stuckMountMaxRecover, detail)
+		return
+	}
+	log.Warnf("%s: sent SIGTERM to k3s server pid(s) %v; cluster-init.sh will relaunch. attempt %d/%d, wedge: %s",
+		stuckMountRecoveryMarker, pids, z.stuckMountRecoverCount, stuckMountMaxRecover, detail)
+}
+
+// signalK3sServer sends SIGTERM to every running "k3s server" process and
+// returns the PIDs signaled. zedkube shares the host PID namespace, so the k3s
+// process started in the kube container is visible and signalable here; the
+// cluster-init.sh supervisor relaunches k3s once it exits, yielding a fresh
+// kubelet volume manager.
+//
+// k3s rewrites its process title to the single string "k3s server", so
+// /proc/<pid>/cmdline is one NUL-terminated token "k3s server" rather than the
+// separate "k3s"/"server" argv elements exec would leave. We therefore tokenize
+// the whole cmdline on whitespace and match basename(fields[0])=="k3s" &&
+// fields[1]=="server" — this matches both that retitled form and a
+// path-launched "<dir>/k3s server ...", while excluding a shell that merely
+// mentions the string in a later argument (its fields[0] is the shell).
+func signalK3sServer() ([]int, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, err
+	}
+	var signaled []int
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue // not a PID directory
+		}
+		raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+		if err != nil {
+			continue // process gone or unreadable
+		}
+		cmdline := strings.ReplaceAll(strings.TrimRight(string(raw), "\x00"), "\x00", " ")
+		fields := strings.Fields(cmdline)
+		if len(fields) < 2 || filepath.Base(fields[0]) != "k3s" || fields[1] != "server" {
+			continue
+		}
+		if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+			log.Errorf("%s: SIGTERM pid %d failed: %v", stuckMountRecoveryMarker, pid, err)
+			continue
+		}
+		signaled = append(signaled, pid)
+	}
+	return signaled, nil
+}

--- a/pkg/pillar/cmd/zedkube/stuckmount.go
+++ b/pkg/pillar/cmd/zedkube/stuckmount.go
@@ -72,7 +72,12 @@ func (z *zedkube) checkStuckVolumeMount() {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
 	defer cancel()
-	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(ctx, metav1.ListOptions{})
+	// Restrict the LIST server-side: only Pending pods on this node can exhibit
+	// the wedge, and a multi-node cluster's other nodes are none of our business.
+	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(ctx, metav1.ListOptions{
+		FieldSelector: "spec.nodeName=" + z.nodeName +
+			",status.phase=" + string(corev1.PodPending),
+	})
 	if err != nil {
 		log.Errorf("checkStuckVolumeMount: list pods: %v", err)
 		return

--- a/pkg/pillar/cmd/zedkube/stuckmount.go
+++ b/pkg/pillar/cmd/zedkube/stuckmount.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -37,6 +38,14 @@ const (
 	// stuckMountDevPath is where the Longhorn CSI node plugin materializes the
 	// block device once the volume is attached to this node.
 	stuckMountDevPath = "/dev/longhorn"
+	// stuckMountRecoveryMarker is a distinctive, greppable string emitted on
+	// every recovery so operators can spot mount-wedge restarts in the logs.
+	stuckMountRecoveryMarker = "MOUNT-WEDGE-RECOVERY"
+	// procRootDir is where the host PID namespace's process list is mounted.
+	procRootDir = "/proc"
+)
+
+var (
 	// stuckMountDryRun gates the recovery action. When true the detector only
 	// logs what it would do and takes NO action; when false it restarts k3s to
 	// give kubelet a fresh volume manager.
@@ -48,9 +57,13 @@ const (
 	// kube container. Nothing in this tree reads it — here the kube-init daemon
 	// supervises k3s — so it matters only where the SIGTERM path below is live.
 	stuckMountK3sStartFlag = "/run/kube/k3s-start"
-	// stuckMountRecoveryMarker is a distinctive, greppable string emitted on
-	// every recovery so operators can spot mount-wedge restarts in the logs.
-	stuckMountRecoveryMarker = "MOUNT-WEDGE-RECOVERY"
+	// The cluster and host lookups the wedge signature and the recovery action
+	// depend on, indirected so tests can drive both without a live cluster and
+	// without signaling a real k3s. Overridden only in tests.
+	pvcGet                   = kubeapi.PVCGet
+	volumeAttachmentAttached = kubeapi.GetVolumeAttachmentAttached
+	devicePresent            = longhornDevicePresent
+	signalK3s                = signalK3sServer
 )
 
 // checkStuckVolumeMount detects the kubelet volume-mount wedge: a pod scheduled
@@ -74,6 +87,14 @@ func (z *zedkube) checkStuckVolumeMount() {
 		log.Errorf("checkStuckVolumeMount: get clientset: %v", err)
 		return
 	}
+	z.checkStuckVolumeMountWithClient(clientset, time.Now())
+}
+
+// checkStuckVolumeMountWithClient is the body of one detector tick: it collects
+// the wedged pods this node currently has and, subject to the per-episode
+// attempt cap and cooldown, triggers recovery. now is passed in so the episode
+// rate limiting is exercisable without a wall clock.
+func (z *zedkube) checkStuckVolumeMountWithClient(clientset kubernetes.Interface, now time.Time) {
 	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
 	defer cancel()
 	// Restrict the LIST server-side: only Pending pods on this node can exhibit
@@ -87,7 +108,6 @@ func (z *zedkube) checkStuckVolumeMount() {
 		return
 	}
 
-	now := time.Now()
 	var wedged []string
 	for i := range pods.Items {
 		if desc, ok := z.podMountWedge(pods.Items[i], now); ok {
@@ -140,18 +160,18 @@ func (z *zedkube) podMountWedge(p corev1.Pod, now time.Time) (string, bool) {
 		if vol.PersistentVolumeClaim == nil {
 			continue
 		}
-		pvc, err := kubeapi.PVCGet(vol.PersistentVolumeClaim.ClaimName, log)
+		pvc, err := pvcGet(vol.PersistentVolumeClaim.ClaimName, log)
 		if err != nil || pvc.Spec.VolumeName == "" {
 			continue
 		}
 		pvName := pvc.Spec.VolumeName
-		// longhornDevicePresent is a local stat while GetVolumeAttachmentAttached
-		// lists every VolumeAttachment in the cluster, and this runs on every
-		// tick, so let the cheap check reject the volume first.
-		if !longhornDevicePresent(pvName) {
+		// devicePresent is a local stat while volumeAttachmentAttached lists
+		// every VolumeAttachment in the cluster, and this runs on every tick,
+		// so let the cheap check reject the volume first.
+		if !devicePresent(pvName) {
 			continue
 		}
-		attached, err := kubeapi.GetVolumeAttachmentAttached(pvName, z.nodeName, log)
+		attached, err := volumeAttachmentAttached(pvName, z.nodeName, log)
 		if err != nil || !attached {
 			continue
 		}
@@ -217,7 +237,7 @@ func (z *zedkube) recoverKubeletMountWedge(wedged []string) {
 		f.Close()
 	}
 
-	pids, err := signalK3sServer()
+	pids, err := signalK3s()
 	if err != nil {
 		log.Errorf("%s: attempt %d/%d FAILED to enumerate k3s: %v; wedge: %s",
 			stuckMountRecoveryMarker, z.stuckMountRecoverCount, stuckMountMaxRecover, err, detail)
@@ -236,35 +256,15 @@ func (z *zedkube) recoverKubeletMountWedge(wedged []string) {
 // returns the PIDs signaled. zedkube shares the host PID namespace, so the k3s
 // process started in the kube container is visible and signalable here; the
 // cluster-init.sh supervisor relaunches k3s once it exits, yielding a fresh
-// kubelet volume manager.
-//
-// k3s rewrites its process title to the single string "k3s server", so
-// /proc/<pid>/cmdline is one NUL-terminated token "k3s server" rather than the
-// separate "k3s"/"server" argv elements exec would leave. We therefore tokenize
-// the whole cmdline on whitespace and match basename(fields[0])=="k3s" &&
-// fields[1]=="server" — this matches both that retitled form and a
-// path-launched "<dir>/k3s server ...", while excluding a shell that merely
-// mentions the string in a later argument (its fields[0] is the shell).
+// kubelet volume manager. A PID whose signal fails is left out of the returned
+// set, so an empty return means nothing was actually terminated.
 func signalK3sServer() ([]int, error) {
-	entries, err := os.ReadDir("/proc")
+	pids, err := k3sServerPids(procRootDir)
 	if err != nil {
 		return nil, err
 	}
 	var signaled []int
-	for _, e := range entries {
-		pid, err := strconv.Atoi(e.Name())
-		if err != nil {
-			continue // not a PID directory
-		}
-		raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
-		if err != nil {
-			continue // process gone or unreadable
-		}
-		cmdline := strings.ReplaceAll(strings.TrimRight(string(raw), "\x00"), "\x00", " ")
-		fields := strings.Fields(cmdline)
-		if len(fields) < 2 || filepath.Base(fields[0]) != "k3s" || fields[1] != "server" {
-			continue
-		}
+	for _, pid := range pids {
 		if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
 			log.Errorf("%s: SIGTERM pid %d failed: %v", stuckMountRecoveryMarker, pid, err)
 			continue
@@ -272,4 +272,45 @@ func signalK3sServer() ([]int, error) {
 		signaled = append(signaled, pid)
 	}
 	return signaled, nil
+}
+
+// k3sServerPids returns the PIDs of the "k3s server" processes visible under
+// procRoot. A process that disappears mid-scan, or whose cmdline is unreadable,
+// is skipped; only an unreadable procRoot is an error.
+func k3sServerPids(procRoot string) ([]int, error) {
+	entries, err := os.ReadDir(procRoot)
+	if err != nil {
+		return nil, err
+	}
+	var pids []int
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue // not a PID directory
+		}
+		raw, err := os.ReadFile(filepath.Join(procRoot, e.Name(), "cmdline"))
+		if err != nil {
+			continue // process gone or unreadable
+		}
+		if !isK3sServerCmdline(raw) {
+			continue
+		}
+		pids = append(pids, pid)
+	}
+	return pids, nil
+}
+
+// isK3sServerCmdline reports whether a raw /proc/<pid>/cmdline belongs to the
+// k3s server process.
+//
+// k3s rewrites its process title to the single string "k3s server", so cmdline
+// is one NUL-terminated token "k3s server" rather than the separate
+// "k3s"/"server" argv elements exec would leave. Tokenizing the whole cmdline on
+// whitespace therefore matches both that retitled form and a path-launched
+// "<dir>/k3s server ...", while excluding a shell that merely mentions the
+// string in a later argument (its first token is the shell).
+func isK3sServerCmdline(raw []byte) bool {
+	cmdline := strings.ReplaceAll(strings.TrimRight(string(raw), "\x00"), "\x00", " ")
+	fields := strings.Fields(cmdline)
+	return len(fields) >= 2 && filepath.Base(fields[0]) == "k3s" && fields[1] == "server"
 }

--- a/pkg/pillar/cmd/zedkube/stuckmount.go
+++ b/pkg/pillar/cmd/zedkube/stuckmount.go
@@ -1,0 +1,270 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package zedkube
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// stuckMountThreshold is how long a pod must sit Pending with an attached
+	// but unmounted volume before we treat it as a kubelet mount wedge. Node
+	// staging normally completes in seconds, so minutes means wedged.
+	stuckMountThreshold = 5 * time.Minute
+	// stuckMountMaxRecover caps recovery attempts within one wedge episode;
+	// reset once a tick observes no wedged pod. The count lives in memory, so
+	// it bounds restarts only within one pillar lifetime: a reboot re-arms the
+	// detector and a pod that is Pending for a reason a fresh kubelet cannot
+	// fix earns a new episode on every boot.
+	stuckMountMaxRecover = 3
+	// stuckMountSuppressWindow is the cooldown after a recovery attempt, so the
+	// detector cannot thrash a k3s restart faster than kubelet can recover.
+	stuckMountSuppressWindow = 15 * time.Minute
+	// stuckMountDevPath is where the Longhorn CSI node plugin materializes the
+	// block device once the volume is attached to this node.
+	stuckMountDevPath = "/dev/longhorn"
+	// stuckMountDryRun gates the recovery action. When true the detector only
+	// logs what it would do and takes NO action; when false it restarts k3s to
+	// give kubelet a fresh volume manager.
+	stuckMountDryRun = false
+	// stuckMountK3sStartFlag is the manual-start flag of the cluster-init.sh
+	// shell supervisor, which runs k3s on the stable branches. Touching it
+	// resets that supervisor's exponential restart backoff so k3s is relaunched
+	// promptly after we terminate it. It lives on the /run bind shared with the
+	// kube container. Nothing in this tree reads it — here the kube-init daemon
+	// supervises k3s — so it matters only where the SIGTERM path below is live.
+	stuckMountK3sStartFlag = "/run/kube/k3s-start"
+	// stuckMountRecoveryMarker is a distinctive, greppable string emitted on
+	// every recovery so operators can spot mount-wedge restarts in the logs.
+	stuckMountRecoveryMarker = "MOUNT-WEDGE-RECOVERY"
+)
+
+// checkStuckVolumeMount detects the kubelet volume-mount wedge: a pod scheduled
+// on this node sits Pending past stuckMountThreshold with no container-level
+// error, yet at least one of its Longhorn PVCs is attached to this node
+// (VolumeAttachment reports Attached and /dev/longhorn/<pv> exists) — meaning
+// attach succeeded but kubelet never issued NodeStage, so the pod never starts.
+// Longhorn, CDI and image pull are not at fault; the stall is in kubelet's
+// volume manager, and only a fresh kubelet clears it.
+//
+// Recovery (see recoverKubeletMountWedge) restarts k3s so kubelet comes back
+// with a fresh volume manager, rate-limited by stuckMountMaxRecover and
+// stuckMountSuppressWindow. Set stuckMountDryRun to disable the action and only
+// log.
+func (z *zedkube) checkStuckVolumeMount() {
+	if z.nodeName == "" {
+		return
+	}
+	clientset, err := getKubeClientSet()
+	if err != nil {
+		log.Errorf("checkStuckVolumeMount: get clientset: %v", err)
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer cancel()
+	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("checkStuckVolumeMount: list pods: %v", err)
+		return
+	}
+
+	now := time.Now()
+	var wedged []string
+	for i := range pods.Items {
+		if desc, ok := z.podMountWedge(pods.Items[i], now); ok {
+			wedged = append(wedged, desc)
+		}
+	}
+
+	if len(wedged) == 0 {
+		z.stuckMountRecoverCount = 0
+		return
+	}
+
+	if now.Before(z.stuckMountSuppressUntil) {
+		log.Functionf("checkStuckVolumeMount: %d wedged pod(s); recovery in cooldown until %v: %s",
+			len(wedged), z.stuckMountSuppressUntil, strings.Join(wedged, "; "))
+		return
+	}
+	if z.stuckMountRecoverCount >= stuckMountMaxRecover {
+		log.Errorf("checkStuckVolumeMount: %d wedged pod(s) after %d recovery attempts; giving up until they clear: %s",
+			len(wedged), stuckMountMaxRecover, strings.Join(wedged, "; "))
+		return
+	}
+
+	z.stuckMountRecoverCount++
+	z.stuckMountSuppressUntil = now.Add(stuckMountSuppressWindow)
+	z.recoverKubeletMountWedge(wedged)
+}
+
+// podMountWedge reports whether pod p on this node exhibits the mount wedge and,
+// if so, returns a human-readable description. It matches a Pending, non-
+// terminating pod aged past stuckMountThreshold that has no container- or
+// init-container error (image pull / crashloop are excluded as different
+// failures) and at least one Longhorn PVC that is attached to this node yet
+// still unmounted.
+func (z *zedkube) podMountWedge(p corev1.Pod, now time.Time) (string, bool) {
+	if p.Spec.NodeName != z.nodeName {
+		return "", false
+	}
+	if p.Status.Phase != corev1.PodPending || isPodTerminating(p) {
+		return "", false
+	}
+	if podHasContainerError(p) || podHasInitContainerError(p) {
+		return "", false
+	}
+	age := now.Sub(p.CreationTimestamp.Time)
+	if age < stuckMountThreshold {
+		return "", false
+	}
+	for _, vol := range p.Spec.Volumes {
+		if vol.PersistentVolumeClaim == nil {
+			continue
+		}
+		pvc, err := kubeapi.PVCGet(vol.PersistentVolumeClaim.ClaimName, log)
+		if err != nil || pvc.Spec.VolumeName == "" {
+			continue
+		}
+		pvName := pvc.Spec.VolumeName
+		// longhornDevicePresent is a local stat while GetVolumeAttachmentAttached
+		// lists every VolumeAttachment in the cluster, and this runs on every
+		// tick, so let the cheap check reject the volume first.
+		if !longhornDevicePresent(pvName) {
+			continue
+		}
+		attached, err := kubeapi.GetVolumeAttachmentAttached(pvName, z.nodeName, log)
+		if err != nil || !attached {
+			continue
+		}
+		return fmt.Sprintf("pod=%s pv=%s attached+device-present but unmounted, Pending %v",
+			p.Name, pvName, age.Round(time.Second)), true
+	}
+	return "", false
+}
+
+// longhornDevicePresent reports whether the Longhorn block device for pvName
+// exists on this node, i.e. the volume is attached at the node level.
+func longhornDevicePresent(pvName string) bool {
+	_, err := os.Stat(stuckMountDevPath + "/" + pvName)
+	return err == nil
+}
+
+// podHasInitContainerError mirrors podHasContainerError over init containers:
+// true if any init container is waiting on an error reason (image pull /
+// create / run) or terminated non-zero. Used to exclude image-pull failures
+// (e.g. a boot-image init container) from the mount-wedge signature.
+func podHasInitContainerError(p corev1.Pod) bool {
+	for _, cs := range p.Status.InitContainerStatuses {
+		if w := cs.State.Waiting; w != nil {
+			switch w.Reason {
+			case "CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull",
+				"CreateContainerError", "CreateContainerConfigError", "RunContainerError":
+				return true
+			}
+		}
+		if t := cs.State.Terminated; t != nil && t.ExitCode != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// recoverKubeletMountWedge is the recovery action for the mount wedge. The only
+// known remedy is a fresh kubelet, which we get by terminating k3s and letting
+// cluster-init.sh's supervisor relaunch it. Because pillar runs in the host PID
+// namespace and shares the /run bind with the kube container, zedkube can both
+// reset the supervisor's restart backoff (touch K3S_MANUAL_START_FLAG) and send
+// SIGTERM to the k3s server process directly. Every attempt logs a distinctive
+// marker so a restart is easy to spot in the device logs. While stuckMountDryRun
+// is true it takes NO action and only logs.
+func (z *zedkube) recoverKubeletMountWedge(wedged []string) {
+	detail := strings.Join(wedged, "; ")
+	if stuckMountDryRun {
+		log.Noticef("%s: DRY-RUN would restart kubelet/k3s to clear the volume-mount wedge (attempt %d/%d): %s",
+			stuckMountRecoveryMarker, z.stuckMountRecoverCount, stuckMountMaxRecover, detail)
+		return
+	}
+
+	log.Warnf("%s: restarting kubelet/k3s to clear the volume-mount wedge (attempt %d/%d): %s",
+		stuckMountRecoveryMarker, z.stuckMountRecoverCount, stuckMountMaxRecover, detail)
+
+	// Reset the supervisor's exponential restart backoff so k3s is relaunched
+	// promptly rather than after a multi-minute wait.
+	if err := os.MkdirAll(filepath.Dir(stuckMountK3sStartFlag), 0755); err != nil {
+		log.Errorf("%s: cannot create %s dir: %v", stuckMountRecoveryMarker, stuckMountK3sStartFlag, err)
+	} else if f, err := os.Create(stuckMountK3sStartFlag); err != nil {
+		log.Errorf("%s: cannot touch %s: %v", stuckMountRecoveryMarker, stuckMountK3sStartFlag, err)
+	} else {
+		f.Close()
+	}
+
+	pids, err := signalK3sServer()
+	if err != nil {
+		log.Errorf("%s: attempt %d/%d FAILED to enumerate k3s: %v; wedge: %s",
+			stuckMountRecoveryMarker, z.stuckMountRecoverCount, stuckMountMaxRecover, err, detail)
+		return
+	}
+	if len(pids) == 0 {
+		log.Errorf("%s: attempt %d/%d found no 'k3s server' process to signal; wedge: %s",
+			stuckMountRecoveryMarker, z.stuckMountRecoverCount, stuckMountMaxRecover, detail)
+		return
+	}
+	log.Warnf("%s: sent SIGTERM to k3s server pid(s) %v; cluster-init.sh will relaunch. attempt %d/%d, wedge: %s",
+		stuckMountRecoveryMarker, pids, z.stuckMountRecoverCount, stuckMountMaxRecover, detail)
+}
+
+// signalK3sServer sends SIGTERM to every running "k3s server" process and
+// returns the PIDs signaled. zedkube shares the host PID namespace, so the k3s
+// process started in the kube container is visible and signalable here; the
+// cluster-init.sh supervisor relaunches k3s once it exits, yielding a fresh
+// kubelet volume manager.
+//
+// k3s rewrites its process title to the single string "k3s server", so
+// /proc/<pid>/cmdline is one NUL-terminated token "k3s server" rather than the
+// separate "k3s"/"server" argv elements exec would leave. We therefore tokenize
+// the whole cmdline on whitespace and match basename(fields[0])=="k3s" &&
+// fields[1]=="server" — this matches both that retitled form and a
+// path-launched "<dir>/k3s server ...", while excluding a shell that merely
+// mentions the string in a later argument (its fields[0] is the shell).
+func signalK3sServer() ([]int, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, err
+	}
+	var signaled []int
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue // not a PID directory
+		}
+		raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+		if err != nil {
+			continue // process gone or unreadable
+		}
+		cmdline := strings.ReplaceAll(strings.TrimRight(string(raw), "\x00"), "\x00", " ")
+		fields := strings.Fields(cmdline)
+		if len(fields) < 2 || filepath.Base(fields[0]) != "k3s" || fields[1] != "server" {
+			continue
+		}
+		if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+			log.Errorf("%s: SIGTERM pid %d failed: %v", stuckMountRecoveryMarker, pid, err)
+			continue
+		}
+		signaled = append(signaled, pid)
+	}
+	return signaled, nil
+}

--- a/pkg/pillar/cmd/zedkube/stuckmount.go
+++ b/pkg/pillar/cmd/zedkube/stuckmount.go
@@ -76,7 +76,12 @@ func (z *zedkube) checkStuckVolumeMount() {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
 	defer cancel()
-	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(ctx, metav1.ListOptions{})
+	// Restrict the LIST server-side: only Pending pods on this node can exhibit
+	// the wedge, and a multi-node cluster's other nodes are none of our business.
+	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).List(ctx, metav1.ListOptions{
+		FieldSelector: "spec.nodeName=" + z.nodeName +
+			",status.phase=" + string(corev1.PodPending),
+	})
 	if err != nil {
 		log.Errorf("checkStuckVolumeMount: list pods: %v", err)
 		return

--- a/pkg/pillar/cmd/zedkube/stuckmount.go
+++ b/pkg/pillar/cmd/zedkube/stuckmount.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -74,6 +75,7 @@ var (
 	volumeAttachmentAttached = kubeapi.GetVolumeAttachmentAttached
 	devicePresent            = longhornDevicePresent
 	signalK3s                = signalK3sServer
+	pvcWanted                = (*zedkube).appWantsPVC
 )
 
 // checkStuckVolumeMount detects the kubelet volume-mount wedge: a pod scheduled
@@ -119,9 +121,22 @@ func (z *zedkube) checkStuckVolumeMountWithClient(clientset kubernetes.Interface
 	}
 
 	var wedged []string
+	unwanted := 0
 	for i := range pods.Items {
-		if desc, ok := z.podMountWedge(pods.Items[i], now); ok {
+		desc, ok, skipped := z.podMountWedgeCounting(pods.Items[i], now)
+		unwanted += skipped
+		if ok {
 			wedged = append(wedged, desc)
+		}
+	}
+	// Logged only on change, because the condition persists across every tick.
+	// It is the hint an operator needs: the wedge signature is present but no app
+	// wants the volume, so the fix is to reap the stale PVC, not to restart k3s.
+	if unwanted != z.stuckMountUnwantedCount {
+		z.stuckMountUnwantedCount = unwanted
+		if unwanted > 0 {
+			log.Noticef("checkStuckVolumeMount: %d attached-but-unmounted volume(s) belong to no app config; not restarting k3s for them (stale CDI upload PVCs?)",
+				unwanted)
 		}
 	}
 
@@ -153,24 +168,44 @@ func (z *zedkube) checkStuckVolumeMountWithClient(clientset kubernetes.Interface
 // failures) and at least one Longhorn PVC that is attached to this node yet
 // still unmounted.
 func (z *zedkube) podMountWedge(p corev1.Pod, now time.Time) (string, bool) {
+	desc, ok, _ := z.podMountWedgeCounting(p, now)
+	return desc, ok
+}
+
+// podMountWedgeCounting is podMountWedge plus the number of the pod's volumes
+// that were skipped because no app config references them, which the tick logs
+// as the operator-visible hint that stale CDI objects are present.
+func (z *zedkube) podMountWedgeCounting(p corev1.Pod, now time.Time) (string, bool, int) {
+	unwanted := 0
 	if p.Spec.NodeName != z.nodeName {
-		return "", false
+		return "", false, unwanted
 	}
 	if p.Status.Phase != corev1.PodPending || isPodTerminating(p) {
-		return "", false
+		return "", false, unwanted
 	}
 	if podHasContainerError(p) || podHasInitContainerError(p) {
-		return "", false
+		return "", false, unwanted
 	}
 	age := now.Sub(p.CreationTimestamp.Time)
 	if age < stuckMountThreshold {
-		return "", false
+		return "", false, unwanted
 	}
 	for _, vol := range p.Spec.Volumes {
 		if vol.PersistentVolumeClaim == nil {
 			continue
 		}
-		pvc, err := pvcGet(vol.PersistentVolumeClaim.ClaimName, log)
+		claim := vol.PersistentVolumeClaim.ClaimName
+		// A fresh kubelet can only help a volume some app is still waiting for.
+		// A CDI upload PVC left behind by a torn-down app keeps this exact
+		// signature indefinitely -- attached, device present, pod Pending -- yet
+		// nothing will ever complete its upload, so restarting k3s would cost a
+		// control-plane outage on every boot and change nothing. This is a local
+		// pubsub read, so it also keeps the apiserver calls below off that path.
+		if !pvcWanted(z, claim) {
+			unwanted++
+			continue
+		}
+		pvc, err := pvcGet(claim, log)
 		if err != nil || pvc.Spec.VolumeName == "" {
 			continue
 		}
@@ -186,9 +221,9 @@ func (z *zedkube) podMountWedge(p corev1.Pod, now time.Time) (string, bool) {
 			continue
 		}
 		return fmt.Sprintf("pod=%s pv=%s attached+device-present but unmounted, Pending %v",
-			p.Name, pvName, age.Round(time.Second)), true
+			p.Name, pvName, age.Round(time.Second)), true, unwanted
 	}
-	return "", false
+	return "", false, unwanted
 }
 
 // longhornDevicePresent reports whether the Longhorn block device for pvName
@@ -196,6 +231,33 @@ func (z *zedkube) podMountWedge(p corev1.Pod, now time.Time) (string, bool) {
 func longhornDevicePresent(pvName string) bool {
 	_, err := os.Stat(stuckMountDevPath + "/" + pvName)
 	return err == nil
+}
+
+// appWantsPVC reports whether any AppInstanceConfig currently references the
+// volume behind pvcName. zedkube already subscribes to AppInstanceConfig, so no
+// apiserver call is needed. VolumeRefConfig.GetPVCName agrees with
+// VolumeStatus.GetPVCName, so a PVC belonging to a live app always matches; one
+// left behind by a torn-down app matches nothing.
+//
+// An empty or not-yet-populated subscription makes every volume unwanted, which
+// suppresses recovery rather than triggering it — the safe direction, at the cost
+// of missing a genuine wedge in the first ticks after start-up.
+func (z *zedkube) appWantsPVC(pvcName string) bool {
+	if z.subAppInstanceConfig == nil {
+		return false
+	}
+	for _, c := range z.subAppInstanceConfig.GetAll() {
+		aiConfig, ok := c.(types.AppInstanceConfig)
+		if !ok {
+			continue
+		}
+		for _, volRef := range aiConfig.VolumeRefConfigList {
+			if volRef.GetPVCName() == pvcName {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // podHasInitContainerError mirrors podHasContainerError over init containers:

--- a/pkg/pillar/cmd/zedkube/stuckmount.go
+++ b/pkg/pillar/cmd/zedkube/stuckmount.go
@@ -8,6 +8,8 @@ package zedkube
 import (
 	"context"
 	"fmt"
+	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -43,6 +45,10 @@ const (
 	stuckMountRecoveryMarker = "MOUNT-WEDGE-RECOVERY"
 	// procRootDir is where the host PID namespace's process list is mounted.
 	procRootDir = "/proc"
+	// k3sSupervisorTimeout bounds both the connect and the reply on the
+	// supervisor socket. A restart request is answered as soon as it is accepted,
+	// not once k3s is back, so this only has to cover the handshake.
+	k3sSupervisorTimeout = 10 * time.Second
 )
 
 var (
@@ -57,6 +63,10 @@ var (
 	// kube container. Nothing in this tree reads it — here the kube-init daemon
 	// supervises k3s — so it matters only where the SIGTERM path below is live.
 	stuckMountK3sStartFlag = "/run/kube/k3s-start"
+	// k3sSupervisorSocket is the kube-init daemon's control socket, which accepts
+	// a "restart" verb. Present only on images where that daemon replaced
+	// cluster-init.sh; its absence is what selects the SIGTERM path below.
+	k3sSupervisorSocket = "/run/k3s-supervisor.sock"
 	// The cluster and host lookups the wedge signature and the recovery action
 	// depend on, indirected so tests can drive both without a live cluster and
 	// without signaling a real k3s. Overridden only in tests.
@@ -209,13 +219,12 @@ func podHasInitContainerError(p corev1.Pod) bool {
 }
 
 // recoverKubeletMountWedge is the recovery action for the mount wedge. The only
-// known remedy is a fresh kubelet, which we get by terminating k3s and letting
-// cluster-init.sh's supervisor relaunch it. Because pillar runs in the host PID
-// namespace and shares the /run bind with the kube container, zedkube can both
-// reset the supervisor's restart backoff (touch K3S_MANUAL_START_FLAG) and send
-// SIGTERM to the k3s server process directly. Every attempt logs a distinctive
-// marker so a restart is easy to spot in the device logs. While stuckMountDryRun
-// is true it takes NO action and only logs.
+// known remedy is a fresh kubelet, which means restarting k3s. Every attempt logs
+// a distinctive marker so a restart is easy to spot in the device logs. While
+// stuckMountDryRun is true it takes NO action and only logs.
+//
+// Which restart mechanism is available depends on what supervises k3s on this
+// image, so it is chosen at run time by restartK3s.
 func (z *zedkube) recoverKubeletMountWedge(wedged []string) {
 	detail := strings.Join(wedged, "; ")
 	if stuckMountDryRun {
@@ -227,8 +236,74 @@ func (z *zedkube) recoverKubeletMountWedge(wedged []string) {
 	log.Warnf("%s: restarting kubelet/k3s to clear the volume-mount wedge (attempt %d/%d): %s",
 		stuckMountRecoveryMarker, z.stuckMountRecoverCount, stuckMountMaxRecover, detail)
 
-	// Reset the supervisor's exponential restart backoff so k3s is relaunched
-	// promptly rather than after a multi-minute wait.
+	how, err := restartK3s()
+	if err != nil {
+		log.Errorf("%s: attempt %d/%d FAILED to restart k3s via %s: %v; wedge: %s",
+			stuckMountRecoveryMarker, z.stuckMountRecoverCount, stuckMountMaxRecover,
+			how, err, detail)
+		return
+	}
+	log.Warnf("%s: requested a k3s restart via %s; attempt %d/%d, wedge: %s",
+		stuckMountRecoveryMarker, how, z.stuckMountRecoverCount, stuckMountMaxRecover, detail)
+}
+
+// restartK3s asks whatever supervises k3s on this image to restart it, and
+// returns which mechanism it used.
+//
+// The kube-init daemon accepts a "restart" on its control socket and runs its own
+// pre-restart hooks, so it is preferred whenever that socket is present. Images
+// built from the stable branches, where the cluster-init.sh shell supervisor runs
+// k3s, have no socket; there the only lever is to terminate the process and let
+// that supervisor relaunch it. Detecting per attempt rather than once at start-up
+// keeps a single pillar binary correct on both, including across an upgrade that
+// swaps the supervisor underneath it.
+func restartK3s() (string, error) {
+	if _, err := os.Stat(k3sSupervisorSocket); err == nil {
+		return "supervisor socket", restartK3sViaSupervisor(k3sSupervisorSocket)
+	}
+	return "SIGTERM", restartK3sViaSignal()
+}
+
+// restartK3sViaSupervisor speaks kube-init's control-socket protocol: write the
+// verb, then read the reply until EOF. The daemon answers a single line, and
+// prefixes it with ERR when the request failed.
+func restartK3sViaSupervisor(socketPath string) error {
+	conn, err := net.DialTimeout("unix", socketPath, k3sSupervisorTimeout)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", socketPath, err)
+	}
+	defer conn.Close()
+	if err := conn.SetDeadline(time.Now().Add(k3sSupervisorTimeout)); err != nil {
+		return fmt.Errorf("set deadline on %s: %w", socketPath, err)
+	}
+	if _, err := fmt.Fprintln(conn, "restart"); err != nil {
+		return fmt.Errorf("write %s: %w", socketPath, err)
+	}
+	reply, err := io.ReadAll(conn)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", socketPath, err)
+	}
+	last := ""
+	for _, line := range strings.Split(strings.TrimRight(string(reply), "\n"), "\n") {
+		if line != "" {
+			last = line
+		}
+	}
+	if last == "" {
+		return fmt.Errorf("no reply from %s", socketPath)
+	}
+	if strings.HasPrefix(last, "ERR") {
+		return fmt.Errorf("supervisor refused: %s", last)
+	}
+	log.Noticef("%s: supervisor replied %q", stuckMountRecoveryMarker, last)
+	return nil
+}
+
+// restartK3sViaSignal is the cluster-init.sh path: reset the supervisor's
+// exponential restart backoff so k3s comes back promptly rather than after a
+// multi-minute wait, then SIGTERM it. pillar runs in the host PID namespace and
+// shares the /run bind with the kube container, so it can do both.
+func restartK3sViaSignal() error {
 	if err := os.MkdirAll(filepath.Dir(stuckMountK3sStartFlag), 0755); err != nil {
 		log.Errorf("%s: cannot create %s dir: %v", stuckMountRecoveryMarker, stuckMountK3sStartFlag, err)
 	} else if f, err := os.Create(stuckMountK3sStartFlag); err != nil {
@@ -239,17 +314,14 @@ func (z *zedkube) recoverKubeletMountWedge(wedged []string) {
 
 	pids, err := signalK3s()
 	if err != nil {
-		log.Errorf("%s: attempt %d/%d FAILED to enumerate k3s: %v; wedge: %s",
-			stuckMountRecoveryMarker, z.stuckMountRecoverCount, stuckMountMaxRecover, err, detail)
-		return
+		return fmt.Errorf("enumerate k3s: %w", err)
 	}
 	if len(pids) == 0 {
-		log.Errorf("%s: attempt %d/%d found no 'k3s server' process to signal; wedge: %s",
-			stuckMountRecoveryMarker, z.stuckMountRecoverCount, stuckMountMaxRecover, detail)
-		return
+		return fmt.Errorf("no 'k3s server' process to signal")
 	}
-	log.Warnf("%s: sent SIGTERM to k3s server pid(s) %v; cluster-init.sh will relaunch. attempt %d/%d, wedge: %s",
-		stuckMountRecoveryMarker, pids, z.stuckMountRecoverCount, stuckMountMaxRecover, detail)
+	log.Noticef("%s: sent SIGTERM to k3s server pid(s) %v; the supervisor relaunches it",
+		stuckMountRecoveryMarker, pids)
+	return nil
 }
 
 // signalK3sServer sends SIGTERM to every running "k3s server" process and

--- a/pkg/pillar/cmd/zedkube/stuckmount.go
+++ b/pkg/pillar/cmd/zedkube/stuckmount.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -34,6 +35,14 @@ const (
 	// stuckMountDevPath is where the Longhorn CSI node plugin materializes the
 	// block device once the volume is attached to this node.
 	stuckMountDevPath = "/dev/longhorn"
+	// stuckMountRecoveryMarker is a distinctive, greppable string emitted on
+	// every recovery so operators can spot mount-wedge restarts in the logs.
+	stuckMountRecoveryMarker = "MOUNT-WEDGE-RECOVERY"
+	// procRootDir is where the host PID namespace's process list is mounted.
+	procRootDir = "/proc"
+)
+
+var (
 	// stuckMountDryRun gates the recovery action. When true the detector only
 	// logs what it would do and takes NO action; when false it restarts k3s to
 	// give kubelet a fresh volume manager.
@@ -44,9 +53,13 @@ const (
 	// after we terminate it. It lives on the /run bind shared with the kube
 	// container.
 	stuckMountK3sStartFlag = "/run/kube/k3s-start"
-	// stuckMountRecoveryMarker is a distinctive, greppable string emitted on
-	// every recovery so operators can spot mount-wedge restarts in the logs.
-	stuckMountRecoveryMarker = "MOUNT-WEDGE-RECOVERY"
+	// The cluster and host lookups the wedge signature and the recovery action
+	// depend on, indirected so tests can drive both without a live cluster and
+	// without signaling a real k3s. Overridden only in tests.
+	pvcGet                   = kubeapi.PVCGet
+	volumeAttachmentAttached = kubeapi.GetVolumeAttachmentAttached
+	devicePresent            = longhornDevicePresent
+	signalK3s                = signalK3sServer
 )
 
 // checkStuckVolumeMount detects the kubelet volume-mount wedge: a pod scheduled
@@ -70,6 +83,14 @@ func (z *zedkube) checkStuckVolumeMount() {
 		log.Errorf("checkStuckVolumeMount: get clientset: %v", err)
 		return
 	}
+	z.checkStuckVolumeMountWithClient(clientset, time.Now())
+}
+
+// checkStuckVolumeMountWithClient is the body of one detector tick: it collects
+// the wedged pods this node currently has and, subject to the per-episode
+// attempt cap and cooldown, triggers recovery. now is passed in so the episode
+// rate limiting is exercisable without a wall clock.
+func (z *zedkube) checkStuckVolumeMountWithClient(clientset kubernetes.Interface, now time.Time) {
 	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
 	defer cancel()
 	// Restrict the LIST server-side: only Pending pods on this node can exhibit
@@ -83,7 +104,6 @@ func (z *zedkube) checkStuckVolumeMount() {
 		return
 	}
 
-	now := time.Now()
 	var wedged []string
 	for i := range pods.Items {
 		if desc, ok := z.podMountWedge(pods.Items[i], now); ok {
@@ -136,16 +156,16 @@ func (z *zedkube) podMountWedge(p corev1.Pod, now time.Time) (string, bool) {
 		if vol.PersistentVolumeClaim == nil {
 			continue
 		}
-		pvc, err := kubeapi.PVCGet(vol.PersistentVolumeClaim.ClaimName, log)
+		pvc, err := pvcGet(vol.PersistentVolumeClaim.ClaimName, log)
 		if err != nil || pvc.Spec.VolumeName == "" {
 			continue
 		}
 		pvName := pvc.Spec.VolumeName
-		attached, err := kubeapi.GetVolumeAttachmentAttached(pvName, z.nodeName, log)
+		attached, err := volumeAttachmentAttached(pvName, z.nodeName, log)
 		if err != nil || !attached {
 			continue
 		}
-		if !longhornDevicePresent(pvName) {
+		if !devicePresent(pvName) {
 			continue
 		}
 		return fmt.Sprintf("pod=%s pv=%s attached+device-present but unmounted, Pending %v",
@@ -210,7 +230,7 @@ func (z *zedkube) recoverKubeletMountWedge(wedged []string) {
 		f.Close()
 	}
 
-	pids, err := signalK3sServer()
+	pids, err := signalK3s()
 	if err != nil {
 		log.Errorf("%s: attempt %d/%d FAILED to enumerate k3s: %v; wedge: %s",
 			stuckMountRecoveryMarker, z.stuckMountRecoverCount, stuckMountMaxRecover, err, detail)
@@ -229,35 +249,15 @@ func (z *zedkube) recoverKubeletMountWedge(wedged []string) {
 // returns the PIDs signaled. zedkube shares the host PID namespace, so the k3s
 // process started in the kube container is visible and signalable here; the
 // cluster-init.sh supervisor relaunches k3s once it exits, yielding a fresh
-// kubelet volume manager.
-//
-// k3s rewrites its process title to the single string "k3s server", so
-// /proc/<pid>/cmdline is one NUL-terminated token "k3s server" rather than the
-// separate "k3s"/"server" argv elements exec would leave. We therefore tokenize
-// the whole cmdline on whitespace and match basename(fields[0])=="k3s" &&
-// fields[1]=="server" — this matches both that retitled form and a
-// path-launched "<dir>/k3s server ...", while excluding a shell that merely
-// mentions the string in a later argument (its fields[0] is the shell).
+// kubelet volume manager. A PID whose signal fails is left out of the returned
+// set, so an empty return means nothing was actually terminated.
 func signalK3sServer() ([]int, error) {
-	entries, err := os.ReadDir("/proc")
+	pids, err := k3sServerPids(procRootDir)
 	if err != nil {
 		return nil, err
 	}
 	var signaled []int
-	for _, e := range entries {
-		pid, err := strconv.Atoi(e.Name())
-		if err != nil {
-			continue // not a PID directory
-		}
-		raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
-		if err != nil {
-			continue // process gone or unreadable
-		}
-		cmdline := strings.ReplaceAll(strings.TrimRight(string(raw), "\x00"), "\x00", " ")
-		fields := strings.Fields(cmdline)
-		if len(fields) < 2 || filepath.Base(fields[0]) != "k3s" || fields[1] != "server" {
-			continue
-		}
+	for _, pid := range pids {
 		if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
 			log.Errorf("%s: SIGTERM pid %d failed: %v", stuckMountRecoveryMarker, pid, err)
 			continue
@@ -265,4 +265,45 @@ func signalK3sServer() ([]int, error) {
 		signaled = append(signaled, pid)
 	}
 	return signaled, nil
+}
+
+// k3sServerPids returns the PIDs of the "k3s server" processes visible under
+// procRoot. A process that disappears mid-scan, or whose cmdline is unreadable,
+// is skipped; only an unreadable procRoot is an error.
+func k3sServerPids(procRoot string) ([]int, error) {
+	entries, err := os.ReadDir(procRoot)
+	if err != nil {
+		return nil, err
+	}
+	var pids []int
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue // not a PID directory
+		}
+		raw, err := os.ReadFile(filepath.Join(procRoot, e.Name(), "cmdline"))
+		if err != nil {
+			continue // process gone or unreadable
+		}
+		if !isK3sServerCmdline(raw) {
+			continue
+		}
+		pids = append(pids, pid)
+	}
+	return pids, nil
+}
+
+// isK3sServerCmdline reports whether a raw /proc/<pid>/cmdline belongs to the
+// k3s server process.
+//
+// k3s rewrites its process title to the single string "k3s server", so cmdline
+// is one NUL-terminated token "k3s server" rather than the separate
+// "k3s"/"server" argv elements exec would leave. Tokenizing the whole cmdline on
+// whitespace therefore matches both that retitled form and a path-launched
+// "<dir>/k3s server ...", while excluding a shell that merely mentions the
+// string in a later argument (its first token is the shell).
+func isK3sServerCmdline(raw []byte) bool {
+	cmdline := strings.ReplaceAll(strings.TrimRight(string(raw), "\x00"), "\x00", " ")
+	fields := strings.Fields(cmdline)
+	return len(fields) >= 2 && filepath.Base(fields[0]) == "k3s" && fields[1] == "server"
 }

--- a/pkg/pillar/cmd/zedkube/stuckmount_restart_test.go
+++ b/pkg/pillar/cmd/zedkube/stuckmount_restart_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package zedkube
+
+import (
+	"bufio"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
+)
+
+// initRestartTestLog gives the package-level logger a value; the restart paths log
+// on success, and an unset log panics.
+func initRestartTestLog() {
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "test-zedkube", 0)
+}
+
+// serveSupervisor answers one connection with reply, and records the verb it was
+// asked for. Returns the socket path.
+func serveSupervisor(t *testing.T, reply string, gotVerb chan<- string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "k3s-supervisor.sock")
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		verb, _ := bufio.NewReader(conn).ReadString('\n')
+		gotVerb <- verb
+		_, _ = conn.Write([]byte(reply))
+	}()
+	return path
+}
+
+// The supervisor is asked to restart, and its OK reply is a success.
+func TestRestartK3sViaSupervisorOK(t *testing.T) {
+	initRestartTestLog()
+	verbs := make(chan string, 1)
+	path := serveSupervisor(t, "OK restarting\n", verbs)
+	if err := restartK3sViaSupervisor(path); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if got := <-verbs; got != "restart\n" {
+		t.Errorf("supervisor asked for %q, want %q", got, "restart\n")
+	}
+}
+
+// An ERR reply must surface as an error rather than be read as success -- the
+// daemon uses the prefix, not the connection, to report refusal.
+func TestRestartK3sViaSupervisorRefused(t *testing.T) {
+	initRestartTestLog()
+	verbs := make(chan string, 1)
+	path := serveSupervisor(t, "ERR k3s is not running\n", verbs)
+	err := restartK3sViaSupervisor(path)
+	if err == nil {
+		t.Fatal("an ERR reply must be an error")
+	}
+	select {
+	case <-verbs:
+	default:
+		t.Error("the supervisor socket was never contacted")
+	}
+}
+
+// A daemon that accepts the connection and says nothing must not count as a
+// restart having happened.
+func TestRestartK3sViaSupervisorSilent(t *testing.T) {
+	initRestartTestLog()
+	verbs := make(chan string, 1)
+	path := serveSupervisor(t, "", verbs)
+	if err := restartK3sViaSupervisor(path); err == nil {
+		t.Fatal("an empty reply must be an error")
+	}
+	select {
+	case <-verbs:
+	default:
+		t.Error("the supervisor socket was never contacted")
+	}
+}
+
+func TestRestartK3sViaSupervisorNoSocket(t *testing.T) {
+	initRestartTestLog()
+	if err := restartK3sViaSupervisor(filepath.Join(t.TempDir(), "absent.sock")); err == nil {
+		t.Fatal("dialing an absent socket must fail")
+	}
+}
+
+// With no supervisor socket present, recovery must fall back to the signal path
+// rather than fail: that is the cluster-init.sh image.
+func TestRestartK3sFallsBackToSignal(t *testing.T) {
+	initRestartTestLog()
+	dir := t.TempDir()
+	savedSock, savedFlag, savedSignal := k3sSupervisorSocket, stuckMountK3sStartFlag, signalK3s
+	t.Cleanup(func() {
+		k3sSupervisorSocket, stuckMountK3sStartFlag, signalK3s = savedSock, savedFlag, savedSignal
+	})
+	k3sSupervisorSocket = filepath.Join(dir, "absent.sock")
+	stuckMountK3sStartFlag = filepath.Join(dir, "kube", "k3s-start")
+	signalK3s = func() ([]int, error) { return []int{4242}, nil }
+
+	how, err := restartK3s()
+	if err != nil {
+		t.Fatalf("fallback must succeed, got %v", err)
+	}
+	if how != "SIGTERM" {
+		t.Errorf("used %q, want SIGTERM", how)
+	}
+	// The backoff-reset flag is the half of the signal path that is easy to drop
+	// silently, so assert it landed.
+	if _, err := os.Stat(stuckMountK3sStartFlag); err != nil {
+		t.Errorf("manual-start flag not created: %v", err)
+	}
+}
+
+// When the socket is present it must be preferred, and the signal path must not
+// run at all -- terminating k3s behind the daemon's back skips its hooks.
+func TestRestartK3sPrefersSupervisor(t *testing.T) {
+	initRestartTestLog()
+	verbs := make(chan string, 1)
+	path := serveSupervisor(t, "OK\n", verbs)
+	savedSock, savedSignal := k3sSupervisorSocket, signalK3s
+	t.Cleanup(func() { k3sSupervisorSocket, signalK3s = savedSock, savedSignal })
+	k3sSupervisorSocket = path
+	signaled := false
+	signalK3s = func() ([]int, error) { signaled = true; return []int{1}, nil }
+
+	how, err := restartK3s()
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if how != "supervisor socket" {
+		t.Errorf("used %q, want the supervisor socket", how)
+	}
+	if signaled {
+		t.Error("the signal path ran even though the supervisor socket was present")
+	}
+	// Non-blocking: an implementation that never dials must fail this test rather
+	// than hang it waiting for a verb that is never sent.
+	select {
+	case got := <-verbs:
+		if got != "restart\n" {
+			t.Errorf("supervisor asked for %q, want %q", got, "restart\n")
+		}
+	default:
+		t.Error("the supervisor socket was never contacted")
+	}
+}

--- a/pkg/pillar/cmd/zedkube/stuckmount_test.go
+++ b/pkg/pillar/cmd/zedkube/stuckmount_test.go
@@ -1,0 +1,573 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package zedkube
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// stuckMountFakes drives the cluster and host lookups the detector makes.
+// claims binds a PVC name to its PV; attachedPVs and presentPVs are the PVs
+// this node reports as attached and as having a /dev/longhorn device.
+type stuckMountFakes struct {
+	claims      map[string]string
+	attachedPVs map[string]bool
+	presentPVs  map[string]bool
+	pvcErr      map[string]error
+	attachErr   map[string]error
+
+	signalPids  []int
+	signalErr   error
+	signalCalls int
+
+	flagPath string
+}
+
+// installStuckMountFakes points the detector's lookups at f and its k3s-start
+// flag at a temporary path, restoring the real ones when the test ends.
+func installStuckMountFakes(t *testing.T, f *stuckMountFakes) {
+	t.Helper()
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "test-zedkube", 0)
+
+	origPVCGet, origAttached := pvcGet, volumeAttachmentAttached
+	origDevice, origSignal := devicePresent, signalK3s
+	origFlag, origDryRun := stuckMountK3sStartFlag, stuckMountDryRun
+	t.Cleanup(func() {
+		pvcGet, volumeAttachmentAttached = origPVCGet, origAttached
+		devicePresent, signalK3s = origDevice, origSignal
+		stuckMountK3sStartFlag, stuckMountDryRun = origFlag, origDryRun
+	})
+
+	f.flagPath = filepath.Join(t.TempDir(), "kube", "k3s-start")
+	stuckMountK3sStartFlag = f.flagPath
+
+	pvcGet = func(pvcName string, _ *base.LogObject) (*corev1.PersistentVolumeClaim, error) {
+		if err := f.pvcErr[pvcName]; err != nil {
+			return nil, err
+		}
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: pvcName},
+			Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: f.claims[pvcName]},
+		}, nil
+	}
+	volumeAttachmentAttached = func(pvName, nodeName string, _ *base.LogObject) (bool, error) {
+		if err := f.attachErr[pvName]; err != nil {
+			return false, err
+		}
+		return f.attachedPVs[pvName] && nodeName == testNodeName, nil
+	}
+	devicePresent = func(pvName string) bool { return f.presentPVs[pvName] }
+	signalK3s = func() ([]int, error) {
+		f.signalCalls++
+		return f.signalPids, f.signalErr
+	}
+}
+
+// wedgeFakes is the all-green setup: pvc-a is bound to pv-a, which is attached
+// to this node and has its device present, so a stale Pending pod referencing
+// pvc-a is wedged.
+func wedgeFakes(t *testing.T) *stuckMountFakes {
+	t.Helper()
+	f := &stuckMountFakes{
+		claims:      map[string]string{"pvc-a": "pv-a"},
+		attachedPVs: map[string]bool{"pv-a": true},
+		presentPVs:  map[string]bool{"pv-a": true},
+		signalPids:  []int{4242},
+	}
+	installStuckMountFakes(t, f)
+	return f
+}
+
+// pendingPod builds a Pending pod on this node, created age ago relative to now,
+// referencing the named PVCs.
+func pendingPod(name string, now time.Time, age time.Duration, claims ...string) corev1.Pod {
+	p := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         kubeapi.EVEKubeNameSpace,
+			CreationTimestamp: metav1.NewTime(now.Add(-age)),
+		},
+		Spec:   corev1.PodSpec{NodeName: testNodeName},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+	for i, claim := range claims {
+		p.Spec.Volumes = append(p.Spec.Volumes, corev1.Volume{
+			Name: "vol" + string(rune('a'+i)),
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: claim},
+			},
+		})
+	}
+	return p
+}
+
+func waitingPod(p corev1.Pod, reason string) corev1.Pod {
+	p.Status.ContainerStatuses = []corev1.ContainerStatus{
+		{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: reason}}},
+	}
+	return p
+}
+
+func waitingInitPod(p corev1.Pod, reason string) corev1.Pod {
+	p.Status.InitContainerStatuses = []corev1.ContainerStatus{
+		{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: reason}}},
+	}
+	return p
+}
+
+func TestIsK3sServerCmdline(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdline string
+		want    bool
+	}{
+		// k3s rewrites its process title to one string, so the whole cmdline
+		// arrives as a single NUL-terminated token.
+		{"retitled single token", "k3s server\x00", true},
+		{"argv form with flags", "k3s\x00server\x00--flannel-backend=none\x00", true},
+		{"path launched retitled", "/var/lib/rancher/k3s/data/abc/bin/k3s server\x00", true},
+		{"path launched argv", "/usr/bin/k3s\x00server\x00", true},
+		{"no trailing NUL", "k3s server", true},
+		// A shell that merely mentions the string must not be signaled.
+		{"shell mentioning k3s server", "/bin/sh\x00-c\x00k3s server\x00", false},
+		{"eve-k cluster-init wrapper", "/bin/sh\x00/usr/bin/cluster-init.sh\x00", false},
+		{"k3s agent", "k3s\x00agent\x00", false},
+		{"k3s alone", "k3s\x00", false},
+		{"killall script", "k3s-killall.sh\x00", false},
+		{"basename must be exact", "k3ss\x00server\x00", false},
+		{"other binary", "kubelet\x00--config\x00", false},
+		{"kernel thread empty cmdline", "", false},
+		{"only NULs", "\x00\x00", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isK3sServerCmdline([]byte(tc.cmdline)))
+		})
+	}
+}
+
+func TestK3sServerPids(t *testing.T) {
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "test-zedkube", 0)
+	procRoot := t.TempDir()
+
+	write := func(dir, cmdline string) {
+		t.Helper()
+		assert.NoError(t, os.MkdirAll(filepath.Join(procRoot, dir), 0755))
+		assert.NoError(t, os.WriteFile(filepath.Join(procRoot, dir, "cmdline"), []byte(cmdline), 0644))
+	}
+	write("123", "k3s\x00server\x00--foo\x00")
+	write("456", "/var/lib/rancher/k3s/data/abc/bin/k3s server\x00")
+	write("789", "/bin/sh\x00-c\x00k3s server\x00")
+	// Non-numeric entries are not processes, even when their cmdline matches.
+	write("self", "k3s server\x00")
+	// A process that exited between the readdir and the read has no cmdline.
+	assert.NoError(t, os.MkdirAll(filepath.Join(procRoot, "999"), 0755))
+	// Plain files at the top of /proc (uptime, meminfo, …) are not PIDs.
+	assert.NoError(t, os.WriteFile(filepath.Join(procRoot, "uptime"), []byte("1 1"), 0644))
+
+	pids, err := k3sServerPids(procRoot)
+	assert.NoError(t, err)
+	assert.Equal(t, []int{123, 456}, pids)
+
+	_, err = k3sServerPids(filepath.Join(procRoot, "no-such-dir"))
+	assert.Error(t, err)
+}
+
+func TestPodHasInitContainerError(t *testing.T) {
+	mk := func(state corev1.ContainerState) corev1.Pod {
+		return corev1.Pod{Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{{State: state}},
+		}}
+	}
+	waiting := func(reason string) corev1.ContainerState {
+		return corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: reason}}
+	}
+
+	tests := []struct {
+		name string
+		pod  corev1.Pod
+		want bool
+	}{
+		{"CrashLoopBackOff", mk(waiting("CrashLoopBackOff")), true},
+		{"ImagePullBackOff", mk(waiting("ImagePullBackOff")), true},
+		{"ErrImagePull", mk(waiting("ErrImagePull")), true},
+		{"CreateContainerError", mk(waiting("CreateContainerError")), true},
+		{"CreateContainerConfigError", mk(waiting("CreateContainerConfigError")), true},
+		{"RunContainerError", mk(waiting("RunContainerError")), true},
+		// A normally-progressing init container is not an error.
+		{"PodInitializing", mk(waiting("PodInitializing")), false},
+		{"ContainerCreating", mk(waiting("ContainerCreating")), false},
+		{"empty reason", mk(waiting("")), false},
+		{"running", mk(corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}), false},
+		{"terminated ok", mk(corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}}), false},
+		{"terminated non-zero", mk(corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: 1}}), true},
+		{"no init containers", corev1.Pod{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, podHasInitContainerError(tc.pod))
+		})
+	}
+}
+
+func TestPodMountWedge(t *testing.T) {
+	now := time.Now()
+	stale := 2 * stuckMountThreshold
+
+	tests := []struct {
+		name    string
+		pod     func(*stuckMountFakes) corev1.Pod
+		mutate  func(*stuckMountFakes)
+		want    bool
+		wantPV  string
+		wantPod string
+	}{
+		{
+			name:    "attached, device present, stale Pending",
+			pod:     func(*stuckMountFakes) corev1.Pod { return pendingPod("cdi-upload", now, stale, "pvc-a") },
+			want:    true,
+			wantPV:  "pv-a",
+			wantPod: "cdi-upload",
+		},
+		{
+			name: "pod on another node",
+			pod: func(*stuckMountFakes) corev1.Pod {
+				p := pendingPod("elsewhere", now, stale, "pvc-a")
+				p.Spec.NodeName = "other-node"
+				return p
+			},
+		},
+		{
+			name: "pod not yet scheduled",
+			pod: func(*stuckMountFakes) corev1.Pod {
+				p := pendingPod("unscheduled", now, stale, "pvc-a")
+				p.Spec.NodeName = ""
+				return p
+			},
+		},
+		{
+			name: "pod already Running",
+			pod: func(*stuckMountFakes) corev1.Pod {
+				p := pendingPod("running", now, stale, "pvc-a")
+				p.Status.Phase = corev1.PodRunning
+				return p
+			},
+		},
+		{
+			name: "pod terminating",
+			pod: func(*stuckMountFakes) corev1.Pod {
+				p := pendingPod("terminating", now, stale, "pvc-a")
+				ts := metav1.NewTime(now)
+				p.DeletionTimestamp = &ts
+				return p
+			},
+		},
+		{
+			name: "image pull failure is a different wedge",
+			pod: func(*stuckMountFakes) corev1.Pod {
+				return waitingPod(pendingPod("badimage", now, stale, "pvc-a"), "ImagePullBackOff")
+			},
+		},
+		{
+			// The orphaned CDI upload pod whose TLS secret was deleted: it sits
+			// Pending on an attached volume forever, but a kubelet restart will
+			// not help it.
+			name: "missing secret is a different wedge",
+			pod: func(*stuckMountFakes) corev1.Pod {
+				return waitingPod(pendingPod("nosecret", now, stale, "pvc-a"), "CreateContainerConfigError")
+			},
+		},
+		{
+			name: "init container image pull failure",
+			pod: func(*stuckMountFakes) corev1.Pod {
+				return waitingInitPod(pendingPod("badinit", now, stale, "pvc-a"), "ErrImagePull")
+			},
+		},
+		{
+			name: "container merely creating is not an error",
+			pod: func(*stuckMountFakes) corev1.Pod {
+				return waitingPod(pendingPod("creating", now, stale, "pvc-a"), "ContainerCreating")
+			},
+			want:    true,
+			wantPV:  "pv-a",
+			wantPod: "creating",
+		},
+		{
+			name: "just under the threshold",
+			pod: func(*stuckMountFakes) corev1.Pod {
+				return pendingPod("young", now, stuckMountThreshold-time.Second, "pvc-a")
+			},
+		},
+		{
+			name: "just over the threshold",
+			pod: func(*stuckMountFakes) corev1.Pod {
+				return pendingPod("old", now, stuckMountThreshold+time.Second, "pvc-a")
+			},
+			want:    true,
+			wantPV:  "pv-a",
+			wantPod: "old",
+		},
+		{
+			name: "no PVC volumes",
+			pod: func(*stuckMountFakes) corev1.Pod {
+				p := pendingPod("configonly", now, stale)
+				p.Spec.Volumes = []corev1.Volume{{
+					Name:         "cfg",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+				}}
+				return p
+			},
+		},
+		{
+			name:   "PVC lookup fails",
+			pod:    func(*stuckMountFakes) corev1.Pod { return pendingPod("pvcerr", now, stale, "pvc-a") },
+			mutate: func(f *stuckMountFakes) { f.pvcErr = map[string]error{"pvc-a": errors.New("nope")} },
+		},
+		{
+			name:   "PVC not yet bound to a PV",
+			pod:    func(*stuckMountFakes) corev1.Pod { return pendingPod("unbound", now, stale, "pvc-a") },
+			mutate: func(f *stuckMountFakes) { f.claims = map[string]string{} },
+		},
+		{
+			name:   "VolumeAttachment lookup fails",
+			pod:    func(*stuckMountFakes) corev1.Pod { return pendingPod("vaerr", now, stale, "pvc-a") },
+			mutate: func(f *stuckMountFakes) { f.attachErr = map[string]error{"pv-a": errors.New("nope")} },
+		},
+		{
+			// Attach requested but not complete: kubelet is not at fault yet.
+			name:   "attach still in progress",
+			pod:    func(*stuckMountFakes) corev1.Pod { return pendingPod("attaching", now, stale, "pvc-a") },
+			mutate: func(f *stuckMountFakes) { f.attachedPVs = map[string]bool{} },
+		},
+		{
+			name:   "attached but no device on this node",
+			pod:    func(*stuckMountFakes) corev1.Pod { return pendingPod("nodev", now, stale, "pvc-a") },
+			mutate: func(f *stuckMountFakes) { f.presentPVs = map[string]bool{} },
+		},
+		{
+			name: "second volume is the wedged one",
+			pod: func(*stuckMountFakes) corev1.Pod {
+				return pendingPod("multivol", now, stale, "pvc-unbound", "pvc-a")
+			},
+			want:    true,
+			wantPV:  "pv-a",
+			wantPod: "multivol",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := wedgeFakes(t)
+			if tc.mutate != nil {
+				tc.mutate(f)
+			}
+			z := &zedkube{nodeName: testNodeName}
+			desc, got := z.podMountWedge(tc.pod(f), now)
+			assert.Equal(t, tc.want, got)
+			if !tc.want {
+				assert.Empty(t, desc)
+				return
+			}
+			// The description is what lands in the operator-facing recovery log.
+			assert.Contains(t, desc, "pod="+tc.wantPod)
+			assert.Contains(t, desc, "pv="+tc.wantPV)
+		})
+	}
+}
+
+// TestCheckStuckVolumeMountEpisode walks one wedge episode through the attempt
+// cap and the cooldown, then confirms a cleared wedge re-arms recovery.
+func TestCheckStuckVolumeMountEpisode(t *testing.T) {
+	f := wedgeFakes(t)
+	t0 := time.Now()
+	pod := pendingPod("cdi-upload", t0, 2*stuckMountThreshold)
+	pod.Spec.Volumes = []corev1.Volume{{
+		Name: "vol",
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-a"},
+		},
+	}}
+	clientset := fake.NewSimpleClientset(&pod)
+	z := &zedkube{nodeName: testNodeName}
+
+	z.checkStuckVolumeMountWithClient(clientset, t0)
+	assert.Equal(t, 1, z.stuckMountRecoverCount)
+	assert.Equal(t, 1, f.signalCalls)
+	assert.Equal(t, t0.Add(stuckMountSuppressWindow), z.stuckMountSuppressUntil)
+	assert.FileExists(t, f.flagPath)
+
+	// Inside the cooldown the detector must not touch k3s again.
+	z.checkStuckVolumeMountWithClient(clientset, t0.Add(stuckMountSuppressWindow/2))
+	assert.Equal(t, 1, z.stuckMountRecoverCount)
+	assert.Equal(t, 1, f.signalCalls)
+
+	// Cooldown expired and still wedged: attempt again, up to the cap.
+	at := t0
+	for i := 2; i <= stuckMountMaxRecover; i++ {
+		at = at.Add(stuckMountSuppressWindow + time.Minute)
+		z.checkStuckVolumeMountWithClient(clientset, at)
+		assert.Equal(t, i, z.stuckMountRecoverCount)
+		assert.Equal(t, i, f.signalCalls)
+	}
+
+	// At the cap the detector gives up rather than thrashing k3s.
+	at = at.Add(stuckMountSuppressWindow + time.Minute)
+	z.checkStuckVolumeMountWithClient(clientset, at)
+	assert.Equal(t, stuckMountMaxRecover, z.stuckMountRecoverCount)
+	assert.Equal(t, stuckMountMaxRecover, f.signalCalls)
+
+	// The wedge clears, which ends the episode and resets the attempt count.
+	f.presentPVs = map[string]bool{}
+	at = at.Add(time.Minute)
+	z.checkStuckVolumeMountWithClient(clientset, at)
+	assert.Equal(t, 0, z.stuckMountRecoverCount)
+	assert.Equal(t, stuckMountMaxRecover, f.signalCalls)
+
+	// A later episode must be able to recover again, or the cap would disarm
+	// the detector for the lifetime of the process.
+	f.presentPVs = map[string]bool{"pv-a": true}
+	at = at.Add(stuckMountSuppressWindow + time.Minute)
+	z.checkStuckVolumeMountWithClient(clientset, at)
+	assert.Equal(t, 1, z.stuckMountRecoverCount)
+	assert.Equal(t, stuckMountMaxRecover+1, f.signalCalls)
+}
+
+func TestCheckStuckVolumeMountNoRecovery(t *testing.T) {
+	t0 := time.Now()
+	wedged := pendingPod("cdi-upload", t0, 2*stuckMountThreshold, "pvc-a")
+
+	tests := []struct {
+		name     string
+		pods     []runtime.Object
+		nodeName string
+	}{
+		{"no pods at all", nil, testNodeName},
+		{"only a healthy pod", []runtime.Object{func() runtime.Object {
+			p := pendingPod("young", t0, time.Minute, "pvc-a")
+			return &p
+		}()}, testNodeName},
+		// The fake clientset does not evaluate field selectors, so these also
+		// prove the client-side re-check in podMountWedge does the filtering.
+		{"wedged pod on another node", []runtime.Object{func() runtime.Object {
+			p := wedged.DeepCopy()
+			p.Spec.NodeName = "other-node"
+			return p
+		}()}, testNodeName},
+		{"node name not yet known", []runtime.Object{wedged.DeepCopy()}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := wedgeFakes(t)
+			z := &zedkube{nodeName: tc.nodeName}
+			z.checkStuckVolumeMountWithClient(fake.NewSimpleClientset(tc.pods...), t0)
+			assert.Equal(t, 0, z.stuckMountRecoverCount)
+			assert.Equal(t, 0, f.signalCalls)
+			assert.NoFileExists(t, f.flagPath)
+		})
+	}
+}
+
+// TestCheckStuckVolumeMountTwoPodsOneRestart checks that a tick with several
+// wedged pods restarts k3s once, not once per pod.
+func TestCheckStuckVolumeMountTwoPodsOneRestart(t *testing.T) {
+	f := wedgeFakes(t)
+	f.claims["pvc-b"] = "pv-b"
+	f.attachedPVs["pv-b"] = true
+	f.presentPVs["pv-b"] = true
+
+	t0 := time.Now()
+	podA := pendingPod("cdi-upload-a", t0, 2*stuckMountThreshold, "pvc-a")
+	podB := pendingPod("cdi-upload-b", t0, 2*stuckMountThreshold, "pvc-b")
+
+	z := &zedkube{nodeName: testNodeName}
+	z.checkStuckVolumeMountWithClient(fake.NewSimpleClientset(&podA, &podB), t0)
+	assert.Equal(t, 1, z.stuckMountRecoverCount)
+	assert.Equal(t, 1, f.signalCalls)
+}
+
+// TestCheckStuckVolumeMountListError checks that an API blip neither triggers
+// recovery nor clears an episode already in progress.
+func TestCheckStuckVolumeMountListError(t *testing.T) {
+	f := wedgeFakes(t)
+	clientset := fake.NewSimpleClientset()
+	clientset.PrependReactor("list", "pods",
+		func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("apiserver unreachable")
+		})
+
+	z := &zedkube{nodeName: testNodeName, stuckMountRecoverCount: 2}
+	z.checkStuckVolumeMountWithClient(clientset, time.Now())
+	assert.Equal(t, 2, z.stuckMountRecoverCount)
+	assert.Equal(t, 0, f.signalCalls)
+}
+
+func TestRecoverKubeletMountWedge(t *testing.T) {
+	wedge := []string{"pod=cdi-upload pv=pv-a attached+device-present but unmounted, Pending 7m0s"}
+
+	t.Run("touches the start flag and signals k3s", func(t *testing.T) {
+		f := wedgeFakes(t)
+		z := &zedkube{nodeName: testNodeName, stuckMountRecoverCount: 1}
+		z.recoverKubeletMountWedge(wedge)
+		assert.Equal(t, 1, f.signalCalls)
+		assert.FileExists(t, f.flagPath)
+	})
+
+	t.Run("dry run takes no action", func(t *testing.T) {
+		f := wedgeFakes(t)
+		stuckMountDryRun = true
+		z := &zedkube{nodeName: testNodeName, stuckMountRecoverCount: 1}
+		z.recoverKubeletMountWedge(wedge)
+		assert.Equal(t, 0, f.signalCalls)
+		assert.NoFileExists(t, f.flagPath)
+	})
+
+	t.Run("unwritable start flag still restarts k3s", func(t *testing.T) {
+		f := wedgeFakes(t)
+		// A regular file where the flag's parent directory should be: MkdirAll
+		// fails regardless of privileges.
+		blocked := filepath.Join(t.TempDir(), "run")
+		assert.NoError(t, os.WriteFile(blocked, nil, 0644))
+		stuckMountK3sStartFlag = filepath.Join(blocked, "k3s-start")
+
+		z := &zedkube{nodeName: testNodeName, stuckMountRecoverCount: 1}
+		z.recoverKubeletMountWedge(wedge)
+		assert.Equal(t, 1, f.signalCalls)
+	})
+
+	t.Run("enumeration failure still touched the flag", func(t *testing.T) {
+		f := wedgeFakes(t)
+		f.signalErr = errors.New("cannot read /proc")
+		z := &zedkube{nodeName: testNodeName, stuckMountRecoverCount: 1}
+		z.recoverKubeletMountWedge(wedge)
+		assert.Equal(t, 1, f.signalCalls)
+		assert.FileExists(t, f.flagPath)
+	})
+
+	t.Run("no k3s process found", func(t *testing.T) {
+		f := wedgeFakes(t)
+		f.signalPids = nil
+		z := &zedkube{nodeName: testNodeName, stuckMountRecoverCount: 1}
+		z.recoverKubeletMountWedge(wedge)
+		assert.Equal(t, 1, f.signalCalls)
+		assert.FileExists(t, f.flagPath)
+	})
+}

--- a/pkg/pillar/cmd/zedkube/stuckmount_test.go
+++ b/pkg/pillar/cmd/zedkube/stuckmount_test.go
@@ -32,6 +32,9 @@ type stuckMountFakes struct {
 	presentPVs  map[string]bool
 	pvcErr      map[string]error
 	attachErr   map[string]error
+	// unwantedPVCs are the PVCs no AppInstanceConfig references; anything not
+	// listed is treated as wanted, so tests that predate the gate are unaffected.
+	unwantedPVCs map[string]bool
 
 	signalPids  []int
 	signalErr   error
@@ -49,11 +52,14 @@ func installStuckMountFakes(t *testing.T, f *stuckMountFakes) {
 	origPVCGet, origAttached := pvcGet, volumeAttachmentAttached
 	origDevice, origSignal := devicePresent, signalK3s
 	origFlag, origDryRun := stuckMountK3sStartFlag, stuckMountDryRun
+	origWanted := pvcWanted
 	t.Cleanup(func() {
 		pvcGet, volumeAttachmentAttached = origPVCGet, origAttached
 		devicePresent, signalK3s = origDevice, origSignal
 		stuckMountK3sStartFlag, stuckMountDryRun = origFlag, origDryRun
+		pvcWanted = origWanted
 	})
+	pvcWanted = func(_ *zedkube, pvcName string) bool { return !f.unwantedPVCs[pvcName] }
 
 	f.flagPath = filepath.Join(t.TempDir(), "kube", "k3s-start")
 	stuckMountK3sStartFlag = f.flagPath
@@ -372,6 +378,25 @@ func TestPodMountWedge(t *testing.T) {
 			wantPV:  "pv-a",
 			wantPod: "multivol",
 		},
+		{
+			// An orphaned CDI upload PVC looks identical from the outside, but a
+			// fresh kubelet cannot complete an upload no app is waiting for.
+			name:   "volume belongs to no app config",
+			pod:    func(*stuckMountFakes) corev1.Pod { return pendingPod("orphan", now, stale, "pvc-a") },
+			mutate: func(f *stuckMountFakes) { f.unwantedPVCs = map[string]bool{"pvc-a": true} },
+		},
+		{
+			// The gate must not hide a real wedge just because the pod also
+			// mounts something stale, e.g. an upload pod's scratch PVC.
+			name: "wanted volume still wedges alongside an unwanted one",
+			pod: func(*stuckMountFakes) corev1.Pod {
+				return pendingPod("mixed", now, stale, "pvc-stale", "pvc-a")
+			},
+			mutate:  func(f *stuckMountFakes) { f.unwantedPVCs = map[string]bool{"pvc-stale": true} },
+			want:    true,
+			wantPV:  "pv-a",
+			wantPod: "mixed",
+		},
 	}
 
 	for _, tc := range tests {
@@ -396,6 +421,32 @@ func TestPodMountWedge(t *testing.T) {
 
 // TestCheckStuckVolumeMountEpisode walks one wedge episode through the attempt
 // cap and the cooldown, then confirms a cleared wedge re-arms recovery.
+// TestCheckStuckVolumeMountOrphanNoRestart pins the whole point of the gate: an
+// orphaned upload PVC has the full wedge signature, so without the gate this tick
+// would restart k3s -- and go on doing it after every reboot, since the attempt
+// cap is in-memory. Nothing must be signaled, and no episode may be opened.
+func TestCheckStuckVolumeMountOrphanNoRestart(t *testing.T) {
+	f := wedgeFakes(t)
+	f.unwantedPVCs = map[string]bool{"pvc-a": true}
+	t0 := time.Now()
+	pod := pendingPod("cdi-upload-orphan", t0, 2*stuckMountThreshold, "pvc-a")
+	clientset := fake.NewSimpleClientset(&pod)
+	z := &zedkube{nodeName: testNodeName}
+
+	z.checkStuckVolumeMountWithClient(clientset, t0)
+	assert.Equal(t, 0, f.signalCalls, "k3s must not be restarted for a volume no app wants")
+	assert.Equal(t, 0, z.stuckMountRecoverCount, "no episode may be opened")
+	assert.True(t, z.stuckMountSuppressUntil.IsZero(), "no cooldown may be armed")
+	assert.Equal(t, 1, z.stuckMountUnwantedCount, "the skip must be counted for the operator hint")
+
+	// A reboot resets the in-memory counters; the gate must still hold, which is
+	// what stops the per-boot restart storm the field data showed.
+	z2 := &zedkube{nodeName: testNodeName}
+	z2.checkStuckVolumeMountWithClient(clientset, t0.Add(24*time.Hour))
+	assert.Equal(t, 0, f.signalCalls)
+	assert.Equal(t, 0, z2.stuckMountRecoverCount)
+}
+
 func TestCheckStuckVolumeMountEpisode(t *testing.T) {
 	f := wedgeFakes(t)
 	t0 := time.Now()

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -151,6 +151,12 @@ type zedkube struct {
 	// window is live, preventing a false-positive delete of a new VMI that is
 	// legitimately Pending during failover start-up.
 	vmiFailoverSuppressUntil map[string]time.Time
+	// Stuck-volume-mount detector state (node-scoped). stuckMountRecoverCount
+	// counts recovery attempts within the current wedge episode (reset when a
+	// tick observes no wedged pod); stuckMountSuppressUntil is the cooldown
+	// after an attempt so the detector cannot thrash a kubelet restart.
+	stuckMountRecoverCount  int
+	stuckMountSuppressUntil time.Time
 	// lbConfigError is set by resolveLBInterfaces when an LB CIDR from the
 	// controller overlaps with a management port IP. When set, the offending
 	// entry is omitted from EdgeNodeClusterStatus.LBInterfaces and the error
@@ -734,6 +740,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		case <-appStatusTimer.C:
 			zedkubeCtx.checkAppsFailover(zedkubeWdUpdate)
 			zedkubeCtx.checkStuckPendingVMI()
+			zedkubeCtx.checkStuckVolumeMount()
 			zedkubeWdUpdate()
 			zedkubeCtx.checkAppsStatus()
 			zedkubeCtx.reconcileVMIRSAffinity(zedkubeWdUpdate)

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -161,6 +161,12 @@ type zedkube struct {
 	// window is live, preventing a false-positive delete of a new VMI that is
 	// legitimately Pending during failover start-up.
 	vmiFailoverSuppressUntil map[string]time.Time
+	// Stuck-volume-mount detector state (node-scoped). stuckMountRecoverCount
+	// counts recovery attempts within the current wedge episode (reset when a
+	// tick observes no wedged pod); stuckMountSuppressUntil is the cooldown
+	// after an attempt so the detector cannot thrash a kubelet restart.
+	stuckMountRecoverCount  int
+	stuckMountSuppressUntil time.Time
 	// lbConfigError is set by resolveLBInterfaces when an LB CIDR from the
 	// controller overlaps with a management port IP. When set, the offending
 	// entry is omitted from EdgeNodeClusterStatus.LBInterfaces and the error
@@ -709,9 +715,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		log.Fatalf("zedkube: initKubePrefixes %v", err)
 	}
 	// Three separate periodic timers replace the former single appLogTimer.
-	// Each branch runs at most two functions with a watchdog touch in between,
-	// so no single select case can block longer than ~2*kubeAPITimeout (60s) —
-	// well within errorTime (3 min) and safely bracketed by StillRunning calls.
+	// Each branch touches the watchdog between its blocking calls, so no
+	// stretch between two StillRunning calls covers more than two of them and
+	// cannot exceed ~2*kubeAPITimeout (60s) — well within errorTime (3 min).
 	appLogTimer := time.NewTimer(logcollectInterval * time.Second)
 	appStatusTimer := time.NewTimer(logcollectInterval * time.Second)
 	kubeStatsTimer := time.NewTimer(kubeStatsInterval * time.Second)
@@ -744,11 +750,15 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			appLogTimer = time.NewTimer(logcollectInterval * time.Second)
 
 		// Timer 2: failover detection and per-app cluster status.
-		// zedkubeWdUpdate between the two calls resets the watchdog budget
-		// so each function gets its own kubeAPITimeout window.
+		// zedkubeWdUpdate between the calls resets the watchdog budget so each
+		// function gets its own kubeAPITimeout window. checkStuckVolumeMount
+		// needs its own because a recovery attempt adds the supervisor-socket
+		// handshake on top of its pod LIST.
 		case <-appStatusTimer.C:
 			zedkubeCtx.checkAppsFailover(zedkubeWdUpdate)
 			zedkubeCtx.checkStuckPendingVMI()
+			zedkubeWdUpdate()
+			zedkubeCtx.checkStuckVolumeMount()
 			zedkubeWdUpdate()
 			zedkubeCtx.checkAppsStatus()
 			zedkubeCtx.reconcileVMIRSAffinity(zedkubeWdUpdate)

--- a/pkg/pillar/cmd/zedkube/zedkube.go
+++ b/pkg/pillar/cmd/zedkube/zedkube.go
@@ -167,6 +167,10 @@ type zedkube struct {
 	// after an attempt so the detector cannot thrash a kubelet restart.
 	stuckMountRecoverCount  int
 	stuckMountSuppressUntil time.Time
+	// stuckMountUnwantedCount is the last-logged number of attached-but-unmounted
+	// volumes no app config references, so that persistent condition is reported
+	// on change instead of on every tick.
+	stuckMountUnwantedCount int
 	// lbConfigError is set by resolveLBInterfaces when an LB CIDR from the
 	// controller overlaps with a management port IP. When set, the offending
 	// entry is omitted from EdgeNodeClusterStatus.LBInterfaces and the error

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -356,6 +356,13 @@ func (config VolumeRefConfig) VolumeKey() string {
 		config.GenerationCounter+config.LocalGenerationCounter)
 }
 
+// GetPVCName : the kubernetes(longhorn) PVC name of the referenced volume.
+// Must agree with VolumeStatus.GetPVCName, since both name the same object.
+func (config VolumeRefConfig) GetPVCName() string {
+	return fmt.Sprintf("%s-pvc-%d", config.VolumeID.String(),
+		config.GenerationCounter+config.LocalGenerationCounter)
+}
+
 // LogCreate :
 func (config VolumeRefConfig) LogCreate(logBase *base.LogObject) {
 	logObject := base.NewLogObject(logBase, base.VolumeRefConfigLogType, "",

--- a/pkg/pillar/types/volumetypes_test.go
+++ b/pkg/pillar/types/volumetypes_test.go
@@ -36,6 +36,33 @@ func TestVolumeStatusGetPVCNameNoHash(t *testing.T) {
 	assert.NotContains(t, name, "#")
 }
 
+// VolumeRefConfig.GetPVCName
+
+// The stuck-mount detector decides whether to restart k3s by matching a pod's
+// PVC name against the volumes apps reference, so the two spellings of the name
+// must not drift apart.
+func TestVolumeRefConfigGetPVCNameMatchesStatus(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	ref := VolumeRefConfig{
+		VolumeID:               id,
+		GenerationCounter:      2,
+		LocalGenerationCounter: 1,
+		AppUUID:                uuid.Must(uuid.NewV4()),
+	}
+	status := VolumeStatus{
+		VolumeID:               id,
+		GenerationCounter:      2,
+		LocalGenerationCounter: 1,
+	}
+	assert.Equal(t, fmt.Sprintf("%s-pvc-3", id.String()), ref.GetPVCName())
+	assert.Equal(t, status.GetPVCName(), ref.GetPVCName())
+	// AppUUID distinguishes refs to one volume from several apps; it must not
+	// reach the PVC name, or the same volume would resolve to different objects.
+	other := ref
+	other.AppUUID = uuid.Must(uuid.NewV4())
+	assert.Equal(t, ref.GetPVCName(), other.GetPVCName())
+}
+
 // VolumesSnapshotAction.String
 
 func TestVolumesSnapshotActionString(t *testing.T) {


### PR DESCRIPTION
# Description

In cluster mode a Longhorn volume can be attached to a node (block device
present under `/dev/longhorn`, its `VolumeAttachment` reporting `Attached`)
while kubelet never issues `NodeStage` for it. The consuming pod — a CDI
importer or a virt-launcher — then sits in `ContainerCreating`/`Init`
indefinitely with **no `FailedMount` event**, and the app never runs. The stall
is in kubelet's volume manager (shipped via k3s) — not Longhorn, CDI or EVE —
and only a fresh kubelet clears it. Nothing on the device detected or recovered
from this before.

This adds a `zedkube` check (`checkStuckVolumeMount`) that flags a pod left
`Pending` past a threshold on this node whose Longhorn PVC is
attached-but-unmounted and shows no container/init image-pull or crash error
(those are excluded as different failure modes). When it finds one it **restarts
k3s** so kubelet comes back with a fresh volume manager.

The restart mechanism is chosen at run time, because what supervises k3s differs
by branch. Where the kube-init daemon is present its control socket takes a
`restart` verb and runs the daemon's own pre-restart hooks, so that is preferred.
On the stable branches, where `cluster-init.sh` still supervises k3s, there is no
socket; there the only lever is to reset the shell supervisor's restart backoff
and `SIGTERM` the `k3s server` process, which the supervisor then relaunches.
Both are possible because pillar runs in the host PID namespace and shares the
`/run` bind with the kube container. Detecting per attempt keeps one pillar binary
correct on both.

## Only recovering a wedge an app is waiting for

The wedge signature is also matched by a volume nothing is waiting for. EVE
imports a volume by running `virtctl image-upload` against a PVC
(`kubeapi/vitoapiserver.go:443`) and reads completion back off the PVC's CDI
annotations (`cdiUploadIsComplete`, `kubeapi/cdiupload.go:54`). If the app is
torn down mid-flight, the upload pod and its data/scratch PVCs can be left
behind. Nothing reaps them, and CDI re-spawns the upload pod on every boot, so
the pod sits `Pending` on a volume that is genuinely attached with its device
genuinely present — indistinguishable from a kubelet wedge from the outside.

A k3s restart cannot complete an upload nobody will ever send, so each attempt
bought a control-plane outage and no progress. Worse, the per-episode attempt cap
is in-memory, so every reboot re-armed the detector: a lab run recorded **ten
futile recoveries out of twelve**, driven by two stale volumes, and the steady
state was three gratuitous k3s restarts per boot indefinitely.

So recovery now requires that some app instance still references the volume.
`VolumeRefConfig.GetPVCName()` resolves to the same name `VolumeStatus` already
resolves to, and zedkube already subscribes to `AppInstanceConfig`, so this is a
local pubsub lookup with no apiserver call. Placed ahead of the PVC and
`VolumeAttachment` lookups, it also keeps those off the stale path entirely. A
volume nothing references is counted and logged once — on change, not every tick
— pointing an operator at the stale object rather than at kubelet.

Recovery remains **rate-limited per episode** — bounded attempts
(`stuckMountMaxRecover`) plus a cooldown (`stuckMountSuppressWindow`). Every
restart logs a distinctive, greppable **`MOUNT-WEDGE-RECOVERY`** marker at Warn
level with the attempt count, the mechanism used, and the wedged pod/PV. Setting
`stuckMountDryRun` in the source disables the action and leaves only detection
logging.

## How to test and validate this PR

On an EVE-k device, when a pod is stuck `ContainerCreating` on an
attached-but-unmounted Longhorn volume for more than ~5 minutes, `zedkube`
restarts k3s and logs:

```
MOUNT-WEDGE-RECOVERY: restarting kubelet/k3s to clear the volume-mount wedge (attempt N/3): pod=<name> pv=<pv> attached+device-present but unmounted, Pending <dur>
MOUNT-WEDGE-RECOVERY: requested a k3s restart via supervisor socket; attempt N/3, wedge: ...
```

On a stable branch without the kube-init daemon the second line instead reads
`... via SIGTERM ...`, preceded by `sent SIGTERM to k3s server pid(s) [<pids>]`.

k3s/kubelet come back within ~1 minute and the previously wedged pod proceeds
to mount and start. With no wedge present the check logs nothing and resets its
per-episode counter. Grep the device newlog for `MOUNT-WEDGE-RECOVERY` to see
every restart — note `/persist/newlog/collect/` holds only the last ~5 minutes,
so sweep all of `/persist/newlog`, not just `collect/`.

### Validated on hardware

On a lab EVE-k device (single node, EVE-k, ztest suite running) this branch
detected two upload pods that had been `Pending` for 242h with their volumes
attached and devices present, and recovered via the **kube-init supervisor
socket** — `OK: restart scheduled` — which is the path that had never previously
run on a device; all earlier field recoveries used the SIGTERM fallback. The
episode rate limiting behaved as designed: one attempt, then two ticks logging
the cooldown, no escalation, and the counter reset once the wedge cleared.
Across 13 subsequent test cycles and several reboots with no stale volumes
present, the detector stayed silent.

The app-reference gate was then validated on the same device, in both
directions.

**It rejects a volume no app wants.** A PVC and a `Pending` pod were placed on the
node with the complete signature — scheduled here, `ContainerCreating` (so not one
of the excluded error reasons), its `VolumeAttachment` reporting attached and its
`/dev/longhorn` device present — and referenced by no `AppInstanceConfig`. Nothing
happened for the first five minutes, and then, as the pod crossed
`stuckMountThreshold`, zedkube logged

```
checkStuckVolumeMount: 1 attached-but-unmounted volume(s) belong to no app config;
not restarting k3s for them (stale CDI upload PVCs?)
```

with **zero** `MOUNT-WEDGE-RECOVERY`. That line sits after the node, phase,
container-error and age checks, so reaching it means the pod was accepted as a
candidate and rejected by the app-reference check alone. The line appearing exactly
at the five-minute mark, rather than merely being present, is what makes this a
result and not a coincidental silence.

**It still accepts a volume an app wants.** This is the way the change could have
been quietly catastrophic — a gate that rejects everything would disable recovery
altogether while looking healthy. On the running device, the name
`VolumeRefConfig.GetPVCName()` computes from the live `AppInstanceConfig`
(`5171ed29-…-pvc-0`) is exactly the app's real PVC, and that PVC's PV was the one
then attached with its device present. So the gate discriminates rather than
suppressing unconditionally.

Caveat on scope: the injected pod was held in `Pending` by an unresolvable
ConfigMap volume, not by a genuine kubelet staging stall. That exercises the
signature the gate keys on — it never inspects the staging mechanism — but it is
not a reproduction of the underlying kubelet bug.

Since the update the suite has run 20 further tests on this image with **no
detector fires**. Three failed: two are `test_app_assigned_audio` and
`test_app_assigned_com`, which fail on every lap of this box for lack of the
hardware, and the third was caused by the injected probe holding a Longhorn volume
across an app purge — the next two runs of the same test passed once it was removed.

## Changelog notes

No user-facing changes.

## PR Backports

- 17.0-stable: Yes
- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device (detection, socket recovery, and the app-reference gate all validated on hardware)
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

