### PR TITLE
evetest: add option to skip already-passed subtests

### DIFF
--- a/evetest/README.md
+++ b/evetest/README.md
@@ -464,6 +464,39 @@ Run a suite like any other test:
 make evetest NAME=TestBootstrapSuite
 ```
 
+### Rerunning Only Failed Subtests
+
+`EVETEST_RESTART_ONLY_FAILED=true` reruns a suite while skipping every subtest that
+already passed in a previous run, reporting it as SKIPPED instead of re-executing it
+(a skip does not count as a failure). This is useful both locally, to quickly tell
+whether a failure is deterministic or a fluke without waiting on the whole suite
+again, and in CI, to quickly confirm whether a failure in an open PR is real by
+rerunning just the failed subtests.
+
+The feature requires `EVETEST_COLLECT_ARTIFACTS` -- it works by reading `gotest.txt`
+(or `gotest.json`, if the previous run used `EVETEST_OUTPUT_FORMAT=json`) from a
+previous run's artifact directory. Since every artifact directory is named
+`<test-name>-<timestamp>` (e.g. `TestBootstrapSuite-2026-08-07_08-16-29`), the
+previous run is simply the newest directory of the same suite that predates the
+current run; runs of other suites are ignored. This also means that a run
+performed elsewhere (e.g. a previous CI attempt) can be consulted just by
+unpacking its artifact directory, under its original name, into the artifacts
+directory. `EVETEST_RESTART_ONLY_FAILED` never applies to a standalone test run
+outside of a suite. A previous run made with `EVETEST_OUTPUT_FORMAT=quiet` cannot
+be used, since that mode records no per-test results at all.
+
+```bash
+EVETEST_COLLECT_ARTIFACTS=/tmp/evetest-artifacts \
+    make evetest NAME=TestBootstrapSuite
+# ... some subtest fails ...
+
+EVETEST_COLLECT_ARTIFACTS=/tmp/evetest-artifacts \
+EVETEST_RESTART_ONLY_FAILED=true \
+    make evetest NAME=TestBootstrapSuite
+# Subtests that passed last time are reported as SKIPPED right away; only the
+# previously-failed (or previously-unreached) subtests actually run.
+```
+
 ## Running Tests
 
 ### Basic Usage
@@ -834,6 +867,7 @@ non-default behavior.
 | `EVETEST_PAUSE_ON_FAILURE` | Pause when a test fails | `false` |
 | `EVETEST_PAUSE_ON_CHECKPOINT` | Pause at the named checkpoint | -- |
 | `EVETEST_SUITE_MAX_FAILURES` | Max failures before aborting suite (`-1` = unlimited) | `1` |
+| `EVETEST_RESTART_ONLY_FAILED` | Skip suite subtests that already passed in a previous run (requires `EVETEST_COLLECT_ARTIFACTS`); see [Rerunning Only Failed Subtests](#rerunning-only-failed-subtests) | `false` |
 
 ### Deployment Variables
 

--- a/evetest/VERSION
+++ b/evetest/VERSION
@@ -1,2 +1,2 @@
 # Evetest version. Increment this manually whenever changes are made to the evetest framework.
-1.2
+1.3

--- a/evetest/constants/config.go
+++ b/evetest/constants/config.go
@@ -67,6 +67,18 @@ const (
 	// This is read by the evetest container.
 	PauseOnFailureEnv = "PAUSE_ON_FAILURE"
 
+	// RestartOnlyFailedEnv, when set to true, makes a rerun of a test suite skip
+	// every subtest that already passed in a previous run of the same suite,
+	// only actually executing the ones that previously failed (or never ran).
+	// A skipped subtest is reported as SKIPPED (not run and not a failure).
+	// The previous run is found by looking for the newest artifact directory of
+	// the same suite that predates the current run, so this is only meaningful
+	// together with EVETEST_COLLECT_ARTIFACTS (the previous run's gotest.txt/json
+	// is what gets inspected) and has no effect when running a single test outside
+	// of a suite.
+	// This is read by the evetest container.
+	RestartOnlyFailedEnv = "RESTART_ONLY_FAILED"
+
 	// EVEVersionEnv specifies the version of EVE to test. This is the *which
 	// build* setting, independent of how its bits are delivered (see
 	// EVELiveImageEnv).
@@ -396,6 +408,7 @@ func InitViperConfig() {
 	viper.SetDefault(PauseOnCheckpointEnv, "")
 	viper.SetDefault(PauseOnFailureEnv, false)
 	viper.SetDefault(CollectCoverageEnv, false)
+	viper.SetDefault(RestartOnlyFailedEnv, false)
 
 	// EVE image config
 	viper.SetDefault(EVEVersionEnv, "") // Empty = derive from repo

--- a/evetest/entrypoint.sh
+++ b/evetest/entrypoint.sh
@@ -11,8 +11,6 @@ fi
 TIMESTAMP="$(date '+%Y-%m-%d_%H-%M-%S')"
 export EVETEST_ARTIFACT_DIR="/artifacts/${EVETEST_NAME}-${TIMESTAMP}"
 mkdir -p "$EVETEST_ARTIFACT_DIR"
-# Write the artifact dir path so CI can locate it after the container exits.
-echo "$EVETEST_ARTIFACT_DIR" > /artifacts/.last-artifact-dir
 
 BROKER_PID=""
 if [ -z "$EVETEST_BROKER_ADDRESS" ]; then

--- a/evetest/harness.go
+++ b/evetest/harness.go
@@ -467,6 +467,20 @@ func Init(t *testing.T) *T {
 		if th.test.initialized {
 			th.t.Fatalf("Multiple Init calls detected")
 		}
+
+		// EVETEST_RESTART_ONLY_FAILED: when running as part of a test suite
+		// (never for a standalone test, since that never reaches this branch),
+		// skip this subtest if it already passed in a previous run of the same
+		// suite. There is no public API to make a test PASS without actually
+		// returning from it, so the subtest is reported as SKIP rather than PASS;
+		// that does not count as a failure for RunTestSuite's own bookkeeping either.
+		if th.suite != nil {
+			if passedAt, ok := th.previouslyPassedAt(th.suite.name, th.test.name); ok {
+				t.Skipf(restartOnlyFailedSkipMsgTmpl,
+					th.suite.name+"/"+th.test.name, passedAt)
+			}
+		}
+
 		th.test.artifactDir = filepath.Join(th.artifactDir, th.test.name)
 		if err := os.MkdirAll(th.test.artifactDir, 0o755); err != nil {
 			th.t.Fatalf("failed to create directory for test artifacts: %v", err)

--- a/evetest/restartfailed.go
+++ b/evetest/restartfailed.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package evetest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/lf-edge/eve/evetest/constants"
+	"github.com/spf13/viper"
+)
+
+// artifactDirTimestampLayout matches the timestamp suffix that entrypoint.sh
+// appends to each run's artifact directory name, e.g.
+// "TestFooSuite-2026-08-07_08-16-29".
+const artifactDirTimestampLayout = "2006-01-02_15-04-05"
+
+// restartOnlyFailedSkipMsgTmpl is logged, with the (sub)test's full name and
+// the original pass timestamp substituted in for the two %s, whenever a subtest
+// is skipped because EVETEST_RESTART_ONLY_FAILED found that it already
+// passed in a previous run. findPreviousPass parses this exact message back
+// out of a previous gotest.txt, using a regex built from this same template
+// (regexp.QuoteMeta leaves "%s" alone, so the timestamp placeholder can just
+// be swapped for a capture group), so that a chain of skipped reruns still
+// reports the timestamp of the run that actually executed the test.
+const restartOnlyFailedSkipMsgTmpl = "%s already passed in a previous run at %s, " +
+	"skipping (EVETEST_RESTART_ONLY_FAILED is enabled)"
+
+// previouslyPassedAt implements EVETEST_RESTART_ONLY_FAILED: it reports
+// whether the given (sub)test of the given suite already passed in a
+// previous run, and if so, the timestamp at which it actually executed
+// (which may predate the previous run itself, if that run had in turn
+// skipped it via this same mechanism).
+//
+// ok is false whenever the feature does not apply: it is disabled, there is
+// no earlier run of the same suite to consult, or the test's pass could not be
+// confirmed there. The caller should just run the test normally in that case.
+func (th *TestHarness) previouslyPassedAt(
+	suiteName, testName string) (passedAt string, ok bool) {
+	if !viper.GetBool(constants.RestartOnlyFailedEnv) {
+		return "", false
+	}
+
+	_, thisRanAt, ok := parseArtifactDirName(filepath.Base(th.artifactDir))
+	if !ok {
+		th.log.Debugf("Artifact dir %q is not timestamped, skipping "+
+			"restart-only-failed check", th.artifactDir)
+		return "", false
+	}
+
+	artifactsRoot := filepath.Dir(th.artifactDir)
+	prevDir, ranAt, err := previousArtifactDir(artifactsRoot, suiteName, thisRanAt)
+	if err != nil {
+		th.log.Debugf("Could not determine the previous artifact directory: %v", err)
+		return "", false
+	}
+
+	// entrypoint.sh writes either gotest.txt (default "go test -v" output, or
+	// no per-test lines at all under EVETEST_OUTPUT_FORMAT=quiet) or
+	// gotest.json (EVETEST_OUTPUT_FORMAT=json), never both -- try the text
+	// form first since it is the default.
+	textPath := filepath.Join(prevDir, "gotest.txt")
+	if data, err := os.ReadFile(textPath); err == nil {
+		return findPreviousPass(string(data), suiteName, testName, ranAt)
+	}
+
+	jsonPath := filepath.Join(prevDir, "gotest.json")
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		th.log.Debugf("Could not read %s or %s", textPath, jsonPath)
+		return "", false
+	}
+
+	return findPreviousPassJSON(data, suiteName, testName, ranAt)
+}
+
+// previousArtifactDir finds the most recent earlier run of the given suite by
+// looking for the newest "<suiteName>-<timestamp>" directory under
+// artifactsRoot that predates the current run (identified by its timestamp,
+// thisRanAt). Nothing needs to record which run came last: the artifact
+// directory names themselves say it, and CI can make the previous attempt's
+// artifact discoverable simply by unpacking it under artifactsRoot with its
+// original name.
+func previousArtifactDir(
+	artifactsRoot, suiteName, thisRanAt string) (dir, ranAt string, err error) {
+	entries, err := os.ReadDir(artifactsRoot)
+	if err != nil {
+		return "", "", fmt.Errorf("cannot list %s: %w", artifactsRoot, err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name, timestamp, ok := parseArtifactDirName(entry.Name())
+		if !ok || name != suiteName {
+			continue
+		}
+		// artifactDirTimestampLayout is zero-padded most-significant-first, so
+		// comparing timestamps as strings orders them chronologically.
+		if timestamp >= thisRanAt || timestamp <= ranAt {
+			continue
+		}
+		dir, ranAt = filepath.Join(artifactsRoot, entry.Name()), timestamp
+	}
+
+	if dir == "" {
+		err = fmt.Errorf("no artifact directory of an earlier %s run found in %s",
+			suiteName, artifactsRoot)
+		return "", "", err
+	}
+	return dir, ranAt, nil
+}
+
+// parseArtifactDirName splits an artifact directory name of the form
+// "<name>-YYYY-MM-DD_HH-MM-SS" (see entrypoint.sh) into the test/suite name
+// and the run timestamp.
+func parseArtifactDirName(dirName string) (name, timestamp string, ok bool) {
+	if len(dirName) <= len(artifactDirTimestampLayout)+1 {
+		return "", "", false
+	}
+	sep := len(dirName) - len(artifactDirTimestampLayout) - 1
+	if dirName[sep] != '-' {
+		return "", "", false
+	}
+	name, timestamp = dirName[:sep], dirName[sep+1:]
+	if _, err := time.Parse(artifactDirTimestampLayout, timestamp); err != nil {
+		return "", "", false
+	}
+	return name, timestamp, true
+}
+
+// findPreviousPass scans plain "go test -v" output (as produced by
+// entrypoint.sh into gotest.txt, or reconstructed from gotest.json by
+// findPreviousPassJSON) for evidence that the "<suiteName>/<testName>"
+// subtest passed: either its own "--- PASS: <suiteName>/<testName> (...)"
+// line, or restartOnlyFailedSkipMsgTmpl recording that it had already passed
+// even earlier. This is purely an optimization to skip redundant work, so
+// anything short of positive proof of a pass -- including a previous run
+// that failed, or was interrupted before completing -- is treated the same
+// as "unknown": ok=false, meaning the caller just runs the test again.
+func findPreviousPass(
+	gotest, suiteName, testName, ranAt string) (passedAt string, ok bool) {
+	fullName := suiteName + "/" + testName
+	pattern := fmt.Sprintf(regexp.QuoteMeta(restartOnlyFailedSkipMsgTmpl),
+		regexp.QuoteMeta(fullName), `(\S+)`)
+	if m := regexp.MustCompile(pattern).FindStringSubmatch(gotest); m != nil {
+		return m[1], true
+	}
+
+	if strings.Contains(gotest, "--- PASS: "+fullName+" (") {
+		return ranAt, true
+	}
+
+	return "", false
+}
+
+// goTestJSONEvent is one line of "go test -json" output (see TestEvent in
+// cmd/test2json). Only the Output events are needed here.
+type goTestJSONEvent struct {
+	Action string
+	Output string
+}
+
+// findPreviousPassJSON is the EVETEST_OUTPUT_FORMAT=json counterpart of
+// findPreviousPass. "go test -json" is a line-oriented conversion of the same
+// "-v" text protocol: every raw line -- "=== RUN"/"--- PASS" lines as well as
+// any output a test logs -- is preserved verbatim, in original order, as some
+// event's Output field. Reassembling those recovers exactly the text
+// findPreviousPass already knows how to parse, so there is no separate
+// implementation (and no separate risk of the two drifting apart) to
+// maintain here.
+func findPreviousPassJSON(
+	gotestJSON []byte, suiteName, testName, ranAt string) (passedAt string, ok bool) {
+	var text strings.Builder
+	dec := json.NewDecoder(bytes.NewReader(gotestJSON))
+	for {
+		var ev goTestJSONEvent
+		if err := dec.Decode(&ev); err != nil {
+			break
+		}
+		if ev.Action == "output" {
+			text.WriteString(ev.Output)
+		}
+	}
+	return findPreviousPass(text.String(), suiteName, testName, ranAt)
+}

--- a/evetest/restartfailed_test.go
+++ b/evetest/restartfailed_test.go
@@ -1,0 +1,333 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package evetest
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lf-edge/eve/evetest/constants"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+func TestParseArtifactDirName(t *testing.T) {
+	cases := []struct {
+		dirName   string
+		wantName  string
+		wantStamp string
+		wantOK    bool
+	}{
+		{"TestTelemetrySuite-2026-08-07_09-17-40", "TestTelemetrySuite", "2026-08-07_09-17-40", true},
+		{"TestSingleNodeCluster-2026-08-07_08-16-29", "TestSingleNodeCluster", "2026-08-07_08-16-29", true},
+		{"garbage", "", "", false},
+		{"-2026-08-07_08-16-29", "", "", false},
+		{"TestFoo-2026-13-99_08-16-29", "", "", false}, // not a valid timestamp
+		{"TestFoo-2026-08-07_08-16", "", "", false},    // truncated timestamp
+	}
+	for _, tc := range cases {
+		name, stamp, ok := parseArtifactDirName(tc.dirName)
+		if ok != tc.wantOK || name != tc.wantName || stamp != tc.wantStamp {
+			t.Errorf("parseArtifactDirName(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tc.dirName, name, stamp, ok, tc.wantName, tc.wantStamp, tc.wantOK)
+		}
+	}
+}
+
+func TestFindPreviousPass(t *testing.T) {
+	const suite = "TestTelemetrySuite"
+	const ranAt = "2026-08-07_09-17-40"
+
+	t.Run("genuine pass", func(t *testing.T) {
+		gotest := "" +
+			"=== RUN   TestTelemetrySuite\n" +
+			"=== RUN   TestTelemetrySuite/TestDeviceInfo\n" +
+			"=== RUN   TestTelemetrySuite/TestDeviceMetrics\n" +
+			"--- PASS: TestTelemetrySuite (343.19s)\n" +
+			"    --- PASS: TestTelemetrySuite/TestDeviceInfo (168.68s)\n" +
+			"    --- PASS: TestTelemetrySuite/TestDeviceMetrics (149.09s)\n" +
+			"PASS\n"
+		passedAt, ok := findPreviousPass(gotest, suite, "TestDeviceInfo", ranAt)
+		if !ok || passedAt != ranAt {
+			t.Fatalf("got (%q, %v), want (%q, true)", passedAt, ok, ranAt)
+		}
+	})
+
+	t.Run("genuine failure", func(t *testing.T) {
+		gotest := "" +
+			"=== RUN   TestTelemetrySuite\n" +
+			"=== RUN   TestTelemetrySuite/TestDeviceInfo\n" +
+			"--- FAIL: TestTelemetrySuite (1.00s)\n" +
+			"    --- FAIL: TestTelemetrySuite/TestDeviceInfo (1.00s)\n" +
+			"FAIL\n"
+		_, ok := findPreviousPass(gotest, suite, "TestDeviceInfo", ranAt)
+		if ok {
+			t.Fatalf("expected ok=false for a failed subtest")
+		}
+	})
+
+	t.Run("go skip is not a pass", func(t *testing.T) {
+		gotest := "" +
+			"=== RUN   TestTelemetrySuite\n" +
+			"=== RUN   TestTelemetrySuite/TestDeviceInfo\n" +
+			"--- PASS: TestTelemetrySuite (1.00s)\n" +
+			"    --- SKIP: TestTelemetrySuite/TestDeviceInfo (1.00s)\n" +
+			"PASS\n"
+		_, ok := findPreviousPass(gotest, suite, "TestDeviceInfo", ranAt)
+		if ok {
+			t.Fatalf("expected ok=false for a skipped subtest")
+		}
+	})
+
+	t.Run("chained skip propagates original timestamp", func(t *testing.T) {
+		const originalPassedAt = "2026-08-05_10-00-00"
+		skipMsg := fmt.Sprintf(restartOnlyFailedSkipMsgTmpl, suite+"/TestDeviceInfo", originalPassedAt)
+		gotest := "" +
+			"=== RUN   TestTelemetrySuite\n" +
+			"=== RUN   TestTelemetrySuite/TestDeviceInfo\n" +
+			"[34mHARNESS [0m time=\"2026-08-07T09:17:46Z\" level=info msg=\"" +
+			skipMsg + "\"\n" +
+			"=== RUN   TestTelemetrySuite/TestDeviceMetrics\n" +
+			"--- PASS: TestTelemetrySuite (0.01s)\n" +
+			"    --- PASS: TestTelemetrySuite/TestDeviceInfo (0.00s)\n" +
+			"    --- PASS: TestTelemetrySuite/TestDeviceMetrics (149.09s)\n" +
+			"PASS\n"
+		passedAt, ok := findPreviousPass(gotest, suite, "TestDeviceInfo", ranAt)
+		if !ok || passedAt != originalPassedAt {
+			t.Fatalf("got (%q, %v), want (%q, true)", passedAt, ok, originalPassedAt)
+		}
+	})
+
+	t.Run("test not present", func(t *testing.T) {
+		gotest := "" +
+			"=== RUN   TestTelemetrySuite\n" +
+			"=== RUN   TestTelemetrySuite/TestDeviceInfo\n" +
+			"--- PASS: TestTelemetrySuite (1.00s)\n" +
+			"    --- PASS: TestTelemetrySuite/TestDeviceInfo (1.00s)\n" +
+			"PASS\n"
+		_, ok := findPreviousPass(gotest, suite, "TestDeviceLogs", ranAt)
+		if ok {
+			t.Fatalf("expected ok=false for a test absent from the log")
+		}
+	})
+
+	t.Run("name prefix collision does not false-match", func(t *testing.T) {
+		gotest := "" +
+			"=== RUN   TestTelemetrySuite\n" +
+			"=== RUN   TestTelemetrySuite/TestDeviceInfoExtra\n" +
+			"--- PASS: TestTelemetrySuite (1.00s)\n" +
+			"    --- PASS: TestTelemetrySuite/TestDeviceInfoExtra (1.00s)\n" +
+			"PASS\n"
+		_, ok := findPreviousPass(gotest, suite, "TestDeviceInfo", ranAt)
+		if ok {
+			t.Fatalf("expected ok=false: TestDeviceInfo must not match TestDeviceInfoExtra")
+		}
+	})
+
+	// This is accepted as "unknown, so just rerun it": determining a pass
+	// relies entirely on the deferred "--- PASS" summary block, which go test
+	// only flushes once the whole top-level suite test returns. If a later
+	// subtest paused on failure (EVETEST_PAUSE_ON_FAILURE) and the run was
+	// killed before that, the block never gets printed for any subtest of
+	// the suite -- not even ones, like TestDeviceInfo here, that already
+	// passed cleanly. EVETEST_RESTART_ONLY_FAILED is only an optimization,
+	// so simply re-running it is an acceptable outcome.
+	t.Run("run killed before the deferred summary is treated as unknown", func(t *testing.T) {
+		gotest := "" +
+			"=== RUN   TestTelemetrySuite\n" +
+			"=== RUN   TestTelemetrySuite/TestDeviceInfo\n" +
+			"=== RUN   TestTelemetrySuite/TestDeviceMetrics\n"
+			// Killed here while TestDeviceMetrics is paused; no deferred
+			// summary block ever gets printed.
+		_, ok := findPreviousPass(gotest, suite, "TestDeviceInfo", ranAt)
+		if ok {
+			t.Fatalf("expected ok=false: no deferred result line and no skip message")
+		}
+	})
+}
+
+// jsonOutputEvent builds a single "go test -json" Action:"output" event line
+// (see TestEvent in cmd/test2json) carrying the given raw output line, used
+// to assemble synthetic gotest.json fixtures below.
+func jsonOutputEvent(t *testing.T, output string) string {
+	t.Helper()
+	data, err := json.Marshal(goTestJSONEvent{Action: "output", Output: output})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	return string(data) + "\n"
+}
+
+// TestFindPreviousPassJSON only exercises the gotest.json -> text
+// reconstruction itself; once reassembled, the actual pass/fail
+// determination is delegated to findPreviousPass and is already covered
+// exhaustively by TestFindPreviousPass.
+func TestFindPreviousPassJSON(t *testing.T) {
+	const suite = "TestTelemetrySuite"
+	const ranAt = "2026-08-07_09-17-40"
+
+	t.Run("reconstructed text is parsed the same as plain gotest.txt", func(t *testing.T) {
+		gotest := jsonOutputEvent(t, "=== RUN   TestTelemetrySuite\n") +
+			jsonOutputEvent(t, "=== RUN   TestTelemetrySuite/TestDeviceInfo\n") +
+			jsonOutputEvent(t, "=== RUN   TestTelemetrySuite/TestDeviceMetrics\n") +
+			jsonOutputEvent(t, "--- PASS: TestTelemetrySuite (2.00s)\n") +
+			jsonOutputEvent(t, "    --- PASS: TestTelemetrySuite/TestDeviceInfo (1.00s)\n") +
+			jsonOutputEvent(t, "    --- PASS: TestTelemetrySuite/TestDeviceMetrics (1.00s)\n") +
+			jsonOutputEvent(t, "PASS\n") +
+			// Non-"output" events (the semantic actions go test -json also
+			// emits alongside the raw line) must be ignored, not double-counted.
+			`{"Action":"run","Test":"TestTelemetrySuite/TestDeviceInfo"}` + "\n" +
+			`{"Action":"pass","Test":"TestTelemetrySuite/TestDeviceInfo","Elapsed":1}` + "\n"
+
+		passedAt, ok := findPreviousPassJSON([]byte(gotest), suite, "TestDeviceInfo", ranAt)
+		if !ok || passedAt != ranAt {
+			t.Fatalf("got (%q, %v), want (%q, true)", passedAt, ok, ranAt)
+		}
+	})
+
+	t.Run("no PASS line and no skip message means unknown", func(t *testing.T) {
+		gotest := jsonOutputEvent(t, "=== RUN   TestTelemetrySuite\n") +
+			jsonOutputEvent(t, "=== RUN   TestTelemetrySuite/TestDeviceInfo\n") +
+			jsonOutputEvent(t, "=== RUN   TestTelemetrySuite/TestDeviceMetrics\n")
+		_, ok := findPreviousPassJSON([]byte(gotest), suite, "TestDeviceInfo", ranAt)
+		if ok {
+			t.Fatalf("expected ok=false: no deferred result line and no skip message")
+		}
+	})
+}
+
+func TestPreviousArtifactDir(t *testing.T) {
+	const suite = "TestTelemetrySuite"
+	const thisRanAt = "2026-08-07_12-00-00"
+
+	// mkArtifactsRoot creates an artifacts root populated with the given
+	// artifact directory names (plus a stray file, which must be ignored).
+	mkArtifactsRoot := func(t *testing.T, dirNames ...string) string {
+		t.Helper()
+		root := t.TempDir()
+		for _, name := range dirNames {
+			if err := os.MkdirAll(filepath.Join(root, name), 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(root, "some-file"), nil, 0o644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+		return root
+	}
+
+	t.Run("newest earlier run of the same suite wins", func(t *testing.T) {
+		root := mkArtifactsRoot(t,
+			suite+"-2026-08-05_10-00-00",
+			suite+"-2026-08-07_09-17-40", // the newest earlier one
+			suite+"-2026-08-06_23-59-59",
+			"TestOtherSuite-2026-08-07_11-00-00", // different suite
+			suite+"-2026-08-07_13-00-00",         // started after the current run
+			suite+"-"+thisRanAt,                  // the current run itself
+			"not-an-artifact-dir",
+		)
+		dir, ranAt, err := previousArtifactDir(root, suite, thisRanAt)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		wantRanAt := "2026-08-07_09-17-40"
+		if want := filepath.Join(root, suite+"-"+wantRanAt); dir != want || ranAt != wantRanAt {
+			t.Fatalf("got (%q, %q), want (%q, %q)", dir, ranAt, want, wantRanAt)
+		}
+	})
+
+	t.Run("no earlier run of this suite", func(t *testing.T) {
+		root := mkArtifactsRoot(t,
+			"TestOtherSuite-2026-08-07_09-17-40",
+			suite+"-"+thisRanAt,
+			suite+"-2026-08-07_13-00-00",
+		)
+		if _, _, err := previousArtifactDir(root, suite, thisRanAt); err == nil {
+			t.Fatalf("expected error when there is no earlier run of the suite")
+		}
+	})
+
+	t.Run("artifacts root does not exist", func(t *testing.T) {
+		root := filepath.Join(t.TempDir(), "nonexistent")
+		if _, _, err := previousArtifactDir(root, suite, thisRanAt); err == nil {
+			t.Fatalf("expected error for a nonexistent artifacts root")
+		}
+	})
+}
+
+func TestPreviouslyPassedAt(t *testing.T) {
+	const suite = "TestTelemetrySuite"
+	const prevRanAt = "2026-08-07_09-17-40"
+
+	// newHarness sets up an artifacts root holding a single previous run of
+	// suite, whose results (in resultFile, i.e. either gotest.txt or
+	// gotest.json) record TestDeviceInfo as passed, and returns a harness whose
+	// own, more recent artifact dir sits under that same root.
+	newHarness := func(t *testing.T, resultFile, results string) *TestHarness {
+		t.Helper()
+		root := t.TempDir()
+		prevDir := filepath.Join(root, suite+"-"+prevRanAt)
+		if err := os.MkdirAll(prevDir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(
+			filepath.Join(prevDir, resultFile), []byte(results), 0o644); err != nil {
+			t.Fatalf("write %s: %v", resultFile, err)
+		}
+		return &TestHarness{
+			log:         logrus.New(),
+			artifactDir: filepath.Join(root, suite+"-2026-08-07_10-00-00"),
+		}
+	}
+
+	gotestTxt := "" +
+		"=== RUN   TestTelemetrySuite\n" +
+		"=== RUN   TestTelemetrySuite/TestDeviceInfo\n" +
+		"--- PASS: TestTelemetrySuite (1.00s)\n" +
+		"    --- PASS: TestTelemetrySuite/TestDeviceInfo (1.00s)\n" +
+		"PASS\n"
+
+	t.Run("disabled by default", func(t *testing.T) {
+		viper.Set(constants.RestartOnlyFailedEnv, false)
+		defer viper.Set(constants.RestartOnlyFailedEnv, false)
+		th := newHarness(t, "gotest.txt", gotestTxt)
+		if _, ok := th.previouslyPassedAt(suite, "TestDeviceInfo"); ok {
+			t.Fatalf("expected ok=false when EVETEST_RESTART_ONLY_FAILED is unset")
+		}
+	})
+
+	t.Run("enabled, same suite, passed", func(t *testing.T) {
+		viper.Set(constants.RestartOnlyFailedEnv, true)
+		defer viper.Set(constants.RestartOnlyFailedEnv, false)
+		th := newHarness(t, "gotest.txt", gotestTxt)
+		passedAt, ok := th.previouslyPassedAt(suite, "TestDeviceInfo")
+		if !ok || passedAt != prevRanAt {
+			t.Fatalf("got (%q, %v), want (%q, true)", passedAt, ok, prevRanAt)
+		}
+	})
+
+	t.Run("enabled, different suite", func(t *testing.T) {
+		viper.Set(constants.RestartOnlyFailedEnv, true)
+		defer viper.Set(constants.RestartOnlyFailedEnv, false)
+		th := newHarness(t, "gotest.txt", gotestTxt)
+		if _, ok := th.previouslyPassedAt("TestOtherSuite", "TestDeviceInfo"); ok {
+			t.Fatalf("expected ok=false for a mismatched suite name")
+		}
+	})
+
+	t.Run("enabled, EVETEST_OUTPUT_FORMAT=json", func(t *testing.T) {
+		viper.Set(constants.RestartOnlyFailedEnv, true)
+		defer viper.Set(constants.RestartOnlyFailedEnv, false)
+		gotestJSON := jsonOutputEvent(t, "=== RUN   TestTelemetrySuite/TestDeviceInfo\n") +
+			jsonOutputEvent(t, "--- PASS: TestTelemetrySuite/TestDeviceInfo (1.00s)\n")
+		th := newHarness(t, "gotest.json", gotestJSON)
+		passedAt, ok := th.previouslyPassedAt(suite, "TestDeviceInfo")
+		if !ok || passedAt != prevRanAt {
+			t.Fatalf("got (%q, %v), want (%q, true)", passedAt, ok, prevRanAt)
+		}
+	})
+}


### PR DESCRIPTION
# Description

Reruns of a test suite normally re-execute every subtest, even ones that
already passed. Set `EVETEST_RESTART_ONLY_FAILED=true` (requires
`EVETEST_COLLECT_ARTIFACTS` enabled) to skip any subtest that already passed
in a previous run of the same suite, reporting it as skipped instead of
re-executing it (a skip does not count as a failure). This makes it much
faster to check whether a failure is deterministic during local development,
or to confirm a CI failure on an open PR without waiting on the whole suite
again.

Every run's artifact directory is already named `<test-name>-<timestamp>`, so
identifying the previous run needs no extra bookkeeping: it is the newest
artifact directory of the same suite that predates the current run (runs of
other suites are ignored), and its `gotest.txt`/`gotest.json` is parsed to
determine prior pass/fail status. A chain of skipped reruns still reports the
timestamp of the run that actually executed the test, not just the
immediately preceding one. This is purely an optimization: anything short of
positive proof of a pass (a previous run that failed, or was interrupted
before completing) is treated as "unknown" and the subtest just runs again.

Local usage:

```bash
EVETEST_COLLECT_ARTIFACTS=/tmp/evetest-artifacts \
    make evetest NAME=TestBootstrapSuite
# ... some subtest fails ...

EVETEST_COLLECT_ARTIFACTS=/tmp/evetest-artifacts \
EVETEST_RESTART_ONLY_FAILED=true \
    make evetest NAME=TestBootstrapSuite
# Subtests that passed last time are reported as skipped right away; only
# the previously-failed (or previously-unreached) subtests actually run.
```

Intended GitHub CI usage (workflow wiring not included in this PR): on a
workflow re-run (`github.run_attempt > 1`), set
`EVETEST_RESTART_ONLY_FAILED=true` and add a step that fetches the previous
attempt's artifact and unpacks it, under its original directory name, into
the artifacts directory before invoking the same test suite again. The
directory name is all that makes it discoverable, so there is nothing else to
configure. This lets a PR re-run quickly confirm whether a failure is real
without re-running subtests that already passed.

## PR dependencies

None.

## How to test and validate this PR

Unit tests cover the parsing/lookup logic in isolation
(`evetest/restartfailed_test.go`), including the plain-text and
`EVETEST_OUTPUT_FORMAT=json` gotest formats, chained-skip timestamp
propagation, and a previous run that was interrupted before writing its
final summary. Run them with:

```bash
cd evetest && GOWORK=off go test ./... -run 'RestartOnlyFailed|PreviousPass|PreviousArtifact|ParseArtifactDirName'
```

To validate end-to-end against a real suite:

```bash
# Potentially add some bug to EVE or to telemetry test to fail some subtests on purpose, then:
EVETEST_COLLECT_ARTIFACTS=/tmp/evetest-artifacts \
    make evetest NAME=TestTelemetrySuite

# Rerun.
# previously-passed subtests should show up as "--- SKIP: ..." immediately,
# logging "<suite>/<test> already passed in a previous run at <timestamp>,
# skipping (EVETEST_RESTART_ONLY_FAILED is enabled)"
EVETEST_COLLECT_ARTIFACTS=/tmp/evetest-artifacts \
EVETEST_RESTART_ONLY_FAILED=true \
    make evetest NAME=TestTelemetrySuite
```

## Changelog notes

No user-facing changes. Test-framework only.

## PR Backports

- 17.0-stable: Eventually to be backported (the entire evetest dir).
- 16.0-stable: No, as evetest is not available there.
- 14.5-stable: No, as evetest is not available there.
- 13.4-stable: No, as evetest is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
