### PR TITLE
EVE-k: gate storage readiness correctly and report it truthfully

### DIFF
--- a/evetest/tests/diag/diag_test.go
+++ b/evetest/tests/diag/diag_test.go
@@ -245,9 +245,9 @@ func TestDiagOutput(test *testing.T) {
 	t.Expect(summary).ToNot(ContainSubstring(
 		"ERROR: No management ports passed test"))
 
-	// volumemgr publishes its status only once its startup waits are over,
-	// hence the poll rather than a single read. Its pubsub state lives in the
-	// pillar container, not in the namespace an SSH session lands in.
+	// volumemgr publishes its status once it is past its early startup, hence
+	// the poll rather than a single read. Its pubsub state lives in the pillar
+	// container, not in the namespace an SSH session lands in.
 	var volumeMgrStatus pillartypes.VolumeMgrStatus
 	t.Eventually(func(t Gomega) {
 		output, _, err := device.RunShellScript(
@@ -259,6 +259,5 @@ func TestDiagOutput(test *testing.T) {
 
 	t.Expect(volumeMgrStatus.Initialized).To(BeTrue(),
 		"storage is usable from the start on a node without cluster storage")
-	t.Expect(summary).ToNot(ContainSubstring(
-		"cluster storage did not become ready at startup"))
+	t.Expect(summary).ToNot(ContainSubstring("cluster storage not ready"))
 }

--- a/evetest/tests/diag/diag_test.go
+++ b/evetest/tests/diag/diag_test.go
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for diag, the on-device diagnostic summary EVE prints for an operator.
+
+package diag_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	eveconfig "github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve-api/go/evecommon"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/netmodels"
+	pillartypes "github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// Structural anchors of a complete diag summary. diag prints the sections in a
+// fixed order and only reaches the port sections once it has the blink counter,
+// the device network status and the port config list, so a dump taken early in
+// boot legitimately stops after the application line. The assertions below are
+// therefore polled until one dump carries all of them.
+//
+// A device that reaches the controller takes the short path through the port
+// section: diag prints one line per port and skips the per-port DNS, routing
+// and ping detail along with the "PASS: All management ports passed test"
+// verdict, all of which appear only once connectivity is already broken.
+var (
+	diagHeaderRE = regexp.MustCompile(
+		`(?m)^INFO: updated diag information at \S+ due to \S+$`)
+	deviceLineRE = regexp.MustCompile(
+		`(?m)^(INFO|WARNING|ERROR): device: online attest: .+ vault: .+ pcr: .+$`)
+	appsLineRE = regexp.MustCompile(
+		`(?m)^INFO: applications: \d+ starting, \d+ running$`)
+	portsLineRE = regexp.MustCompile(
+		`(?m)^INFO: Have \d+ total ports\. \d+ ports should be connected to EV controller$`)
+	mgmtPortLineRE = regexp.MustCompile(
+		`(?m)^INFO: Port \S+: .*link: up use: mgmt .+$`)
+)
+
+// TestDiagOutput verifies that diag produces its full diagnostic summary on a
+// healthy, onboarded device, and that an application can retrieve it through
+// the metadata server.
+//
+// Why this matters
+// ----------------
+// diag is EVE's only operator-facing summary of device health: connectivity to
+// the controller, attestation and vault state, application status and the
+// readiness of cluster storage. None of it is reported through the EVE API, so
+// nothing else in the test suites would notice diag going silent, losing a
+// section, or filling with errors on an otherwise healthy device.
+//
+// The output has three sinks, all fed by the same content: /dev/tty1 for a
+// physically attached console, /run/diag.out for a shell on the device, and
+// GET /eve/v1/diag on the metadata server for applications. This test asserts
+// through the metadata endpoint, which is the one documented for consumers and
+// exercises msrv's handler along the way.
+//
+// Network model
+// -------------
+//   - netmodels.SingleEthWithDHCP -- one mgmt+app port with the SDN DNS server
+//     and a static entry for the controller. diag reports per-port
+//     connectivity, so the port must genuinely reach the controller for the
+//     healthy-path assertions to mean anything.
+//
+// Device configuration
+// --------------------
+//   - ethernet0 (eth0, mgmt+app): DHCP.
+//   - A Local NI ("local-ni") with a container application attached, which is
+//     what makes the metadata server reachable at 169.254.169.254 from inside
+//     the application. diag itself does not depend on either.
+//
+// Phases
+// ------
+//  1. Bring up the port, the Local NI and the application, and wait until the
+//     application answers over SSH through the 2222->22 port-forward.
+//  2. Fetch GET /eve/v1/diag from inside the application until one response
+//     carries a complete summary, and assert on its structure: the update
+//     header, the device/attest/vault/pcr line reporting the device online,
+//     the application counts, the summary line naming the device onboarded
+//     and connected, the port count, the management port up, and the
+//     deployed application listed as running.
+//  3. Cross-check the storage state diag reports against volumemgr's own
+//     VolumeMgrStatus publication: on a non-EVE-k node storage is usable from
+//     the start, so the status must say so and diag must not print the
+//     cluster-storage warning.
+//
+// Parameters
+// ----------
+//   - HYPERVISOR: kvm or xen. Kubevirt is skipped -- it is reserved for the
+//     cluster tests, and this test deploys an application.
+func TestDiagOutput(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+	)
+	hypervisor := evetest.GetHypervisorParameterValue()
+	if hypervisor == evetest.HypervisorKubevirt {
+		evetestT.Skipf("HYPERVISOR %s is reserved for the cluster tests",
+			hypervisor)
+	}
+
+	devName := "edge-dev"
+	evetest.Setup(
+		evetest.RequireEdgeDevice{
+			Name:              devName,
+			WithHypervisor:    hypervisor,
+			DeviceReusePolicy: evetest.ResetDeviceConfig,
+		},
+		evetest.RequireNetworkModel{
+			NetworkModel: netmodels.SingleEthWithDHCP,
+		},
+	)
+	device := evetest.GetEdgeDevice(devName)
+	evetest.Checkpoint("setup-done")
+
+	log := evetest.Logger()
+
+	devConfig := evetest.NewEdgeDeviceConfig(devName)
+	dhcpNet := devConfig.AddNetwork(
+		evetest.DHCPNetworkConfig{
+			NetworkType: evecommon.NetworkType_V4Only,
+		})
+	devConfig.AddNetworkAdapter(
+		evetest.NetworkAdapterConfig{
+			LogicalLabel:  "ethernet0",
+			PhysicalLabel: "eth0",
+			InterfaceName: "eth0",
+			NetworkUUID:   dhcpNet,
+			Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+		})
+	device.ApplyConfig(devConfig, true, true)
+
+	niUUID := devConfig.AddNetworkInstance(evetest.LocalNetworkInstanceConfig{
+		DisplayName: "local-ni",
+		Port:        "ethernet0",
+		Subnet:      evetest.IPSubnet("10.11.12.0/24"),
+		DHCPRange: pillartypes.IPRange{
+			Start: evetest.IPAddress("10.11.12.2"),
+			End:   evetest.IPAddress("10.11.12.254"),
+		},
+		Gateway:       evetest.IPAddress("10.11.12.1"),
+		EnableFlowlog: false,
+		MTU:           1500,
+		ForwardLLDP:   false,
+	})
+	appUUID := devConfig.AddApplication(evetest.ApplicationInstanceConfig{
+		DisplayName: "diag-reader",
+		Activate:    true,
+		Image: evetest.DockerContainer{
+			ImageName: "lfedge/evetest-ubuntu-ctr",
+			Tag:       "1.0",
+		},
+		VirtualizationMode: eveconfig.VmMode_HVM,
+		CPUs:               1,
+		MemoryBytes:        500 * evetest.MiB,
+		NetworkAdapters: []evetest.AppNetworkAdapter{
+			evetest.VirtualNetworkAdapter{
+				LogicalLabel:        "vif0",
+				NetworkInstanceUUID: niUUID,
+				MAC:                 evetest.MACAddress("02:16:3e:00:00:01"),
+				PortFwdRules: []evetest.PortFwdRule{
+					{
+						Protocol:     evetest.NetworkProtocolTCP,
+						EdgeNodePort: 2222,
+						AppPort:      22,
+					},
+				},
+				ACLAllowRules: []evetest.ACLAllowRule{
+					{
+						Protocol:     evetest.NetworkProtocolAny,
+						RemoteSubnet: evetest.IPSubnet("0.0.0.0/0"),
+					},
+				},
+			},
+		},
+	})
+	device.ApplyConfig(devConfig, false, false)
+
+	timeoutExcludingDownload := 5 * time.Minute
+	device.WaitUntilAppIsRunning(appUUID, timeoutExcludingDownload)
+	evetest.Checkpoint("app-running")
+
+	appAuth := evetest.UsernamePasswordAuth{
+		Username: "root",
+		Password: "testpassword",
+	}
+	sshTimeout := 20 * time.Second
+	timeout := 3 * time.Minute
+	polling := 3 * time.Second
+
+	log.Infof("Waiting for the application to become reachable over SSH")
+	t.Eventually(func(t Gomega) {
+		output, _, err := device.RunShellScriptInsideApp(appUUID, appAuth,
+			"hostname", sshTimeout, 0)
+		t.Expect(err).ToNot(HaveOccurred())
+		t.Expect(output).To(ContainSubstring(appUUID.String()))
+	}, timeout, polling).Should(Succeed())
+
+	// The status code is appended on its own line so that a non-200 response
+	// is distinguishable from an empty body.
+	const fetchDiag = `curl -sS -w '\nHTTP_STATUS:%{http_code}\n' ` +
+		`http://169.254.169.254/eve/v1/diag`
+
+	log.Infof("Fetching the diag summary from inside the application")
+	var summary string
+	t.Eventually(func(t Gomega) {
+		output, _, err := device.RunShellScriptInsideApp(appUUID, appAuth,
+			fetchDiag, sshTimeout, 0)
+		t.Expect(err).ToNot(HaveOccurred())
+		t.Expect(output).To(ContainSubstring("HTTP_STATUS:200"))
+		summary = strings.SplitN(output, "HTTP_STATUS:", 2)[0]
+
+		t.Expect(summary).To(MatchRegexp(diagHeaderRE.String()),
+			"diag must state when it last updated")
+		t.Expect(summary).To(MatchRegexp(deviceLineRE.String()),
+			"diag must report device, attestation, vault and PCR state")
+		t.Expect(summary).To(MatchRegexp(appsLineRE.String()),
+			"diag must report the application counts")
+		t.Expect(summary).To(ContainSubstring(
+			"INFO: Summary: Connected to EV Controller and onboarded"))
+		t.Expect(summary).To(MatchRegexp(portsLineRE.String()),
+			"diag must report how many ports should reach the controller")
+		t.Expect(summary).To(MatchRegexp(mgmtPortLineRE.String()),
+			"diag must report the management port as up")
+		t.Expect(summary).To(ContainSubstring(fmt.Sprintf(
+			"INFO: App diag-reader uuid %s state RUNNING", appUUID)))
+	}, timeout, polling).Should(Succeed())
+	evetest.Checkpoint("diag-summary-fetched")
+
+	log.Infof("diag summary:\n%s", summary)
+	t.Expect(summary).ToNot(ContainSubstring("WARNING: state "),
+		"the device network state must be SUCCESS")
+	t.Expect(summary).ToNot(ContainSubstring(
+		"ERROR: No management ports passed test"))
+
+	// volumemgr publishes its status only once its startup waits are over,
+	// hence the poll rather than a single read. Its pubsub state lives in the
+	// pillar container, not in the namespace an SSH session lands in.
+	var volumeMgrStatus pillartypes.VolumeMgrStatus
+	t.Eventually(func(t Gomega) {
+		output, _, err := device.RunShellScript(
+			`eve exec pillar cat /run/volumemgr/VolumeMgrStatus/volumemgr.json`,
+			sshTimeout, 0)
+		t.Expect(err).ToNot(HaveOccurred())
+		t.Expect(json.Unmarshal([]byte(output), &volumeMgrStatus)).To(Succeed())
+	}, timeout, polling).Should(Succeed())
+
+	t.Expect(volumeMgrStatus.Initialized).To(BeTrue(),
+		"storage is usable from the start on a node without cluster storage")
+	t.Expect(summary).ToNot(ContainSubstring(
+		"cluster storage did not become ready at startup"))
+}

--- a/evetest/tests/diag/testsuite_test.go
+++ b/evetest/tests/diag/testsuite_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package diag_test
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve/evetest"
+)
+
+// TestDiagSuite drives the scenarios covering diag, EVE's on-device diagnostic
+// summary. diag reports nothing through the EVE API, so these are the only
+// tests that notice it losing a section, going silent, or reporting errors on a
+// healthy device.
+//
+// The suite declares the HYPERVISOR parameter once; every subtest deploys an
+// application to read the summary from the metadata server and reads the value
+// via evetest.GetHypervisorParameterValue().
+//
+// Subtests
+// --------
+//   - TestDiagOutput -- the full summary on a healthy onboarded device, read
+//     through GET /eve/v1/diag, plus a cross-check of the reported cluster
+//     storage state against volumemgr's own publication.
+func TestDiagSuite(test *testing.T) {
+	evetest.Init(test)
+	defer evetest.Close()
+
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+	)
+
+	evetest.RunTestSuite(
+		evetest.TestCase{
+			Test: TestDiagOutput,
+		},
+	)
+}

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -68,6 +68,8 @@ type diagContext struct {
 	zedagentStatus          types.ZedAgentStatus
 	subVaultStatus          pubsub.Subscription
 	vaultStatus             types.VaultStatus
+	subVolumeMgrStatus      pubsub.Subscription
+	volumeMgrStatus         types.VolumeMgrStatus
 	subAppInstanceSummary   pubsub.Subscription
 	appInstanceSummary      types.AppInstanceSummary
 	subAppInstanceStatus    pubsub.Subscription
@@ -349,6 +351,25 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	ctx.subVaultStatus = subVaultStatus
 	subVaultStatus.Activate()
 
+	// Look for VolumeMgrStatus from volumemgr, to show whether cluster storage
+	// became usable on an EVE-k node.
+	subVolumeMgrStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:     "volumemgr",
+		MyAgentName:   agentName,
+		TopicImpl:     types.VolumeMgrStatus{},
+		Activate:      false,
+		Ctx:           &ctx,
+		CreateHandler: handleVolumeMgrStatusCreate,
+		ModifyHandler: handleVolumeMgrStatusModify,
+		WarningTime:   warningTime,
+		ErrorTime:     errorTime,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.subVolumeMgrStatus = subVolumeMgrStatus
+	subVolumeMgrStatus.Activate()
+
 	// Look for AppInstanceSummary from zedmanager
 	subAppInstanceSummary, err := ps.NewSubscription(pubsub.SubscriptionOptions{
 		AgentName:     "zedmanager",
@@ -448,6 +469,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 
 		case change := <-subVaultStatus.MsgChan():
 			subVaultStatus.ProcessChange(change)
+
+		case change := <-subVolumeMgrStatus.MsgChan():
+			subVolumeMgrStatus.ProcessChange(change)
 
 		case change := <-subAppInstanceSummary.MsgChan():
 			subAppInstanceSummary.ProcessChange(change)
@@ -569,6 +593,24 @@ func handleVaultStatusImpl(ctxArg interface{}, key string,
 	}
 	ctx.vaultStatus = status
 	triggerPrintOutput(ctx, "VaultStatus")
+}
+
+func handleVolumeMgrStatusCreate(ctxArg interface{}, key string,
+	statusArg interface{}) {
+	handleVolumeMgrStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleVolumeMgrStatusModify(ctxArg interface{}, key string,
+	statusArg interface{}, oldStatusArg interface{}) {
+	handleVolumeMgrStatusImpl(ctxArg, key, statusArg)
+}
+
+func handleVolumeMgrStatusImpl(ctxArg interface{}, key string,
+	statusArg interface{}) {
+
+	ctx := ctxArg.(*diagContext)
+	ctx.volumeMgrStatus = statusArg.(types.VolumeMgrStatus)
+	triggerPrintOutput(ctx, "VolumeMgrStatus")
 }
 
 func handleAppInstanceSummaryCreate(ctxArg interface{}, key string,
@@ -871,6 +913,14 @@ func printOutput(ctx *diagContext, caller string) {
 		} else {
 			ctx.ph.Print("WARNING: Air-gap mode enabled without LOC configuration\n")
 		}
+	}
+
+	// volumemgr decides once, at startup, whether cluster storage became
+	// usable; a node where it never did cannot create any application volume.
+	// An empty Name means volumemgr has not published a status yet.
+	if ctx.volumeMgrStatus.Name != "" && !ctx.volumeMgrStatus.Initialized {
+		ctx.ph.Print("WARNING: cluster storage did not become ready at startup: %s\n",
+			ctx.volumeMgrStatus.UnmetCondition)
 	}
 
 	// Determine what we print for app summary

--- a/pkg/pillar/cmd/diag/diag.go
+++ b/pkg/pillar/cmd/diag/diag.go
@@ -915,11 +915,11 @@ func printOutput(ctx *diagContext, caller string) {
 		}
 	}
 
-	// volumemgr decides once, at startup, whether cluster storage became
-	// usable; a node where it never did cannot create any application volume.
-	// An empty Name means volumemgr has not published a status yet.
+	// A node whose cluster storage is not usable cannot create any application
+	// volume; the condition says whether volumemgr is still waiting for it or
+	// gave up. An empty Name means volumemgr has not published a status yet.
 	if ctx.volumeMgrStatus.Name != "" && !ctx.volumeMgrStatus.Initialized {
-		ctx.ph.Print("WARNING: cluster storage did not become ready at startup: %s\n",
+		ctx.ph.Print("WARNING: cluster storage not ready: %s\n",
 			ctx.volumeMgrStatus.UnmetCondition)
 	}
 

--- a/pkg/pillar/cmd/diag/printoutput_test.go
+++ b/pkg/pillar/cmd/diag/printoutput_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package diag
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/sirupsen/logrus"
+)
+
+const storageWarning = "WARNING: cluster storage did not become ready at startup"
+
+// printSummary renders one diag summary for the given volumemgr status and
+// returns what landed in the state file. Leaving gotDNS, gotBC and gotDPCList
+// unset stops printOutput right after the storage and application lines, which
+// is as far as these tests need it to go and keeps them free of any pubsub
+// subscription.
+func printSummary(t *testing.T, status types.VolumeMgrStatus) string {
+	t.Helper()
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "diag", 0)
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer devNull.Close()
+	stateFile, err := os.CreateTemp(t.TempDir(), "diag.out")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stateFile.Close()
+
+	ctx := &diagContext{
+		DeviceNetworkStatus:  &types.DeviceNetworkStatus{},
+		DevicePortConfigList: &types.DevicePortConfigList{},
+		volumeMgrStatus:      status,
+	}
+	ctx.ph = PrintIfSpaceInit(devNull, stateFile.Name(), 100, 200)
+	printOutput(ctx, "test")
+
+	content, err := os.ReadFile(stateFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(content)
+}
+
+func TestDiagReportsUnmetStorageCondition(t *testing.T) {
+	const condition = "longhorn not ready: daemonset:longhorn-manager not running on node"
+	out := printSummary(t, types.VolumeMgrStatus{
+		Name:           "volumemgr",
+		UnmetCondition: condition,
+	})
+	if !strings.Contains(out, storageWarning+": "+condition) {
+		t.Fatalf("summary must name the outstanding storage gate, got:\n%s", out)
+	}
+}
+
+func TestDiagQuietWhenStorageIsReady(t *testing.T) {
+	out := printSummary(t, types.VolumeMgrStatus{
+		Name:        "volumemgr",
+		Initialized: true,
+	})
+	if strings.Contains(out, storageWarning) {
+		t.Fatalf("a node with usable storage must not be warned about, got:\n%s", out)
+	}
+}
+
+// volumemgr publishes nothing while its startup waits are still running, and an
+// absent status must not be reported as a storage failure.
+func TestDiagQuietBeforeVolumeMgrPublishes(t *testing.T) {
+	out := printSummary(t, types.VolumeMgrStatus{})
+	if strings.Contains(out, storageWarning) {
+		t.Fatalf("no warning is due before volumemgr publishes, got:\n%s", out)
+	}
+}

--- a/pkg/pillar/cmd/diag/printoutput_test.go
+++ b/pkg/pillar/cmd/diag/printoutput_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const storageWarning = "WARNING: cluster storage did not become ready at startup"
+const storageWarning = "WARNING: cluster storage not ready"
 
 // printSummary renders one diag summary for the given volumemgr status and
 // returns what landed in the state file. Leaving gotDNS, gotBC and gotDPCList
@@ -71,8 +71,7 @@ func TestDiagQuietWhenStorageIsReady(t *testing.T) {
 	}
 }
 
-// volumemgr publishes nothing while its startup waits are still running, and an
-// absent status must not be reported as a storage failure.
+// An absent status must not be reported as a storage failure.
 func TestDiagQuietBeforeVolumeMgrPublishes(t *testing.T) {
 	out := printSummary(t, types.VolumeMgrStatus{})
 	if strings.Contains(out, storageWarning) {

--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -140,12 +140,20 @@ func generateAndPublishVolumeMgrStatus(ctx *volumemgrContext) {
 		log.Error(err)
 		return
 	}
-	st := types.VolumeMgrStatus{
+	st := ctx.volumeMgrStatus(remaining)
+	ctx.pubVolumeMgrStatus.Publish(st.Key(), st)
+}
+
+// volumeMgrStatus describes volumemgr itself: whether storage ever became
+// usable, the gate still outstanding when it did not, and the space left for
+// volumes after everything reserved for EVE has been subtracted.
+func (ctxPtr *volumemgrContext) volumeMgrStatus(remaining uint64) types.VolumeMgrStatus {
+	return types.VolumeMgrStatus{
 		Name:           agentName,
-		Initialized:    true,
+		Initialized:    ctxPtr.storageReady,
+		UnmetCondition: ctxPtr.storageUnmet,
 		RemainingSpace: remaining,
 	}
-	ctx.pubVolumeMgrStatus.Publish(st.Key(), st)
 }
 
 // createOrUpdateDiskMetrics creates or updates metrics for all disks, mountpaths and volumeStatuses

--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -94,9 +94,9 @@ func lookupAppDiskMetric(ctx *volumemgrContext, key string) *types.AppDiskMetric
 	return &status
 }
 
-// diskMetricsTimerTask calculates and publishes disk metrics periodically
-// Also publishes remaining space so nodeagent can decide if we should
-// go into MaintenanceMode.
+// diskMetricsTimerTask calculates and publishes disk metrics periodically.
+// The remaining space nodeagent uses to decide on MaintenanceMode is reported
+// by volumeMgrStatusTask, which reads the metrics published here.
 func diskMetricsTimerTask(ctx *volumemgrContext, handleChannel chan interface{}) {
 	log.Functionln("starting report diskMetricsTimerTask timer task")
 
@@ -105,7 +105,6 @@ func diskMetricsTimerTask(ctx *volumemgrContext, handleChannel chan interface{})
 	ctx.ps.RegisterFileWatchdog(wdName)
 
 	createOrUpdateDiskMetrics(ctx, wdName)
-	generateAndPublishVolumeMgrStatus(ctx)
 
 	diskMetricInterval := time.Duration(ctx.globalConfig.GlobalValueInt(types.DiskScanMetricInterval)) * time.Second
 	max := float64(diskMetricInterval)
@@ -124,35 +123,12 @@ func diskMetricsTimerTask(ctx *volumemgrContext, handleChannel chan interface{})
 			start := time.Now()
 			createOrUpdateDiskMetrics(ctx, wdName)
 			createOrUpdatePvcDiskMetrics(ctx)
-			generateAndPublishVolumeMgrStatus(ctx)
 			ctx.ps.CheckMaxTimeTopic(wdName, "createOrUpdateDiskMetrics", start,
 				warningTime, errorTime)
 
 		case <-stillRunning.C:
 		}
 		ctx.ps.StillRunning(wdName, warningTime, errorTime)
-	}
-}
-
-func generateAndPublishVolumeMgrStatus(ctx *volumemgrContext) {
-	remaining, err := getRemainingDiskSpace(ctx)
-	if err != nil {
-		log.Error(err)
-		return
-	}
-	st := ctx.volumeMgrStatus(remaining)
-	ctx.pubVolumeMgrStatus.Publish(st.Key(), st)
-}
-
-// volumeMgrStatus describes volumemgr itself: whether storage ever became
-// usable, the gate still outstanding when it did not, and the space left for
-// volumes after everything reserved for EVE has been subtracted.
-func (ctxPtr *volumemgrContext) volumeMgrStatus(remaining uint64) types.VolumeMgrStatus {
-	return types.VolumeMgrStatus{
-		Name:           agentName,
-		Initialized:    ctxPtr.storageReady,
-		UnmetCondition: ctxPtr.storageUnmet,
-		RemainingSpace: remaining,
 	}
 }
 

--- a/pkg/pillar/cmd/volumemgr/handlevolume_test.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume_test.go
@@ -22,7 +22,7 @@ func TestIsErrorSourceOnPubSub(t *testing.T) {
 	status.SetErrorWithSource(errStr, types.ContentTreeStatus{}, time.Now())
 	log.Functionf("set error %s", status.Error)
 	ctx := initStatusCtx(t)
-	publishVolumeStatus(&ctx, status)
+	publishVolumeStatus(ctx, status)
 	status = ctx.LookupVolumeStatus(status.Key())
 	assert.True(t, status.HasError())
 	assert.True(t, status.IsErrorSource(types.ContentTreeStatus{}),
@@ -37,8 +37,8 @@ func TestIsErrorSourceOnPubSub(t *testing.T) {
 	assert.Equal(t, "", status.Error)
 }
 
-func initStatusCtx(t *testing.T) volumemgrContext {
-	ctx := volumemgrContext{}
+func initStatusCtx(t *testing.T) *volumemgrContext {
+	ctx := &volumemgrContext{}
 	logger := logrus.StandardLogger()
 	log = base.NewSourceLogObject(logger, "test", 1234)
 	ps := pubsub.New(&pubsub.EmptyDriver{}, logger, log)
@@ -56,7 +56,7 @@ func initStatusCtx(t *testing.T) volumemgrContext {
 // subscriptions/config handleVolumeModify's call chain (updateVolumeStatusRefCount,
 // doUpdateVol, updateVolumeRefStatus) touches, so handleVolumeModify can be
 // exercised directly instead of only its pubsub-facing helpers.
-func initVolumeModifyCtx(t *testing.T) volumemgrContext {
+func initVolumeModifyCtx(t *testing.T) *volumemgrContext {
 	ctx := initStatusCtx(t)
 	ctx.globalConfig = types.DefaultConfigItemValueMap()
 	ctx.volumeConfigCreateDeferredMap = make(map[string]*types.VolumeConfig)
@@ -67,7 +67,7 @@ func initVolumeModifyCtx(t *testing.T) volumemgrContext {
 		AgentName:   "zedagent",
 		MyAgentName: agentName,
 		TopicImpl:   types.VolumeConfig{},
-		Ctx:         &ctx,
+		Ctx:         ctx,
 	})
 	assert.Nil(t, err)
 	ctx.subVolumeConfig = subVolumeConfig
@@ -77,7 +77,7 @@ func initVolumeModifyCtx(t *testing.T) volumemgrContext {
 		AgentName:   "zedmanager",
 		MyAgentName: agentName,
 		TopicImpl:   types.VolumeRefConfig{},
-		Ctx:         &ctx,
+		Ctx:         ctx,
 	})
 	assert.Nil(t, err)
 	ctx.subVolumeRefConfig = subVolumeRefConfig
@@ -110,7 +110,7 @@ func TestHandleVolumeModifyResyncsIsReplicated(t *testing.T) {
 		SubState:     types.VolumeSubStateCreated,
 		IsReplicated: true,
 	}
-	publishVolumeStatus(&ctx, status)
+	publishVolumeStatus(ctx, status)
 
 	// Controller reassigns DNID to this node: same volume, same content,
 	// only IsReplicated flips to false.
@@ -121,7 +121,7 @@ func TestHandleVolumeModifyResyncsIsReplicated(t *testing.T) {
 		IsReplicated: false,
 	}
 
-	handleVolumeModify(&ctx, config.Key(), config, types.VolumeConfig{})
+	handleVolumeModify(ctx, config.Key(), config, types.VolumeConfig{})
 
 	got := ctx.LookupVolumeStatus(config.Key())
 	assert.NotNil(t, got)

--- a/pkg/pillar/cmd/volumemgr/storagereadiness_test.go
+++ b/pkg/pillar/cmd/volumemgr/storagereadiness_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testUnmetCondition = "timed out waiting for the condition (last unmet " +
+	"condition: longhorn not ready: daemonset:longhorn-manager not running on node)"
+
+// A node whose cluster storage never came up must say so, and name the gate it
+// was still waiting on. Reporting success here is indistinguishable, to
+// everything outside volumemgr, from a node that is genuinely healthy.
+func TestVolumeMgrStatusReportsUnmetCondition(t *testing.T) {
+	ctx := volumemgrContext{
+		storageReady: false,
+		storageUnmet: testUnmetCondition,
+	}
+	status := ctx.volumeMgrStatus(1024)
+	assert.False(t, status.Initialized)
+	assert.Equal(t, testUnmetCondition, status.UnmetCondition)
+	assert.Equal(t, uint64(1024), status.RemainingSpace)
+}
+
+func TestVolumeMgrStatusReportsStorageReady(t *testing.T) {
+	ctx := volumemgrContext{storageReady: true}
+	status := ctx.volumeMgrStatus(1024)
+	assert.True(t, status.Initialized)
+	assert.Empty(t, status.UnmetCondition)
+}

--- a/pkg/pillar/cmd/volumemgr/storagereadiness_test.go
+++ b/pkg/pillar/cmd/volumemgr/storagereadiness_test.go
@@ -16,10 +16,8 @@ const testUnmetCondition = "timed out waiting for the condition (last unmet " +
 // was still waiting on. Reporting success here is indistinguishable, to
 // everything outside volumemgr, from a node that is genuinely healthy.
 func TestVolumeMgrStatusReportsUnmetCondition(t *testing.T) {
-	ctx := volumemgrContext{
-		storageReady: false,
-		storageUnmet: testUnmetCondition,
-	}
+	ctx := volumemgrContext{statusTrigger: make(chan struct{}, 1)}
+	ctx.setStorageReadiness(false, testUnmetCondition)
 	status := ctx.volumeMgrStatus(1024)
 	assert.False(t, status.Initialized)
 	assert.Equal(t, testUnmetCondition, status.UnmetCondition)
@@ -27,8 +25,31 @@ func TestVolumeMgrStatusReportsUnmetCondition(t *testing.T) {
 }
 
 func TestVolumeMgrStatusReportsStorageReady(t *testing.T) {
-	ctx := volumemgrContext{storageReady: true}
+	ctx := volumemgrContext{statusTrigger: make(chan struct{}, 1)}
+	ctx.setStorageReadiness(true, "")
 	status := ctx.volumeMgrStatus(1024)
 	assert.True(t, status.Initialized)
 	assert.Empty(t, status.UnmetCondition)
+}
+
+// While the EVE-k cluster-storage wait is still running the status must already
+// say what is outstanding: the wait can last tens of minutes, and a node that
+// reports nothing is indistinguishable from one that never started.
+func TestVolumeMgrStatusReportsPendingWait(t *testing.T) {
+	ctx := volumemgrContext{statusTrigger: make(chan struct{}, 1)}
+	ctx.setStorageReadiness(false, storageWaitPending)
+	status := ctx.volumeMgrStatus(1024)
+	assert.False(t, status.Initialized)
+	assert.Equal(t, storageWaitPending, status.UnmetCondition)
+}
+
+// setStorageReadiness must not block when nothing is draining the trigger, so a
+// verdict recorded before the status task runs cannot wedge startup.
+func TestSetStorageReadinessNeverBlocks(t *testing.T) {
+	ctx := volumemgrContext{statusTrigger: make(chan struct{}, 1)}
+	ctx.setStorageReadiness(false, testUnmetCondition)
+	ctx.setStorageReadiness(true, "")
+	ready, unmet := ctx.storageReadiness()
+	assert.True(t, ready)
+	assert.Empty(t, unmet)
 }

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -9,6 +9,7 @@ package volumemgr
 import (
 	"flag"
 	"fmt"
+	"sync"
 	"time"
 
 	zconfig "github.com/lf-edge/eve-api/go/config"
@@ -89,12 +90,15 @@ type volumemgrContext struct {
 	gcRunning            bool
 	initGced             bool // Will be marked true after initObjects are garbage collected
 
-	// storageReady is false only on an EVE-k node whose cluster storage never
-	// came up; storageUnmet then carries the outstanding gate. Both are
-	// reported through VolumeMgrStatus. Written once during startup, before
-	// the disk-metrics task that reads them is launched.
-	storageReady bool
-	storageUnmet string
+	// storageReady is false while an EVE-k node's cluster storage is not usable,
+	// whether the startup wait is still running or gave up; storageUnmet then
+	// carries the outstanding gate. Both are reported through VolumeMgrStatus.
+	// The startup path writes them while volumeMgrStatusTask reads them from
+	// another goroutine, so storageMu must be held for either.
+	storageMu     sync.Mutex
+	storageReady  bool
+	storageUnmet  string
+	statusTrigger chan struct{}
 
 	globalConfig       *types.ConfigItemValueMap
 	GCInitialized      bool
@@ -178,7 +182,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		hvTypeKube:         base.IsHVTypeKube(),
 		// Only an EVE-k node has cluster storage to wait for; everywhere else
 		// storage is usable as soon as volumemgr is up.
-		storageReady: !base.IsHVTypeKube(),
+		storageReady:  !base.IsHVTypeKube(),
+		statusTrigger: make(chan struct{}, 1),
+	}
+	if ctx.hvTypeKube {
+		ctx.storageUnmet = storageWaitPending
 	}
 	agentbase.Init(&ctx, logger, log, agentName,
 		agentbase.WithPidFile(),
@@ -281,6 +289,12 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	log.Functionf("user containerd ready")
 
+	// Start reporting VolumeMgrStatus before the EVE-k readiness wait below, so
+	// a node stuck on that wait still says which gate is outstanding instead of
+	// staying silent for as long as the wait runs.
+	initStatusPublications(ps, &ctx)
+	go volumeMgrStatusTask(&ctx)
+
 	// wait for kubernetes up if in kube mode, if gets error, move on
 	if ctx.hvTypeKube {
 		log.Noticef("volumemgr run: wait for kubernetes")
@@ -351,7 +365,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			})
 		if err != nil {
 			log.Errorf("volumemgr run: wait for kubernetes error %v", err)
-			ctx.storageUnmet = err.Error()
+			ctx.setStorageReadiness(false, err.Error())
 		} else {
 			log.Noticef("volumemgr run: kubernetes node ready, longhorn ready")
 		}
@@ -382,14 +396,15 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			}
 		}
 		storageDeadline.Stop()
-		ctx.storageReady = storageReady
 		if storageReady {
-			ctx.storageUnmet = ""
+			ctx.setStorageReadiness(true, "")
 			log.Noticef("volumemgr run: cluster storage (longhorn+CDI) ready")
 		} else {
-			if ctx.storageUnmet == "" {
-				ctx.storageUnmet = "cluster storage (longhorn+CDI) not ready"
+			_, unmet := ctx.storageReadiness()
+			if unmet == "" || unmet == storageWaitPending {
+				unmet = "cluster storage (longhorn+CDI) not ready"
 			}
+			ctx.setStorageReadiness(false, unmet)
 			log.Warnf("volumemgr run: timeout waiting for cluster storage; " +
 				"volumes will defer and retry")
 		}
@@ -452,24 +467,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	}
 	ctx.pubResolveConfig = pubResolveConfig
 
-	pubContentTreeStatus, err := ps.NewPublication(pubsub.PublicationOptions{
-		AgentName: agentName,
-		TopicType: types.ContentTreeStatus{},
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	ctx.pubContentTreeStatus = pubContentTreeStatus
-
-	pubVolumeStatus, err := ps.NewPublication(pubsub.PublicationOptions{
-		AgentName: agentName,
-		TopicType: types.VolumeStatus{},
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	ctx.pubVolumeStatus = pubVolumeStatus
-
 	pubVolumeRefStatus, err := ps.NewPublication(pubsub.PublicationOptions{
 		AgentName: agentName,
 		TopicType: types.VolumeRefStatus{},
@@ -515,17 +512,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		log.Fatal(err)
 	}
 	ctx.pubBlobStatus = pubBlobStatus
-
-	pubDiskMetric, err := ps.NewPublication(
-		pubsub.PublicationOptions{
-			AgentName: agentName,
-			TopicType: types.DiskMetric{},
-		},
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-	ctx.pubDiskMetric = pubDiskMetric
 
 	pubAppDiskMetric, err := ps.NewPublication(
 		pubsub.PublicationOptions{
@@ -724,17 +710,6 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		log.Fatal(err)
 	}
 	ctx.pubVolumesSnapStatus = pubVolumesSnapshotStatus
-
-	pubVolumeMgrStatus, err := ps.NewPublication(
-		pubsub.PublicationOptions{
-			AgentName: agentName,
-			TopicType: types.VolumeMgrStatus{},
-		},
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-	ctx.pubVolumeMgrStatus = pubVolumeMgrStatus
 
 	if ctx.casClient, err = cas.NewCAS(casClientType); err != nil {
 		err = fmt.Errorf("Run: exception while initializing CAS client: %s", err.Error())

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -89,6 +89,13 @@ type volumemgrContext struct {
 	gcRunning            bool
 	initGced             bool // Will be marked true after initObjects are garbage collected
 
+	// storageReady is false only on an EVE-k node whose cluster storage never
+	// came up; storageUnmet then carries the outstanding gate. Both are
+	// reported through VolumeMgrStatus. Written once during startup, before
+	// the disk-metrics task that reads them is launched.
+	storageReady bool
+	storageUnmet string
+
 	globalConfig       *types.ConfigItemValueMap
 	GCInitialized      bool
 	vdiskGCTime        uint32 // In seconds; XXX delete when OldVolumeStatus is deleted
@@ -169,6 +176,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		globalConfig:       types.DefaultConfigItemValueMap(),
 		persistType:        persist.ReadPersistType(),
 		hvTypeKube:         base.IsHVTypeKube(),
+		// Only an EVE-k node has cluster storage to wait for; everywhere else
+		// storage is usable as soon as volumemgr is up.
+		storageReady: !base.IsHVTypeKube(),
 	}
 	agentbase.Init(&ctx, logger, log, agentName,
 		agentbase.WithPidFile(),
@@ -341,6 +351,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			})
 		if err != nil {
 			log.Errorf("volumemgr run: wait for kubernetes error %v", err)
+			ctx.storageUnmet = err.Error()
 		} else {
 			log.Noticef("volumemgr run: kubernetes node ready, longhorn ready")
 		}
@@ -371,9 +382,14 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			}
 		}
 		storageDeadline.Stop()
+		ctx.storageReady = storageReady
 		if storageReady {
+			ctx.storageUnmet = ""
 			log.Noticef("volumemgr run: cluster storage (longhorn+CDI) ready")
 		} else {
+			if ctx.storageUnmet == "" {
+				ctx.storageUnmet = "cluster storage (longhorn+CDI) not ready"
+			}
 			log.Warnf("volumemgr run: timeout waiting for cluster storage; " +
 				"volumes will defer and retry")
 		}

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -41,6 +41,15 @@ const (
 	casClientType = "containerd"
 
 	blankVolumeFormat = zconfig.Format_RAW // format of blank volume TODO: make configurable
+
+	// clusterStorageWait bounds the second EVE-k startup wait, the one that
+	// blocks until Longhorn and CDI can serve a volume. It is separate from the
+	// readiness budget kubeapi applies ahead of it: by the time this wait starts
+	// the node and Longhorn are already up, so what remains is mostly CDI
+	// becoming available, and its images have been the slow half on a contended
+	// link. 20 minutes was too tight for that on the topologies where the
+	// Longhorn pull alone ran past it.
+	clusterStorageWait = 30 * time.Minute
 )
 
 var (
@@ -380,7 +389,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		// deliberately coexist so we can observe how often the gate/retry fires
 		// after this wait has passed. Once we decide whether the retry earns its
 		// keep, drop one of the two so a volume is gated in a single place.
-		storageDeadline := time.NewTimer(20 * time.Minute)
+		storageDeadline := time.NewTimer(clusterStorageWait)
 		storageReady := false
 	storageWait:
 		for {

--- a/pkg/pillar/cmd/volumemgr/volumemgrstatus.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgrstatus.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/flextimer"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// storageWaitPending is the condition reported while the EVE-k cluster-storage
+// wait is still running, as opposed to having given up.
+const storageWaitPending = "waiting for cluster storage (longhorn+CDI)"
+
+// initStatusPublications creates the publications volumeMgrStatusTask needs.
+// They are created ahead of the EVE-k cluster-storage wait, rather than with the
+// rest of the publications further down Run(), because the task reports through
+// them while that wait is still in progress.
+func initStatusPublications(ps *pubsub.PubSub, ctx *volumemgrContext) {
+	pubVolumeMgrStatus, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.VolumeMgrStatus{},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.pubVolumeMgrStatus = pubVolumeMgrStatus
+
+	pubContentTreeStatus, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.ContentTreeStatus{},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.pubContentTreeStatus = pubContentTreeStatus
+
+	pubVolumeStatus, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.VolumeStatus{},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.pubVolumeStatus = pubVolumeStatus
+
+	pubDiskMetric, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.DiskMetric{},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx.pubDiskMetric = pubDiskMetric
+}
+
+// volumeMgrStatusTask publishes VolumeMgrStatus for the lifetime of volumemgr:
+// once immediately, then on every trigger from the startup path and on a timer
+// at the disk-metric interval so RemainingSpace keeps up with actual usage.
+//
+// It is the sole publisher of the topic and runs separately from
+// diskMetricsTimerTask so that it can start before the EVE-k cluster-storage
+// wait, which the disk-metrics task runs after. No watchdog is registered: a
+// stall here leaves a stale status, which does not warrant rebooting the device.
+func volumeMgrStatusTask(ctx *volumemgrContext) {
+	log.Functionln("starting volumeMgrStatusTask")
+
+	interval := time.Duration(ctx.globalConfig.GlobalValueInt(
+		types.DiskScanMetricInterval)) * time.Second
+	maxInterval := float64(interval)
+	minInterval := maxInterval * 0.3
+	ticker := flextimer.NewRangeTicker(time.Duration(minInterval),
+		time.Duration(maxInterval))
+
+	for {
+		publishVolumeMgrStatus(ctx)
+		select {
+		case <-ctx.statusTrigger:
+		case <-ticker.C:
+		}
+	}
+}
+
+// publishVolumeMgrStatus publishes volumemgr's own status. A device whose
+// remaining space cannot be determined publishes nothing rather than a zero,
+// which nodeagent would read as a reason to enter MaintenanceMode.
+func publishVolumeMgrStatus(ctx *volumemgrContext) {
+	remaining, err := getRemainingDiskSpace(ctx)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	st := ctx.volumeMgrStatus(remaining)
+	ctx.pubVolumeMgrStatus.Publish(st.Key(), st)
+}
+
+// volumeMgrStatus describes volumemgr itself: whether storage is usable, the
+// gate still outstanding when it is not, and the space left for volumes after
+// everything reserved for EVE has been subtracted.
+func (ctxPtr *volumemgrContext) volumeMgrStatus(remaining uint64) types.VolumeMgrStatus {
+	ready, unmet := ctxPtr.storageReadiness()
+	return types.VolumeMgrStatus{
+		Name:           agentName,
+		Initialized:    ready,
+		UnmetCondition: unmet,
+		RemainingSpace: remaining,
+	}
+}
+
+// setStorageReadiness records the storage verdict and wakes the status task so
+// the change is reported without waiting for the next tick.
+func (ctxPtr *volumemgrContext) setStorageReadiness(ready bool, unmet string) {
+	ctxPtr.storageMu.Lock()
+	ctxPtr.storageReady = ready
+	ctxPtr.storageUnmet = unmet
+	ctxPtr.storageMu.Unlock()
+
+	select {
+	case ctxPtr.statusTrigger <- struct{}{}:
+	default:
+	}
+}
+
+// storageReadiness returns whether storage is usable and, when it is not, the
+// outstanding gate.
+func (ctxPtr *volumemgrContext) storageReadiness() (bool, string) {
+	ctxPtr.storageMu.Lock()
+	defer ctxPtr.storageMu.Unlock()
+	return ctxPtr.storageReady, ctxPtr.storageUnmet
+}

--- a/pkg/pillar/cmd/volumemgr/volumemgrstatus.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgrstatus.go
@@ -100,8 +100,8 @@ func publishVolumeMgrStatus(ctx *volumemgrContext) {
 // volumeMgrStatus describes volumemgr itself: whether storage is usable, the
 // gate still outstanding when it is not, and the space left for volumes after
 // everything reserved for EVE has been subtracted.
-func (ctxPtr *volumemgrContext) volumeMgrStatus(remaining uint64) types.VolumeMgrStatus {
-	ready, unmet := ctxPtr.storageReadiness()
+func (ctx *volumemgrContext) volumeMgrStatus(remaining uint64) types.VolumeMgrStatus {
+	ready, unmet := ctx.storageReadiness()
 	return types.VolumeMgrStatus{
 		Name:           agentName,
 		Initialized:    ready,
@@ -112,22 +112,22 @@ func (ctxPtr *volumemgrContext) volumeMgrStatus(remaining uint64) types.VolumeMg
 
 // setStorageReadiness records the storage verdict and wakes the status task so
 // the change is reported without waiting for the next tick.
-func (ctxPtr *volumemgrContext) setStorageReadiness(ready bool, unmet string) {
-	ctxPtr.storageMu.Lock()
-	ctxPtr.storageReady = ready
-	ctxPtr.storageUnmet = unmet
-	ctxPtr.storageMu.Unlock()
+func (ctx *volumemgrContext) setStorageReadiness(ready bool, unmet string) {
+	ctx.storageMu.Lock()
+	ctx.storageReady = ready
+	ctx.storageUnmet = unmet
+	ctx.storageMu.Unlock()
 
 	select {
-	case ctxPtr.statusTrigger <- struct{}{}:
+	case ctx.statusTrigger <- struct{}{}:
 	default:
 	}
 }
 
 // storageReadiness returns whether storage is usable and, when it is not, the
 // outstanding gate.
-func (ctxPtr *volumemgrContext) storageReadiness() (bool, string) {
-	ctxPtr.storageMu.Lock()
-	defer ctxPtr.storageMu.Unlock()
-	return ctxPtr.storageReady, ctxPtr.storageUnmet
+func (ctx *volumemgrContext) storageReadiness() (bool, string) {
+	ctx.storageMu.Lock()
+	defer ctx.storageMu.Unlock()
+	return ctx.storageReady, ctx.storageUnmet
 }

--- a/pkg/pillar/docs/volumemgr.md
+++ b/pkg/pillar/docs/volumemgr.md
@@ -47,6 +47,8 @@ Volume Manager interacts with the Cloud controller (e.g. zedcontrol) indirectly 
 
 Both VolumeStatus and VolumeConfig use the agentScope mechanism to keep the baseosmgr and zedmanager use separately.
 
+Volume Manager also publishes a single VolumeMgrStatus describing itself rather than any one volume. `RemainingSpace` drives nodeagent's decision to enter MaintenanceMode when the device is out of disk space. `Initialized` says whether storage is usable at all: on an EVE-k node it is the outcome of waiting for cluster storage (Longhorn and CDI) to come up, and when it is false `UnmetCondition` names the gate that was still outstanding, which diag prints on the console.
+
 Volume Manager in turn requests work from downloader and verifier. This consists of a set of objects (all using the agentScope mechanism):
 
 - DownloaderConfig is published by volumemgr and subscribed to by downloader. This specifies the desire to find a downloaded blob for a particular object.

--- a/pkg/pillar/kubeapi/kubeapi.go
+++ b/pkg/pillar/kubeapi/kubeapi.go
@@ -241,7 +241,7 @@ func WaitForKubernetes(agentName string, ps *pubsub.PubSub, stillRunning *time.T
 	var lastUnmet error
 	doneCh := make(chan struct{}, 1)
 	go func() {
-		nodeReadyErr = wait.PollImmediate(time.Second, time.Minute*20, func() (bool, error) {
+		nodeReadyErr = wait.PollImmediate(time.Second, componentsReadyTimeout(opts), func() (bool, error) {
 			if err := nodeReadyByName(client, nodeName); err != nil {
 				lastUnmet = fmt.Errorf("node not ready: %w", err)
 				return false, nil

--- a/pkg/pillar/kubeapi/kubeapi.go
+++ b/pkg/pillar/kubeapi/kubeapi.go
@@ -295,13 +295,21 @@ func checkLonghornReady(client kubernetes.Interface, nodeName string) error {
 		"longhorn-csi-plugin": false,
 		"engine-image":        false,
 	}
-	// Check if each daemonset is running and ready on this node
+	// Check if each daemonset is running and ready on this node. Only the
+	// expected daemonsets above gate readiness: anything else sharing the
+	// namespace is not ours to judge, and a permanently unready stray would
+	// otherwise block every volume on this node for as long as it exists.
 	for _, lhDaemonset := range lhDaemonsets.Items {
 		lhDsName := lhDaemonset.GetName()
+		expected := false
 		for dsPrefix := range lhExpectedDaemonsets {
 			if strings.HasPrefix(lhDsName, dsPrefix) {
 				lhExpectedDaemonsets[dsPrefix] = true
+				expected = true
 			}
+		}
+		if !expected {
+			continue
 		}
 
 		var labelSelectors []string

--- a/pkg/pillar/kubeapi/kubeapi.go
+++ b/pkg/pillar/kubeapi/kubeapi.go
@@ -344,7 +344,7 @@ func checkLonghornReady(client kubernetes.Interface, nodeName string) error {
 		}
 	}
 
-	return nil
+	return instanceManagerReady(ctx, nodeName)
 }
 
 // nodeReadyByName confirms this device's Kubernetes node object exists. nodeName is the

--- a/pkg/pillar/kubeapi/longhorninstancemanager.go
+++ b/pkg/pillar/kubeapi/longhorninstancemanager.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package kubeapi
+
+import (
+	"context"
+	"fmt"
+
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// instanceManagerLister is the subset of the generated Longhorn client this
+// file needs, kept narrow so the state logic below can be exercised without a
+// live API server.
+type instanceManagerLister interface {
+	List(ctx context.Context, opts metav1.ListOptions) (*lhv1beta2.InstanceManagerList, error)
+}
+
+// instanceManagerRunningOnNode reports whether nodeName has an InstanceManager
+// in the running state.
+//
+// Longhorn runs a volume's engine and replica processes inside the
+// instance-manager pod, so the node cannot serve any volume until one is
+// running. The pod is owned by an InstanceManager CR rather than a DaemonSet,
+// which is why the daemonset sweep in checkLonghornReady cannot observe it.
+//
+// InstanceManager.Spec.NodeID carries the Kubernetes node name, the same value
+// checkLonghornReady uses to select per-node DaemonSet pods.
+func instanceManagerRunningOnNode(ctx context.Context, lister instanceManagerLister,
+	nodeName string) (bool, error) {
+	ims, err := lister.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+	for _, im := range ims.Items {
+		if im.Spec.NodeID != nodeName {
+			continue
+		}
+		if im.Status.CurrentState == lhv1beta2.InstanceManagerStateRunning {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// instanceManagerReady is the gate checkLonghornReady applies once the Longhorn
+// DaemonSets look healthy. It is a variable so that tests driving
+// checkLonghornReady with a fake clientset can substitute it: the real
+// implementation builds a Longhorn client from the on-device kubeconfig, which
+// a fake clientset cannot supply.
+var instanceManagerReady = checkLonghornInstanceManagerReady
+
+// checkLonghornInstanceManagerReady fails while nodeName has no running
+// InstanceManager.
+//
+// Longhorn creates the CR during node setup rather than on first volume
+// request, so waiting on it cannot deadlock against a volume whose own creation
+// is gated on storage readiness.
+func checkLonghornInstanceManagerReady(ctx context.Context, nodeName string) error {
+	config, err := GetKubeConfig()
+	if err != nil {
+		return fmt.Errorf("longhorn instance-manager: kubeconfig: %v", err)
+	}
+	lhClient, err := versioned.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("longhorn instance-manager: versioned client: %v", err)
+	}
+	running, err := instanceManagerRunningOnNode(ctx,
+		lhClient.LonghornV1beta2().InstanceManagers(longhornNamespace), nodeName)
+	if err != nil {
+		return fmt.Errorf("longhorn instance-manager: list: %v", err)
+	}
+	if !running {
+		return fmt.Errorf("longhorn instance-manager not running on node")
+	}
+	return nil
+}

--- a/pkg/pillar/kubeapi/longhorninstancemanager.go
+++ b/pkg/pillar/kubeapi/longhorninstancemanager.go
@@ -8,11 +8,35 @@ package kubeapi
 import (
 	"context"
 	"fmt"
+	"time"
 
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const (
+	// baseComponentsReadyTimeout bounds the wait for the node object plus any
+	// optional components when Longhorn is not among them.
+	baseComponentsReadyTimeout = 20 * time.Minute
+
+	// longhornComponentsReadyTimeout applies once Longhorn is in the predicate.
+	// The node cannot serve a volume until the instance-manager pod runs, and
+	// that pod pulls a ~440 MB image: measured at 8m20s and 8m41s on single-disk
+	// topologies but over 20 minutes on two-disk ZFS, which alone exhausts the
+	// base budget and leaves nothing for the node and kubevirt checks ahead of
+	// it. Sized to clear the slowest observed pull with room to spare.
+	longhornComponentsReadyTimeout = 45 * time.Minute
+)
+
+// componentsReadyTimeout returns the deadline for the readiness poll, widened
+// when the caller waits on Longhorn.
+func componentsReadyTimeout(opts WaitForKubernetesOptions) time.Duration {
+	if opts.WaitForLonghorn {
+		return longhornComponentsReadyTimeout
+	}
+	return baseComponentsReadyTimeout
+}
 
 // instanceManagerLister is the subset of the generated Longhorn client this
 // file needs, kept narrow so the state logic below can be exercised without a

--- a/pkg/pillar/kubeapi/longhorninstancemanager_test.go
+++ b/pkg/pillar/kubeapi/longhorninstancemanager_test.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package kubeapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type fakeInstanceManagerLister struct {
+	items []lhv1beta2.InstanceManager
+	err   error
+}
+
+func (f fakeInstanceManagerLister) List(context.Context, metav1.ListOptions) (
+	*lhv1beta2.InstanceManagerList, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &lhv1beta2.InstanceManagerList{Items: f.items}, nil
+}
+
+func instanceManager(nodeID string, state lhv1beta2.InstanceManagerState) lhv1beta2.InstanceManager {
+	return lhv1beta2.InstanceManager{
+		Spec:   lhv1beta2.InstanceManagerSpec{NodeID: nodeID},
+		Status: lhv1beta2.InstanceManagerStatus{CurrentState: state},
+	}
+}
+
+func TestInstanceManagerRunningOnNode(t *testing.T) {
+	const thisNode = "node-a"
+
+	testMatrix := map[string]struct {
+		items       []lhv1beta2.InstanceManager
+		expectReady bool
+	}{
+		"running on this node": {
+			items:       []lhv1beta2.InstanceManager{instanceManager(thisNode, lhv1beta2.InstanceManagerStateRunning)},
+			expectReady: true,
+		},
+		// The reported failure: the pod is still pulling its ~440 MB image, so
+		// the CR exists but cannot serve a volume yet.
+		"starting on this node": {
+			items:       []lhv1beta2.InstanceManager{instanceManager(thisNode, lhv1beta2.InstanceManagerStateStarting)},
+			expectReady: false,
+		},
+		"error on this node": {
+			items:       []lhv1beta2.InstanceManager{instanceManager(thisNode, lhv1beta2.InstanceManagerStateError)},
+			expectReady: false,
+		},
+		"running only on another node": {
+			items:       []lhv1beta2.InstanceManager{instanceManager("node-b", lhv1beta2.InstanceManagerStateRunning)},
+			expectReady: false,
+		},
+		"another node running, this one starting": {
+			items: []lhv1beta2.InstanceManager{
+				instanceManager("node-b", lhv1beta2.InstanceManagerStateRunning),
+				instanceManager(thisNode, lhv1beta2.InstanceManagerStateStarting),
+			},
+			expectReady: false,
+		},
+		"several on this node, one running": {
+			items: []lhv1beta2.InstanceManager{
+				instanceManager(thisNode, lhv1beta2.InstanceManagerStateStopped),
+				instanceManager(thisNode, lhv1beta2.InstanceManagerStateRunning),
+			},
+			expectReady: true,
+		},
+		"none at all": {
+			items:       nil,
+			expectReady: false,
+		},
+	}
+
+	for name, test := range testMatrix {
+		t.Run(name, func(t *testing.T) {
+			ready, err := instanceManagerRunningOnNode(context.Background(),
+				fakeInstanceManagerLister{items: test.items}, thisNode)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ready != test.expectReady {
+				t.Errorf("ready = %v, want %v", ready, test.expectReady)
+			}
+		})
+	}
+}
+
+func TestInstanceManagerRunningOnNodeListError(t *testing.T) {
+	listErr := errors.New("api unreachable")
+	ready, err := instanceManagerRunningOnNode(context.Background(),
+		fakeInstanceManagerLister{err: listErr}, "node-a")
+	if !errors.Is(err, listErr) {
+		t.Errorf("err = %v, want %v", err, listErr)
+	}
+	if ready {
+		t.Error("ready = true on list error, want false")
+	}
+}
+
+const imTestNode = "im-test-node"
+
+func imDaemonset(name string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: longhornNamespace},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+			},
+		},
+	}
+}
+
+func imPod(dsName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dsName + "-pod",
+			Namespace: longhornNamespace,
+			Labels:    map[string]string{"app": dsName},
+		},
+		Spec: corev1.PodSpec{NodeName: imTestNode},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{Ready: true}},
+		},
+	}
+}
+
+func imHealthyDaemonsets() []runtime.Object {
+	names := []string{"longhorn-manager", "longhorn-csi-plugin", "engine-image-ei-abcdef12"}
+	objs := make([]runtime.Object, 0, len(names)*2)
+	for _, n := range names {
+		objs = append(objs, imDaemonset(n), imPod(n))
+	}
+	return objs
+}
+
+// Healthy DaemonSets alone must not make the node ready: the instance-manager
+// gate runs afterwards and its verdict is what checkLonghornReady returns.
+func TestCheckLonghornReadyAppliesInstanceManagerGate(t *testing.T) {
+	gateErr := errors.New("longhorn instance-manager not running on node")
+
+	testMatrix := map[string]struct {
+		gate      func(context.Context, string) error
+		expectErr error
+	}{
+		"gate satisfied": {
+			gate:      func(context.Context, string) error { return nil },
+			expectErr: nil,
+		},
+		"gate unsatisfied": {
+			gate:      func(context.Context, string) error { return gateErr },
+			expectErr: gateErr,
+		},
+	}
+
+	for name, test := range testMatrix {
+		t.Run(name, func(t *testing.T) {
+			saved := instanceManagerReady
+			t.Cleanup(func() { instanceManagerReady = saved })
+			instanceManagerReady = test.gate
+
+			client := fake.NewSimpleClientset(imHealthyDaemonsets()...)
+			err := checkLonghornReady(client, imTestNode)
+			if !errors.Is(err, test.expectErr) {
+				t.Errorf("err = %v, want %v", err, test.expectErr)
+			}
+		})
+	}
+}

--- a/pkg/pillar/kubeapi/longhorninstancemanager_test.go
+++ b/pkg/pillar/kubeapi/longhorninstancemanager_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	appsv1 "k8s.io/api/apps/v1"
@@ -106,6 +107,20 @@ func TestInstanceManagerRunningOnNodeListError(t *testing.T) {
 	}
 	if ready {
 		t.Error("ready = true on list error, want false")
+	}
+}
+
+// The instance-manager pull is the slowest thing in the readiness predicate, so
+// adding it to checkLonghornReady must come with a budget that can absorb it --
+// the two-disk ZFS leg regressed on the un-widened 20m deadline.
+func TestComponentsReadyTimeout(t *testing.T) {
+	withLH := componentsReadyTimeout(WaitForKubernetesOptions{WaitForLonghorn: true})
+	withoutLH := componentsReadyTimeout(WaitForKubernetesOptions{})
+	if withLH <= withoutLH {
+		t.Errorf("longhorn timeout %v must exceed base %v", withLH, withoutLH)
+	}
+	if withLH < 30*time.Minute {
+		t.Errorf("longhorn timeout %v too small for a 20m+ instance-manager pull", withLH)
 	}
 }
 

--- a/pkg/pillar/kubeapi/longhornready_test.go
+++ b/pkg/pillar/kubeapi/longhornready_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package kubeapi
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const lhTestNode = "test-node"
+
+func lhDaemonset(name string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "longhorn-system"},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+			},
+		},
+	}
+}
+
+func lhPod(dsName string, ready bool) *corev1.Pod {
+	phase := corev1.PodRunning
+	if !ready {
+		phase = corev1.PodPending
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dsName + "-pod",
+			Namespace: "longhorn-system",
+			Labels:    map[string]string{"app": dsName},
+		},
+		Spec: corev1.PodSpec{NodeName: lhTestNode},
+		Status: corev1.PodStatus{
+			Phase:             phase,
+			ContainerStatuses: []corev1.ContainerStatus{{Ready: ready}},
+		},
+	}
+}
+
+// healthyLonghornObjects returns the three daemonsets checkLonghornReady
+// expects, each with a Running-and-Ready pod on lhTestNode.
+func healthyLonghornObjects() []runtime.Object {
+	names := []string{"longhorn-manager", "longhorn-csi-plugin", "engine-image-ei-abcdef12"}
+	objs := make([]runtime.Object, 0, len(names)*2)
+	for _, n := range names {
+		objs = append(objs, lhDaemonset(n), lhPod(n, true))
+	}
+	return objs
+}
+
+func TestCheckLonghornReadyHealthy(t *testing.T) {
+	client := fake.NewSimpleClientset(healthyLonghornObjects()...)
+	if err := checkLonghornReady(client, lhTestNode); err != nil {
+		t.Fatalf("expected ready, got %v", err)
+	}
+}
+
+// A daemonset that is not one of longhorn's own must not gate storage. EVE's
+// collect-info leaves a SupportBundle agent daemonset behind in this namespace
+// which never becomes ready, and it used to block every volume on the node.
+func TestCheckLonghornReadyIgnoresStrayDaemonset(t *testing.T) {
+	objs := healthyLonghornObjects()
+	objs = append(objs, lhDaemonset("longhorn-support-bundle-agent"))
+	client := fake.NewSimpleClientset(objs...)
+	if err := checkLonghornReady(client, lhTestNode); err != nil {
+		t.Fatalf("stray daemonset must not gate readiness, got %v", err)
+	}
+}
+
+func TestCheckLonghornReadyMissingExpectedDaemonset(t *testing.T) {
+	objs := []runtime.Object{
+		lhDaemonset("longhorn-manager"), lhPod("longhorn-manager", true),
+		lhDaemonset("longhorn-csi-plugin"), lhPod("longhorn-csi-plugin", true),
+	}
+	client := fake.NewSimpleClientset(objs...)
+	err := checkLonghornReady(client, lhTestNode)
+	if err == nil {
+		t.Fatal("expected an error when engine-image is absent")
+	}
+}
+
+func TestCheckLonghornReadyExpectedDaemonsetNotReady(t *testing.T) {
+	names := []string{"longhorn-manager", "longhorn-csi-plugin", "engine-image-ei-abcdef12"}
+	var objs []runtime.Object
+	for _, n := range names {
+		objs = append(objs, lhDaemonset(n), lhPod(n, n != "longhorn-manager"))
+	}
+	client := fake.NewSimpleClientset(objs...)
+	if err := checkLonghornReady(client, lhTestNode); err == nil {
+		t.Fatal("expected an error when an expected daemonset pod is not ready")
+	}
+}

--- a/pkg/pillar/kubeapi/longhornready_test.go
+++ b/pkg/pillar/kubeapi/longhornready_test.go
@@ -6,6 +6,7 @@
 package kubeapi
 
 import (
+	"context"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -58,7 +59,18 @@ func healthyLonghornObjects() []runtime.Object {
 	return objs
 }
 
+// stubInstanceManagerGate satisfies the instance-manager gate for the tests that
+// exercise the daemonset sweep. The real gate builds a Longhorn client from the
+// on-device kubeconfig, which a fake clientset cannot supply, so a test that
+// wants to reach a positive verdict has to substitute it.
+func stubInstanceManagerGate(t *testing.T) {
+	saved := instanceManagerReady
+	t.Cleanup(func() { instanceManagerReady = saved })
+	instanceManagerReady = func(context.Context, string) error { return nil }
+}
+
 func TestCheckLonghornReadyHealthy(t *testing.T) {
+	stubInstanceManagerGate(t)
 	client := fake.NewSimpleClientset(healthyLonghornObjects()...)
 	if err := checkLonghornReady(client, lhTestNode); err != nil {
 		t.Fatalf("expected ready, got %v", err)
@@ -69,6 +81,7 @@ func TestCheckLonghornReadyHealthy(t *testing.T) {
 // collect-info leaves a SupportBundle agent daemonset behind in this namespace
 // which never becomes ready, and it used to block every volume on the node.
 func TestCheckLonghornReadyIgnoresStrayDaemonset(t *testing.T) {
+	stubInstanceManagerGate(t)
 	objs := healthyLonghornObjects()
 	objs = append(objs, lhDaemonset("longhorn-support-bundle-agent"))
 	client := fake.NewSimpleClientset(objs...)

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -619,8 +619,14 @@ func (status VolumeCreatePending) LogDelete(logBase *base.LogObject) {
 
 // VolumeMgrStatus :
 type VolumeMgrStatus struct {
-	Name           string
-	Initialized    bool
+	Name        string
+	Initialized bool
+	// UnmetCondition names the readiness gate still outstanding when
+	// Initialized is false, e.g. "longhorn not ready: longhorn missing
+	// daemonset:engine-image". Empty when Initialized is true. Informational:
+	// it exists so an operator can tell a converging cluster from a stuck one
+	// without correlating agent logs.
+	UnmetCondition string
 	RemainingSpace uint64 // In bytes. Takes into account "reserved" for dom0
 }
 


### PR DESCRIPTION
# Description

On an EVE-k node, cluster storage could be blocked forever by a daemonset that is
none of Longhorn's, be declared ready before the node could actually serve a volume,
and report success either way. Three related fixes, plus the reporting that makes the
outcome visible.

**Nothing but Longhorn's own daemonsets gates storage.** `checkLonghornReady` swept
every daemonset in `longhorn-system` and required each to be Ready on this node. EVE's
collect-info leaves a SupportBundle agent daemonset behind there which never becomes
Ready, so a single leaked object blocked every volume on the node for as long as it
existed. Only the three expected daemonsets gate readiness now.

**A running instance-manager is required before storage counts as ready.** Longhorn
runs a volume's engine and replica processes inside the instance-manager pod, so the
node cannot serve any volume until one is running — and because that pod is owned by an
`InstanceManager` CR rather than a DaemonSet, the daemonset sweep never observed it.
Pillar's readiness path now waits for it; kube-init's Longhorn wait already gates on
the same object.

**Both ready budgets absorb it.** That pod pulls a ~440 MB image: measured at 8m20s and
8m41s on single-disk topologies, and over 20 minutes on two-disk ZFS, which alone
exhausted the old 20-minute budget and left nothing for the node and kubevirt checks
ahead of it. kubeapi's readiness poll is widened to 45 minutes, but only when Longhorn
is in the predicate.

Two waits run back to back before volumemgr proceeds, and only the first was widened
originally. The second — the one that blocks until Longhorn and CDI can actually serve
a volume — kept an unexplained 20-minute cap of its own, so the same contended link
could still expire it and leave every volume to defer and retry. It is now a named
bound at 30 minutes: by the time it starts the node and Longhorn are up, so what
remains is mostly CDI, whose images are what the slow half of a first boot spends its
time on.

**And volumemgr says what happened.** `VolumeMgrStatus.Initialized` was hardcoded true,
so a node whose storage never came up was indistinguishable from a healthy one. It now
reports the truth along with `UnmetCondition`, the gate still outstanding, and diag
surfaces it. The status is published from its own task started before the readiness
waits, so a node stuck on those waits says which gate it is on instead of publishing
nothing for tens of minutes — the waits can run the better part of an hour, and that was
exactly the window with no reporting.

## PR dependencies

None. **This PR supersedes #6259**, whose two commits are included here: the
instance-manager gate and the widened budget. #6259 is closed in favour of this one.

They were merged because they cannot land independently: #6259 makes
`checkLonghornReady` end in the instance-manager gate, whose real implementation builds
a Longhorn client from the on-device kubeconfig, while this PR's two positive
`checkLonghornReady` tests drive that function with a fake clientset. Whichever landed
second would have turned those tests red, and CI on the first could not have warned.
Carrying both here lets the stub that resolves it (`kubeapi: stub the instance-manager
gate in the daemonset tests`, folded into the gate commit) ship with the change that
needs it.

## How to test and validate this PR

`go build -tags k ./...`, `go vet -tags k ./kubeapi/... ./cmd/volumemgr/... ./cmd/diag/...`
and `go test -tags k ./kubeapi/... ./cmd/volumemgr/... ./cmd/diag/...` under `pkg/pillar`.
The `k` tag is required: this code is behind `//go:build k`, and a build without it
compiles none of it while still reporting success. Every commit in the series is green on
its own.

New unit tests: the stray-daemonset case and the three daemonset-failure cases; the
instance-manager state mapping and its list-error path; the readiness budget selection;
the reported status for ready / unmet / still-waiting; and the diag warning's presence,
absence and pre-publication silence. `evetest/tests/diag` covers the summary end to end.

On an EVE-k device the observable effects are:

- `cat /run/volumemgr/VolumeMgrStatus/volumemgr.json` reports `Initialized: false` with
  an `UnmetCondition` naming the outstanding gate while storage is not usable, and does
  so during the wait rather than only after it resolves.
- `diag` prints `WARNING: cluster storage not ready: <condition>` in that state.
- With a leaked `longhorn-support-bundle-agent` daemonset present, volumes are created
  normally instead of stalling in `CREATING_VOLUME`.

### Result in the kvm→k conversion matrix

The stray-daemonset fix, the truthful reporting and the readiness-publish task were
carried in integration image `0.0.0-newgo-allprs2-f40d7876` through the 7-leg
EVE-kvm→EVE-k conversion matrix: **7/7**, every leg faster than on the two previous
green images of that line. That image also carries #5971, so it exercises the pillar
readiness paths against the Go `kube-init` bring-up. It is a no-regression result rather
than a targeted test of these fixes; the targeted evidence is the unit and evetest
coverage above.

## Changelog notes

On EVE-k, a leaked daemonset in the `longhorn-system` namespace no longer prevents
volumes from being created, storage is not declared ready until the node can actually
serve a volume, and a node whose cluster storage did not come up now reports that
instead of reporting success.

## PR Backports

- 17.0-stable: yes, the stray-daemonset fix in particular — a leaked SupportBundle
  daemonset blocks all volumes on affected nodes today.
- 16.0-stable / 14.5-stable / 13.4-stable: to be decided by the maintainers.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't

Reasons for the unchecked boxes: `pkg/pillar/docs/volumemgr.md` gains the readiness
fields, but there is no new operator knob to document beyond that. Exercised on an amd64
EVE-k node via the conversion matrix above; arm64 untested. Labels left as they are.



## Relationship to #6257

This PR does **not** carry the orphaned-PVC reclaim (`gcPVCs` in
`cmd/volumemgr/initialvolumestatus.go`). That work is #6257's — it is the
counterpart to the stale-generation purge sweep introduced there, and it is
kept in one place so the two cannot drift apart.

#6240 and #6257 are siblings off master and both touch volumemgr, so carrying
the reclaim in both means any branch integrating the two gets it twice, under
different SHAs, and has to dedup by hand. Integration branches should take it
from #6257 — #6271 is based on #6257 and delivers it transitively.

No code dependency in either direction: this PR builds and tests standalone
on master.


