### PR TITLE
build: raise default MEDIA_SIZE to 64 GiB for HV=k

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,14 @@ PROTO_LANGS=go python
 HV=$(HV_DEFAULT)
 # Enable development build (disabled by default)
 DEV=n
-# How large to we want the disk to be in Mb
+# How large to we want the disk to be in Mb.
+# HV=k defaults larger so Longhorn on /persist has room after its
+# 25% reserve; kube-init's pre-flight warns otherwise.
+ifeq ($(HV),k)
+MEDIA_SIZE?=65536
+else
 MEDIA_SIZE?=32768
+endif
 # Image type for final disk images
 IMG_FORMAT=qcow2
 ifdef LIVE_UPDATE


### PR DESCRIPTION
# Description

EVE-k (`HV=k`) runs Longhorn on `/persist`. Longhorn refuses to place replicas once a disk drops below its documented `storageMinimalAvailablePercentage` reserve (default 25%). With the historical `MEDIA_SIZE=32768` (32 GiB), a `make live HV=k` produces a qcow2 in which `/persist` ends up small enough that the install-time pre-flight in `kube-init` warns and replicas will not schedule.

Observed on a fresh `make run-live-gui HV=k` run:

```
WARNING: Longhorn default disk /persist has 3 GiB free of 7 GiB; after the 25% Longhorn reserve only ~2 GiB is schedulable (< 16 GiB). Replicas may fail to schedule; a 64 GiB boot disk is recommended for EVE-k.
```

This change raises the `MEDIA_SIZE` default to 64 GiB **only when `HV=k`**, so `make live` / `make run-live` / `make run-live-gui` produce a qcow2 large enough for `/persist` after partitioning. Other HVs (`kvm`, `xen`, `mini`) keep the historical 32 GiB default. An explicit `MEDIA_SIZE=...` on the command line still overrides either default.

The choice of 64 GiB matches the value already documented in `kube-init`'s Longhorn install-time pre-flight warning as the recommended floor for EVE-k.

## How to test and validate this PR

1. `make live HV=k` — the resulting live image should be 64 GiB (qcow2 sparse, so on-host allocation stays small).
2. `make run-live HV=k` (or `run-live-gui`) — inside the VM, `df -h /persist` should show a partition well above 16 GiB free, and `k3s-install.log` should NOT contain the "Replicas may fail to schedule" warning from `kube-init/components`.
3. `make live HV=kvm` — the image should still be 32 GiB (unchanged behaviour).
4. `make live HV=k MEDIA_SIZE=32768` — the explicit override still wins and yields a 32 GiB image.

## Changelog notes

No user-facing changes. Build-time / development-flow default: `make live HV=k` (and the `run-live*` variants) now produce a 64 GiB qcow2 by default instead of 32 GiB, so the bundled Longhorn no longer complains about insufficient schedulable space out of the box.

## PR Backports

- 16.0-stable: No, master-only. Stable branches do not carry the `kube-init` daemon that emits the Longhorn pre-flight warning motivating this change.
- 14.5-stable: No, same reason.
- 13.4-stable: No, same reason.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.