### PR TITLE
pillar: Implement console disabling during runtime

### DIFF
--- a/pkg/dom0-ztools/rootfs/usr/bin/rungetty.sh
+++ b/pkg/dom0-ztools/rootfs/usr/bin/rungetty.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
 
 infinite_loop() {
-	while true; do
-		$@
+	stop=0
+	child=""
+	trap 'stop=1; [ -n "$child" ] && kill $child 2> /dev/null' USR1
+	while [ "$stop" -eq 0 ]; do
+		$@ &
+		child=$!
+		wait "$child"
 	done
 }
 

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -11,7 +11,7 @@ ARG BUILD_PKGS_BASE="git gcc linux-headers libc-dev make linux-pam-dev m4 findut
 ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db
 
 FROM lfedge/eve-uefi:d0986c2acfe313bb03370b7073bdbc6066667e7f AS uefi-build
-FROM lfedge/eve-dom0-ztools:4a6b5ec00bb7bcbbac22596339c584b98cf305b1 AS zfs
+FROM lfedge/eve-dom0-ztools:ec0fd42f63df575519665bccd8cc0f85b129fb1f  AS zfs
 RUN mkdir /out
 # copy zfs-related files from dom0-ztools using prepared list of files
 RUN while read -r x; do \

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -3392,7 +3392,7 @@ func mountDirsToUserData(diskStatusList []types.DiskStatus) string {
 		return ""
 	}
 	var sb strings.Builder
-	any := false
+	found := false
 	for i := 1; i < len(diskStatusList); i++ {
 		ds := diskStatusList[i]
 		if ds.Devtype == "cdrom" {
@@ -3400,10 +3400,10 @@ func mountDirsToUserData(diskStatusList []types.DiskStatus) string {
 		}
 		fmt.Fprintf(&sb, "#EVE_VOLMOUNT=%s\n", ds.MountDir)
 		if ds.MountDir != "" {
-			any = true
+			found = true
 		}
 	}
-	if !any {
+	if !found {
 		return ""
 	}
 	return sb.String()

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -515,8 +515,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 	if !domainCtx.setInitialConsoleAccess {
 		log.Functionf("GCComplete but not setInitialConsoleAccess => first boot")
-		// Enable Console
-		domainCtx.consoleAccess = true
+		// Auto-enable the console only while the device is not yet
+		// onboarded to a controller.
+		domainCtx.consoleAccess = !isDeviceOnboarded(ps)
 		updateConsoleAccess(&domainCtx)
 		domainCtx.setInitialConsoleAccess = true
 	}
@@ -4279,10 +4280,41 @@ func updateVgaAccess(ctx *domainContext) {
 
 func updateConsoleAccess(ctx *domainContext) {
 	log.Functionf("updateConsoleAccess(%t)", ctx.consoleAccess)
-	// FIXME: explore the way to stop getty/login
 	if ctx.consoleAccess {
 		startGetty(log)
+	} else {
+		stopGetty(log)
 	}
+}
+
+// isDeviceOnboarded reports whether the device has already been onboarded to a
+// controller.
+func isDeviceOnboarded(ps *pubsub.PubSub) bool {
+	sub, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:   "zedclient",
+		MyAgentName: agentName,
+		TopicImpl:   types.OnboardingStatus{},
+		Persistent:  true,
+		Activate:    false,
+	})
+	if err != nil {
+		log.Errorf("isDeviceOnboarded: subscription failed: %v", err)
+		return false
+	}
+	defer sub.Close()
+	// Activate() populates a persistent subscription synchronously from the
+	// on-disk JSON, so GetAll() below observes the persisted status.
+	if err := sub.Activate(); err != nil {
+		log.Errorf("isDeviceOnboarded: activate failed: %v", err)
+		return false
+	}
+	for _, st := range sub.GetAll() {
+		if status, ok := st.(types.OnboardingStatus); ok &&
+			status.DeviceUUID != nilUUID {
+			return true
+		}
+	}
+	return false
 }
 
 // Track which ones of these are loaded

--- a/pkg/pillar/cmd/domainmgr/handlegetty.go
+++ b/pkg/pillar/cmd/domainmgr/handlegetty.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/shirou/gopsutil/process"
 )
 
 // cmdlineGettyFlag should be aligned with grub.cfg in grub and 001-getty in dom0-ztools
@@ -50,4 +52,34 @@ func startGetty(log *base.LogObject) {
 	}
 	log.Noticeln("getty started")
 	gettyStarted = true
+}
+
+func stopGetty(log *base.LogObject) {
+	if !gettyStarted {
+		return
+	}
+	if hasInitGettyStarted(log) {
+		log.Noticeln("Not killing getty because it was started in init")
+		return
+	}
+
+	// Find and send USR1 signal to all rungetty.sh processes
+	procs, err := process.Processes()
+	if err != nil {
+		log.Errorf("Cannot list processes: %v", err)
+		return
+	}
+	for _, p := range procs {
+		cmdline, _ := p.Cmdline()
+		if strings.Contains(cmdline, "rungetty.sh") {
+			proc, err := os.FindProcess(int(p.Pid))
+			if err != nil {
+				continue
+			}
+			if err := proc.Signal(syscall.SIGUSR1); err != nil {
+				log.Errorf("Failed to signal pid %d: %v", p.Pid, err)
+			}
+		}
+	}
+	gettyStarted = false
 }

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023-2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-dom0-ztools:4a6b5ec00bb7bcbbac22596339c584b98cf305b1 AS dom0
+FROM lfedge/eve-dom0-ztools:ec0fd42f63df575519665bccd8cc0f85b129fb1f  AS dom0
 
 # ===========================================================================
 # C builds (libtpms, swtpm, tpm2-tss, tpm2-tools, ptpm)


### PR DESCRIPTION
# Description

Pillar starts on a fresh boot with USB, VGA and console enabled. This isn't an issue if no serial consoles are present in the cmdline because for video terminals, the TUI + VGA + usb inputs can be disabled during runtime. So as soon as pillar gets the global configuration from the controller, it can disabled all of them. However, if any serial console is present at the cmdline, like console=ttyAMA0, pillar will start getty on that console through the rungetty.sh script, which spawns a getty process on every console from /proc/cmdline. The script use to run a infinte loop, so even if pillar killed the getty process, it would be restarted again.
    
The behavior of rungetty.sh was changed so it really stops getty if it receives a USR1 signal. This commit implements the stopGetty() to send the signal and really stop the console, allowing disabling serial consoles during runtime if if debug.enable.console" is set to false. Also, it always check if device is onboarded during initialization, if device is onboarded, it will not enable console by default but wait until `debug.enable.console` is read.

## How to test and validate this PR

I tested with QEMU, but it can be tested on any device with a working UART console and the `console=<serial device>` is present in the kernel command line.

1. Build and run live image: `make live run-live` or  `make live run-live-gui`, although VGA is not required. The focus is the serial console.
2. First boot device will not be onboarded, so serial console must be enabled and functional
3. Onboard the device
4. Set device property `debug.enable.console` to `false` (if it's not false by default)
5. Serial console must be disabled during runtime for inputs
6. Set device property `debug.enable.console` to `true`
7. Serial console access should be recovered during runtime

Different combinations can also be tried:

1. Set `debug.enable.console` to `false`, reboot the device to ensure serial console is never enabled
2. Set `debug.enable.console` to `true`, reboot the device to ensure serial console is enabled

## Changelog notes

Fix: allow disabling serial consoles at runtime when debug.enable.console is set to false and skip default console enablement on onboarded devices.

## PR Backports

This fix will be required for users running 16.0.x, I think it makes sense to backport at least to 17.0 and 16.0-stable. I can backport to other branches as well, if required.

- [ ] 17.0-stable
- [x] 16.0-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.