### PR TITLE
fix(eve-k): ensure longhorn disk path exists before storage-readiness gates

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -166,6 +166,18 @@ wait_for_vault() {
         logmsg "Vault ready"
 }
 
+# Longhorn is told to use LONGHORN_DISK_PATH as its default disk but only stats
+# it, never creating it; pillar's volumemgr creates it once the vault is
+# unsealed. Block here so we never install/annotate Longhorn against a missing
+# path, which would leave its disk unschedulable.
+wait_for_longhorn_disk_path() {
+        logmsg "Starting wait for Longhorn disk path ${LONGHORN_DISK_PATH}"
+        while [ ! -d "$LONGHORN_DISK_PATH" ]; do
+                sleep 1
+        done
+        logmsg "Longhorn disk path ${LONGHORN_DISK_PATH} ready"
+}
+
 mount_kube_root() {
         persistType=$(cat /run/eve.persist_type)
         if [ "$persistType" = "zfs" ]; then
@@ -217,6 +229,7 @@ setup_prereqs () {
         wait_for_device_name
         chmod o+rw /dev/null
         wait_for_vault
+        wait_for_longhorn_disk_path
         migrate_var_lib
         mount_kube_root
         # We need /var/lib to be mounted before we go for network connection check.

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -248,6 +248,17 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	log.Functionf("processed Vault Status")
 
+	// On EVE-k, user containerd is started by pkg/kube cluster-init.sh, which
+	// blocks until the Longhorn disk dir (/persist/vault/volumes) exists -- and
+	// that dir is created by initializeDirs(). So it must be created before
+	// WaitForUserContainerd below, otherwise volumemgr waits for containerd
+	// while cluster-init waits for the dir (deadlock). The vault is unsealed at
+	// this point, so MkdirAll under it is safe; the later call in the
+	// persistType switch is idempotent and becomes a no-op.
+	if ctx.hvTypeKube {
+		initializeDirs()
+	}
+
 	if err := containerd.WaitForUserContainerd(ps, log, agentName, warningTime, errorTime); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Description

Longhorn is configured to use /persist/vault/volumes as its default disk, but it only stats that path -- it never creates it. The path is created by pillar's volumemgr (initializeDirs), which previously ran only after volumemgr's kubernetes/cluster-storage readiness waits. Those waits block on a Longhorn disk reporting Schedulable=True, so on a genuine first boot -- where the path does not yet exist on the freshly mounted vault -- the disk could never become schedulable until the wait had already timed out.

Close the race on both sides:
- pillar: hoist initializeDirs() to the top of the kube (hvTypeKube) block, right after the vault is unlocked, so the disk directory exists before the readiness gates run. The later call in the persistType switch is idempotent and becomes a no-op; the kube-API-dependent populateExistingVolumesFormatPVC stays after the waits.
- pkg/kube: add wait_for_longhorn_disk_path() and call it in setup_prereqs right after wait_for_vault, so cluster-init never installs/annotates Longhorn against a missing disk path.

## PR dependencies

None

## How to test and validate this PR

Covered by existing evetest 'TestSingleNodeCluster'

## Changelog notes

fix: resolve race in vault/volumes existence between pkg/kube longhorn install and volumemgr init

## PR Backports

- 17.0-stable: Yes
- 16.0-stable: No
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
