### PR TITLE
zedagent: re-read config after maintenance mode change/clear

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -1045,12 +1045,28 @@ func needRequestLocConfig(getconfigCtx *getconfigContext,
 		getconfigCtx.locConfig.LocURL != ""
 }
 
+// forgetConfigHashOnLeavingMaintenanceMode discards the remembered config hash once
+// the device has left maintenance mode, so the next request fetches the configuration
+// in full. parseConfig applied nothing while maintenance mode was set, yet the hash was
+// already recorded and the controller answers "not modified" while it matches; the local
+// reasons are lifted by nodeagent rather than by a configuration change, so nothing else
+// re-drives the dropped configuration.
+func forgetConfigHashOnLeavingMaintenanceMode(getconfigCtx *getconfigContext) {
+	maintenanceMode := getconfigCtx.zedagentCtx.maintenanceMode
+	if prevMaintenanceMode && !maintenanceMode {
+		log.Notice("Left maintenance mode; re-reading the configuration")
+		prevConfigHash = ""
+	}
+	prevMaintenanceMode = maintenanceMode
+}
+
 func getLatestConfig(getconfigCtx *getconfigContext, iteration int,
 	withNetTracing bool) (configProcessingRetval, []netdump.TracedNetRequest) {
 
 	if ctrlClient == nil {
 		log.Fatal("nil ctrlClient in getLatestConfig")
 	}
+	forgetConfigHashOnLeavingMaintenanceMode(getconfigCtx)
 	url := controllerconn.URLPathString(serverNameAndPort,
 		devUUID, "config")
 
@@ -1181,6 +1197,12 @@ func readSavedProtoMessageConfig(ctrlClient *controllerconn.Client, URL string,
 
 // The most recent config hash we received. Starts empty
 var prevConfigHash string
+
+// Value of zedagentContext.maintenanceMode as last seen by the config goroutine, which
+// is the only one to touch this and prevConfigHash, so neither needs a lock. Other
+// goroutines change maintenanceMode itself, hence sampling it here rather than acting
+// where it is set.
+var prevMaintenanceMode bool
 
 func generateConfigRequest(getconfigCtx *getconfigContext, isCompoundConfig bool) (
 	[]byte, error) {

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -3262,6 +3262,11 @@ func mergeMaintenanceMode(ctx *zedagentContext, caller string) {
 		log.Noticef("%s changed maintenanceMode to %t, with reason as %s, considering {%v, %v, %v}",
 			caller, ctx.maintenanceMode, ctx.maintModeReasons.String(), ctx.gcpMaintenanceMode,
 			ctx.apiMaintenanceMode, ctx.localMaintenanceMode)
+		if !ctx.maintenanceMode && ctx.getconfigCtx.configTickerHandle != nil {
+			// Fetch at once rather than waiting out timer.config.interval, which can
+			// be as high as a day. Only a hint; the fetch discards the hash itself.
+			triggerGetConfig(ctx.getconfigCtx.configTickerHandle)
+		}
 	}
 	publishZedAgentStatus(ctx.getconfigCtx)
 }

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -2729,6 +2729,45 @@ func TestParseConfigHarness(t *testing.T) {
 	}
 }
 
+// TestForgetConfigHashOnLeavingMaintenanceMode checks that only the leaving edge
+// discards the config hash. The other three transitions must keep it, so that an
+// unchanged configuration is still answered with "not modified".
+func TestForgetConfigHashOnLeavingMaintenanceMode(t *testing.T) {
+	getconfigCtx, _ := newFuzzGetConfigCtx(t)
+
+	tests := []struct {
+		name       string
+		before     bool
+		now        bool
+		wantForget bool
+	}{
+		{name: "entering", before: false, now: true, wantForget: false},
+		{name: "still-in", before: true, now: true, wantForget: false},
+		{name: "leaving", before: true, now: false, wantForget: true},
+		{name: "still-out", before: false, now: false, wantForget: false},
+	}
+
+	const hash = "6ba7b8109dad11d180b400c04fd430c8"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			prevConfigHash = hash
+			prevMaintenanceMode = tt.before
+			getconfigCtx.zedagentCtx.maintenanceMode = tt.now
+
+			forgetConfigHashOnLeavingMaintenanceMode(getconfigCtx)
+
+			if tt.wantForget {
+				g.Expect(prevConfigHash).To(BeEmpty())
+			} else {
+				g.Expect(prevConfigHash).To(Equal(hash))
+			}
+			// Otherwise the leaving edge would fire on every fetch.
+			g.Expect(prevMaintenanceMode).To(Equal(tt.now))
+		})
+	}
+}
+
 // TestParseEdgeNodeClusterLB verifies that the LoadBalancerService is parsed
 // into EdgeNodeClusterConfig.LBInterfaces exactly when native k8s orchestration
 // is enabled: always for K3S_BASE, and for REPLICATED_STORAGE only when the

--- a/pkg/pillar/docs/zedagent-internals.md
+++ b/pkg/pillar/docs/zedagent-internals.md
@@ -176,6 +176,10 @@ When `maintenanceMode` is set:
   maintenance mode remotely.
 - New application deployments and base OS updates are deferred until maintenance mode
   is cleared.
+- Leaving maintenance mode discards the remembered config hash, so the following fetch
+  re-reads the configuration in full and applies what was deferred. The local reasons
+  are cleared by `nodeagent` rather than by a configuration change, so nothing else
+  would re-drive it.
 
 ## Eden Test Coverage Map
 


### PR DESCRIPTION
# Description

This was discovered during multi-week stress/soak testing which consumes storage in /persist and later frees it up, but the issue is more general than that. When maintenance mode is set, the config fetch updates prevConfigHash to indicate that it has received the configuration but does not process it. When the maintenance mode goes away it will not re-process that config (unless/until there is some other config change on the controller so that the prevConfigHash no longer matches). This can e.g., happen due to vault lockup and later release due to updated PCR policy on the controller, and for the other maintenance mode reasons.

## How to test and validate this PR

Automated: `TestForgetConfigHashOnLeavingMaintenanceMode` in `pkg/pillar/cmd/zedagent`,
via `make -C pkg/pillar test`. Validated against the unfixed code -- with the fix
removed the `leaving` case fails and the other three still pass.

On a device, using disk space as the local reason (needs no TPM or controller setup):

1. Fill `/persist` until `volumemgr` reports `RemainingSpace == 0`; the device enters
   maintenance mode.
2. Push a config change. A base OS update is clearest, since its absence shows in the
   partition table. `zedagent` logs `Ignoring config due to maintenanceMode`.
3. Free the space so maintenance mode is lifted, without changing the config again.
4. Expected: `zedagent` logs `Left maintenance mode; re-reading the configuration` and
   the base OS update starts. Without the fix nothing further happens, indefinitely.

A vault needing remote attestation reproduces the same shape: reboot with the vault
still locked `timer.vault.ready.cutoff` (default 300s) later and no base OS update in
progress, push a config change, then let attestation complete.

## Changelog notes

A configuration change pushed while the device is in maintenance mode is now applied
once maintenance mode is lifted, instead of being ignored until the controller sends a
different configuration or the device restarts.

## PR Backports

The permanent drop dates to 5.19, the first release carrying a locally-set maintenance
mode; 5.17 and 5.18 have the gate but derive maintenance mode purely from the config, so
they self-heal. Every supported LTS branch is therefore affected:

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

Older branches have fewer local reasons -- `EdgeNodeCertsRefused` is 17.0 and later, and
13.4 also lacks `TpmEncFailure` -- but `NoDiskSpace` and `VaultLockedUp` are present
throughout.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Not yet run on a device; verification so far is the unit test above, `make pkg/pillar`,
`go vet` and `revive`.

