### PR TITLE
pkg/debug: Do not populate productURL and logo fields in the device model

### DIFF
--- a/pkg/debug/spec.sh
+++ b/pkg/debug/spec.sh
@@ -189,7 +189,7 @@ LSPCI_D=$(lspci -D)
 cat <<__EOT__
 {
   "arch": $ARCH,
-  "productURL": "$(cat /persist/status/hardwaremodel 2> /dev/null || cat /config/hardwaremodel 2> /dev/null || echo 'not found' )",
+  "productURL": "",
   "productStatus": "production",
   "attr": {
     "memory": "${MEM}M",

--- a/pkg/debug/spec.sh
+++ b/pkg/debug/spec.sh
@@ -200,8 +200,8 @@ cat <<__EOT__
     "leds": "0"
   },
   "logo": {
-    "logo_back":"/workspace/spec/logo_back_.jpg",
-    "logo_front":"/workspace/spec/logo_front_.jpg"
+    "logo_back":"",
+    "logo_front":""
   },
   "ioMemberList": [
 __EOT__

--- a/pkg/installer/Dockerfile
+++ b/pkg/installer/Dockerfile
@@ -28,7 +28,7 @@ RUN cargo sbom > sbom.spdx.json
 
 RUN cp "/usr/local/my-installer/target/$CARGO_BUILD_TARGET/release/installer" /usr/local/my-installer/target/installer
 
-FROM lfedge/eve-debug:2eecb77c2a7b039e5896c2ca433d6ac6add938ff AS debug
+FROM lfedge/eve-debug:c72b4655d19fa518aa764f6b1eb29d46b7216f7d AS debug
 
 # Dockerfile to build installer img initrd
 FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build


### PR DESCRIPTION
# Description

The productURL field from the device model expects an URL that points to a product page of the device. Such information is not provided through SMBIOS table by default, and usually unlikely to be present. Given some controllers might impose a valid URL, it doesn't make sense to populate this field with the device model, so better to let it empty so it can be populated later with a valid URL without break the device model for the controller.

In the same context, the logo_back and logo_front fields from the device model are populated with default file names by the spec.sh script. However, the upload of the model to the controller will fail if these files don't exist. This PR clears both logo fields, so it makes the upload to controller less error prone. The fields can still be manually populated by the user with the proper image files that do exist in the system.

## How to test and validate this PR

Run `spec.sh`, the `productURL`, `logo_front` and `logo_back` fields of the output model must be empty.

## Changelog notes

`spec.sh`: Do not populate `productURL` and `logo` fields when generating device model, so it can be populated later by the user with a valid URL and file paths.

## PR Backports

This is just a behavior changing to improve portability across controllers, not a bug, so no backports. However, worth to backport to 17.0-stable so it can be included in the next patch release.

- [x] 17.0-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.