### PR TITLE
Bump nvidia-jp7 to Jetpack 7.2 and name the Thor CDI kind per board

### DIFF
--- a/.github/workflows/buildondemand.yml
+++ b/.github/workflows/buildondemand.yml
@@ -108,6 +108,9 @@ jobs:
             platform: "nvidia-jp6"
           - arch: arm64
             hv: kvm
+            platform: "nvidia-jp7"
+          - arch: arm64
+            hv: kvm
             platform: "imx8mp_pollux"
           - arch: arm64
             hv: kvm

--- a/docs/HARDWARE-MODEL.md
+++ b/docs/HARDWARE-MODEL.md
@@ -255,6 +255,24 @@ containers can access the GPU on a Jetson Xavier platform through the following 
 }
 ```
 
+### CDI kind naming
+
+The kind is board specific, so the string used in the device model depends on which Jetson board the image targets:
+
+| Platform     | Board            | CDI kind                |
+|--------------|------------------|-------------------------|
+| `nvidia-jp7` | Jetson AGX Thor  | `nvidia.com/thor-gpu`   |
+| `nvidia-jp6` | Jetson Orin      | `nvidia.com/gpu`        |
+| `nvidia-jp5` | Jetson Orin Nano | `nvidia.com/gpu`        |
+| `nvidia-jp5` | Jetson Xavier NX | `nvidia.com/xavier-gpu` |
+
+New boards follow the `nvidia.com/<board>-gpu` convention. The bare `nvidia.com/gpu` of the jp5 Orin Nano and jp6 Orin
+specs predates it and is kept for compatibility with device models already deployed.
+
+Two CDI files must never declare the same kind and device name. The CDI registry treats a duplicated qualified device
+name as a conflict and drops the device from *both* specs, so the GPU would stop being injectable on every board
+involved. This is why a platform supporting several board families gives each one its own kind.
+
 Notice that the CDI mechanism is available only for container Edge Applications running through the __HV_NOHYPER__
 virtualization mode (bare metal). Since it's intend to be used for GPU direct access, only I/O adapters of type HDMI can
 use the CDI string in the device model. Serial devices can also be exposed to bare metal containers in the same way done

--- a/docs/NVIDIA.md
+++ b/docs/NVIDIA.md
@@ -1,7 +1,7 @@
 # How to use EVE-OS on a NVIDIA Jetson platform
 
 NVIDIA Jetpack is the NVIDIA's software stack for Jetson modules and
-developer kits. EVE supports three versions of the Jetpack: 5.1.3, 6.0, and 7.1.
+developer kits. EVE supports three versions of the Jetpack: 5.1.3, 6.0, and 7.2.
 These versions covers different devices from different Jetson platforms, as
 shown by the Tables __1__ and __2__.
 
@@ -14,9 +14,16 @@ Table __1__: Jetpack support. _Source: [Jetson Linux Archive](https://developer.
 
 |            | Jetson T5000 | Jetson T4000 | Jetson AGX Orin | Jetson Orin NX | Jetson Orin Nano |
 |------------|--------------|--------------|-----------------|----------------|------------------|
-| Jetpack 7.1 |:heavy_check_mark:|:heavy_check_mark:| | | |
+| Jetpack 7.2 |:heavy_check_mark:|:heavy_check_mark:| | | |
 
-Table __2__: Jetpack 7.1 support. _Source: [Jetson Linux Archive](https://developer.nvidia.com/embedded/jetson-linux-archive)._
+Table __2__: Jetpack 7.2 support in EVE. _Source: [Jetson Linux Archive](https://developer.nvidia.com/embedded/jetson-linux-archive)._
+
+Note that Jetpack 7.2 (Jetson Linux 39.2) is the first 7.x release covering the
+Jetson Orin family as well, but EVE does not support Orin on the `nvidia-jp7`
+platform yet: use `nvidia-jp6` for Orin devices. Jetpack 7 also drives the Orin
+GPU through a different driver model than Thor does (`nvgpu` rather than
+`openrm`), so the two boards need different kernel modules, firmware and CDI
+specs even though they share one Jetpack release.
 
 For each Jetpack version supported, EVE provides all default libraries and
 related files present in a regular installation of Jetpack under
@@ -58,7 +65,7 @@ See [NVIDIA-NX.md](./NVIDIA-NX.md) for instructions on how to build and deploy E
 
 ## How to use on a Jetson Thor device
 
-EVE supports Nvidia Jetpack 7.1 on the [Jetson Thor device](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-thor/). The installation process is pretty standard:
+EVE supports Nvidia Jetpack 7.2 on the [Jetson Thor device](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-thor/). The installation process is pretty standard:
 
 1. Build an installation raw image `make ZARCH=arm64 HV=<kvm or k> PLATFORM=nvidia-jp7 installer-raw` (`xen` is not supported)
 1. Flash the `dist/arm64/current/installer.raw` install EVE image onto an USB Stick [following these instructions](../README.md#3-flash-the-image-to-the-device)

--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -116,7 +116,7 @@ options.
 
 Note that NVIDIA images are only valid for a specific plataform. For
 instance: nvidia-jp6 images cannot be used with any other platform other
-than nvidia-jp6. The same applies for nvidia-jp5.
+than nvidia-jp6. The same applies for nvidia-jp5 and nvidia-jp7.
 
 Example:
 docker run --rm lfedge/eve -f raw -p imx8mq_evk live > live.raw

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -15,12 +15,15 @@ RUN mkdir /wireless-regdb &&\
     tar -xz --strip-components=1 -C /wireless-regdb -f /wireless-regdb.tar.gz &&\
     cp /wireless-regdb/regulatory.db /wireless-regdb/regulatory.db.p7s /lib/firmware
 
-# Nvidia Firmwares for Jetpack 5.1.3, Jetpack 6.0, and Jetpack 7.1
+# Nvidia Firmwares for Jetpack 5.1.3, Jetpack 6.0, and Jetpack 7.2
 ENV JETPACK5_DEB=nvidia-l4t-firmware_35.5.0-20240219203809_arm64.deb
 ENV JETPACK5_URL=https://repo.download.nvidia.com/jetson/t194/pool/main/n/nvidia-l4t-firmware/${JETPACK5_DEB}
 ENV JETPACK6_DEB=nvidia-l4t-firmware_36.3.0-20240506102626_arm64.deb
 ENV JETPACK6_URL=https://repo.download.nvidia.com/jetson/t234/pool/main/n/nvidia-l4t-firmware/${JETPACK6_DEB}
-ENV JETPACK7_DEB=nvidia-l4t-firmware-openrm_38.4.0-20251230160601_arm64.deb
+# Jetpack 7.2 splits the firmware per GPU driver model: -openrm (Thor) and
+# -nvgpu (Orin). Only Thor is supported so far, so only -openrm is fetched;
+# adding Orin means fetching both (and the common nvidia-l4t-firmware).
+ENV JETPACK7_DEB=nvidia-l4t-firmware-openrm_39.2.0-20260601141651_arm64.deb
 ENV JETPACK7_URL=https://repo.download.nvidia.com/jetson/som/pool/main/n/nvidia-l4t-firmware-openrm/${JETPACK7_DEB}
 
 FROM build-base AS generic

--- a/pkg/grub/rootfs.cfg
+++ b/pkg/grub/rootfs.cfg
@@ -361,7 +361,7 @@ function set_arm64_baremetal {
       set_global dom0_console "console=ttyTCU0,115200 console=ttyAMA0,115200 console=tty1"
       set_global dom0_platform_tweaks "fbcon=map:0 nospectre_bhb video=efifb:off bl_prof_dataptr=2031616@0x102C610000 bl_prof_ro_ptr=65536@0x102C600000 nvethernet.macsec_enable=0 eve_install_disk=mmcblk0 eve_persist_disk=nvme0n1"
    fi
-   # Jetson AGX Thor Developer Kit (Jetpack 7.1)
+   # Jetson AGX Thor Developer Kit (Jetpack 7.2)
    if [ "$smb_product" = "NVIDIA Jetson AGX Thor Developer Kit" ]; then
       set_global dom0_console "earlycon=tegra_utc,mmio32,0xc5a0000 console=ttyUTC0,115200 console=tty1"
       set_global dom0_platform_tweaks "clk_ignore_unused fbcon=map:0 nospectre_bhb efi=runtime bl_prof_dataptr=6225920@0x2008010000 bl_prof_ro_ptr=65536@0x20 bl_prof_dataptr=6225920@0x2004010000 bl_prof_ro_ptr=65536@0x2004000000"

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -186,6 +186,50 @@ mount_kube_root() {
 }
 
 #Prereqs
+# Jetpack 7 ships one CDI spec per supported board family, each with its own
+# kind (nvidia.com/thor-gpu, nvidia.com/orin-gpu), so unlike the single
+# nvidia.com/gpu of jp5 and jp6 the kind cannot be baked into config.toml. The
+# k8s device plugin requests devices unqualified and nvidia-container-runtime
+# resolves those through default-kind, so point it at the spec belonging to the
+# board we booted on.
+#
+# config.toml lives on the kube container's own filesystem, so this has to run
+# on every container start rather than once at cluster init.
+set_nvidia_cdi_default_kind() {
+        local ctk_config="/etc/nvidia-container-runtime/config.toml"
+        local cdi_spec cdi_kind
+
+        [ -d /opt/vendor/nvidia ] || return 0
+        [ -f "$ctk_config" ] || return 0
+
+        # jp5 and jp6 declare nvidia.com/gpu, which is already the built-in
+        # default. Leave those released platforms alone.
+        [ "$(cat /opt/vendor/nvidia/eve-platform 2>/dev/null)" = "nvidia-jp7" ] || return 0
+
+        case "$(tr '\0' '\n' < /proc/device-tree/compatible 2>/dev/null)" in
+                *nvidia,tegra264*) cdi_spec="/etc/cdi/jetson-thor.yaml" ;;
+                *nvidia,tegra234*) cdi_spec="/etc/cdi/jetson-orin.yaml" ;;
+                *)
+                        logmsg "NVIDIA CDI: unrecognized Jetson SoC, leaving default-kind unchanged"
+                        return 0
+                        ;;
+        esac
+
+        if [ ! -f "$cdi_spec" ]; then
+                logmsg "NVIDIA CDI: $cdi_spec not present, leaving default-kind unchanged"
+                return 0
+        fi
+
+        cdi_kind=$(sed -n 's/^kind:[[:space:]]*//p' "$cdi_spec" | head -1)
+        if [ -z "$cdi_kind" ]; then
+                logmsg "NVIDIA CDI: no kind in $cdi_spec, leaving default-kind unchanged"
+                return 0
+        fi
+
+        sed -i "s|^default-kind = .*|default-kind = \"${cdi_kind}\"|" "$ctk_config"
+        logmsg "NVIDIA CDI: default-kind set to $cdi_kind from $cdi_spec"
+}
+
 setup_prereqs () {
         if [ ! -f "${K3S_LOG_DIR}/initial_k3s_version" ]; then
                 # Record the k3s version the node is initialized at, this is an important record:
@@ -220,6 +264,8 @@ setup_prereqs () {
         # We need /var/lib to be mounted before we go for network connection check.
         check_network_connection
         check_and_clean_cpu_manager_state
+        # Must happen before containerd starts using nvidia-container-runtime.
+        set_nvidia_cdi_default_kind
 }
 
 config_cluster_roles() {

--- a/pkg/nvidia/Dockerfile
+++ b/pkg/nvidia/Dockerfile
@@ -21,7 +21,7 @@ RUN git config --global user.email 'builder@projecteve.dev' && \
 # Jetpack tarballs
 ENV JETSON_JP5=https://developer.nvidia.com/downloads/embedded/l4t/r35_release_v5.0/release/jetson_linux_r35.5.0_aarch64.tbz2
 ENV JETSON_JP6=https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v3.0/release/jetson_linux_r36.3.0_aarch64.tbz2
-ENV JETSON_JP7=https://developer.nvidia.com/downloads/embedded/L4T/r38_Release_v4.0/release/Jetson_Linux_R38.4.0_aarch64.tbz2
+ENV JETSON_JP7=https://developer.nvidia.com/downloads/embedded/L4T/r39_Release_v2.0/release/Jetson_Linux_R39.2.0_aarch64.tbz2
 
 # Default Jetpack version
 ENV JETSON_LINUX=${JETSON_JP5}
@@ -96,7 +96,7 @@ RUN mkdir -p /ldconfig-bin && \
 RUN case "${JETPACK_VER}" in \
         jp5) JL_VER=r35.5.0 ;; \
         jp6) JL_VER=r36.3.0 ;; \
-        jp7) JL_VER=r38.4.0 ;; \
+        jp7) JL_VER=r39.2.0 ;; \
         *)   JL_VER="${JETPACK_VER}" ;; \
     esac && \
     register-sbom-pkg.sh -n jetson-linux -v "${JL_VER}" -l proprietary -u https://developer.nvidia.com/embedded/jetson-linux -o /sbom-out && \

--- a/pkg/nvidia/README.md
+++ b/pkg/nvidia/README.md
@@ -27,10 +27,23 @@ The output container will provide a directory /opt/vendor/nvidia, where:
 
 All supported CDI files will be available at /etc/cdi.
 
-The following CDI files are provided:
+One CDI file is provided per board family, under `cdi/<jetpack version>/`:
 
-* jetson-xavier-nx.yaml: For devices based on Jetson Xavier NX
-* jetson-orin-nano.yaml: For devices based on Jetson Orin Nano
+| File                      | Jetpack | Devices          | CDI kind              |
+|---------------------------|---------|------------------|-----------------------|
+| jp5/jetson-xavier-nx.yaml | 5.1.3   | Jetson Xavier NX | nvidia.com/xavier-gpu |
+| jp5/jetson-orin-nano.yaml | 5.1.3   | Jetson Orin Nano | nvidia.com/gpu        |
+| jp6/jetson-orin.yaml      | 6.0     | Jetson Orin      | nvidia.com/gpu        |
+| jp7/jetson-thor.yaml      | 7.2     | Jetson AGX Thor  | nvidia.com/thor-gpu   |
+
+New board families follow the `nvidia.com/<board>-gpu` convention. The bare
+nvidia.com/gpu of the jp5 Orin Nano and jp6 Orin specs predates it and is
+kept so that deployed device models keep working.
+
+The kind must be unique across every file installed in /etc/cdi. Two specs
+declaring the same qualified device name are treated as a conflict by the
+CDI registry, which then drops the device from both of them, disabling the
+GPU on every board involved.
 
 ## CDI generation
 
@@ -80,8 +93,21 @@ should be considered:
 1. Ensure EVE's NVIDIA custom kernel is compatible with the new Jetpack version
 1. Update NVIDIA firmwares on pkg/fw (if required)
 1. Update the Jetpack tarball URL at pkg/nvidia/Dockerfile (JETSON_LINUX)
-1. Generate the CDI yaml files on a running (bare-metal) Jetpack
-1. Adjust device names inside each CDI file (e.g., _nvidia.com/gpu_, etc)
+1. Update the Jetson Linux version in the SBOM registration (JL_VER) at
+   pkg/nvidia/Dockerfile
+1. Generate the CDI yaml files on a running (bare-metal) Jetpack, using the
+   same nvidia-container-toolkit revision as NVIDIA_CONTAINER_TOOLKIT_REV in
+   pkg/nvidia/Dockerfile, and keeping the emitted cdiVersion within the range
+   supported by the CDI library vendored in pillar
+1. Set the kind of each CDI file to `nvidia.com/<board>-gpu`, keeping it unique
+   across all the files installed in /etc/cdi
+1. If the CDI kind of a board changes, check pkg/kube: the default-kind of
+   the nvidia-container-runtime config is derived from the shipped spec, and
+   cluster-init.sh maps a board to its CDI file by name
+1. From Jetpack 7 on, a single Jetpack release can drive different boards with
+   different GPU driver models (Thor uses openrm, Orin uses nvgpu). Those
+   boards need their own kernel modules, firmware packages, udev rules,
+   module load list and CDI spec, even though they share one Jetpack.
 
 ## References
 

--- a/pkg/nvidia/cdi/jp7/jetson-thor.yaml
+++ b/pkg/nvidia/cdi/jp7/jetson-thor.yaml
@@ -1,6 +1,6 @@
 ---
 cdiVersion: 0.5.0
-kind: nvidia.com/gpu
+kind: nvidia.com/thor-gpu
 devices:
   - name: '0'
     containerEdits:


### PR DESCRIPTION
# Description

Bumps the `nvidia-jp7` platform from Jetpack 7.1 (Jetson Linux R38.4.0) to
Jetpack 7.2 (Jetson Linux R39.2.0), and renames the jp7 CDI kind so that the
platform can grow a second board family later.

Jetpack 7.1 supports the Jetson AGX Thor only. Jetpack 7.2 is the first 7.x
release that also covers the Jetson Orin family, and ships as a single BSP
tarball for both. **This PR does not add Orin support** — see "What is not in
this PR" below. It bumps the Jetpack release for Thor and lays the groundwork,
so that the Thor regression surface stays reviewable on its own.

### CDI kind rename (breaking for jp7 device models)

The jp7 spec used `kind: nvidia.com/gpu`, which cannot stay once a second board
family is added to the same Jetpack: the CDI registry treats two specs in the
same directory declaring the same qualified device name as a conflict and drops
the device from *both* of them
(`pkg/pillar/vendor/tags.cncf.io/container-device-interface/pkg/cdi/cache.go`,
`refresh()`), so the GPU would stop being injectable on every board involved.

Thor therefore becomes `nvidia.com/thor-gpu`, following the
`nvidia.com/xavier-gpu` convention already used by the jp5 Jetson Xavier NX
spec. A device model for a Thor must change `nvidia.com/gpu=0` to
`nvidia.com/thor-gpu=0`. **`nvidia-jp7` has not been released, so no deployed
device model is affected.** The jp5 Orin Nano and jp6 Orin specs keep the
legacy `nvidia.com/gpu` name precisely because those platforms are released.

Dropping `nvidia.com/gpu` on jp7 breaks GPU allocation under `HV=k`, because
`nvidia-container-runtime` hardcoded `default-kind = "nvidia.com/gpu"` and that
is the path the k8s device plugin resolves through (it requests devices
unqualified, and the plugin manifest sets no CDI-kind override). Since one kube
image serves every NVIDIA platform, the kind cannot be baked in per platform
either, so `cluster-init.sh` now detects the Jetson SoC from the device-tree
compatible string, picks the CDI spec for that board, and reads the kind out of
the spec itself. jp5 and jp6 are deliberately left untouched.

### Notes on Jetpack 7.2 for whoever picks up Orin

Worth recording, because it shapes the remaining work:

- Jetpack 7 drives the two boards with **different GPU driver models** — Thor
  uses `openrm`, Orin uses `nvgpu`. Confirmed by the r39.2 Developer Guide,
  which lists `nvidia-l4t-rt-kernel-openrm` for Thor and
  `nvidia-l4t-rt-kernel-nvgpu` for Orin.
- The split runs through the whole stack, not just the kernel. The r39.2 `som`
  repository carries parallel `-nvgpu` and `-openrm` variants of
  `nvidia-l4t-kernel`, `-bsp`, `-cuda`, `-firmware`, `-init`, `-multimedia` and
  `-vulkan-sc`. So a single image serving both boards needs two firmware sets
  **and** two `/opt/vendor/nvidia/dist` trees, and `process-cdi.sh` must stop
  extracting every `.deb` it finds into one tree.
- The base kernel version is unchanged at `6.8.12` in both variants, so the
  eve-kernel branch name and `KVER_nvidia-jp7` stay as they are.

## PR dependencies

None.

## How to test and validate this PR

Nothing here can be exercised on amd64; all of it needs a Jetson AGX Thor.

**Build (no device needed)**

```sh
make ZARCH=arm64 PLATFORM=nvidia-jp7 pkg/nvidia pkg/fw
make ZARCH=arm64 HV=kvm PLATFORM=nvidia-jp7 installer-raw
make ZARCH=arm64 HV=k   PLATFORM=nvidia-jp7 installer-raw
# regression: the other NVIDIA platforms must be unaffected
make ZARCH=arm64 HV=kvm PLATFORM=nvidia-jp6 rootfs
make ZARCH=arm64 HV=kvm PLATFORM=nvidia-jp5 rootfs
```

The `pkg/nvidia` build is the real check on the Jetpack 7.2 bump: it downloads
the R39.2.0 BSP and runs the whole `process-cdi.sh` plus
`nvidia-ctk cdi transform root` pipeline against it.

Verify the shipped kind in the built package:

```sh
docker create --name nv lfedge/eve-nvidia:<hash>-nvidia-jp7
docker export nv | tar -xO etc/cdi/jetson-thor.yaml | yq '.kind'   # nvidia.com/thor-gpu
nvidia-ctk cdi list   # must not report "conflicting device"
```

**On a Jetson AGX Thor, HV=kvm**

1. Flash `installer.raw`, install, boot. Note the device needs a Jetpack 7.2
   bootloader in QSPI; a 7.1 bootloader is not sufficient.
2. `cat /etc/eve-platform` → `nvidia-jp7`, `uname -r` → 6.8.x.
3. `ls /etc/cdi/` → `jetson-thor.yaml`; check every `deviceNodes` path in it
   exists (`/dev/nvidia0`, `/dev/nvidia-uvm`, `/dev/fb0`, `/dev/dri/*`, ...).
4. Deploy a CUDA container as a bare-metal (`HV_NOHYPER`) app with an HDMI I/O
   adapter whose `cbattr.cdi` is `nvidia.com/thor-gpu=0`. `nvidia-smi` and a
   `deviceQuery`/`cudaMalloc` must pass inside the container.
5. Negative case: the same app with `nvidia.com/gpu=0` must now fail with a
   clear error rather than hang.

**On a Jetson AGX Thor, HV=k**

1. Confirm the default-kind derivation fired, inside the kube container:
   `grep default-kind /etc/nvidia-container-runtime/config.toml` →
   `nvidia.com/thor-gpu`.
2. `kubectl describe node | grep nvidia.com/gpu` → non-zero (this is the
   *resource* name, which does not change).
3. Same CUDA container as a Pod with `resources.limits: nvidia.com/gpu: 1`.
4. `/var/log/nvidia-container-runtime.log` for kind-resolution errors.

**Automated coverage**

The `set_nvidia_cdi_default_kind()` logic was validated against fixtures under
Alpine busybox `sed` (the kube container runtime) over 10 scenarios: Thor and
Orin selection, missing spec, unknown SoC, absent device tree, jp5/jp6
untouched, absent `eve-platform`, and idempotency across two runs. The fixture
harness is not included in this PR; say the word if it would be useful as a
checked-in test.

## What is not in this PR

Everything below needs hardware I do not have, and I would rather leave it
open than guess at it:

- **Orin support on jp7.** Needs an Orin running bare-metal JL 39.2 to generate
  `cdi/jp7/jetson-orin.yaml`, determine its udev rules and its module load
  list. Orin stays on `nvidia-jp6`.
- **The eve-kernel side.** The jp7 branch builds with `OPENRM=1`, which stubs
  the `nvgpu` target to a no-op and selects `unifiedgpudisp`. Supporting both
  boards from one image means building both display trees into distinct module
  directories, since `nvdisplay` and `unifiedgpudisp` both emit `nvidia.ko`,
  `nvidia-modeset.ko` and `nvidia-drm.ko` at the same `NVIDIA_VERSION` and
  currently install to the same place. That needs validating on a device.
- **The kernel pin.** `kernel-commits.mk` still points at the JL 38.4 commit,
  so a jp7 build today pairs a 38.4 kernel with 39.2 userspace. The eve-kernel
  branch has to be rebased onto R39.2.0 and published first.
- **Regenerating `cdi/jp7/jetson-thor.yaml` on JL 39.2.** Only the `kind` is
  changed here. The `create-symlinks` hook arguments carry driver sonames that
  will have moved with the release, so the spec should be regenerated on a Thor
  rather than hand-edited.
- **Per-board udev/init restructuring** and the **grub cmdline split** for
  Orin, both of which need the device to derive correct values.

## Changelog notes

The `nvidia-jp7` platform is now based on NVIDIA Jetpack 7.2 (Jetson Linux
R39.2.0) instead of Jetpack 7.1. The CDI device name used to give an Edge
Application access to the GPU on a Jetson AGX Thor changes from
`nvidia.com/gpu` to `nvidia.com/thor-gpu`, and device models for Thor devices
must be updated accordingly. Jetson Orin devices are not supported on
`nvidia-jp7` and continue to use `nvidia-jp6`.

## PR Backports

- 16.0-stable: No, `nvidia-jp7` is not available there.
- 14.5-stable: No, `nvidia-jp7` is not available there.
- 13.4-stable: No, `nvidia-jp7` is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Not tested on hardware: I have no Jetson AGX Thor available. The changes are
build-level and, for the `HV=k` part, validated against fixtures as described
above. **This PR should not be merged before someone runs the Thor validation
steps**, in particular that a Jetpack 7.2 image still boots and that GPU
passthrough works under both `HV=kvm` and `HV=k`. Marked as draft for that
reason. amd64 is not applicable — `nvidia-jp7` is arm64 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
