### PR TITLE
[17.0-stable] pkg/debug: Do not populate productURL and logo fields in the device model

### DIFF
--- a/pkg/debug/spec.sh
+++ b/pkg/debug/spec.sh
@@ -189,7 +189,7 @@ LSPCI_D=$(lspci -D)
 cat <<__EOT__
 {
   "arch": $ARCH,
-  "productURL": "$(cat /persist/status/hardwaremodel 2> /dev/null || cat /config/hardwaremodel 2> /dev/null || echo 'not found' )",
+  "productURL": "",
   "productStatus": "production",
   "attr": {
     "memory": "${MEM}M",

--- a/pkg/debug/spec.sh
+++ b/pkg/debug/spec.sh
@@ -200,8 +200,8 @@ cat <<__EOT__
     "leds": "0"
   },
   "logo": {
-    "logo_back":"/workspace/spec/logo_back_.jpg",
-    "logo_front":"/workspace/spec/logo_front_.jpg"
+    "logo_back":"",
+    "logo_front":""
   },
   "ioMemberList": [
 __EOT__

--- a/pkg/installer/Dockerfile
+++ b/pkg/installer/Dockerfile
@@ -28,7 +28,7 @@ RUN cargo sbom > sbom.spdx.json
 
 RUN cp "/usr/local/my-installer/target/$CARGO_BUILD_TARGET/release/installer" /usr/local/my-installer/target/installer
 
-FROM lfedge/eve-debug:86d119744e5d405338a25f09fb08324efa52728c AS debug
+FROM lfedge/eve-debug:98e79f897da89ab5472e0a25e0f92171ed9556f4 AS debug
 
 # Dockerfile to build installer img initrd
 FROM lfedge/eve-alpine:39f46094f640424c345164420ed789afd8a4088b AS build


### PR DESCRIPTION
# Description

Backport of https://github.com/lf-edge/eve/pull/6234

## How to test and validate this PR

Run `spec.sh`, the `productURL`, `logo_front` and `logo_back fields` of the output model must be empty.

## Changelog notes

`spec.sh`: Do not populate `productURL` and `logo` fields when generating device model, so it can be populated later by the user with a valid URL and file paths.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.