### PR TITLE
Stop the disk-metrics walk from watchdogging

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -154,6 +154,10 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext, wdName string) {
 	var diskMetricList []*types.DiskMetric
 	startPubTime := time.Now()
 
+	// Measuring a single directory can take longer than the watchdog tolerates,
+	// so the walks report progress as they go rather than only between paths.
+	wdTick := func() { ctx.ps.StillRunning(wdName, warningTime, errorTime) }
+
 	disks := diskmetrics.FindDisksPartitions(log)
 	for _, d := range disks {
 		ctx.ps.StillRunning(wdName, warningTime, errorTime)
@@ -230,7 +234,7 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext, wdName string) {
 
 	for _, path := range types.ReportDirPaths {
 		ctx.ps.StillRunning(wdName, warningTime, errorTime)
-		usage, err := diskmetrics.DirUsage(log, path)
+		usage, err := diskmetrics.DirUsage(log, path, wdTick)
 		log.Tracef("createOrUpdateDiskMetrics: ReportDirPath %s usage %d err %v", path, usage, err)
 		if err != nil {
 			// Do not report
@@ -253,7 +257,7 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext, wdName string) {
 
 	for _, path := range types.AppPersistPaths {
 		ctx.ps.StillRunning(wdName, warningTime, errorTime)
-		usage, err := diskmetrics.DirUsage(log, path)
+		usage, err := diskmetrics.DirUsage(log, path, wdTick)
 		log.Tracef("createOrUpdateDiskMetrics: AppPersistPath %s usage %d err %v", path, usage, err)
 		if err != nil {
 			// Do not report
@@ -278,7 +282,7 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext, wdName string) {
 	excludeDirs = append(excludeDirs, types.ReportDirPaths...)
 	excludeDirs = append(excludeDirs, types.AppPersistPaths...)
 	list, err := diskmetrics.FindLargeFiles(types.PersistDir, 1024*1024,
-		excludeDirs)
+		excludeDirs, wdTick)
 	if err != nil {
 		log.Errorf("FindLargeFiles Failed: %s", err)
 	} else {

--- a/pkg/pillar/diskmetrics/usage.go
+++ b/pkg/pillar/diskmetrics/usage.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/containerd/containerd/mount"
 	"github.com/lf-edge/eve/pkg/pillar/base"
@@ -40,10 +41,50 @@ func StatAllocatedBytes(path string) (uint64, error) {
 	return uint64(stat.Blocks * C.DEV_BSIZE), nil
 }
 
+// walkTickInterval bounds how often a walk reports progress. Reporting per
+// directory entry would cost more than the walk itself, while the watchdog
+// tolerates minutes of silence, so seconds of granularity are ample.
+const walkTickInterval = 5 * time.Second
+
+// walkHeartbeat rate-limits the progress callback threaded through a directory
+// walk. A nil *walkHeartbeat is usable and reports nothing.
+type walkHeartbeat struct {
+	tick func()
+	next time.Time
+}
+
+func newWalkHeartbeat(tick func()) *walkHeartbeat {
+	if tick == nil {
+		return nil
+	}
+	return &walkHeartbeat{tick: tick}
+}
+
+func (h *walkHeartbeat) beat() {
+	if h == nil {
+		return
+	}
+	now := time.Now()
+	if now.Before(h.next) {
+		return
+	}
+	h.next = now.Add(walkTickInterval)
+	h.tick()
+}
+
 // SizeFromDir performs a du -s equivalent operation.
 // Didn't use os.ReadDir and filepath.Walk because they sort (quick_sort) all files per directory
 // which is an unnecessary costly operation.
-func SizeFromDir(log *base.LogObject, dirname string) (uint64, error) {
+// tick, when not nil, is called as the walk advances, at most once every
+// walkTickInterval; a caller whose goroutine is watched by the watchdog uses it
+// to report liveness while measuring a tree that takes minutes. It fires only
+// after a directory read returns, so a walk stuck in the kernel stays silent and
+// the watchdog still catches it.
+func SizeFromDir(log *base.LogObject, dirname string, tick func()) (uint64, error) {
+	return sizeFromDir(log, dirname, newWalkHeartbeat(tick))
+}
+
+func sizeFromDir(log *base.LogObject, dirname string, hb *walkHeartbeat) (uint64, error) {
 	var totalUsed uint64
 	fileInfo, err := os.Stat(dirname)
 	if err != nil {
@@ -71,11 +112,12 @@ func SizeFromDir(log *base.LogObject, dirname string) (uint64, error) {
 		if err != nil {
 			return totalUsed, err
 		}
+		hb.beat()
 		for _, location := range locations {
 			filename := dirname + "/" + location.Name()
 			log.Tracef("Looking in %s\n", filename)
 			if location.IsDir() {
-				size, _ := SizeFromDir(log, filename)
+				size, _ := sizeFromDir(log, filename, hb)
 				log.Tracef("Dir %s size %d\n", filename, size)
 				totalUsed += size
 			} else {
@@ -223,14 +265,14 @@ func FindLargestDisk(log *base.LogObject) string {
 // DirUsage calculates usage of directory.
 // When dir holds a whole filesystem, usage comes from that filesystem - one
 // dataset query for ZFS, one statfs otherwise - rather than from walking the
-// tree. Anything else is walked with SizeFromDir.
-func DirUsage(log *base.LogObject, dir string) (uint64, error) {
+// tree. Anything else is walked with SizeFromDir, which is what tick is for.
+func DirUsage(log *base.LogObject, dir string, tick func()) (uint64, error) {
 	mi, err := mount.Lookup(dir)
 	if err != nil {
 		// Lookup do not return error in case of dir is not mountpoint
 		// it returns the longest found parent mountpoint for provided dir
 		log.Errorf("dirUsage: Lookup returns error (%s), fallback to SizeFromDir", err)
-		return SizeFromDir(log, dir)
+		return SizeFromDir(log, dir, tick)
 	}
 	if isWholeFilesystem(mi, dir) {
 		// The dataset name is derived from the path, which only holds inside
@@ -250,7 +292,7 @@ func DirUsage(log *base.LogObject, dir string) (uint64, error) {
 		log.Errorf("dirUsage: disk.Usage(%s) returns error (%s), fallback to SizeFromDir",
 			dir, err)
 	}
-	return SizeFromDir(log, dir)
+	return SizeFromDir(log, dir, tick)
 }
 
 // isWholeFilesystem reports whether mi describes a filesystem mounted in its
@@ -334,14 +376,18 @@ type PathAndSize struct {
 }
 
 // FindLargeFiles walks a directory and reports all files larger than minSize
-// unless they are in an excluded (sub)directory
-func FindLargeFiles(root string, minSize int64, excludePaths []string) ([]PathAndSize, error) {
+// unless they are in an excluded (sub)directory.
+// tick has the same meaning as in SizeFromDir.
+func FindLargeFiles(root string, minSize int64, excludePaths []string,
+	tick func()) ([]PathAndSize, error) {
 	var list []PathAndSize
+	hb := newWalkHeartbeat(tick)
 	walkErr := filepath.WalkDir(filepath.Clean(root), func(path string, di fs.DirEntry, err error) error {
 		// if there is any problem with path we stop
 		if err != nil {
 			return err
 		}
+		hb.beat()
 
 		// Part of excludePath?
 		for _, ex := range excludePaths {

--- a/pkg/pillar/diskmetrics/usage.go
+++ b/pkg/pillar/diskmetrics/usage.go
@@ -220,12 +220,11 @@ func FindLargestDisk(log *base.LogObject) string {
 	return maxdisk
 }
 
-// DirUsage calculates usage of directory
-// it checks if provided directory is zfs mountpoint and take usage from zfs in that case
+// DirUsage calculates usage of directory.
+// When dir holds a whole filesystem, usage comes from that filesystem - one
+// dataset query for ZFS, one statfs otherwise - rather than from walking the
+// tree. Anything else is walked with SizeFromDir.
 func DirUsage(log *base.LogObject, dir string) (uint64, error) {
-	if persist.ReadPersistType() != types.PersistZFS || !strings.HasPrefix(dir, types.PersistDir) {
-		return SizeFromDir(log, dir)
-	}
 	mi, err := mount.Lookup(dir)
 	if err != nil {
 		// Lookup do not return error in case of dir is not mountpoint
@@ -233,15 +232,33 @@ func DirUsage(log *base.LogObject, dir string) (uint64, error) {
 		log.Errorf("dirUsage: Lookup returns error (%s), fallback to SizeFromDir", err)
 		return SizeFromDir(log, dir)
 	}
-	// if it is zfs mountpoint and we mount exactly the directory of interest (not parent folder)
-	if mi.FSType == types.PersistZFS.String() && mi.Mountpoint == dir {
-		usageStat, err := zfs.GetDatasetUsageStat(strings.TrimPrefix(dir, "/"))
-		if err != nil {
-			return 0, err
+	if isWholeFilesystem(mi, dir) {
+		// The dataset name is derived from the path, which only holds inside
+		// the persist pool.
+		if mi.FSType == types.PersistZFS.String() &&
+			strings.HasPrefix(dir, types.PersistDir) {
+			usageStat, err := zfs.GetDatasetUsageStat(strings.TrimPrefix(dir, "/"))
+			if err != nil {
+				return 0, err
+			}
+			return usageStat.Used, nil
 		}
-		return usageStat.Used, nil
+		usage, err := disk.Usage(dir)
+		if err == nil {
+			return usage.Used, nil
+		}
+		log.Errorf("dirUsage: disk.Usage(%s) returns error (%s), fallback to SizeFromDir",
+			dir, err)
 	}
 	return SizeFromDir(log, dir)
+}
+
+// isWholeFilesystem reports whether mi describes a filesystem mounted in its
+// entirety at dir, so that filesystem-wide usage accounts for exactly the tree
+// under dir. A Root other than "/" is a bind mount of a subtree, whose backing
+// filesystem also holds data outside dir.
+func isWholeFilesystem(mi mount.Info, dir string) bool {
+	return mi.Mountpoint == dir && mi.Root == "/"
 }
 
 // Dom0DiskReservedSize returns reserved space for EVE-OS

--- a/pkg/pillar/diskmetrics/usage_test.go
+++ b/pkg/pillar/diskmetrics/usage_test.go
@@ -4,13 +4,81 @@
 package diskmetrics
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/containerd/containerd/mount"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
 )
+
+func TestWalkHeartbeat(t *testing.T) {
+	beats := 0
+	hb := newWalkHeartbeat(func() { beats++ })
+
+	hb.beat()
+	hb.beat()
+	if beats != 1 {
+		t.Fatalf("beats = %d, want 1: beat() within walkTickInterval must be dropped", beats)
+	}
+
+	hb.next = time.Now().Add(-time.Second)
+	hb.beat()
+	if beats != 2 {
+		t.Fatalf("beats = %d, want 2: beat() after walkTickInterval must report", beats)
+	}
+
+	// A walk with no callback carries a nil heartbeat.
+	newWalkHeartbeat(nil).beat()
+}
+
+func TestSizeFromDirReportsProgress(t *testing.T) {
+	log := base.NewSourceLogObject(logrus.StandardLogger(), t.Name(), 0) //nolint:staticcheck
+	tmpdir := t.TempDir()
+
+	const (
+		dirs          = 3
+		filesPerDir   = 25
+		bytesPerFile  = 100
+		expectedTotal = dirs * filesPerDir * bytesPerFile
+	)
+	for d := 0; d < dirs; d++ {
+		subdir := fmt.Sprintf("%s/sub%d", tmpdir, d)
+		if err := os.Mkdir(subdir, 0755); err != nil {
+			t.Fatalf("os.Mkdir failed: %v", err)
+		}
+		for f := 0; f < filesPerDir; f++ {
+			name := fmt.Sprintf("%s/file%d", subdir, f)
+			if err := os.WriteFile(name, make([]byte, bytesPerFile), 0644); err != nil {
+				t.Fatalf("os.WriteFile failed: %v", err)
+			}
+		}
+	}
+
+	beats := 0
+	size, err := SizeFromDir(log, tmpdir, func() { beats++ })
+	if err != nil {
+		t.Fatalf("SizeFromDir failed: %v", err)
+	}
+	if size != expectedTotal {
+		t.Fatalf("SizeFromDir = %d, want %d", size, expectedTotal)
+	}
+	if beats == 0 {
+		t.Fatalf("SizeFromDir never reported progress")
+	}
+
+	size, err = SizeFromDir(log, tmpdir, nil)
+	if err != nil {
+		t.Fatalf("SizeFromDir with no callback failed: %v", err)
+	}
+	if size != expectedTotal {
+		t.Fatalf("SizeFromDir with no callback = %d, want %d", size, expectedTotal)
+	}
+}
 
 func TestIsWholeFilesystem(t *testing.T) {
 	tests := []struct {

--- a/pkg/pillar/diskmetrics/usage_test.go
+++ b/pkg/pillar/diskmetrics/usage_test.go
@@ -8,7 +8,58 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/containerd/containerd/mount"
 )
+
+func TestIsWholeFilesystem(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  string
+		mi   mount.Info
+		want bool
+	}{
+		{
+			name: "ext4 filesystem mounted at dir",
+			dir:  "/persist/vault",
+			mi:   mount.Info{Mountpoint: "/persist/vault", Root: "/", FSType: "ext4"},
+			want: true,
+		},
+		{
+			name: "zfs dataset mounted at dir",
+			dir:  "/persist/reserved",
+			mi:   mount.Info{Mountpoint: "/persist/reserved", Root: "/", FSType: "zfs"},
+			want: true,
+		},
+		{
+			name: "dir is a plain subdirectory of a mountpoint",
+			dir:  "/persist/vault/volumes",
+			mi:   mount.Info{Mountpoint: "/persist", Root: "/", FSType: "zfs"},
+			want: false,
+		},
+		{
+			name: "bind mount of a subtree",
+			dir:  "/persist/kubelog",
+			mi:   mount.Info{Mountpoint: "/persist/kubelog", Root: "/log", FSType: "ext4"},
+			want: false,
+		},
+		{
+			name: "mountpoint is a prefix of dir",
+			dir:  "/persist/vault2",
+			mi:   mount.Info{Mountpoint: "/persist/vault", Root: "/", FSType: "ext4"},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isWholeFilesystem(tc.mi, tc.dir); got != tc.want {
+				t.Fatalf("isWholeFilesystem(%+v, %s) = %v, want %v",
+					tc.mi, tc.dir, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestStatAllocatedBytes(t *testing.T) {
 	// Generate a tmpfile path

--- a/pkg/pillar/volumehandlers/containerhandler.go
+++ b/pkg/pillar/volumehandlers/containerhandler.go
@@ -40,7 +40,7 @@ func (handler *volumeHandlerContainer) GetVolumeDetails() (uint64, uint64, strin
 		// we did not create snapshot yet
 		handler.log.Warnf("GetVolumeSize: Failed get snapshot usage: %s for %s. Error %s",
 			snapshotID, handler.status.FileLocation, err)
-		size, err = diskmetrics.SizeFromDir(handler.log, handler.status.FileLocation)
+		size, err = diskmetrics.SizeFromDir(handler.log, handler.status.FileLocation, nil)
 	}
 	return size, size, "CONTAINER", false, err
 }


### PR DESCRIPTION
# Description

Fixes #6300.

A node with `/persist` on ZFS can reboot itself while nothing is wrong. The
watchdog declares volumemgr hung because its periodic disk-metrics collection
spent longer measuring **one** directory than the 500 s EVE allows any watched
file to go untouched (`set_global hv_watchdog_timer "change=500"` in
`pkg/grub/rootfs.cfg`, stamped onto every watched file by `pkg/watchdog/init.sh`).
The reboot takes every application on the node with it.

The directory is `/persist/vault`. Collection kicks the watchdog once per
reported path and then measures that path, so the fixed budget has to cover the
slowest single directory — and on a ZFS-persist device `/persist/vault` is a
large ext4 filesystem on a zvol, so measuring it walks the containerd image
store, every app volume, and the downloader and verifier trees. Its measured
cost across newlog windows from one device was **568 s** (the reboot), 410 s,
329 s, 123 s and 2 s, while every other reported path stayed under ~6 s. The
410 s sample is a near miss, so this is not a rare tail. Full evidence chain in
#6300.

Two commits, either of which helps on its own:

1. **`diskmetrics: use statfs for a whole filesystem`** — a directory that holds
   a whole mounted filesystem can be measured with one statfs call. That
   shortcut existed but only recognized ZFS mountpoints; it now applies to any
   mountpoint whose root is the filesystem root. A bind mount of a subtree is
   still walked, since filesystem-wide usage would there cover data living
   outside the directory.
2. **`diskmetrics: report progress while walking`** — the remaining walks report
   progress as they advance, so watchdog liveness stops depending on tree size.
   Reporting is rate-limited to seconds (a walk visits far more entries than the
   watchdog needs heartbeats) and happens only after a directory read returns,
   so a walk genuinely stuck in the kernel still trips the watchdog.

The second commit is what removes the failure mode rather than moving it.
`/persist/vault` is measured twice per cycle today — once as itself and once as
its children in `AppPersistPaths` (`/persist/vault/{volumes,containerd,`
`downloader,verifier}`). Those children measured 0.2–2 s, but always immediately
after the parent walk had warmed the dentry cache. With the parent gone they
become the cold walks and their cold cost is unmeasured, with the containerd
image store the obvious candidate for the new worst case.

Two things deliberately **not** done:

- **Not the ZFS shortcut for `/persist/vault`.** It is mechanically possible — a
  zvol is a dataset — but it answers a different question. Measured on the
  device: `zfs list` reports `USED 12.4G` / `LOGICALUSED 22.6G` /
  `VOLSIZE 719G` where statfs inside the ext4 reports 29.8 GiB used. And for a
  zvol carrying a `refreservation`, `GetDatasetUsageStat` short-circuits to
  `Total = Used = refreservation, Free = 0`; `/persist/reserved` on that device
  has one, so that branch is live in the field.
- **Not raising `change=`.** That would hide every stale-touch bug on the
  device, not just this one.

Behavior change worth calling out: `DiskMetric.UsedBytes` for a directory that
holds a whole filesystem now reports blocks in use, which includes filesystem
metadata, instead of the sum of apparent file sizes. For a whole filesystem the
statfs number is the more defensible one, but it is not the same number, so the
value reported for `/persist/vault` will move.

## How to test and validate this PR

Automated — new unit tests in `pkg/pillar/diskmetrics/usage_test.go`, run by
`make -C pkg/pillar test`:

- `TestIsWholeFilesystem` — the mountpoint decision, including that a bind mount
  of a subtree is *not* treated as a whole filesystem.
- `TestWalkHeartbeat` — progress reporting is rate-limited, and a walk with no
  callback is safe.
- `TestSizeFromDirReportsProgress` — a walk over a synthetic tree reports
  progress and still returns the right total.

On a device with `/persist` on ZFS and a populated `/persist/vault` (the effect
scales with how much is in the vault, so a device with apps and images is
needed):

1. Rebuild the per-path cost table before and after. Consecutive
   `createOrUpdateDiskMetrics: updating DiskMetric for <path>` records give the
   per-path duration:

   ```sh
   eve exec pillar sh -c 'find /persist/newlog -name "dev.log.*" -exec zcat -f {} \;' \
       | grep -a "updating DiskMetric for"
   ```

   Success is `/persist/vault` dropping to milliseconds **and** no other path
   inheriting a multi-hundred-second duration.
2. Confirm the heartbeat advances *during* a walk, not only between paths: watch
   `stat -c %y /run/volumemgrmetrics.touch` in a loop across a metrics cycle.
   On a device where a walk takes minutes, the pre-change mtime sits still for
   the whole walk.
3. Watch for the pre-fix watchdog signature disappearing — newlog records with
   `source: "watchdog"` saying
   `file /run/volumemgrmetrics.touch was not changed in N seconds (more than 500)`.
4. Sanity-check the reported numbers: `DiskMetric.UsedBytes` for `/persist/vault`
   should agree with `df` inside the vault filesystem rather than with the old
   walked total.

Not yet exercised on hardware — unit tests and a pillar build only. On-device
before/after per the steps above is the validation this needs.

## Changelog notes

A device with a large `/persist` using ZFS no longer reboots itself while collecting disk
metrics. Disk usage reported for a directory that holds a whole filesystem now
comes from the filesystem itself, so it accounts for filesystem metadata.

## PR Backports

The vulnerable code is byte-identical on all four LTS branches (checked
`pkg/pillar/diskmetrics/usage.go` on each), so:

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — no doc change; the fix has no
  operator-facing knob
- [ ] I've tested my PR on amd64 device — unit tests and a pillar build only, see
  above
- [ ] I've tested my PR on arm64 device — same
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR — needs `stable` for the backports
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them
