### PR TITLE
hypervisor: reject config-injection chars in controller-supplied fields

### DIFF
--- a/pkg/pillar/hypervisor/config_validate.go
+++ b/pkg/pillar/hypervisor/config_validate.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package hypervisor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// injectionChars break out of a config directive. The QEMU (-readconfig) and
+// Xen xl configs are line-oriented, so a newline or CR starts a new directive;
+// NUL truncates the value in the C-level hypervisor tooling.
+const injectionChars = "\n\r\x00"
+
+// validateConfigField rejects a controller-supplied value that could inject
+// extra config lines. Quotes and commas are allowed: they are legitimate in
+// paths and kernel command lines and cannot break out of a single line.
+func validateConfigField(name, value string) error {
+	if i := strings.IndexAny(value, injectionChars); i >= 0 {
+		return fmt.Errorf("invalid character %q in %s: control characters "+
+			"are not allowed (possible hypervisor config injection)",
+			value[i], name)
+	}
+	return nil
+}
+
+// validateDomainConfig rejects injectionChars in every controller-supplied
+// string rendered into the QEMU/Xen config, as a single choke point at the top
+// of each CreateDomConfig. It covers the full set of rendered strings, not a
+// subset, so it does not rot as the templates change. Not checked: the
+// cloud-init payload (written to a separate image and may contain newlines),
+// numeric/enum fields and the parsed MAC (cannot carry these chars), and
+// DisplayName (overwritten with the validated domainName before rendering).
+func validateDomainConfig(domainName string, config types.DomainConfig,
+	diskStatusList []types.DiskStatus, aa *types.AssignableAdapters) error {
+
+	fields := []struct {
+		name, value string
+	}{
+		{"domain name", domainName},
+		{"kernel path", config.Kernel},
+		{"ramdisk path", config.Ramdisk},
+		{"device tree path", config.DeviceTree},
+		{"boot loader path", config.BootLoader},
+		{"root device", config.RootDev},
+		{"extra boot args", config.ExtraArgs},
+		{"VNC password", config.VncPasswd},
+	}
+	for _, f := range fields {
+		if err := validateConfigField(f.name, f.value); err != nil {
+			return err
+		}
+	}
+
+	// Xen dtdev= and iomem= list entries.
+	for _, dt := range config.DtDev {
+		if err := validateConfigField("device tree device", dt); err != nil {
+			return err
+		}
+	}
+	for _, im := range config.IOMem {
+		if err := validateConfigField("iomem range", im); err != nil {
+			return err
+		}
+	}
+
+	for i := range diskStatusList {
+		ds := &diskStatusList[i]
+		if err := validateConfigField("disk file location", ds.FileLocation); err != nil {
+			return err
+		}
+		if err := validateConfigField("disk WWN", ds.WWN); err != nil {
+			return err
+		}
+		if err := validateConfigField("disk vdev", ds.Vdev); err != nil {
+			return err
+		}
+	}
+
+	for i := range config.VifList {
+		vif := &config.VifList[i]
+		if err := validateConfigField("bridge name", vif.Bridge); err != nil {
+			return err
+		}
+		if err := validateConfigField("vif name", vif.Vif); err != nil {
+			return err
+		}
+	}
+
+	// Passthrough attributes rendered into the KVM vfio-pci address and the Xen
+	// pci=/irqs=/ioports=/serial=/usb= lines. Only this domain's bundles are
+	// checked, so another app's bad bundle can't block it.
+	if aa != nil {
+		for i := range aa.IoBundleList {
+			ib := &aa.IoBundleList[i]
+			if ib.UsedByUUID != config.UUIDandVersion.UUID {
+				continue
+			}
+			ioFields := []struct {
+				name, value string
+			}{
+				{"PCI address", ib.PciLong},
+				{"IRQ", ib.Irq},
+				{"I/O ports", ib.Ioports},
+				{"serial device", ib.Serial},
+				{"USB address", ib.UsbAddr},
+			}
+			for _, f := range ioFields {
+				if err := validateConfigField(f.name, f.value); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -1729,6 +1729,13 @@ func (ctx KvmContext) CreateDomConfig(domainName string,
 	diskStatusList []types.DiskStatus, aa *types.AssignableAdapters,
 	globalConfig *types.ConfigItemValueMap, swtpmCtrlSock string, file *os.File) error {
 
+	// Reject controller-supplied strings that would let a newline break out of
+	// a config directive and inject extra QEMU sections (config template
+	// injection). This is the single choke point before any template runs.
+	if err := validateDomainConfig(domainName, config, diskStatusList, aa); err != nil {
+		return logError("refusing to build domain config for %s: %v", domainName, err)
+	}
+
 	virtualizationMode := ""
 	bootLoaderSettingsFile, err := getOVMFSettingsFilename(domainName)
 	if err != nil {

--- a/pkg/pillar/hypervisor/kvm_injection_test.go
+++ b/pkg/pillar/hypervisor/kvm_injection_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package hypervisor
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+)
+
+// TestCreateDomConfigInjectionExtraArgs verifies that a newline in a
+// controller-supplied field (VmConfig.ExtraArgs) cannot inject extra QEMU
+// directives: CreateDomConfig rejects it instead of rendering the smuggled
+// [device] section.
+func TestCreateDomConfigInjectionExtraArgs(t *testing.T) {
+	id, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("NewV4 failed: %v", err)
+	}
+
+	// Payload tries to close the append="..." line and add a vfio-pci device.
+	payload := "console=hvc0\"\n\n[device \"injected\"]\n  driver = \"vfio-pci\"\n  host = \"00:1f.0\"\n"
+
+	config := types.DomainConfig{
+		UUIDandVersion: types.UUIDandVersion{UUID: id, Version: "1.0"},
+		VmConfig: types.VmConfig{
+			Kernel:    "/boot/kernel",
+			ExtraArgs: payload,
+			Memory:    1024 * 1024 * 10,
+			VCpus:     2,
+		},
+	}
+
+	conf, err := os.CreateTemp("/tmp", "config-injection")
+	if err != nil {
+		t.Fatalf("Can't create config file: %v", err)
+	}
+	defer os.Remove(conf.Name())
+
+	err = kvmIntel.CreateDomConfig(DefaultDomainName, config, types.DomainStatus{},
+		nil, &types.AssignableAdapters{Initialized: true}, nil, "", conf)
+	if err == nil {
+		t.Fatalf("expected CreateDomConfig to reject the injected ExtraArgs, got nil")
+	}
+
+	result, readErr := os.ReadFile(conf.Name())
+	if readErr != nil {
+		t.Fatalf("reading conf file failed: %v", readErr)
+	}
+	if strings.Contains(string(result), "[device \"injected\"]") {
+		t.Fatalf("injected section rendered despite rejection:\n%s", result)
+	}
+}

--- a/pkg/pillar/hypervisor/xen.go
+++ b/pkg/pillar/hypervisor/xen.go
@@ -153,6 +153,12 @@ func (ctx xenContext) CreateDomConfig(domainName string,
 	config types.DomainConfig, diskStatusList []types.DiskStatus,
 	aa *types.AssignableAdapters, globalConfig *types.ConfigItemValueMap,
 	file *os.File) error {
+	// Reject controller-supplied strings that would let a newline break out of
+	// a config directive and inject extra Xen xl config entries (config
+	// template injection). Shared choke point with the KVM backend.
+	if err := validateDomainConfig(domainName, config, diskStatusList, aa); err != nil {
+		return logError("refusing to build domain config for %s: %v", domainName, err)
+	}
 	xenType := "pvh"
 	rootDev := ""
 	extra := config.ExtraArgs


### PR DESCRIPTION
# Description

The QEMU (`-readconfig`) and Xen (`xl`) config files that `domainmgr` generates are line-oriented: every value sits on its own `key = "value"` line and a new `[section]`/directive begins on a fresh line. Many controller-supplied strings are rendered verbatim into these files with no escaping — boot args, kernel/ramdisk/device-tree/bootloader paths, VNC password, domain name, disk file location/WWN/vdev, bridge/vif names, device-tree and iomem list entries, and the PCI address / IRQ / ioports / serial / USB attributes of every passthrough device assigned to the domain.

A field containing a newline therefore lets a malicious controller terminate the intended directive and smuggle in entirely new config lines — for example an extra `vfio-pci` host-device passthrough or a debug backend that exposes guest memory — none of which EVE ever authorized. This is a config injection.

This PR adds a single validation choke point (`validateDomainConfig`) invoked at the top of both the KVM and Xen `CreateDomConfig`, before any config is written, that checks **every string reaching either config file** and rejects newline, carriage-return and NUL — the characters that actually enable a new-directive break-out. To keep the check from rotting as the config templates evolve, it aims to cover the full set of rendered strings rather than a hand-picked subset:

- Numeric and enum fields (memory, vcpus, disk format, PCI/disk/SATA IDs) and the already-parsed MAC address cannot carry these characters and are skipped.
- The free-form cloud-init payload is skipped too, because it legitimately contains newlines and is written to a **separate** cloud-init image, not this config file.
- Quotes and commas are **not** rejected — they are legitimate in kernel command lines and file paths and, confined to a single line, cannot introduce a new directive on their own.

## How to test and validate this PR

Covered by an automated unit test (`pkg/pillar/hypervisor/kvm_injection_test.go`): it renders a real QEMU config with a malicious `ExtraArgs` value that tries to break out of the `append="..."` line and inject an extra `[device "injected"]` vfio-pci section, and asserts the injected section is no longer emitted (the build is now refused).

Run it with:

```sh
make -C pkg/pillar test
# or, inside `make shell`:
go test -tags kvm ./hypervisor/ -run TestCreateDomConfigInjection -v
```

Manual check: configure an app whose boot args (or any path field) contain a newline via the controller; `domainmgr` refuses to build the domain config and logs `refusing to build domain config for <name>: invalid character ...` instead of writing a config file with attacker-controlled extra directives.

## Changelog notes

Hardened the hypervisor against a malicious controller injecting unauthorized QEMU/Xen configuration (e.g. extra device passthrough) through newline characters in app configuration fields. No user-facing changes for legitimate configurations.

## PR Backports

- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.