### PR TITLE
github/workflows: Fix permissions for assets on publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -310,6 +310,8 @@ jobs:
   trigger_assets:
     if: ${{ (startsWith(github.ref, 'refs/tags/')) && (github.event.repository.full_name == 'lf-edge/eve') }}
     needs: [manifest, eve]
+    permissions:
+      contents: write
     uses: lf-edge/eve/.github/workflows/assets.yml@master  # zizmor: ignore[unpinned-uses] same-repo reusable workflow; @master is this repo's own head, which tagged release builds invoke
     secrets:
       DOCKERHUB_PULL_TOKEN: ${{ secrets.DOCKERHUB_PULL_TOKEN }}


### PR DESCRIPTION
# Description

Commit 0474ec035340a99be37e151ef516043f2a794a69 added scoped permissions to workflows. Permissions to contents were set to read only in the publish workflow, which breaks the creation of releases.

This commit fix the contents permission to write only to the trigger assets job, so releases can be created and assets uploaded.

Fixes the issue with publish workflow:

- https://github.com/lf-edge/eve/actions/runs/30037045726/job/89491018765

## How to test and validate this PR

Run publish workflow.

## Changelog notes

None.

## PR Backports

Only master is affected. No backports needed.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.