### PR TITLE
[17.0] pillar/cloudconfig: fix path-traversal in WriteFile containment check

### DIFF
--- a/pkg/pillar/utils/cloudconfig/cloudconfig.go
+++ b/pkg/pillar/utils/cloudconfig/cloudconfig.go
@@ -74,8 +74,11 @@ func WriteFile(log *base.LogObject, file WritableFile, rootPath string) error {
 	mode := os.FileMode(perm)
 
 	writePath := filepath.Join(rootPath, file.Path)
-	// sanitize path
-	if !strings.HasPrefix(filepath.Clean(writePath), rootPath) {
+	// Reject any write that escapes rootPath. filepath.Rel expresses the
+	// resolved writePath relative to rootPath: a contained path yields a
+	// normal subpath, while an escape yields ".." or a "../"-prefixed result.
+	rel, err := filepath.Rel(rootPath, writePath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 		return fmt.Errorf("detected possible attempt to write file outside of root path. invalid path %s", file.Path)
 	}
 

--- a/pkg/pillar/utils/cloudconfig/cloudconfig_test.go
+++ b/pkg/pillar/utils/cloudconfig/cloudconfig_test.go
@@ -17,11 +17,20 @@ func TestCloudConfig(t *testing.T) {
 
 	log := base.NewSourceLogObject(logrus.StandardLogger(), "cloudconfig", 0)
 	// create a temporary directory to write files to
-	rootPath, err := os.MkdirTemp("", "cloudconfig_test")
+	baseDir, err := os.MkdirTemp("", "cloudconfig_test")
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %v", err)
 	}
-	t.Cleanup(func() { os.RemoveAll(rootPath) })
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
+
+	// Mirror cas.GetRoofFsPath, whose filepath.Join drops the trailing
+	// separator so rootPath ends in a bare "rootfs" component. This lets the
+	// "sibling directory traversal" case below exercise the prefix bypass: a
+	// sibling such as "rootfs_evil" shares "rootfs" as a leading string.
+	rootPath := filepath.Join(baseDir, "rootfs")
+	if err := os.MkdirAll(rootPath, 0755); err != nil {
+		t.Fatalf("failed to create root path: %v", err)
+	}
 
 	// define the test cases
 	testCases := []struct {
@@ -135,6 +144,21 @@ write_files:
 			expected: []cloudconfig.WritableFile{},
 			errParse: nil,
 			errWrite: fmt.Errorf("detected possible attempt to write file outside of root path. invalid path %s", "../../etc/passwd"),
+		},
+		{
+			// A sibling directory that merely shares a leading string with
+			// rootPath (e.g. "rootfs" vs "rootfs_evil") is still outside it
+			// and must be rejected.
+			name: "sibling directory traversal",
+			input: `#cloud-config
+write_files:
+- path: ../rootfs_evil/etc/profile.d/x.sh
+  content: cHduZWQK
+  permissions: "0644"
+  encoding: b64`,
+			expected: []cloudconfig.WritableFile{},
+			errParse: nil,
+			errWrite: fmt.Errorf("detected possible attempt to write file outside of root path. invalid path %s", "../rootfs_evil/etc/profile.d/x.sh"),
 		},
 		{
 			name: "gzip encoding",


### PR DESCRIPTION
Backport of #6193

- #6193 — pillar/cloudconfig: fix path-traversal in WriteFile containment check

## Description

Security fix (path traversal in a cloud-init `write_files` handler). Clean
cherry-pick of the single commit from the original PR — no adaptations were
needed; the affected code is identical on this branch.

## How to test and validate this PR

See original PR.

## Changelog notes

See original PR.

## Checklist

- [x] The title of the PR follows the backport template: `[<stable-branch>] <original title>`
- [x] I've referenced the original PR (#6193) in the description

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.