### PR TITLE
kubevirt: keep domain bookkeeping until Cleanup

### DIFF
--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -1309,14 +1309,12 @@ func (ctx kubevirtContext) Stop(domainName string, force bool) error {
 	}
 	kubeconfig := ctx.kubeConfig
 
-	keyToDelete := domainName
 	vmis, ok := ctx.vmiList[domainName]
 	if !ok {
 		if stale, oldKey := ctx.lookupVMIByUUIDPrefix(domainName); stale != nil {
 			logrus.Warnf("Stop: domainName %s not in vmiList; using stale entry under %s",
 				domainName, oldKey)
 			vmis = stale
-			keyToDelete = oldKey
 		} else {
 			return logError("domain %s failed to get vmlist", domainName)
 		}
@@ -1344,10 +1342,9 @@ func (ctx kubevirtContext) Stop(domainName string, force bool) error {
 
 	ctx.clearSRIOVAdminMACs(vmis)
 
-	delete(ctx.vmiList, keyToDelete)
-
-	delete(ctx.prevDomainMetric, keyToDelete)
-
+	// The vmiList entry must outlive Stop: Info() needs it to read the guest's
+	// phase, and without it can only report SCHEDULING while domainmgr polls
+	// for the domain to stop. Delete() and Cleanup() own the removal.
 	return nil
 }
 
@@ -1743,16 +1740,28 @@ func (ctx kubevirtContext) Cleanup(domainName string) error {
 	}
 
 	var err error
+	key := domainName
 	vmis, ok := ctx.vmiList[domainName]
 	if !ok {
 		if stale, oldKey := ctx.lookupVMIByUUIDPrefix(domainName); stale != nil {
 			logrus.Warnf("Cleanup: domainName %s not in vmiList; using stale entry under %s",
 				domainName, oldKey)
 			vmis = stale
+			key = oldKey
 		} else {
 			return logError("cleanup domain %s failed to get vmlist", domainName)
 		}
 	}
+
+	// Cleanup is the unconditional tail of doInactivate, whereas Delete only
+	// runs while DomainId is still set, so the bookkeeping is released here.
+	// Deferred so a Cleanup that fails partway still releases it rather than
+	// leaking the entry for the lifetime of the agent.
+	defer func() {
+		delete(ctx.vmiList, key)
+		delete(ctx.prevDomainMetric, key)
+	}()
+
 	if vmis.mtype == IsMetaReplicaPod {
 		_, err = InfoReplicaSetContainer(ctx, vmis)
 		if err == nil {

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -1370,6 +1370,11 @@ func (ctx kubevirtContext) Delete(domainName string) (result error) {
 	}
 
 	onMe, scheduledOnNone, err := ctx.scheduledOnMe(vmis.mtype, vmis.name)
+	if err != nil {
+		// A failed lookup reports onMe=false, which is indistinguishable
+		// from the "scheduled elsewhere" case below.
+		return err
+	}
 	if !onMe && !scheduledOnNone {
 		// Not scheduled on me, but is scheduled elsewhere.
 		return nil

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -1644,6 +1644,15 @@ func (t kubevirtTask) Info(domainName string) (int, types.SwState, error) {
 		var rerr error
 		vmirs, rerr = getVmirs(virtClient, kubeName)
 		if rerr != nil {
+			if errors.IsNotFound(rerr) {
+				// Present at the existence check above and gone by this Get,
+				// so this is the same confirmed-absent answer arriving one
+				// call later. Returning here also skips the fall-through's
+				// own Get, which can only reach the same conclusion.
+				logrus.Infof("Info(%s): %s confirmed absent after the existence check",
+					domainName, kubeName)
+				return 0, types.HALTED, nil
+			}
 			if isK3sUnreachable(rerr) {
 				// Unknown, not absent: hold the caller's id rather than
 				// emitting the "confirmed gone" token.
@@ -1670,6 +1679,14 @@ func (t kubevirtTask) Info(domainName string) (int, types.SwState, error) {
 		onMe, scheduledOnNone, err = t.scheduledOnMe(vmis.mtype, kubeName)
 	}
 	if err != nil {
+		if errors.IsNotFound(err) {
+			// Backstop for the lookups that do their own Get: the NOHYPER
+			// dispatch and the fall-through above. Absence is absence
+			// wherever it is observed.
+			logrus.Infof("Info(%s): %s confirmed absent during the scheduling lookup",
+				domainName, kubeName)
+			return 0, types.HALTED, nil
+		}
 		if isK3sUnreachable(err) {
 			logrus.Infof("Info(%s): k3s unreachable while determining scheduled node: %v",
 				domainName, err)

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -1430,7 +1430,7 @@ func StopReplicaVMI(kubeconfig *rest.Config, repVmiName string) error {
 		logrus.Infof("Stop VMI Replicaset, Domain already deleted: %v", repVmiName)
 		return nil
 	}
-	logrus.Errorf("Stop VMI Replicaset error %v\n", err)
+	logrus.Errorf("Stop VMI Replicaset %s error %v", repVmiName, err)
 	return err
 }
 

--- a/pkg/pillar/hypervisor/kubevirt_info_test.go
+++ b/pkg/pillar/hypervisor/kubevirt_info_test.go
@@ -125,6 +125,49 @@ func TestInfoContract(t *testing.T) {
 	})
 }
 
+// TestInfoVmirsDeletedMidCall covers a VMIRS that is present for Info's
+// existence check and deleted before the Get that follows it. Absence
+// observed at the second Get must produce the same answer as absence
+// observed at the first - HALTED, zero id, no error - rather than the
+// SCHEDULING-with-an-error that a NotFound would otherwise fall through to.
+// That error matters beyond the state it carries: waitForDomainGone treats
+// any error from Info as "the domain is gone" and stops waiting.
+func TestInfoVmirsDeletedMidCall(t *testing.T) {
+	const lastKnownID = 918273645
+	task, status := newInfoTestTask(t, lastKnownID)
+	status.DomainName = "11111111-1111-1111-1111-111111111111.1.1"
+	task.vmiList = map[string]*vmiMetaData{
+		status.DomainName: {mtype: IsMetaReplicaVMI, name: task.kubeName()},
+	}
+
+	ctrl := gomock.NewController(t)
+	mockClient := kubecli.NewMockKubevirtClient(ctrl)
+	mockRS := kubecli.NewMockReplicaSetInterface(ctrl)
+	mockClient.EXPECT().ReplicaSet(gomock.Any()).Return(mockRS).AnyTimes()
+
+	notFound := apierrors.NewNotFound(
+		schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineinstancereplicasets"},
+		task.kubeName())
+	gomock.InOrder(
+		// The existence check finds it...
+		mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			&v1.VirtualMachineInstanceReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{Name: task.kubeName(), UID: "some-uid"},
+			}, nil),
+		// ...and it is gone from here on. Left unbounded rather than pinned
+		// to a single call so this asserts the answer Info returns, not how
+		// many times it asks.
+		mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, notFound).AnyTimes(),
+	)
+	swapKubevirtClient(t, mockClient)
+
+	id, state, err := task.Info(status.DomainName)
+	assert.NoError(t, err, "a confirmed-absent domain is not an error")
+	assert.Equal(t, types.HALTED, state)
+	assert.Zero(t, id)
+}
+
 // TestInfoUnreachableKeepsLastID is a focused restatement of the second
 // case in TestInfoContract: a range of different last-known ids must all
 // survive an existence-check failure unchanged.


### PR DESCRIPTION
# Description

Fixes to the KubeVirt hypervisor backend, found while investigating why an app
restart on EVE-k behaves differently from the same operation on EVE-kvm.

**1. `kubevirt: keep domain bookkeeping until Cleanup`**

`domainmgr` asks the hypervisor to shut a domain down and then polls `Info()`
until it reports the domain gone, before creating any replacement.
`kubevirtContext.Stop()` dropped the `vmiList` entry that `Info()` resolves a
domain through, so every poll after `Stop` failed. `waitForDomainGone` treats a
failed poll as "the domain is gone", so it returned on its first one-second tick
and cleared `DomainId`.

The effect is that domainmgr requests deletion of a VMIRS and creates the
replacement roughly a second later, while KubeVirt is still shutting the old VMI
down — virt-handler signals a graceful shutdown and only kills the VMI once the
grace period expires (30 s by default). On a lab device two `virt-launcher` pods
for the same app were observed running at once as a result. Clearing `DomainId`
also made the forced-shutdown escalation in `doInactivate` unreachable, since it
is guarded on `DomainId` being set.

The entry now stays in place in `Stop` and is removed in `Cleanup`, the
unconditional tail of `doInactivate`. `Delete` cannot own the removal: it only
runs while `DomainId` is still set, which is no longer true once the domain goes
away during the graceful wait, and `Cleanup`'s `IsMetaReplicaVMI` path did not
remove it either — so dropping the `Stop` removal on its own would leak an entry
on every successful graceful shutdown. The removal is deferred, since `Cleanup`
can fail after the domain is already on its way out.

For contrast, the same sequence on EVE-kvm polls real domain state, backs off
1/2/4/8/16/32 s, and escalates before anything replaces the domain, because the
containerd-backed `Stop` it inherits keeps no such state.

**2. `kubevirt: name the replicaset in the delete error`**

A failed VMIRS delete logged only the error, so an operator could not tell which
app's replicaset failed to go away — and this path fires during every teardown that
races the Kubernetes API. The name is now included, and the trailing newline logrus
adds itself is dropped.

**3. `kubevirt: don't ignore the scheduling lookup error on Delete`**

`Delete` asked `scheduledOnMe()` which node the domain is placed on and then
discarded its error. A failed lookup reports `onMe=false`, which is indistinguishable
from the legitimate "scheduled on another node" case tested on the next line, so
`Delete` returned nil — reporting a successful teardown while deleting nothing —
whenever the Kubernetes API was briefly unavailable. `Stop` already checks the same
error. (Not every failure path is `(false, false)`: `replicaPodScheduledOnMe`'s
"Unhandled scheduling state" returns `scheduledOnNone=true` alongside its error, so the
check has to key on the error rather than on `scheduledOnNone`.)

All five `Delete` call sites in domainmgr log the error and continue (three of
them are behind `!ctx.hvTypeKube` and unreachable on EVE-k), so no caller's
control flow changes. Note this also surfaces an already-deleted ReplicaSet as a
`Delete` error rather than a silent success, since the lookup's `Get` reports
`NotFound` through the same path.

**4. `kubevirt: treat a mid-call NotFound as gone`**

`Info` confirms the replicaset exists and then fetches it again to read the guest's
phase. A workload deleted between those two calls made the second lookup fail with
`NotFound`, which `Info` reported as an error alongside a still-scheduling state —
and `waitForDomainGone` returns true on any `Info` error before it inspects the
state, so the graceful wait ended early. That is the same premature "domain is
gone" commit 1 exists to prevent, reached through a one-poll race rather than on
every shutdown. `NotFound` now reports absence identically wherever it is observed,
which also drops a redundant third `Get` of an object already known to be gone.

Raised by @naiming-zededa in review: the concern was that keeping the `vmiList`
entry past `Stop` would let a deleted replicaset reach `scheduledOnMe` and be
reported `BROKEN`. The `Info` rework that landed in master with #6257 removed
that specific outcome, but the error path it named was still wrong for the
reason above.

## Known gaps (deliberately not addressed here)

- `Stop`'s `force` parameter is still ignored. This matches `KvmContext.Stop`,
  which also discards it (`_ bool`); in both backends the actual forcing is done
  by the subsequent `Delete`. Now that the escalation is reachable, a stuck
  domain can spend an extra `maxDelay` in `force-true` before `Delete` runs.
  The KVM-analogous fix would be to make kubevirt's `Delete` the forcing step
  (delete with `GracePeriodSeconds: 0`), not to act on `force` in `Stop`.
- An error returned from `Stop` still skips the graceful wait entirely, because
  `doInactivate` only calls `waitForDomainGone` on the success branch.

## How to test and validate this PR

Automated: `go build -tags k ./hypervisor/`, `go vet -tags k ./hypervisor/` and
`go test -tags k ./hypervisor/` under `pkg/pillar`. Note the `k` build tag is
required — `hypervisor/kubevirt.go` is behind `//go:build k`, so a build without
it does not compile this file at all. `TestCreateReplicaPodConfig` fails in that
bare host run, on `master` too — it mocks the kubeconfig at the real
`/run/.kube/k3s/k3s.yaml`, which a non-root user cannot create; CI runs in a
container as root and is unaffected (#6290).

On an EVE-k device, restart or deactivate an app instance and watch
`waitForDomainGone` in the device log:

- Before: a single `waiting for 1s` followed by `error info domain <name>`, then
  a replacement VMIRS created within about a second.
- After: `state still RUNNING waited …` with the delay backing off, until the
  VMI is actually gone (or the budget expires and the forced path runs), and no
  replacement until then.

Cross-check that `kubectl get pods -n eve-kube-app` never shows two
`virt-launcher` pods for the same app during a restart.

### Result on hardware (amd64 EVE-k)

Run on a Supermicro SYS-E300-8D EVE-k node with the patched image, using the
preceding build without these commits as the control. The exercise is an
integration test that writes ~128 KB inside a VM app's guest and then restarts
the app instance; each test run does one cycle where the restart is requested
90–240 s after the write and one where it is requested in the same millisecond.

**The graceful wait now happens.** Time from the restart request to the app being
back online:

| image | range | cycles |
|---|---|---|
| control | 34.4 – 100.2 s | 4 |
| patched | 113.5 – 167.3 s | 6 |

The ranges do not overlap. That is the intended effect: `waitForDomainGone` polls
real domain state instead of accepting the first failed `Info` as "gone", so the
replacement is no longer created about a second after the delete request.

**Data survival is improved but not fixed.** Only the same-millisecond cycle ever
loses the guest's write:

| cycle shape | control | patched |
|---|---|---|
| restart +90…240 s | kept 2/2 | kept 3/3 |
| restart +0.00 s | **lost 2/2** | **lost 1/3** |

**Why, from the device log.** The wait this change enables cannot currently
succeed, because `Stop` deletes the VMIRS and the wait then polls that same
VMIRS by name:

```
13:45:08.446  DomainShutdown force-false 27d4050e….6.1        <- Stop deletes the VMIRS
13:45:08.706  waitForDomainGone …: waiting for 1s
13:45:09.761  waitForDomainGone … error Failed to determine scheduled node:
              virtualmachineinstancereplicasets.kubevirt.io "ztest-…-27d40-1" not found
13:45:09.762  waitForVMI … waiting for 1s     (then 2s, 4s, 8s, 16s, 32s)
13:46:13.278  waitForVMI … giving up at state:Unknown
13:46:13.278  VMI still available
13:46:13.307  doActivate({27d4050e… 7})       <- replacement created regardless
```

Every tick returns `NotFound`, so the state never resolves, the full 1+2+4+8+16+32
= 63 s backoff runs out, and the replacement is created with the old VMI still
present — by the code's own `VMI still available` on the preceding line. The
identical sequence appears in a cycle that kept its data (`98ea9e82…`, VMIRS
`ztest-…-98ea9-1`, give-up at 04:38:42.782, `doActivate` 20 ms later), so the
overlap is now the steady state of every EVE-k app restart on this build, and
whether the guest's last write survives is a race inside that window.

So this change converts a 1-second false "domain is gone" into a 63-second wait
that ends in the same conclusion. It removes the misleading bookkeeping and the
misleading log, and it is a prerequisite for a correct wait, but on its own it
does not stop the replacement from overlapping the old VMI. A follow-up should
make the wait poll the VMI object (which outlives its ReplicaSet) rather than the
ReplicaSet that `Stop` has just removed.

Also visible in both cycles, and probably worth its own fix:
`kubeapi.DetachOldWorkload: a node name is required` — the old workload's volume
detach does not happen.

**Those numbers predate #6257**, which has since merged and is part of the base this
branch now sits on. They were measured against an `Info` that returned an error whenever
`vmiList` had no entry for the domain; master's `Info` instead resolves existence through
a live VMIRS `Get` and reports `HALTED` only when the object is confirmed absent. How the
graceful wait behaves on the current base therefore needs re-deriving, and I have not
re-measured it on hardware since the rebase.

The rest of the suite was unaffected: 46 passes, plus failures this node also
produces without the change (it has no assignable audio/COM hardware).

### Result in the kvm→k conversion matrix (with #5971)

Separately from the hardware run above, the two substantive commits were exercised in the
7-leg EVE-kvm→EVE-k boot-disk conversion matrix, on integration image
`0.0.0-newgo-allprs2-f40d7876`. That build carries **#5971** (the Go `kube-init` daemon)
and rucoder/eve#3 on top of the conversion chain, plus #6257, #6197, #6240, #6259 and
#6190 — so it is the combination this PR will actually ship into, not a standalone build.

**7/7.** Six legs green in the batch (`ext4-shrink`, `twodisk-ext4`, `twodisk-zfs`,
`zfs-grow`, `ext4-toofull`, `zfs-notail`); `ext4-grow` lost its emulator to a QEMU AHCI
abort (`prdt_warnings=4 aborts=1`) while another test shared the host, and passed on
re-run with `prdt_warnings=0 aborts=0`. Every leg came in faster than on the two previous
7/7 images of that branch line, including `twodisk-zfs`, which is the historically
fragile leg.

Scope of that evidence, precisely:

- It covers `keep domain bookkeeping until Cleanup` and `don't ignore the scheduling
  lookup error on Delete` — content-identical in that image to the commits here
  (patch-ids `7d1df4a12b16` and `c21b35662d3f`).
- It does **not** cover `name the replicaset in the delete error` or `treat a mid-call
  NotFound as gone`, both committed after that image was built.
- It demonstrates **no regression** in the conversion path with #5971's bring-up. It is
  not a targeted test of the graceful-stop behaviour itself; that evidence is the
  hardware section above.

## Changelog notes

On EVE-k, an app restart or deactivate no longer creates the replacement while
the previous instance is still shutting down.

## PR Backports

- 17.0-stable: To be decided by the maintainers — the change is small, but the
  behaviour it alters only matters for EVE-k.
- 16.0-stable: Same.
- 14.5-stable: Same.
- 13.4-stable: Same.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Reasons for the unchecked boxes: no documentation change — this alters
bookkeeping ownership inside one hypervisor backend, with no new knob or
user-visible surface. The patched image has been run on an amd64 EVE-k device
(see the hardware result above); arm64 is untested.









