### PR TITLE
assets: declare release permissions and fail loudly

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -14,9 +14,13 @@ on:  # yamllint disable-line rule:truthy
       DOCKERHUB_PULL_USER:
         required: true
 
+permissions: {}
+
 jobs:
   create_release:
     runs-on: zededa-ubuntu-2204
+    permissions:
+      contents: write
     outputs:
       release_id: ${{ steps.create_release.outputs.release_id }}
       upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -43,6 +47,8 @@ jobs:
   build:
     runs-on: zededa-ubuntu-2204
     needs: create_release
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -30,16 +30,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_REF: ${{ inputs.tag_ref }}
+          REPO: ${{ github.repository }}
         run: |
+          payload=$(jq -n --arg tag "$TAG_REF" \
+            '{tag_name: $tag, name: $tag, draft: false, prerelease: true}')
           response=$(curl -s --show-error -X POST \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Content-Type: application/json" \
-            -d '{
-              "tag_name": "${{ inputs.tag_ref }}",
-              "name": "${{ inputs.tag_ref }}",
-              "draft": false,
-              "prerelease": true
-            }' https://api.github.com/repos/${{ github.repository }}/releases)
+            -d "$payload" \
+            "https://api.github.com/repos/$REPO/releases")
           release_id=$(echo "$response" | jq -r '.id // empty')
           upload_url=$(echo "$response" | jq -r '.upload_url // empty' | sed -e "s/{?name,label}//")
           if [ -z "$release_id" ] || [ -z "$upload_url" ]; then

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -29,8 +29,9 @@ jobs:
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_REF: ${{ inputs.tag_ref }}
         run: |
-          response=$(curl -s -X POST \
+          response=$(curl -s --show-error -X POST \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Content-Type: application/json" \
             -d '{
@@ -39,9 +40,13 @@ jobs:
               "draft": false,
               "prerelease": true
             }' https://api.github.com/repos/${{ github.repository }}/releases)
-          release_id=$(echo "$response" | jq -r .id)
-          upload_url=$(echo "$response" | jq -r .upload_url | sed -e "s/{?name,label}//")
-          echo $upload_url
+          release_id=$(echo "$response" | jq -r '.id // empty')
+          upload_url=$(echo "$response" | jq -r '.upload_url // empty' | sed -e "s/{?name,label}//")
+          if [ -z "$release_id" ] || [ -z "$upload_url" ]; then
+            echo "::error::Creating release $TAG_REF failed: $response"
+            exit 1
+          fi
+          echo "$upload_url"
           echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
           echo "upload_url=$upload_url" >> "$GITHUB_OUTPUT"
   build:
@@ -180,12 +185,14 @@ jobs:
           for file in assets/*; do
             file_name=$(basename $file)
             echo "Uploading ${file_name}..."
-            upload_response=$(curl -s -X POST \
-              -H "Authorization: Bearer $GITHUB_TOKEN" \
-              -H "Content-Type: application/octet-stream" \
-              -T "$file" \
-              "$UPLOAD_URL?name=$file_name")
-            if echo "$upload_response" | jq -e .id > /dev/null; then
+            # The assignment sits inside the `if` so that a curl exit code does
+            # not trip `bash -e` and abandon the assets queued behind this one.
+            if upload_response=$(curl -s --show-error -X POST \
+                 -H "Authorization: Bearer $GITHUB_TOKEN" \
+                 -H "Content-Type: application/octet-stream" \
+                 -T "$file" \
+                 "$UPLOAD_URL?name=$file_name") \
+               && echo "$upload_response" | jq -e .id > /dev/null; then
               echo "$file_name uploaded successfully."
             else
               echo "::error::Failed to upload $file_name: $upload_response"


### PR DESCRIPTION
# Description

**The key fix for this landed in #6221 (thanks @rene) — this PR is follow-up
cleanup only, and is not needed to unblock a release.**

Background: tagged release builds stopped publishing anything.
Introduced by Claude in #5967, which gave `publish.yml` a workflow-wide
`contents: read` token. Tagged builds hand off to the reusable release-assets
workflow, which creates the GitHub release and then uploads the disk images,
installers, checksums and source bundles into it — all needing a token that can
write repository contents. A called workflow can narrow an inherited token but
never widen it, so release creation was refused. #6221 grants `contents: write`
on the calling job, which restores publishing.

Two things are still worth cleaning up, and both live in `assets.yml`:

**1. The requirement is not recorded where it applies.** `assets.yml` declared no
permissions at all, so it silently took whatever the caller granted. That is why
tightening the caller could break release publishing with nothing in the
release-assets workflow to contradict it — and it is why zizmor never flagged
this file: its `excessive-permissions` audit exempts `workflow_call` workflows,
since their scope comes from the caller. Verified by copying `assets.yml`
byte-for-byte and changing only the trigger to `push`, which makes the audit fire
on both jobs. So the file that embodies the requirement is invisible to the tool
that motivated #5967. Declaring `permissions: {}` plus `contents: write` on the
two jobs that use the releases API does not change the effective token while the
caller grants write, but it puts the requirement where a future caller-side
change can see it, and caps these jobs if a caller ever grants more.

**2. The failure was designed to be silent, and that is what made it expensive.**
`create_release` read `.id` and `.upload_url` with `jq -r` and never checked
either. On refusal both became the literal string `"null"` and the job **exited 0
and reported success**, logging one line: `null`. All ten build jobs then ran to
completion — roughly 20-25 minutes each of installers, live images and source
bundles — before `curl -T … "null?name=…"` failed with exit 6, "couldn't resolve
host". A 403 that was knowable in under a second surfaced ~25 minutes later, in a
different job, as a DNS error, with the real cause nowhere in the logs. See run
[30037045726](https://github.com/lf-edge/eve/actions/runs/30037045726).

This makes a missing id or upload URL fatal and prints the API reply, which
carries the reason (`Resource not accessible by integration`). It also fixes the
upload loop, which the step's own comment says should attempt every asset and
fail once at the end, but which actually stopped at the first file: a `curl` that
never reaches the API returns non-zero and ends the step under `bash -e`.

The value here is that it protects against the *next* cause of a bad upload URL,
not just this one.

## How to test and validate this PR

No automated coverage — the path only runs on a release tag push to
`lf-edge/eve`. Both changes are behavior-preserving on the success path.

The permission plumbing itself is cheap to exercise without an EVE build: a
caller job with `permissions: contents: read`, a reusable callee, and a single
`curl` POST to the releases API reproduces the original failure in about 30
seconds in a scratch repo.

To validate on a real release:

1. Push a throwaway `rc` tag matching the `publish.yml` tag filter.
2. Confirm `trigger_assets / create_release` prints an upload URL under
   `https://uploads.github.com/...`.
3. Confirm the release gets assets from all ten matrix legs, including
   `<arch>.<hv>.<platform>.sha256sums`.

To confirm the error handling, temporarily set the calling job back to
`contents: read`: `create_release` should fail immediately with the API's refusal
message, instead of going green and burning 20 minutes per build job.

Locally verified: `actionlint` with the CI flags is clean; zizmor 1.28.0 with
`.github/zizmor.yml` reports no new findings versus the pre-#5967 tree; and both
shell fragments were exercised against stub inputs, where the upload loop now
walks all files and exits 1 rather than dying with exit 6 on the first.

## Changelog notes

None — CI only, no user-facing changes.

## PR Backports

- 16.0-stable: No. The branch has no `permissions:` block in `publish.yml` and no
  `assets.yml` at all, so it is unaffected.
- 14.5-stable: No, same reason.
- 13.4-stable: No, same reason.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — n/a, no documented behavior changes
- [ ] I've tested my PR on amd64 device — n/a, CI workflow change with no device impact
- [ ] I've tested my PR on arm64 device — n/a, same
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
