### PR TITLE
yetus: Fix bufcompat parameters

### DIFF
--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -55,7 +55,7 @@ jobs:
             --patch-dir=/workspace/out \
             --build-tool=nobuild \
             --continuous-improvement=true \
-            --buf-basedir=/workspace/src/evetest \
+            --buf-basedir=/workspace/src/evetest/grpcapi/proto \
             --user-plugins=/workspace/src/.yetus/plugins.d \
             --plugins='all,-asflicense,-author,-findbugs,-gitlab,-jira,-shelldocs' \
             --revive-config=.revive.toml \

--- a/.yetus/personality.sh
+++ b/.yetus/personality.sh
@@ -8,7 +8,7 @@ personality_globals() {
   BUILDTOOL=nobuild
 
   # configure buf
-  BUF_BASEDIR=evetest
+  BUF_BASEDIR=evetest/grpcapi/proto
 
   # we want this on so master does not break
   CONTINUOUS_IMPROVEMENT=true


### PR DESCRIPTION
# Description

We use evetest as base directory for protobuf files, but inside evetest we have more than one protbuf module:

- evetest/grpcapi/eve-api
- evetest/grpcapi/proto

Every time .proto files are touched on evetest, two images will be merged into one but the bufcompat plugin will later check against each one of the module, leading to the following error:

```
Failure: input contained 2 images, whereas against contained 1 images
```

Fix it by pointing only to evetest/grpcapi/proto (eve-api it's a separated project, we don't need to check it here).

## How to test and validate this PR

Run Yetus CI with .proto files changed on evetest.

## Changelog notes

None.

## PR Backports

- [ ] 17.0-stable

Other branches: No, since they don't have evetest.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.