### PR TITLE
vtpm: mount /config so vtpm detects the SHA256 PCR bank

### DIFF
--- a/pkg/apparmor/profiles/usr.bin.vtpm
+++ b/pkg/apparmor/profiles/usr.bin.vtpm
@@ -20,6 +20,11 @@ profile vtpm /usr/bin/vtpm {
     /dev/tpm0                       rw,
     /dev/tpmrm0                     rw,
 
+    # etpm.IsTpmEnabled() stats these to detect TPM-backed identity, which
+    # gates SHA256 PCR bank detection and the sealed disk-key path.
+    /config/device.cert.pem         r,
+    /config/device.key.pem          r,
+
     # allow executing swtpm
     /usr/bin/swtpm                  Px,
 

--- a/pkg/vtpm/build.yml
+++ b/pkg/vtpm/build.yml
@@ -12,6 +12,7 @@ config:
     - /dev:/dev
     - /run/swtpm:/run/swtpm
     - /persist/swtpm:/persist/swtpm
+    - /config:/config:ro
   devices:
     - path: all
       type: a


### PR DESCRIPTION
# Description

The vTPM that EVE hands to app VMs encrypts its state with a key derived from the host TPM. On devices whose TPM has a SHA256 PCR bank, vtpm is supposed to use the *sealed* key, but it was silently using the old *legacy* NV key instead. The moment that derived key changes (e.g. after a base-OS upgrade), swtpm can no longer decrypt its state, so vtpm resets it.

The reason is is that vtpm picks the key path via anincent `etpm.PCRBankSHA256Enabled()`, and it first calls `etpm.IsTpmEnabled()`, which `stat`s `/config/device.cert.pem` and `/config/device.key.pem`. The vtpm container never mounted `/config`, so inside vtpm `IsTpmEnabled()` was always false, so `PCRBankSHA256Enabled()` always answered "no SHA256 bank" regardless of what the TPM actually has. A "does this TPM have a SHA256 bank?" query has no business reading device-identity files from `/config` really ¯\_(ツ)_/¯ . I fear changing it would alter behavior for every other caller across pillar, so I left it unchanged.

### Fix:
- Mount `/config` read-only into the vtpm container.
- Let the vtpm AppArmor profile read `device.cert.pem` / `device.key.pem`.

## PR dependencies

None

## How to test and validate this PR

On a device/VM whose TPM has a SHA256 PCR bank (i.e. a normal TPM, not SHA1-only):

1. Deploy an app that is given a vTPM and let it come up.
2. Look at the vtpm log around first key use. It must show it **unsealing** the disk key (`Trying to unseal disk key with PCRs ...`) and must **not** mention `the legacy disk key`. Before this fix it takes the legacy path; after, it unseals.
3. Check `dmesg` shows no `apparmor="DENIED" profile="vtpm"` lines touching `/config`.

End-to-end: upgrading from a build without this fix to one with it should keep the app's endorsement key stable instead of resetting it.

## Changelog notes

Fixed a regression in master/16.0.1-lts where, on devices whose TPM has a SHA256 PCR bank, an application's vTPM endorsement key could change after updating to >= 16.0.1-lts, forcing the affected application to be re-provisioned.

## PR Backports

```text
- 17.0.0 : To be backported.
- 16.0-stable: To be backported..
- 14.5-stable: No. getEncryptionKey calls UnsealDiskKeyWithRecovery() directly,
  with no PCRBankSHA256Enabled()/IsTpmEnabled()/config dependency — not affected.
- 13.4-stable: No. Same as 14.5-stable.
```

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
