### PR TITLE
[17.0-stable] msrv: serve zvol-backed patch envelope artifacts with correct size

### DIFF
--- a/pkg/pillar/cmd/msrv/handlers.go
+++ b/pkg/pillar/cmd/msrv/handlers.go
@@ -661,7 +661,7 @@ func (msrv *Msrv) handlePatchFileDownload() func(http.ResponseWriter, *http.Requ
 		e := envelopes.FindPatchEnvelopeByID(patchID)
 		if e != nil {
 			if idx := types.CompletedBinaryBlobIdxByName(e.BinaryBlobs, fileName); idx != -1 {
-				http.ServeFile(w, r, e.BinaryBlobs[idx].URL)
+				msrv.serveBinaryBlob(w, r, e.BinaryBlobs[idx])
 				msrv.increasePatchEnvelopeDownloadCounter(appUUID, *e)
 				return
 			} else if idx := types.CompletedCipherBlobIdxByName(e.CipherBlobs, fileName); idx != -1 {
@@ -680,6 +680,64 @@ func (msrv *Msrv) handlePatchFileDownload() func(http.ResponseWriter, *http.Requ
 		}
 
 		sendError(w, http.StatusNotFound, "patch is not found")
+	}
+}
+
+// serveBinaryBlob serves a patch-envelope binary blob to an app instance.
+//
+// For regular files it defers to http.ServeFile, which derives Content-Length
+// from os.Stat() and also supports Range and conditional requests - preserving
+// the existing behavior for file/qcow-backed volumes.
+//
+// A volume-backed blob may instead live on a block device (e.g. a ZFS zvol),
+// where os.Stat().Size() reports 0. http.ServeFile would then answer with
+// Content-Length: 0 and an empty body, so the in-VM downloader receives an
+// empty artifact and never deploys the app. For such non-regular files we
+// serve exactly blob.Size content bytes (VolumeStatus.TotalSize, i.e. the
+// content-tree size). Serving exactly blob.Size also avoids the block-device
+// padding that trails the real content (a zvol is rounded up to the volume
+// block size), which would otherwise corrupt the artifact's checksum.
+func (msrv *Msrv) serveBinaryBlob(w http.ResponseWriter, r *http.Request, blob types.BinaryBlobCompleted) {
+	fi, err := os.Stat(blob.URL)
+	if err != nil {
+		msrv.Log.Errorf("serveBinaryBlob: stat %s failed: %v", blob.URL, err)
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	}
+
+	if fi.Mode().IsRegular() {
+		http.ServeFile(w, r, blob.URL)
+		return
+	}
+
+	// Non-regular file (block device, fifo, ...): os.Stat size is unreliable,
+	// so we must know the content length up front.
+	if blob.Size <= 0 {
+		msrv.Log.Errorf("serveBinaryBlob: %s is not a regular file and blob size is unknown (%d)",
+			blob.URL, blob.Size)
+		http.Error(w, http.StatusText(http.StatusInternalServerError),
+			http.StatusInternalServerError)
+		return
+	}
+
+	f, err := os.Open(blob.URL)
+	if err != nil {
+		msrv.Log.Errorf("serveBinaryBlob: open %s failed: %v", blob.URL, err)
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	}
+	defer f.Close()
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", blob.Size))
+	w.WriteHeader(http.StatusOK)
+
+	if n, err := io.CopyN(w, f, blob.Size); err != nil {
+		// Headers (including Content-Length) are already flushed, so the error
+		// cannot be surfaced via status code; the client will observe a short
+		// body. Log it for diagnosis.
+		msrv.Log.Errorf("serveBinaryBlob: served %d of %d bytes from %s: %v",
+			n, blob.Size, blob.URL, err)
 	}
 }
 

--- a/pkg/pillar/cmd/msrv/serveblob_test.go
+++ b/pkg/pillar/cmd/msrv/serveblob_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package msrv
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+func serveBlobTestMsrv() *Msrv {
+	logger := logrus.StandardLogger()
+	log := base.NewSourceLogObject(logger, "msrv-serveblob-test", 0)
+	return &Msrv{Log: log, Logger: logger}
+}
+
+// TestServeBinaryBlobRegularFile is the regression guard for file/qcow-backed
+// volumes: os.Stat().Size() is correct for a regular file, so serveBinaryBlob
+// must defer to http.ServeFile and return the whole file with a matching
+// Content-Length.
+func TestServeBinaryBlobRegularFile(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewGomegaWithT(t)
+
+	content := []byte("hello patch envelope content")
+	path := filepath.Join(t.TempDir(), "blob.bin")
+	g.Expect(os.WriteFile(path, content, 0600)).To(gomega.Succeed())
+
+	blob := types.BinaryBlobCompleted{
+		FileName: "blob.bin",
+		URL:      path,
+		Size:     int64(len(content)),
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/eve/v1/patch/download/p/blob.bin", nil)
+	serveBlobTestMsrv().serveBinaryBlob(rr, req, blob)
+
+	g.Expect(rr.Code).To(gomega.Equal(http.StatusOK))
+	g.Expect(rr.Body.Bytes()).To(gomega.Equal(content))
+	g.Expect(rr.Result().ContentLength).To(gomega.Equal(int64(len(content))))
+}
+
+// TestServeBinaryBlobBlockDeviceSized exercises the ZFS zvol scenario. A zvol
+// is a block device whose os.Stat().Size() reports 0 (so http.ServeFile would
+// answer Content-Length: 0) and whose readable length is rounded up to the
+// volume block size (so reading to EOF would append padding and corrupt the
+// artifact's checksum).
+//
+// A FIFO reproduces both properties without needing a real block device (root):
+// Mode().IsRegular() is false and Stat().Size() is 0. We write content plus
+// trailing padding and assert serveBinaryBlob returns exactly blob.Size content
+// bytes - no Content-Length: 0, and no padding.
+func TestServeBinaryBlobBlockDeviceSized(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewGomegaWithT(t)
+
+	content := []byte(strings.Repeat("A", 4096))
+	// Simulate the zvol being rounded up past the real content length.
+	padding := make([]byte, 512)
+
+	fifo := filepath.Join(t.TempDir(), "zvol.fifo")
+	g.Expect(syscall.Mkfifo(fifo, 0600)).To(gomega.Succeed())
+
+	// Opening a FIFO blocks until the other end is opened, so the writer must
+	// run concurrently with serveBinaryBlob's os.Open. content+padding stays
+	// well under the pipe buffer, so the Write returns even though the reader
+	// consumes only blob.Size bytes - no deadlock, no goroutine leak.
+	writeErr := make(chan error, 1)
+	go func() {
+		f, err := os.OpenFile(fifo, os.O_WRONLY, 0)
+		if err != nil {
+			writeErr <- err
+			return
+		}
+		defer f.Close()
+		_, err = f.Write(append(append([]byte{}, content...), padding...))
+		writeErr <- err
+	}()
+
+	blob := types.BinaryBlobCompleted{
+		FileName: "zvol.fifo",
+		URL:      fifo,
+		Size:     int64(len(content)),
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/eve/v1/patch/download/p/zvol.fifo", nil)
+	serveBlobTestMsrv().serveBinaryBlob(rr, req, blob)
+
+	g.Expect(rr.Code).To(gomega.Equal(http.StatusOK))
+	g.Expect(rr.Header().Get("Content-Length")).To(gomega.Equal(strconv.Itoa(len(content))))
+	g.Expect(rr.Body.Len()).To(gomega.Equal(len(content)))
+	g.Expect(rr.Body.Bytes()).To(gomega.Equal(content))
+
+	g.Eventually(writeErr).Should(gomega.Receive(gomega.BeNil()))
+}
+
+// TestServeBinaryBlobNonRegularUnknownSize verifies we fail loudly rather than
+// silently serving an empty body when the backing is a non-regular file but the
+// content length is unknown.
+func TestServeBinaryBlobNonRegularUnknownSize(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewGomegaWithT(t)
+
+	fifo := filepath.Join(t.TempDir(), "zvol.fifo")
+	g.Expect(syscall.Mkfifo(fifo, 0600)).To(gomega.Succeed())
+
+	blob := types.BinaryBlobCompleted{
+		FileName: "zvol.fifo",
+		URL:      fifo,
+		Size:     0,
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/eve/v1/patch/download/p/zvol.fifo", nil)
+	serveBlobTestMsrv().serveBinaryBlob(rr, req, blob)
+
+	g.Expect(rr.Code).To(gomega.Equal(http.StatusInternalServerError))
+}


### PR DESCRIPTION
# Description

Backport of #6147

handlePatchFileDownload served binary artifacts via http.ServeFile, which
derives Content-Length from os.Stat().Size(). For a patch envelope artifact
backed by a volume, the served path is the volume's FileLocation. On ZFS that is
a zvol block device whose stat size is 0, so the artifact was returned with
Content-Length: 0 and an empty body, and the requesting app instance could never
fetch it. File- and qcow-backed volumes were unaffected because their stat size
is correct.

Add serveBinaryBlob: regular files keep using http.ServeFile, preserving Range
and conditional-request support. For a non-regular backing the content length is
taken from blob.Size (VolumeStatus.TotalSize, the content-tree size) and exactly
that many bytes are copied. Serving exactly blob.Size also drops the trailing
padding of a zvol, whose size is rounded up to the volume block size and would
otherwise corrupt the artifact checksum. A non-regular backing with an unknown
size now fails with 500 rather than silently serving an empty body.

Add unit tests covering the regular-file path, the block-device path (a FIFO
reproduces a zvol's zero stat size and trailing padding), and the unknown-size
error case.

The commit applied cleanly to 17.0-stable with no adaptation. Confirmed absent
from 17.0.0-lts (= 17.0.0-rc5): no cherry-pick trailer, no matching subject,
serveblob_test.go not present, and the pre-fix http.ServeFile path still in
place, so 17.0.0-lts ships the zero-length-artifact behaviour.

## PR dependencies

None

## How to test and validate this PR

- deploy eve HV=kvm with zfs persist
- deploy a VM app instance (eg. ubuntu with a local network instance and route to msrv)
- attach a patch envelope with an artifact backed by a local block device volume instance
- Verify the size reported in the patch envelope artifact description.json http endpoint output is correct

## Changelog notes

Fix size reported by disk backed patch envelope artifacts from ZFS persist backed HV=kvm nodes

## PR Backports

This is the backport

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs:

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.