### PR TITLE
github/workflows: Fix yetus upstream checkout

### DIFF
--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -34,7 +34,7 @@ jobs:
           # Now diff against the correct base
           git diff upstream/${{ github.base_ref }}...HEAD > ${{ github.workspace }}/pr.patch
           # Get back to upstream master so patch can be applied
-          git checkout upstream/master
+          git checkout upstream/${{ github.base_ref }} -b ${{ github.base_ref }}
           git submodule update --init --recursive
 
       - name: Prepare gitconfig for container


### PR DESCRIPTION
# Description

In order to generate the patch for Yetus, the official EVE repo is added and then the master branch is always checked-out since it's hard coded in the command `git checkout upstream/master`. This will always apply the PR's patch against master and not against the target branch (e.g., 17.0-stable, 16.0-stable, etc). This commit fix the git command to get the corresponding target branch of the PR, so the same yetus workflow can be used across stable branches without changes.

## How to test and validate this PR

Run Yetus workflow.

## Changelog notes

None.

## PR Backports

- [x] 17.0-stable
- [x] 16.0-stable
- [x] 14.5-stable
- [x] 13.4-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.