### PR TITLE
newlog: capture cgo aborts and full tracebacks

### DIFF
--- a/pkg/newlog/cmd/getMemlogMsg.go
+++ b/pkg/newlog/cmd/getMemlogMsg.go
@@ -21,8 +21,38 @@ const (
 	ansi = "(?:\u001B|\\\\u001[bB])\\[[0-9;]*[A-Za-z]|(?:\u001B|\\\\u001[bB])[\\(\\)\\[\\]#;?]*[A-Za-z0-9]|(?:\u009B|\\\\u009[bB])[0-9;]*[A-Za-z]"
 )
 
+const (
+	// panicQuietPeriod is how long the capture waits for more traceback lines
+	// before writing the panic files.
+	panicQuietPeriod = 2 * time.Second
+)
+
 var (
 	memlogdSocket = "/run/memlogdq.sock"
+
+	// Budget for one capture, kept in variables so tests can shrink it. zedbox
+	// dumps every goroutine as one memlogd record per line, which runs to
+	// thousands of records and hundreds of KiB, and the frames that explain a
+	// crash are rarely the first ones.
+	maxPanicRecords = 20000
+	maxPanicBufSize = 2 << 20
+
+	// Prefixes of the first stderr line of a fatal pillar failure. Signal
+	// banners appear both bare ("SIGABRT: abort") and inside a Go panic
+	// message ("[signal SIGSEGV: segmentation violation ...").
+	panicStartMarkers = []string{
+		"panic:",
+		"fatal error:",
+		"ASSERT at ",
+		"[signal SIG",
+		"SIGABRT:",
+		"SIGSEGV:",
+		"SIGBUS:",
+		"SIGFPE:",
+		"SIGILL:",
+		"SIGTRAP:",
+		"signal arrived during cgo execution",
+	}
 )
 
 // getMemlogMsg - goroutine to get messages from memlogd queue
@@ -77,7 +107,7 @@ func processMemlogStream(conn net.Conn, logChan chan inputEntry, panicFileChan c
 		}
 
 		// if we are in watchdog going down. fsync often
-		checkWatchdogRestart(&entry, &panicStackCount, string(bytes), panicFileChan)
+		checkWatchdogRestart(&entry, &panicStackCount, panicFileChan)
 
 		logChan <- entry
 	}
@@ -261,7 +291,7 @@ func cleanForLogParsing(str string) string {
 }
 
 // flush more often when we are going down by reading from watchdog log message itself
-func checkWatchdogRestart(entry *inputEntry, panicStackCount *int, origMsg string, panicFileChan chan []byte) {
+func checkWatchdogRestart(entry *inputEntry, panicStackCount *int, panicFileChan chan []byte) {
 	// source can be watchdog or watchdog.err
 	if strings.HasPrefix(entry.source, "watchdog") {
 		if strings.Contains(entry.content, "Retry timed-out at") {
@@ -275,31 +305,60 @@ func checkWatchdogRestart(entry *inputEntry, panicStackCount *int, origMsg strin
 	}
 
 	// the panic generated message can have the source either as 'pillar' or 'pillar.out'
-	// this origMsg is the raw message, the ";" is the deliminator between source and content.
-	if strings.Contains(entry.source, "pillar") && strings.Contains(origMsg, ";panic:") &&
-		!strings.Contains(entry.content, "rebootReason") {
-		*panicStackCount = 1
-		panicBuf = append(panicBuf, []byte(origMsg)...)
-		// in case there is only few log messages after this, kick off a timer to write the panic files
-		panicWriteTimer = time.NewTimer(2 * time.Second)
-	} else if *panicStackCount > 0 {
-		var done bool
-		if strings.Contains(entry.source, "pillar") {
-			panicBuf = append(panicBuf, []byte(origMsg)...)
-		} else {
-			// conclude the capture when log source is not 'pillar'
-			done = true
+	if !strings.Contains(entry.source, "pillar") {
+		return
+	}
+
+	panicBufLock.Lock()
+	defer panicBufLock.Unlock()
+
+	if *panicStackCount == 0 {
+		if !isPanicStart(entry.content) ||
+			strings.Contains(entry.content, "rebootReason") {
+			return
 		}
+		*panicStackCount = 1
+		appendPanicLine(entry.content)
+		panicWriteTimer.Reset(panicQuietPeriod)
+		return
+	}
 
-		*panicStackCount++
+	*panicStackCount++
+	appendPanicLine(entry.content)
 
-		if *panicStackCount > 15 || done {
-			panicWriteTimer.Stop()
-			*panicStackCount = 0
-			panicFileChan <- panicBuf
-			panicBuf = nil
+	// A traceback arrives as a burst of one record per line and other services
+	// keep logging in between, so the capture ends on a quiet period rather
+	// than on the first record from another source. The budget only bounds how
+	// much of a dying process's stack is kept.
+	if *panicStackCount >= maxPanicRecords || len(panicBuf) >= maxPanicBufSize {
+		panicWriteTimer.Stop()
+		*panicStackCount = 0
+		panicFileChan <- panicBuf
+		panicBuf = nil
+		return
+	}
+	panicWriteTimer.Reset(panicQuietPeriod)
+}
+
+// appendPanicLine adds one traceback line to panicBuf. Caller must hold
+// panicBufLock.
+func appendPanicLine(content string) {
+	panicBuf = append(panicBuf, content...)
+	panicBuf = append(panicBuf, '\n')
+}
+
+// isPanicStart reports whether a pillar stderr line begins a fatal failure.
+// Go panics and runtime throws print "panic:"/"fatal error:", while a C
+// assertion or fatal signal raised under cgo runs no Go panic machinery at all
+// and prints only the assert text followed by a signal banner.
+func isPanicStart(content string) bool {
+	content = strings.TrimLeft(content, " \t")
+	for _, marker := range panicStartMarkers {
+		if strings.HasPrefix(content, marker) {
+			return true
 		}
 	}
+	return false
 }
 
 // MemlogLogEntry is copied from memlogd; maybe it should provide a parser

--- a/pkg/newlog/cmd/getMemlogMsg_test.go
+++ b/pkg/newlog/cmd/getMemlogMsg_test.go
@@ -8,7 +8,9 @@ import (
 	"encoding/json"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
@@ -318,4 +320,117 @@ func TestCleanForLogParsing(t *testing.T) {
 			g.Expect(result).To(gomega.Equal(tt.expected))
 		})
 	}
+}
+
+// feedPanicRecords runs a sequence of memlogd records through
+// checkWatchdogRestart and returns whatever was sent to the panic file
+// channel, plus the buffer still being accumulated.
+func feedPanicRecords(t *testing.T, records []inputEntry) (sent []byte, pending string) {
+	t.Helper()
+
+	panicWriteTimer = time.NewTimer(time.Hour)
+	panicWriteTimer.Stop()
+	panicBuf = nil
+	t.Cleanup(func() { panicBuf = nil })
+
+	panicFileChan := make(chan []byte, 1)
+	var count int
+	for i := range records {
+		checkWatchdogRestart(&records[i], &count, panicFileChan)
+	}
+
+	select {
+	case sent = <-panicFileChan:
+	default:
+	}
+	panicBufLock.Lock()
+	defer panicBufLock.Unlock()
+	return sent, string(panicBuf)
+}
+
+// A C assertion failing under cgo, in the order the dying process prints it:
+// no "panic:" appears anywhere and Go's traceback only starts several lines in.
+var cgoAbortRecords = []string{
+	"ASSERT at lib/cgolib/tree.c:190:tree_reload()",
+	"avl_find(hdl->tree, node, &where) == NULL",
+	"  PID: 4280      COMM: zedbox",
+	"SIGABRT: abort",
+	"signal arrived during cgo execution",
+	"goroutine 4490 gp=0xc002b81500 m=13 mp=0xc0005f4808 [syscall]:",
+	"github.com/example/cgolib.OpenAll()",
+}
+
+func pillarRecords(lines []string) []inputEntry {
+	entries := make([]inputEntry, 0, len(lines))
+	for _, l := range lines {
+		entries = append(entries, inputEntry{source: "pillar", content: l})
+	}
+	return entries
+}
+
+func TestPanicCaptureStart(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	t.Run("cgo abort is captured from its first line", func(t *testing.T) {
+		_, pending := feedPanicRecords(t, pillarRecords(cgoAbortRecords))
+		g.Expect(pending).To(gomega.HavePrefix("ASSERT at lib/cgolib/tree.c:190"),
+			"capture must start at the C assert line, not at the Go traceback")
+		g.Expect(pending).To(gomega.ContainSubstring("cgolib.OpenAll()"))
+		g.Expect(pending).To(gomega.ContainSubstring("signal arrived during cgo execution"))
+	})
+
+	t.Run("go panic and runtime throw are captured", func(t *testing.T) {
+		for _, first := range []string{
+			"panic: runtime error: invalid memory address or nil pointer dereference",
+			"fatal error: concurrent map writes",
+			"[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x123]",
+		} {
+			_, pending := feedPanicRecords(t, pillarRecords([]string{first, "goroutine 1 [running]:"}))
+			g.Expect(pending).To(gomega.HavePrefix(first), "should trigger on %q", first)
+		}
+	})
+
+	t.Run("ordinary pillar logs do not trigger a capture", func(t *testing.T) {
+		_, pending := feedPanicRecords(t, pillarRecords([]string{
+			`{"level":"info","msg":"periodic metrics published","pid":4280}`,
+			`{"level":"error","msg":"handling panic: recovered"}`,
+		}))
+		g.Expect(pending).To(gomega.BeEmpty())
+	})
+
+	t.Run("a reported rebootReason does not re-trigger", func(t *testing.T) {
+		_, pending := feedPanicRecords(t, pillarRecords([]string{
+			`panic: some old crash rebootReason from the previous boot`,
+		}))
+		g.Expect(pending).To(gomega.BeEmpty())
+	})
+}
+
+func TestPanicCaptureSpansOtherSources(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	// A traceback is a burst of thousands of records; other services keep
+	// logging in between, and those interleaved records must not end it.
+	records := pillarRecords(cgoAbortRecords[:4])
+	records = append(records, inputEntry{source: "zedbox", content: "some other service logged"})
+	records = append(records, inputEntry{source: "kube", content: "and another"})
+	records = append(records, pillarRecords(cgoAbortRecords[4:])...)
+
+	_, pending := feedPanicRecords(t, records)
+	g.Expect(pending).To(gomega.ContainSubstring("cgolib.OpenAll()"),
+		"records after an interleaved non-pillar record must still be captured")
+	g.Expect(pending).ToNot(gomega.ContainSubstring("some other service logged"))
+}
+
+func TestPanicCaptureBudget(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	origRecords, origSize := maxPanicRecords, maxPanicBufSize
+	maxPanicRecords = 5
+	t.Cleanup(func() { maxPanicRecords, maxPanicBufSize = origRecords, origSize })
+
+	sent, _ := feedPanicRecords(t, pillarRecords(cgoAbortRecords))
+	g.Expect(sent).ToNot(gomega.BeEmpty(), "hitting the record budget must flush the capture")
+	g.Expect(string(sent)).To(gomega.HavePrefix("ASSERT at"))
+	g.Expect(strings.Count(string(sent), "\n")).To(gomega.Equal(5))
 }

--- a/pkg/newlog/cmd/newlogd.go
+++ b/pkg/newlog/cmd/newlogd.go
@@ -60,6 +60,9 @@ var (
 	syncToFileCnt int    // every 'N' log event count flush to log file
 	persistMbytes uint64 // '/persist' disk space total in Mbytes
 	panicBuf      []byte // buffer to save panic crash stack
+	// panicBuf is appended by the memlogd reader goroutine and drained by the
+	// main loop when panicWriteTimer fires.
+	panicBufLock sync.Mutex
 
 	enableFastUpload bool // enable fast upload to controller similar to previous log operation
 
@@ -355,10 +358,12 @@ func main() {
 			subNestedAppDomainStatus.ProcessChange(change)
 
 		case <-panicWriteTimer.C:
+			panicBufLock.Lock()
 			if len(panicBuf) > 0 {
 				savePanicFiles(panicBuf)
 				panicBuf = nil
 			}
+			panicBufLock.Unlock()
 
 		case <-schedResetTimer.C:
 			syncToFileCnt = defaultSyncCount


### PR DESCRIPTION
# Description

A fatal pillar failure that is not a Go panic currently leaves no trail at all. When a C assertion reached through cgo raises `SIGABRT` — as libzfs does from zfsmanager's storage-metrics collection, lf-edge/eve#6299 — the process dies before any Go panic machinery runs, so the reboot that follows has an empty `/persist/reboot-reason`, an empty `/persist/reboot-stack` and no `panicStacks` entry. Searching for the usual markers comes back clean and the reboot looks unexplained.

Two separate reasons, both cause-agnostic:

* The capture keyed on a `";panic:"` substring of the raw memlogd record, i.e. the `<time>;<source>;<msg>` text form. memlogd answers the query socket with `json.NewEncoder` (`pkg/memlogd/cmd/memlogd/main.go`, `linuxkit/memlogd:v1.3.0` as pinned in `images/`), so that delimiter is not present in what newlogd reads and no capture ran for **any** failure of this kind — including plain Go panics and runtime throws.
* The capture stopped after 15 records, and at the first record from another source. A traceback is a burst of one record per line, and other services keep logging during it.

This changes detection to run on the parsed line, over a marker set that covers Go panics and runtime throws as well as C asserts and bare signal banners, so the capture starts at the `ASSERT at …` line rather than several lines into the Go traceback. The capture now ends after a quiet period instead of at the first foreign record, with a budget of 20000 records / 2 MiB. The shared buffer is appended by the memlogd reader and drained by the main loop, so it is now locked.

Sizing comes from a real occurrence: the abort in #6299 dumped **2547 records / 172 KiB over 47 ms** and was *still* truncated at 116 goroutines, which is why the old limit of 15 kept only the first few frames.

## How to test and validate this PR

Covered by automated tests in `pkg/newlog/cmd/getMemlogMsg_test.go` (`go test -C pkg/newlog/cmd/ -race`), driven by the record sequence recorded from the device in #6299:

* `TestPanicCaptureStart` — a cgo abort is captured from its first line; Go panics, runtime throws and `[signal SIG…` also trigger; ordinary pillar logs and a reported `rebootReason` do not.
* `TestPanicCaptureSpansOtherSources` — interleaved records from other services no longer end the capture.
* `TestPanicCaptureBudget` — hitting the record budget flushes the files.

All three fail on the pre-change trigger (on their assertions, not compilation), and the package suite passes with `-race`.

On a device: any pillar crash should now leave `/persist/reboot-reason`, `/persist/reboot-stack` and a `/persist/newlog/panicStacks/pillar-panic-stack.<ts>` holding the whole traceback rather than nothing.

## Changelog notes

Crashes of the pillar process that come from native code (for example a ZFS library assertion) now record a reboot reason and a full stack trace, instead of rebooting with no explanation.

## PR Backports

The dead trigger is present on every LTS branch (`pkg/newlog/cmd/getMemlogMsg.go` on 17.0/16.0, `pkg/newlog/cmd/newlogd.go` on 14.5/13.4), so crash triage is equally blind there:

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — no doc change; `docs/LOGGING.md` does not describe the panic-capture trigger
- [ ] I've tested my PR on amd64 device — unit tests only so far; the input sequence is taken verbatim from an amd64 device abort
- [ ] I've tested my PR on arm64 device — not run; the change is architecture-independent string handling
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
