### PR TITLE
ci: install libvirt headers for the yetus job

### DIFF
--- a/tools/yetus/Dockerfile
+++ b/tools/yetus/Dockerfile
@@ -9,7 +9,7 @@ FROM ghcr.io/apache/yetus:0.15.1 as build
 
 ARG TARGETARCH
 
-ENV PKG_DEPS="alien autoconf automake build-essential debhelper dh-autoreconf dh-python dkms fakeroot gawk git libaio-dev libattr1-dev libblkid-dev libcurl4-openssl-dev libelf-dev libffi-dev libpam0g-dev libssl-dev libtirpc-dev libtool libudev-dev linux-headers-generic parallel po-debconf python3 python3-all-dev python3-cffi python3-dev python3-packaging python3-setuptools python3-sphinx uuid-dev zlib1g-dev"
+ENV PKG_DEPS="alien autoconf automake build-essential debhelper dh-autoreconf dh-python dkms fakeroot gawk git libaio-dev libattr1-dev libblkid-dev libcurl4-openssl-dev libelf-dev libffi-dev libpam0g-dev libssl-dev libtirpc-dev libtool libudev-dev libvirt-dev linux-headers-generic parallel pkg-config po-debconf python3 python3-all-dev python3-cffi python3-dev python3-packaging python3-setuptools python3-sphinx uuid-dev zlib1g-dev"
 
 # should be aligned with kernel
 #  * ZFS on Linux


### PR DESCRIPTION
# Description

`evetest/broker/provider/libvirt.go` is built under the `cgo` tag and imports `libvirt.org/go/libvirt`, which needs libvirt development headers to compile. The yetus image does not have them, so the job reports:

```
could not import libvirt.org/go/libvirt (-: # libvirt.org/go/libvirt
```

`typecheck` and the golangci-lint passes that depend on it therefore cannot compile that file at all, and it goes effectively unlinted in CI — it is the largest file in the libvirt provider.

This adds `libvirt-dev` and `pkg-config` to the yetus image's package list.

Note the image is published by `buildyetusondemand.yml`, so this takes effect once that image is rebuilt and republished; the import error will persist on in-flight PRs until then.

## How to test and validate this PR

Build the yetus image from `tools/yetus/Dockerfile` and confirm the package is present:

```bash
docker run --rm <image> pkg-config --modversion libvirt
```

Then a yetus run over a branch touching `evetest/broker/provider/libvirt.go` should no longer report `could not import libvirt.org/go/libvirt`.

## Changelog notes

No user-facing changes. CI tooling only.

## PR Backports

- 16.0-stable: No -- CI tooling change, not a fix.
- 14.5-stable: No -- CI tooling change, not a fix.
- 13.4-stable: No -- CI tooling change, not a fix.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.

Not device-tested: the change only affects the CI linting image and touches no device code.
