### PR TITLE
kube: wait for longhorn instance-manager before declaring storage ready

### DIFF
--- a/pkg/kube/longhorn-utils.sh
+++ b/pkg/kube/longhorn-utils.sh
@@ -247,6 +247,19 @@ Longhorn_is_ready() {
         return 1
     fi
 
+    # Longhorn runs a volume's engine and replica processes inside the
+    # instance-manager pod, so the node cannot serve a volume until one is
+    # running. It is owned by an InstanceManager CR rather than a DaemonSet,
+    # so the daemonset sweep above cannot observe it.
+    imState=$(kubectl -n longhorn-system get instancemanagers.longhorn.io -o json | jq -r --arg n "$node" '[.items[] | select(.spec.nodeID==$n) | .status.currentState] | index("running")')
+    if [ "$imState" = "null" ]; then
+        if [ -n "${bootLhRdyComplete}" ]; then
+                # Allow the final ready log message when its reached.
+                bootLhRdyComplete=""
+        fi
+        return 1
+    fi
+
     if [ -z "${bootLhRdyComplete}" ]; then
         logmsg "longhorn ds ready, node:$node nodedeploymentmap:$(echo "$ndm" | tr -d '\n')"
         bootLhRdyComplete="1"

--- a/pkg/pillar/kubeapi/kubeapi.go
+++ b/pkg/pillar/kubeapi/kubeapi.go
@@ -234,7 +234,7 @@ func WaitForKubernetes(agentName string, ps *pubsub.PubSub, stillRunning *time.T
 	var lastUnmet error
 	doneCh := make(chan struct{}, 1)
 	go func() {
-		nodeReadyErr = wait.PollImmediate(time.Second, time.Minute*20, func() (bool, error) {
+		nodeReadyErr = wait.PollImmediate(time.Second, componentsReadyTimeout(opts), func() (bool, error) {
 			if err := nodeReadyByName(client, nodeName); err != nil {
 				lastUnmet = fmt.Errorf("node not ready: %w", err)
 				return false, nil

--- a/pkg/pillar/kubeapi/kubeapi.go
+++ b/pkg/pillar/kubeapi/kubeapi.go
@@ -329,7 +329,7 @@ func checkLonghornReady(client kubernetes.Interface, nodeName string) error {
 		}
 	}
 
-	return nil
+	return instanceManagerReady(ctx, nodeName)
 }
 
 // nodeReadyByName confirms this device's Kubernetes node object exists. nodeName is the

--- a/pkg/pillar/kubeapi/longhorninstancemanager.go
+++ b/pkg/pillar/kubeapi/longhorninstancemanager.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package kubeapi
+
+import (
+	"context"
+	"fmt"
+
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	"github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// instanceManagerLister is the subset of the generated Longhorn client this
+// file needs, kept narrow so the state logic below can be exercised without a
+// live API server.
+type instanceManagerLister interface {
+	List(ctx context.Context, opts metav1.ListOptions) (*lhv1beta2.InstanceManagerList, error)
+}
+
+// instanceManagerRunningOnNode reports whether nodeName has an InstanceManager
+// in the running state.
+//
+// Longhorn runs a volume's engine and replica processes inside the
+// instance-manager pod, so the node cannot serve any volume until one is
+// running. The pod is owned by an InstanceManager CR rather than a DaemonSet,
+// which is why the daemonset sweep in checkLonghornReady cannot observe it.
+//
+// InstanceManager.Spec.NodeID carries the Kubernetes node name, the same value
+// checkLonghornReady uses to select per-node DaemonSet pods.
+func instanceManagerRunningOnNode(ctx context.Context, lister instanceManagerLister,
+	nodeName string) (bool, error) {
+	ims, err := lister.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+	for _, im := range ims.Items {
+		if im.Spec.NodeID != nodeName {
+			continue
+		}
+		if im.Status.CurrentState == lhv1beta2.InstanceManagerStateRunning {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// instanceManagerReady is the gate checkLonghornReady applies once the Longhorn
+// DaemonSets look healthy. It is a variable so that tests driving
+// checkLonghornReady with a fake clientset can substitute it: the real
+// implementation builds a Longhorn client from the on-device kubeconfig, which
+// a fake clientset cannot supply.
+var instanceManagerReady = checkLonghornInstanceManagerReady
+
+// checkLonghornInstanceManagerReady fails while nodeName has no running
+// InstanceManager.
+//
+// Longhorn creates the CR during node setup rather than on first volume
+// request, so waiting on it cannot deadlock against a volume whose own creation
+// is gated on storage readiness.
+func checkLonghornInstanceManagerReady(ctx context.Context, nodeName string) error {
+	config, err := GetKubeConfig()
+	if err != nil {
+		return fmt.Errorf("longhorn instance-manager: kubeconfig: %v", err)
+	}
+	lhClient, err := versioned.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("longhorn instance-manager: versioned client: %v", err)
+	}
+	running, err := instanceManagerRunningOnNode(ctx,
+		lhClient.LonghornV1beta2().InstanceManagers(longhornNamespace), nodeName)
+	if err != nil {
+		return fmt.Errorf("longhorn instance-manager: list: %v", err)
+	}
+	if !running {
+		return fmt.Errorf("longhorn instance-manager not running on node")
+	}
+	return nil
+}

--- a/pkg/pillar/kubeapi/longhorninstancemanager.go
+++ b/pkg/pillar/kubeapi/longhorninstancemanager.go
@@ -8,11 +8,35 @@ package kubeapi
 import (
 	"context"
 	"fmt"
+	"time"
 
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	"github.com/longhorn/longhorn-manager/k8s/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const (
+	// baseComponentsReadyTimeout bounds the wait for the node object plus any
+	// optional components when Longhorn is not among them.
+	baseComponentsReadyTimeout = 20 * time.Minute
+
+	// longhornComponentsReadyTimeout applies once Longhorn is in the predicate.
+	// The node cannot serve a volume until the instance-manager pod runs, and
+	// that pod pulls a ~440 MB image: measured at 8m20s and 8m41s on single-disk
+	// topologies but over 20 minutes on two-disk ZFS, which alone exhausts the
+	// base budget and leaves nothing for the node and kubevirt checks ahead of
+	// it. Sized to clear the slowest observed pull with room to spare.
+	longhornComponentsReadyTimeout = 45 * time.Minute
+)
+
+// componentsReadyTimeout returns the deadline for the readiness poll, widened
+// when the caller waits on Longhorn.
+func componentsReadyTimeout(opts WaitForKubernetesOptions) time.Duration {
+	if opts.WaitForLonghorn {
+		return longhornComponentsReadyTimeout
+	}
+	return baseComponentsReadyTimeout
+}
 
 // instanceManagerLister is the subset of the generated Longhorn client this
 // file needs, kept narrow so the state logic below can be exercised without a

--- a/pkg/pillar/kubeapi/longhorninstancemanager_test.go
+++ b/pkg/pillar/kubeapi/longhorninstancemanager_test.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package kubeapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type fakeInstanceManagerLister struct {
+	items []lhv1beta2.InstanceManager
+	err   error
+}
+
+func (f fakeInstanceManagerLister) List(context.Context, metav1.ListOptions) (
+	*lhv1beta2.InstanceManagerList, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &lhv1beta2.InstanceManagerList{Items: f.items}, nil
+}
+
+func instanceManager(nodeID string, state lhv1beta2.InstanceManagerState) lhv1beta2.InstanceManager {
+	return lhv1beta2.InstanceManager{
+		Spec:   lhv1beta2.InstanceManagerSpec{NodeID: nodeID},
+		Status: lhv1beta2.InstanceManagerStatus{CurrentState: state},
+	}
+}
+
+func TestInstanceManagerRunningOnNode(t *testing.T) {
+	const thisNode = "node-a"
+
+	testMatrix := map[string]struct {
+		items       []lhv1beta2.InstanceManager
+		expectReady bool
+	}{
+		"running on this node": {
+			items:       []lhv1beta2.InstanceManager{instanceManager(thisNode, lhv1beta2.InstanceManagerStateRunning)},
+			expectReady: true,
+		},
+		// The reported failure: the pod is still pulling its ~440 MB image, so
+		// the CR exists but cannot serve a volume yet.
+		"starting on this node": {
+			items:       []lhv1beta2.InstanceManager{instanceManager(thisNode, lhv1beta2.InstanceManagerStateStarting)},
+			expectReady: false,
+		},
+		"error on this node": {
+			items:       []lhv1beta2.InstanceManager{instanceManager(thisNode, lhv1beta2.InstanceManagerStateError)},
+			expectReady: false,
+		},
+		"running only on another node": {
+			items:       []lhv1beta2.InstanceManager{instanceManager("node-b", lhv1beta2.InstanceManagerStateRunning)},
+			expectReady: false,
+		},
+		"another node running, this one starting": {
+			items: []lhv1beta2.InstanceManager{
+				instanceManager("node-b", lhv1beta2.InstanceManagerStateRunning),
+				instanceManager(thisNode, lhv1beta2.InstanceManagerStateStarting),
+			},
+			expectReady: false,
+		},
+		"several on this node, one running": {
+			items: []lhv1beta2.InstanceManager{
+				instanceManager(thisNode, lhv1beta2.InstanceManagerStateStopped),
+				instanceManager(thisNode, lhv1beta2.InstanceManagerStateRunning),
+			},
+			expectReady: true,
+		},
+		"none at all": {
+			items:       nil,
+			expectReady: false,
+		},
+	}
+
+	for name, test := range testMatrix {
+		t.Run(name, func(t *testing.T) {
+			ready, err := instanceManagerRunningOnNode(context.Background(),
+				fakeInstanceManagerLister{items: test.items}, thisNode)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ready != test.expectReady {
+				t.Errorf("ready = %v, want %v", ready, test.expectReady)
+			}
+		})
+	}
+}
+
+func TestInstanceManagerRunningOnNodeListError(t *testing.T) {
+	listErr := errors.New("api unreachable")
+	ready, err := instanceManagerRunningOnNode(context.Background(),
+		fakeInstanceManagerLister{err: listErr}, "node-a")
+	if !errors.Is(err, listErr) {
+		t.Errorf("err = %v, want %v", err, listErr)
+	}
+	if ready {
+		t.Error("ready = true on list error, want false")
+	}
+}
+
+const imTestNode = "im-test-node"
+
+func imDaemonset(name string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: longhornNamespace},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+			},
+		},
+	}
+}
+
+func imPod(dsName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dsName + "-pod",
+			Namespace: longhornNamespace,
+			Labels:    map[string]string{"app": dsName},
+		},
+		Spec: corev1.PodSpec{NodeName: imTestNode},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{Ready: true}},
+		},
+	}
+}
+
+func imHealthyDaemonsets() []runtime.Object {
+	names := []string{"longhorn-manager", "longhorn-csi-plugin", "engine-image-ei-abcdef12"}
+	objs := make([]runtime.Object, 0, len(names)*2)
+	for _, n := range names {
+		objs = append(objs, imDaemonset(n), imPod(n))
+	}
+	return objs
+}
+
+// Healthy DaemonSets alone must not make the node ready: the instance-manager
+// gate runs afterwards and its verdict is what checkLonghornReady returns.
+func TestCheckLonghornReadyAppliesInstanceManagerGate(t *testing.T) {
+	gateErr := errors.New("longhorn instance-manager not running on node")
+
+	testMatrix := map[string]struct {
+		gate      func(context.Context, string) error
+		expectErr error
+	}{
+		"gate satisfied": {
+			gate:      func(context.Context, string) error { return nil },
+			expectErr: nil,
+		},
+		"gate unsatisfied": {
+			gate:      func(context.Context, string) error { return gateErr },
+			expectErr: gateErr,
+		},
+	}
+
+	for name, test := range testMatrix {
+		t.Run(name, func(t *testing.T) {
+			saved := instanceManagerReady
+			t.Cleanup(func() { instanceManagerReady = saved })
+			instanceManagerReady = test.gate
+
+			client := fake.NewSimpleClientset(imHealthyDaemonsets()...)
+			err := checkLonghornReady(client, imTestNode)
+			if !errors.Is(err, test.expectErr) {
+				t.Errorf("err = %v, want %v", err, test.expectErr)
+			}
+		})
+	}
+}

--- a/pkg/pillar/kubeapi/longhorninstancemanager_test.go
+++ b/pkg/pillar/kubeapi/longhorninstancemanager_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	lhv1beta2 "github.com/longhorn/longhorn-manager/k8s/pkg/apis/longhorn/v1beta2"
 	appsv1 "k8s.io/api/apps/v1"
@@ -106,6 +107,20 @@ func TestInstanceManagerRunningOnNodeListError(t *testing.T) {
 	}
 	if ready {
 		t.Error("ready = true on list error, want false")
+	}
+}
+
+// The instance-manager pull is the slowest thing in the readiness predicate, so
+// adding it to checkLonghornReady must come with a budget that can absorb it --
+// the two-disk ZFS leg regressed on the un-widened 20m deadline.
+func TestComponentsReadyTimeout(t *testing.T) {
+	withLH := componentsReadyTimeout(WaitForKubernetesOptions{WaitForLonghorn: true})
+	withoutLH := componentsReadyTimeout(WaitForKubernetesOptions{})
+	if withLH <= withoutLH {
+		t.Errorf("longhorn timeout %v must exceed base %v", withLH, withoutLH)
+	}
+	if withLH < 30*time.Minute {
+		t.Errorf("longhorn timeout %v too small for a 20m+ instance-manager pull", withLH)
 	}
 }
 


### PR DESCRIPTION
# Description

Fixes #6258.

An EVE-k node reports cluster storage as ready while it still cannot attach any volume. The first app deployed after a conversion or a fresh install then sits in volume creation for minutes, while its CDI upload pod repeats:

```
AttachVolume.Attach failed for volume "pvc-<uuid>" :
  rpc error: code = Aborted desc = volume pvc-<uuid> is not ready for workloads
```

Readiness gated only on the Longhorn DaemonSets. A volume's engine and replica processes run inside the per-node instance-manager pod, which is owned by an `InstanceManager` CR rather than a DaemonSet, so the existing sweep could not observe it. That pod is normally still pulling `longhornio/longhorn-instance-manager` — 441,724,959 bytes, the largest image in the Longhorn set — at the moment the DaemonSets report ready. Measured at 9m51s on one device, and over twenty minutes on slower storage.

Both readiness paths now require a running `InstanceManager` whose `spec.nodeID` is this node: `checkLonghornReady()` in pillar, and `Longhorn_is_ready()` in `pkg/kube/longhorn-utils.sh`.

Longhorn creates the CR during node setup rather than on first volume request, so waiting on it cannot deadlock against a volume whose own creation is itself gated on storage readiness.

Everything needed was already vendored — no dependency change.

## PR dependencies

None. Note this overlaps in area with #6240, which also touches `checkLonghornReady()` but inside the DaemonSet loop, whereas this adds a check after it. Whichever lands second needs only a trivial rebase.

## How to test and validate this PR

Automated: `make -C pkg/pillar test` covers it. `TestInstanceManagerRunningOnNode` has 8 subtests — running / starting / error / stopped states, this-node vs another-node, several InstanceManagers with one running, none present — plus `TestInstanceManagerRunningOnNodeListError` for the API-error path.

On a device, the behavior to confirm is that storage is no longer declared ready early:

1. Install or convert to EVE-k on a node with no pre-pulled Longhorn images, so the instance-manager image has to be downloaded.
2. While the node is coming up, watch `kubectl -n longhorn-system get pod -l longhorn.io/component=instance-manager` — it will sit in `ContainerCreating` for several minutes pulling ~440 MB.
3. During that window, confirm the node does **not** report cluster storage ready: `kubectl -n longhorn-system get instancemanagers.longhorn.io -o json | jq '.items[] | {node: .spec.nodeID, state: .status.currentState}'` shows a non-`running` state, and volumes stay unready rather than being offered and failing to attach.
4. Deploy an app with a volume. Before this change the volume attach fails repeatedly with `not ready for workloads` while the pull is in flight; after it, the deployment simply waits until storage is genuinely ready and then attaches on the first try.

The premature-ready window was characterized across a 7-leg kvm→EVE-k conversion matrix on amd64 (all 7 legs passed — it cost wall-clock time, not correctness), which is where the 9m51s and 20-minute figures come from.

## Changelog notes

Fixed an issue where a Kubernetes-enabled (EVE-k) node could report cluster storage as ready before it was able to attach volumes, causing the first application deployed on a newly installed or converted node to fail its volume attach repeatedly for several minutes before recovering on its own.

## PR Backports

- 17.0-stable: To be backported — `checkLonghornReady` is present there.
- 16.0-stable: No, the affected code is not present on that branch.
- 14.5-stable: No, the affected code is not present on that branch.
- 13.4-stable: No, the affected code is not present on that branch.

(Verified by checking for `func checkLonghornReady` in `pkg/pillar/kubeapi/kubeapi.go` on each branch.)

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.

Reasons for the unchecked boxes: no documentation change — this corrects an existing readiness check rather than adding a knob or a user-visible feature. The pillar half of this patch has now run on an amd64 device (QEMU under Eden) across the full seven-leg kvm→EVE-k conversion matrix, 7/7; arm64 is still untested, and the `pkg/kube/longhorn-utils.sh` half has not run anywhere, because the branch used for that matrix carries #5971 and #5971 deletes that file. Labels: `stable` should be added for the 17.0-stable backport.


