### PR TITLE
hypervisor: recover a VMIRS stranded at Spec.Replicas == 0

### DIFF
--- a/evetest/tests/cluster/purge_test.go
+++ b/evetest/tests/cluster/purge_test.go
@@ -1,0 +1,307 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	uuid "github.com/satori/go.uuid"
+
+	"github.com/lf-edge/eve-api/go/evecommon"
+	eveinfo "github.com/lf-edge/eve-api/go/info"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/matchers"
+	"github.com/lf-edge/eve/evetest/netmodels"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// purgeMarkerPath is written into the app's root filesystem before the purge.
+// A purge keeps the app's existing volumes (zedmanager's doUpdate: "Keep the
+// old volumes in place"), so the marker is expected to SURVIVE. Only a
+// purge&update, where the controller sends volume refs with new generation
+// counters, causes volumemgr to build fresh volumes.
+const purgeMarkerPath = "/root/purge-marker"
+
+// appPurgeMarkerState reports "PRESENT" or "ABSENT" for purgeMarkerPath inside
+// the app. Phrased as an echo rather than relying on the exit status of `test`,
+// so the result does not depend on how a non-zero exit is surfaced.
+func appPurgeMarkerState(device *evetest.EdgeDevice, appUUID uuid.UUID,
+	auth evetest.AuthMethod, timeout time.Duration) (string, string, error) {
+	return device.RunShellScriptInsideApp(appUUID, auth,
+		"test -f "+purgeMarkerPath+" && echo PRESENT || echo ABSENT", timeout, 0)
+}
+
+// clusterHasVMIWithPrefix reports whether ZInfoKubeCluster lists a VMI whose
+// name starts with prefix. VMIs created by a VMIRS are named
+// "<vmirs-name>-<random suffix>", so the prefix identifies the owning VMIRS.
+func clusterHasVMIWithPrefix(info *eveinfo.ZInfoKubeCluster, prefix string) bool {
+	for _, vmi := range info.GetEveVmApps() {
+		if strings.HasPrefix(vmi.GetName(), prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestAppInstancePurge verifies the happy-path purge of a running application on
+// a single-node EVE-K cluster: no node outage, no node reboot, no injected
+// fault. The controller increments the app's purge counter and EVE is expected
+// to tear the old workload down and bring an equivalent one back up.
+//
+// Under Kubevirt a purge changes the app's Kubernetes identity -- the VMIRS name
+// embeds the purge counter (base.GetAppKubeNameWithPurge) -- so the old VMIRS
+// must be deleted before the new one is created. That teardown runs through
+// domainmgr's handleModify path with impatient=true, which deliberately bypasses
+// the cluster-trust guard in doInactivate that otherwise leaves a VMIRS alone
+// while UserActivate=true. This test is the happy-path counterpart to
+// TestVMIRSStrandedReplicasRecovery: that one injects a fault, this one checks
+// the ordinary lifecycle is not disturbed.
+//
+// Purge vs. purge&update
+// ----------------------
+// A purge on its own does NOT recreate the app's volumes: zedmanager's doUpdate
+// hands the teardown to doRemove with uninstall=false explicitly to "keep the
+// old volumes in place", and purgeCmdDone only drops volume refs that the new
+// config no longer references. Volumes are rebuilt only when the config carries
+// new volume generation counters, i.e. a purge&update. This test therefore
+// asserts the marker file SURVIVES; a future purge&update test should assert the
+// opposite.
+//
+// Network model
+// -------------
+//   - netmodels.SingleEthWithDHCP -- one mgmt+app port, SDN DNS, controller
+//     reachable. Port forwarding (2222->22) is needed so the marker file can be
+//     written and re-checked inside the app over SSH.
+//
+// Device configuration
+// --------------------
+//   - clusterDeviceRequirements (cluster_test.go): WithHypervisor=Kubevirt,
+//     DeviceReusePolicy=CreateFromScratchWithLiveImage, ext4, plus grub options
+//     that cap dom0/eve/ctrd vcpus so cluster formation is fast. That policy
+//     re-creates the VM even when a matching one exists, so this test always
+//     forms its own cluster; only the harness (Adam, SDN, broker) is shared with
+//     the other subtests. Running it standalone therefore costs no more than
+//     running it as part of the suite.
+//   - SystemAdapter on eth0 (DHCP, mgmt+app, NetworkType=V4Only).
+//   - One Local NI "local-ni" and one container app (VirtualizationMode left at
+//     its default, i.e. not NOHYPER, so the app is backed by a VMIRS/VMI rather
+//     than a plain k8s ReplicaSet -- the code path a purge has to rename).
+//
+// Test parameters
+// ---------------
+//   - TPM via evetest.TPMParameter() (suite-wide, see TestNodeClusterSuite).
+//
+// Phases
+// ------
+//  1. setup-done -> initial-config-applied: apply the device config.
+//  2. app-is-deployed: WaitUntilAppIsRunning (10 min budget excluding download).
+//  3. marker-written: touch purgeMarkerPath inside the app and confirm it reads
+//     back as PRESENT, wrapped in Eventually since the app's SSH daemon comes up
+//     some time after the app reports RUNNING.
+//  4. watches-started: subscribe to ZInfoApp and ZInfoKubeCluster, and record the
+//     pre-purge VMIRS name. The watches are started HERE, immediately before the
+//     purge, and not earlier: they are live subscriptions with buffered channels,
+//     so a watch opened before the deployment would hand the assertions below the
+//     entire deploy backlog and they would match stale RUNNING / non-RUNNING
+//     messages instantly, passing without observing the purge at all.
+//  5. purge-requested: increment the purge counter via PurgeApplication.
+//     waitUntilPurged=false because that helper waits via IterateDeviceInfoMsgs,
+//     which replays Adam's stored messages before following and so would match
+//     the pre-purge RUNNING immediately.
+//  6. app-left-running: ZInfoApp reports a state other than RUNNING. This proves
+//     the purge was acted on rather than coalescing into a no-op, and is
+//     deliberately "not RUNNING" rather than a specific PURGING/HALTING so the
+//     test does not depend on which transitional states get published.
+//  7. app-recovered: ZInfoApp returns to State=RUNNING with no AppErr.
+//  8. vmirs-renamed: ZInfoKubeCluster lists a VMI belonging to the purge-counter-1
+//     VMIRS and none belonging to the purge-counter-0 one. This is what separates
+//     a purge from a plain restart -- a restart reuses the VMIRS name -- and it is
+//     the assertion that would catch the old VMIRS being left behind.
+//  9. volumes-preserved: purgeMarkerPath still reads PRESENT (see "Purge vs.
+//     purge&update" above).
+//
+// Suite placement
+// ---------------
+//   - TestNodeClusterSuite (cluster tests are pinned to Kubevirt; purge under
+//     Kubevirt is the path being exercised).
+func TestAppInstancePurge(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	// Define configurable parameters available for the test.
+	evetest.DefineTestParameters(
+		evetest.TPMParameter(),
+	)
+	withTPM := evetest.GetTPMParameterValue()
+
+	// Set up the test harness and specify the test prerequisites.
+	devName := "edge-dev"
+	requiredDevice := clusterDeviceRequirements(devName, withTPM, evetest.FilesystemEXT4)
+	requiredNetModel := evetest.RequireNetworkModel{
+		NetworkModel: netmodels.SingleEthWithDHCP,
+	}
+	evetest.Setup(requiredDevice, requiredNetModel)
+	evetest.Checkpoint("setup-done")
+
+	// Build and apply the initial device configuration.
+	devConfig := evetest.NewEdgeDeviceConfig(devName)
+	dhcpNet := devConfig.AddNetwork(
+		evetest.DHCPNetworkConfig{
+			NetworkType: evecommon.NetworkType_V4Only,
+		})
+	devConfig.AddNetworkAdapter(
+		evetest.NetworkAdapterConfig{
+			LogicalLabel:  "ethernet0",
+			PhysicalLabel: "eth0",
+			InterfaceName: "eth0",
+			NetworkUUID:   dhcpNet,
+			Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+		})
+
+	niUUID := devConfig.AddNetworkInstance(evetest.LocalNetworkInstanceConfig{
+		DisplayName: "local-ni",
+		Port:        "ethernet0",
+		Subnet:      evetest.IPSubnet("10.11.12.0/24"),
+		DHCPRange: types.IPRange{
+			Start: evetest.IPAddress("10.11.12.2"),
+			End:   evetest.IPAddress("10.11.12.254"),
+		},
+		Gateway: evetest.IPAddress("10.11.12.1"),
+		MTU:     1500,
+	})
+	const appDisplayName = "purge-app"
+	appUUID := devConfig.AddApplication(evetest.ApplicationInstanceConfig{
+		DisplayName: appDisplayName,
+		Activate:    true,
+		Image: evetest.DockerContainer{
+			ImageName: "lfedge/evetest-ubuntu-ctr",
+			Tag:       "1.0",
+		},
+		CPUs:        1,
+		MemoryBytes: 500 * evetest.MiB,
+		NetworkAdapters: []evetest.AppNetworkAdapter{
+			evetest.VirtualNetworkAdapter{
+				LogicalLabel:        "vif0",
+				NetworkInstanceUUID: niUUID,
+				PortFwdRules: []evetest.PortFwdRule{
+					{
+						Protocol:     evetest.NetworkProtocolTCP,
+						EdgeNodePort: 2222,
+						AppPort:      22,
+					},
+				},
+				ACLAllowRules: []evetest.ACLAllowRule{
+					{
+						Protocol:     evetest.NetworkProtocolAny,
+						RemoteSubnet: evetest.IPSubnet("0.0.0.0/0"),
+					},
+				},
+			},
+		},
+	})
+
+	device := evetest.GetEdgeDevice(devName)
+	device.ApplyConfig(devConfig, true, true)
+	log := evetest.Logger()
+	log.Infof("Submitted config with app UUID=%v", appUUID)
+	evetest.Checkpoint("initial-config-applied")
+
+	timeoutExcludingDownload := 10 * time.Minute
+	device.WaitUntilAppIsRunning(appUUID, timeoutExcludingDownload)
+	evetest.Checkpoint("app-is-deployed")
+
+	// Mark the app's root filesystem so volume handling across the purge is
+	// observable. RunShellScriptInsideApp uses the 2222->22 port forwarding rule.
+	appAuth := evetest.UsernamePasswordAuth{
+		Username: "root",
+		Password: "testpassword",
+	}
+	sshTimeout := 20 * time.Second
+	sshReadyTimeout := 3 * time.Minute
+	polling := 3 * time.Second
+	log.Infof("Writing purge marker %s inside the app", purgeMarkerPath)
+	t.Eventually(func(t Gomega) {
+		_, stderr, err := device.RunShellScriptInsideApp(appUUID, appAuth,
+			"touch "+purgeMarkerPath, sshTimeout, 0)
+		t.Expect(err).ToNot(HaveOccurred(), stderr)
+	}, sshReadyTimeout, polling).Should(Succeed())
+	stdout, stderr, err := appPurgeMarkerState(device, appUUID, appAuth, sshTimeout)
+	t.Expect(err).ToNot(HaveOccurred(), stderr)
+	t.Expect(stdout).To(ContainSubstring("PRESENT"))
+	evetest.Checkpoint("marker-written")
+
+	// Start the watches only now: they are live subscriptions over buffered
+	// channels, so opening them earlier would leave the assertions below matching
+	// the deploy backlog instead of the purge.
+	//
+	// The VMIRS name is GetAppKubeName(displayName, uuid) + "-" + purgeCounter
+	// (pkg/pillar/base/kubevirt.go, GetAppKubeNameWithPurge); the counter is 0 for
+	// a freshly deployed app and 1 after this test's purge. Appended manually
+	// rather than calling GetAppKubeNameWithPurge directly since that helper
+	// postdates the pkg/pillar version currently pinned in evetest/go.mod.
+	kubeName := base.GetAppKubeName(appDisplayName, appUUID)
+	vmirsBeforePurge := fmt.Sprintf("%s-0", kubeName)
+	vmirsAfterPurge := fmt.Sprintf("%s-1", kubeName)
+	appUpdates, stopAppWatch := device.WatchAppInfo(appUUID)
+	defer stopAppWatch()
+	clusterUpdates, stopClusterWatch := device.WatchClusterInfo()
+	defer stopClusterWatch()
+	evetest.Checkpoint("watches-started")
+
+	// Request the purge.
+	log.Infof("Purging app %v (VMIRS %s -> %s)", appUUID,
+		vmirsBeforePurge, vmirsAfterPurge)
+	device.PurgeApplication(appUUID, false, 0)
+	evetest.Checkpoint("purge-requested")
+
+	// The app must actually leave RUNNING, otherwise a purge dropped on the floor
+	// would satisfy the recovery assertion below trivially.
+	purgeStartTimeout := 3 * time.Minute
+	t.Eventually(appUpdates, purgeStartTimeout).Should(Receive(matchers.SatisfyPredicate(
+		"app left the RUNNING state to be purged",
+		func(ainfo *eveinfo.ZInfoApp) bool {
+			return ainfo.GetState() != eveinfo.ZSwState_RUNNING
+		})))
+	evetest.Checkpoint("app-left-running")
+
+	// The app should come back with no error reported.
+	recoveryTimeout := 10 * time.Minute
+	t.Eventually(appUpdates, recoveryTimeout).Should(Receive(matchers.SatisfyPredicate(
+		"app returned to RUNNING with no error after the purge",
+		func(ainfo *eveinfo.ZInfoApp) bool {
+			return ainfo.GetState() == eveinfo.ZSwState_RUNNING &&
+				len(ainfo.GetAppErr()) == 0
+		})))
+	evetest.Checkpoint("app-recovered")
+
+	// The purge counter is part of the VMIRS name, so the workload must have moved
+	// to the new VMIRS and the old one must be gone. A plain restart would keep
+	// the old name, and a failed teardown would leave both present.
+	vmirsTimeout := 5 * time.Minute
+	t.Eventually(clusterUpdates, vmirsTimeout).Should(Receive(matchers.SatisfyPredicate(
+		fmt.Sprintf("VMI moved to VMIRS %s and none left on %s",
+			vmirsAfterPurge, vmirsBeforePurge),
+		func(info *eveinfo.ZInfoKubeCluster) bool {
+			return clusterHasVMIWithPrefix(info, vmirsAfterPurge) &&
+				!clusterHasVMIWithPrefix(info, vmirsBeforePurge)
+		})))
+	evetest.Checkpoint("vmirs-renamed")
+
+	// A purge keeps the app's volumes, so the marker must still be there.
+	log.Infof("Checking that purge marker %s survived the purge", purgeMarkerPath)
+	t.Eventually(func(t Gomega) {
+		stdout, stderr, err := appPurgeMarkerState(device, appUUID, appAuth, sshTimeout)
+		t.Expect(err).ToNot(HaveOccurred(), stderr)
+		t.Expect(stdout).To(ContainSubstring("PRESENT"))
+	}, sshReadyTimeout, polling).Should(Succeed())
+	evetest.Checkpoint("volumes-preserved")
+}

--- a/evetest/tests/cluster/testsuite_test.go
+++ b/evetest/tests/cluster/testsuite_test.go
@@ -10,15 +10,20 @@ import (
 )
 
 // TestNodeClusterSuite is the top-level entry point for cluster tests.
-// It runs TestSingleNodeCluster followed by TestThreeNodesCluster,
-// reusing the evetest harness (Adam controller, SDN, broker) across both
-// subtests for efficiency. Both subtests pin the device to the Kubevirt
-// hypervisor (cluster tests are the only ones that use Kubevirt).
+// It runs TestSingleNodeCluster, TestAppInstancePurge,
+// TestVMIRSStrandedReplicasRecovery, and TestThreeNodesCluster, reusing the
+// evetest harness (Adam controller, SDN, broker) across all subtests for
+// efficiency. All subtests pin the device to the Kubevirt hypervisor (cluster
+// tests are the only ones that use Kubevirt).
+//
+// The single-node subtests run before the three-node one, and the happy-path
+// purge runs before the fault-injecting VMIRS test, so a failure in the
+// ordinary app lifecycle is not masked by chaos.
 //
 // Test parameters
 // ---------------
 //   - TPM (bool) via evetest.TPMParameter(). The suite passes the same
-//     TPM choice to both subtests.
+//     TPM choice to all subtests.
 func TestNodeClusterSuite(test *testing.T) {
 	evetest.Init(test)
 	defer evetest.Close()
@@ -31,6 +36,12 @@ func TestNodeClusterSuite(test *testing.T) {
 	evetest.RunTestSuite(
 		evetest.TestCase{
 			Test: TestSingleNodeCluster,
+		},
+		evetest.TestCase{
+			Test: TestAppInstancePurge,
+		},
+		evetest.TestCase{
+			Test: TestVMIRSStrandedReplicasRecovery,
 		},
 		evetest.TestCase{
 			Test: TestThreeNodesCluster,

--- a/evetest/tests/cluster/vmirs_replica_recovery_test.go
+++ b/evetest/tests/cluster/vmirs_replica_recovery_test.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	"github.com/lf-edge/eve-api/go/evecommon"
+	eveinfo "github.com/lf-edge/eve-api/go/info"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/matchers"
+	"github.com/lf-edge/eve/evetest/netmodels"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	pillartypes "github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// TestVMIRSStrandedReplicasRecovery is a chaos-style test: it deploys an app
+// on a single-node EVE-K cluster, then bypasses the controller entirely and
+// scales the app's VirtualMachineInstanceReplicaSet to 0 replicas directly
+// via kubectl over SSH -- reproducing the state an interrupted
+// DetachUtilVmirsReplicaReset (pkg/pillar/kubeapi/kubeapi.go) can leave
+// behind on a real failover, without needing to actually trigger a failover.
+// It then verifies that EVE notices and self-heals: the app surfaces a
+// retryable warning instead of silently staying "RUNNING", and later
+// returns to RUNNING with no error once domainmgr's boot-retry loop repairs
+// the replica count.
+//
+// Network model
+// -------------
+//   - netmodels.SingleEthWithDHCP -- one mgmt+app port, SDN DNS, controller
+//     reachable. No app-facing connectivity is exercised by this test, so no
+//     port forwarding or outbound ACL is needed.
+//
+// Device configuration
+// --------------------
+//   - clusterDeviceRequirements (cluster_test.go): WithHypervisor=Kubevirt,
+//     DeviceReusePolicy=CreateFromScratchWithLiveImage, ext4, plus grub
+//     options that cap dom0/eve/ctrd vcpus so cluster formation is fast.
+//   - SystemAdapter on eth0 (DHCP, mgmt+app, NetworkType=V4Only).
+//   - timer.boot.retry (DomainBootRetryTime) lowered to its 10s floor
+//     (GlobalConfigMinimums), so domainmgr's boot-retry loop -- which
+//     defaults to a 600s interval -- runs often enough to keep this test's
+//     runtime reasonable.
+//   - One Local NI "local-ni" and one container app (VirtualizationMode
+//     left at its default, i.e. not NOHYPER, so the app is backed by a
+//     VMIRS/VMI rather than a plain k8s ReplicaSet -- the code path this
+//     bug is specific to).
+//
+// Test parameters
+// ---------------
+//   - TPM via evetest.TPMParameter() (suite-wide, see TestNodeClusterSuite).
+//
+// Phases
+// ------
+//  1. setup-done -> initial-config-applied: apply the device config and
+//     start watching the app's ZInfoApp.
+//  2. app-is-deployed: WaitUntilAppIsRunning (10 min budget excluding
+//     download).
+//  3. vmirs-scaled-to-zero: over SSH, `eve exec kube kubectl patch vmirs
+//     --type=merge` (kubectl only exists inside the "kube" container) the
+//     app's VMIRS (name computed via base.GetAppKubeName, matching how
+//     pillar names it) to Spec.Replicas=0. This is the same
+//     recipe used to reproduce the bug manually (see the design doc's
+//     on-device reproduction section); StopReplicaVMI deletes the VMIRS
+//     rather than scaling it, so zero replicas is never a state the
+//     control plane produces on its own -- an SSH-injected patch is the
+//     only way to reach it deterministically without a real, racy
+//     failover.
+//  4. stranded-vmirs-detected: ZInfoApp reports an AppErr with
+//     Severity=WARNING and a non-empty RetryCondition -- domainmgr's
+//     Info()/verifyStatus path noticing the stranded VMIRS, rather than
+//     silently keeping the app "RUNNING" with a non-existent VMI.
+//  5. app-recovered: ZInfoApp returns to State=RUNNING with no AppErr --
+//     maybeRetryBoot re-invoked Start(), which raised Spec.Replicas back
+//     to 1, and a new VMI/pod came up.
+//
+// Assertions are made purely against ZInfoApp (the EVE API); the SSH
+// session is used only to inject the fault, never to read pillar's
+// internal state.
+//
+// Suite placement
+// ---------------
+//   - TestNodeClusterSuite (cluster tests are pinned to Kubevirt; this bug
+//     is specific to the VMIRS/VMI code path).
+func TestVMIRSStrandedReplicasRecovery(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	// Define configurable parameters available for the test.
+	evetest.DefineTestParameters(
+		evetest.TPMParameter(),
+	)
+	withTPM := evetest.GetTPMParameterValue()
+
+	// Set up the test harness and specify the test prerequisites.
+	devName := "edge-dev"
+	requiredDevice := clusterDeviceRequirements(devName, withTPM, evetest.FilesystemEXT4)
+	requiredNetModel := evetest.RequireNetworkModel{
+		NetworkModel: netmodels.SingleEthWithDHCP,
+	}
+	evetest.Setup(requiredDevice, requiredNetModel)
+	evetest.Checkpoint("setup-done")
+
+	// Build and apply the initial device configuration.
+	devConfig := evetest.NewEdgeDeviceConfig(devName)
+	cfgProps := pillartypes.NewConfigItemValueMap()
+	cfgProps.SetGlobalValueInt(pillartypes.DomainBootRetryTime, 10)
+	devConfig.SetConfigProperties(cfgProps)
+	dhcpNet := devConfig.AddNetwork(
+		evetest.DHCPNetworkConfig{
+			NetworkType: evecommon.NetworkType_V4Only,
+		})
+	devConfig.AddNetworkAdapter(
+		evetest.NetworkAdapterConfig{
+			LogicalLabel:  "ethernet0",
+			PhysicalLabel: "eth0",
+			InterfaceName: "eth0",
+			NetworkUUID:   dhcpNet,
+			Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+		})
+
+	niUUID := devConfig.AddNetworkInstance(evetest.LocalNetworkInstanceConfig{
+		DisplayName: "local-ni",
+		Port:        "ethernet0",
+		Subnet:      evetest.IPSubnet("10.11.12.0/24"),
+		DHCPRange: pillartypes.IPRange{
+			Start: evetest.IPAddress("10.11.12.2"),
+			End:   evetest.IPAddress("10.11.12.254"),
+		},
+		Gateway: evetest.IPAddress("10.11.12.1"),
+		MTU:     1500,
+	})
+	const appDisplayName = "vmirs-chaos-app"
+	appUUID := devConfig.AddApplication(evetest.ApplicationInstanceConfig{
+		DisplayName: appDisplayName,
+		Activate:    true,
+		Image: evetest.DockerContainer{
+			ImageName: "lfedge/evetest-ubuntu-ctr",
+			Tag:       "1.0",
+		},
+		CPUs:        1,
+		MemoryBytes: 500 * evetest.MiB,
+		NetworkAdapters: []evetest.AppNetworkAdapter{
+			evetest.VirtualNetworkAdapter{
+				LogicalLabel:        "vif0",
+				NetworkInstanceUUID: niUUID,
+			},
+		},
+	})
+
+	device := evetest.GetEdgeDevice(devName)
+	updates, stopWatch := device.WatchAppInfo(appUUID)
+	defer stopWatch()
+	device.ApplyConfig(devConfig, true, true)
+	log := evetest.Logger()
+	log.Infof("Submitted config with app UUID=%v", appUUID)
+	evetest.Checkpoint("initial-config-applied")
+
+	timeoutExcludingDownload := 10 * time.Minute
+	device.WaitUntilAppIsRunning(appUUID, timeoutExcludingDownload)
+	evetest.Checkpoint("app-is-deployed")
+
+	// Scale the app's VMIRS to 0 replicas, bypassing the controller. This is
+	// the exact state DetachUtilVmirsReplicaReset can strand a VMIRS in if
+	// interrupted between its scale-to-0 and scale-to-1 writes.
+	//
+	// The VMIRS name is GetAppKubeName(displayName, uuid) + "-" + purgeCounter
+	// (pkg/pillar/base/kubevirt.go, GetAppKubeNameWithPurge); purgeCounter is
+	// 0 for a freshly deployed app. Appended manually rather than calling
+	// GetAppKubeNameWithPurge directly since that helper postdates the
+	// pkg/pillar version currently pinned in evetest/go.mod.
+	vmirsName := fmt.Sprintf("%s-0", base.GetAppKubeName(appDisplayName, appUUID))
+	sshTimeout := 20 * time.Second
+	// kubectl only exists inside the "kube" container, not the host SSH
+	// shell, so run it via "eve exec kube" (see vaultLogicalUsed in
+	// tests/storage/vault_trim_test.go for the equivalent "eve exec pillar"
+	// pattern).
+	patchCmd := fmt.Sprintf(
+		`eve exec kube kubectl -n eve-kube-app patch vmirs %s --type=merge -p '{"spec":{"replicas":0}}'`,
+		vmirsName)
+	log.Infof("Injecting fault: %s", patchCmd)
+	_, stderr, err := device.RunShellScript(patchCmd, sshTimeout, 0)
+	t.Expect(err).ToNot(HaveOccurred(), stderr)
+	evetest.Checkpoint("vmirs-scaled-to-zero")
+
+	// EVE should notice the stranded VMIRS and report a retryable warning,
+	// rather than silently keeping the app "RUNNING" (the pre-fix behavior:
+	// Info() returned UNKNOWN with a nil error for a zero-replica VMIRS,
+	// which verifyStatus never surfaces as an error).
+	detectionTimeout := 3 * time.Minute
+	t.Eventually(updates, detectionTimeout).Should(Receive(matchers.SatisfyPredicate(
+		"app reports a retryable warning for the stranded VMIRS",
+		func(ainfo *eveinfo.ZInfoApp) bool {
+			for _, appErr := range ainfo.GetAppErr() {
+				if appErr.GetSeverity() == eveinfo.Severity_SEVERITY_WARNING &&
+					appErr.GetRetryCondition() != "" {
+					return true
+				}
+			}
+			return false
+		})))
+	evetest.Checkpoint("stranded-vmirs-detected")
+
+	// domainmgr's maybeRetryBoot should re-invoke Start(), which raises
+	// Spec.Replicas back to 1 (ensureVmirsReplicas), and the app should
+	// return to RUNNING with the error cleared, without any further
+	// intervention.
+	recoveryTimeout := 5 * time.Minute
+	t.Eventually(updates, recoveryTimeout).Should(Receive(matchers.SatisfyPredicate(
+		"app recovered to RUNNING with no error",
+		func(ainfo *eveinfo.ZInfoApp) bool {
+			return ainfo.GetState() == eveinfo.ZSwState_RUNNING && len(ainfo.GetAppErr()) == 0
+		})))
+	evetest.Checkpoint("app-recovered")
+}

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -801,8 +801,13 @@ func (ctx kubevirtContext) Start(domainName string) error {
 			break
 		}
 		if errors.IsAlreadyExists(err) {
-			// VMI could have been already started, for example failover from other node.
+			// VMI could have been already started, for example failover from
+			// other node. An interrupted DetachUtilVmirsReplicaReset can leave
+			// the existing object scaled to 0 replicas; ensure it is not.
 			logrus.Warnf("VMI replicaset %v already exists", repvmi)
+			if ensureErr := ensureVmirsReplicas(virtClient, vmis.name); ensureErr != nil {
+				return logError("Start domain %s: failed to ensure vmirs %s replicas: %v", domainName, vmis.name, ensureErr)
+			}
 			break
 		}
 		if retries <= 0 {
@@ -844,22 +849,29 @@ func (ctx kubevirtContext) replicaVmiScheduledOnMe(vmirsName string) (scheduledO
 	if err != nil {
 		return false, false, err
 	}
-	kubeconfig := ctx.kubeConfig
 
-	nodeName, ok := ctx.nodeNameMap["nodename"]
-	if !ok {
-		return false, false, fmt.Errorf("Failed to get nodeName")
-	}
-
-	virtClient, err := kubecli.GetKubevirtClientFromRESTConfig(kubeconfig)
+	virtClient, err := kubecli.GetKubevirtClientFromRESTConfig(ctx.kubeConfig)
 	if err != nil {
 		logrus.Errorf("couldn't get the kubernetes client API config: %v", err)
 		return false, false, err
 	}
 
-	vmirs, err := virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).Get(context.Background(), vmirsName, metav1.GetOptions{})
+	vmirs, err := getVmirs(virtClient, vmirsName)
 	if err != nil {
 		return false, false, err
+	}
+	return ctx.vmiScheduledOnMeFromVmirs(virtClient, vmirs)
+}
+
+// vmiScheduledOnMeFromVmirs is the tail of replicaVmiScheduledOnMe, taking an
+// already-fetched VMIRS instead of fetching its own copy. Shared with Info(),
+// which already fetched the VMIRS for the stranded-replica check and would
+// otherwise Get the same object a second time in the same call.
+func (ctx kubevirtContext) vmiScheduledOnMeFromVmirs(virtClient kubecli.KubevirtClient,
+	vmirs *v1.VirtualMachineInstanceReplicaSet) (scheduledOnMe bool, scheduledOnNone bool, err error) {
+	nodeName, ok := ctx.nodeNameMap["nodename"]
+	if !ok {
+		return false, false, fmt.Errorf("Failed to get nodeName")
 	}
 	appDomainNameSelector := vmirs.Status.LabelSelector
 
@@ -1100,14 +1112,98 @@ func StopReplicaVMI(kubeconfig *rest.Config, repVmiName string) error {
 	// Stop the VMI ReplicaSet
 
 	err = virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).Delete(context.Background(), repVmiName, metav1.DeleteOptions{})
+	if err == nil {
+		logrus.Infof("Stop VMI Replicaset %s deleted", repVmiName)
+		return nil
+	}
 	if errors.IsNotFound(err) {
 		logrus.Infof("Stop VMI Replicaset, Domain already deleted: %v", repVmiName)
-	} else {
-		logrus.Errorf("Stop VMI Replicaset error %v\n", err)
-		return err
+		return nil
 	}
+	logrus.Errorf("Stop VMI Replicaset error %v\n", err)
+	return err
+}
 
-	return nil
+// getVmirs fetches the named VMIRS. Split out from vmirsDesiredReplicas so
+// Info() can reuse the fetched object for the scheduling check afterward
+// instead of fetching the same VMIRS twice.
+func getVmirs(virtClient kubecli.KubevirtClient, vmiRsName string) (*v1.VirtualMachineInstanceReplicaSet, error) {
+	getCtx, getCancel := context.WithTimeout(context.Background(), kubeapi.KubeAPITimeout())
+	defer getCancel()
+	return virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).Get(getCtx, vmiRsName, metav1.GetOptions{})
+}
+
+// vmirsDesiredReplicas returns the VMIRS Spec.Replicas value. A nil
+// Spec.Replicas is reported as 1, matching the KubeVirt default.
+func vmirsDesiredReplicas(vmirs *v1.VirtualMachineInstanceReplicaSet) int32 {
+	if vmirs.Spec.Replicas == nil {
+		return 1
+	}
+	return *vmirs.Spec.Replicas
+}
+
+// vmirsStranded reports whether a VMIRS exists but is scaled to zero
+// replicas. This is never a legitimate steady state in EVE: StopReplicaVMI
+// deletes the VMIRS rather than scaling it, so zero means an interrupted
+// replica reset (see DetachUtilVmirsReplicaReset).
+func vmirsStranded(desiredReplicas int32) bool {
+	return desiredReplicas == 0
+}
+
+// ensureVmirsReplicaRetries bounds the Get/mutate/Update retry loop in
+// ensureVmirsReplicas. The budget covers exactly one error: a 409 Conflict on
+// the Update, meaning another writer -- KubeVirt's VMIRS controller, or
+// zedkube's own vmirsReplicaCountSet -- advanced resourceVersion between our
+// Get and our Update. A conflicted body cannot be resent as-is, so the loop
+// has to re-Get and re-decide rather than retry the write; that re-Get is the
+// only reason the Get lives inside the loop.
+//
+// Every other error -- NotFound, transient apiserver failures, an expired
+// context -- returns immediately and consumes none of this budget. Retrying
+// those is the caller's concern, not this loop's.
+const ensureVmirsReplicaRetries = 3
+
+// ensureVmirsReplicas repairs a stranded VMIRS by setting Spec.Replicas to 1.
+// An interrupted DetachUtilVmirsReplicaReset can leave it at 0, which no other
+// code path restores.
+//
+// Zero is the only value treated as broken, via the same vmirsStranded check
+// Info() uses, so the two cannot disagree about what "stranded" means. EVE only
+// ever creates a VMIRS with Replicas=1 and nothing scales it up, so a value
+// above 1 is not a state EVE produces; if one is observed anyway it is left
+// alone rather than scaled in. That keeps every write this function makes an
+// upward one, which is what lets concurrent callers converge -- a downward write
+// would both fight the other writers of this field (KubeVirt's controller,
+// zedkube's vmirsReplicaCountSet) and delete a VMI that may be the one actually
+// serving the app.
+func ensureVmirsReplicas(virtClient kubecli.KubevirtClient, vmiRsName string) error {
+	for attempt := 1; attempt <= ensureVmirsReplicaRetries; attempt++ {
+		getCtx, getCancel := context.WithTimeout(context.Background(), kubeapi.KubeAPITimeout())
+		vmirs, err := virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).Get(getCtx, vmiRsName, metav1.GetOptions{})
+		getCancel()
+		if err != nil {
+			return err
+		}
+		if !vmirsStranded(vmirsDesiredReplicas(vmirs)) {
+			return nil
+		}
+
+		reps := int32(1)
+		vmirs.Spec.Replicas = &reps
+		updateCtx, updateCancel := context.WithTimeout(context.Background(), kubeapi.KubeAPITimeout())
+		_, err = virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).Update(updateCtx, vmirs, metav1.UpdateOptions{})
+		updateCancel()
+		if err == nil {
+			return nil
+		}
+		if !errors.IsConflict(err) {
+			return err
+		}
+		logrus.Warnf("ensureVmirsReplicas: conflict updating vmirs %s, retrying (%d/%d)",
+			vmiRsName, attempt, ensureVmirsReplicaRetries)
+	}
+	return fmt.Errorf("ensureVmirsReplicas: exhausted %d retries updating vmirs %s replicas",
+		ensureVmirsReplicaRetries, vmiRsName)
 }
 
 func (ctx kubevirtContext) Info(domainName string) (int, types.SwState, error) {
@@ -1135,7 +1231,40 @@ func (ctx kubevirtContext) Info(domainName string) (int, types.SwState, error) {
 		}
 	}
 
-	onMe, _, err := ctx.scheduledOnMe(vmis.mtype, vmis.name)
+	// Check for a stranded VMIRS before the scheduledOnMe/!onMe short-circuit
+	// below: with zero replicas there is no VMI and no virt-launcher pod, so
+	// onMe would be false and this domain would otherwise be reported as
+	// UNKNOWN forever instead of recovering. The VMIRS fetched here is reused
+	// for the scheduling check below instead of fetching it a second time.
+	var vmirs *v1.VirtualMachineInstanceReplicaSet
+	var virtClient kubecli.KubevirtClient
+	if vmis.mtype == IsMetaReplicaVMI {
+		var verr error
+		virtClient, verr = kubecli.GetKubevirtClientFromRESTConfig(ctx.kubeConfig)
+		if verr != nil {
+			return 0, types.BROKEN, logError("couldn't get the kubernetes client API config: %v", verr)
+		}
+		var rerr error
+		vmirs, rerr = getVmirs(virtClient, vmis.name)
+		if rerr != nil {
+			if isK3sUnreachable(rerr) {
+				return 0, types.UNKNOWN, nil
+			}
+			// Non-unreachable Get failure: fall through to scheduledOnMe's own
+			// independent fetch attempt below, same as before this reuse was
+			// added -- vmirs stays nil so the generic dispatch runs.
+			vmirs = nil
+		} else if vmirsStranded(vmirsDesiredReplicas(vmirs)) {
+			return 0, types.HALTED, logError("domain %s vmirs %s scaled to 0 replicas", domainName, vmis.name)
+		}
+	}
+
+	var onMe bool
+	if vmirs != nil {
+		onMe, _, err = ctx.vmiScheduledOnMeFromVmirs(virtClient, vmirs)
+	} else {
+		onMe, _, err = ctx.scheduledOnMe(vmis.mtype, vmis.name)
+	}
 	if err != nil {
 		if isK3sUnreachable(err) {
 			return 0, types.UNKNOWN, nil

--- a/pkg/pillar/hypervisor/kubevirt_test.go
+++ b/pkg/pillar/hypervisor/kubevirt_test.go
@@ -6,6 +6,7 @@
 package hypervisor
 
 import (
+	"context"
 	"net"
 	"os"
 	"testing"
@@ -14,8 +15,13 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	gomock "go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	virtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
 )
 
 // k3sPem is used for a mock k3s.yaml file
@@ -114,6 +120,137 @@ func TestPodListToSchedulingState(t *testing.T) {
 			assert.Equal(t, tc.wantAnyNode, anyNode)
 		})
 	}
+}
+
+func mkVmirs(name string, replicas *int32) *virtv1.VirtualMachineInstanceReplicaSet {
+	return &virtv1.VirtualMachineInstanceReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       virtv1.VirtualMachineInstanceReplicaSetSpec{Replicas: replicas},
+	}
+}
+
+func int32Ptr(v int32) *int32 { return &v }
+
+func TestVmirsStranded(t *testing.T) {
+	tests := []struct {
+		name     string
+		replicas int32
+		want     bool
+	}{
+		{"zero replicas is stranded", 0, true},
+		{"one replica is healthy", 1, false},
+		{"two replicas is healthy", 2, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, vmirsStranded(tc.replicas))
+		})
+	}
+}
+
+func TestVmirsDesiredReplicas(t *testing.T) {
+	const name = "test-vmirs"
+
+	t.Run("nil Spec.Replicas defaults to 1", func(t *testing.T) {
+		assert.Equal(t, int32(1), vmirsDesiredReplicas(mkVmirs(name, nil)))
+	})
+
+	t.Run("explicit replicas returned as-is", func(t *testing.T) {
+		assert.Equal(t, int32(0), vmirsDesiredReplicas(mkVmirs(name, int32Ptr(0))))
+		assert.Equal(t, int32(2), vmirsDesiredReplicas(mkVmirs(name, int32Ptr(2))))
+	})
+}
+
+func TestGetVmirs(t *testing.T) {
+	const name = "test-vmirs"
+
+	t.Run("returns the fetched object", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mc := kubecli.NewMockKubevirtClient(ctrl)
+		mrs := kubecli.NewMockReplicaSetInterface(ctrl)
+		mc.EXPECT().ReplicaSet(gomock.Any()).Return(mrs)
+		mrs.EXPECT().Get(gomock.Any(), name, metav1.GetOptions{}).Return(mkVmirs(name, int32Ptr(1)), nil)
+
+		vmirs, err := getVmirs(mc, name)
+		assert.NoError(t, err)
+		assert.Equal(t, name, vmirs.Name)
+	})
+
+	t.Run("get error propagates", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mc := kubecli.NewMockKubevirtClient(ctrl)
+		mrs := kubecli.NewMockReplicaSetInterface(ctrl)
+		mc.EXPECT().ReplicaSet(gomock.Any()).Return(mrs)
+		mrs.EXPECT().Get(gomock.Any(), name, metav1.GetOptions{}).Return(
+			nil, k8serrors.NewServiceUnavailable("unreachable"))
+
+		_, err := getVmirs(mc, name)
+		assert.Error(t, err)
+	})
+}
+
+func TestEnsureVmirsReplicas(t *testing.T) {
+	const name = "test-vmirs"
+	conflictErr := k8serrors.NewConflict(schema.GroupResource{}, name, assert.AnError)
+
+	t.Run("zero replicas triggers update to one", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mc := kubecli.NewMockKubevirtClient(ctrl)
+		mrs := kubecli.NewMockReplicaSetInterface(ctrl)
+		mc.EXPECT().ReplicaSet(gomock.Any()).Return(mrs).Times(2)
+		mrs.EXPECT().Get(gomock.Any(), name, metav1.GetOptions{}).Return(mkVmirs(name, int32Ptr(0)), nil)
+		mrs.EXPECT().Update(gomock.Any(), gomock.Any(), metav1.UpdateOptions{}).DoAndReturn(
+			func(_ context.Context, vmirs *virtv1.VirtualMachineInstanceReplicaSet, _ metav1.UpdateOptions) (*virtv1.VirtualMachineInstanceReplicaSet, error) {
+				assert.Equal(t, int32(1), *vmirs.Spec.Replicas)
+				return vmirs, nil
+			})
+
+		assert.NoError(t, ensureVmirsReplicas(mc, name))
+	})
+
+	t.Run("already at one replica: no update", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mc := kubecli.NewMockKubevirtClient(ctrl)
+		mrs := kubecli.NewMockReplicaSetInterface(ctrl)
+		mc.EXPECT().ReplicaSet(gomock.Any()).Return(mrs)
+		mrs.EXPECT().Get(gomock.Any(), name, metav1.GetOptions{}).Return(mkVmirs(name, int32Ptr(1)), nil)
+		// No Update expectation: gomock fails the test if Update is called.
+
+		assert.NoError(t, ensureVmirsReplicas(mc, name))
+	})
+
+	t.Run("conflict once then succeeds", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mc := kubecli.NewMockKubevirtClient(ctrl)
+		mrs := kubecli.NewMockReplicaSetInterface(ctrl)
+		mc.EXPECT().ReplicaSet(gomock.Any()).Return(mrs).Times(4)
+		// A fresh object per Get call: ensureVmirsReplicas mutates Spec.Replicas
+		// on the returned object in place, so a shared/reused mock return value
+		// would carry that mutation into the next Get.
+		mrs.EXPECT().Get(gomock.Any(), name, metav1.GetOptions{}).DoAndReturn(
+			func(context.Context, string, metav1.GetOptions) (*virtv1.VirtualMachineInstanceReplicaSet, error) {
+				return mkVmirs(name, int32Ptr(0)), nil
+			}).Times(2)
+		mrs.EXPECT().Update(gomock.Any(), gomock.Any(), metav1.UpdateOptions{}).Return(nil, conflictErr)
+		mrs.EXPECT().Update(gomock.Any(), gomock.Any(), metav1.UpdateOptions{}).Return(mkVmirs(name, int32Ptr(1)), nil)
+
+		assert.NoError(t, ensureVmirsReplicas(mc, name))
+	})
+
+	t.Run("conflict past retry budget returns error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mc := kubecli.NewMockKubevirtClient(ctrl)
+		mrs := kubecli.NewMockReplicaSetInterface(ctrl)
+		mc.EXPECT().ReplicaSet(gomock.Any()).Return(mrs).Times(ensureVmirsReplicaRetries * 2)
+		mrs.EXPECT().Get(gomock.Any(), name, metav1.GetOptions{}).DoAndReturn(
+			func(context.Context, string, metav1.GetOptions) (*virtv1.VirtualMachineInstanceReplicaSet, error) {
+				return mkVmirs(name, int32Ptr(0)), nil
+			}).Times(ensureVmirsReplicaRetries)
+		mrs.EXPECT().Update(gomock.Any(), gomock.Any(), metav1.UpdateOptions{}).Return(
+			nil, conflictErr).Times(ensureVmirsReplicaRetries)
+
+		assert.Error(t, ensureVmirsReplicas(mc, name))
+	})
 }
 
 // TestCreateReplicaPodConfig tests the CreateReplicaPodConfig function

--- a/pkg/pillar/kubeapi/kubeapi.go
+++ b/pkg/pillar/kubeapi/kubeapi.go
@@ -78,6 +78,13 @@ const (
 	detachUtilVmirsReplicaResetTimeout = 2 * time.Minute
 )
 
+// KubeAPITimeout returns the budget this package uses for a single k8s API
+// call, so other packages (e.g. hypervisor) can bound their own k8s API
+// calls with the same budget instead of redeclaring it.
+func KubeAPITimeout() time.Duration {
+	return kubeAPITimeout
+}
+
 // GetKubeConfig : Get handle to Kubernetes config
 func GetKubeConfig() (*rest.Config, error) {
 	// Build the configuration from the kubeconfig file
@@ -997,7 +1004,9 @@ func DetachOldWorkload(log *base.LogObject, failedNodeName string, appDomainName
 
 	// Push the kubevirt control plane to schedule new pod, otherwise this can be a larger delay
 	if vmiRsName != "" {
-		DetachUtilVmirsReplicaReset(log, vmiRsName)
+		if err := DetachUtilVmirsReplicaReset(log, vmiRsName); err != nil {
+			log.Errorf("DetachOldWorkload vmirs scale reset failed for %s: %v", vmiRsName, err)
+		}
 	}
 
 	// Delete virt-launcher pod on failed node


### PR DESCRIPTION
## Description

DetachUtilVmirsReplicaReset scales a VMIRS 0 then 1 under one bounded context; if the deadline expires, the API server flaps, or the process dies between the two writes, Replicas stays 0 forever. Nothing else in pillar ever reads or repairs Spec.Replicas, and StopReplicaVMI deletes the VMIRS rather than scaling it, so zero replicas is never a legitimate steady state.

Two compounding gaps let this go unnoticed and unrepaired: Start() treats IsAlreadyExists on Create() as success without checking the existing object's replica count, and Info() reports a zero-replica VMIRS (no VMI, no virt-launcher pod) as UNKNOWN with a nil error, before scheduledOnMe's !onMe short-circuit is ever reached. That left domainmgr reporting the app RUNNING to the controller indefinitely while the cluster ran it with zero replicas.

- Info() now checks desired replicas for IsMetaReplicaVMI domains before the scheduledOnMe short-circuit, and reports HALTED with an error on a stranded VMIRS. This is deliberately HALTED, not BROKEN, so verifyStatus's recovery branch sets BootFailed and (for kube) publishes BOOTING while skipping Delete/Cleanup, letting maybeRetryBoot drive recovery through the existing retry loop.
- Start()'s IsAlreadyExists branch now calls ensureVmirsReplicas, which raises Spec.Replicas to at least 1 with a bounded Get/mutate/Update retry on conflicting writers. The repair only ever writes upward on observing zero, so concurrent callers converge and it can never produce the stranded state itself.
- Both new k8s API calls are bounded by kubeapi.KubeAPITimeout() (exported getter over kubeapi's existing private constant, to avoid a third redeclaration of the same budget) rather than context.Background(), since Info()/Start() run on domainmgr's watchdog-timed verifyStatus tick and an unbounded call against a degraded apiserver would otherwise risk a watchdog reboot.
- DetachOldWorkload no longer discards DetachUtilVmirsReplicaReset's return value, so a stranded VMIRS is attributable in logs.
- StopReplicaVMI no longer logs "Stop VMI Replicaset error <nil>" on every successful stop, which polluted the logs used to verify this fix.

Adds an evetest chaos test (evetest/tests/cluster) that deploys an app on a single-node EVE-K cluster, scales its VMIRS to 0 replicas directly over SSH to reproduce the stranded state without needing a real failover, and asserts via the EVE API that the app surfaces a retryable warning and then self-heals back to RUNNING.

## PR dependencies

None

## How to test and validate this PR

**Unit tests** (`pkg/pillar/hypervisor/kubevirt_test.go`): covers
`vmirsStranded`, `vmirsDesiredReplicas`, `ensureVmirsReplicas` (including
conflict-retry). `make -C pkg/pillar test` passes, no regressions.

**evetest** (`TestVMIRSStrandedReplicasRecovery`, `tests/cluster`): deploys
an app on eve-k, scales its VMIRS to 0 via SSH, asserts self-recovery via
the EVE API. Build/vet-clean; not yet run against real hardware — run with
`make evetest NAME=TestVMIRSStrandedReplicasRecovery`.

**Manual repro:**

```sh
kubectl -n eve-kube-app patch vmirs <name> --type=merge -p '{"spec":{"replicas":0}}'

Before: app stays falsely RUNNING with 0 replicas forever. After: within
one timer.boot.retry interval, DomainStatus shows a retryable warning,
then Replicas returns to 1 and the app recovers to RUNNING.

Also check no regression on the normal paths (start/purge/stop/failover).
```

## Changelog notes

Enhanced error recovery on failover of app instances during periods of kube-apiserver instability. 

## PR Backports

- 17.0-stable: To be backported.
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
