### PR TITLE
evetest: port the Eden vector and newlogd log pipeline tests

### DIFF
--- a/evetest/tests/telemetry/helpers_test.go
+++ b/evetest/tests/telemetry/helpers_test.go
@@ -4,8 +4,17 @@
 package telemetry_test
 
 import (
+	"crypto/sha256"
+	"fmt"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
 	"github.com/lf-edge/eve-api/go/evecommon"
 	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/netmodels"
+	pillartypes "github.com/lf-edge/eve/pkg/pillar/types"
 )
 
 const (
@@ -18,12 +27,53 @@ const (
 	// the underlying Linux interface.
 	portLogicalLabel = "ethernet0"
 	portIfName       = "eth0"
+
+	// Prefix of the markers written to /dev/kmsg. A per-probe nonce is
+	// appended so that no assertion can be satisfied - or broken - by a marker
+	// from another probe or from an earlier test run.
+	logProbeMarkerPrefix = "evetest-log-probe"
+
+	probeSSHTimeout = 30 * time.Second
+
+	// Generous, because log entries are batched into gzip bundles before they
+	// are uploaded.
+	logProbeUploadTimeout = 10 * time.Minute
+
+	// Bringing up k3s takes minutes; same allowance as the other suites that
+	// run under kubevirt.
+	//
+	// Under kubevirt every test has to wait for its node to become ready, and
+	// that wait belongs *after* the first ApplyConfig: kube-init blocks the
+	// cluster bring-up on the device name, which zedagent publishes only when
+	// it parses a configuration received from the controller.
+	clusterNodeReadyTimeout = 20 * time.Minute
 )
+
+// setupTelemetryTestDevice declares the prerequisites shared by every test in
+// this package and returns a handle to the device. They are stated in one place
+// because the framework compares device requirements field by field to decide
+// whether the VM from the previous test can be reused: any divergence between
+// two tests in the suite silently costs a full device recreation.
+func setupTelemetryTestDevice(hypervisor evetest.Hypervisor,
+	useTPM bool) *evetest.EdgeDevice {
+	evetest.Setup(
+		evetest.RequireEdgeDevice{
+			Name:              devName,
+			WithHypervisor:    hypervisor,
+			WithTPM:           useTPM,
+			DeviceReusePolicy: evetest.ResetDeviceConfig,
+		},
+		evetest.RequireNetworkModel{
+			NetworkModel: netmodels.SingleEthWithDHCP,
+		},
+	)
+	return evetest.GetEdgeDevice(devName)
+}
 
 // singleMgmtPortConfig builds the device configuration shared by the tests in
 // this package: one DHCP-configured management+apps port. No network instance
-// and no application - these tests are only about what EVE reports about
-// itself.
+// and no application - these tests only need the device to report about itself
+// and to reach the controller, so that logs can be uploaded.
 func singleMgmtPortConfig() *evetest.EdgeDeviceConfig {
 	devConfig := evetest.NewEdgeDeviceConfig(devName)
 	dhcpNet := devConfig.AddNetwork(evetest.DHCPNetworkConfig{
@@ -37,4 +87,106 @@ func singleMgmtPortConfig() *evetest.EdgeDeviceConfig {
 		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
 	})
 	return devConfig
+}
+
+// replaceConfigProperties overwrites the device-wide configuration properties
+// of devConfig, so that the same configuration object can be re-applied with
+// different properties without rebuilding (and thus renumbering) its networks
+// and adapters. SetConfigProperties appends, hence the reset; the framework
+// adds its own defaults for whatever the test leaves unset on every apply.
+func replaceConfigProperties(devConfig *evetest.EdgeDeviceConfig,
+	cfgProps *pillartypes.ConfigItemValueMap) {
+	devConfig.ConfigItems = nil
+	devConfig.SetConfigProperties(cfgProps)
+}
+
+// sha256Hex returns the hex-encoded SHA-256 digest of b.
+func sha256Hex(b []byte) string {
+	return fmt.Sprintf("%x", sha256.Sum256(b))
+}
+
+// installMarkerConfig pushes a freshly rendered marker Vector config (see
+// newMarkerConfig) and returns only once the controller has received an
+// uploaded log event stamped with its sentinel source, i.e. the config has been
+// promoted and is processing uploads. It returns the sentinel and the exact
+// config bytes that were pushed.
+//
+// Note that while a marker config is promoted, the source of *every* uploaded
+// device log event is overwritten with the sentinel - including the entries a
+// later assertion in the same test may want to match by source.
+func installMarkerConfig(t *WithT, device *evetest.EdgeDevice) (
+	markerSource string, markerConfig []byte) {
+	markerSource, markerConfig = newMarkerConfig(t)
+	markedLogs, stopLogWatch := device.WatchLogs(evetest.LogMsgMatch{
+		Source: markerSource,
+	})
+	defer stopLogWatch()
+	device.ApplyConfig(vectorConfigItem(markerConfig), true, true)
+	evetest.Checkpoint("marker-applied")
+
+	evetest.Logger().Infof(
+		"Waiting for the marker Vector config to become active...")
+	t.Eventually(markedLogs, vectorLogUploadTimeout).Should(Receive(),
+		"the marker Vector config was never promoted: no uploaded log event "+
+			"carried its sentinel source")
+	evetest.Checkpoint("marker-active")
+	return markerSource, markerConfig
+}
+
+// clearVectorConfig empties the vector.config item, which makes newlogd restore
+// the Vector config built into the EVE image.
+//
+// Tests do not need to call this to clean up after themselves: the framework's
+// ResetDeviceConfig policy nils ConfigItems, so vector.config is cleared between
+// tests anyway. It is here for the test whose subject is the clearing itself.
+func clearVectorConfig(device *evetest.EdgeDevice) {
+	device.ApplyConfig(vectorConfigItem(nil), true, true)
+}
+
+// newLogProbeMarker returns a marker string unique to a single probe.
+func newLogProbeMarker(probeName string) string {
+	return fmt.Sprintf("%s-%s-%d",
+		logProbeMarkerPrefix, probeName, time.Now().UnixNano())
+}
+
+// emitKernelLogProbe writes the given marker to /dev/kmsg, producing exactly
+// one identifiable device log entry attributed to the kernel log source.
+//
+// /dev/kmsg is an ingestion path EVE documents and relies on itself
+// (ssh-service.sh writes there with the comment "this is picked up by
+// newlogd"), which makes the probe deterministic and independent of the wording
+// of any third-party daemon's messages. Matching on a daemon's own output was
+// tried first and does not work: SSH sessions are established, so sshd
+// definitely handled them, yet no matching entry ever reaches the controller.
+func emitKernelLogProbe(t Gomega, device *evetest.EdgeDevice, marker string) {
+	_, _, err := device.RunShellScript(
+		fmt.Sprintf("echo %q > /dev/kmsg", marker), probeSSHTimeout, 0)
+	t.Expect(err).ToNot(HaveOccurred())
+	evetest.Logger().Infof("Emitted kernel log probe %q on the device", marker)
+}
+
+// expectKernelLogProbe emits a kernel log probe and waits until it shows up at
+// the controller, attributed to the kernel log source. The subscription is
+// established before the marker is emitted, because a log watch only delivers
+// entries that arrive after it was set up.
+//
+// Two preconditions: the caller must have configured
+// debug.kernel.remote.loglevel to "info" or lower, because the kernel path is
+// gated by its own knobs, separate from the debug.default.* ones the framework
+// sets; and no Vector config that rewrites `source` may be promoted at the time
+// (see installMarkerConfig), or the Source assertion below cannot hold.
+func expectKernelLogProbe(t Gomega, device *evetest.EdgeDevice, probeName string) {
+	marker := newLogProbeMarker(probeName)
+	logs, stopLogWatch := device.WatchLogs(evetest.LogMsgMatch{
+		MsgHasSubstring: marker,
+	})
+	defer stopLogWatch()
+	emitKernelLogProbe(t, device, marker)
+
+	var logMsg evetest.LogMsg
+	t.Eventually(logs, logProbeUploadTimeout).Should(Receive(&logMsg),
+		"the kernel log probe was not uploaded to the controller")
+	t.Expect(logMsg.Message).To(ContainSubstring(marker))
+	t.Expect(logMsg.Source).To(Equal("kernel"))
+	t.Expect(logMsg.Severity).ToNot(BeEmpty())
 }

--- a/evetest/tests/telemetry/info_test.go
+++ b/evetest/tests/telemetry/info_test.go
@@ -15,7 +15,6 @@ import (
 	eveinfo "github.com/lf-edge/eve-api/go/info"
 	"github.com/lf-edge/eve/evetest"
 	"github.com/lf-edge/eve/evetest/matchers"
-	"github.com/lf-edge/eve/evetest/netmodels"
 )
 
 // TestDeviceInfo verifies the ZInfoDevice message EVE publishes to the
@@ -74,11 +73,12 @@ import (
 // -----------
 //   - TPM. Drives both whether the device VM gets an emulated TPM and the
 //     expected HSMStatus.
+//   - HYPERVISOR. Not asserted on; declared so that every test in the suite
+//     states the same device requirements and the framework can reuse one VM.
 //
 // Suite placement
 // ---------------
-//   - TestTelemetrySuite. No application is deployed, so the hypervisor is
-//     hardcoded to KVM like the other non-app suites.
+//   - TestTelemetrySuite.
 func TestDeviceInfo(test *testing.T) {
 	evetestT := evetest.Init(test)
 	t := NewGomegaWithT(evetestT)
@@ -86,27 +86,20 @@ func TestDeviceInfo(test *testing.T) {
 
 	// Define configurable parameters available for the test.
 	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
 		evetest.TPMParameter(),
 	)
 
 	// Get parameter values set for this test execution.
+	hypervisor := evetest.GetHypervisorParameterValue()
 	useTPM := evetest.GetTPMParameterValue()
 
-	// Set up the test harness and specify the test prerequisites.
+	// Set up the test harness and specify the test prerequisites. MinCPUs is
+	// deliberately not requested: 4 is already the framework's default, and
+	// stating it here would make this test's device requirements differ from
+	// its siblings', costing a device recreation.
 	const minCPUs = 4
-	evetest.Setup(
-		evetest.RequireEdgeDevice{
-			Name:              devName,
-			MinCPUs:           minCPUs,
-			WithHypervisor:    evetest.HypervisorKVM,
-			WithTPM:           useTPM,
-			DeviceReusePolicy: evetest.ResetDeviceConfig,
-		},
-		evetest.RequireNetworkModel{
-			NetworkModel: netmodels.SingleEthWithDHCP,
-		},
-	)
-	device := evetest.GetEdgeDevice(devName)
+	device := setupTelemetryTestDevice(hypervisor, useTPM)
 	evetest.Checkpoint("setup-done")
 
 	// Build and apply the device configuration.
@@ -115,6 +108,9 @@ func TestDeviceInfo(test *testing.T) {
 	defer stopDevWatch()
 	device.ApplyConfig(devConfig, true, true)
 	evetest.Checkpoint("config-applied")
+	if hypervisor == evetest.HypervisorKubevirt {
+		device.WaitForClusterNodeIsReady(clusterNodeReadyTimeout)
+	}
 
 	// Phase 2: EVE reports the network configuration it applied.
 	timeout := 5 * time.Minute

--- a/evetest/tests/telemetry/logs_test.go
+++ b/evetest/tests/telemetry/logs_test.go
@@ -6,35 +6,23 @@
 package telemetry_test
 
 import (
-	"fmt"
 	"testing"
-	"time"
 
 	// revive:disable:dot-imports
 	. "github.com/onsi/gomega"
 
 	"github.com/lf-edge/eve/evetest"
-	"github.com/lf-edge/eve/evetest/netmodels"
 	pillartypes "github.com/lf-edge/eve/pkg/pillar/types"
 )
-
-// Prefix of the marker written to /dev/kmsg. A per-run nonce is appended so
-// the assertion cannot be satisfied by a log entry from an earlier run.
-const kmsgMarkerPrefix = "evetest-device-log-marker"
 
 // TestDeviceLogs verifies that EVE collects logs and uploads them to the
 // controller: a message emitted on the device in response to an externally
 // triggered event must become visible to the controller, and the log stream
 // of EVE's own microservices must be flowing as well.
 //
-// The trigger is a marker written to /dev/kmsg rather than something logged by
-// a third-party daemon. Driving SSH sessions and matching on sshd's
-// "Disconnected from" was tried first and does not work: the sessions are
-// established (so sshd definitely handled them), but no matching entry ever
-// reaches the controller within 10 minutes. /dev/kmsg is an ingestion path EVE
-// documents and relies on itself -- ssh-service.sh writes there with the
-// comment "this is picked up by newlogd" -- which makes the trigger
-// deterministic and the assertion immune to third-party log wording.
+// The trigger is a kernel log probe (see emitKernelLogProbe) rather than
+// something logged by a third-party daemon, which makes it deterministic and
+// the assertion immune to third-party log wording.
 //
 // Two ingestion paths are covered:
 //   - /dev/kmsg -> getKernelMsg -> newlogd (source "kernel"), driven by the
@@ -61,29 +49,25 @@ const kmsgMarkerPrefix = "evetest-device-log-marker"
 // Phases / assertions
 // -------------------
 //  1. setup-done -> config-applied.
-//  2. Subscribe to device logs matching a per-run marker string *before*
-//     emitting it, then write the marker to /dev/kmsg over SSH.
-//  3. kernel-log-received: the marker reaches the controller. Assert
-//     Source="kernel" (the entry was attributed to the right ingestion
-//     path), Severity is populated, and the timestamp is not in the future --
-//     i.e. a well-formed log record, not merely a matching string.
-//  4. The pillar agents' log stream is flowing too: entries with
+//  2. kernel-log-received: a kernel log probe reaches the controller,
+//     attributed to Source="kernel" and with Severity populated, i.e. a
+//     well-formed log record rather than merely a matching string.
+//  3. The pillar agents' log stream is flowing too: entries with
 //     Source="zedagent" have been uploaded (base/logobjecttypes.go sets the
 //     "source" field to the agent name).
 //
 // Timing note: logs are batched into gzip bundles before upload, so the wait
-// in phase 3 is generous even with fast upload enabled.
+// in phase 2 is generous even with fast upload enabled.
 //
 // Test params
 // -----------
-//   - TPM. Declared only so that every test in the suite states the same
-//     device requirements and the framework can reuse one VM; nothing here
-//     depends on the TPM.
+//   - HYPERVISOR, TPM. Neither is asserted on here; both are declared so that
+//     every test in the suite states the same device requirements and the
+//     framework can reuse one VM.
 //
 // Suite placement
 // ---------------
-//   - TestTelemetrySuite. No application is deployed, so the hypervisor is
-//     hardcoded to KVM like the other non-app suites.
+//   - TestTelemetrySuite.
 func TestDeviceLogs(test *testing.T) {
 	evetestT := evetest.Init(test)
 	t := NewGomegaWithT(evetestT)
@@ -91,25 +75,16 @@ func TestDeviceLogs(test *testing.T) {
 
 	// Define configurable parameters available for the test.
 	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
 		evetest.TPMParameter(),
 	)
 
 	// Get parameter values set for this test execution.
+	hypervisor := evetest.GetHypervisorParameterValue()
 	useTPM := evetest.GetTPMParameterValue()
 
 	// Set up the test harness and specify the test prerequisites.
-	evetest.Setup(
-		evetest.RequireEdgeDevice{
-			Name:              devName,
-			WithHypervisor:    evetest.HypervisorKVM,
-			WithTPM:           useTPM,
-			DeviceReusePolicy: evetest.ResetDeviceConfig,
-		},
-		evetest.RequireNetworkModel{
-			NetworkModel: netmodels.SingleEthWithDHCP,
-		},
-	)
-	device := evetest.GetEdgeDevice(devName)
+	device := setupTelemetryTestDevice(hypervisor, useTPM)
 	evetest.Checkpoint("setup-done")
 
 	// Build and apply the device configuration. The kernel log path has its
@@ -121,36 +96,15 @@ func TestDeviceLogs(test *testing.T) {
 	devConfig.SetConfigProperties(cfgProps)
 	device.ApplyConfig(devConfig, true, true)
 	evetest.Checkpoint("config-applied")
+	if hypervisor == evetest.HypervisorKubevirt {
+		device.WaitForClusterNodeIsReady(clusterNodeReadyTimeout)
+	}
 
-	// Phase 2: subscribe first, then emit the marker.
-	marker := fmt.Sprintf("%s-%d", kmsgMarkerPrefix, time.Now().UnixNano())
-	logs, stopLogWatch := device.WatchLogs(evetest.LogMsgMatch{
-		MsgHasSubstring: marker,
-	})
-	defer stopLogWatch()
-
-	const (
-		sshTimeout = 30 * time.Second
-		logTimeout = 10 * time.Minute
-	)
-	_, _, err := device.RunShellScript(
-		fmt.Sprintf("echo %q > /dev/kmsg", marker), sshTimeout, 0)
-	t.Expect(err).ToNot(HaveOccurred())
-	evetest.Logger().Infof(
-		"Emitted marker %q on the device, waiting for it to reach the controller...",
-		marker)
-
-	// Phase 3: the message reaches the controller.
-	var logMsg evetest.LogMsg
-	t.Eventually(logs, logTimeout).Should(Receive(&logMsg),
-		"device log marker was not uploaded to the controller")
-	t.Expect(logMsg.Message).To(ContainSubstring(marker))
-	t.Expect(logMsg.Source).To(Equal("kernel"))
-	t.Expect(logMsg.Severity).ToNot(BeEmpty())
-	t.Expect(logMsg.Timestamp).To(BeTemporally("<", time.Now()))
+	// Phase 2: a kernel log probe reaches the controller.
+	expectKernelLogProbe(t, device, "device-logs")
 	evetest.Checkpoint("kernel-log-received")
 
-	// Phase 4: EVE's own microservices are logging to the controller as well.
+	// Phase 3: EVE's own microservices are logging to the controller as well.
 	agentLogs := device.GetLogs(evetest.LogMsgMatch{Source: "zedagent"})
 	t.Expect(agentLogs).ToNot(BeEmpty(),
 		"no zedagent log messages were uploaded to the controller")

--- a/evetest/tests/telemetry/metrics_test.go
+++ b/evetest/tests/telemetry/metrics_test.go
@@ -15,7 +15,6 @@ import (
 	evemetrics "github.com/lf-edge/eve-api/go/metrics"
 	"github.com/lf-edge/eve/evetest"
 	"github.com/lf-edge/eve/evetest/matchers"
-	"github.com/lf-edge/eve/evetest/netmodels"
 )
 
 // TestDeviceMetrics verifies the DeviceMetric message EVE publishes to the
@@ -65,14 +64,13 @@ import (
 //
 // Test params
 // -----------
-//   - TPM. Declared only so that every test in the suite states the same
-//     device requirements and the framework can reuse one VM; nothing here
-//     depends on the TPM.
+//   - HYPERVISOR, TPM. Neither is asserted on here; both are declared so that
+//     every test in the suite states the same device requirements and the
+//     framework can reuse one VM.
 //
 // Suite placement
 // ---------------
-//   - TestTelemetrySuite. No application is deployed, so the hypervisor is
-//     hardcoded to KVM like the other non-app suites.
+//   - TestTelemetrySuite.
 func TestDeviceMetrics(test *testing.T) {
 	evetestT := evetest.Init(test)
 	t := NewGomegaWithT(evetestT)
@@ -80,25 +78,16 @@ func TestDeviceMetrics(test *testing.T) {
 
 	// Define configurable parameters available for the test.
 	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
 		evetest.TPMParameter(),
 	)
 
 	// Get parameter values set for this test execution.
+	hypervisor := evetest.GetHypervisorParameterValue()
 	useTPM := evetest.GetTPMParameterValue()
 
 	// Set up the test harness and specify the test prerequisites.
-	evetest.Setup(
-		evetest.RequireEdgeDevice{
-			Name:              devName,
-			WithHypervisor:    evetest.HypervisorKVM,
-			WithTPM:           useTPM,
-			DeviceReusePolicy: evetest.ResetDeviceConfig,
-		},
-		evetest.RequireNetworkModel{
-			NetworkModel: netmodels.SingleEthWithDHCP,
-		},
-	)
-	device := evetest.GetEdgeDevice(devName)
+	device := setupTelemetryTestDevice(hypervisor, useTPM)
 	evetest.Checkpoint("setup-done")
 
 	// Build and apply the device configuration.
@@ -107,6 +96,9 @@ func TestDeviceMetrics(test *testing.T) {
 	defer stopMetricWatch()
 	device.ApplyConfig(devConfig, true, true)
 	evetest.Checkpoint("config-applied")
+	if hypervisor == evetest.HypervisorKubevirt {
+		device.WaitForClusterNodeIsReady(clusterNodeReadyTimeout)
+	}
 
 	// Phase 2: per-port network counters are reported and moving.
 	timeout := 5 * time.Minute

--- a/evetest/tests/telemetry/newlogd_test.go
+++ b/evetest/tests/telemetry/newlogd_test.go
@@ -1,0 +1,334 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test how the configured log levels govern which device logs EVE forwards to
+// the controller.
+
+package telemetry_test
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	eveinfo "github.com/lf-edge/eve-api/go/info"
+	evemetrics "github.com/lf-edge/eve-api/go/metrics"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/matchers"
+	pillartypes "github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+const (
+	// Every source stays verbose locally while nothing is forwarded, so that what
+	// the test observes is attributable to the remote setting alone.
+	mutedLocalLogLevel  = "debug"
+	mutedRemoteLogLevel = "none"
+
+	// The kernel path has its own knobs, separate from the debug.default.* ones
+	// the framework sets. "info" is also EVE's default for them.
+	unmutedKernelLogLevel = "info"
+
+	// The one entry class a remote level of "none" still uploads.
+	panicSeverity = "panic"
+)
+
+// TestRemoteLogLevelNone verifies the controller-observable contract of setting
+// every remote log level to "none": log upload stops, the device stays alive and
+// keeps reporting throughout, and clearing the setting starts upload again.
+//
+// The central claim is negative ("no logs arrive"), which a broken test satisfies
+// as well as a working EVE. Three things keep it honest: a positive control
+// before the mute, liveness during the silence, and a positive control after
+// unmuting.
+//
+// Deliberate gap: nothing here verifies that EVE keeps collecting logs locally
+// while muted. That is not controller-observable by construction, so a
+// regression in which local filtering followed the *remote* level would leave
+// every assertion green. Covering it belongs in a pkg/newlog unit test, not in
+// an E2E test coupled to newlogd's on-disk layout.
+//
+// Network model
+// -------------
+//   - netmodels.SingleEthWithDHCP -- log upload only needs controller
+//     connectivity over a single mgmt port.
+//
+// Device configuration
+// --------------------
+//   - SystemAdapter for eth0 (DHCP, mgmt+apps). The base config object is built
+//     once and only its ConfigItems are replaced: rebuilding it would mint a
+//     fresh network UUID and churn EVE through a new DPC.
+//   - Unmuted: the two kernel knobs at "info". Muted: all three local levels at
+//     "debug", all three remote levels at "none".
+//   - The framework default newlog.allow.fastupload is what makes the negative
+//     assertion's window practical (10s file close, 3s upload poll).
+//
+// Phases / assertions
+// -------------------
+//  1. unmuted-config-applied.
+//  2. logs-arrive-unmuted: a /dev/kmsg probe reaches the controller with
+//     Source="kernel". Positive control.
+//  3. logging-muted.
+//  4. device-rebooted: produces a fresh set of logs (kernel boot messages plus
+//     every agent starting up) under the muted config. This is what exercises
+//     newlogd's on-disk log level cache, which handles logs produced before
+//     zedagent publishes the live config. The phase *depends* on that cache, so
+//     do not clear it mid-test; it also sets the EVE floor -- present from
+//     17.0.0-rc2 (including 17.0.0-lts) and on master, absent from 17.0.0 and
+//     17.0.0-rc1.
+//  5. Anchor at ZInfoDevice.BootTime of the post-reboot message, minus 2s for
+//     its +-1s jitter. LastRebootTime only identifies the message: with no
+//     recorded reboot reason it is stamped during nodeagent startup, well into
+//     the boot, so anchoring on it would exclude the boot logs.
+//  6. A fresh probe, so the negative assertion has an entry that provably
+//     postdates the mute.
+//  7. device-alive-while-muted: a metric message still arrives, which is the
+//     assertion -- the silence cannot be blamed on a dead or disconnected
+//     device. Its failedToSend flag is a weak extra: newlogd refreshes those
+//     values only every 90-300s and nothing in the message dates them, so read
+//     it as "the uploader was not already broken going in". Phases 2 and 9 are
+//     the real bracketing; an upload wedge that begins and heals inside the
+//     muted window stays uncovered.
+//  8. no-logs-while-muted: for two minutes neither a post-anchor entry nor the
+//     probe is present. Polls are 30s apart because each re-reads the device's
+//     entire log history from Adam, and the claim covers the whole period since
+//     the anchor regardless of poll count. A panic-level entry fails this phase
+//     deliberately, with its own message: "none" still uploads those by design,
+//     so it is a finding about the agent.
+//  9. logs-arrive-again: a third probe arrives while the muted one stays absent,
+//     showing suppressed entries never entered the upload queue.
+//
+// Expect three to four minutes after setup; the ~35 minute ceiling is almost all
+// in the two 10-minute probe-upload limits, which normally complete in seconds.
+//
+// Test params
+// -----------
+//   - HYPERVISOR, TPM. Neither is asserted on here; both are declared so that
+//     every test in the suite states the same device requirements and the
+//     framework can reuse one VM.
+//
+// Suite placement
+// ---------------
+//   - TestTelemetrySuite, last: it is the only subtest that reboots, and the
+//     others would otherwise pay for it.
+func TestRemoteLogLevelNone(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	// Define configurable parameters available for the test.
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+		evetest.TPMParameter(),
+	)
+
+	// Get parameter values set for this test execution.
+	hypervisor := evetest.GetHypervisorParameterValue()
+	useTPM := evetest.GetTPMParameterValue()
+
+	// Set up the test harness and specify the test prerequisites.
+	device := setupTelemetryTestDevice(hypervisor, useTPM)
+	evetest.Checkpoint("setup-done")
+
+	// Phase 1: start from a configuration that forwards logs to the controller.
+	devConfig := singleMgmtPortConfig()
+	setUnmutedLogLevels(devConfig)
+	device.ApplyConfig(devConfig, true, true)
+	evetest.Checkpoint("unmuted-config-applied")
+	if hypervisor == evetest.HypervisorKubevirt {
+		device.WaitForClusterNodeIsReady(clusterNodeReadyTimeout)
+	}
+
+	// Phase 2: positive control.
+	expectKernelLogProbe(t, device, "unmuted")
+	evetest.Checkpoint("logs-arrive-unmuted")
+
+	// Phase 3: mute every log source. Unmute on the way out even on failure:
+	// teardown builds the device log artifact by reading the controller, so
+	// leaving the device muted would blank the artifact needed to diagnose the
+	// failure. It cannot affect any assertion - suppressed entries never enter
+	// the upload queue, so unmuting cannot bring them back.
+	muted := false
+	defer func() {
+		if muted {
+			setUnmutedLogLevels(devConfig)
+			device.ApplyConfig(devConfig, false, false)
+		}
+	}()
+	setMutedLogLevels(devConfig)
+	device.ApplyConfig(devConfig, true, true)
+	muted = true
+	evetest.Checkpoint("logging-muted")
+
+	// Phase 4: reboot to generate fresh logs under the muted config.
+	prevRebootTime := device.GetDeviceInfo().GetLastRebootTime().AsTime()
+	devUpdates, stopDevWatch := device.WatchDeviceInfo()
+	defer stopDevWatch()
+	device.SoftReboot(true)
+	evetest.Checkpoint("device-rebooted")
+
+	// Phase 5: anchor at the boot time reported by the post-reboot info message.
+	var rebootAnchor time.Time
+	t.Eventually(devUpdates, 3*time.Minute).Should(Receive(matchers.SatisfyPredicate(
+		"Device reports the reboot triggered by the test",
+		func(info *eveinfo.ZInfoDevice) bool {
+			rebootTime := info.GetLastRebootTime()
+			bootTime := info.GetBootTime()
+			if rebootTime == nil || bootTime == nil ||
+				!rebootTime.AsTime().After(prevRebootTime) {
+				return false
+			}
+			rebootAnchor = bootTime.AsTime().Add(-2 * time.Second)
+			return true
+		})))
+	evetest.Logger().Infof(
+		"Anchoring the assertion at the device-reported boot time %s", rebootAnchor)
+
+	// Phase 6: emit the probe. Subscribe to metrics first, so the message the
+	// liveness assertion waits for is one published while muted.
+	metricUpdates, stopMetricWatch := device.WatchDeviceMetrics()
+	defer stopMetricWatch()
+	probeMarker := newLogProbeMarker("muted")
+	emitKernelLogProbe(t, device, probeMarker)
+
+	// Phase 7: the device is still talking to the controller.
+	var metric *evemetrics.DeviceMetric
+	t.Eventually(metricUpdates, 90*time.Second).Should(Receive(&metric),
+		"the device stopped reporting metrics to the controller while muted")
+	t.Expect(metric.GetNewlog().GetFailedToSend()).To(BeFalse(),
+		"EVE reports its log uploader as failing to send, so an absence of "+
+			"uploaded logs would not be attributable to the remote log levels")
+	evetest.Checkpoint("device-alive-while-muted")
+
+	// Phase 8: Consistently rather than Eventually - the claim is that the
+	// controller stays log-free, not that it becomes so.
+	const (
+		quietWindow   = 2 * time.Minute
+		quietPollIntv = 30 * time.Second
+	)
+	t.Consistently(func(g Gomega) {
+		var afterReboot, probes, panics []evetest.LogMsg
+		for _, logMsg := range device.GetLogs(evetest.LogMsgMatch{}) {
+			if strings.Contains(logMsg.Message, probeMarker) {
+				probes = append(probes, logMsg)
+			}
+			if logMsg.Timestamp.Before(rebootAnchor) {
+				continue
+			}
+			if logMsg.Severity == panicSeverity {
+				panics = append(panics, logMsg)
+				continue
+			}
+			afterReboot = append(afterReboot, logMsg)
+		}
+		g.Expect(len(panics)).To(BeZero(),
+			"an EVE agent panicked during the muted window. A remote log level of "+
+				"%q still uploads panic-level entries by design, so this is a "+
+				"genuine finding about the agent, not a muting failure.\n%s",
+			mutedRemoteLogLevel, summarizeLogMsgs(panics))
+		g.Expect(len(afterReboot)).To(BeZero(),
+			"EVE uploaded device logs generated after the reboot even though every "+
+				"remote log level is set to %q.\n%s",
+			mutedRemoteLogLevel, summarizeLogMsgs(afterReboot))
+		g.Expect(len(probes)).To(BeZero(),
+			"the kernel log probe emitted after the reboot reached the "+
+				"controller.\n%s", summarizeLogMsgs(probes))
+	}, quietWindow, quietPollIntv).Should(Succeed())
+	evetest.Checkpoint("no-logs-while-muted")
+
+	// Phase 9: unmute and confirm recovery. This confirmed apply doubles as the
+	// cleanup: waiting for LastProcessedConfig means newlogd has rewritten its
+	// on-disk log level cache with the unmuted levels.
+	setUnmutedLogLevels(devConfig)
+	device.ApplyConfig(devConfig, true, true)
+	muted = false
+	evetest.Checkpoint("logging-unmuted")
+	expectKernelLogProbe(t, device, "unmuted-again")
+	t.Expect(device.GetLogs(evetest.LogMsgMatch{MsgHasSubstring: probeMarker})).
+		To(BeEmpty(), "the kernel log probe emitted while muted was uploaded "+
+			"once remote logging was re-enabled")
+	evetest.Checkpoint("logs-arrive-again")
+}
+
+// summarizeLogMsgs renders log messages for a failure message: per-source counts,
+// busiest first, then the first few verbatim, so a failure answers "which source
+// leaked?" without dumping thousands of lines.
+func summarizeLogMsgs(logMsgs []evetest.LogMsg) string {
+	if len(logMsgs) == 0 {
+		return "no matching log messages"
+	}
+	perSource := make(map[string]int)
+	for _, logMsg := range logMsgs {
+		perSource[logMsg.Source]++
+	}
+	sources := make([]string, 0, len(perSource))
+	for source := range perSource {
+		sources = append(sources, source)
+	}
+	sort.Slice(sources, func(i, j int) bool {
+		if perSource[sources[i]] != perSource[sources[j]] {
+			return perSource[sources[i]] > perSource[sources[j]]
+		}
+		return sources[i] < sources[j]
+	})
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d log messages; by source:", len(logMsgs))
+	for _, source := range sources {
+		fmt.Fprintf(&sb, " %s=%d", source, perSource[source])
+	}
+	const (
+		maxSamples    = 3
+		maxSampleLen  = 200
+		sampleElision = "..."
+	)
+	for i, logMsg := range logMsgs {
+		if i == maxSamples {
+			break
+		}
+		content := logMsg.Message
+		if len(content) > maxSampleLen {
+			content = content[:maxSampleLen] + sampleElision
+		}
+		fmt.Fprintf(&sb, "\n  %s [%s] %s: %s",
+			logMsg.Timestamp.Format(time.RFC3339), logMsg.Severity, logMsg.Source,
+			content)
+	}
+	return sb.String()
+}
+
+// setUnmutedLogLevels makes devConfig forward logs to the controller. Only the
+// kernel knobs are stated; debug.default.* are left to the framework defaults.
+func setUnmutedLogLevels(devConfig *evetest.EdgeDeviceConfig) {
+	cfgProps := pillartypes.NewConfigItemValueMap()
+	cfgProps.SetGlobalValueString(pillartypes.KernelLogLevel, unmutedKernelLogLevel)
+	cfgProps.SetGlobalValueString(pillartypes.KernelRemoteLogLevel, unmutedKernelLogLevel)
+	replaceConfigProperties(devConfig, cfgProps)
+}
+
+// setMutedLogLevels makes devConfig log every source locally at "debug" while
+// forwarding none of them. All six keys are stated explicitly; restating the
+// framework's own debug.default.loglevel is safe because the framework skips its
+// defaults for keys the test already set, so no key lands in ConfigItems twice.
+func setMutedLogLevels(devConfig *evetest.EdgeDeviceConfig) {
+	cfgProps := pillartypes.NewConfigItemValueMap()
+	for _, key := range []pillartypes.GlobalSettingKey{
+		pillartypes.DefaultLogLevel,
+		pillartypes.SyslogLogLevel,
+		pillartypes.KernelLogLevel,
+	} {
+		cfgProps.SetGlobalValueString(key, mutedLocalLogLevel)
+	}
+	for _, key := range []pillartypes.GlobalSettingKey{
+		pillartypes.DefaultRemoteLogLevel,
+		pillartypes.SyslogRemoteLogLevel,
+		pillartypes.KernelRemoteLogLevel,
+	} {
+		cfgProps.SetGlobalValueString(key, mutedRemoteLogLevel)
+	}
+	replaceConfigProperties(devConfig, cfgProps)
+}

--- a/evetest/tests/telemetry/testdata/faulty.yaml
+++ b/evetest/tests/telemetry/testdata/faulty.yaml
@@ -1,0 +1,56 @@
+# Copyright (c) 2025-2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+sources:
+  dev_keep:
+    type: socket
+    mode: unix_stream
+    path: "${DEV_KEEP_SOURCE_SOCK:-/run/devKeep_source.sock}"
+
+  dev_upload:
+    type: socket
+    mode: unix_stream
+    path: "${DEV_UPLOAD_SOURCE_SOCK:-/run/devUpload_source.sock}"
+
+transforms:
+  parse_json_keep:
+    type: remap
+    inputs:
+      - dev_keep
+    source: |
+      . = parse_json!(.message)
+
+  # parse_json_upload:
+  #   type: remap
+  #   inputs:
+  #     - dev_upload
+  #   source: |
+  #     . = parse_json!(.message)
+
+sinks:
+  keep_sent_queue_socket:
+    type: socket
+    inputs:
+      - parse_json_keep
+    mode: unix_stream
+    path: "${DEV_KEEP_SINK_SOCK:-/run/devKeep_sink.sock}"
+    encoding:
+      codec: json  # write events as JSON objects
+    buffer:
+      type: disk
+      max_size: 268435488  # 256 MB
+      when_full: block
+
+  dev_upload_socket:
+    type: socket
+    inputs:
+      - parse_json_upload
+    mode: unix_stream
+    path: "${DEV_UPLOAD_SINK_SOCK:-/run/devUpload_sink.sock}"
+    encoding:
+      codec: json
+    buffer:
+      type: disk
+      max_size: 268435488  # 256 MB
+      when_full: block

--- a/evetest/tests/telemetry/testdata/marker.yaml
+++ b/evetest/tests/telemetry/testdata/marker.yaml
@@ -1,0 +1,81 @@
+# Copyright (c) 2025-2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+data_dir: "${VECTOR_DATA_DIR:-/var/lib/vector}"  # where Vector stores its data files (mostly buffers)
+
+sources:
+  dev_keep:
+    type: socket
+    mode: unix_stream
+    path: "${DEV_KEEP_SOURCE_SOCK:-/run/devKeep_source.sock}"
+
+  dev_upload:
+    type: socket
+    mode: unix_stream
+    path: "${DEV_UPLOAD_SOURCE_SOCK:-/run/devUpload_source.sock}"
+
+  vector_metrics:
+    type: internal_metrics
+
+transforms:
+  parse_json_keep:
+    type: remap
+    inputs:
+      - dev_keep
+    source: |
+      . = parse_json!(.message)
+
+  parse_json_upload:
+    type: remap
+    inputs:
+      - dev_upload
+    source: |
+      . = parse_json!(.message)
+
+  # this transform overwrites the `source` field of every upload event with a
+  # sentinel value. `source` is one of the few log fields the controller parses
+  # and exposes for matching, so a test can confirm that this config is the one
+  # Vector runs by asking the controller for logs carrying the sentinel.
+  # @MARKER_SOURCE@ is substituted with a run-unique value before the config is
+  # pushed; keep the placeholder in sync with markerSourcePlaceholder.
+  mark_upload:
+    type: remap
+    inputs:
+      - parse_json_upload
+    source: |
+      .source = "@MARKER_SOURCE@"
+
+sinks:
+  keep_sent_queue_socket:
+    type: socket
+    inputs:
+      - parse_json_keep
+    mode: unix_stream
+    path: "${DEV_KEEP_SINK_SOCK:-/run/devKeep_sink.sock}"
+    encoding:
+      codec: json  # write events as JSON objects
+    buffer:
+      type: disk
+      max_size: 268435488  # 256 MB
+      when_full: block
+
+  dev_upload_socket:
+    type: socket
+    inputs:
+      - mark_upload
+    mode: unix_stream
+    path: "${DEV_UPLOAD_SINK_SOCK:-/run/devUpload_sink.sock}"
+    encoding:
+      codec: json
+    buffer:
+      type: disk
+      max_size: 268435488  # 256 MB
+      when_full: block
+
+  prometheus:
+    type: prometheus_exporter
+    inputs:
+      - vector_metrics
+    address: "127.0.0.1:8889"
+    namespace: "vector"

--- a/evetest/tests/telemetry/testsuite_test.go
+++ b/evetest/tests/telemetry/testsuite_test.go
@@ -9,17 +9,30 @@ import (
 	"github.com/lf-edge/eve/evetest"
 )
 
-// TestTelemetrySuite drives the three channels through which EVE reports
-// itself to the controller: info messages, metric messages and logs. None of
-// the subtests deploys an application -- they exercise the EVE control plane
-// only -- and therefore none parameterizes the hypervisor; all hardcode
-// HypervisorKVM, as the other non-application suites do.
+// TestTelemetrySuite drives the channels through which EVE reports itself to the
+// controller - info messages, metric messages and logs - and the configuration
+// of the on-device pipeline that produces the logs. That pipeline is newlogd,
+// which collects events from memlogd and the kernel, routes them through Vector
+// (EVE's log-processing engine, configured with the vector.config global config
+// item) and uploads them to the controller in gzip batches.
 //
-// Every subtest declares the TPM parameter and passes it to
-// RequireEdgeDevice, so all three state identical device requirements and the
-// framework reuses a single VM across the suite. Only TestDeviceInfo actually
-// asserts on the TPM (via HSMStatus); for the other two the parameter merely
-// selects which device flavor the suite runs on.
+// Every subtest declares the HYPERVISOR and TPM parameters and passes both to
+// setupTelemetryTestDevice, which states the device requirements in one place.
+// That is what lets the framework reuse a single VM across the suite: it
+// compares the requirements field by field, so any divergence silently costs a
+// full device recreation. Only TestDeviceInfo asserts on the TPM (via
+// HSMStatus); for the others both parameters merely select the device flavor.
+// None of the subtests deploys an application, but the hypervisor is a parameter
+// regardless, so that the suite can be run against eve-k - where the log
+// pipeline and the reporting paths are worth covering even though nothing here
+// is hypervisor-specific. It has so far only been run under KVM.
+//
+// The subtests are grouped by subject - what EVE reports, then how the log
+// pipeline is configured - and TestRemoteLogLevelNone goes last because it is
+// the only one that reboots, which the others would otherwise pay for. Nothing
+// beyond that is load-bearing: the framework resets the device configuration
+// between subtests, and each subtest establishes the state it needs before it
+// asserts anything, so the order can be changed freely.
 //
 // Subtests
 // --------
@@ -27,13 +40,25 @@ import (
 //     a plausible hardware inventory and the HSM state.
 //   - TestDeviceMetrics -- DeviceMetric reports moving per-port network
 //     counters plus memory, CPU and controller-connectivity counters.
-//   - TestDeviceLogs -- logs produced by EVE services reach the controller.
+//   - TestDeviceLogs -- logs produced by EVE services and by the kernel reach
+//     the controller.
+//   - TestWorkingConfig -- a valid custom Vector config is promoted and
+//     actively transforms the upload stream.
+//   - TestFaultyConfig -- a Vector config that fails validation is never
+//     promoted and the running pipeline keeps uploading.
+//   - TestEmptyConfig -- clearing vector.config restores the Vector config
+//     built into the image.
+//   - TestInvalidBase64Config -- a vector.config value that is not base64 is
+//     rejected by pillar and never reaches Vector.
+//   - TestRemoteLogLevelNone -- remote log levels set to "none" stop log upload
+//     without stopping the device or its local log collection.
 func TestTelemetrySuite(test *testing.T) {
 	evetest.Init(test)
 	defer evetest.Close()
 
 	// Define parameters for the entire test suite.
 	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
 		evetest.TPMParameter(),
 	)
 
@@ -46,6 +71,21 @@ func TestTelemetrySuite(test *testing.T) {
 		},
 		evetest.TestCase{
 			Test: TestDeviceLogs,
+		},
+		evetest.TestCase{
+			Test: TestWorkingConfig,
+		},
+		evetest.TestCase{
+			Test: TestFaultyConfig,
+		},
+		evetest.TestCase{
+			Test: TestEmptyConfig,
+		},
+		evetest.TestCase{
+			Test: TestInvalidBase64Config,
+		},
+		evetest.TestCase{
+			Test: TestRemoteLogLevelNone,
 		},
 	)
 }

--- a/evetest/tests/telemetry/vector_test.go
+++ b/evetest/tests/telemetry/vector_test.go
@@ -1,0 +1,715 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test the life cycle of the vector.config global config item, i.e. how EVE
+// accepts, promotes, rejects and reverts the configuration of Vector, its
+// on-device log-processing pipeline.
+
+package telemetry_test
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	eveinfo "github.com/lf-edge/eve-api/go/info"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/matchers"
+	pillartypes "github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// The Vector configs are embedded instead of being read at run time: a test may
+// be started from any directory, which makes relative paths unreliable.
+
+//go:embed testdata/faulty.yaml
+var faultyConfig []byte
+
+//go:embed testdata/marker.yaml
+var markerConfigTemplate []byte
+
+const (
+	// Placeholder in testdata/marker.yaml, substituted with a run-unique
+	// sentinel by newMarkerConfig.
+	markerSourcePlaceholder = "@MARKER_SOURCE@"
+
+	// Prefix of the run-unique sentinel that the rendered marker config writes
+	// into the `source` field of every uploaded log event.
+	markerSourcePrefix = "evetest-vector-marker"
+
+	// Source of log events that EVE uploads while running a Vector config which
+	// does not rewrite `source`. zedagent logs continuously at the framework's
+	// (debug) remote log level and base/logobjecttypes.go sets `source` to the
+	// agent name, so such events are always available.
+	vectorUnmarkedLogSource = "zedagent"
+
+	// Substring of the message that pkg/vector's entrypoint logs when
+	// `vector validate` rejects a config candidate. The Vector container's
+	// output is ingested by newlogd like any other EVE service log, which makes
+	// Vector's own verdict observable from the controller. Only the ASCII part
+	// of the message is matched; it is surrounded by an emoji and an em dash.
+	vectorRejectionLogMsg = "Candidate invalid"
+
+	// A vector.config value that is not valid base64 at all, so it is rejected
+	// by pillar's own validator before newlogd ever sees it.
+	invalidVectorConfigValue = "not!base64!"
+)
+
+const (
+	// liveVectorConfigPath is the config Vector actually runs. newlogd writes a
+	// candidate next to it (vector.yaml.new) and pkg/vector's entrypoint
+	// promotes the candidate to this path only after `vector validate` passes.
+	liveVectorConfigPath = "/persist/vector/config/vector.yaml"
+
+	// candidateVectorConfigPath is where newlogd writes a config it received
+	// from the controller. pkg/vector's entrypoint consumes it either way: it is
+	// renamed over the live config when it validates, and deleted when it does
+	// not, so an absent candidate means it has been dealt with.
+	candidateVectorConfigPath = "/persist/vector/config/vector.yaml.new"
+
+	// defaultVectorConfigPath holds a copy of the Vector config built into the
+	// EVE image, which newlogd restores whenever vector.config is empty.
+	defaultVectorConfigPath = "/persist/vector/config/vector.yaml.default"
+)
+
+const (
+	// Log events are batched into gzip bundles before upload, so waiting for a
+	// particular event to reach the controller takes a while even with the fast
+	// upload that the framework enables by default.
+	vectorLogUploadTimeout = 10 * time.Minute
+
+	// Promotion of a config candidate takes seconds (an inotify event, a
+	// `vector validate` run and a rename), but it is gated on newlogd having
+	// received the new global config first.
+	vectorPromotionTimeout   = 5 * time.Minute
+	vectorConfigPollInterval = 10 * time.Second
+
+	// Polling interval for assertions that re-read the whole uploaded log
+	// history on every attempt.
+	vectorLogPollInterval = 15 * time.Second
+
+	// How long the live Vector config must stay unchanged for a candidate to be
+	// considered rejected rather than merely not promoted yet.
+	vectorRejectionWindow = time.Minute
+
+	// Device info carries the config item status; the framework configures EVE
+	// to publish device info every 30 seconds.
+	vectorDevInfoTimeout = 5 * time.Minute
+)
+
+// newMarkerConfig renders testdata/marker.yaml with a sentinel `source` value
+// unique to this test run and returns both the sentinel and the rendered config.
+//
+// The marker config is a copy of EVE's Vector config with one added remap
+// transform that overwrites the `source` field of every uploaded event.
+// `source` is exposed by the controller for matching, which turns "is this
+// config the one Vector runs?" into a question answerable from the controller
+// alone, without inspecting the device. Being a standalone copy, it may drift
+// from the config shipped in the image; all it has to remain is a config that
+// `vector validate` accepts and that keeps both socket sinks wired up.
+//
+// The sentinel must be unique per run: with a fixed one, an uploaded event
+// carrying it would also be produced by a marker config that an earlier test in
+// the suite installed, or flushed late from Vector's disk buffer (which lives on
+// /persist and survives a config reset), so it would no longer be evidence that
+// *this* test's config push took effect.
+func newMarkerConfig(t *WithT) (markerSource string, config []byte) {
+	t.Expect(string(markerConfigTemplate)).To(ContainSubstring(markerSourcePlaceholder),
+		"testdata/marker.yaml must contain the %s placeholder", markerSourcePlaceholder)
+	markerSource = fmt.Sprintf("%s-%d", markerSourcePrefix, time.Now().UnixNano())
+	config = bytes.ReplaceAll(markerConfigTemplate,
+		[]byte(markerSourcePlaceholder), []byte(markerSource))
+	return markerSource, config
+}
+
+// vectorConfigBase64 encodes a Vector config the way the vector.config item
+// requires. It is the single encoding site, so a test that compares the value
+// EVE reports back cannot drift from what vectorConfigItem sent.
+func vectorConfigBase64(vectorConfig []byte) string {
+	return base64.StdEncoding.EncodeToString(vectorConfig)
+}
+
+// vectorConfigItemRaw layers the vector.config global config item, carrying
+// value verbatim, on top of the device configuration shared by this package.
+// Only the test that pushes a value pillar has to reject needs this; anything
+// that pushes an actual Vector config goes through vectorConfigItem.
+//
+// vector.enabled is set explicitly even though it already defaults to true:
+// every assertion in this file depends on newlogd routing log events through
+// Vector, so the test states that dependency instead of inheriting it. Never
+// set it to false here: newlogd creates the Vector socket writers only if the
+// flag was true when it started, but re-reads it for every log entry, so
+// flipping it back to true at run time makes newlogd panic.
+func vectorConfigItemRaw(value string) *evetest.EdgeDeviceConfig {
+	devConfig := singleMgmtPortConfig()
+	cfgProps := pillartypes.NewConfigItemValueMap()
+	cfgProps.SetGlobalValueBool(pillartypes.VectorEnabled, true)
+	cfgProps.SetGlobalValueString(pillartypes.VectorConfig, value)
+	devConfig.SetConfigProperties(cfgProps)
+	return devConfig
+}
+
+// vectorConfigItem layers the vector.config global config item, carrying the
+// given Vector config, on top of the device configuration shared by this
+// package. An empty config clears the item.
+func vectorConfigItem(vectorConfig []byte) *evetest.EdgeDeviceConfig {
+	return vectorConfigItemRaw(vectorConfigBase64(vectorConfig))
+}
+
+// liveVectorConfigHash returns the SHA-256 digest of the Vector config that is
+// currently promoted on the device.
+func liveVectorConfigHash(device *evetest.EdgeDevice) (string, error) {
+	content, err := device.ReadFile(liveVectorConfigPath)
+	if err != nil {
+		return "", err
+	}
+	return sha256Hex(content), nil
+}
+
+// defaultVectorConfigHash returns the digest of the Vector config built into the
+// EVE image. pkg/vector's entrypoint copies it onto /persist at every container
+// start and is its only writer, so it is an independent reference rather than a
+// restatement of whatever is currently promoted.
+func defaultVectorConfigHash(t *WithT, device *evetest.EdgeDevice) string {
+	defaultConfig, err := device.ReadFile(defaultVectorConfigPath)
+	t.Expect(err).ToNot(HaveOccurred(),
+		"failed to read the image's default Vector config from the device")
+	return sha256Hex(defaultConfig)
+}
+
+// expectLiveVectorConfigHash waits until the promoted Vector config hashes to
+// wantHash, reporting description if it never does. A read failure gets its own
+// message so that a transfer problem is not mistaken for the wrong config.
+func expectLiveVectorConfigHash(t *WithT, device *evetest.EdgeDevice,
+	wantHash, description string) {
+	t.Eventually(func(g Gomega) {
+		hash, err := liveVectorConfigHash(device)
+		g.Expect(err).ToNot(HaveOccurred(),
+			"failed to read the promoted Vector config from the device")
+		g.Expect(hash).To(Equal(wantHash))
+	}, vectorPromotionTimeout, vectorConfigPollInterval).Should(Succeed(), description)
+}
+
+// consistentlyLiveVectorConfig requires the promoted Vector config to keep
+// hashing to wantHash for the whole rejection window, reporting description if
+// it does not.
+//
+// Every sample shells out to scp, so a failed read is logged and retried on the
+// next poll rather than failing the check - a transient transfer error must
+// never be reported as the config having changed. Enough reads still have to
+// succeed to span the window: the first poll fires immediately, so a run whose
+// only successful read is that first one would report "unchanged for a whole
+// minute" on the strength of a single sample taken before a promotion could
+// plausibly have happened.
+func consistentlyLiveVectorConfig(t *WithT, device *evetest.EdgeDevice,
+	wantHash, description string) {
+	// The window fits about six polls; requiring half of them leaves room for
+	// transfer hiccups without letting the check shrink to a point.
+	const minReads = 3
+	log := evetest.Logger()
+	var reads int
+	t.Consistently(func(g Gomega) {
+		hash, err := liveVectorConfigHash(device)
+		if err != nil {
+			log.Warnf("Failed to read %s, retrying: %v", liveVectorConfigPath, err)
+			return
+		}
+		reads++
+		g.Expect(hash).To(Equal(wantHash), description)
+	}, vectorRejectionWindow, vectorConfigPollInterval).Should(Succeed())
+	t.Expect(reads).To(BeNumerically(">=", minReads),
+		"the promoted Vector config could be read only %d time(s) during the "+
+			"%v window, too few for it to have been checked over that period",
+		reads, vectorRejectionWindow)
+}
+
+// TestWorkingConfig verifies that a valid custom Vector config delivered through
+// vector.config is promoted and actively processes the device log upload stream.
+//
+// The assertion is purely controller-side: the pushed config stamps every
+// uploaded log event with a run-unique sentinel `source` (see newMarkerConfig),
+// so a single uploaded event carrying that sentinel proves the config was
+// accepted by pillar, validated and promoted by the Vector container, and is
+// transforming events right now. That is strictly more than the on-device config
+// file could show, which is why this test does not look at the device at all.
+//
+// There is deliberately no separate "Vector is running" check, because the
+// assertion above subsumes it: with vector.enabled true newlogd has no bypass -
+// it writes upload-path entries only to the Vector socket and drops them if that
+// write fails - so any uploaded event proves Vector is running and forwarding,
+// and one carrying the sentinel proves it is doing so through this config. A
+// controller-side health check would not be available anyway: ZInfoDevice.tasks
+// exists in eve-api but pillar never populates it, and domainmgr's per-process
+// metrics do reach the controller inside ZMetricMsg.Pr carrying process names,
+// but the framework exposes no accessor for them - EdgeDevice surfaces only the
+// device, app, network-instance, volume and cluster metrics.
+//
+// Network model
+// -------------
+//   - netmodels.SingleEthWithDHCP -- log upload only needs working controller
+//     connectivity over a single mgmt port.
+//
+// Device configuration
+// --------------------
+//   - SystemAdapter for eth0 (DHCP, mgmt+apps), logical label "ethernet0".
+//   - vector.config set to the base64-encoded marker config.
+//   - vector.enabled set to true (also its default).
+//
+// Phases / assertions
+// -------------------
+//  1. setup-done -> config-applied: subscribe to log events carrying the
+//     sentinel source *before* pushing the config (a watch only delivers what
+//     arrives after it was created), then push the marker config.
+//  2. marker-observed: such an event reaches the controller. It is additionally
+//     asserted to be a well-formed log record (non-empty content and severity),
+//     so that a match cannot be an artifact of string filtering alone.
+//
+// No time-based guard is needed on the match: the sentinel is unique to this
+// test run, so nothing but the config pushed here can produce it.
+//
+// Test params
+// -----------
+//   - HYPERVISOR, TPM. Neither is asserted on here; both are declared so that
+//     every test in the suite states the same device requirements and the
+//     framework can reuse one VM.
+//
+// Suite placement
+// ---------------
+//   - TestTelemetrySuite.
+func TestWorkingConfig(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	// Define configurable parameters available for the test.
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+		evetest.TPMParameter(),
+	)
+
+	// Get parameter values set for this test execution.
+	hypervisor := evetest.GetHypervisorParameterValue()
+	useTPM := evetest.GetTPMParameterValue()
+
+	// Set up the test harness and specify the test prerequisites.
+	device := setupTelemetryTestDevice(hypervisor, useTPM)
+	log := evetest.Logger()
+	evetest.Checkpoint("setup-done")
+
+	// Build and apply the device configuration.
+	markerSource, markerConfig := newMarkerConfig(t)
+	markedLogs, stopLogWatch := device.WatchLogs(evetest.LogMsgMatch{
+		Source: markerSource,
+	})
+	defer stopLogWatch()
+	device.ApplyConfig(vectorConfigItem(markerConfig), true, true)
+	evetest.Checkpoint("config-applied")
+	if hypervisor == evetest.HypervisorKubevirt {
+		device.WaitForClusterNodeIsReady(clusterNodeReadyTimeout)
+	}
+
+	// Phase 2: the promoted config stamps uploaded events with the sentinel.
+	log.Infof("Waiting for an uploaded log event with source %q...", markerSource)
+	var logMsg evetest.LogMsg
+	t.Eventually(markedLogs, vectorLogUploadTimeout).Should(Receive(&logMsg),
+		"no uploaded log event carried the sentinel source: the custom Vector "+
+			"config was either not promoted or is not processing uploads")
+	t.Expect(logMsg.Source).To(Equal(markerSource))
+	t.Expect(logMsg.Message).ToNot(BeEmpty())
+	t.Expect(logMsg.Severity).ToNot(BeEmpty())
+	evetest.Checkpoint("marker-observed")
+}
+
+// TestFaultyConfig verifies that a Vector config which fails `vector validate`
+// is never promoted, and that the previously promoted config keeps running.
+//
+// testdata/faulty.yaml is valid base64 and parses as YAML, so pillar stores it,
+// but its dev_upload_socket sink lists a transform that the file leaves
+// commented out. pkg/vector's entrypoint therefore fails to validate the
+// candidate and deletes it instead of renaming it over the live config.
+//
+// Two independent signals are needed, because neither alone is conclusive:
+//   - Vector's own verdict. The Vector container's output is ingested by newlogd
+//     as device logs, so the message the entrypoint prints when it discards an
+//     invalid candidate reaches the controller like any other log event. This is
+//     the direct evidence that the validation gate ran and rejected this config,
+//     and without it the test would also pass if the candidate had never been
+//     written at all - the live config would be equally unchanged. It does rest
+//     on the wording of a shell echo, which is why it is not the only signal.
+//   - The content of the promoted config. "Marker-stamped events still arrive"
+//     would hold even if the faulty config *had* been promoted: Vector refuses
+//     to hot-reload a config it cannot validate and keeps serving the previous
+//     one, the entrypoint does not restart it on a config change, and a Vector
+//     that died would still flush its disk-backed sink buffer for a while. EVE
+//     reports the promoted config to the controller in no form at all, hence the
+//     file read, done through the framework's SCP-based ReadFile rather than raw
+//     SSH, against the path that pkg/vector defines as the live config.
+//
+// Network model
+// -------------
+//   - netmodels.SingleEthWithDHCP -- log upload only needs working controller
+//     connectivity over a single mgmt port.
+//
+// Device configuration
+// --------------------
+//   - SystemAdapter for eth0 (DHCP, mgmt+apps), logical label "ethernet0".
+//   - vector.config set first to the marker config, then to the faulty config.
+//   - vector.enabled set to true (also its default).
+//
+// Phases / assertions
+// -------------------
+//  1. marker-applied -> marker-active: push the marker config and wait for an
+//     uploaded event carrying its run-unique sentinel source. Promoting a valid
+//     custom config first is what stops "the live config did not change" in
+//     phase 4 from being satisfied by a promotion path that never works.
+//  2. faulty-applied: push the faulty config and wait until device info reports
+//     vector.config holding exactly the faulty value. That the value survives
+//     the round trip byte for byte is all this proves - it catches truncation in
+//     transit, and nothing more. It is deliberately not asserted that the item
+//     carries no error, which pillar's own validator cannot produce for a value
+//     that is valid base64 by construction; newlogd's failures never reach the
+//     item status either, so Vector's verdict has to be looked for in the logs.
+//  3. faulty-rejected: Vector reports the candidate as invalid, queried from the
+//     uploaded log history rather than a log watch, because this single entry
+//     would be lost for good if the watch's stream reconnected. The filter pairs
+//     the message with the sentinel source: on its way to the controller the
+//     entry passes through the marker pipeline, which rewrites its source, so
+//     matching both scopes it to this run and shows the marker pipeline was
+//     still stamping at the moment of the rejection. The candidate file is then
+//     required to be gone. That covers the cleanup only - the valid path renames
+//     the candidate away and leaves it equally absent - so it corroborates
+//     nothing about the rejection itself; the wording-independent evidence for
+//     that is phase 4.
+//  4. live-config-unchanged: the promoted config keeps hashing to the marker
+//     config for the whole rejection window, which by then starts well after the
+//     verdict of phase 3.
+//  5. pipeline-alive: an event that arrives *after* the rejection has been
+//     confirmed still carries the sentinel source. The watch is created here
+//     rather than earlier for two reasons. While the marker config is promoted
+//     its filter matches the device's entire log stream, so an earlier
+//     subscription would fill its buffer and stall the reading of its own HTTP
+//     body for the minutes that phases 3 and 4 take. And a watch created here
+//     starts out empty, so the wait cannot be satisfied out of events buffered
+//     before the rejection was confirmed - which also removes the need for a
+//     timestamp guard, and with it a comparison between the host and device
+//     clocks. This phase subsumes the "Vector is still running" check: newlogd
+//     drops upload-path entries when the write to the Vector socket fails, so an
+//     uploaded event proves Vector is forwarding.
+//
+// Test params
+// -----------
+//   - HYPERVISOR, TPM. Neither is asserted on here; both are declared so that
+//     every test in the suite states the same device requirements and the
+//     framework can reuse one VM.
+//
+// Suite placement
+// ---------------
+//   - TestTelemetrySuite.
+func TestFaultyConfig(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	// Define configurable parameters available for the test.
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+		evetest.TPMParameter(),
+	)
+
+	// Get parameter values set for this test execution.
+	hypervisor := evetest.GetHypervisorParameterValue()
+	useTPM := evetest.GetTPMParameterValue()
+
+	// Set up the test harness and specify the test prerequisites.
+	device := setupTelemetryTestDevice(hypervisor, useTPM)
+	log := evetest.Logger()
+	evetest.Checkpoint("setup-done")
+
+	// Phase 1: establish a promoted custom config as the baseline.
+	markerSource, markerConfig := installMarkerConfig(t, device)
+	markerHash := sha256Hex(markerConfig)
+	if hypervisor == evetest.HypervisorKubevirt {
+		device.WaitForClusterNodeIsReady(clusterNodeReadyTimeout)
+	}
+
+	// Phase 2: push the faulty config.
+	devUpdates, stopDevWatch := device.WatchDeviceInfo()
+	defer stopDevWatch()
+	device.ApplyConfig(vectorConfigItem(faultyConfig), true, true)
+	evetest.Checkpoint("faulty-applied")
+
+	faultyBase64 := vectorConfigBase64(faultyConfig)
+	t.Eventually(devUpdates, vectorDevInfoTimeout).Should(Receive(matchers.SatisfyPredicate(
+		"EVE reports the faulty vector.config item back verbatim",
+		func(devInfo *eveinfo.ZInfoDevice) bool {
+			items := devInfo.GetConfigItemStatus().GetConfigItems()
+			return items[string(pillartypes.VectorConfig)].GetValue() == faultyBase64
+		})))
+
+	// Phase 3: Vector itself rejects the candidate. Queried from the log history
+	// rather than watched: each query re-reads everything, so a stream gap cannot
+	// lose the one entry that carries the verdict.
+	log.Infof("Waiting for Vector to report the candidate as invalid...")
+	t.Eventually(func() []evetest.LogMsg {
+		return device.GetLogs(evetest.LogMsgMatch{
+			MsgHasSubstring: vectorRejectionLogMsg,
+			Source:          markerSource,
+		})
+	}, vectorLogUploadTimeout, vectorLogPollInterval).ShouldNot(BeEmpty(),
+		"Vector never reported the faulty candidate as invalid, so the "+
+			"validation gate was not exercised")
+
+	// A rejected candidate is also cleaned up. Absence alone does not imply
+	// rejection - promotion removes the candidate too, by renaming it.
+	t.Eventually(func() bool {
+		return device.FileExists(candidateVectorConfigPath)
+	}, vectorPromotionTimeout, vectorConfigPollInterval).Should(BeFalse(),
+		"the rejected Vector config candidate was left behind on the device")
+	evetest.Checkpoint("faulty-rejected")
+
+	// Phase 4: and the rejected candidate never becomes the live config.
+	log.Infof("Verifying that the promoted Vector config is left alone...")
+	consistentlyLiveVectorConfig(t, device, markerHash,
+		"the promoted Vector config changed: the faulty candidate was applied")
+	evetest.Checkpoint("live-config-unchanged")
+
+	// Phase 5: the marker pipeline still processes uploads. Subscribing only now
+	// keeps the assertion about the present: with the marker config promoted this
+	// filter matches every uploaded event, so an earlier subscription would both
+	// stall its own stream and let an event buffered before the rejection satisfy
+	// the wait.
+	postPushLogs, stopPostPushWatch := device.WatchLogs(evetest.LogMsgMatch{
+		Source: markerSource,
+	})
+	defer stopPostPushWatch()
+	log.Infof("Verifying that the marker pipeline survived the faulty push...")
+	t.Eventually(postPushLogs, vectorLogUploadTimeout).Should(Receive(),
+		"no log event arrived with the sentinel source after the rejection: "+
+			"the marker pipeline stopped processing uploads")
+	evetest.Checkpoint("pipeline-alive")
+}
+
+// TestEmptyConfig verifies that clearing vector.config makes EVE restore the
+// Vector config built into the image.
+//
+// The revert is observed twice, from both sides:
+//   - Controller-side: uploaded events ingested after the clear carry their
+//     original `source` again instead of the sentinel. This is a positive
+//     assertion about identifiable events, not an argument from the absence of
+//     sentinel events, which would be unsound - a dead pipeline uploads nothing
+//     either, and Vector's disk-backed sink buffer keeps flushing already
+//     stamped events for a while after a config change.
+//   - On-device: the promoted config file becomes byte-identical to the
+//     image's default config. This is what pins the outcome to *the default*
+//     config rather than to any config that merely does not stamp events, and
+//     EVE exposes no representation of the promoted Vector config to the
+//     controller. The file is read through the framework's SCP-based ReadFile,
+//     at the paths that pkg/vector's entrypoint defines. The reference copy is
+//     not circular: the entrypoint rewrites it from the image on every start
+//     and is its only writer.
+//
+// Because the framework clears all config items at setup, the device runs the
+// default config by the time the test starts; the marker config is installed
+// first so that the revert is an observable change.
+//
+// Network model
+// -------------
+//   - netmodels.SingleEthWithDHCP -- log upload only needs working controller
+//     connectivity over a single mgmt port.
+//
+// Device configuration
+// --------------------
+//   - SystemAdapter for eth0 (DHCP, mgmt+apps), logical label "ethernet0".
+//   - vector.config set to the marker config, then cleared.
+//   - vector.enabled set to true (also its default).
+//
+// Phases / assertions
+// -------------------
+//  1. marker-applied -> marker-active: push the marker config and wait for an
+//     uploaded event carrying its run-unique sentinel source. The marker config
+//     and the image default must also differ, otherwise the revert would not be
+//     observable.
+//  2. empty-applied -> default-restored: clear vector.config and wait until the
+//     promoted config file hashes to the image default.
+//  3. real-source-restored: an event ingested after the clear reaches the
+//     controller with source "zedagent", i.e. the running pipeline no longer
+//     contains the marker transform and log uploads still work. The latter also
+//     subsumes the "Vector is still running" check: newlogd drops upload-path
+//     entries when the write to the Vector socket fails, so an uploaded event
+//     proves Vector is forwarding.
+//
+// Test params
+// -----------
+//   - HYPERVISOR, TPM. Neither is asserted on here; both are declared so that
+//     every test in the suite states the same device requirements and the
+//     framework can reuse one VM.
+//
+// Suite placement
+// ---------------
+//   - TestTelemetrySuite.
+func TestEmptyConfig(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	// Define configurable parameters available for the test.
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+		evetest.TPMParameter(),
+	)
+
+	// Get parameter values set for this test execution.
+	hypervisor := evetest.GetHypervisorParameterValue()
+	useTPM := evetest.GetTPMParameterValue()
+
+	// Set up the test harness and specify the test prerequisites.
+	device := setupTelemetryTestDevice(hypervisor, useTPM)
+	log := evetest.Logger()
+	evetest.Checkpoint("setup-done")
+
+	// Phase 1: install the marker config and confirm it is running. The default
+	// config is captured beforehand, while it is still the promoted one.
+	defaultHash := defaultVectorConfigHash(t, device)
+	_, markerConfig := installMarkerConfig(t, device)
+	t.Expect(sha256Hex(markerConfig)).ToNot(Equal(defaultHash),
+		"the marker and the default Vector config must differ for the revert "+
+			"to be observable")
+	if hypervisor == evetest.HypervisorKubevirt {
+		device.WaitForClusterNodeIsReady(clusterNodeReadyTimeout)
+	}
+
+	// Phase 2: clear vector.config. EVE keeps logging continuously, so the
+	// watch for unmarked events can be created after the push - unlike a
+	// one-shot trigger, the signal does not run out.
+	clearVectorConfig(device)
+	unmarkedLogs, stopLogWatch := device.WatchLogs(evetest.LogMsgMatch{
+		Source:    vectorUnmarkedLogSource,
+		NotBefore: time.Now(),
+	})
+	defer stopLogWatch()
+	evetest.Checkpoint("empty-applied")
+
+	log.Infof("Waiting for the live Vector config to revert to the default...")
+	expectLiveVectorConfigHash(t, device, defaultHash,
+		"the promoted Vector config did not revert to the image default")
+	evetest.Checkpoint("default-restored")
+
+	// Phase 3: uploaded events carry their original source again.
+	log.Infof("Waiting for an uploaded log event with source %q...",
+		vectorUnmarkedLogSource)
+	t.Eventually(unmarkedLogs, vectorLogUploadTimeout).Should(Receive(),
+		"no log event ingested after the clear carried its original source: "+
+			"the marker transform is still in the pipeline, or uploads stopped")
+	evetest.Checkpoint("real-source-restored")
+}
+
+// TestInvalidBase64Config verifies that a vector.config value which is not
+// base64 at all is rejected by pillar and never reaches Vector.
+//
+// This is the first of the two gates a Vector config passes: pillar validates
+// the item with base64Validator when it parses the config, long before newlogd
+// writes a candidate and Vector validates the YAML. The tests that push real
+// Vector configs never exercise it, because they encode their payload correctly
+// by construction.
+//
+// Both halves are asserted, because a gate that drops the value silently and one
+// that lets it through are both regressions and only the pair distinguishes
+// them: EVE must report the item as unparsable, and the config Vector runs must
+// not change. The second half needs the device to actually be running the image
+// default when the invalid value is pushed, which the framework's config reset
+// makes likely but does not guarantee - it waits for the device to fetch the
+// cleared vector.config, not for Vector to have reloaded - so that is a
+// precondition the test establishes rather than assumes.
+//
+// Network model
+// -------------
+//   - netmodels.SingleEthWithDHCP -- nothing here needs more than controller
+//     connectivity over a single mgmt port.
+//
+// Device configuration
+// --------------------
+//   - SystemAdapter for eth0 (DHCP, mgmt+apps), logical label "ethernet0".
+//   - vector.config set to a string that is not valid base64.
+//   - vector.enabled set to true (also its default).
+//
+// Phases / assertions
+// -------------------
+//  1. default-config-running: wait until the promoted config hashes to the
+//     image's default, so that a later change is attributable to this test.
+//  2. invalid-config-applied -> invalid-config-rejected: push the invalid value
+//     and wait until device info reports vector.config with a non-empty error.
+//     The reported value is asserted *not* to be the pushed string: on a
+//     validator failure pillar substitutes the previously live value, or the
+//     item's default when there is none, and reports that instead.
+//  3. live-config-unchanged: the promoted config keeps hashing to the image
+//     default for the whole rejection window, i.e. the unparsable value never
+//     made it as far as a config candidate.
+//
+// Test params
+// -----------
+//   - HYPERVISOR, TPM. Neither is asserted on here; both are declared so that
+//     every test in the suite states the same device requirements and the
+//     framework can reuse one VM.
+//
+// Suite placement
+// ---------------
+//   - TestTelemetrySuite.
+func TestInvalidBase64Config(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	// Define configurable parameters available for the test.
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+		evetest.TPMParameter(),
+	)
+
+	// Get parameter values set for this test execution.
+	hypervisor := evetest.GetHypervisorParameterValue()
+	useTPM := evetest.GetTPMParameterValue()
+
+	// Set up the test harness and specify the test prerequisites.
+	device := setupTelemetryTestDevice(hypervisor, useTPM)
+	log := evetest.Logger()
+	evetest.Checkpoint("setup-done")
+
+	// Phase 1: establish the precondition.
+	defaultHash := defaultVectorConfigHash(t, device)
+	log.Infof("Waiting for the live Vector config to be the image default...")
+	expectLiveVectorConfigHash(t, device, defaultHash,
+		"the device does not run the image's default Vector config, so a later "+
+			"change could not be attributed to the invalid value pushed here")
+	evetest.Checkpoint("default-config-running")
+
+	// Phase 2: push a value that is not base64.
+	devUpdates, stopDevWatch := device.WatchDeviceInfo()
+	defer stopDevWatch()
+	device.ApplyConfig(vectorConfigItemRaw(invalidVectorConfigValue), true, true)
+	evetest.Checkpoint("invalid-config-applied")
+	if hypervisor == evetest.HypervisorKubevirt {
+		device.WaitForClusterNodeIsReady(clusterNodeReadyTimeout)
+	}
+
+	t.Eventually(devUpdates, vectorDevInfoTimeout).Should(Receive(matchers.SatisfyPredicate(
+		"EVE reports vector.config as unparsable and does not store the value",
+		func(devInfo *eveinfo.ZInfoDevice) bool {
+			items := devInfo.GetConfigItemStatus().GetConfigItems()
+			item := items[string(pillartypes.VectorConfig)]
+			return item.GetError() != "" &&
+				item.GetValue() != invalidVectorConfigValue
+		})))
+	evetest.Checkpoint("invalid-config-rejected")
+
+	// Phase 3: and it never reaches Vector.
+	log.Infof("Verifying that the promoted Vector config is left alone...")
+	consistentlyLiveVectorConfig(t, device, defaultHash,
+		"the promoted Vector config changed: an unparsable vector.config value "+
+			"reached Vector")
+	evetest.Checkpoint("live-config-unchanged")
+}


### PR DESCRIPTION
# Description

Ports the Eden `eden_vector` and `eden_newlogd` tests to evetest, adding four
Vector subtests and one newlogd subtest to the existing
`evetest/tests/telemetry` package and its `TestTelemetrySuite`.

Per review, these live alongside `logs_test.go` rather than in a package of
their own, and the hypervisor is a parameter on every test in the package
(including the three pre-existing ones) rather than hardcoded to KVM, so the
suite can be pointed at eve-k in a nightly run. `HypervisorParameter` defaults
to KVM, so current behaviour is unchanged.

The duplication that motivated the move is gone too: `devName`,
`singleMgmtPortConfig` and the port labels existed in both packages and now
exist once, and `TestDeviceLogs` was refactored onto the shared `/dev/kmsg`
probe helpers instead of carrying its own copy. All eight tests now state their
device requirements through one shared setup helper, which is what lets the
framework reuse a single VM across the suite -- `TestDeviceInfo` previously set
`MinCPUs` explicitly and so forced a VM recreation mid-suite.

Vector's configuration arrives as a base64 global config item, is decoded by
newlogd into a candidate file, and is promoted by the Vector container only once
`vector validate` accepts it. None of that is visible to a controller, so the
tests drive it with a custom config whose only addition is a remap transform
rewriting the `source` field of every uploaded log event to a per-run sentinel.
An uploaded event carrying that sentinel proves the config was promoted and is
processing uploads, observed entirely from the controller. The sentinel has to be
per-run: Vector's sink buffer lives on `/persist` and survives both a config
reset and a reboot, so a fixed value could be satisfied by a late flush or by an
earlier subtest.

Rejection is taken from Vector's own verdict, which reaches the controller
because the container's stdout is ingested as a device log, rather than merely
inferred from a config file that did not change. A separate subtest covers the
pillar half of the gate — a value that is not base64 — which is rejected before
Vector ever sees it, and where the reported value reverts to the previously live
one instead of echoing what was sent.

One on-device read remains, in the subtest that clears the item. EVE exposes no
representation of the promoted Vector config, so pinning the revert to *the image
default* — rather than to any config that merely stops stamping events — means
comparing the promoted file against the default the container writes.

The newlogd subtest asserts the controller-observable contract of remote log
levels set to `none`: upload stops, the device keeps reporting throughout, and
clearing the setting starts upload again. The reboot in the middle is the point
rather than scaffolding, because it is what exercises newlogd's on-disk log level
cache, which governs logs produced before zedagent publishes the live config.

A negative assertion is easy to satisfy by accident, so it is bracketed by a
kernel log probe that must arrive before the mute and another that must arrive
after it, with a liveness check in between so the silence cannot be explained by
a dead or disconnected device.

What the newlogd subtest deliberately does **not** cover is EVE continuing to
collect logs locally while muted. That is not controller-observable — keeping
logs off the wire is precisely what the feature does — and checking it means
reading newlogd's directory layout, temp-file prefixes, rotation threshold and
compression scheme. That invariant belongs in a `pkg/newlog` unit test instead,
and the gap is recorded in the test's doc comment.

## PR dependencies

None.

## How to test and validate this PR

Fully covered by automated tests. From the repository root:

```sh
EVETEST_EVE_VERSION=17.0.0-lts make evetest NAME=TestTelemetrySuite
```

Each subtest is also runnable on its own, e.g.
`make evetest NAME=TestFaultyConfig`. The suite shares a single device VM across
all eight subtests.

Validated on amd64/KVM against EVE `17.0.0-lts` — all eight subtests pass in
~12 minutes total, with one device VM provisioned:

| Subtest | What it proves | Time |
|---|---|---|
| `TestDeviceInfo` | pre-existing | 155 s |
| `TestDeviceMetrics` | pre-existing | 15 s |
| `TestDeviceLogs` | pre-existing, refactored onto the shared probe helpers | 32 s |
| `TestWorkingConfig` | a valid custom config is promoted and transforms the upload stream | 20 s |
| `TestFaultyConfig` | a config failing `vector validate` is rejected by Vector, never promoted, and the running pipeline keeps uploading | 100 s |
| `TestEmptyConfig` | clearing `vector.config` restores the config built into the image | 45 s |
| `TestInvalidBase64Config` | a non-base64 value is rejected by pillar and never reaches Vector | 97 s |
| `TestRemoteLogLevelNone` | remote log levels of `none` stop upload across all three ingest paths and across a reboot, then recover when cleared | 252 s |

**Minimum EVE version.** `TestRemoteLogLevelNone` depends on newlogd's on-disk
log level cache, which is present from `17.0.0-rc2` onwards (including
`17.0.0-lts`) and on master, but absent from the `17.0.0` and `17.0.0-rc1` tags —
those predate rc2 despite the higher-looking names. On a build without it, the
test fails as though muting were broken. The three Vector subtests need
`vector.config`, i.e. EVE >= 15.8.0.

Only exercised on amd64/KVM. The hypervisor parameter makes an eve-k or xen run
possible but nothing here has been run that way yet, so I am not claiming it
passes. Two places I would look first if it does not: `TestDeviceMetrics` reads
host CPU/memory through a per-hypervisor implementation, and xen's shells out to
`xl info` with a comment that the output can be empty or partial; and
`TestRemoteLogLevelNone`'s negative assertion fails on any panic-level entry,
which is by design but has a larger service set to be unlucky with on eve-k.

## Changelog notes

No user-facing changes.

## PR Backports

- 17.0-stable: No, test-only change; the Eden equivalents still cover these
  areas on stable branches.
- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device (KVM)
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Not tested on arm64, xen or kubevirt: these are test-only additions, and the
evetest suites are not currently run on those targets by CI. The hypervisor
parameter added here is what makes such a run possible.
