### PR TITLE
evetest: make blank-volume encryption an explicit choice

### DIFF
--- a/evetest/devconfig.go
+++ b/evetest/devconfig.go
@@ -2519,11 +2519,14 @@ func (dc *EdgeDeviceConfig) deleteVolumeAndDeps(volUUID string) bool {
 // AppDiskMetric.ProvisionedBytes, which zedagent surfaces to the controller as
 // ZMetricVolume.TotalBytes and VolumeResources.MaxSizeBytes.
 //
-// The volume is created in clear text so that it does not depend on the vault
-// being unlocked, keeping the volume-creation path independent of vault
-// readiness.
+// clearText selects whether the volume is created outside the vault. A
+// clear-text volume can be created while the vault is still locked, which
+// isolates a test from vault readiness; an encrypted one exercises the
+// vault-dependent path instead. Tests that are not about encryption should
+// say which they mean rather than relying on a default, since the choice
+// changes what the volume creation actually exercises.
 func (dc *EdgeDeviceConfig) AddBlankVolume(
-	displayName string, sizeBytes uint64) uuid.UUID {
+	displayName string, sizeBytes uint64, clearText bool) uuid.UUID {
 	volumeUUID := dc.th.newUUID("blank volume")
 	dc.Volumes = append(dc.Volumes, &eveconfig.Volume{
 		Uuid: volumeUUID.String(),
@@ -2532,7 +2535,7 @@ func (dc *EdgeDeviceConfig) AddBlankVolume(
 		},
 		Maxsizebytes: int64(sizeBytes),
 		DisplayName:  displayName,
-		ClearText:    true,
+		ClearText:    clearText,
 	})
 	return volumeUUID
 }

--- a/evetest/tests/storage/disk_test.go
+++ b/evetest/tests/storage/disk_test.go
@@ -162,7 +162,7 @@ func TestExtraDiskAttach(test *testing.T) {
 	// Step 2: create a standalone blank volume and mount it with an empty
 	// MountDir -- attached as a raw (unmounted) disk.
 	const extraDiskSize = 16 * evetest.MiB
-	extraDiskVolUUID := devConfig.AddBlankVolume("disk-app-extra-disk", extraDiskSize)
+	extraDiskVolUUID := devConfig.AddBlankVolume("disk-app-extra-disk", extraDiskSize, true)
 	appConfig.Mounts = []evetest.MountConfig{
 		{VolumeUUID: extraDiskVolUUID, MountDir: ""},
 	}

--- a/evetest/tests/storage/volumes_test.go
+++ b/evetest/tests/storage/volumes_test.go
@@ -218,7 +218,7 @@ func TestVolumes(test *testing.T) {
 	halfTotalBytes := halfTotalMiB * mib
 	blankVol1Bytes := blankVol1SizeMiB * mib
 
-	blankVol1UUID := devConfig.AddBlankVolume("blank-vol-1", blankVol1Bytes)
+	blankVol1UUID := devConfig.AddBlankVolume("blank-vol-1", blankVol1Bytes, true)
 	blankVol1Updates, stopBlankVol1Watch := device.WatchVolumeInfo(blankVol1UUID)
 	device.ApplyConfig(devConfig, false, false)
 	evetest.Checkpoint("blank-vol-1-config-applied")
@@ -232,7 +232,7 @@ func TestVolumes(test *testing.T) {
 	evetest.Checkpoint("blank-vol-1-created")
 
 	// blank-vol-2 is expected to fail: not enough free space remains.
-	blankVol2UUID := devConfig.AddBlankVolume("blank-vol-2", halfTotalBytes)
+	blankVol2UUID := devConfig.AddBlankVolume("blank-vol-2", halfTotalBytes, true)
 	blankVol2Updates, stopBlankVol2Watch := device.WatchVolumeInfo(blankVol2UUID)
 	device.ApplyConfig(devConfig, false, false)
 	evetest.Checkpoint("blank-vol-2-config-applied")

--- a/evetest/tests/storage/zvol_provisioned_size_test.go
+++ b/evetest/tests/storage/zvol_provisioned_size_test.go
@@ -110,7 +110,7 @@ func TestZVolProvisionedSizeReported(test *testing.T) {
 		NetworkUUID:   dhcpNet,
 		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
 	})
-	volUUID := devConfig.AddBlankVolume("zvol-provisioned-test", blankVolumeSize)
+	volUUID := devConfig.AddBlankVolume("zvol-provisioned-test", blankVolumeSize, true)
 
 	volInfoUpdates, stopVolInfoWatch := device.WatchVolumeInfo(volUUID)
 	defer stopVolInfoWatch()


### PR DESCRIPTION
# Description

`AddBlankVolume` hardcoded `ClearText: true`, so every blank volume the suite
creates is made outside the vault — whether or not the test cares.

That was a deliberate choice where it originated (24ef31510, the zvol
provisioned-size test: volume creation shouldn't depend on vault readiness).
The two storage tests added later reused the helper and inherited the flag as a
side effect — nothing in them is about encryption. `ClearText` appears exactly
once in the whole `evetest` tree, in this helper, and `AddVolume` never sets it,
so the framework also had no way to create an encrypted blank volume: that path
has no coverage at all.

This takes the flag as a parameter. All four existing call sites pass `true`, so
behavior is unchanged; tests that want the vault-dependent path can now ask for
it.

Prompted by work on the kvm→k conversion tests, which attach blank data volumes
and do want to exercise the vault-dependent path.

## How to test and validate this PR

Static checks, from `evetest/`:

- `GOWORK=off go vet ./tests/...` — clean
- `gofmt -l evetest/` — clean

Behavioral equivalence is by construction: every pre-existing caller now passes
`true`, which is exactly the value the helper previously hardcoded, so the four
affected tests build the same device config as before. The storage tests that
exercise this helper are `TestDiskLayout` (disk_test.go), the blank-volume cases
in volumes_test.go, and zvol_provisioned_size_test.go; running the storage suite
confirms no change.

## Changelog notes

No user-facing changes — test framework only.

## PR Backports

- 17.0-stable: No, test-framework only, not needed on a stable branch.
- 16.0-stable: No, same.
- 14.5-stable: No, same.
- 13.4-stable: No, same.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — not applicable, the behavior change
  is captured in the helper's doc comment
- [ ] I've tested my PR on amd64 device — static checks only so far; the
  affected tests are unchanged in behavior by construction
- [ ] I've tested my PR on arm64 device — same
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
