### PR TITLE
Potential fix for code scanning alert no. 2390: Arbitrary file write extracting an archive containing symbolic links

### DIFF
--- a/evetest/utils/tar.go
+++ b/evetest/utils/tar.go
@@ -9,19 +9,63 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
+	"strings"
 )
 
 // MaxDecompressedContentSize is the maximum size of a file that can be written to disk after decompression.
 // This is to prevent a DoS attack by unpacking a compressed file that is too big to be decompressed.
 const MaxDecompressedContentSize = 1024 * 1024 * 1024 // 1 GB
 
+func resolveDestinationRoot(destination string) (string, error) {
+	absDest, err := filepath.Abs(destination)
+	if err != nil {
+		return "", err
+	}
+	realDest, err := filepath.EvalSymlinks(absDest)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return absDest, nil
+		}
+		return "", err
+	}
+	return realDest, nil
+}
+
+func safeJoinWithinDestination(destinationRoot, archivePath string) (string, error) {
+	if filepath.IsAbs(archivePath) {
+		return "", fmt.Errorf("absolute archive path is not allowed: %s", archivePath)
+	}
+	candidate := filepath.Join(destinationRoot, archivePath)
+	parent := filepath.Dir(candidate)
+
+	realParent, err := filepath.EvalSymlinks(parent)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		realParent = parent
+	}
+
+	resolved := filepath.Join(realParent, filepath.Base(candidate))
+	rel, err := filepath.Rel(destinationRoot, resolved)
+	if err != nil {
+		return "", err
+	}
+	rel = filepath.Clean(rel)
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("archive path escapes destination: %s", archivePath)
+	}
+	return resolved, nil
+}
+
 // ExtractFromTar extracts files from a tar reader into the destination directory
 func ExtractFromTar(u io.Reader, destination string) error {
-	// path inside tar is relative
-	pathBuilder := func(oldPath string) string {
-		return path.Join(destination, oldPath)
+	destinationRoot, err := resolveDestinationRoot(destination)
+	if err != nil {
+		return fmt.Errorf("ExtractFromTar: failed to resolve destination: %w", err)
 	}
+
 	tarReader := tar.NewReader(u)
 	for {
 		header, err := tarReader.Next()
@@ -31,19 +75,25 @@ func ExtractFromTar(u io.Reader, destination string) error {
 		if err != nil {
 			return fmt.Errorf("ExtractFromTar: Next() failed: %w", err)
 		}
+
+		outputPath, err := safeJoinWithinDestination(destinationRoot, header.Name)
+		if err != nil {
+			return fmt.Errorf("ExtractFromTar: invalid archive entry path %q: %w", header.Name, err)
+		}
+
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(pathBuilder(header.Name), os.FileMode(header.Mode)); err != nil {
+			if err := os.MkdirAll(outputPath, os.FileMode(header.Mode)); err != nil {
 				return fmt.Errorf("ExtractFromTar: Mkdir() failed: %w", err)
 			}
 		case tar.TypeReg:
-			if _, err := os.Lstat(pathBuilder(header.Name)); err == nil {
-				err = os.Remove(pathBuilder(header.Name))
+			if _, err := os.Lstat(outputPath); err == nil {
+				err = os.Remove(outputPath)
 				if err != nil {
 					return fmt.Errorf("ExtractFromTar: cannot remove old file: %w", err)
 				}
 			}
-			outFile, err := os.OpenFile(pathBuilder(header.Name), os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+			outFile, err := os.OpenFile(outputPath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 			if err != nil {
 				return fmt.Errorf("ExtractFromTar: OpenFile() failed: %w", err)
 			}
@@ -60,15 +110,19 @@ func ExtractFromTar(u io.Reader, destination string) error {
 				return fmt.Errorf("ExtractFromTar: outFile.Close() failed: %w", err)
 			}
 		case tar.TypeLink, tar.TypeSymlink:
-			if _, err := os.Lstat(pathBuilder(header.Name)); err == nil {
-				err = os.Remove(pathBuilder(header.Name))
+			linkTargetPath, err := safeJoinWithinDestination(destinationRoot, header.Linkname)
+			if err != nil {
+				return fmt.Errorf("ExtractFromTar: invalid symlink target %q: %w", header.Linkname, err)
+			}
+			if _, err := os.Lstat(outputPath); err == nil {
+				err = os.Remove(outputPath)
 				if err != nil {
 					return fmt.Errorf("ExtractFromTar: cannot remove old symlink: %w", err)
 				}
 			}
-			if err := os.Symlink(pathBuilder(header.Linkname), pathBuilder(header.Name)); err != nil {
+			if err := os.Symlink(linkTargetPath, outputPath); err != nil {
 				return fmt.Errorf("ExtractFromTar: Symlink(%s, %s) failed: %w",
-					pathBuilder(header.Name), pathBuilder(header.Linkname), err)
+					outputPath, linkTargetPath, err)
 			}
 		default:
 			return fmt.Errorf(


### PR DESCRIPTION
Potential fix for [https://github.com/lf-edge/eve/security/code-scanning/2390](https://github.com/lf-edge/eve/security/code-scanning/2390)

General fix: before extracting any tar entry (especially symlinks/hardlinks), compute a candidate output path under `destination`, resolve symlinks for the parent path (or full path where possible), and verify the resolved path is still within the resolved extraction root. Reject entries that escape.

Best single approach here (without changing intended behavior):  
1. Resolve `destination` once with `filepath.Abs` + `filepath.EvalSymlinks` fallback handling.  
2. Add a helper that:
   - rejects absolute archive paths,
   - joins with destination,
   - resolves the parent directory with `filepath.EvalSymlinks`,
   - rebuilds the final path and verifies with `filepath.Rel` that it remains inside destination.
3. Use this helper for `header.Name` and `header.Linkname` before file/symlink operations.
4. For symlink creation, use the validated full target path and validated link path.

Changes needed only in `evetest/utils/tar.go`:  
- Add import: `path/filepath` and `strings`.  
- Add helper methods for path safety checks.  
- Replace direct `pathBuilder(...)` calls with validated path resolution results.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
