### PR TITLE
ci: checkout Rust tests with non-root user

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -33,9 +33,6 @@ jobs:
   test:
     name: cargo test (${{ matrix.crate }})
     runs-on: zededa-ubuntu-2204
-    # Reuse the same Rust toolchain image the package Dockerfiles build with.
-    container:
-      image: lfedge/eve-rust:1.93.1-1
     strategy:
       fail-fast: false
       matrix:
@@ -47,15 +44,24 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: cargo test
-        working-directory: ${{ matrix.crate }}
+        # Reuse the same Rust toolchain image the package Dockerfiles build
+        # with. Run it with the runner's UID/GID so files created in the
+        # mounted workspace remain owned by the runner.
+        #
         # The image configures the mold linker for the musl cross target it
         # builds release binaries with; that can't link the host proc-macros a
         # test build pulls in (mold: library not found: gcc). Tests run
         # natively, so drop the cross linker flags and use the default.
-        env:
-          RUSTFLAGS: ""
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: ""
-        run: cargo test --locked
+        run: |
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -e HOME=/tmp \
+            -e RUSTFLAGS="" \
+            -e CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="" \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -w "/workspace/${{ matrix.crate }}" \
+            lfedge/eve-rust:1.93.1-1 \
+            cargo test --locked
 
   # Verify the committed generated contract (Rust + Go union codec) matches what
   # the generator produces. This needs both pkg/pillar and pkg/monitor, so it


### PR DESCRIPTION
# Description

We run all our CI jobs as non-root user - so we need to avoid meddling with file ownership - in this case checking out the whole repo inside a container that runs as root.

## PR dependencies

None.

## How to test and validate this PR

Just run this CI job and see that the next job succeeds (otherwise it will fail to checkout the repo because the .git directory belongs to root).

## Changelog notes

N/A

## PR Backports

- 16.0-stable: Backport together with https://github.com/lf-edge/eve/pull/6003
- 14.5-stable: Backport together with https://github.com/lf-edge/eve/pull/6003
- 13.4-stable: No, as the workflow is not available there.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
