### PR TITLE
[17.0] vtpm: mount /config so vtpm detects the SHA256 PCR bank

### DIFF
--- a/pkg/apparmor/profiles/usr.bin.vtpm
+++ b/pkg/apparmor/profiles/usr.bin.vtpm
@@ -20,6 +20,11 @@ profile vtpm /usr/bin/vtpm {
     /dev/tpm0                       rw,
     /dev/tpmrm0                     rw,
 
+    # etpm.IsTpmEnabled() stats these to detect TPM-backed identity, which
+    # gates SHA256 PCR bank detection and the sealed disk-key path.
+    /config/device.cert.pem         r,
+    /config/device.key.pem          r,
+
     # allow executing swtpm
     /usr/bin/swtpm                  Px,
 

--- a/pkg/vtpm/build.yml
+++ b/pkg/vtpm/build.yml
@@ -12,6 +12,7 @@ config:
     - /dev:/dev
     - /run/swtpm:/run/swtpm
     - /persist/swtpm:/persist/swtpm
+    - /config:/config:ro
   devices:
     - path: all
       type: a


### PR DESCRIPTION
Backport of https://github.com/lf-edge/eve/pull/6206