### PR TITLE
fix(kubeapi): report replica placement node for non-running replicas

### DIFF
--- a/pkg/pillar/kubeapi/longhorninfo.go
+++ b/pkg/pillar/kubeapi/longhorninfo.go
@@ -318,7 +318,7 @@ func populateKVIInner(
 
 		kviRep := types.KubeVolumeReplicaInfo{}
 		kviRep.Name = lhReplica.ObjectMeta.Name
-		kviRep.OwnerNode = ""
+		kviRep.OwnerNode = lhReplica.Spec.NodeID
 		kviRep.RebuildProgressPercentage = 0
 
 		replicaEngineName := lhReplica.Spec.EngineName
@@ -328,7 +328,6 @@ func populateKVIInner(
 		switch lhReplica.Status.CurrentState {
 		case lhv1beta2.InstanceStateRunning:
 			kviRep.Status = types.StorageVolumeReplicaStatusOnline
-			kviRep.OwnerNode = lhReplica.Status.OwnerID
 
 			engine, err := lhEngines.Get(ctx, replicaEngineName, metav1.GetOptions{})
 			if err != nil {

--- a/pkg/pillar/kubeapi/longhorninfo_test.go
+++ b/pkg/pillar/kubeapi/longhorninfo_test.go
@@ -656,6 +656,56 @@ func TestPopulateKVIInner(t *testing.T) {
 			},
 		},
 		{
+			// Regression: an offline (Stopped) replica must report the node its
+			// data lives on (Spec.NodeID), not Status.OwnerID. When the data node
+			// is down, Longhorn reassigns Status.OwnerID to a surviving manager
+			// node, so sourcing OwnerNode from OwnerID would misattribute the
+			// offline replica to the wrong node. A running replica keeps reporting
+			// its own node.
+			name:   "offline replica reports data node not owner survivor",
+			pvcs:   stdPVC,
+			lhVols: lhVolDegraded,
+			replicas: funcLHReplicaLister{fn: func(metav1.ListOptions) (*lhv1beta2.ReplicaList, error) {
+				// OwnerID is set to a different node than NodeID on BOTH replicas
+				// so either assertion below fails if OwnerNode is sourced from
+				// Status.OwnerID instead of Spec.NodeID.
+				rRun := fakeReplica("r1", eng1, "10.0.0.1", 8502, lhv1beta2.InstanceStateRunning)
+				rRun.Spec.NodeID = "node-a"
+				rRun.Status.OwnerID = "node-survivor"
+				rOffline := fakeReplica("r2", eng1, "10.0.0.2", 8502, lhv1beta2.InstanceStateStopped)
+				rOffline.Spec.NodeID = "node-b"           // data placement (down node)
+				rOffline.Status.OwnerID = "node-survivor" // survivor manager reconciling the CR
+				return &lhv1beta2.ReplicaList{Items: []lhv1beta2.Replica{rRun, rOffline}}, nil
+			}},
+			engines: funcLHEngineGetter{fn: func(string) (*lhv1beta2.Engine, error) {
+				return fakeEngine(eng1,
+					map[string]lhv1beta2.ReplicaMode{"r1": lhv1beta2.ReplicaModeRW},
+					nil,
+					map[string]string{"r1": r1RawAddr},
+				), nil
+			}},
+			wantSubstate: types.StorageHealthStatusDegraded1ReplicaAvailableNotReplicating,
+			checkFn: func(t *testing.T, kvi *types.KubeVolumeInfo) {
+				rRun := findReplica(kvi, "r1")
+				if rRun == nil {
+					t.Fatal("r1 not found")
+				}
+				if rRun.OwnerNode != "node-a" {
+					t.Errorf("r1.OwnerNode = %q, want %q", rRun.OwnerNode, "node-a")
+				}
+				rOff := findReplica(kvi, "r2")
+				if rOff == nil {
+					t.Fatal("r2 not found")
+				}
+				if rOff.Status != types.StorageVolumeReplicaStatusOffline {
+					t.Errorf("r2.Status = %v, want Offline", rOff.Status)
+				}
+				if rOff.OwnerNode != "node-b" {
+					t.Errorf("r2.OwnerNode = %q, want %q (data node, not owner survivor)", rOff.OwnerNode, "node-b")
+				}
+			},
+		},
+		{
 			name:   "engine fetch error",
 			pvcs:   stdPVC,
 			lhVols: lhVolHealthy,


### PR DESCRIPTION
## Description

populateKVIInner only set KubeVolumeReplicaInfo.OwnerNode inside the InstanceStateRunning case, and sourced it from Status.OwnerID. This had two problems for replicas that are not running (offline/failed):

  1. OwnerNode was left empty, so KubeClusterInfo reported offline replicas with no node at all.
  2. Even if the assignment were hoisted, Status.OwnerID is the longhorn-manager node currently reconciling the CR, not where the replica's data lives. When the data node is down, Longhorn reassigns ownership to a surviving node, so OwnerNode would name the wrong node (e.g. an offline replica whose data is on the down node would be reported as living on the survivor).

Source OwnerNode from Spec.NodeID (the scheduled data placement) unconditionally, before the state switch. Spec.NodeID is stable across stop/fail/rebuild and is guaranteed present for every replica we report (replicaHasNoFsBacking already filters out unscheduled ones). Running replicas are unaffected: their Spec.NodeID and Status.OwnerID coincide in steady state.

Add a TestPopulateKVIInner regression case with an offline replica whose Spec.NodeID differs from Status.OwnerID (the survivor), asserting OwnerNode reports the data node for both the running and offline replica.

## PR dependencies

None

## How to test and validate this PR

1. go tests: `make ZARCH=arm64 TESTPKGS=./kubeapi/... TESTRUN='TestPopulateKVIInner/offline_replica_reports_data_node_not_owner_survivor' test`
2. manual test:
a. deploy a 3 node cluster
b. deploy one or more VM app instances
c. remove power from a node
d. wait for pubsub KubeClusterInfo to report volumes have an offline replica matching the powered off node.

## Changelog notes

Fix empty node name reported in offline replicas.

## PR Backports

```text
- 16.0-stable: No
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
