### PR TITLE
pillar: diagnose stuck EVE-k app bring-up (CDI + readiness gate)

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -719,7 +719,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 				break
 			}
 			if waitForKubevirtFlag {
-				log.Warnf("Domainmgr: WaitForKubernetes kubevirt not ready: %v, retrying", err)
+				log.Warnf("Domainmgr: WaitForKubernetes not satisfied: %v, retrying", err)
 				continue
 			}
 			log.Errorf("Domainmgr: WaitForKubernetes error %v", err)

--- a/pkg/pillar/kubeapi/kubeapi.go
+++ b/pkg/pillar/kubeapi/kubeapi.go
@@ -230,22 +230,28 @@ func WaitForKubernetes(agentName string, ps *pubsub.PubSub, stillRunning *time.T
 	// nodeName is the caller-supplied EVE-k node name (from EdgeNodeInfo.DeviceName),
 	// not os.Hostname().
 	var nodeReadyErr error
+	// Record the last failing sub-check; PollImmediate's timeout error alone does not say which of node/kubevirt/longhorn was unmet.
+	var lastUnmet error
 	doneCh := make(chan struct{}, 1)
 	go func() {
 		nodeReadyErr = wait.PollImmediate(time.Second, time.Minute*20, func() (bool, error) {
 			if err := nodeReadyByName(client, nodeName); err != nil {
+				lastUnmet = fmt.Errorf("node not ready: %w", err)
 				return false, nil
 			}
 			if opts.WaitForKubevirt {
 				if err := waitForKubevirtReady(config); err != nil {
+					lastUnmet = fmt.Errorf("kubevirt not ready: %w", err)
 					return false, nil
 				}
 			}
 			if opts.WaitForLonghorn {
 				if err := checkLonghornReady(client, nodeName); err != nil {
+					lastUnmet = fmt.Errorf("longhorn not ready: %w", err)
 					return false, nil
 				}
 			}
+			lastUnmet = nil
 			return true, nil
 		})
 		doneCh <- struct{}{}
@@ -261,6 +267,9 @@ func WaitForKubernetes(agentName string, ps *pubsub.PubSub, stillRunning *time.T
 	})
 	watches = append(watches, alsoWatch...)
 	pubsub.MultiChannelWatch(watches)
+	if nodeReadyErr != nil && lastUnmet != nil {
+		return fmt.Errorf("%w (last unmet condition: %v)", nodeReadyErr, lastUnmet)
+	}
 	return nodeReadyErr
 }
 

--- a/pkg/pillar/kubeapi/vitoapiserver.go
+++ b/pkg/pillar/kubeapi/vitoapiserver.go
@@ -513,6 +513,26 @@ func RolloutDiskToPVC(ctx context.Context, log *base.LogObject, exists bool,
 		return transientf("PVC Upload for pvc:%s attempts to upload image failed, upload pod:%s does not exist", pvcName, cdiUploadPodName)
 	}
 	uploadNodeName := pod.Spec.NodeName
+	// 3b. The upload pod can reach Ready yet get torn down by CDI (pod.phase Failed /
+	// ContainerStatusUnknown) with the local-path scratch PVC left stuck Terminating —
+	// a wedge the data-vol/PV/engine checks below do not surface, so log it explicitly.
+	log.Noticef("RolloutDiskToPVC pvc:%s upload pod:%s phase:%s cdi.pod.phase:%q cdi.running.reason:%q cdi.running.msg:%q",
+		pvcName, cdiUploadPodName, pod.Status.Phase,
+		pvc.ObjectMeta.Annotations["cdi.kubevirt.io/storage.pod.phase"],
+		pvc.ObjectMeta.Annotations["cdi.kubevirt.io/storage.condition.running.reason"],
+		pvc.ObjectMeta.Annotations["cdi.kubevirt.io/storage.condition.running.message"])
+	scratchName := pvcName + "-scratch"
+	if scratchPvc, scratchErr := PVCGet(scratchName, log); scratchErr != nil {
+		log.Noticef("RolloutDiskToPVC pvc:%s scratch PVC %s not found: %v", pvcName, scratchName, scratchErr)
+	} else {
+		scratchSC := ""
+		if scratchPvc.Spec.StorageClassName != nil {
+			scratchSC = *scratchPvc.Spec.StorageClassName
+		}
+		log.Noticef("RolloutDiskToPVC pvc:%s scratch PVC %s phase:%s terminating:%t storageClass:%q finalizers:%v",
+			pvcName, scratchName, scratchPvc.Status.Phase,
+			scratchPvc.ObjectMeta.DeletionTimestamp != nil, scratchSC, scratchPvc.ObjectMeta.Finalizers)
+	}
 	// 4. Did the PVC claim get a backing pv?
 	lhVol, err := lhVolGet(pvName)
 	if err != nil {


### PR DESCRIPTION
# Description

EVE-k app bring-up after a volume-create can stall in two spots that leave no clear signal in the device's own logs. This adds diagnostics for both; no behavior change. This is useful for troubleshooting issues in the field and also when running regression and stress tests.

1. **CDI upload-pod teardown wedge** (`RolloutDiskToPVC`, follow-up to #6121). When the CDI upload pod reaches Ready and is then torn down — the data PVC shows `pod.phase=Failed` / `ContainerStatusUnknown` and its local-path scratch PVC is left stuck `Terminating` under the `pvc-protection` finalizer — the upload never completes and the volume stays `CREATING_VOLUME`. The existing failure walk inspects only the data PVC/PV/engine and misses this, so log the upload-pod phase, the CDI teardown annotations on the data PVC, and the scratch PVC's phase / deletion-pending / storage class / finalizers.

2. **`WaitForKubernetes` readiness gate.** The boot-time gate polls node-Ready, KubeVirt-CR-Available, and (optionally) Longhorn; on the 20-minute timeout it returned only `"timed out waiting for the condition"`, and domainmgr then logged a hardcoded `"kubevirt not ready"` regardless of which check actually failed. That mislabels a stuck node/Longhorn check as a kubevirt problem and leaves an app wedged at `INSTALLED` undiagnosable from the log alone. Now the returned error names the last unmet sub-check (node / kubevirt / longhorn) and domainmgr logs it verbatim.

Related: #6197 (kubelet mount-wedge detector) covers a distinct wedge — a `Pending` pod whose Longhorn volume is attached but never `NodeStage`d.

## How to test and validate this PR

EVE-k only, and diagnostic-only (readiness gating and volume-create success/failure are unchanged; only log content differs). On an EVE-k device:

- Drive an app-volume CDI import that wedges until `RolloutDiskToPVC` exhausts its retries → `volumemgr` logs the upload-pod / scratch-PVC teardown state in `/persist/newlog`.
- Stall the readiness gate (e.g. kubevirt never reaches Available) → `domainmgr` logs `WaitForKubernetes not satisfied: … (last unmet condition: kubevirt not ready: …)`.

Not covered by an automated test (log output only).

## Changelog notes

No user-facing changes.

## PR Backports

Part of this extends the #6121 diagnostic block, which is not on the current LTS branches.

 -17.0: Yes
- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — N/A (diagnostic logging, no doc change)
- [ ] I've tested my PR on amd64 device — builds cleanly (`gofmt`, `go vet -tags k`) and ships in the resize-allprs-stress soak build; not independently device-verified as a standalone at open time
- [ ] I've tested my PR on arm64 device — no
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
