### PR TITLE
fix(kube): use disable+ so local-storage doesn't clobber servicelb/traefik disable

### DIFF
--- a/pkg/kube/cfg-manifests/03-enc-disable-local-path.yaml
+++ b/pkg/kube/cfg-manifests/03-enc-disable-local-path.yaml
@@ -2,4 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 # Use longhorn storage
-disable: local-storage
+#
+# appends to the base config.yaml's "disable" list
+disable+: local-storage


### PR DESCRIPTION
# Description

 k3s only appends to a "disable" list across config.yaml.d files when
 the key uses the "+" suffix; a bare "disable: local-storage" in
 03-enc-disable-local-path.yaml was replacing the base config.yaml's
 "disable: [servicelb, traefik]" instead of adding to it, silently
 re-enabling k3s's built-in servicelb on every fresh cluster-init.
 see:
 https://docs.k3s.io/installation/configuration#value-merge-behavior

## PR dependencies

## How to test and validate this PR

with this patch, we should see the svclb and traefik disabled in pods and svc.

## Changelog notes

fix(kube): use disable+ so local-storage doesn't clobber servicelb/traefik disable

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
