### PR TITLE
Restore SBOM coverage for source-built packages

### DIFF
--- a/eve-tools/bpftrace-compiler/root/Dockerfile
+++ b/eve-tools/bpftrace-compiler/root/Dockerfile
@@ -5,7 +5,7 @@ ARG EVE_KERNEL
 # hadolint ignore=DL3006
 FROM ${EVE_KERNEL} AS kernel
 
-FROM lfedge/eve-bpftrace:2dedee5a76a5ebc5c07d3c7cebb4be862428a1a1 AS eve-bpftrace
+FROM lfedge/eve-bpftrace:d411336b71859e7f6a21eb2c84c32c5d921e1394 AS eve-bpftrace
 
 FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS bpftrace
 

--- a/eve-tools/bpftrace-compiler/root/Dockerfile
+++ b/eve-tools/bpftrace-compiler/root/Dockerfile
@@ -5,9 +5,9 @@ ARG EVE_KERNEL
 # hadolint ignore=DL3006
 FROM ${EVE_KERNEL} AS kernel
 
-FROM lfedge/eve-bpftrace:db21ca8a24d3f4e9f2e3fccc558ec0ffcf2ec137 AS eve-bpftrace
+FROM lfedge/eve-bpftrace:2dedee5a76a5ebc5c07d3c7cebb4be862428a1a1 AS eve-bpftrace
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS bpftrace
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS bpftrace
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache --initdb binutils make gcc g++ git perl musl-dev cmake zlib-dev bcc-dev libbpf-dev cereal flex bison llvm17-libs llvm17-dev llvm17-static clang17-dev clang17-static pahole gtest-dev bash

--- a/pkg/alpine/Dockerfile
+++ b/pkg/alpine/Dockerfile
@@ -50,7 +50,7 @@ ARG GO_VERSION=1.25.12
 COPY --from=cache-build /etc/apk/repositories* /etc/apk/
 COPY --from=cache-build /etc/apk/keys /etc/apk/keys/
 COPY --from=cache-build /mirror /mirror/
-COPY eve-alpine-deploy.sh go-compile.sh register-sbom-pkg.sh /bin/
+COPY eve-alpine-deploy.sh go-compile.sh register-sbom-pkg.sh merge-sbom-db.sh /bin/
 
 RUN apk update && apk upgrade -a
 

--- a/pkg/alpine/merge-sbom-db.sh
+++ b/pkg/alpine/merge-sbom-db.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# merge-sbom-db.sh - Merge APK DBs into one, dropping duplicate packages.
+#
+# Usage:
+#   merge-sbom-db.sh -o <output> <input> [<input> ...]
+#
+# Use this instead of "cat a b >> db" whenever several stages contribute
+# packages to one image's SBOM.
+#
+# apk keeps one record per package and identifies it by its C: checksum. Any two
+# DBs built on an Alpine rootfs share its base packages, so concatenating them
+# yields duplicate checksums: apk frees a still-referenced package (SIGSEGV) and
+# the SBOM double-counts.
+#
+# First record per name wins, so list the image's own DB first. Missing inputs
+# are skipped so arch-specific stages that contribute nothing don't break builds.
+#
+set -e
+
+usage() {
+    echo "Usage: $0 -o <output> <input> [<input> ...]" >&2
+    exit 1
+}
+
+OUTFILE=""
+
+while getopts "o:" opt; do
+    case "$opt" in
+        o) OUTFILE="$OPTARG" ;;
+        *) usage ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+[ -n "$OUTFILE" ] || { echo "ERROR: -o (output) is required" >&2; usage; }
+[ $# -gt 0 ]      || { echo "ERROR: at least one input DB is required" >&2; usage; }
+
+INPUTS=""
+for db in "$@"; do
+    if [ -f "$db" ]; then
+        INPUTS="$INPUTS $db"
+    else
+        echo "merge-sbom-db.sh: skipping missing $db" >&2
+    fi
+done
+[ -n "$INPUTS" ] || { echo "ERROR: none of the input DBs exist" >&2; exit 1; }
+
+mkdir -p "$(dirname "$OUTFILE")"
+
+# The output is usually also an input, so build the result aside first.
+TMPFILE="$(mktemp)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+# Paragraph mode keys on blank-line separated records; busybox awk supports RS="".
+# shellcheck disable=SC2086
+awk 'BEGIN { RS = ""; FS = "\n" }
+{
+    name = ""
+    for (i = 1; i <= NF; i++)
+        if (substr($i, 1, 2) == "P:") { name = substr($i, 3); break }
+    if (name == "" || (name in seen)) next
+    seen[name] = 1
+    printf "%s\n\n", $0
+    kept++
+}
+END { printf "merged %d packages\n", kept > "/dev/stderr" }' $INPUTS > "$TMPFILE"
+
+cat "$TMPFILE" > "$OUTFILE"
+
+echo "Merged$INPUTS into $OUTFILE"

--- a/pkg/alpine/register-sbom-pkg.sh
+++ b/pkg/alpine/register-sbom-pkg.sh
@@ -23,6 +23,11 @@
 #
 # The entry is appended to <outdir>/lib/apk/db/installed.
 #
+# apk purges these records on its next transaction (they are not reachable from
+# /etc/apk/world). Harmless: no caller runs apk after registering. Do NOT add the
+# name to /etc/apk/world to keep them - apk would then replace the source-built
+# package with an upstream one of the same name.
+#
 set -e
 
 usage() {
@@ -53,10 +58,6 @@ APK_DB="${OUTDIR}/lib/apk/db/installed"
 mkdir -p "$(dirname "$APK_DB")"
 [ -e "$APK_DB" ] || touch "$APK_DB"
 
-# FIX-ME : disabled for now: writing to /lib/apk/db/installed causes "apk add" to segfault
-# will revert back once the fix has landed in upstream
-exit 0
-
 # Init-only mode: if no package fields were supplied, we just ensured the
 # file exists and we're done.
 if [ -z "$PKG_NAME" ] && [ -z "$PKG_VERSION" ] && [ -z "$PKG_LICENSE" ] && [ -z "$PKG_URL" ]; then
@@ -72,8 +73,42 @@ fi
 PKG_DESC="${PKG_DESC:-${PKG_NAME} (built from source)}"
 PKG_ARCH="$(apk --print-arch)"
 
-printf 'P:%s\nV:%s\nL:%s\nA:%s\nT:%s\nU:%s\n\n' \
-    "$PKG_NAME" "$PKG_VERSION" "$PKG_LICENSE" "$PKG_ARCH" "$PKG_DESC" "$PKG_URL" \
+# C: is mandatory: apk keys package identity on it, and APK_BLOB_CSUM takes the
+# checksum type as the blob length, so a C:-less record hashes to a zero-length
+# key. Two of them then collide and apk frees a still-referenced package
+# (SIGSEGV); a single one makes apk commit a DB truncated at that record. No .apk
+# file exists to hash, so derive a stable synthetic SHA-1 from name and version.
+PKG_CSUM="Q1$(printf '%s' "${PKG_NAME}-${PKG_VERSION}" | sha1sum | cut -d' ' -f1 | xxd -r -p | base64)"
+
+# A base64'd SHA-1 is always 28 chars; a short one would void the whole record.
+[ ${#PKG_CSUM} -eq 30 ] || { echo "ERROR: could not compute checksum for $PKG_NAME (got '$PKG_CSUM')" >&2; exit 1; }
+
+# Re-registering the same package is a no-op; two records must never share a C:.
+if grep -Fqx "C:${PKG_CSUM}" "$APK_DB"; then
+    echo "Skipping $PKG_NAME-$PKG_VERSION: already registered in $APK_DB"
+    exit 0
+fi
+
+# Name taken by a different record, normally an apk-installed package. apk keeps
+# one record per name, so the existing entry wins either way. Source-built names
+# are not expected to collide with Alpine ones; report it rather than silently
+# dropping the source-built attribution.
+if grep -Fqx "P:${PKG_NAME}" "$APK_DB"; then
+    echo "WARNING: $APK_DB already has a package named $PKG_NAME;" >&2
+    echo "         not registering source-built $PKG_NAME-$PKG_VERSION, so the SBOM" >&2
+    echo "         will report the existing entry instead." >&2
+    exit 0
+fi
+
+# Without the blank separator apk folds these fields into the preceding package.
+if [ -s "$APK_DB" ] && [ -n "$(tail -c 2 "$APK_DB")" ]; then
+    printf '\n' >> "$APK_DB"
+fi
+
+# Field order matches what apk writes back, so the record round-trips unchanged.
+# I:0 marks it virtual, keeping apk from resolving it against a repository.
+printf 'C:%s\nP:%s\nV:%s\nA:%s\nS:0\nI:0\nT:%s\nU:%s\nL:%s\n\n' \
+    "$PKG_CSUM" "$PKG_NAME" "$PKG_VERSION" "$PKG_ARCH" "$PKG_DESC" "$PKG_URL" "$PKG_LICENSE" \
     >> "$APK_DB"
 
 echo "Registered $PKG_NAME-$PKG_VERSION in $APK_DB"

--- a/pkg/apparmor/Dockerfile
+++ b/pkg/apparmor/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 ENV BUILD_PKGS linux-headers musl-dev musl-utils musl-libintl git gcc g++ \
                autoconf autoconf-archive automake libtool make flex bison \
                bash sed gettext

--- a/pkg/bpftrace/Dockerfile
+++ b/pkg/bpftrace/Dockerfile
@@ -14,6 +14,7 @@ RUN ln -s /usr/lib/cmake/clang17 /usr/lib/cmake/clang
 WORKDIR /usr/src
 # bcc compilation process needs .git directory
 ADD --keep-git-dir=true https://github.com/iovisor/bcc.git#v0.27.0 /usr/src/bcc
+RUN register-sbom-pkg.sh -n bcc -v 0.27.0 -l Apache-2.0 -u https://github.com/iovisor/bcc
 RUN mkdir /usr/src/bcc/build
 WORKDIR /usr/src/bcc/build
 RUN perl -pni.bak -e 's/CMAKE_CXX_STANDARD 14/CMAKE_CXX_STANDARD 17/g' ../CMakeLists.txt
@@ -23,11 +24,9 @@ RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_COMPILER=clang++-17 -DCMA
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN make install
 
-# Register bcc in the APK DB, mandatory for it to be included in the SBOM.
-RUN register-sbom-pkg.sh -n bcc -v 0.27.0 -l Apache-2.0 -u https://github.com/iovisor/bcc.git
-
 RUN mkdir -p /usr/src
 ADD https://github.com/bpftrace/bpftrace.git#v0.20.3 /usr/src/bpftrace
+RUN register-sbom-pkg.sh -n bpftrace -v 0.20.3 -l Apache-2.0 -u https://github.com/bpftrace/bpftrace
 COPY patches /usr/src/bpftrace/patches
 WORKDIR /usr/src/bpftrace
 RUN for i in patches/*.patch; do git apply "$i"; done
@@ -36,9 +35,6 @@ WORKDIR /usr/src/bpftrace/build
 RUN cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_COMPILER=clang++-17 -DCMAKE_C_COMPILER=clang-17 ..
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN make install
-
-# Register bpftrace in the APK DB, mandatory for it to be included in the SBOM.
-RUN register-sbom-pkg.sh -n bpftrace -v 0.20.3 -l Apache-2.0 -u https://github.com/bpftrace/bpftrace.git
 
 # portability analyser is disabled, therefore skip those tests
 # skip file exist test - probably broken because of container
@@ -72,6 +68,7 @@ COPY --from=build /usr/lib/liblzma.so.5 /bpftrace-aotrt//usr/lib/liblzma.so.5
 COPY --from=build /usr/lib/libfts.so.0 /bpftrace-aotrt//usr/lib/libfts.so.0
 COPY --from=build /usr/lib/libzstd.so.1 /bpftrace-aotrt//usr/lib/libzstd.so.1
 COPY --from=build /usr/lib/libbz2.so.1 /bpftrace-aotrt//usr/lib/libbz2.so.1
+COPY --from=build /out/lib/apk/db/installed /bpftrace-aotrt/
 
 FROM bin AS bin-amd64
 FROM bin AS bin-arm64

--- a/pkg/bpftrace/Dockerfile
+++ b/pkg/bpftrace/Dockerfile
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 
 ENV BUILD_PKGS libbpf-dev make gcc g++ git perl linux-headers musl-dev cmake elfutils-dev llvm17-libs llvm17-dev llvm17-gtest llvm17-static cereal flex bison clang17-extra-tools clang17-dev clang17-static pahole gtest-dev bash py3-setuptools zip zlib-dev
 

--- a/pkg/bsp-imx/Dockerfile
+++ b/pkg/bsp-imx/Dockerfile
@@ -4,10 +4,10 @@
 ARG BUILD_PKGS_BASE="bash binutils-dev build-base bc bison flex openssl-dev util-linux-dev swig gnutls-dev perl python3 python3-dev py3-setuptools py3-pycryptodome py3-elftools"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c
 
 # OPTEE-OS images
-FROM lfedge/eve-optee-os:dfda7b90187210c1070b88407dd3b0dcd41c1768 AS optee-os
+FROM lfedge/eve-optee-os:70a19334969c2d1eb8748a31203e63d54b2d3530 AS optee-os
 
 # hadolint ignore=DL3006
 FROM ${EVE_ALPINE_IMAGE} AS build-native

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -9,7 +9,7 @@
 # to be a perfect place to put any other kind of debug info
 # into the package: see abuild/etc/abuild.conf.
 FROM lfedge/eve-recovertpm:4f7fffac608645ba89716cda0ecabca4f817023e AS recovertpm
-FROM lfedge/eve-bpftrace:2dedee5a76a5ebc5c07d3c7cebb4be862428a1a1 AS bpftrace
+FROM lfedge/eve-bpftrace:d411336b71859e7f6a21eb2c84c32c5d921e1394 AS bpftrace
 FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 ENV BUILD_PKGS="abuild curl tar make linux-headers patch g++ git gcc gpg gettext gettext-static ncurses-dev jq autoconf openssl-dev zlib-dev zlib-static gpg-agent"
 # Feel free to add additional packages here, but be aware that
@@ -83,6 +83,15 @@ RUN sed -i -e 's#AllowTcpForwarding.*$#AllowTcpForwarding yes#' ./etc/ssh/sshd_c
 RUN mkdir /bpftrace
 COPY --from=bpftrace / /bpftrace
 RUN mkdir -p /bpftrace/bpftrace-aotrt
+
+# Fold bpftrace's package list into the SBOM DB. This has to be a deduplicating
+# merge rather than a concatenation: both DBs are built on an Alpine rootfs and
+# so share its base packages, and duplicate records make apk segfault the next
+# time it runs (collect-info.sh and qemu-affinities.sh both call "apk add").
+# Merging here rather than in the final stage keeps it in the one stage that has
+# the helper -- the scratch stage only has what /out provides.
+RUN merge-sbom-db.sh -o /out/lib/apk/db/installed \
+        /out/lib/apk/db/installed /bpftrace/bpftrace-aotrt/installed
 
 # add recover-tpm to debug container
 WORKDIR /

--- a/pkg/debug/Dockerfile
+++ b/pkg/debug/Dockerfile
@@ -8,9 +8,9 @@
 # has a fast path for stack unwinding. This also happens
 # to be a perfect place to put any other kind of debug info
 # into the package: see abuild/etc/abuild.conf.
-FROM lfedge/eve-recovertpm:203719f368277ef86ebc51b6879e252c02f48024 AS recovertpm
-FROM lfedge/eve-bpftrace:db21ca8a24d3f4e9f2e3fccc558ec0ffcf2ec137 AS bpftrace
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-recovertpm:4f7fffac608645ba89716cda0ecabca4f817023e AS recovertpm
+FROM lfedge/eve-bpftrace:2dedee5a76a5ebc5c07d3c7cebb4be862428a1a1 AS bpftrace
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 ENV BUILD_PKGS="abuild curl tar make linux-headers patch g++ git gcc gpg gettext gettext-static ncurses-dev jq autoconf openssl-dev zlib-dev zlib-static gpg-agent"
 # Feel free to add additional packages here, but be aware that
 # EVE's rootfs image can be no larger than 300Mb (and don't

--- a/pkg/dom0-ztools/Dockerfile
+++ b/pkg/dom0-ztools/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS zfs
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS zfs
 ENV BUILD_PKGS="git patch ca-certificates util-linux build-base gettext-dev libtirpc-dev automake autoconf \
     libtool linux-headers attr-dev e2fsprogs-dev glib-dev openssl-dev util-linux-dev coreutils"
 ENV PKGS="ca-certificates util-linux libintl libuuid libtirpc libblkid libcrypto3 zlib"

--- a/pkg/edgeview/Dockerfile
+++ b/pkg/edgeview/Dockerfile
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # hadolint ignore=DL3006
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS runtime
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS runtime
 ENV PKGS alpine-baselayout musl-utils iproute2 iptables
 RUN eve-alpine-deploy.sh
 
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 ARG TARGETARCH
 
 COPY src/  /edge-view/.

--- a/pkg/eve/Dockerfile.in
+++ b/pkg/eve/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS tools
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS tools
 ENV PKGS="qemu-img tar u-boot-tools coreutils dosfstools"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/fscrypt/Dockerfile
+++ b/pkg/fscrypt/Dockerfile
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build-base
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build-base
 
 FROM build-base AS build-amd64
 FROM build-base AS build-arm64

--- a/pkg/fw/Dockerfile
+++ b/pkg/fw/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
 ARG PLATFORM=generic
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build-base
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build-base
 
 ARG TARGETARCH
 
@@ -122,7 +122,7 @@ RUN if [ "${TARGETARCH}" = "arm64" ]; then \
 
 # generate initrd for Intel's and AMD's microcode
 # it makes sense only for x86_64 platform
-FROM --platform=${TARGETPLATFORM} lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS ucode-build-common
+FROM --platform=${TARGETPLATFORM} lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS ucode-build-common
 RUN mkdir -p /boot /tmp/ucode/intel /tmp/ucode/amd /usr/share/licenses/ucode
 # Ensure /sbom-out/lib/apk/db/installed exists for all archs so the COPY in
 # compactor-common works even when no ucode registrations run (arm64/riscv64).
@@ -170,7 +170,7 @@ FROM ucode-build-common AS ucode-build-arm64
 FROM ucode-build-common AS ucode-build-riscv64
 FROM ucode-build-${TARGETARCH} AS ucode-build
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS compactor-common
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS compactor-common
 ENTRYPOINT []
 WORKDIR /
 # Reset the APK DB so the final image only reports source-built/firmware packages
@@ -254,7 +254,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
     fi
 
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS compactor-full
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS compactor-full
 # Reset the APK DB so the final image only reports source-built/firmware packages
 RUN rm -f /lib/apk/db/installed && register-sbom-pkg.sh -o /
 COPY --from=build /sbom-out/lib/apk/db/installed /tmp/sbom-fw

--- a/pkg/gpt-tools/Dockerfile
+++ b/pkg/gpt-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 ENV BUILD_PKGS="gcc make file patch libc-dev linux-headers openssl-dev g++ tar coreutils"
 # util-linux-static on riscv64 is broken; we build libuuid from source instead (see below).
 ENV BUILD_PKGS_amd64="util-linux-static util-linux-dev"

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) 2025-2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS grub-build-base
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS grub-build-base
 ENV BUILD_PKGS="automake \
                make \
                bison \

--- a/pkg/guacd/Dockerfile
+++ b/pkg/guacd/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 ENV BUILD_PKGS cairo-dev jpeg-dev libpng-dev gcc make libc-dev openssl-dev libvncserver-dev file patch
 ENV PKGS alpine-baselayout musl-utils libtasn1-progs p11-kit cairo jpeg libpng libvncserver
 RUN eve-alpine-deploy.sh

--- a/pkg/installer/Dockerfile
+++ b/pkg/installer/Dockerfile
@@ -28,10 +28,10 @@ RUN cargo sbom > sbom.spdx.json
 
 RUN cp "/usr/local/my-installer/target/$CARGO_BUILD_TARGET/release/installer" /usr/local/my-installer/target/installer
 
-FROM lfedge/eve-debug:d305eebe8cc4f5abd48ecab1bb87037820c3a53b AS debug
+FROM lfedge/eve-debug:dd87bff70cb32a324b9ea835152b15058830f62a AS debug
 
 # Dockerfile to build installer img initrd
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 ENV BUILD_PKGS="mkinitfs grep patch make coreutils musl-dev gcc g++ perl \
     autoconf automake libtool file bsd-compat-headers libc-dev \

--- a/pkg/installer/Dockerfile
+++ b/pkg/installer/Dockerfile
@@ -28,7 +28,7 @@ RUN cargo sbom > sbom.spdx.json
 
 RUN cp "/usr/local/my-installer/target/$CARGO_BUILD_TARGET/release/installer" /usr/local/my-installer/target/installer
 
-FROM lfedge/eve-debug:dd87bff70cb32a324b9ea835152b15058830f62a AS debug
+FROM lfedge/eve-debug:4e226b944ad42812e62f82b430ebc83fcbed182c AS debug
 
 # Dockerfile to build installer img initrd
 FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build

--- a/pkg/ipxe/Dockerfile
+++ b/pkg/ipxe/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 
 ENV BUILD_PKGS="patch make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev"
 RUN eve-alpine-deploy.sh

--- a/pkg/kdump/Dockerfile
+++ b/pkg/kdump/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 
 ENV BUILD_PKGS patch curl make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev elfutils-dev libbz2
 ENV PKGS xz-libs elfutils-dev libbz2

--- a/pkg/kexec/Dockerfile
+++ b/pkg/kexec/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 
 ENV BUILD_PKGS patch curl make gcc perl util-linux-dev git mtools linux-headers musl-dev xz-dev elfutils-dev libbz2
 ENV PKGS xz-libs util-linux elfutils-dev libbz2

--- a/pkg/kube/Dockerfile
+++ b/pkg/kube/Dockerfile
@@ -19,7 +19,7 @@
 # hadolint ignore=DL3029
 FROM --platform=linux/amd64 ghcr.io/k8snetworkplumbingwg/sriov-cni@sha256:fce504e683275ab59215065ddf6433ca80d1b4b53f0d4b0cdf037da6701c7cb4 AS sriov-cni-bin
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 
 ARG TARGETARCH
 ENV PKGS="alpine-baselayout musl-utils iproute2 iptables curl openrc \

--- a/pkg/measure-config/Dockerfile
+++ b/pkg/measure-config/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 ARG TARGETARCH
 
 COPY src/  /measure-config/.

--- a/pkg/memory-monitor/Dockerfile
+++ b/pkg/memory-monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS memory-monitor-build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS memory-monitor-build
 
 ENV BUILD_PKGS gcc musl-dev make linux-headers cmake build-base
 ENV PKGS alpine-baselayout curl strace

--- a/pkg/mkconf/Dockerfile
+++ b/pkg/mkconf/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 
 ENV PKGS mtools dosfstools
 RUN eve-alpine-deploy.sh

--- a/pkg/mkimage-iso-efi/Dockerfile
+++ b/pkg/mkimage-iso-efi/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 
 ENV PKGS="dosfstools libarchive-tools binutils mtools xorriso mkinitfs squashfs-tools"
 RUN eve-alpine-deploy.sh

--- a/pkg/mkimage-raw-efi/Dockerfile
+++ b/pkg/mkimage-raw-efi/Dockerfile
@@ -5,7 +5,7 @@
 #   /EFI/BOOT/grub.cfg - Chainloads main bootloader
 #   /UsbInvocationScript.txt - Enables USB boot on Dell 3000 series
 #
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 ENV BUILD_PKGS="grep patch git make gcc linux-headers musl-dev autoconf automake pkgconfig kmod-dev util-linux-dev cryptsetup-dev lddtree libgcc mkinitfs"
 ENV PKGS="mtools dosfstools libarchive-tools sgdisk e2fsprogs util-linux squashfs-tools coreutils tar dmidecode \

--- a/pkg/mkrootfs-ext4/Dockerfile
+++ b/pkg/mkrootfs-ext4/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools sfdisk sgdisk xfsprogs \
          e2fsprogs util-linux coreutils multipath-tools squashfs-tools

--- a/pkg/mkrootfs-squash/Dockerfile
+++ b/pkg/mkrootfs-squash/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 
 ENV PKGS dosfstools libarchive-tools binutils mtools sfdisk sgdisk \
     xfsprogs e2fsprogs util-linux coreutils multipath-tools squashfs-tools

--- a/pkg/monitor/Dockerfile
+++ b/pkg/monitor/Dockerfile
@@ -53,7 +53,7 @@ RUN cp "/app/target/$CARGO_BUILD_TARGET/release/monitor" /app/target/
 RUN awk -F'"' '/^version = / {print $2; exit}' Cargo.toml > /app/monitor-version.txt
 
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS runtime
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS runtime
 ENV PKGS="kbd pciutils usbutils"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/newlog/Dockerfile
+++ b/pkg/newlog/Dockerfile
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # hadolint ignore=DL3006
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS runtime
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS runtime
 ENV PKGS coreutils
 RUN eve-alpine-deploy.sh
 
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 ARG TARGETARCH
 
 COPY go.mod /newlog/

--- a/pkg/nvidia/Dockerfile
+++ b/pkg/nvidia/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG PLATFORM=generic
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build-base
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build-base
 ENV BUILD_PKGS="autoconf automake build-base coreutils gettext git glib-dev libtool libmd-dev ncurses-dev tar xz-dev yq zstd-dev dpkg"
 
 RUN eve-alpine-deploy.sh

--- a/pkg/optee-client/Dockerfile
+++ b/pkg/optee-client/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build-arm64
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build-arm64
 
 ARG BUILD_PKGS="bash binutils-dev bsd-compat-headers build-base bc bison \
   cmake flex openssl-dev util-linux-dev linux-headers swig git gnutls-dev \

--- a/pkg/optee-os/Dockerfile
+++ b/pkg/optee-os/Dockerfile
@@ -4,7 +4,7 @@
 ARG BUILD_PKGS_BASE="autoconf automake bash binutils binutils-dev build-base bc bison curl dtc expat flex openssl-dev util-linux-dev swig gnutls-dev perl python3 python3-dev py3-setuptools py3-pycryptodome py3-elftools py3-cryptography"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c
 
 # hadolint ignore=DL3006
 FROM ${EVE_ALPINE_IMAGE} AS build-native

--- a/pkg/pillar/Dockerfile
+++ b/pkg/pillar/Dockerfile
@@ -8,10 +8,10 @@ ARG BUILD_PKGS_BASE="git gcc linux-headers libc-dev make linux-pam-dev m4 findut
                      libintl libuuid libtirpc libblkid libcrypto3 zlib tar"
 
 # we use the same image in several places
-ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db
+ARG EVE_ALPINE_IMAGE=lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c
 
-FROM lfedge/eve-uefi:d0986c2acfe313bb03370b7073bdbc6066667e7f AS uefi-build
-FROM lfedge/eve-dom0-ztools:ec0fd42f63df575519665bccd8cc0f85b129fb1f  AS zfs
+FROM lfedge/eve-uefi:64153003641b262bf3021da93a7954a7a34f9414 AS uefi-build
+FROM lfedge/eve-dom0-ztools:ce1fdf85a2596f0b3c8df9d82564939f31fa7067  AS zfs
 RUN mkdir /out
 # copy zfs-related files from dom0-ztools using prepared list of files
 RUN while read -r x; do \
@@ -147,8 +147,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build if [ "${TEST_TOOLS}" = "y" ]
     GOBIN=/final/opt/ GOFLAGS="" go install gotest.tools/gotestsum@v1.7.0; \
 fi
 
-FROM lfedge/eve-fscrypt:3ceeaa9636b8e52bba5c2f74c29f6437c951eace AS fscrypt
-FROM lfedge/eve-gpt-tools:334690e2871f162f53e16e03c55b23681d7bf865 AS gpttools
+FROM lfedge/eve-fscrypt:002b585701715d13daf11da0ef86b25c8eaef68e AS fscrypt
+FROM lfedge/eve-gpt-tools:8d3ae5c8f34f575bfb70c5e8088188ff97bb21f1 AS gpttools
 
 # dhcpcd: Alpine 3.21+ ships a sufficiently up-to-date version (10.x with required IPv6 fixes).
 # No --platform means Docker BuildKit uses the target platform, giving us the correct binary arch.
@@ -223,12 +223,13 @@ COPY --from=fscrypt /lib/apk/db/installed /tmp/apk-fscrypt.installed
 COPY --from=gpttools /lib/apk/db/installed /tmp/apk-gpttools.installed
 COPY --from=uefi-build /lib/apk/db/installed /tmp/apk-uefi.installed
 COPY --from=dhcpcd-bin /out/lib/apk/db/installed /tmp/apk-dhcpcd.installed
-RUN cat /tmp/apk-collector.installed \
+RUN merge-sbom-db.sh -o /out/lib/apk/db/installed \
+        /tmp/apk-collector.installed \
         /tmp/apk-zfs.installed \
         /tmp/apk-fscrypt.installed \
         /tmp/apk-gpttools.installed \
         /tmp/apk-uefi.installed \
-        /tmp/apk-dhcpcd.installed > /out/lib/apk/db/installed && \
+        /tmp/apk-dhcpcd.installed && \
     rm -f /tmp/apk-*.installed
 
 FROM scratch

--- a/pkg/recovertpm/Dockerfile
+++ b/pkg/recovertpm/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 ARG TARGETARCH
 
 # build the tpm-recovery tool

--- a/pkg/rngd/Dockerfile
+++ b/pkg/rngd/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 ENV BUILD_PKGS gcc musl-dev linux-headers
 RUN eve-alpine-deploy.sh
 

--- a/pkg/sources/Dockerfile
+++ b/pkg/sources/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS tools
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS tools
 
 COPY collected_sources.tar.gz /var/collected_sources.tar.gz
 RUN mkdir -p /var/sources && tar -C /var/sources -xzf /var/collected_sources.tar.gz

--- a/pkg/storage-init/Dockerfile
+++ b/pkg/storage-init/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 ENV PKGS="alpine-baselayout musl-utils bash glib squashfs-tools util-linux e2fsprogs e2fsprogs-extra keyutils dosfstools coreutils sgdisk smartmontools"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/u-boot/Dockerfile
+++ b/pkg/u-boot/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) 2025-2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build-base
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build-base
 ENV BUILD_PKGS bash binutils-dev build-base bc bison flex gnutls gnutls-dev openssl-dev python3 swig dtc git
 ENV BUILD_PKGS_amd64 linux-headers python3-dev py-pip
 RUN eve-alpine-deploy.sh

--- a/pkg/u-boot/Dockerfile
+++ b/pkg/u-boot/Dockerfile
@@ -96,7 +96,7 @@ RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN cp /u-boot/u-boot.bin /boot
 
 # Register u-boot in the APK DB, mandatory for it to be included in the SBOM.
-RUN register-sbom-pkg.sh -n u-boot -v "${VERSION}" -l GPL-2.0-only -u https://www.denx.de/wiki/U-Boot
+RUN register-sbom-pkg.sh -n u-boot -v "${UBOOT_VERSION}" -l GPL-2.0-only -u https://www.denx.de/wiki/U-Boot
 
 # Register raspberrypi-firmware in the APK DB, mandatory for it to be included in the SBOM.
 RUN if [ "$(uname -m)" = aarch64 ]; then \

--- a/pkg/udev/Dockerfile
+++ b/pkg/udev/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2024 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 ENV PKGS="udev kmod"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/uefi/Dockerfile
+++ b/pkg/uefi/Dockerfile
@@ -10,7 +10,7 @@
 #   git clone https://git.linaro.org/uefi/uefi-tools.git
 #   ./uefi-tools/edk2-build.sh -b DEBUG -b RELEASE all
 #
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 ENV BUILD_PKGS make gcc g++ python3 libuuid nasm util-linux-dev bash git util-linux patch
 ENV BUILD_PKGS_amd64 iasl
 ENV BUILD_PKGS_arm64 iasl

--- a/pkg/vector/Dockerfile
+++ b/pkg/vector/Dockerfile
@@ -62,7 +62,7 @@ RUN cargo build --release $VECTOR_FEATURES
 RUN cargo sbom > sbom.spdx.json
 RUN cp "/app/target/$CARGO_BUILD_TARGET/release/vector" /app/target/
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS runtime
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS runtime
 ENV PKGS="inotify-tools"
 RUN eve-alpine-deploy.sh
 

--- a/pkg/vtpm/Dockerfile
+++ b/pkg/vtpm/Dockerfile
@@ -3,14 +3,14 @@
 # Copyright (c) 2023-2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-dom0-ztools:ec0fd42f63df575519665bccd8cc0f85b129fb1f  AS dom0
+FROM lfedge/eve-dom0-ztools:ce1fdf85a2596f0b3c8df9d82564939f31fa7067  AS dom0
 
 # ===========================================================================
 # C builds (libtpms, swtpm, tpm2-tss, tpm2-tools, ptpm)
 # These use autoconf/automake with many -dev dependencies, so for now they
 # remain under QEMU emulation when cross-building.
 # ===========================================================================
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build-c
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build-c
 ENV BUILD_PKGS="gcc g++ autoconf automake libtool make openssl-dev libtasn1-dev \
     json-glib-dev gnutls bash expect gawk socat libseccomp-dev gmp-dev \
     musl-utils autoconf-archive git json-c json-c-dev libcurl curl-dev \
@@ -99,7 +99,7 @@ RUN rm /out/usr/lib/libprotoc.so*
 # This avoids QEMU, which is known to deadlock on go vet / go build.
 # ===========================================================================
 # hadolint ignore=DL3029
-FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build-go
+FROM --platform=$BUILDPLATFORM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build-go
 ARG TARGETARCH
 
 WORKDIR /vtpm-build

--- a/pkg/watchdog/Dockerfile
+++ b/pkg/watchdog/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS watchdog-build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS watchdog-build
 ENV BUILD_PKGS build-base file libtirpc-dev linux-headers tar util-linux
 ENV PKGS alpine-baselayout musl-utils libsmartcols
 RUN eve-alpine-deploy.sh

--- a/pkg/wwan/Dockerfile
+++ b/pkg/wwan/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2023-2025 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 ENV BUILD_PKGS meson ninja git libc-dev glib-dev make gcc udev dbus-dev libgudev-dev
 ENV PKGS alpine-baselayout dbus glib kmod kmod-dev libgudev
 RUN eve-alpine-deploy.sh

--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -3,8 +3,8 @@
 # Copyright (c) 2023-2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM lfedge/eve-uefi:d0986c2acfe313bb03370b7073bdbc6066667e7f AS uefi-build
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS runx-build
+FROM lfedge/eve-uefi:64153003641b262bf3021da93a7954a7a34f9414 AS uefi-build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS runx-build
 ENV BUILD_PKGS="mkinitfs gcc musl-dev e2fsprogs chrony agetty"
 RUN eve-alpine-deploy.sh
 
@@ -20,7 +20,7 @@ RUN gcc -s -o /chroot2 /tmp/chroot2.c -Wall -Werror
 RUN gcc -s -o /hacf /tmp/hacf.c -Wall -Werror
 RUN mkinitfs -n -F base -i /init-initrd -o /runx-initrd
 
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build
 ENV BUILD_PKGS="\
     gcc make libc-dev dev86 xz-dev perl bash python3-dev \
     gettext iasl util-linux-dev ncurses-dev glib-dev \

--- a/pkg/xen/Dockerfile
+++ b/pkg/xen/Dockerfile
@@ -1,4 +1,4 @@
-FROM lfedge/eve-alpine:b79fd3384162534a9bdb99506adb2f19f60f26db AS kernel-build
+FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS kernel-build
 
 ENV BUILD_PKGS argp-standalone automake bash bc binutils-dev bison build-base \
                diffutils flex git gmp-dev gnupg installkernel kmod \


### PR DESCRIPTION
# Description

`register-sbom-pkg.sh` registers source-built packages in the APK DB so that
syft picks them up. It has been a no-op since commit ad69d069 gave it an early
`exit 0`, added to work around `apk add` segfaulting on the records it wrote.
The workaround was expected to be temporary, pending an upstream apk fix. As a
result no source-built package (grub, u-boot, edk2, libtpms, swtpm, bpftrace,
bcc, lshw, zfs, the firmware blobs, …) has appeared in an EVE SBOM since.

The segfault was not an upstream apk bug. The records were missing the `C:`
checksum field, and apk needs it.

apk stores a package's identity in `C:` and hashes on it, and `APK_BLOB_CSUM()`
uses the checksum **type** as the blob length (`APK_CHECKSUM_NONE == 0`). A
record without `C:` therefore hashes to a zero-length key, so every such record
collides and compares equal. `apk_db_pkg_add()` treats the second one as a
duplicate and `apk_pkg_free()`s a package that is still linked into the
installed list — hence the SIGSEGV, which is what the debug container's
`collect-info.sh` was hitting.

A single `C:`-less record is no better, just quieter.
`apk_pkg_write_index_header()` pushes the checksum unconditionally, and for
`APK_CHECKSUM_NONE` `apk_blob_push_csum()` nulls the output buffer. That is
misreported as `Metadata for package X is too long` and returns `-ENOBUFS`,
which `apk_db_write_config()` **discards** before closing the stream — so apk
renames a truncated temp file over `/lib/apk/db/installed`. Every package
sorted after the bad record is silently erased; a record whose name sorts first
leaves a 0-byte DB.

This PR:

- writes a `C:` field, derived as a stable synthetic SHA-1 of name and version
  (there is no `.apk` file to hash), and makes registration idempotent, because
  duplicate records crash apk even when their checksums are valid;
- adds `pkg/alpine/merge-sbom-db.sh`, because the other source of duplicates is
  packages that assemble their SBOM DB by `cat`-ing the DBs of contributing
  stages. Any two DBs built on an Alpine rootfs share its base packages, so the
  concatenation produces exactly the colliding records described above. Against
  the real `eve-bpftrace` DB this reproduced independently of
  `register-sbom-pkg.sh`: 16 overlapping packages, `apk add` → SIGSEGV. The
  helper merges on package name, first input winning;
- fixes `pkg/bpftrace`, which registered `bpftrace` twice (once with a `.git`
  URL suffix) and never exported the DB holding its records;
- fixes an empty `VERSION` in `pkg/u-boot`'s registration call.

Note on lifetime, since it looks like a bug but is not: apk recomputes the
installed set as the dependency closure of `/etc/apk/world` on every
transaction, so it purges these synthetic records the next time `apk add` runs
in the same root. That is harmless — no caller runs an apk transaction after
registering, and the DB is scanned in a `FROM scratch` image. It must **not** be
"fixed" by adding names to `/etc/apk/world`, which makes apk resolve them
against the Alpine repositories and replace the source-built package with an
upstream one of the same name. This is written down in the script header.

## How to test and validate this PR

**1. Source-built packages are in the SBOM (the actual fix)**

```sh
make ZARCH=amd64 pkgs rootfs
tar --warning=no-unknown-keyword -xf dist/amd64/current/rootfs-generic.tar -O sbom.spdx.json \
  | jq -r '.packages[] | select(.name|test("bpftrace|^bcc$")) | "\(.name) \(.versionInfo)"' | sort -u
```

Expected — and this is the output from an actual amd64 build of this branch:

```text
bcc 0.27.0
bpftrace 0.20.3
```

On `master` both are absent. The same SBOM should also now list other
source-built packages, e.g.:

```sh
tar --warning=no-unknown-keyword -xf dist/amd64/current/rootfs-generic.tar -O sbom.spdx.json \
  | jq -r '.packages[].name' | grep -xE 'grub|u-boot|edk2|libtpms|swtpm|lshw|hexedit|zfs' | sort -u
```

**2. No duplicate records, i.e. the segfault cannot recur**

Every duplicated `C:` value is one SIGSEGV trigger, so this must print `0`:

```sh
docker run --rm lfedge/eve-debug:<tag-built-above> \
  sh -c 'grep "^C:" /lib/apk/db/installed | sort | uniq -d | wc -l'
```

**3. `apk add` works inside the debug container (the reported crash)**

`collect-info.sh` and `qemu-affinities.sh` both call `apk add`, which is what
was crashing on-device. With network available:

```sh
docker run --rm lfedge/eve-debug:<tag-built-above> sh -c 'apk add procps; echo "rc=$?"'
```

Expected `rc=0`. Before this PR, with `register-sbom-pkg.sh` enabled, this
returned `rc=139` (SIGSEGV).

**4. Regression check to confirm the diagnosis**

Appending a `C:`-less record to any Alpine image's DB and running `apk add`
reproduces both failure modes, and is the check that the `C:` field is what
matters:

```sh
docker run --rm alpine:3.22 sh -c '
  printf "P:aa-test\nV:1.0\nL:MIT\nA:x86_64\nT:t\nU:https://e.com\n\n" >> /lib/apk/db/installed
  echo aa-test >> /etc/apk/world
  apk add vim; echo "rc=$?"; wc -c < /lib/apk/db/installed'
```

Before: `Metadata for package aa-test-1.0 is too long` and a **0-byte** DB. Two
such records instead of one give `rc=139`.

Not covered by an automated test — there is no unit-test harness for the
linuxkit package build scripts. The behaviour is covered by step 1, which the
existing `sbom-coverage-check` workflow complements by ensuring every
source-built package calls the script.

## Changelog notes

Source-built components (bootloaders, firmware, TPM tooling, bpftrace, and
others built from source rather than installed from Alpine) are listed in the
EVE SBOM again. They had been silently missing.

## PR Backports

- 17.0-stable: To be backported. `register-sbom-pkg.sh` is present there and
  carries the same early `exit 0`, so its SBOMs are missing source-built
  packages too. Only the `pkg/alpine` part applies — 17.0-stable has neither the
  `pkg/debug` DB concatenation nor the duplicated `bpftrace` registration.
- 16.0-stable: No, `register-sbom-pkg.sh` does not exist on that branch.
- 14.5-stable: No, `register-sbom-pkg.sh` does not exist on that branch.
- 13.4-stable: No, `register-sbom-pkg.sh` does not exist on that branch.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — no `docs/` page covers SBOM
  registration; the non-obvious apk constraints are documented in the headers of
  `register-sbom-pkg.sh` and `merge-sbom-db.sh`, where anyone editing them will
  read them, and in the commit messages.
- [x] I've tested my PR on amd64 device — validated on an amd64 `pkgs rootfs`
  build (the SBOM output in step 1 is from it) and the apk regressions were
  reproduced and re-tested in containers; not booted on amd64 hardware.
- [x] I've tested my PR on arm64 device 
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR — needs `stable` for the 17.0
  backport; leaving label selection to a maintainer.

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
