### PR TITLE
Add eden tests workflow for 17.0 stable

### DIFF
--- a/.github/workflows/eden-trusted.yml
+++ b/.github/workflows/eden-trusted.yml
@@ -215,6 +215,19 @@ jobs:
       artifact_run_id: ${{ needs.context.outputs.original_run_id }}
       eden_version: "EVE-16.0-stable"
 
+  tests-17-0-stable:
+    name: ${{ needs.context.outputs.eden_parent_job_title }} for 17.0-stable
+    needs: context
+    if: needs.context.outputs.skip_run == 'false' && needs.context.outputs.pr_base_ref == '17.0-stable'
+    uses: lf-edge/eden/.github/workflows/test.yml@1.0.15
+    secrets: inherit
+    with:
+      eve_image: "evebuild/pr:${{ needs.context.outputs.pr_id }}"
+      eve_log_level: "debug"
+      eve_artifact_name: "eve-${{ needs.context.outputs.hv }}-${{ needs.context.outputs.arch }}-${{ needs.context.outputs.platform }}"
+      artifact_run_id: ${{ needs.context.outputs.original_run_id }}
+      eden_version: "EVE-17.0-stable"
+
   tests-master:
     name: ${{ needs.context.outputs.eden_parent_job_title }} for master
     needs: context


### PR DESCRIPTION
# Description

The 17.0-stable branch is now officially released, so the proper workflow for Eden tests must be added.

## How to test and validate this PR

Run Eden tests workflow on 17.0-stable branch.

## Changelog notes

None.

## PR Backports

- [x] 17.0-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.