### PR TITLE
Potential fix for code scanning alert no. 2388: Use of insecure HostKeyCallback implementation

### DIFF
--- a/evetest/ssh.go
+++ b/evetest/ssh.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lf-edge/eve/evetest/utils"
 	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 type watchdogWriter struct {
@@ -61,8 +62,13 @@ func (th *TestHarness) runScriptOverSSH(ctx context.Context,
 	addr string, auth AuthMethod, script string,
 	stdout, stderr io.Writer, stdoutWatchdogTimeout time.Duration) error {
 
+	hostKeyCallback, err := knownhosts.New("/root/.ssh/known_hosts")
+	if err != nil {
+		return fmt.Errorf("failed to initialize SSH known_hosts callback: %w", err)
+	}
+
 	sshConfig := &ssh.ClientConfig{
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: hostKeyCallback,
 		Timeout:         5 * time.Second,
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/lf-edge/eve/security/code-scanning/2388](https://github.com/lf-edge/eve/security/code-scanning/2388)

Use a validating host key callback instead of `ssh.InsecureIgnoreHostKey()`. The best minimal, functionality-preserving fix here is to verify against the user’s `known_hosts` file using `knownhosts.New(...)` from `golang.org/x/crypto/ssh/knownhosts`. This keeps behavior aligned with standard SSH trust-on-first-use / pinned-known-host workflows and avoids introducing custom key parsing logic.

In `evetest/ssh.go`, inside `runScriptOverSSH`, replace insecure callback initialization with:
1. Build known_hosts path (e.g., `/root/.ssh/known_hosts` for current environment consistency).
2. Create callback via `knownhosts.New(...)`.
3. Return a clear error if callback cannot be initialized.
4. Set `HostKeyCallback` to that callback in `ssh.ClientConfig`.

Also add the required import for `golang.org/x/crypto/ssh/knownhosts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
