### PR TITLE
[17.0-stable] hypervisor: recover a VMIRS stranded at Spec.Replicas == 0

### DIFF
--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -800,8 +800,13 @@ func (ctx kubevirtContext) Start(domainName string) error {
 			break
 		}
 		if errors.IsAlreadyExists(err) {
-			// VMI could have been already started, for example failover from other node.
+			// VMI could have been already started, for example failover from
+			// other node. An interrupted DetachUtilVmirsReplicaReset can leave
+			// the existing object scaled to 0 replicas; ensure it is not.
 			logrus.Warnf("VMI replicaset %v already exists", repvmi)
+			if ensureErr := ensureVmirsReplicas(virtClient, vmis.name); ensureErr != nil {
+				return logError("Start domain %s: failed to ensure vmirs %s replicas: %v", domainName, vmis.name, ensureErr)
+			}
 			break
 		}
 		if retries <= 0 {
@@ -843,22 +848,29 @@ func (ctx kubevirtContext) replicaVmiScheduledOnMe(vmirsName string) (scheduledO
 	if err != nil {
 		return false, false, err
 	}
-	kubeconfig := ctx.kubeConfig
 
-	nodeName, ok := ctx.nodeNameMap["nodename"]
-	if !ok {
-		return false, false, fmt.Errorf("Failed to get nodeName")
-	}
-
-	virtClient, err := kubecli.GetKubevirtClientFromRESTConfig(kubeconfig)
+	virtClient, err := kubecli.GetKubevirtClientFromRESTConfig(ctx.kubeConfig)
 	if err != nil {
 		logrus.Errorf("couldn't get the kubernetes client API config: %v", err)
 		return false, false, err
 	}
 
-	vmirs, err := virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).Get(context.Background(), vmirsName, metav1.GetOptions{})
+	vmirs, err := getVmirs(virtClient, vmirsName)
 	if err != nil {
 		return false, false, err
+	}
+	return ctx.vmiScheduledOnMeFromVmirs(virtClient, vmirs)
+}
+
+// vmiScheduledOnMeFromVmirs is the tail of replicaVmiScheduledOnMe, taking an
+// already-fetched VMIRS instead of fetching its own copy. Shared with Info(),
+// which already fetched the VMIRS for the stranded-replica check and would
+// otherwise Get the same object a second time in the same call.
+func (ctx kubevirtContext) vmiScheduledOnMeFromVmirs(virtClient kubecli.KubevirtClient,
+	vmirs *v1.VirtualMachineInstanceReplicaSet) (scheduledOnMe bool, scheduledOnNone bool, err error) {
+	nodeName, ok := ctx.nodeNameMap["nodename"]
+	if !ok {
+		return false, false, fmt.Errorf("Failed to get nodeName")
 	}
 	appDomainNameSelector := vmirs.Status.LabelSelector
 
@@ -1099,14 +1111,98 @@ func StopReplicaVMI(kubeconfig *rest.Config, repVmiName string) error {
 	// Stop the VMI ReplicaSet
 
 	err = virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).Delete(context.Background(), repVmiName, metav1.DeleteOptions{})
+	if err == nil {
+		logrus.Infof("Stop VMI Replicaset %s deleted", repVmiName)
+		return nil
+	}
 	if errors.IsNotFound(err) {
 		logrus.Infof("Stop VMI Replicaset, Domain already deleted: %v", repVmiName)
-	} else {
-		logrus.Errorf("Stop VMI Replicaset error %v\n", err)
-		return err
+		return nil
 	}
+	logrus.Errorf("Stop VMI Replicaset error %v\n", err)
+	return err
+}
 
-	return nil
+// getVmirs fetches the named VMIRS. Split out from vmirsDesiredReplicas so
+// Info() can reuse the fetched object for the scheduling check afterward
+// instead of fetching the same VMIRS twice.
+func getVmirs(virtClient kubecli.KubevirtClient, vmiRsName string) (*v1.VirtualMachineInstanceReplicaSet, error) {
+	getCtx, getCancel := context.WithTimeout(context.Background(), kubeapi.KubeAPITimeout())
+	defer getCancel()
+	return virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).Get(getCtx, vmiRsName, metav1.GetOptions{})
+}
+
+// vmirsDesiredReplicas returns the VMIRS Spec.Replicas value. A nil
+// Spec.Replicas is reported as 1, matching the KubeVirt default.
+func vmirsDesiredReplicas(vmirs *v1.VirtualMachineInstanceReplicaSet) int32 {
+	if vmirs.Spec.Replicas == nil {
+		return 1
+	}
+	return *vmirs.Spec.Replicas
+}
+
+// vmirsStranded reports whether a VMIRS exists but is scaled to zero
+// replicas. This is never a legitimate steady state in EVE: StopReplicaVMI
+// deletes the VMIRS rather than scaling it, so zero means an interrupted
+// replica reset (see DetachUtilVmirsReplicaReset).
+func vmirsStranded(desiredReplicas int32) bool {
+	return desiredReplicas == 0
+}
+
+// ensureVmirsReplicaRetries bounds the Get/mutate/Update retry loop in
+// ensureVmirsReplicas. The budget covers exactly one error: a 409 Conflict on
+// the Update, meaning another writer -- KubeVirt's VMIRS controller, or
+// zedkube's own vmirsReplicaCountSet -- advanced resourceVersion between our
+// Get and our Update. A conflicted body cannot be resent as-is, so the loop
+// has to re-Get and re-decide rather than retry the write; that re-Get is the
+// only reason the Get lives inside the loop.
+//
+// Every other error -- NotFound, transient apiserver failures, an expired
+// context -- returns immediately and consumes none of this budget. Retrying
+// those is the caller's concern, not this loop's.
+const ensureVmirsReplicaRetries = 3
+
+// ensureVmirsReplicas repairs a stranded VMIRS by setting Spec.Replicas to 1.
+// An interrupted DetachUtilVmirsReplicaReset can leave it at 0, which no other
+// code path restores.
+//
+// Zero is the only value treated as broken, via the same vmirsStranded check
+// Info() uses, so the two cannot disagree about what "stranded" means. EVE only
+// ever creates a VMIRS with Replicas=1 and nothing scales it up, so a value
+// above 1 is not a state EVE produces; if one is observed anyway it is left
+// alone rather than scaled in. That keeps every write this function makes an
+// upward one, which is what lets concurrent callers converge -- a downward write
+// would both fight the other writers of this field (KubeVirt's controller,
+// zedkube's vmirsReplicaCountSet) and delete a VMI that may be the one actually
+// serving the app.
+func ensureVmirsReplicas(virtClient kubecli.KubevirtClient, vmiRsName string) error {
+	for attempt := 1; attempt <= ensureVmirsReplicaRetries; attempt++ {
+		getCtx, getCancel := context.WithTimeout(context.Background(), kubeapi.KubeAPITimeout())
+		vmirs, err := virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).Get(getCtx, vmiRsName, metav1.GetOptions{})
+		getCancel()
+		if err != nil {
+			return err
+		}
+		if !vmirsStranded(vmirsDesiredReplicas(vmirs)) {
+			return nil
+		}
+
+		reps := int32(1)
+		vmirs.Spec.Replicas = &reps
+		updateCtx, updateCancel := context.WithTimeout(context.Background(), kubeapi.KubeAPITimeout())
+		_, err = virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).Update(updateCtx, vmirs, metav1.UpdateOptions{})
+		updateCancel()
+		if err == nil {
+			return nil
+		}
+		if !errors.IsConflict(err) {
+			return err
+		}
+		logrus.Warnf("ensureVmirsReplicas: conflict updating vmirs %s, retrying (%d/%d)",
+			vmiRsName, attempt, ensureVmirsReplicaRetries)
+	}
+	return fmt.Errorf("ensureVmirsReplicas: exhausted %d retries updating vmirs %s replicas",
+		ensureVmirsReplicaRetries, vmiRsName)
 }
 
 func (ctx kubevirtContext) Info(domainName string) (int, types.SwState, error) {
@@ -1134,7 +1230,40 @@ func (ctx kubevirtContext) Info(domainName string) (int, types.SwState, error) {
 		}
 	}
 
-	onMe, _, err := ctx.scheduledOnMe(vmis.mtype, vmis.name)
+	// Check for a stranded VMIRS before the scheduledOnMe/!onMe short-circuit
+	// below: with zero replicas there is no VMI and no virt-launcher pod, so
+	// onMe would be false and this domain would otherwise be reported as
+	// UNKNOWN forever instead of recovering. The VMIRS fetched here is reused
+	// for the scheduling check below instead of fetching it a second time.
+	var vmirs *v1.VirtualMachineInstanceReplicaSet
+	var virtClient kubecli.KubevirtClient
+	if vmis.mtype == IsMetaReplicaVMI {
+		var verr error
+		virtClient, verr = kubecli.GetKubevirtClientFromRESTConfig(ctx.kubeConfig)
+		if verr != nil {
+			return 0, types.BROKEN, logError("couldn't get the kubernetes client API config: %v", verr)
+		}
+		var rerr error
+		vmirs, rerr = getVmirs(virtClient, vmis.name)
+		if rerr != nil {
+			if isK3sUnreachable(rerr) {
+				return 0, types.UNKNOWN, nil
+			}
+			// Non-unreachable Get failure: fall through to scheduledOnMe's own
+			// independent fetch attempt below, same as before this reuse was
+			// added -- vmirs stays nil so the generic dispatch runs.
+			vmirs = nil
+		} else if vmirsStranded(vmirsDesiredReplicas(vmirs)) {
+			return 0, types.HALTED, logError("domain %s vmirs %s scaled to 0 replicas", domainName, vmis.name)
+		}
+	}
+
+	var onMe bool
+	if vmirs != nil {
+		onMe, _, err = ctx.vmiScheduledOnMeFromVmirs(virtClient, vmirs)
+	} else {
+		onMe, _, err = ctx.scheduledOnMe(vmis.mtype, vmis.name)
+	}
 	if err != nil {
 		if isK3sUnreachable(err) {
 			return 0, types.UNKNOWN, nil

--- a/pkg/pillar/hypervisor/kubevirt_test.go
+++ b/pkg/pillar/hypervisor/kubevirt_test.go
@@ -6,6 +6,7 @@
 package hypervisor
 
 import (
+	"context"
 	"net"
 	"os"
 	"testing"
@@ -14,8 +15,13 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	gomock "go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	virtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
 )
 
 // k3sPem is used for a mock k3s.yaml file
@@ -114,6 +120,137 @@ func TestPodListToSchedulingState(t *testing.T) {
 			assert.Equal(t, tc.wantAnyNode, anyNode)
 		})
 	}
+}
+
+func mkVmirs(name string, replicas *int32) *virtv1.VirtualMachineInstanceReplicaSet {
+	return &virtv1.VirtualMachineInstanceReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       virtv1.VirtualMachineInstanceReplicaSetSpec{Replicas: replicas},
+	}
+}
+
+func int32Ptr(v int32) *int32 { return &v }
+
+func TestVmirsStranded(t *testing.T) {
+	tests := []struct {
+		name     string
+		replicas int32
+		want     bool
+	}{
+		{"zero replicas is stranded", 0, true},
+		{"one replica is healthy", 1, false},
+		{"two replicas is healthy", 2, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, vmirsStranded(tc.replicas))
+		})
+	}
+}
+
+func TestVmirsDesiredReplicas(t *testing.T) {
+	const name = "test-vmirs"
+
+	t.Run("nil Spec.Replicas defaults to 1", func(t *testing.T) {
+		assert.Equal(t, int32(1), vmirsDesiredReplicas(mkVmirs(name, nil)))
+	})
+
+	t.Run("explicit replicas returned as-is", func(t *testing.T) {
+		assert.Equal(t, int32(0), vmirsDesiredReplicas(mkVmirs(name, int32Ptr(0))))
+		assert.Equal(t, int32(2), vmirsDesiredReplicas(mkVmirs(name, int32Ptr(2))))
+	})
+}
+
+func TestGetVmirs(t *testing.T) {
+	const name = "test-vmirs"
+
+	t.Run("returns the fetched object", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mc := kubecli.NewMockKubevirtClient(ctrl)
+		mrs := kubecli.NewMockReplicaSetInterface(ctrl)
+		mc.EXPECT().ReplicaSet(gomock.Any()).Return(mrs)
+		mrs.EXPECT().Get(gomock.Any(), name, metav1.GetOptions{}).Return(mkVmirs(name, int32Ptr(1)), nil)
+
+		vmirs, err := getVmirs(mc, name)
+		assert.NoError(t, err)
+		assert.Equal(t, name, vmirs.Name)
+	})
+
+	t.Run("get error propagates", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mc := kubecli.NewMockKubevirtClient(ctrl)
+		mrs := kubecli.NewMockReplicaSetInterface(ctrl)
+		mc.EXPECT().ReplicaSet(gomock.Any()).Return(mrs)
+		mrs.EXPECT().Get(gomock.Any(), name, metav1.GetOptions{}).Return(
+			nil, k8serrors.NewServiceUnavailable("unreachable"))
+
+		_, err := getVmirs(mc, name)
+		assert.Error(t, err)
+	})
+}
+
+func TestEnsureVmirsReplicas(t *testing.T) {
+	const name = "test-vmirs"
+	conflictErr := k8serrors.NewConflict(schema.GroupResource{}, name, assert.AnError)
+
+	t.Run("zero replicas triggers update to one", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mc := kubecli.NewMockKubevirtClient(ctrl)
+		mrs := kubecli.NewMockReplicaSetInterface(ctrl)
+		mc.EXPECT().ReplicaSet(gomock.Any()).Return(mrs).Times(2)
+		mrs.EXPECT().Get(gomock.Any(), name, metav1.GetOptions{}).Return(mkVmirs(name, int32Ptr(0)), nil)
+		mrs.EXPECT().Update(gomock.Any(), gomock.Any(), metav1.UpdateOptions{}).DoAndReturn(
+			func(_ context.Context, vmirs *virtv1.VirtualMachineInstanceReplicaSet, _ metav1.UpdateOptions) (*virtv1.VirtualMachineInstanceReplicaSet, error) {
+				assert.Equal(t, int32(1), *vmirs.Spec.Replicas)
+				return vmirs, nil
+			})
+
+		assert.NoError(t, ensureVmirsReplicas(mc, name))
+	})
+
+	t.Run("already at one replica: no update", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mc := kubecli.NewMockKubevirtClient(ctrl)
+		mrs := kubecli.NewMockReplicaSetInterface(ctrl)
+		mc.EXPECT().ReplicaSet(gomock.Any()).Return(mrs)
+		mrs.EXPECT().Get(gomock.Any(), name, metav1.GetOptions{}).Return(mkVmirs(name, int32Ptr(1)), nil)
+		// No Update expectation: gomock fails the test if Update is called.
+
+		assert.NoError(t, ensureVmirsReplicas(mc, name))
+	})
+
+	t.Run("conflict once then succeeds", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mc := kubecli.NewMockKubevirtClient(ctrl)
+		mrs := kubecli.NewMockReplicaSetInterface(ctrl)
+		mc.EXPECT().ReplicaSet(gomock.Any()).Return(mrs).Times(4)
+		// A fresh object per Get call: ensureVmirsReplicas mutates Spec.Replicas
+		// on the returned object in place, so a shared/reused mock return value
+		// would carry that mutation into the next Get.
+		mrs.EXPECT().Get(gomock.Any(), name, metav1.GetOptions{}).DoAndReturn(
+			func(context.Context, string, metav1.GetOptions) (*virtv1.VirtualMachineInstanceReplicaSet, error) {
+				return mkVmirs(name, int32Ptr(0)), nil
+			}).Times(2)
+		mrs.EXPECT().Update(gomock.Any(), gomock.Any(), metav1.UpdateOptions{}).Return(nil, conflictErr)
+		mrs.EXPECT().Update(gomock.Any(), gomock.Any(), metav1.UpdateOptions{}).Return(mkVmirs(name, int32Ptr(1)), nil)
+
+		assert.NoError(t, ensureVmirsReplicas(mc, name))
+	})
+
+	t.Run("conflict past retry budget returns error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mc := kubecli.NewMockKubevirtClient(ctrl)
+		mrs := kubecli.NewMockReplicaSetInterface(ctrl)
+		mc.EXPECT().ReplicaSet(gomock.Any()).Return(mrs).Times(ensureVmirsReplicaRetries * 2)
+		mrs.EXPECT().Get(gomock.Any(), name, metav1.GetOptions{}).DoAndReturn(
+			func(context.Context, string, metav1.GetOptions) (*virtv1.VirtualMachineInstanceReplicaSet, error) {
+				return mkVmirs(name, int32Ptr(0)), nil
+			}).Times(ensureVmirsReplicaRetries)
+		mrs.EXPECT().Update(gomock.Any(), gomock.Any(), metav1.UpdateOptions{}).Return(
+			nil, conflictErr).Times(ensureVmirsReplicaRetries)
+
+		assert.Error(t, ensureVmirsReplicas(mc, name))
+	})
 }
 
 // TestCreateReplicaPodConfig tests the CreateReplicaPodConfig function

--- a/pkg/pillar/kubeapi/kubeapi.go
+++ b/pkg/pillar/kubeapi/kubeapi.go
@@ -78,6 +78,13 @@ const (
 	detachUtilVmirsReplicaResetTimeout = 2 * time.Minute
 )
 
+// KubeAPITimeout returns the budget this package uses for a single k8s API
+// call, so other packages (e.g. hypervisor) can bound their own k8s API
+// calls with the same budget instead of redeclaring it.
+func KubeAPITimeout() time.Duration {
+	return kubeAPITimeout
+}
+
 // GetKubeConfig : Get handle to Kubernetes config
 func GetKubeConfig() (*rest.Config, error) {
 	// Build the configuration from the kubeconfig file
@@ -988,7 +995,9 @@ func DetachOldWorkload(log *base.LogObject, failedNodeName string, appDomainName
 
 	// Push the kubevirt control plane to schedule new pod, otherwise this can be a larger delay
 	if vmiRsName != "" {
-		DetachUtilVmirsReplicaReset(log, vmiRsName)
+		if err := DetachUtilVmirsReplicaReset(log, vmiRsName); err != nil {
+			log.Errorf("DetachOldWorkload vmirs scale reset failed for %s: %v", vmiRsName, err)
+		}
 	}
 
 	// Delete virt-launcher pod on failed node


### PR DESCRIPTION
## Description

Backport of #6269

DetachUtilVmirsReplicaReset scales a VMIRS 0 then 1 under one bounded context; if the deadline expires, the API server flaps, or the process dies between the two writes, Replicas stays 0 forever. Nothing else in pillar ever reads or repairs Spec.Replicas, and StopReplicaVMI deletes the VMIRS rather than scaling it, so zero replicas is never a legitimate steady state.

Two compounding gaps let this go unnoticed and unrepaired: Start() treats IsAlreadyExists on Create() as success without checking the existing object's replica count, and Info() reports a zero-replica VMIRS (no VMI, no virt-launcher pod) as UNKNOWN with a nil error, before scheduledOnMe's !onMe short-circuit is ever reached. That left domainmgr reporting the app RUNNING to the controller indefinitely while the cluster ran it with zero replicas.

- Info() now checks desired replicas for IsMetaReplicaVMI domains before the scheduledOnMe short-circuit, and reports HALTED with an error on a stranded VMIRS. This is deliberately HALTED, not BROKEN, so verifyStatus's recovery branch sets BootFailed and (for kube) publishes BOOTING while skipping Delete/Cleanup, letting maybeRetryBoot drive recovery through the existing retry loop.
- Start()'s IsAlreadyExists branch now calls ensureVmirsReplicas, which raises Spec.Replicas to at least 1 with a bounded Get/mutate/Update retry on conflicting writers. The repair only ever writes upward on observing zero, so concurrent callers converge and it can never produce the stranded state itself.
- Both new k8s API calls are bounded by kubeapi.KubeAPITimeout() (exported getter over kubeapi's existing private constant, to avoid a third redeclaration of the same budget) rather than context.Background(), since Info()/Start() run on domainmgr's watchdog-timed verifyStatus tick and an unbounded call against a degraded apiserver would otherwise risk a watchdog reboot.
- DetachOldWorkload no longer discards DetachUtilVmirsReplicaReset's return value, so a stranded VMIRS is attributable in logs.
- StopReplicaVMI no longer logs "Stop VMI Replicaset error <nil>" on every successful stop, which polluted the logs used to verify this fix.

**Backport note:** the master commit also added an evetest chaos test (`evetest/tests/cluster/purge_test.go`, `evetest/tests/cluster/vmirs_replica_recovery_test.go` and the matching `testsuite_test.go` entries). Those three files are dropped from this backport because they do not compile against this branch's evetest: they call `clusterDeviceRequirements` with the filesystem parameter added by #6177, and use `evetest.MiB` from the `KB`->`KiB` rename in #6074, neither of which is on 17.0-stable. The pillar change is unchanged from master.

## PR dependencies

None

## How to test and validate this PR

**Unit tests** (`pkg/pillar/hypervisor/kubevirt_test.go`): covers
`vmirsStranded`, `vmirsDesiredReplicas`, `ensureVmirsReplicas` (including
conflict-retry). `make -C pkg/pillar test` passes, no regressions.

**evetest**: the chaos test from the original PR is not part of this
backport (see the note above) and stays on master. `evetest` on this
branch is untouched and still builds (`GOOS=linux go vet ./tests/...`).

**Manual repro:**

```sh
kubectl -n eve-kube-app patch vmirs <name> --type=merge -p '{"spec":{"replicas":0}}'
```

Before: app stays falsely RUNNING with 0 replicas forever. After: within
one timer.boot.retry interval, DomainStatus shows a retryable warning,
then Replicas returns to 1 and the app recovers to RUNNING.

Also check no regression on the normal paths (start/purge/stop/failover).

## Changelog notes

Enhanced error recovery on failover of app instances during periods of kube-apiserver instability.

## PR Backports

This is the backport.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.

