### PR TITLE
github/workflows: Fix Eden Tests Complete job for 17.0-stable branch

### DIFF
--- a/.github/workflows/eden-trusted.yml
+++ b/.github/workflows/eden-trusted.yml
@@ -219,7 +219,7 @@ jobs:
     name: ${{ needs.context.outputs.eden_parent_job_title }} for 17.0-stable
     needs: context
     if: needs.context.outputs.skip_run == 'false' && needs.context.outputs.pr_base_ref == '17.0-stable'
-    uses: lf-edge/eden/.github/workflows/test.yml@1.0.15
+    uses: lf-edge/eden/.github/workflows/test.yml@1.0.15  # zizmor: ignore[unpinned-uses] eden release tag versioned with our EVE release branches; a SHA pin would force a cross-repo bump on every eden patch release
     secrets: inherit
     with:
       eve_image: "evebuild/pr:${{ needs.context.outputs.pr_id }}"
@@ -243,7 +243,7 @@ jobs:
 
   finalize:
     name: Eden Tests Complete
-    needs: [context, tests-13-4-stable, tests-14-5-stable, tests-16-0-stable, tests-master]
+    needs: [context, tests-13-4-stable, tests-14-5-stable, tests-16-0-stable, tests-17-0-stable, tests-master]
     if: always() && needs.context.outputs.skip_run == 'false'
     runs-on: ubuntu-latest
     permissions:
@@ -259,6 +259,8 @@ jobs:
             result="${{ needs.tests-14-5-stable.result }}"
           elif [[ "${{ needs.tests-16-0-stable.result }}" != "skipped" ]]; then
             result="${{ needs.tests-16-0-stable.result }}"
+          elif [[ "${{ needs.tests-17-0-stable.result }}" != "skipped" ]]; then
+            result="${{ needs.tests-17-0-stable.result }}"
           else
             result="${{ needs.tests-master.result }}"
           fi


### PR DESCRIPTION
# Description

Add some checks for the 17.0-stable branch that were missing in the Eden Tests Complete job.

Also add the inline zizmor unpinned-uses suppression that the tests-17-0-stable job was missing, matching the other stable jobs.

## How to test and validate this PR

Run Eden Tests workflow on 17.0-stable branch (after backport). It doesn't make sense to validate on master.

## Changelog notes

None.

## PR Backports

- [ ] 17.0-stable

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.