### PR TITLE
evetest: return errors from device file and publication reads

### DIFF
--- a/evetest/README.md
+++ b/evetest/README.md
@@ -302,10 +302,10 @@ stdout, stderr, err := device.RunShellScript("uptime", timeout, stdoutWatchdogTi
 
 // Read EVE's internal published state (pubsub)
 var dpcl pillartypes.DevicePortConfigList
-evetest.ReadPublication(device, "nim", true, "global", &dpcl)
+err := evetest.ReadPublication(device, "nim", true, "global", &dpcl)
 
 // Read all publications of a type
-items := evetest.ReadAllPublications[pillartypes.AppInstanceStatus](
+items, err := evetest.ReadAllPublications[pillartypes.AppInstanceStatus](
     device, "zedmanager", false)
 
 // Get the latest device info/metrics (or nil if not yet received)

--- a/evetest/VERSION
+++ b/evetest/VERSION
@@ -1,2 +1,2 @@
 # Evetest version. Increment this manually whenever changes are made to the evetest framework.
-1.1
+1.2

--- a/evetest/edgedevice.go
+++ b/evetest/edgedevice.go
@@ -1830,13 +1830,13 @@ func (d *EdgeDevice) FileExists(fileName string) bool {
 }
 
 // ReadFile reads the contents of a file from the device.
-func (d *EdgeDevice) ReadFile(fileName string) []byte {
+func (d *EdgeDevice) ReadFile(fileName string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(d.th.ctx, fileTransferTimeout)
 	defer cancel()
 
 	tmpFile, err := os.CreateTemp("", "eve-file-*")
 	if err != nil {
-		d.th.t.Fatalf("ReadFile: failed to create temp file: %v", err)
+		return nil, fmt.Errorf("ReadFile: failed to create temp file: %w", err)
 	}
 	tmpPath := tmpFile.Name()
 	tmpFile.Close()
@@ -1844,15 +1844,15 @@ func (d *EdgeDevice) ReadFile(fileName string) []byte {
 
 	err = d.th.scpFromEVE(ctx, d.devName, fileName, tmpPath, false)
 	if err != nil {
-		d.th.t.Fatalf("ReadFile: failed to copy %q from device %q: %v",
+		return nil, fmt.Errorf("ReadFile: failed to copy %q from device %q: %w",
 			fileName, d.devName, err)
 	}
 
 	data, err := os.ReadFile(tmpPath)
 	if err != nil {
-		d.th.t.Fatalf("ReadFile: failed to read temp file: %v", err)
+		return nil, fmt.Errorf("ReadFile: failed to read temp file: %w", err)
 	}
-	return data
+	return data, nil
 }
 
 // WriteFile writes content to a file on the device.
@@ -2782,12 +2782,11 @@ func (d *EdgeDevice) WatchClusterMetrics() (
 //   - key: identifies the specific message within the topic to fetch
 //   - output: pointer to a value of type T to unmarshal the message into
 //
-// Returns false if the topic or message does not exist yet (e.g. before the
-// agent has first published it) -- callers that need to wait for it should
-// poll on the returned bool instead of treating absence as an error. Calls
-// t.Fatalf on any other read or unmarshal failure.
+// Returns an error if the message does not exist yet (e.g. before the agent has
+// first published it), cannot be read, or does not unmarshal into T. Callers
+// waiting for a message to appear should poll until the error clears.
 func ReadPublication[T any](d *EdgeDevice, fromAgent string, persistent bool,
-	key string, output *T) bool {
+	key string, output *T) error {
 	fullName := fmt.Sprintf("%T", *new(T))
 	typeName := fullName[strings.LastIndex(fullName, ".")+1:]
 	var path string
@@ -2796,15 +2795,15 @@ func ReadPublication[T any](d *EdgeDevice, fromAgent string, persistent bool,
 	} else {
 		path = fmt.Sprintf("/run/%s/%s/%s.json", fromAgent, typeName, key)
 	}
-	if !d.FileExists(path) {
-		return false
+	data, err := d.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("ReadPublication: %w", err)
 	}
-	data := d.ReadFile(path)
 	if err := json.Unmarshal(data, output); err != nil {
-		d.th.t.Fatalf("ReadPublication: failed to unmarshal %q from device %q: %v",
+		return fmt.Errorf("ReadPublication: failed to unmarshal %q from device %q: %w",
 			path, d.devName, err)
 	}
-	return true
+	return nil
 }
 
 // ReadAllPublications retrieves all messages from a pub-sub topic published by
@@ -2816,7 +2815,8 @@ func ReadPublication[T any](d *EdgeDevice, fromAgent string, persistent bool,
 //
 // Returns a slice of values of type T representing all messages from the topic,
 // or an error if reading or unmarshaling fails.
-func ReadAllPublications[T any](d *EdgeDevice, fromAgent string, persistent bool) []T {
+func ReadAllPublications[T any](d *EdgeDevice, fromAgent string,
+	persistent bool) ([]T, error) {
 	fullName := fmt.Sprintf("%T", *new(T))
 	typeName := fullName[strings.LastIndex(fullName, ".")+1:]
 	var dir string
@@ -2830,20 +2830,24 @@ func ReadAllPublications[T any](d *EdgeDevice, fromAgent string, persistent bool
 		"find "+shellEscape(dir)+" -maxdepth 1 -name '*.json' -type f 2>/dev/null || true",
 		quickSSHCommandTimeout, 0)
 	if err != nil {
-		d.th.t.Fatalf("ReadAllPublications: failed to list %q on device %q: %v",
+		return nil, fmt.Errorf("ReadAllPublications: failed to list %q on device %q: %w",
 			dir, d.devName, err)
 	}
 	var results []T
 	for _, file := range strings.Fields(stdout) {
-		data := d.ReadFile(file)
+		data, err := d.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("ReadAllPublications: %w", err)
+		}
 		var item T
 		if err := json.Unmarshal(data, &item); err != nil {
-			d.th.t.Fatalf("ReadAllPublications: failed to unmarshal %q from device %q: %v",
+			return nil, fmt.Errorf(
+				"ReadAllPublications: failed to unmarshal %q from device %q: %w",
 				file, d.devName, err)
 		}
 		results = append(results, item)
 	}
-	return results
+	return results, nil
 }
 
 // getDevUUID returns the device UUID, calling t.Fatalf if not found/onboarded.

--- a/evetest/edgedevice.go
+++ b/evetest/edgedevice.go
@@ -2834,7 +2834,12 @@ func ReadAllPublications[T any](d *EdgeDevice, fromAgent string,
 			dir, d.devName, err)
 	}
 	var results []T
-	for _, file := range strings.Fields(stdout) {
+	// Pubsub keys become file names and may contain spaces.
+	for _, file := range strings.Split(stdout, "\n") {
+		file = strings.TrimRight(file, "\r")
+		if file == "" {
+			continue
+		}
 		data, err := d.ReadFile(file)
 		if err != nil {
 			return nil, fmt.Errorf("ReadAllPublications: %w", err)

--- a/evetest/ssh.go
+++ b/evetest/ssh.go
@@ -210,15 +210,14 @@ func (th *TestHarness) scpFromEVE(ctx context.Context,
 	if recursive {
 		scpArgs = append(scpArgs, "-r")
 	}
-	// The path after the colon is interpreted by a remote shell, so it needs
-	// its own shell quoting independent of how this argv element is split
-	// locally (scp itself is invoked directly via exec, with no local shell
-	// involved) -- otherwise a remote path containing spaces (e.g. a pubsub
-	// key like "Application Data Store") gets split into multiple arguments
-	// remotely.
+	// Pass the remote path verbatim: scp speaks SFTP (the OpenSSH 9.x default,
+	// and no -O here selects the legacy protocol), so no remote shell splits
+	// it and quoting it would make the quotes part of the file name. Spaces
+	// are safe because this is a single argv element -- exec runs scp
+	// directly, with no local shell.
 	scpArgs = append(scpArgs,
 		"-i", "/root/.ssh/eve_rsa",
-		"root@"+eveIP+":"+shellEscape(remotePath),
+		"root@"+eveIP+":"+remotePath,
 		localPath,
 	)
 	cmd := exec.CommandContext(ctx, "scp", scpArgs...)
@@ -250,7 +249,7 @@ func (th *TestHarness) scpToEVE(ctx context.Context,
 	scpArgs = append(scpArgs,
 		"-i", "/root/.ssh/eve_rsa",
 		localPath,
-		"root@"+eveIP+":"+shellEscape(remotePath),
+		"root@"+eveIP+":"+remotePath,
 	)
 	cmd := exec.CommandContext(ctx, "scp", scpArgs...)
 	var stderr bytes.Buffer

--- a/evetest/ssh.go
+++ b/evetest/ssh.go
@@ -222,7 +222,15 @@ func (th *TestHarness) scpFromEVE(ctx context.Context,
 		localPath,
 	)
 	cmd := exec.CommandContext(ctx, "scp", scpArgs...)
-	return cmd.Run()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return fmt.Errorf("%w: %s", err, msg)
+		}
+		return err
+	}
+	return nil
 }
 
 // scpToEVE copies a file (or, when recursive is true, a directory) from a
@@ -245,7 +253,15 @@ func (th *TestHarness) scpToEVE(ctx context.Context,
 		"root@"+eveIP+":"+shellEscape(remotePath),
 	)
 	cmd := exec.CommandContext(ctx, "scp", scpArgs...)
-	return cmd.Run()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return fmt.Errorf("%w: %s", err, msg)
+		}
+		return err
+	}
+	return nil
 }
 
 // getReachableEVEAddr finds a reachable IP for the given device at the specified

--- a/evetest/tests/networking/dns_test.go
+++ b/evetest/tests/networking/dns_test.go
@@ -319,8 +319,9 @@ func TestDNSFunctionality(test *testing.T) {
 	// ------------------------------------------------------------------
 	log.Infof("Phase 2: verifying /etc/resolv.conf and mgmt dnsmasq config...")
 
-	resolvConf := string(device.ReadFile("/etc/resolv.conf"))
-	t.Expect(resolvConf).To(ContainSubstring("nameserver 127.0.0.1"))
+	resolvConf, err := device.ReadFile("/etc/resolv.conf")
+	t.Expect(err).NotTo(HaveOccurred())
+	t.Expect(string(resolvConf)).To(ContainSubstring("nameserver 127.0.0.1"))
 
 	// The main config file contains static options only; upstream server
 	// entries live in the separate servers file re-read on SIGHUP.
@@ -328,13 +329,16 @@ func TestDNSFunctionality(test *testing.T) {
 		configFilePath  = "/run/nim/dnsmasq.mgmt.conf"
 		serversFilePath = "/run/nim/dnsmasq.mgmt.servers"
 	)
-	dnsmasqConf := string(device.ReadFile(configFilePath))
-	t.Expect(dnsmasqConf).To(ContainSubstring("servers-file=" + serversFilePath))
+	dnsmasqConf, err := device.ReadFile(configFilePath)
+	t.Expect(err).NotTo(HaveOccurred())
+	t.Expect(string(dnsmasqConf)).To(ContainSubstring("servers-file=" + serversFilePath))
 
 	// The servers file may still be updating after Phase 1 — wait for it
 	// to contain all expected servers in cost-ascending order.
 	t.Eventually(func(g Gomega) {
-		dnsmasqServers := string(device.ReadFile(serversFilePath))
+		serversFile, err := device.ReadFile(serversFilePath)
+		g.Expect(err).NotTo(HaveOccurred())
+		dnsmasqServers := string(serversFile)
 		// All expected upstream servers must be present.
 		g.Expect(dnsmasqServers).To(ContainSubstring(badDNS3IP),
 			"eth3 (cost=0) server must appear in mgmt dnsmasq servers file")

--- a/evetest/tests/networking/pciback_error_test.go
+++ b/evetest/tests/networking/pciback_error_test.go
@@ -74,7 +74,8 @@ func portPciLong(t *WithT, device *evetest.EdgeDevice, phylabel string) string {
 	var pci string
 	t.Eventually(func() string {
 		var aa pillartypes.AssignableAdapters
-		if !evetest.ReadPublication(device, "domainmgr", false, "global", &aa) {
+		if err := evetest.ReadPublication(
+			device, "domainmgr", false, "global", &aa); err != nil {
 			return ""
 		}
 		for _, b := range aa.IoBundleList {

--- a/evetest/tests/storage/vault_trim_test.go
+++ b/evetest/tests/storage/vault_trim_test.go
@@ -69,8 +69,8 @@ func TestVaultZvolTrimReclaimsBlocks(test *testing.T) {
 	// Wait for vaultmgr to report the default vault ConversionComplete.
 	t.Eventually(func() bool {
 		var status pillartypes.VaultStatus
-		if !evetest.ReadPublication(device, "vaultmgr", false,
-			pillartypes.DefaultVaultName, &status) {
+		if err := evetest.ReadPublication(device, "vaultmgr", false,
+			pillartypes.DefaultVaultName, &status); err != nil {
 			return false // status not published yet
 		}
 		return status.ConversionComplete

--- a/evetest/tests/storage/zvol_provisioned_size_test.go
+++ b/evetest/tests/storage/zvol_provisioned_size_test.go
@@ -155,9 +155,11 @@ func TestZVolProvisionedSizeReported(test *testing.T) {
 	// volumemgr pubsub object: AppDiskMetric.ProvisionedBytes is the value the
 	// fix populates. The zvol device path embeds the volume UUID, so match on
 	// it. Poll because volumemgr recomputes disk metrics on its own interval.
-	t.Eventually(func() uint64 {
-		for _, m := range evetest.ReadAllPublications[pillartypes.AppDiskMetric](
-			device, "volumemgr", false) {
+	t.Eventually(func(g Gomega) uint64 {
+		diskMetrics, err := evetest.ReadAllPublications[pillartypes.AppDiskMetric](
+			device, "volumemgr", false)
+		g.Expect(err).NotTo(HaveOccurred())
+		for _, m := range diskMetrics {
 			if strings.Contains(m.DiskPath, volUUID.String()) {
 				return m.ProvisionedBytes
 			}


### PR DESCRIPTION
# Description

The evetest read helpers -- `EdgeDevice.ReadFile`, `ReadPublication` and
`ReadAllPublications` -- ended the test through `t.Fatalf` on any failure.
That is the wrong contract for state EVE produces asynchronously: a caller
polling for a file or a publication that has not appeared yet dies on its
first attempt instead of failing one `Eventually` iteration and retrying.

Two call sites depend on polling today:

- `tests/networking/dns_test.go` reads `/run/nim/dnsmasq.mgmt.servers` inside
  an `Eventually` while nim is still writing it.
- `tests/storage/zvol_provisioned_size_test.go` reads volumemgr's
  `AppDiskMetric` the same way. `ReadAllPublications` was racy in a second
  way: it lists the topic directory and then reads each file, so an unpublish
  in between killed the test.

`ReadPublication` already supported polling, but reported absence as a `bool`
after a separate `FileExists` probe. That costs an extra SSH round trip per
read, races between the probe and the read, and collapses "not published yet"
and "device unreachable" into the same `false`. An error covers both and says
which -- and matches `RunShellScript`, the other way tests reach into a
device. `Fatalf` stays for harness faults, where no test can proceed.

## `ReadFile` is broken on master today

While validating the above, `ReadFile` turned out to fail for **every** path,
not just as an edge case. `scpFromEVE`/`scpToEVE` shell-quote the remote path,
but scp has spoken the SFTP protocol by default since OpenSSH 9.0 and evetest
passes no `-O` to select the legacy one, so no remote shell ever sees the
path. The quotes become part of the file name:

```
scp: '/etc/resolv.conf': No such file or directory
```

The clearest demonstration is from `TestZVolProvisionedSizeReported`:
`ReadAllPublications` runs `find` on the device, which *locates*
`/run/volumemgr/AppDiskMetric/dev-zvol-....json`, and scp then reports that
exact path -- quoted -- as missing.

Spaces were the reason the quoting was added (`types.DefaultVaultName` is
`"Application Data Store"`), but they are already safe: exec runs scp directly
with no local shell, so the path reaches scp as a single argv element either
way. Verified against a throwaway sshd with the same OpenSSH 9.9 client the
evetest image ships, invoking scp with **no shell** so the quotes survive into
argv exactly as they do here:

| remote-path argument | spaced path | plain path |
|---|---|---|
| shell-quoted (current master) | FAIL | FAIL |
| raw | OK | OK |

This affects `dns_test.go` directly and `vault_trim_test.go` /
`pciback_error_test.go` through `ReadPublication`. It was previously masked:
`scpFromEVE` returned a bare `exit status 1`, and `ReadFile` turned that into
a `Fatalf` that named no cause.

## Also in this PR

- `scpFromEVE` and `scpToEVE` now wrap scp's own stderr, which is what makes
  "missing file" distinguishable from "unreachable device" -- and what made
  the bug above legible in the first place.
- `ReadAllPublications` split `find` output with `strings.Fields`. `find`
  prints one path per line, and pubsub keys become file names, so a key
  containing a space was torn into several nonexistent paths. Splitting on
  whitespace happened to work only because every key read so far has been a
  UUID, `"global"`, or a device path.
- `evetest/VERSION` 1.1 -> 1.2. `tests/` is bind-mounted into the evetest
  container, but the framework it links against is compiled into the image,
  so a test written for the new signatures does not build until the image is
  rebuilt -- which only happens for a version the local docker daemon does
  not already have.

## How to test and validate this PR

Both tests were run against a **locally built live image** from this branch
(`make live`, then `EVETEST_EVE_LIVE_IMAGE=true`). That matters: both assert
recent pillar fixes (`24ef31510` zvol volsize, `2e739c88e` mgmt dnsmasq) that
are absent from `17.0.0-lts`, so against a published release they fail before
reaching any of this code.

```sh
make live
EVETEST_EVE_LIVE_IMAGE=true make evetest NAME=TestZVolProvisionedSizeReported  # PASSES
EVETEST_EVE_LIVE_IMAGE=true make evetest NAME=TestDNSFunctionality
```

- `TestZVolProvisionedSizeReported` **passes**, exercising
  `ReadAllPublications` end to end (error return and the newline split).
- `TestDNSFunctionality` gets through Phase 1 and Phase 2 -- Phase 2 is all
  three changed `ReadFile` calls, one of them inside an `Eventually` -- and
  then fails in Phase 3 on an unrelated assertion about EVE rejecting a
  broken-DNS DPC and falling back to the previous one. That phase reads
  device info from the controller and touches none of this code. I have not
  investigated it; flagging it rather than claiming this PR green.

Before the scp fix, both tests failed *at* the changed calls with the quoted
path error above, so the fix is what the runs actually demonstrate.

## Changelog notes

No user-facing changes. Test-framework only.

## PR Backports

```text
- 17.0-stable: Eventually to be backported (the entire evetest dir).
- 16.0-stable: No, as evetest is not available there.
- 14.5-stable: No, as evetest is not available there.
- 13.4-stable: No, as evetest is not available there.
```

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Documentation: `evetest/README.md` is updated for the new signatures. Not
tested on arm64 -- the change is arch-independent and the local live image is
amd64.
