### PR TITLE
[13.4-stable] pillar: fix decimal literals used as file modes

### DIFF
--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -883,7 +883,7 @@ func storeIntegrityToken(token []byte) {
 	if len(token) == 0 {
 		log.Warnf("[ATTEST] Received empty integrity token")
 	}
-	err := os.WriteFile(types.ITokenFile, token, 644)
+	err := os.WriteFile(types.ITokenFile, token, 0644)
 	if err != nil {
 		log.Fatalf("Failed to store integrity token, err: %v", err)
 	}

--- a/pkg/pillar/dpcreconciler/linuxitems/wlan.go
+++ b/pkg/pillar/dpcreconciler/linuxitems/wlan.go
@@ -118,7 +118,7 @@ func (c *WlanConfigurator) NeedsRecreate(oldItem, newItem depgraph.Item) (recrea
 
 func (c *WlanConfigurator) installWifiConfig(config []WifiConfig) error {
 	if _, err := os.Stat(devicenetwork.RunWlanDir); os.IsNotExist(err) {
-		err = os.Mkdir(devicenetwork.RunWlanDir, 600)
+		err = os.Mkdir(devicenetwork.RunWlanDir, 0700)
 		if err != nil {
 			err = fmt.Errorf("failed to create directory %s: %v",
 				devicenetwork.RunWlanDir, err)

--- a/pkg/pillar/vault/handler_ext4.go
+++ b/pkg/pillar/vault/handler_ext4.go
@@ -100,7 +100,7 @@ func (h *Ext4Handler) SetupDefaultVault() error {
 		if os.IsNotExist(err) {
 			// No TPM or TPM lacks required features
 			// Vault is just a plain folder in those cases
-			return os.MkdirAll(defaultVault, 755)
+			return os.MkdirAll(defaultVault, 0755)
 		}
 		if err == nil && h.isFscryptEnabled(defaultVault) {
 			// old versions of EVE created vault on TPM platforms
@@ -345,7 +345,7 @@ func (h *Ext4Handler) setupVault(vaultPath string, deprecated bool) error {
 	}
 	if err != nil && !deprecated {
 		// Create vault dir
-		if err := os.MkdirAll(vaultPath, 755); err != nil {
+		if err := os.MkdirAll(vaultPath, 0755); err != nil {
 			return err
 		}
 	}

--- a/pkg/pillar/vault/handler_unsupported.go
+++ b/pkg/pillar/vault/handler_unsupported.go
@@ -45,7 +45,7 @@ func (h *UnsupportedHandler) SetupDefaultVault() error {
 	if os.IsNotExist(err) {
 		// No TPM or TPM lacks required features
 		// Vault is just a plain folder in those cases
-		return os.MkdirAll(defaultVault, 755)
+		return os.MkdirAll(defaultVault, 0755)
 	}
 	return nil
 }

--- a/pkg/pillar/vault/handler_zfs.go
+++ b/pkg/pillar/vault/handler_zfs.go
@@ -341,7 +341,7 @@ func MountVaultZvol(log *base.LogObject, datasetPath string) error {
 	_, err = os.Stat("/" + types.SealedDataset)
 	if err != nil {
 		if os.IsNotExist(err) {
-			err = os.Mkdir("/"+types.SealedDataset, os.FileMode(755))
+			err = os.Mkdir("/"+types.SealedDataset, 0755)
 			if err != nil {
 				return fmt.Errorf("MountVaultZvol path %s creation error: %v", "/"+types.SealedDataset, err)
 			}

--- a/pkg/pillar/vault/key.go
+++ b/pkg/pillar/vault/key.go
@@ -64,7 +64,7 @@ func deriveVaultKey(log *base.LogObject, cloudKeyOnlyMode, useSealedKey, tpmKeyO
 // returns function to unstage the key
 func stageKey(log *base.LogObject, cloudKeyOnlyMode, useSealedKey, tpmKeyOnlyMode bool, keyDirName string, keyFileName string) (func(), error) {
 	// Create a tmpfs file to pass the secret to fscrypt
-	if err := os.MkdirAll(keyDirName, 755); err != nil {
+	if err := os.MkdirAll(keyDirName, 0700); err != nil {
 		return nil, fmt.Errorf("error creating keyDir %s %v", keyDirName, err)
 	}
 


### PR DESCRIPTION
# Description

Backport of #6264

Six file-mode arguments in pillar are written as decimal literals, so the
permission bits they produce are not the ones they read as:

| Literal | Go value | Resulting permission bits |
| --- | --- | --- |
| `755` | `0o1363` | `0o363` — `-wxrw--wx` |
| `644` | `0o1204` | `0o204` — `-w----r--` |

Measured, not inferred:

```
os.MkdirAll(dir, 755)  -> d-wxrw--wx (0363)
os.MkdirAll(dir, 0755) -> drwxr-xr-x (0755)
```

So the vault directories were created world-writable, and the attestation
integrity token file (`/run/eve.integrity_token`) was written world-readable
while not being readable by its owner. Affected call sites:

- `pkg/pillar/vault/key.go` — key staging directory
- `pkg/pillar/vault/handler_ext4.go` (x2) — default vault and vault path
- `pkg/pillar/vault/handler_unsupported.go` — default vault
- `pkg/pillar/vault/handler_zfs.go` — sealed dataset mount point
- `pkg/pillar/cmd/zedagent/attesttask.go` — integrity token file

Each site is switched to an octal literal keeping the permissions it already
intended, so there is no change of intent anywhere — only the notation bug.

Cherry-picked with `git cherry-pick -x`, applies cleanly with no conflicts.

Only the fix commit of #6264 is backported. That PR's second commit,
`semgrep: run the rules from make and in CI`, is developer tooling (a make
target and a CI workflow) rather than a fix, and it modifies
`tests/semgrep-rules/os-openfile-non-perm-mode.yaml`, which is absent from
16.0-stable, 14.5-stable and 13.4-stable.

In addition, this PR carries one fix that is **not** part of #6264, because the
affected code does not exist on master and so cannot be cherry-picked:

`pkg/pillar/dpcreconciler/linuxitems/wlan.go` creates `/run/wlan` with
`os.Mkdir(RunWlanDir, 600)`. 600 decimal is `0o1130`, permission bits `0o130`
(`--x-wx---`), so the directory is group-writable and not readable by its
owner — and it holds the generated wpa_supplicant configuration, i.e. the WiFi
credentials. It is changed to `0700` rather than `0600`, since a directory also
needs the execute bit to be traversable. On master this code was removed by
b92d1ff35, which moved wpa_supplicant into pillar.

## How to test and validate this PR

The mistake is checkable statically. This reports nothing after this PR, and
the six call sites above before it:

```sh
grep -rnE '\.(MkdirAll|Mkdir|WriteFile|OpenFile|Chmod)\(([^()]|\([^()]*\))*,\s*(os\.FileMode\()?[1-9][0-9]*\s*\)?\)' \
    --include='*.go' . | grep -v /vendor/
```

Also run:

```sh
make -C pkg/pillar fmt-check
make -C pkg/pillar vet
make -C pkg/pillar test
```

On a device, the permission change can be confirmed directly. Since `MkdirAll`
only applies its mode when creating the directory, the vault checks need a
device whose vault does not exist yet (fresh install, or an installation
without TPM where the vault is a plain folder):

1. Boot a device with this build and confirm the vault directory is
   `drwxr-xr-x` rather than `d-wxrw--wx`:
   `stat -c '%a %A %n' /persist/vault`
2. Confirm the vault still unlocks normally and app instances with encrypted
   volumes start. All the affected directories are used by root-owned
   processes only, so no functional change is expected.
3. On a ZFS install, confirm the sealed dataset mount point is `drwxr-xr-x`:
   `stat -c '%a %A %n' /persist/vault`
4. After a successful attestation, confirm the integrity token file is
   `-rw-r--r--` rather than `--w----r--`:
   `stat -c '%a %A %n' /run/eve.integrity_token`
5. Confirm the wlan run directory is `drwx------` rather than `d--x-wx---`
   on a device with a WiFi port configured:
   `stat -c '%a %A %n' /run/wlan`

Suggested QA regression focus: vault creation and unlock on a fresh install,
both with and without TPM, on ext4 and zfs; plus one attestation cycle.

## Changelog notes

Fixed file permissions on the vault directories, the vault key staging
directory and the attestation integrity token file, which were created with
different permission bits than intended.

## PR Backports

Original: #6264

- 17.0-stable: #6281
- 16.0-stable: #6282
- 14.5-stable: #6283
- 13.4-stable: #6284 (this PR)

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them

Reasons for the unchecked boxes:

- Documentation: no user-facing or architectural behaviour changes, so there is
  nothing to document.
- Device testing on amd64/arm64: not yet done, hence the draft status. The
  changes are architecture-independent, but the vault paths are device
  management code, so the on-device steps above still need to be run before
  this leaves draft.
