### PR TITLE
pillar: retry deferred info messages the controller may still accept

### DIFF
--- a/evetest/README.md
+++ b/evetest/README.md
@@ -893,6 +893,7 @@ non-default behavior.
 | `EVETEST_PAUSE_ON_CHECKPOINT` | Pause at the named checkpoint | -- |
 | `EVETEST_SUITE_MAX_FAILURES` | Max failures before aborting suite (`-1` = unlimited) | `1` |
 | `EVETEST_RESTART_ONLY_FAILED` | Skip suite subtests that already passed in a previous run (requires `EVETEST_COLLECT_ARTIFACTS`); see [Rerunning Only Failed Subtests](#rerunning-only-failed-subtests) | `false` |
+| `EVETEST_CONTROLLER_FAULTS` | Run the controller behind a proxy which a test can tell to answer, delay or drop selected device requests (`ArmControllerFault`). Off by default: with no fault armed the proxy forwards everything unchanged, but it terminates TLS and re-originates the request, so it stays out of the path unless a test needs it. Tests which arm faults skip without it | `false` |
 
 ### Deployment Variables
 

--- a/evetest/constants/config.go
+++ b/evetest/constants/config.go
@@ -262,6 +262,13 @@ const (
 	// completion. Requires EVE to be built with COVER=y.
 	CollectCoverageEnv = "COLLECT_COVERAGE"
 
+	// ControllerFaultsEnv runs the controller behind a proxy which a test can tell
+	// to answer, delay or drop selected device requests (see ArmControllerFault).
+	// Off by default: the proxy forwards everything unchanged, but it terminates
+	// TLS and re-originates the request, so keeping it out of the path unless a
+	// test needs it leaves an unrelated failure one suspect fewer.
+	ControllerFaultsEnv = "CONTROLLER_FAULTS"
+
 	// InternalArtifactDirEnv specifies a container-internal directory path where all
 	// test artifacts are written.
 	// This variable is always set by the container entrypoint and must not be set
@@ -420,6 +427,7 @@ func InitViperConfig() {
 	viper.SetDefault(PauseOnFailureEnv, false)
 	viper.SetDefault(CollectCoverageEnv, false)
 	viper.SetDefault(RestartOnlyFailedEnv, false)
+	viper.SetDefault(ControllerFaultsEnv, false)
 
 	// EVE image config
 	viper.SetDefault(EVEVersionEnv, "") // Empty = derive from repo

--- a/evetest/controller/adam.go
+++ b/evetest/controller/adam.go
@@ -69,6 +69,10 @@ const (
 	streamValue  = "true"
 )
 
+// Port offset applied to Adam itself when a fault injecting proxy takes over
+// the device-facing port.
+const adamFaultProxyPortOffset = 1000
+
 // AdamClient manages the lifecycle of an Adam controller instance.
 // It is responsible for generating TLS assets, starting the Adam process,
 // monitoring it for unexpected exits, and shutting it down cleanly.
@@ -78,6 +82,12 @@ type AdamClient struct {
 	hostname   string
 	listenIPs  []net.IP
 	listenPort uint16
+	// adamPort is the port Adam itself listens on, and the one the harness uses
+	// to reach it. It differs from listenPort only with fault injection enabled,
+	// where the fault proxy takes over the device-facing listenPort.
+	adamPort   uint16
+	withFaults bool
+	faultProxy *FaultProxy
 
 	// Certificates and their corresponding private keys that are never rotated:
 	// the CA is set at construction, the TLS pair once in generateCerts.
@@ -203,12 +213,30 @@ func NewAdamClient(log *logrus.Entry,
 		hostname:       hostname,
 		listenIPs:      listenIPs,
 		listenPort:     listenPort,
+		adamPort:       listenPort,
 		caCert:         caCert,
 		caKey:          caKey,
 		statusCh:       statusCh,
 		knownDevices:   make(map[uuid.UUID]struct{}),
 		onboardSerials: make(map[string]map[string]struct{}),
 	}
+}
+
+// EnableFaultInjection moves Adam itself to an internal port and puts a fault
+// injecting proxy in front of it on the port the devices connect to, so that a
+// test can make the controller fail in a chosen way (see FaultProxy). The
+// harness keeps talking to Adam directly on the internal port, so reading what
+// the controller knows is never affected by an injected fault.
+// Must be called before Start.
+func (ac *AdamClient) EnableFaultInjection() {
+	ac.withFaults = true
+	ac.adamPort = ac.listenPort + adamFaultProxyPortOffset
+}
+
+// FaultProxy returns the fault injecting proxy, or nil if fault injection was
+// not enabled before Start.
+func (ac *AdamClient) FaultProxy() *FaultProxy {
+	return ac.faultProxy
 }
 
 // Start generates TLS certificates and launches the Adam controller.
@@ -240,7 +268,7 @@ func (ac *AdamClient) Start() error {
 	var args []string
 	args = append(args,
 		"server",
-		"--port", strconv.Itoa(int(ac.listenPort)))
+		"--port", strconv.Itoa(int(ac.adamPort)))
 	for _, listenIP := range ac.listenIPs {
 		args = append(args,
 			"--ip", listenIP.String())
@@ -276,7 +304,7 @@ func (ac *AdamClient) Start() error {
 	ac.adamCmd = cmd
 	ac.adamPid = cmd.Process.Pid
 	ac.log.Infof("Adam process started and listening on IPs:%v, port:%d",
-		ac.listenIPs, ac.listenPort)
+		ac.listenIPs, ac.adamPort)
 	ac.publish(AdamStateRunning, nil)
 
 	// Signal when qemu process exits.
@@ -294,6 +322,23 @@ func (ac *AdamClient) Start() error {
 			ac.publish(AdamStateStopped, nil)
 		}
 	}()
+
+	if ac.withFaults {
+		caPool := x509.NewCertPool()
+		caPool.AddCert(ac.caCert)
+		ac.faultProxy = NewFaultProxy(
+			ac.log.WithField("component", "fault-proxy"),
+			ac.listenIPs, ac.listenPort,
+			filepath.Join(certDir, "tls.pem"),
+			filepath.Join(certDir, "tls-key.pem"),
+			net.JoinHostPort(ac.listenIPs[0].String(),
+				strconv.Itoa(int(ac.adamPort))),
+			ac.hostname, caPool)
+		if err := ac.faultProxy.Start(); err != nil {
+			ac.publish(AdamStateCrashed, err)
+			return err
+		}
+	}
 	return nil
 }
 
@@ -305,6 +350,10 @@ func (ac *AdamClient) Stop() error {
 
 	ac.publish(AdamStateStopping, nil)
 	ac.log.Info("Stopping Adam")
+
+	if ac.faultProxy != nil {
+		ac.faultProxy.Stop()
+	}
 
 	if err := ac.adamCmd.Process.Signal(syscall.SIGTERM); err != nil {
 		err = fmt.Errorf("failed to send SIGTERM to Adam: %v", err)
@@ -336,7 +385,7 @@ func (ac *AdamClient) httpClient() *http.Client {
 
 func (ac *AdamClient) adminURL(pathSuffix string) string {
 	return fmt.Sprintf("https://%s:%d/admin/%s",
-		ac.listenIPs[0].String(), ac.listenPort, pathSuffix)
+		ac.listenIPs[0].String(), ac.adamPort, pathSuffix)
 }
 
 func (ac *AdamClient) checkAdamRunning() error {

--- a/evetest/controller/adam.go
+++ b/evetest/controller/adam.go
@@ -69,9 +69,12 @@ const (
 	streamValue  = "true"
 )
 
-// Port offset applied to Adam itself when a fault injecting proxy takes over
-// the device-facing port.
-const adamFaultProxyPortOffset = 1000
+// adamLoopbackIP is the address Adam listens on when a fault proxy takes over
+// the device-facing addresses. Only the proxy and the harness then reach Adam,
+// both from inside the harness' network namespace, which keeps Adam off the
+// device network: a device cannot sidestep an injected fault by reaching the
+// controller directly.
+const adamLoopbackIP = "127.0.0.1"
 
 // AdamClient manages the lifecycle of an Adam controller instance.
 // It is responsible for generating TLS assets, starting the Adam process,
@@ -82,10 +85,6 @@ type AdamClient struct {
 	hostname   string
 	listenIPs  []net.IP
 	listenPort uint16
-	// adamPort is the port Adam itself listens on, and the one the harness uses
-	// to reach it. It differs from listenPort only with fault injection enabled,
-	// where the fault proxy takes over the device-facing listenPort.
-	adamPort   uint16
 	withFaults bool
 	faultProxy *FaultProxy
 
@@ -213,7 +212,6 @@ func NewAdamClient(log *logrus.Entry,
 		hostname:       hostname,
 		listenIPs:      listenIPs,
 		listenPort:     listenPort,
-		adamPort:       listenPort,
 		caCert:         caCert,
 		caKey:          caKey,
 		statusCh:       statusCh,
@@ -222,19 +220,40 @@ func NewAdamClient(log *logrus.Entry,
 	}
 }
 
-// EnableFaultInjection moves Adam itself to an internal port and puts a fault
-// injecting proxy in front of it on the port the devices connect to, so that a
-// test can make the controller fail in a chosen way (see FaultProxy). The
-// harness keeps talking to Adam directly on the internal port, so reading what
-// the controller knows is never affected by an injected fault.
+// EnableFaultInjection puts a fault injecting proxy on the addresses the devices
+// connect to and moves Adam itself to loopback behind it, so that a test can make
+// the controller fail in a chosen way (see FaultRule). The harness goes on
+// reaching Adam directly, so reading what the controller knows is never affected
+// by an injected fault.
 // Must be called before Start.
 func (ac *AdamClient) EnableFaultInjection() {
 	ac.withFaults = true
-	ac.adamPort = ac.listenPort + adamFaultProxyPortOffset
 }
 
-// FaultProxy returns the fault injecting proxy, or nil if fault injection was
-// not enabled before Start.
+// adamListenIPs returns the addresses Adam itself binds: the device-facing ones,
+// or loopback when the fault proxy has taken those over.
+func (ac *AdamClient) adamListenIPs() []string {
+	if ac.withFaults {
+		return []string{adamLoopbackIP}
+	}
+	ips := make([]string, 0, len(ac.listenIPs))
+	for _, listenIP := range ac.listenIPs {
+		ips = append(ips, listenIP.String())
+	}
+	return ips
+}
+
+// adamHostIP returns the address the harness reaches Adam at.
+func (ac *AdamClient) adamHostIP() string {
+	if ac.withFaults {
+		return adamLoopbackIP
+	}
+	return ac.listenIPs[0].String()
+}
+
+// FaultProxy returns the proxy the devices reach Adam through, which a test uses
+// to make the controller fail in a chosen way (see FaultRule). It is nil unless
+// EnableFaultInjection was called before Start.
 func (ac *AdamClient) FaultProxy() *FaultProxy {
 	return ac.faultProxy
 }
@@ -268,10 +287,9 @@ func (ac *AdamClient) Start() error {
 	var args []string
 	args = append(args,
 		"server",
-		"--port", strconv.Itoa(int(ac.adamPort)))
-	for _, listenIP := range ac.listenIPs {
-		args = append(args,
-			"--ip", listenIP.String())
+		"--port", strconv.Itoa(int(ac.listenPort)))
+	for _, adamIP := range ac.adamListenIPs() {
+		args = append(args, "--ip", adamIP)
 	}
 	args = append(args,
 		"--db-url", dbDir,
@@ -304,7 +322,7 @@ func (ac *AdamClient) Start() error {
 	ac.adamCmd = cmd
 	ac.adamPid = cmd.Process.Pid
 	ac.log.Infof("Adam process started and listening on IPs:%v, port:%d",
-		ac.listenIPs, ac.adamPort)
+		ac.adamListenIPs(), ac.listenPort)
 	ac.publish(AdamStateRunning, nil)
 
 	// Signal when qemu process exits.
@@ -331,10 +349,12 @@ func (ac *AdamClient) Start() error {
 			ac.listenIPs, ac.listenPort,
 			filepath.Join(certDir, "tls.pem"),
 			filepath.Join(certDir, "tls-key.pem"),
-			net.JoinHostPort(ac.listenIPs[0].String(),
-				strconv.Itoa(int(ac.adamPort))),
+			net.JoinHostPort(adamLoopbackIP, strconv.Itoa(int(ac.listenPort))),
 			ac.hostname, caPool)
 		if err := ac.faultProxy.Start(); err != nil {
+			// Nothing can reach Adam on loopback without the proxy in front of
+			// it, so do not leave it running and holding its database directory.
+			_ = ac.Stop()
 			ac.publish(AdamStateCrashed, err)
 			return err
 		}
@@ -378,6 +398,10 @@ func (ac *AdamClient) httpClient() *http.Client {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			RootCAs: pool,
+			// Behind the fault proxy Adam is reached over loopback, an address
+			// its certificate does not name, so verify against the name it is
+			// issued for instead of the one dialed.
+			ServerName: ac.hostname,
 		},
 	}
 	return &http.Client{Transport: tr}
@@ -385,7 +409,7 @@ func (ac *AdamClient) httpClient() *http.Client {
 
 func (ac *AdamClient) adminURL(pathSuffix string) string {
 	return fmt.Sprintf("https://%s:%d/admin/%s",
-		ac.listenIPs[0].String(), ac.adamPort, pathSuffix)
+		ac.adamHostIP(), ac.listenPort, pathSuffix)
 }
 
 func (ac *AdamClient) checkAdamRunning() error {

--- a/evetest/controller/faultproxy.go
+++ b/evetest/controller/faultproxy.go
@@ -1,0 +1,249 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// devAPIPathPrefix is the path prefix of the API the device talks to. A fault
+// rule can only ever match a request below it, so that the admin API - which
+// the test harness itself uses to read what the controller knows - can never be
+// disturbed by an injected fault.
+const devAPIPathPrefix = "/api/v2/edgedevice/"
+
+// FaultAction says what the proxy does with a device request a rule matched.
+type FaultAction int
+
+const (
+	// FaultActionStatus answers the request with a chosen status code without
+	// passing it to the controller.
+	FaultActionStatus FaultAction = iota
+	// FaultActionCloseConn drops the connection without answering at all, which
+	// the device sees as a failure to reach the controller rather than as an
+	// answer from it.
+	FaultActionCloseConn
+	// FaultActionDelay passes the request to the controller, but only after
+	// waiting, to exercise slow answers and request timeouts.
+	FaultActionDelay
+)
+
+// FaultRule describes which device requests to interfere with, and how.
+type FaultRule struct {
+	// Method to match, e.g. "POST". Empty matches any method.
+	Method string
+	// PathSuffix matches the end of the request path, e.g. "/info" or
+	// "/config". Empty matches any path below the device API.
+	PathSuffix string
+	// Action to take on a matching request.
+	Action FaultAction
+	// StatusCode to answer with, for FaultActionStatus.
+	StatusCode int
+	// Delay to wait for, for FaultActionDelay.
+	Delay time.Duration
+	// Count is how many matching requests the rule applies to. Zero means it
+	// applies until cleared.
+	Count int
+
+	// matched counts how many requests the rule has been applied to so far.
+	matched int
+}
+
+// matches tells whether the rule applies to the given request, without
+// accounting for how many times it has already been used.
+func (r *FaultRule) matches(req *http.Request) bool {
+	if r.Method != "" && !strings.EqualFold(r.Method, req.Method) {
+		return false
+	}
+	if !strings.HasPrefix(req.URL.Path, devAPIPathPrefix) {
+		return false
+	}
+	return r.PathSuffix == "" || strings.HasSuffix(req.URL.Path, r.PathSuffix)
+}
+
+// FaultProxy sits between the edge devices and the controller and can be told
+// to answer, delay or drop selected device requests, so that a test can see how
+// EVE reacts to a controller which fails in a particular way. With no rules
+// armed it forwards everything unchanged.
+type FaultProxy struct {
+	log         *logrus.Entry
+	listenIPs   []net.IP
+	listenPort  uint16
+	certFile    string
+	keyFile     string
+	upstream    *url.URL
+	upstreamCAs *x509.CertPool
+	// upstreamName is the name the upstream certificate is verified against.
+	upstreamName string
+
+	lock    sync.Mutex
+	rules   []*FaultRule
+	servers []*http.Server
+}
+
+// NewFaultProxy creates a proxy which terminates TLS for the device-facing
+// endpoint using the controller's own certificate, and forwards to the
+// controller over a verified TLS connection.
+func NewFaultProxy(log *logrus.Entry, listenIPs []net.IP, listenPort uint16,
+	certFile, keyFile string, upstreamAddr string, upstreamName string,
+	upstreamCAs *x509.CertPool) *FaultProxy {
+	return &FaultProxy{
+		log:        log,
+		listenIPs:  listenIPs,
+		listenPort: listenPort,
+		certFile:   certFile,
+		keyFile:    keyFile,
+		upstream: &url.URL{
+			Scheme: "https",
+			Host:   upstreamAddr,
+		},
+		upstreamCAs:  upstreamCAs,
+		upstreamName: upstreamName,
+	}
+}
+
+// Start begins serving on every configured address.
+func (p *FaultProxy) Start() error {
+	cert, err := tls.LoadX509KeyPair(p.certFile, p.keyFile)
+	if err != nil {
+		return fmt.Errorf("fault proxy: failed to load controller cert: %w", err)
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(p.upstream)
+	proxy.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:    p.upstreamCAs,
+			ServerName: p.upstreamName,
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+	// Answers are relayed as they arrive; some of the controller API streams.
+	proxy.FlushInterval = -1
+	proxy.ErrorLog = nil
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if rule := p.takeRule(req); rule != nil {
+			p.applyRule(rule, w, req, proxy)
+			return
+		}
+		proxy.ServeHTTP(w, req)
+	})
+
+	for _, ip := range p.listenIPs {
+		addr := net.JoinHostPort(ip.String(), fmt.Sprint(p.listenPort))
+		listener, err := tls.Listen("tcp", addr, &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+		})
+		if err != nil {
+			p.stopServers()
+			return fmt.Errorf("fault proxy: failed to listen on %s: %w", addr, err)
+		}
+		server := &http.Server{
+			Handler:           handler,
+			ReadHeaderTimeout: 30 * time.Second,
+		}
+		p.lock.Lock()
+		p.servers = append(p.servers, server)
+		p.lock.Unlock()
+		go func(l net.Listener) {
+			if err := server.Serve(l); err != nil &&
+				!errors.Is(err, http.ErrServerClosed) {
+				p.log.Warnf("fault proxy stopped serving: %v", err)
+			}
+		}(listener)
+		p.log.Infof("Fault proxy listening on %s, forwarding to %s",
+			addr, p.upstream.Host)
+	}
+	return nil
+}
+
+// Stop shuts the proxy down.
+func (p *FaultProxy) Stop() {
+	p.stopServers()
+}
+
+func (p *FaultProxy) stopServers() {
+	p.lock.Lock()
+	servers := p.servers
+	p.servers = nil
+	p.lock.Unlock()
+	for _, server := range servers {
+		_ = server.Close()
+	}
+}
+
+// ArmFault adds a rule. Rules are consulted in the order they were added, and
+// the first one still applicable to a request wins.
+func (p *FaultProxy) ArmFault(rule FaultRule) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	copied := rule
+	p.rules = append(p.rules, &copied)
+	p.log.Infof("Armed controller fault: %+v", rule)
+}
+
+// ClearFaults removes every rule, so that the proxy forwards everything again.
+func (p *FaultProxy) ClearFaults() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.rules = nil
+	p.log.Info("Cleared controller faults")
+}
+
+// takeRule returns the rule to apply to the request, counting the use against
+// the rule's own limit.
+func (p *FaultProxy) takeRule(req *http.Request) *FaultRule {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	for _, rule := range p.rules {
+		if rule.Count > 0 && rule.matched >= rule.Count {
+			continue
+		}
+		if rule.matches(req) {
+			rule.matched++
+			return rule
+		}
+	}
+	return nil
+}
+
+func (p *FaultProxy) applyRule(rule *FaultRule, w http.ResponseWriter,
+	req *http.Request, proxy *httputil.ReverseProxy) {
+	switch rule.Action {
+	case FaultActionStatus:
+		p.log.Infof("Fault proxy: answering %s %s with %d",
+			req.Method, req.URL.Path, rule.StatusCode)
+		w.WriteHeader(rule.StatusCode)
+
+	case FaultActionCloseConn:
+		p.log.Infof("Fault proxy: dropping the connection for %s %s",
+			req.Method, req.URL.Path)
+		// Aborts the response and closes the connection, whatever the protocol
+		// version, without the server logging a stack trace for it.
+		panic(http.ErrAbortHandler)
+
+	case FaultActionDelay:
+		p.log.Infof("Fault proxy: delaying %s %s by %v",
+			req.Method, req.URL.Path, rule.Delay)
+		select {
+		case <-time.After(rule.Delay):
+		case <-req.Context().Done():
+			return
+		}
+		proxy.ServeHTTP(w, req)
+	}
+}

--- a/evetest/controller/faultproxy.go
+++ b/evetest/controller/faultproxy.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -132,7 +133,9 @@ func (p *FaultProxy) Start() error {
 	}
 	// Answers are relayed as they arrive; some of the controller API streams.
 	proxy.FlushInterval = -1
-	proxy.ErrorLog = nil
+	// Left unset, the reverse proxy reports its errors through the global
+	// standard logger, which does not reach the harness log.
+	proxy.ErrorLog = log.New(logrusWriter{p.log}, "", 0)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if rule := p.takeRule(req); rule != nil {
@@ -246,4 +249,15 @@ func (p *FaultProxy) applyRule(rule *FaultRule, w http.ResponseWriter,
 		}
 		proxy.ServeHTTP(w, req)
 	}
+}
+
+// logrusWriter adapts a logrus entry to io.Writer, for packages which report
+// errors through a *log.Logger.
+type logrusWriter struct {
+	entry *logrus.Entry
+}
+
+func (w logrusWriter) Write(msg []byte) (int, error) {
+	w.entry.Warn(strings.TrimRight(string(msg), "\n"))
+	return len(msg), nil
 }

--- a/evetest/controllerfaults.go
+++ b/evetest/controllerfaults.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package evetest
+
+import (
+	"time"
+
+	"github.com/lf-edge/eve/evetest/controller"
+)
+
+// ControllerFault describes which of the requests a device sends to the
+// controller should fail, and how. See ArmControllerFault.
+type ControllerFault = controller.FaultRule
+
+// Ways in which the controller can be made to fail a device request.
+const (
+	// FaultAnswerStatus answers the request with ControllerFault.StatusCode
+	// instead of passing it to the controller.
+	FaultAnswerStatus = controller.FaultActionStatus
+	// FaultCloseConn drops the connection without answering, which the device
+	// sees as a failure to reach the controller rather than as an answer.
+	FaultCloseConn = controller.FaultActionCloseConn
+	// FaultDelay passes the request on after ControllerFault.Delay, to exercise
+	// slow answers and timeouts.
+	FaultDelay = controller.FaultActionDelay
+)
+
+// controllerFaultsEnabled records the request to run the controller behind a
+// fault injecting proxy. It is read while the harness starts the controller,
+// hence it has to be set before the first Init call.
+var controllerFaultsEnabled bool
+
+// EnableControllerFaults puts the controller behind a proxy which can be told to
+// fail selected device requests, and must be called before Init - the controller
+// is started while the harness comes up.
+//
+// Only the requests devices make are affected. The harness keeps reading what
+// the controller knows over a separate connection, so watching info or metrics
+// is never disturbed by an injected fault.
+//
+// A test suite enables it once and then arms individual faults where needed:
+//
+//	func TestSomeSuite(test *testing.T) {
+//		evetest.EnableControllerFaults()
+//		evetest.Init(test)
+//		defer evetest.Close()
+//		...
+//	}
+func EnableControllerFaults() {
+	controllerFaultsEnabled = true
+}
+
+// ArmControllerFault makes the controller fail the device requests matching the
+// given description, until the fault is used up (ControllerFault.Count) or
+// cleared with ClearControllerFaults. Several faults can be armed at once; the
+// first one matching a request applies.
+//
+// Requires EnableControllerFaults to have been called before Init.
+//
+// For example, to make every info message fail with 503 while leaving the
+// device config alone:
+//
+//	evetest.ArmControllerFault(evetest.ControllerFault{
+//		Method:     "POST",
+//		PathSuffix: "/info",
+//		Action:     evetest.FaultAnswerStatus,
+//		StatusCode: http.StatusServiceUnavailable,
+//	})
+func ArmControllerFault(fault ControllerFault) {
+	th := getTestHarness()
+	proxy := th.adamClient.FaultProxy()
+	if proxy == nil {
+		th.t.Fatalf("ArmControllerFault requires EnableControllerFaults " +
+			"to be called before Init")
+	}
+	proxy.ArmFault(fault)
+}
+
+// ClearControllerFaults removes every armed fault, so that the controller
+// answers device requests normally again.
+func ClearControllerFaults() {
+	th := getTestHarness()
+	proxy := th.adamClient.FaultProxy()
+	if proxy == nil {
+		th.t.Fatalf("ClearControllerFaults requires EnableControllerFaults " +
+			"to be called before Init")
+	}
+	proxy.ClearFaults()
+}
+
+// WithControllerFault arms a fault, runs the given function, and clears the
+// fault afterwards even if the function fails the test.
+func WithControllerFault(fault ControllerFault, run func()) {
+	ArmControllerFault(fault)
+	defer ClearControllerFaults()
+	run()
+}
+
+// FaultForDuration is a convenience for a fault which stays armed for a window
+// of time rather than for a number of requests.
+func FaultForDuration(fault ControllerFault, window time.Duration, run func()) {
+	ArmControllerFault(fault)
+	timer := time.AfterFunc(window, ClearControllerFaults)
+	defer timer.Stop()
+	defer ClearControllerFaults()
+	run()
+}

--- a/evetest/controllerfaults.go
+++ b/evetest/controllerfaults.go
@@ -6,7 +6,9 @@ package evetest
 import (
 	"time"
 
+	"github.com/lf-edge/eve/evetest/constants"
 	"github.com/lf-edge/eve/evetest/controller"
+	"github.com/spf13/viper"
 )
 
 // ControllerFault describes which of the requests a device sends to the
@@ -26,29 +28,11 @@ const (
 	FaultDelay = controller.FaultActionDelay
 )
 
-// controllerFaultsEnabled records the request to run the controller behind a
-// fault injecting proxy. It is read while the harness starts the controller,
-// hence it has to be set before the first Init call.
-var controllerFaultsEnabled bool
-
-// EnableControllerFaults puts the controller behind a proxy which can be told to
-// fail selected device requests, and must be called before Init - the controller
-// is started while the harness comes up.
-//
-// Only the requests devices make are affected. The harness keeps reading what
-// the controller knows over a separate connection, so watching info or metrics
-// is never disturbed by an injected fault.
-//
-// A test suite enables it once and then arms individual faults where needed:
-//
-//	func TestSomeSuite(test *testing.T) {
-//		evetest.EnableControllerFaults()
-//		evetest.Init(test)
-//		defer evetest.Close()
-//		...
-//	}
-func EnableControllerFaults() {
-	controllerFaultsEnabled = true
+// ControllerFaultsEnabled reports whether the controller runs behind the fault
+// injecting proxy, which EVETEST_CONTROLLER_FAULTS asks for. It is off by
+// default, so a test which arms faults has to skip when it returns false.
+func ControllerFaultsEnabled() bool {
+	return viper.GetBool(constants.ControllerFaultsEnv)
 }
 
 // ArmControllerFault makes the controller fail the device requests matching the
@@ -56,7 +40,9 @@ func EnableControllerFaults() {
 // cleared with ClearControllerFaults. Several faults can be armed at once; the
 // first one matching a request applies.
 //
-// Requires EnableControllerFaults to have been called before Init.
+// Requires EVETEST_CONTROLLER_FAULTS - see ControllerFaultsEnabled. Only the
+// requests devices make can be failed: the harness reaches the controller
+// directly, so watching info or metrics is never disturbed by an injected fault.
 //
 // For example, to make every info message fail with 503 while leaving the
 // device config alone:
@@ -71,8 +57,8 @@ func ArmControllerFault(fault ControllerFault) {
 	th := getTestHarness()
 	proxy := th.adamClient.FaultProxy()
 	if proxy == nil {
-		th.t.Fatalf("ArmControllerFault requires EnableControllerFaults " +
-			"to be called before Init")
+		th.t.Fatalf("ArmControllerFault requires %s%s=true",
+			constants.EnvPrefix, constants.ControllerFaultsEnv)
 	}
 	proxy.ArmFault(fault)
 }
@@ -83,8 +69,8 @@ func ClearControllerFaults() {
 	th := getTestHarness()
 	proxy := th.adamClient.FaultProxy()
 	if proxy == nil {
-		th.t.Fatalf("ClearControllerFaults requires EnableControllerFaults " +
-			"to be called before Init")
+		th.t.Fatalf("ClearControllerFaults requires %s%s=true",
+			constants.EnvPrefix, constants.ControllerFaultsEnv)
 	}
 	proxy.ClearFaults()
 }

--- a/evetest/harness.go
+++ b/evetest/harness.go
@@ -669,6 +669,9 @@ func Init(t *testing.T) *T {
 	th.adamClient = controller.NewAdamClient(
 		adamLog, th.artifactDir, GetControllerHostname(),
 		adamIPs, GetControllerPort(), th.caCert, th.caKey, th.adamStatusCh)
+	if controllerFaultsEnabled {
+		th.adamClient.EnableFaultInjection()
+	}
 	err = th.adamClient.Start()
 	if err != nil {
 		th.t.Fatalf("Failed to start Adam controller: %v", err)

--- a/evetest/harness.go
+++ b/evetest/harness.go
@@ -669,7 +669,7 @@ func Init(t *testing.T) *T {
 	th.adamClient = controller.NewAdamClient(
 		adamLog, th.artifactDir, GetControllerHostname(),
 		adamIPs, GetControllerPort(), th.caCert, th.caKey, th.adamStatusCh)
-	if controllerFaultsEnabled {
+	if ControllerFaultsEnabled() {
 		th.adamClient.EnableFaultInjection()
 	}
 	err = th.adamClient.Start()

--- a/evetest/tests/controllerfaults/deferredinfo_test.go
+++ b/evetest/tests/controllerfaults/deferredinfo_test.go
@@ -69,11 +69,12 @@ const convergeTimeout = 8 * time.Minute
 // -----------
 //   - HYPERVISOR (defaults to KVM).
 func TestInfoRetriedAfterServerError(test *testing.T) {
-	// Also needed when this test runs on its own rather than through the suite;
-	// it has no effect once the controller is already up.
-	evetest.EnableControllerFaults()
 	evetestT := evetest.Init(test)
 	defer evetest.Close()
+	if !evetest.ControllerFaultsEnabled() {
+		test.Skip("controller fault injection is off; " +
+			"set EVETEST_CONTROLLER_FAULTS=true to run this test")
+	}
 	t := NewGomegaWithT(evetestT)
 
 	// Define configurable parameters available for the test.
@@ -172,11 +173,12 @@ func TestInfoRetriedAfterServerError(test *testing.T) {
 // -----------
 //   - HYPERVISOR (defaults to KVM).
 func TestInfoRetriedAfterLostController(test *testing.T) {
-	// Also needed when this test runs on its own rather than through the suite;
-	// it has no effect once the controller is already up.
-	evetest.EnableControllerFaults()
 	evetestT := evetest.Init(test)
 	defer evetest.Close()
+	if !evetest.ControllerFaultsEnabled() {
+		test.Skip("controller fault injection is off; " +
+			"set EVETEST_CONTROLLER_FAULTS=true to run this test")
+	}
 	t := NewGomegaWithT(evetestT)
 
 	// Define configurable parameters available for the test.
@@ -283,11 +285,12 @@ func TestInfoRetriedAfterLostController(test *testing.T) {
 // -----------
 //   - HYPERVISOR (defaults to KVM).
 func TestInfoDroppedOnRejectionKeepsDeviceReporting(test *testing.T) {
-	// Also needed when this test runs on its own rather than through the suite;
-	// it has no effect once the controller is already up.
-	evetest.EnableControllerFaults()
 	evetestT := evetest.Init(test)
 	defer evetest.Close()
+	if !evetest.ControllerFaultsEnabled() {
+		test.Skip("controller fault injection is off; " +
+			"set EVETEST_CONTROLLER_FAULTS=true to run this test")
+	}
 	t := NewGomegaWithT(evetestT)
 
 	// Define configurable parameters available for the test.

--- a/evetest/tests/controllerfaults/deferredinfo_test.go
+++ b/evetest/tests/controllerfaults/deferredinfo_test.go
@@ -1,0 +1,379 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// What EVE does with a state report the controller does not accept.
+
+package controllerfaults_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	eveinfo "github.com/lf-edge/eve-api/go/info"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/matchers"
+	"github.com/lf-edge/eve/evetest/netmodels"
+	pillartypes "github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// How long the controller keeps failing info messages, which has to cover the
+// application state transition the tests make during it.
+const faultWindow = 2 * time.Minute
+
+// How long to wait for the controller to catch up once it accepts info messages
+// again. The device holds a refused message back for a delay which doubles with
+// every refusal, so by the end of faultWindow the next attempt can be a few
+// minutes out, and nothing prompts the device to try sooner.
+const convergeTimeout = 8 * time.Minute
+
+// TestInfoRetriedAfterServerError verifies that a state change which happens
+// while the controller answers info messages with 503 still reaches the
+// controller once it stops doing so.
+//
+// This is the end-to-end form of lf-edge/eve#6302: application state is
+// reported only when it changes, and nothing re-asserts it later, so a report
+// discarded because of a temporary server error leaves the controller's view of
+// the application wrong for as long as the application stays in that state -
+// for a steady-state application, indefinitely.
+//
+// Network model
+// -------------
+//   - netmodels.SingleEthWithDHCP -- the fault is injected at the controller,
+//     not in the network, so a single management port is all this needs.
+//
+// Device configuration
+// --------------------
+//   - ethernet0 (mgmt+apps, DHCP), one local network instance, one container
+//     application, activated.
+//
+// Phases
+// ------
+//  1. Deploy the application and wait until the controller reports it RUNNING,
+//     which establishes that info messages flow.
+//  2. Arm a fault answering every info request with 503, and confirm the
+//     controller stops learning anything: no info message arrives while it is
+//     armed.
+//  3. With the fault still armed, deactivate the application. EVE notices the
+//     transition and reports it; every attempt is refused.
+//  4. Clear the fault. The controller must converge on the state the
+//     application actually has, without anything else prompting the device.
+//
+// Before the fix the message is discarded on the first 503 and phase 4 times
+// out with the controller still reporting RUNNING.
+//
+// Test params
+// -----------
+//   - HYPERVISOR (defaults to KVM).
+func TestInfoRetriedAfterServerError(test *testing.T) {
+	// Also needed when this test runs on its own rather than through the suite;
+	// it has no effect once the controller is already up.
+	evetest.EnableControllerFaults()
+	evetestT := evetest.Init(test)
+	defer evetest.Close()
+	t := NewGomegaWithT(evetestT)
+
+	// Define configurable parameters available for the test.
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+	)
+
+	hypervisor := evetest.GetHypervisorParameterValue()
+	evetest.Setup(
+		evetest.RequireEdgeDevice{
+			Name:              devName,
+			WithHypervisor:    hypervisor,
+			DeviceReusePolicy: evetest.ResetDeviceConfig,
+		},
+		evetest.RequireNetworkModel{NetworkModel: netmodels.SingleEthWithDHCP},
+	)
+	device := evetest.GetEdgeDevice(devName)
+	log := evetest.Logger()
+	evetest.Checkpoint("setup-done")
+
+	// Phase 1: the application runs and the controller knows it.
+	devConfig, appUUID := appDeviceConfig()
+	appUpdates, stopAppWatch := device.WatchAppInfo(appUUID)
+	defer stopAppWatch()
+	device.ApplyConfig(devConfig, true, true)
+	device.WaitUntilAppIsRunning(appUUID, 5*time.Minute)
+	evetest.Checkpoint("app-running")
+
+	// Phase 2: the controller refuses every info message from now on.
+	evetest.ArmControllerFault(evetest.ControllerFault{
+		Method:     http.MethodPost,
+		PathSuffix: infoPath,
+		Action:     evetest.FaultAnswerStatus,
+		StatusCode: http.StatusServiceUnavailable,
+	})
+	defer evetest.ClearControllerFaults()
+	log.Info("Controller now answers 503 to every info message")
+
+	// Drain what was already in flight, then confirm nothing new arrives.
+	drainAppUpdates(appUpdates)
+	t.Consistently(appUpdates, 45*time.Second, 5*time.Second).
+		ShouldNot(Receive(), "controller kept receiving info despite the 503s")
+	evetest.Checkpoint("info-refused")
+
+	// Phase 3: change the application state while reports cannot get through.
+	// The config request itself is not affected, so the device applies it and
+	// starts tearing the application down.
+	device.DeactivateApplication(appUUID, false, 0)
+	log.Info("Application deactivated while info messages are refused")
+
+	// The transition has to complete while the fault is still armed, otherwise
+	// the report of it is produced after the controller is answering normally
+	// again and the test would pass whether or not a refused report survives.
+	// How far the device has got cannot be observed from here - that is exactly
+	// what the fault is blocking - so allow generously more than an application
+	// takes to stop, and keep requiring that nothing reaches the controller.
+	t.Consistently(appUpdates, faultWindow, 10*time.Second).
+		ShouldNot(Receive(), "a refused info message was delivered anyway")
+	evetest.Checkpoint("app-deactivated-during-fault")
+
+	// Phase 4: with the controller accepting info again, its view has to catch
+	// up on its own.
+	evetest.ClearControllerFaults()
+	log.Info("Controller accepts info messages again")
+	t.Eventually(appUpdates, convergeTimeout).Should(Receive(
+		matchers.SatisfyPredicate("Application is reported HALTED",
+			isAppState(eveinfo.ZSwState_HALTED)).StopIf(appHasError)))
+	evetest.Checkpoint("controller-converged")
+}
+
+// TestInfoRetriedAfterLostController verifies the same convergence when the
+// controller cannot be reached at all, rather than answering with an error.
+//
+// The two are handled differently by EVE: an answer from the controller is a
+// verdict on that one message, while a failure to reach the controller says
+// nothing about it and stops the queue until connectivity returns. Both must
+// end with the controller knowing the current state.
+//
+// Network model
+// -------------
+//   - netmodels.SingleEthWithDHCP -- the connection is dropped at the
+//     controller, so no network impairment is needed.
+//
+// Device configuration
+// --------------------
+//   - As in TestInfoRetriedAfterServerError.
+//
+// Phases
+// ------
+//  1. Deploy the application and wait until it is reported RUNNING.
+//  2. Arm a fault dropping the connection for every info request.
+//  3. Deactivate the application while its reports cannot be delivered.
+//  4. Clear the fault; the controller must converge on the actual state.
+//
+// Test params
+// -----------
+//   - HYPERVISOR (defaults to KVM).
+func TestInfoRetriedAfterLostController(test *testing.T) {
+	// Also needed when this test runs on its own rather than through the suite;
+	// it has no effect once the controller is already up.
+	evetest.EnableControllerFaults()
+	evetestT := evetest.Init(test)
+	defer evetest.Close()
+	t := NewGomegaWithT(evetestT)
+
+	// Define configurable parameters available for the test.
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+	)
+
+	hypervisor := evetest.GetHypervisorParameterValue()
+	evetest.Setup(
+		evetest.RequireEdgeDevice{
+			Name:              devName,
+			WithHypervisor:    hypervisor,
+			DeviceReusePolicy: evetest.ResetDeviceConfig,
+		},
+		evetest.RequireNetworkModel{NetworkModel: netmodels.SingleEthWithDHCP},
+	)
+	device := evetest.GetEdgeDevice(devName)
+	log := evetest.Logger()
+	evetest.Checkpoint("setup-done")
+
+	devConfig, appUUID := appDeviceConfig()
+	appUpdates, stopAppWatch := device.WatchAppInfo(appUUID)
+	defer stopAppWatch()
+	device.ApplyConfig(devConfig, true, true)
+	device.WaitUntilAppIsRunning(appUUID, 5*time.Minute)
+	evetest.Checkpoint("app-running")
+
+	evetest.ArmControllerFault(evetest.ControllerFault{
+		Method:     http.MethodPost,
+		PathSuffix: infoPath,
+		Action:     evetest.FaultCloseConn,
+	})
+	defer evetest.ClearControllerFaults()
+	log.Info("Controller now drops the connection for every info message")
+
+	drainAppUpdates(appUpdates)
+	t.Consistently(appUpdates, 45*time.Second, 5*time.Second).
+		ShouldNot(Receive(), "controller kept receiving info despite the drops")
+	evetest.Checkpoint("info-undeliverable")
+
+	device.DeactivateApplication(appUUID, false, 0)
+	log.Info("Application deactivated while info messages cannot be delivered")
+
+	// As in TestInfoRetriedAfterServerError, the transition has to happen while
+	// the fault is still armed for the test to mean anything.
+	t.Consistently(appUpdates, faultWindow, 10*time.Second).
+		ShouldNot(Receive(), "an undeliverable info message arrived anyway")
+	evetest.Checkpoint("app-deactivated-during-fault")
+
+	evetest.ClearControllerFaults()
+	log.Info("Controller reachable again")
+	t.Eventually(appUpdates, convergeTimeout).Should(Receive(
+		matchers.SatisfyPredicate("Application is reported HALTED",
+			isAppState(eveinfo.ZSwState_HALTED)).StopIf(appHasError)))
+	evetest.Checkpoint("controller-converged")
+}
+
+// TestInfoDroppedOnRejectionKeepsDeviceReporting verifies that a message the
+// controller rejects outright is given up on - which is intended, since
+// retrying bytes the controller has refused would achieve nothing - and that
+// doing so leaves the device reporting normally afterwards.
+//
+// This is the counterpart to the two tests above: the fix must distinguish a
+// controller which cannot accept a message right now from one which will never
+// accept it, and a message dropped for the latter reason must not take the
+// reporting of everything else down with it.
+//
+// Network model
+// -------------
+//   - netmodels.SingleEthWithDHCP.
+//
+// Device configuration
+// --------------------
+//   - As in TestInfoRetriedAfterServerError.
+//
+// Whether the application has finished stopping cannot be observed while its
+// reports are being rejected, and how long it takes varies by minutes, so this
+// test deliberately does not depend on it. It uses the device information
+// instead: that is the one report EVE re-sends on a timer even when nothing
+// changed (zedagent's configTimerTask), so its arrival after the rejections is
+// a reliable signal that the queue is still delivering. The interval is lowered
+// to the allowed minimum to keep the wait short.
+//
+// Network model
+// -------------
+//   - netmodels.SingleEthWithDHCP.
+//
+// Device configuration
+// --------------------
+//   - As in TestInfoRetriedAfterServerError, plus timer.deviceinfo.interval
+//     lowered to 30s.
+//
+// Phases
+// ------
+//  1. Deploy the application and wait until it is reported RUNNING.
+//  2. Arm a fault rejecting every info request with 404, the answer a controller
+//     gives for an object it no longer knows about.
+//  3. Deactivate the application. The reports of the transition are rejected and
+//     dropped, and nothing about the application reaches the controller.
+//  4. Clear the fault. Device information has to start arriving again, which is
+//     what proves the drops did not leave the queue unable to deliver.
+//
+// Test params
+// -----------
+//   - HYPERVISOR (defaults to KVM).
+func TestInfoDroppedOnRejectionKeepsDeviceReporting(test *testing.T) {
+	// Also needed when this test runs on its own rather than through the suite;
+	// it has no effect once the controller is already up.
+	evetest.EnableControllerFaults()
+	evetestT := evetest.Init(test)
+	defer evetest.Close()
+	t := NewGomegaWithT(evetestT)
+
+	// Define configurable parameters available for the test.
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+	)
+
+	hypervisor := evetest.GetHypervisorParameterValue()
+	evetest.Setup(
+		evetest.RequireEdgeDevice{
+			Name:              devName,
+			WithHypervisor:    hypervisor,
+			DeviceReusePolicy: evetest.ResetDeviceConfig,
+		},
+		evetest.RequireNetworkModel{NetworkModel: netmodels.SingleEthWithDHCP},
+	)
+	device := evetest.GetEdgeDevice(devName)
+	log := evetest.Logger()
+	evetest.Checkpoint("setup-done")
+
+	devConfig, appUUID := appDeviceConfig()
+	// EVE re-sends the device information on this timer even when nothing about
+	// the device changed, which is what phase 4 waits for.
+	cfgProps := pillartypes.NewConfigItemValueMap()
+	cfgProps.SetGlobalValueInt(pillartypes.DevInfoInterval, 30)
+	devConfig.SetConfigProperties(cfgProps)
+
+	appUpdates, stopAppWatch := device.WatchAppInfo(appUUID)
+	defer stopAppWatch()
+	deviceUpdates, stopDeviceWatch := device.WatchDeviceInfo()
+	defer stopDeviceWatch()
+	device.ApplyConfig(devConfig, true, true)
+	device.WaitUntilAppIsRunning(appUUID, 5*time.Minute)
+	evetest.Checkpoint("app-running")
+
+	evetest.ArmControllerFault(evetest.ControllerFault{
+		Method:     http.MethodPost,
+		PathSuffix: infoPath,
+		Action:     evetest.FaultAnswerStatus,
+		StatusCode: http.StatusNotFound,
+	})
+	defer evetest.ClearControllerFaults()
+	log.Info("Controller now rejects every info message with 404")
+
+	drainAppUpdates(appUpdates)
+	device.DeactivateApplication(appUUID, false, 0)
+	log.Info("Application deactivated while info messages are rejected")
+
+	// Nothing about the application reaches the controller: the reports of the
+	// transition are rejected, and a rejected report is not offered again.
+	t.Consistently(appUpdates, faultWindow, 10*time.Second).
+		ShouldNot(Receive(), "a rejected info message was delivered anyway")
+	evetest.Checkpoint("info-rejected-during-fault")
+
+	// The device information which the rejections dropped along the way has to
+	// start arriving again. Nothing prompts it other than its own timer, so this
+	// is the queue proving it still works after giving up on messages.
+	evetest.ClearControllerFaults()
+	log.Info("Controller accepts info messages again")
+	drainDeviceUpdates(deviceUpdates)
+	t.Eventually(deviceUpdates, convergeTimeout).Should(Receive(),
+		"device stopped reporting after its messages were rejected")
+	evetest.Checkpoint("reporting-recovered")
+}
+
+// drainDeviceUpdates empties the device information channel, so that a later
+// wait is satisfied by a message published after that point rather than before.
+func drainDeviceUpdates(updates <-chan *eveinfo.ZInfoDevice) {
+	for {
+		select {
+		case <-updates:
+		case <-time.After(2 * time.Second):
+			return
+		}
+	}
+}
+
+// drainAppUpdates empties the watch channel of messages published before a
+// fault was armed, so that a later assertion about what does or does not arrive
+// is not satisfied by a stale message.
+func drainAppUpdates(updates <-chan *eveinfo.ZInfoApp) {
+	for {
+		select {
+		case <-updates:
+		case <-time.After(2 * time.Second):
+			return
+		}
+	}
+}

--- a/evetest/tests/controllerfaults/helpers_test.go
+++ b/evetest/tests/controllerfaults/helpers_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerfaults_test
+
+import (
+	"github.com/lf-edge/eve-api/go/evecommon"
+	eveinfo "github.com/lf-edge/eve-api/go/info"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+)
+
+const (
+	// Logical name of the (single) edge device used by every test in this package.
+	devName = "edge-dev"
+
+	// The single management port configured by every test in this package.
+	portLogicalLabel = "ethernet0"
+	portIfName       = "eth0"
+
+	// Path of the info endpoint, i.e. the request through which EVE reports the
+	// state of the device and of everything on it. All info types share it, so a
+	// fault armed on this path affects every kind of info message.
+	infoPath = "/info"
+)
+
+// appDeviceConfig builds the configuration shared by the tests in this package:
+// one DHCP management+apps port, one local network instance, and one container
+// application on it whose state the tests then change.
+func appDeviceConfig() (*evetest.EdgeDeviceConfig, uuid.UUID) {
+	devConfig := evetest.NewEdgeDeviceConfig(devName)
+	dhcpNet := devConfig.AddNetwork(evetest.DHCPNetworkConfig{
+		NetworkType: evecommon.NetworkType_V4Only,
+	})
+	devConfig.AddNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  portLogicalLabel,
+		PhysicalLabel: portIfName,
+		InterfaceName: portIfName,
+		NetworkUUID:   dhcpNet,
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+	})
+	niUUID := devConfig.AddNetworkInstance(evetest.LocalNetworkInstanceConfig{
+		DisplayName: "local-ni",
+		Port:        portLogicalLabel,
+		Subnet:      evetest.IPSubnet("10.11.12.0/24"),
+		DHCPRange: types.IPRange{
+			Start: evetest.IPAddress("10.11.12.2"),
+			End:   evetest.IPAddress("10.11.12.254"),
+		},
+		Gateway: evetest.IPAddress("10.11.12.1"),
+		MTU:     1500,
+	})
+	appUUID := devConfig.AddApplication(evetest.ApplicationInstanceConfig{
+		DisplayName: "reported-app",
+		Activate:    true,
+		Image: evetest.DockerContainer{
+			ImageName: "lfedge/evetest-ubuntu-ctr",
+			Tag:       "1.0",
+		},
+		CPUs:        1,
+		MemoryBytes: 500 * evetest.MiB,
+		NetworkAdapters: []evetest.AppNetworkAdapter{
+			evetest.VirtualNetworkAdapter{
+				LogicalLabel:        "vif0",
+				NetworkInstanceUUID: niUUID,
+				ACLAllowRules: []evetest.ACLAllowRule{
+					{
+						Protocol:     evetest.NetworkProtocolAny,
+						RemoteSubnet: evetest.IPSubnet("0.0.0.0/0"),
+					},
+				},
+			},
+		},
+	})
+	return devConfig, appUUID
+}
+
+// appHasError reports an application which failed, so that a wait for some
+// expected state gives up instead of running to its timeout.
+func appHasError(info *eveinfo.ZInfoApp) (string, bool) {
+	if info.GetState() == eveinfo.ZSwState_ERROR {
+		return "Application instance is in error state", true
+	}
+	return "", false
+}
+
+// isAppState returns a predicate matching an app info message reporting the
+// given state.
+func isAppState(state eveinfo.ZSwState) func(*eveinfo.ZInfoApp) bool {
+	return func(info *eveinfo.ZInfoApp) bool {
+		return info.GetState() == state
+	}
+}

--- a/evetest/tests/controllerfaults/testsuite_test.go
+++ b/evetest/tests/controllerfaults/testsuite_test.go
@@ -14,6 +14,9 @@ import (
 // behind a proxy which the subtests tell to answer, reject or drop selected
 // device requests; every subtest arms its own faults and clears them again.
 //
+// Requires EVETEST_CONTROLLER_FAULTS=true. Without it the devices reach the
+// controller directly and these tests skip.
+//
 // The subtests share one device and one network model so that the framework
 // reuses a single VM across the suite, and all of them hardcode the hypervisor
 // parameter's default, as the other non-application suites do.
@@ -28,12 +31,12 @@ import (
 //     controller rejects outright is given up on, and later changes are still
 //     reported.
 func TestControllerFaultsSuite(test *testing.T) {
-	// The controller is started while the harness comes up, so it has to be
-	// told to run behind the fault injecting proxy before Init.
-	evetest.EnableControllerFaults()
-
 	evetest.Init(test)
 	defer evetest.Close()
+	if !evetest.ControllerFaultsEnabled() {
+		test.Skip("controller fault injection is off; " +
+			"set EVETEST_CONTROLLER_FAULTS=true to run this test")
+	}
 
 	evetest.DefineTestParameters(
 		evetest.HypervisorParameter(),

--- a/evetest/tests/controllerfaults/testsuite_test.go
+++ b/evetest/tests/controllerfaults/testsuite_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerfaults_test
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve/evetest"
+)
+
+// TestControllerFaultsSuite covers how EVE behaves when the controller fails
+// the requests through which a device reports itself. The controller runs
+// behind a proxy which the subtests tell to answer, reject or drop selected
+// device requests; every subtest arms its own faults and clears them again.
+//
+// The subtests share one device and one network model so that the framework
+// reuses a single VM across the suite, and all of them hardcode the hypervisor
+// parameter's default, as the other non-application suites do.
+//
+// Subtests
+// --------
+//   - TestInfoRetriedAfterServerError -- a state change reported while the
+//     controller answers 503 still reaches it afterwards.
+//   - TestInfoRetriedAfterLostController -- the same when the controller cannot
+//     be reached at all.
+//   - TestInfoDroppedOnRejectionKeepsDeviceReporting -- a message the
+//     controller rejects outright is given up on, and later changes are still
+//     reported.
+func TestControllerFaultsSuite(test *testing.T) {
+	// The controller is started while the harness comes up, so it has to be
+	// told to run behind the fault injecting proxy before Init.
+	evetest.EnableControllerFaults()
+
+	evetest.Init(test)
+	defer evetest.Close()
+
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+	)
+
+	evetest.RunTestSuite(
+		evetest.TestCase{
+			Test: TestInfoRetriedAfterServerError,
+		},
+		evetest.TestCase{
+			Test: TestInfoRetriedAfterLostController,
+		},
+		evetest.TestCase{
+			Test: TestInfoDroppedOnRejectionKeepsDeviceReporting,
+		},
+	)
+}

--- a/pkg/pillar/cmd/zedagent/handlecertconfig.go
+++ b/pkg/pillar/cmd/zedagent/handlecertconfig.go
@@ -603,13 +603,13 @@ func sendAttestReqProtobuf(
 	// We queue the message and then get the highest priority message to send.
 	// If there are no failures and defers we'll send this message,
 	// but if there is a queue we'll retry sending the highest priority message.
-	// Since attest messages can fail if there is a certificate mismatch
-	// we set IgnoreErr to allow other messages to be sent as well.
+	// An attest message that fails, e.g. on a certificate mismatch, is not worth
+	// keeping queued: the sentHandler callback re-triggers the request instead.
 	ctx.deferredEventQueue.SetDeferred(deferKey, buf, attestURL,
 		attestReq.ReqType, controllerconn.DeferredItemOpts{
-			BailOnHTTPErr:  false,
-			WithNetTracing: false,
-			IgnoreErr:      true,
+			BailOnHTTPErr:    false,
+			WithNetTracing:   false,
+			DiscardOnFailure: true,
 		})
 }
 

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -1487,8 +1487,6 @@ func PublishEdgeviewToZedCloud(ctx *zedagentContext,
 
 	log.Functionf("PublishEdgeviewToZedCloud")
 	var ReportInfo = &info.ZInfoMsg{}
-	bailOnHTTPErr := true
-	forcePeriodic := false
 
 	evType := new(info.ZInfoTypes)
 	*evType = info.ZInfoTypes_ZiEdgeview
@@ -1503,15 +1501,6 @@ func PublishEdgeviewToZedCloud(ctx *zedagentContext,
 		ReportEvInfo.CountDev = evStatus.CmdCountDev
 		ReportEvInfo.CountApp = evStatus.CmdCountApp
 		ReportEvInfo.CountExt = evStatus.CmdCountExt
-
-		// The first update is important, and that informs zedcloud the edgeivew is 'Active'.
-		// Edgeview publish the status when it first connects to dispatcher, which the counters
-		// are zeros. Notice that the edgeview container can start/stop at any time, and the
-		// counters will be cleared after every start.
-		if evStatus.CmdCountDev == 0 && evStatus.CmdCountApp == 0 && evStatus.CmdCountExt == 0 {
-			bailOnHTTPErr = false
-			forcePeriodic = true
-		}
 	}
 
 	ReportInfo.InfoContent = new(info.ZInfoMsg_Evinfo)
@@ -1534,7 +1523,7 @@ func PublishEdgeviewToZedCloud(ctx *zedagentContext,
 	//We queue the message and then get the highest priority message to send.
 	//If there are no failures and defers we'll send this message,
 	//but if there is a queue we'll retry sending the highest priority message.
-	queueInfoToDest(ctx, dest, "global", buf, bailOnHTTPErr, false, forcePeriodic,
+	queueInfoToDest(ctx, dest, "global", buf, true, false, false,
 		info.ZInfoTypes_ZiEdgeview)
 }
 

--- a/pkg/pillar/cmd/zedagent/zedagent.go
+++ b/pkg/pillar/cmd/zedagent/zedagent.go
@@ -309,8 +309,13 @@ const (
 // destination. Once deferred item has been added the queue is kicked
 // to start processing requests immediately from a separate task.
 //
-// @forcePeriodic forces all deferred requests to be added
-// to the deferred queue and errors will be ignored.
+// @bailOnHTTPErr stops the send from trying the remaining ports once the
+// controller has answered with a 4xx or 5xx status; it does not affect whether
+// a refused message is retried later.
+//
+// @forcePeriodic puts the request on the best-effort periodic queue, where a
+// message is discarded rather than retried if the send fails, on the grounds
+// that the next period supersedes it.
 func queueInfoToDest(ctx *zedagentContext, dest destinationBitset,
 	key string, buf *bytes.Buffer, bailOnHTTPErr,
 	withNetTracing, forcePeriodic bool, itemType interface{}) {
@@ -326,18 +331,19 @@ func queueInfoToDest(ctx *zedagentContext, dest destinationBitset,
 	if dest&ControllerDest != 0 {
 		url := controllerconn.URLPathString(serverNameAndPort,
 			devUUID, "info")
-		// Ignore all errors in case of periodic
-		ignoreErr := forcePeriodic
+		// A periodic message is superseded by the next period, so nothing is
+		// gained from retrying this one.
+		discardOnFailure := forcePeriodic
 		deferredQueue := ctx.deferredEventQueue
 		if forcePeriodic {
 			deferredQueue = ctx.deferredPeriodicQueue
 		}
 		deferredQueue.SetDeferred(key, buf, url, itemType,
 			controllerconn.DeferredItemOpts{
-				BailOnHTTPErr:  bailOnHTTPErr,
-				WithNetTracing: withNetTracing,
-				IgnoreErr:      ignoreErr,
-				SuppressLogs:   ctx.airgapMode,
+				BailOnHTTPErr:    bailOnHTTPErr,
+				WithNetTracing:   withNetTracing,
+				DiscardOnFailure: discardOnFailure,
+				SuppressLogs:     ctx.airgapMode,
 			})
 	}
 	if dest&LOCDest != 0 && locURL != "" {
@@ -348,7 +354,7 @@ func queueInfoToDest(ctx *zedagentContext, dest destinationBitset,
 				BailOnHTTPErr:  bailOnHTTPErr,
 				WithNetTracing: withNetTracing,
 				// Ignore errors for all the LOC info messages
-				IgnoreErr: true,
+				DiscardOnFailure: true,
 			})
 	}
 }
@@ -2994,9 +3000,9 @@ func getDeferredSentHandlerFunction(ctx *zedagentContext) controllerconn.SentHan
 				}
 				if !ctx.publishedEdgeNodeCerts {
 					// Attestation request does not clog the send queue (issued
-					// with the `ignoreErr` set to true), but once fails has to
-					// be repeated in reasonable time to avoid tight fail-repeat
-					// loop.
+					// with the `DiscardOnFailure` set to true), but once fails
+					// has to be repeated in reasonable time to avoid tight
+					// fail-repeat loop.
 					triggerEdgeNodeCertDelayedEvent(ctx, 10*time.Second)
 				}
 			}

--- a/pkg/pillar/controllerconn/deferred.go
+++ b/pkg/pillar/controllerconn/deferred.go
@@ -7,6 +7,8 @@ package controllerconn
 
 import (
 	"bytes"
+	"context"
+	"net/http"
 	"sync"
 	"time"
 
@@ -23,19 +25,36 @@ import (
 // In order to send created deferred item immediately:
 //     queue.SetDeferred(key, buf, url, ...)
 //
-// If item was created with the `ignoreErr` flag set,
-// then item will be removed from the queue regardless
-// the actual send result.
-//
-// If `ignoreErr` is not set and an error occurs during
-// the send, then queue processing is interrupted. The
-// queue process will be repeated by the timer, see the
-// `startTimer()` routine. `KickTimerNow` can be called
-// in order to restart queue processing immediately.
-//
 // The deferred item can be removed from the queue if
 // the send failed:
 //     queue.RemoveDeferred(key)
+//
+// An item stays in the queue until the controller accepts it. There are only
+// two cases where a message is given up on and lost:
+//
+//   - The item was created with the `DiscardOnFailure` flag, meaning the payload
+//     will be superseded by the next periodic publication of the same key.
+//   - The controller responded with a status code which tells that it will
+//     reject the very same payload again (see retriableHTTPStatus).
+//
+// Anything else is retried indefinitely, because for most of what travels this
+// queue nothing else re-asserts the state later, so discarding a message would
+// leave the controller's view of an object wrong until that object changes
+// again. An item being retried is held back by a growing delay and moved behind
+// its peers, so it costs one request per retry interval and blocks nothing.
+//
+// Retrying forever must not be silent, so two conditions are logged as
+// warnings: a backlog of more than queueBacklogWarn undelivered messages, and
+// an individual payload refused warnAfterAttempts times. Re-publishing the same
+// key with unchanged content keeps the retry state of the queued message, so
+// that neither the delay nor the count is reset by an object being reported
+// again without having changed.
+//
+// A send failure with no response from the controller at all interrupts the
+// queue processing, because the remaining items would fail the same way. The
+// queue processing will be repeated by the timer, see the `startTimer()`
+// routine. `KickTimerNow` can be called in order to restart queue processing
+// immediately.
 
 type deferredItem struct {
 	itemType interface{}
@@ -43,22 +62,29 @@ type deferredItem struct {
 	buf      *bytes.Buffer
 	url      string
 	opts     DeferredItemOpts
+	// Number of times the controller refused the payload currently in buf.
+	attempts int
+	// The earliest time of the next send attempt. Zero means "no delay".
+	retryAt time.Time
 }
 
 // DeferredItemOpts defines configurable options for processing a deferred item.
 // These options control request behavior such as error handling, network tracing,
 // logging, and retry policy across network interfaces.
 type DeferredItemOpts struct {
-	// Return 4xx and 5xx without trying other interfaces
+	// BailOnHTTPErr has the same meaning as RequestOptions.BailOnHTTPErr: stop
+	// trying the remaining ports once the controller has answered with a 4xx or
+	// 5xx status. It does not influence whether the item is retried later - that
+	// is decided by the status code alone (see retriableHTTPStatus).
 	BailOnHTTPErr bool
 	// WithNetTracing enables network tracing for post-mortem troubleshooting purposes.
 	WithNetTracing bool
-	// IgnoreErr, when set to true, allows the deferred queue to continue processing
-	// subsequent items even if sending this item fails (e.g., due to network errors
-	// or non-2xx HTTP responses). If false, a send failure will pause the queue
-	// processing until retried later. All results, including failures, are still
-	// reported to the sentHandler callback.
-	IgnoreErr bool
+	// DiscardOnFailure, when set to true, discards the item if the send fails instead of
+	// keeping it queued for another attempt. Use it for payloads which the next
+	// periodic publication of the same key supersedes, so that nothing is gained
+	// from retrying this one. All results, including failures, are reported to the
+	// sentHandler callback.
+	DiscardOnFailure bool
 	// SuppressLogs lowers the log severity to Trace for all Send-related methods,
 	// suppressing higher-severity log output.
 	SuppressLogs bool
@@ -78,6 +104,23 @@ const shortTime1 = time.Minute * 1
 const shortTime2 = time.Minute * 15
 const noise = shortTime1
 
+// Per-item exponential backoff applied after the controller has refused an item
+// with a status code which may not repeat. The queue is kicked on every
+// SetDeferred, so without a per-item delay a refused item would be re-attempted
+// on every unrelated event.
+const minRetryDelay = time.Minute
+const maxRetryDelay = time.Minute * 15
+
+// Number of undelivered messages left in the queue at which the backlog is
+// called out. Reaching it means reports for a large number of objects are
+// waiting, which the controller has no other way of noticing.
+const queueBacklogWarn = 50
+
+// Number of refusals of the same payload after which the message is called out,
+// and again on every further multiple. With the delay above this is a matter of
+// hours, well past any transient trouble at the controller.
+const warnAfterAttempts = 20
+
 // DeferredQueue is used so defer send requests and execute them later
 // in the background.
 type DeferredQueue struct {
@@ -87,8 +130,16 @@ type DeferredQueue struct {
 	Ticker                 flextimer.FlexTickerHandle
 	priorityCheckFunctions []TypePriorityCheckFunction
 	sentHandler            SentHandlerFunction
-	ctrlClient             *Client
+	ctrlClient             deferredSender
 	iteration              int
+}
+
+// deferredSender is the part of Client which the queue uses to deliver an item.
+// Having it as an interface keeps the queue policy exercisable without a network.
+type deferredSender interface {
+	SendOnAllIntf(ctx context.Context, url string, b *bytes.Buffer,
+		opts RequestOptions) (SendRetval, error)
+	GetContextForAllIntfFunctions() (context.Context, context.CancelFunc)
 }
 
 // TypePriorityCheckFunction returns true in case of find type with high priority
@@ -191,7 +242,180 @@ func (q *DeferredQueue) mergeQueuesNoLock(notSentReqs []*deferredItem) {
 	q.deferredItems = append(notSentReqs, q.deferredItems...)
 }
 
-// handleDeferred try to send all deferred items
+// retriableHTTPStatus tells whether re-sending the very same payload later has
+// any chance of being accepted by a controller which responded with the given
+// status code.
+//
+// Server errors, rate limiting and timeouts are temporary by nature. So is a
+// refusal to authenticate or authorize the device: EVE responds to those by
+// renewing what the controller rejected - a 403 restarts attestation, a
+// certificate problem triggers a fetch of new controller certs - after which
+// the same payload is expected to be accepted.
+//
+// The rest of the 4xx range means the controller objects to the request itself
+// and will object to the identical bytes again. 404 in particular is the case
+// this distinction was originally introduced for: the controller no longer
+// knows about an object the device is still reporting.
+func retriableHTTPStatus(statusCode int) bool {
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden,
+		http.StatusProxyAuthRequired, http.StatusRequestTimeout,
+		http.StatusTooManyRequests:
+		return true
+	}
+	return statusCode >= 500 && statusCode < 600
+}
+
+// retryDelay returns for how long to hold off the next attempt of an item which
+// the controller has refused, doubling with every attempt made so far.
+func retryDelay(attempts int) time.Duration {
+	delay := minRetryDelay
+	for i := 1; i < attempts && delay < maxRetryDelay; i++ {
+		delay *= 2
+	}
+	if delay > maxRetryDelay {
+		delay = maxRetryDelay
+	}
+	return delay
+}
+
+// allSuppressLogs tells whether every one of the items asked for send problems
+// to be kept out of the log.
+func allSuppressLogs(items []*deferredItem) bool {
+	for _, item := range items {
+		if !item.opts.SuppressLogs {
+			return false
+		}
+	}
+	return true
+}
+
+// sameContent tells whether two queued payloads carry identical bytes.
+func sameContent(a, b *bytes.Buffer) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return bytes.Equal(a.Bytes(), b.Bytes())
+}
+
+// itemDisposition says what should happen to a deferred item after an attempt
+// to send it.
+type itemDisposition int
+
+const (
+	// itemDone - the item leaves the queue, either because the controller
+	// accepted it or because it is not worth offering again.
+	itemDone itemDisposition = iota
+	// itemRetry - the item stays in the queue for a later attempt.
+	itemRetry
+	// itemStopPass - the controller could not be reached at all; the item stays
+	// in the queue and the rest of this pass is abandoned.
+	itemStopPass
+)
+
+// reportSendResult passes the outcome of a send attempt to the sentHandler
+// callback. A failure is always reported with a non-zero status, since
+// SenderStatusNone means success to the callback.
+func (q *DeferredQueue) reportSendResult(item *deferredItem, rv SendRetval,
+	failed bool) {
+	if q.sentHandler == nil {
+		return
+	}
+	if failed && rv.Status == types.SenderStatusNone {
+		rv.Status = types.SenderStatusFailed
+	}
+	q.sentHandler(item.itemType, item.buf, rv.Status, rv.TracedReqs)
+}
+
+// sendItem makes a single attempt to send a deferred item and returns what
+// should happen to the item afterwards.
+func (q *DeferredQueue) sendItem(ctx context.Context,
+	item *deferredItem) itemDisposition {
+
+	rv, err := q.ctrlClient.SendOnAllIntf(ctx, item.url, item.buf,
+		RequestOptions{
+			SuppressLogs:     item.opts.SuppressLogs,
+			WithNetTracing:   item.opts.WithNetTracing,
+			NetTraceFolder:   types.NetTraceFolder,
+			BailOnHTTPErr:    item.opts.BailOnHTTPErr,
+			Iteration:        q.iteration,
+			AllowLoopbackDNS: item.opts.AllowLoopbackDNS,
+		})
+
+	//try with another interface next time
+	q.iteration++
+
+	// An airgapped device is not expected to reach the controller at all, so it
+	// asks for the noise to be kept out of the log.
+	errorLog := q.log.Errorf
+	warnLog := q.log.Warnf
+	noticeLog := q.log.Noticef
+	if item.opts.SuppressLogs {
+		errorLog = q.log.Tracef
+		warnLog = q.log.Tracef
+		noticeLog = q.log.Tracef
+	}
+
+	status := rv.LastHTTPStatusCode
+	// A status code means that the controller was reached and answered, so the
+	// failure belongs to this item alone and the rest of the queue is still
+	// worth a try.
+	refused := status >= 400 && status < 600
+
+	switch {
+	case refused:
+		// Logged below, once the disposition of the item is known.
+	case err != nil:
+		q.log.Functionf("handleDeferred: for %s status %d failed %s",
+			item.key, rv.Status, err)
+	case rv.Status != types.SenderStatusNone:
+		q.log.Functionf("handleDeferred: for %s received unexpected status %d",
+			item.key, rv.Status)
+	default:
+		q.reportSendResult(item, rv, false)
+		return itemDone
+	}
+
+	q.reportSendResult(item, rv, true)
+	switch {
+	case !refused:
+		if item.opts.DiscardOnFailure {
+			return itemDone
+		}
+		return itemStopPass
+
+	case item.opts.DiscardOnFailure:
+		q.log.Functionf("handleDeferred: for %s dropping superseded message, "+
+			"controller responded %d %s", item.key, status,
+			http.StatusText(status))
+		return itemDone
+
+	case !retriableHTTPStatus(status):
+		// Nothing else re-asserts most of what travels this queue, so record
+		// the loss at a severity that reaches the controller and the operator.
+		errorLog("handleDeferred: for %s dropping message, controller "+
+			"responded %d %s", item.key, status, http.StatusText(status))
+		return itemDone
+
+	default:
+		item.attempts++
+		item.retryAt = time.Now().Add(retryDelay(item.attempts))
+		// A message refused this many times is no longer a passing hiccup, and
+		// since it is never given up on, saying so is the only way anyone finds
+		// out that this state is not reaching the controller.
+		logRetry := noticeLog
+		if item.attempts%warnAfterAttempts == 0 {
+			logRetry = warnLog
+		}
+		logRetry("handleDeferred: for %s controller responded %d %s, "+
+			"attempt %d, retrying in %v", item.key, status,
+			http.StatusText(status), item.attempts,
+			retryDelay(item.attempts))
+		return itemRetry
+	}
+}
+
+// handleDeferred try to send all deferred items which are due
 func (q *DeferredQueue) handleDeferred() bool {
 	q.deferredItemsLock.Lock()
 	reqs := q.deferredItems
@@ -205,7 +429,6 @@ func (q *DeferredQueue) handleDeferred() bool {
 	q.log.Functionf("handleDeferred items %d", len(reqs))
 
 	exit := false
-	sent := 0
 	ctx, cancel := q.ctrlClient.GetContextForAllIntfFunctions()
 	defer cancel()
 	for _, f := range q.priorityCheckFunctions {
@@ -218,78 +441,61 @@ func (q *DeferredQueue) handleDeferred() bool {
 			if item.buf == nil {
 				continue
 			}
-			q.log.Functionf("handleDeferred: Trying to send for %s", key)
 			if item.buf.Len() == 0 {
 				q.log.Functionf("handleDeferred: Zero length deferred item for %s",
 					key)
 				continue
 			}
-
-			//SenderStatusNone indicates no problems
-			rv, err := q.ctrlClient.SendOnAllIntf(ctx, item.url, item.buf,
-				RequestOptions{
-					SuppressLogs:     item.opts.SuppressLogs,
-					WithNetTracing:   item.opts.WithNetTracing,
-					NetTraceFolder:   types.NetTraceFolder,
-					BailOnHTTPErr:    item.opts.BailOnHTTPErr,
-					Iteration:        q.iteration,
-					AllowLoopbackDNS: item.opts.AllowLoopbackDNS,
-				})
-			// We check StatusCode before err since we do not want
-			// to exit the loop just because some message is rejected
-			// by the controller.
-			if item.opts.BailOnHTTPErr && rv.HTTPResp != nil &&
-				rv.HTTPResp.StatusCode >= 400 && rv.HTTPResp.StatusCode < 600 {
-				q.log.Functionf("handleDeferred: for %s ignore code %d",
-					key, rv.HTTPResp.StatusCode)
-			} else if err != nil {
-				q.log.Functionf("handleDeferred: for %s status %d failed %s",
-					key, rv.Status, err)
-				exit = !item.opts.IgnoreErr
-				// Make sure we pass a non-zero result to the sentHandler.
-				if rv.Status == types.SenderStatusNone {
-					rv.Status = types.SenderStatusFailed
-				}
-			} else if rv.Status != types.SenderStatusNone {
-				q.log.Functionf("handleDeferred: for %s received unexpected status %d",
-					key, rv.Status)
-				exit = !item.opts.IgnoreErr
+			if time.Now().Before(item.retryAt) {
+				q.log.Functionf("handleDeferred: for %s next attempt in %v",
+					key, time.Until(item.retryAt).Round(time.Second))
+				continue
 			}
-			if q.sentHandler != nil {
-				q.sentHandler(item.itemType, item.buf, rv.Status, rv.TracedReqs)
+			q.log.Functionf("handleDeferred: Trying to send for %s", key)
+
+			switch q.sendItem(ctx, item) {
+			case itemDone:
+				item.buf = nil
+			case itemRetry:
+			case itemStopPass:
+				exit = true
 			}
-
-			//try with another interface next time
-			q.iteration++
-
 			if exit {
 				break
 			}
-			item.buf = nil
-			sent++
 		}
 		if exit {
 			break
 		}
 	}
 
-	var notSentReqs []*deferredItem
-	if sent == 0 {
-		// Take the whole queue
-		notSentReqs = reqs
-	} else {
-		// Keep not sent requests
-		for _, el := range reqs {
-			if el.buf != nil {
-				notSentReqs = append(notSentReqs, el)
-			}
+	// Keep the not sent requests, with the ones waiting out a backoff at the
+	// tail, so that an item the controller keeps refusing cannot hold up the
+	// items behind it.
+	var notSentReqs, backoffReqs []*deferredItem
+	now := time.Now()
+	for _, el := range reqs {
+		switch {
+		case el.buf == nil:
+			// Sent or given up on.
+		case el.retryAt.After(now):
+			backoffReqs = append(backoffReqs, el)
+		default:
+			notSentReqs = append(notSentReqs, el)
 		}
 	}
+	notSentReqs = append(notSentReqs, backoffReqs...)
 
 	if len(notSentReqs) > 0 {
-		// Log the content of the rest in the queue
-		q.log.Functionf("handleDeferred() the rest to be sent: %d",
-			len(notSentReqs))
+		// Log the content of the rest in the queue. A backlog this long means
+		// the reports for many objects are undelivered, which is worth saying
+		// out loud once per pass - unless every one of them asked for quiet,
+		// as an airgapped device does.
+		logRest := q.log.Functionf
+		if len(notSentReqs) > queueBacklogWarn && !allSuppressLogs(notSentReqs) {
+			logRest = q.log.Warnf
+		}
+		logRest("handleDeferred() the rest to be sent: %d", len(notSentReqs))
 		if q.sentHandler != nil {
 			for _, item := range notSentReqs {
 				q.sentHandler(item.itemType, item.buf, types.SenderStatusDebug, nil)
@@ -313,9 +519,8 @@ func (q *DeferredQueue) handleDeferred() bool {
 // starts the timer. Key is used for identifying the channel. Please
 // note that for deviceUUID key is used for attestUrl, which is not the
 // same for other Urls, where in other case, the key is very specific
-// for the object. If @opts.IgnoreErr is true the queue processing is not
-// stopped on any error and will continue, although all errors will be
-// passed to @sentHandler callback (see the CreateDeferredCtx()).
+// for the object. Replacing an item also resets the retry state, since
+// the controller has not seen the new payload yet.
 func (q *DeferredQueue) SetDeferred(
 	key string, buf *bytes.Buffer, url string, itemType interface{},
 	opts DeferredItemOpts) {
@@ -348,6 +553,14 @@ func (q *DeferredQueue) SetDeferred(
 		}
 	}
 	if found {
+		// Re-publishing the very same bytes is the same message, so it inherits
+		// the retry state: an object whose reported state has not actually
+		// changed must not restart the backoff on every publication, nor hide
+		// how long the message has been undeliverable.
+		if sameContent(q.deferredItems[ind].buf, buf) {
+			item.attempts = q.deferredItems[ind].attempts
+			item.retryAt = q.deferredItems[ind].retryAt
+		}
 		q.log.Tracef("Replacing key %s", key)
 		q.deferredItems[ind] = &item
 	} else {

--- a/pkg/pillar/controllerconn/deferred_policy_test.go
+++ b/pkg/pillar/controllerconn/deferred_policy_test.go
@@ -1,0 +1,693 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerconn
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/flextimer"
+	"github.com/lf-edge/eve/pkg/pillar/netdump"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/sirupsen/logrus"
+)
+
+// fakeSender answers every send with a canned outcome, selected by the URL of
+// the request, and records the URLs it was asked to send to.
+type fakeSender struct {
+	sync.Mutex
+	outcomes map[string][]fakeOutcome
+	sentURLs []string
+}
+
+type fakeOutcome struct {
+	statusCode int
+	status     types.SenderStatus
+	err        error
+}
+
+func newFakeSender() *fakeSender {
+	return &fakeSender{outcomes: make(map[string][]fakeOutcome)}
+}
+
+// respond queues the outcomes to return for the consecutive sends to url. The
+// last one is repeated once the others have been used up.
+func (f *fakeSender) respond(url string, outcomes ...fakeOutcome) {
+	f.Lock()
+	defer f.Unlock()
+	f.outcomes[url] = outcomes
+}
+
+func (f *fakeSender) SendOnAllIntf(_ context.Context, url string, _ *bytes.Buffer,
+	_ RequestOptions) (SendRetval, error) {
+	f.Lock()
+	defer f.Unlock()
+	f.sentURLs = append(f.sentURLs, url)
+	outcomes := f.outcomes[url]
+	if len(outcomes) == 0 {
+		return SendRetval{ReqURL: url}, nil
+	}
+	outcome := outcomes[0]
+	if len(outcomes) > 1 {
+		f.outcomes[url] = outcomes[1:]
+	}
+	rv := SendRetval{
+		ReqURL:             url,
+		Status:             outcome.status,
+		LastHTTPStatusCode: outcome.statusCode,
+	}
+	err := outcome.err
+	if err == nil && outcome.statusCode != 0 &&
+		(outcome.statusCode < 200 || outcome.statusCode >= 300) {
+		// SendOnIntf turns any non-2xx into an error as well.
+		err = errors.New(http.StatusText(outcome.statusCode))
+	}
+	return rv, err
+}
+
+func (f *fakeSender) GetContextForAllIntfFunctions() (context.Context,
+	context.CancelFunc) {
+	return context.WithCancel(context.Background())
+}
+
+func (f *fakeSender) sends() []string {
+	f.Lock()
+	defer f.Unlock()
+	return append([]string{}, f.sentURLs...)
+}
+
+// levelRecorder captures the severity of every log record a queue emits, so a
+// test can assert that a condition is reported loudly rather than in passing.
+type levelRecorder struct {
+	sync.Mutex
+	messages map[logrus.Level][]string
+}
+
+func newLevelRecorder() *levelRecorder {
+	return &levelRecorder{messages: make(map[logrus.Level][]string)}
+}
+
+func (r *levelRecorder) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (r *levelRecorder) Fire(entry *logrus.Entry) error {
+	r.Lock()
+	defer r.Unlock()
+	r.messages[entry.Level] = append(r.messages[entry.Level], entry.Message)
+	return nil
+}
+
+func (r *levelRecorder) at(level logrus.Level) []string {
+	r.Lock()
+	defer r.Unlock()
+	return append([]string{}, r.messages[level]...)
+}
+
+// newTestQueueWithLog returns a queue whose log records are captured.
+// The log source has to be unique per test: NewSourceLogObject keeps a global
+// map keyed by source name and hands back the object already registered under
+// that name, which would leave the records going to another test's logger.
+func newTestQueueWithLog(test *testing.T,
+	sender deferredSender) (*DeferredQueue, *levelRecorder) {
+	recorder := newLevelRecorder()
+	logger := logrus.New()
+	logger.SetLevel(logrus.TraceLevel)
+	logger.SetOutput(io.Discard)
+	logger.AddHook(recorder)
+	queue := newTestQueue(sender, nil)
+	queue.log = base.NewSourceLogObject(logger, test.Name(), 1234)
+	return queue, recorder
+}
+
+// newTestQueue returns a queue with no background processing task, so that a
+// test drives the passes itself by calling handleDeferred.
+func newTestQueue(sender deferredSender,
+	sentHandler SentHandlerFunction) *DeferredQueue {
+	logger := logrus.StandardLogger()
+	return &DeferredQueue{
+		log:               base.NewSourceLogObject(logger, "deferred-test", 1234),
+		deferredItemsLock: &sync.Mutex{},
+		Ticker:            flextimer.NewRangeTicker(longTime1, longTime2),
+		sentHandler:       sentHandler,
+		priorityCheckFunctions: []TypePriorityCheckFunction{
+			func(interface{}) bool { return true },
+		},
+		ctrlClient: sender,
+	}
+}
+
+// reportedStatuses collects the outcomes handed to the sentHandler callback,
+// leaving out the SenderStatusDebug notifications for items left in the queue.
+type reportedStatuses struct {
+	sync.Mutex
+	statuses []types.SenderStatus
+}
+
+func (r *reportedStatuses) handler() SentHandlerFunction {
+	return func(_ interface{}, _ *bytes.Buffer, result types.SenderStatus,
+		_ []netdump.TracedNetRequest) {
+		if result == types.SenderStatusDebug {
+			return
+		}
+		r.Lock()
+		defer r.Unlock()
+		r.statuses = append(r.statuses, result)
+	}
+}
+
+func (r *reportedStatuses) get() []types.SenderStatus {
+	r.Lock()
+	defer r.Unlock()
+	return append([]types.SenderStatus{}, r.statuses...)
+}
+
+func (q *DeferredQueue) queuedKeys() []string {
+	q.deferredItemsLock.Lock()
+	defer q.deferredItemsLock.Unlock()
+	var keys []string
+	for _, item := range q.deferredItems {
+		keys = append(keys, item.key)
+	}
+	return keys
+}
+
+func (q *DeferredQueue) queuedItem(key string) *deferredItem {
+	q.deferredItemsLock.Lock()
+	defer q.deferredItemsLock.Unlock()
+	for _, item := range q.deferredItems {
+		if item.key == key {
+			return item
+		}
+	}
+	return nil
+}
+
+func (q *DeferredQueue) queuedItems() []*deferredItem {
+	q.deferredItemsLock.Lock()
+	defer q.deferredItemsLock.Unlock()
+	return append([]*deferredItem{}, q.deferredItems...)
+}
+
+const testURL = "https://controller.example.com/api/v2/edgedevice/id/dev/info"
+
+func TestDeferredRetriesTemporaryRejection(test *testing.T) {
+	t := NewGomegaWithT(test)
+	sender := newFakeSender()
+	sender.respond(testURL, fakeOutcome{
+		statusCode: http.StatusServiceUnavailable,
+		status:     types.SenderStatusUpgrade,
+	})
+	reported := &reportedStatuses{}
+	queue := newTestQueue(sender, reported.handler())
+
+	queue.SetDeferred("appInfo", bytes.NewBufferString("app is running"),
+		testURL, nil, DeferredItemOpts{BailOnHTTPErr: true})
+
+	t.Expect(queue.handleDeferred()).To(BeFalse())
+	t.Expect(queue.queuedKeys()).To(Equal([]string{"appInfo"}))
+	item := queue.queuedItem("appInfo")
+	t.Expect(item.attempts).To(Equal(1))
+	t.Expect(item.retryAt).To(BeTemporally(">", time.Now()))
+	t.Expect(reported.get()).To(Equal([]types.SenderStatus{types.SenderStatusUpgrade}))
+
+	// A second pass before the backoff has elapsed must not touch the controller.
+	t.Expect(queue.handleDeferred()).To(BeFalse())
+	t.Expect(sender.sends()).To(HaveLen(1))
+
+	// Once it has elapsed, the very same payload is offered again and accepted.
+	sender.respond(testURL, fakeOutcome{statusCode: http.StatusOK})
+	queue.queuedItem("appInfo").retryAt = time.Now().Add(-time.Second)
+	t.Expect(queue.handleDeferred()).To(BeTrue())
+	t.Expect(sender.sends()).To(HaveLen(2))
+	t.Expect(queue.queuedKeys()).To(BeEmpty())
+}
+
+func TestDeferredDropsPermanentRejection(test *testing.T) {
+	t := NewGomegaWithT(test)
+	sender := newFakeSender()
+	sender.respond(testURL, fakeOutcome{
+		statusCode: http.StatusBadRequest,
+		status:     types.SenderStatusNotFound,
+	})
+	reported := &reportedStatuses{}
+	queue := newTestQueue(sender, reported.handler())
+
+	queue.SetDeferred("appInfo", bytes.NewBufferString("app is running"),
+		testURL, nil, DeferredItemOpts{BailOnHTTPErr: true})
+
+	t.Expect(queue.handleDeferred()).To(BeTrue())
+	t.Expect(queue.queuedKeys()).To(BeEmpty())
+	t.Expect(reported.get()).To(Equal([]types.SenderStatus{types.SenderStatusNotFound}))
+	t.Expect(sender.sends()).To(HaveLen(1))
+}
+
+// A rejected item must not keep the items behind it from being delivered, and
+// must not be the first one tried on the next pass either.
+func TestDeferredRejectedItemDoesNotBlockOthers(test *testing.T) {
+	t := NewGomegaWithT(test)
+	const otherURL = "https://controller.example.com/api/v2/edgedevice/id/dev/other"
+	sender := newFakeSender()
+	sender.respond(testURL, fakeOutcome{statusCode: http.StatusInternalServerError})
+	sender.respond(otherURL, fakeOutcome{statusCode: http.StatusOK})
+	queue := newTestQueue(sender, nil)
+
+	// Queued the way NTP sources and patch envelope status are: errors are not
+	// ignored and other ports are tried on an HTTP error.
+	queue.SetDeferred("refused", bytes.NewBufferString("refused payload"),
+		testURL, nil, DeferredItemOpts{})
+	queue.SetDeferred("accepted", bytes.NewBufferString("accepted payload"),
+		otherURL, nil, DeferredItemOpts{})
+
+	t.Expect(queue.handleDeferred()).To(BeFalse())
+	t.Expect(sender.sends()).To(Equal([]string{testURL, otherURL}))
+	t.Expect(queue.queuedKeys()).To(Equal([]string{"refused"}))
+
+	// The item waiting out its backoff goes to the tail of the queue.
+	queue.SetDeferred("fresh", bytes.NewBufferString("fresh payload"),
+		otherURL, nil, DeferredItemOpts{})
+	t.Expect(queue.queuedKeys()).To(Equal([]string{"refused", "fresh"}))
+	t.Expect(queue.handleDeferred()).To(BeFalse())
+	t.Expect(queue.queuedKeys()).To(Equal([]string{"refused"}))
+}
+
+// Losing the controller entirely is not a reason to give up on a message, and
+// it stops the pass because the remaining items would fail the same way.
+func TestDeferredKeepsItemWhenControllerUnreachable(test *testing.T) {
+	t := NewGomegaWithT(test)
+	const otherURL = "https://controller.example.com/api/v2/edgedevice/id/dev/other"
+	sender := newFakeSender()
+	sender.respond(testURL, fakeOutcome{err: errors.New("no route to host")})
+	sender.respond(otherURL, fakeOutcome{statusCode: http.StatusOK})
+	reported := &reportedStatuses{}
+	queue := newTestQueue(sender, reported.handler())
+
+	queue.SetDeferred("unreachable", bytes.NewBufferString("payload"),
+		testURL, nil, DeferredItemOpts{BailOnHTTPErr: true})
+	queue.SetDeferred("behind", bytes.NewBufferString("payload"),
+		otherURL, nil, DeferredItemOpts{BailOnHTTPErr: true})
+
+	t.Expect(queue.handleDeferred()).To(BeFalse())
+	t.Expect(sender.sends()).To(Equal([]string{testURL}))
+	t.Expect(queue.queuedKeys()).To(Equal([]string{"unreachable", "behind"}))
+	item := queue.queuedItem("unreachable")
+	t.Expect(item.attempts).To(BeZero())
+	t.Expect(item.retryAt).To(BeZero())
+	t.Expect(reported.get()).To(Equal([]types.SenderStatus{types.SenderStatusFailed}))
+}
+
+// A payload which the next period supersedes is discarded rather than retried.
+func TestDeferredDiscardsSupersededPayload(test *testing.T) {
+	t := NewGomegaWithT(test)
+	sender := newFakeSender()
+	sender.respond(testURL, fakeOutcome{statusCode: http.StatusServiceUnavailable})
+	queue := newTestQueue(sender, nil)
+
+	queue.SetDeferred("metrics", bytes.NewBufferString("metrics"), testURL, nil,
+		DeferredItemOpts{DiscardOnFailure: true})
+
+	t.Expect(queue.handleDeferred()).To(BeTrue())
+	t.Expect(queue.queuedKeys()).To(BeEmpty())
+}
+
+// A message nothing else re-asserts is never given up on while the controller
+// keeps answering with a temporary error, however long that lasts. The delay
+// between attempts grows to its ceiling and stays there.
+func TestDeferredNeverGivesUpOnTemporaryRejection(test *testing.T) {
+	t := NewGomegaWithT(test)
+	sender := newFakeSender()
+	sender.respond(testURL, fakeOutcome{statusCode: http.StatusBadGateway})
+	queue := newTestQueue(sender, nil)
+
+	queue.SetDeferred("appInfo", bytes.NewBufferString("app is running"),
+		testURL, nil, DeferredItemOpts{BailOnHTTPErr: true})
+
+	const attempts = 50
+	for i := 1; i <= attempts; i++ {
+		t.Expect(queue.handleDeferred()).To(BeFalse())
+		item := queue.queuedItem("appInfo")
+		t.Expect(item).ToNot(BeNil())
+		t.Expect(item.attempts).To(Equal(i))
+		t.Expect(item.retryAt).To(BeTemporally(">", time.Now()))
+		// Let the backoff elapse so that the next pass attempts the item again.
+		item.retryAt = time.Now().Add(-time.Second)
+	}
+	t.Expect(sender.sends()).To(HaveLen(attempts))
+	t.Expect(queue.queuedKeys()).To(Equal([]string{"appInfo"}))
+
+	// It is still the same payload, and it is delivered once accepted.
+	sender.respond(testURL, fakeOutcome{statusCode: http.StatusOK})
+	t.Expect(queue.handleDeferred()).To(BeTrue())
+	t.Expect(queue.queuedKeys()).To(BeEmpty())
+}
+
+// The queue holds at most one item per key, so keeping messages instead of
+// discarding them cannot grow it beyond the number of objects being reported.
+func TestDeferredQueueLengthBoundedByKeys(test *testing.T) {
+	t := NewGomegaWithT(test)
+	sender := newFakeSender()
+	sender.respond(testURL, fakeOutcome{statusCode: http.StatusServiceUnavailable})
+	queue := newTestQueue(sender, nil)
+
+	const keys = 5
+	const rounds = 10
+	for round := 0; round < rounds; round++ {
+		for k := 0; k < keys; k++ {
+			queue.SetDeferred(fmt.Sprintf("appInfo%d", k),
+				bytes.NewBufferString(fmt.Sprintf("state %d", round)),
+				testURL, nil, DeferredItemOpts{BailOnHTTPErr: true})
+		}
+		queue.handleDeferred()
+		for _, item := range queue.queuedItems() {
+			item.retryAt = time.Now().Add(-time.Second)
+		}
+	}
+
+	t.Expect(queue.queuedKeys()).To(HaveLen(keys))
+	// Only the newest payload per key is retained.
+	for _, item := range queue.queuedItems() {
+		t.Expect(item.buf.String()).To(Equal(fmt.Sprintf("state %d", rounds-1)))
+	}
+}
+
+// Replacing the payload of a queued item makes it eligible again, since the
+// controller has not seen the new bytes yet.
+func TestDeferredResetsBackoffOnNewPayload(test *testing.T) {
+	t := NewGomegaWithT(test)
+	sender := newFakeSender()
+	sender.respond(testURL, fakeOutcome{statusCode: http.StatusServiceUnavailable},
+		fakeOutcome{statusCode: http.StatusOK})
+	queue := newTestQueue(sender, nil)
+
+	queue.SetDeferred("appInfo", bytes.NewBufferString("app is booting"),
+		testURL, nil, DeferredItemOpts{BailOnHTTPErr: true})
+	t.Expect(queue.handleDeferred()).To(BeFalse())
+	t.Expect(queue.queuedItem("appInfo").attempts).To(Equal(1))
+
+	queue.SetDeferred("appInfo", bytes.NewBufferString("app is running"),
+		testURL, nil, DeferredItemOpts{BailOnHTTPErr: true})
+	item := queue.queuedItem("appInfo")
+	t.Expect(item.attempts).To(BeZero())
+	t.Expect(item.retryAt).To(BeZero())
+	t.Expect(queue.handleDeferred()).To(BeTrue())
+}
+
+// itemKind stands in for the info/attest types zedagent uses to assign priority.
+type itemKind string
+
+// newPriorityTestQueue builds a queue with the same shape of priority functions
+// as zedagent installs: attest first, then app info, then everything else.
+func newPriorityTestQueue(sender deferredSender) *DeferredQueue {
+	queue := newTestQueue(sender, nil)
+	isKind := func(want itemKind) TypePriorityCheckFunction {
+		return func(itemType interface{}) bool {
+			kind, ok := itemType.(itemKind)
+			return ok && kind == want
+		}
+	}
+	queue.priorityCheckFunctions = []TypePriorityCheckFunction{
+		isKind("attest"), isKind("app"),
+		func(interface{}) bool { return true },
+	}
+	return queue
+}
+
+// A refused item must not stop the classes behind it from being sent in the same
+// pass. Before, one failure broke out of both the item loop and the loop over
+// priority classes, so everything of lower priority waited for the next pass.
+func TestDeferredRefusedItemDoesNotBlockLowerPriorityClasses(test *testing.T) {
+	t := NewGomegaWithT(test)
+	const attestURL = "https://controller.example.com/api/v2/edgedevice/id/dev/attest"
+	const otherURL = "https://controller.example.com/api/v2/edgedevice/id/dev/other"
+	sender := newFakeSender()
+	sender.respond(attestURL, fakeOutcome{statusCode: http.StatusServiceUnavailable})
+	sender.respond(testURL, fakeOutcome{statusCode: http.StatusOK})
+	sender.respond(otherURL, fakeOutcome{statusCode: http.StatusOK})
+	queue := newPriorityTestQueue(sender)
+
+	// Enqueued in reverse priority order to prove the order of sending comes
+	// from the priority functions and not from the order of arrival.
+	queue.SetDeferred("volumeInfo", bytes.NewBufferString("volume"), otherURL,
+		itemKind("volume"), DeferredItemOpts{BailOnHTTPErr: true})
+	queue.SetDeferred("appInfo", bytes.NewBufferString("app"), testURL,
+		itemKind("app"), DeferredItemOpts{BailOnHTTPErr: true})
+	queue.SetDeferred("attest", bytes.NewBufferString("attest"), attestURL,
+		itemKind("attest"), DeferredItemOpts{BailOnHTTPErr: true})
+
+	t.Expect(queue.handleDeferred()).To(BeFalse())
+	// The refused highest-priority item did not stop the two behind it.
+	t.Expect(sender.sends()).To(Equal([]string{attestURL, testURL, otherURL}))
+	t.Expect(queue.queuedKeys()).To(Equal([]string{"attest"}))
+}
+
+// Priority decides the order of sending; the demotion of a refused item applies
+// within the queue and must not let a lower-priority item overtake a
+// higher-priority one that is ready to be sent.
+func TestDeferredPriorityOrderSurvivesDemotion(test *testing.T) {
+	t := NewGomegaWithT(test)
+	const otherURL = "https://controller.example.com/api/v2/edgedevice/id/dev/other"
+	sender := newFakeSender()
+	// App info is refused once, then accepted; the volume info always fails to
+	// reach the controller, so it stays queued as well.
+	sender.respond(testURL, fakeOutcome{statusCode: http.StatusServiceUnavailable},
+		fakeOutcome{statusCode: http.StatusOK})
+	sender.respond(otherURL, fakeOutcome{statusCode: http.StatusServiceUnavailable})
+	queue := newPriorityTestQueue(sender)
+
+	queue.SetDeferred("appInfo", bytes.NewBufferString("app"), testURL,
+		itemKind("app"), DeferredItemOpts{BailOnHTTPErr: true})
+	queue.SetDeferred("volumeInfo", bytes.NewBufferString("volume"), otherURL,
+		itemKind("volume"), DeferredItemOpts{BailOnHTTPErr: true})
+
+	t.Expect(queue.handleDeferred()).To(BeFalse())
+	t.Expect(sender.sends()).To(Equal([]string{testURL, otherURL}))
+	t.Expect(queue.queuedKeys()).To(ConsistOf("appInfo", "volumeInfo"))
+
+	// Once both backoffs elapse, app info is still offered before volume info.
+	for _, item := range queue.queuedItems() {
+		item.retryAt = time.Now().Add(-time.Second)
+	}
+	t.Expect(queue.handleDeferred()).To(BeFalse())
+	t.Expect(sender.sends()).To(Equal([]string{
+		testURL, otherURL, testURL, otherURL}))
+	t.Expect(queue.queuedKeys()).To(Equal([]string{"volumeInfo"}))
+}
+
+// Losing the controller entirely still abandons the pass, including the classes
+// behind the item that could not be delivered - there is nothing to be gained
+// from trying them over the same dead link.
+func TestDeferredUnreachableControllerStopsLowerPriorityClasses(test *testing.T) {
+	t := NewGomegaWithT(test)
+	const otherURL = "https://controller.example.com/api/v2/edgedevice/id/dev/other"
+	sender := newFakeSender()
+	sender.respond(testURL, fakeOutcome{err: errors.New("no route to host")})
+	sender.respond(otherURL, fakeOutcome{statusCode: http.StatusOK})
+	queue := newPriorityTestQueue(sender)
+
+	queue.SetDeferred("appInfo", bytes.NewBufferString("app"), testURL,
+		itemKind("app"), DeferredItemOpts{BailOnHTTPErr: true})
+	queue.SetDeferred("volumeInfo", bytes.NewBufferString("volume"), otherURL,
+		itemKind("volume"), DeferredItemOpts{BailOnHTTPErr: true})
+
+	t.Expect(queue.handleDeferred()).To(BeFalse())
+	t.Expect(sender.sends()).To(Equal([]string{testURL}))
+	t.Expect(queue.queuedKeys()).To(Equal([]string{"appInfo", "volumeInfo"}))
+}
+
+// Items arriving while a pass is running must not corrupt the queue or the retry
+// state of the items being sent. Run with -race to make this meaningful.
+func TestDeferredConcurrentSetDeferred(test *testing.T) {
+	t := NewGomegaWithT(test)
+	sender := newFakeSender()
+	sender.respond(testURL, fakeOutcome{statusCode: http.StatusServiceUnavailable})
+	queue := newTestQueue(sender, nil)
+
+	queue.SetDeferred("appInfo", bytes.NewBufferString("app"), testURL, nil,
+		DeferredItemOpts{BailOnHTTPErr: true})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for j := 0; j < 25; j++ {
+				queue.SetDeferred(fmt.Sprintf("key%d", n),
+					bytes.NewBufferString("payload"), testURL, nil,
+					DeferredItemOpts{BailOnHTTPErr: true})
+			}
+		}(i)
+	}
+	for i := 0; i < 25; i++ {
+		queue.handleDeferred()
+	}
+	wg.Wait()
+
+	// Every key that was set is either still queued or was accepted; nothing
+	// may be lost or duplicated.
+	t.Expect(queue.queuedKeys()).To(ContainElement("appInfo"))
+	seen := make(map[string]int)
+	for _, key := range queue.queuedKeys() {
+		seen[key]++
+	}
+	for key, count := range seen {
+		t.Expect(count).To(Equal(1), "key %s queued %d times", key, count)
+	}
+}
+
+// A payload the controller keeps refusing has to be called out, since it is
+// never given up on and nothing else reports that the state is not getting
+// through.
+func TestDeferredWarnsAboutRepeatedlyRefusedMessage(test *testing.T) {
+	t := NewGomegaWithT(test)
+	sender := newFakeSender()
+	sender.respond(testURL, fakeOutcome{statusCode: http.StatusServiceUnavailable})
+	queue, recorder := newTestQueueWithLog(test, sender)
+
+	queue.SetDeferred("appInfo", bytes.NewBufferString("app is running"),
+		testURL, nil, DeferredItemOpts{BailOnHTTPErr: true})
+
+	for i := 1; i < warnAfterAttempts; i++ {
+		queue.handleDeferred()
+		queue.queuedItem("appInfo").retryAt = time.Now().Add(-time.Second)
+	}
+	// Up to the threshold the retries are reported without raising the alarm.
+	t.Expect(recorder.at(logrus.WarnLevel)).To(BeEmpty())
+	t.Expect(recorder.at(logrus.InfoLevel)).To(HaveLen(warnAfterAttempts - 1))
+
+	queue.handleDeferred()
+	warnings := recorder.at(logrus.WarnLevel)
+	t.Expect(warnings).To(HaveLen(1))
+	t.Expect(warnings[0]).To(ContainSubstring("attempt 20"))
+	// The message is still queued: being loud about it is not giving up on it.
+	t.Expect(queue.queuedKeys()).To(Equal([]string{"appInfo"}))
+}
+
+// Reporting an object again without its reported state having changed must not
+// restart the delay nor reset how many times the message has been refused,
+// otherwise a busy device would both hammer the controller and never reach the
+// threshold that makes a stuck message visible.
+func TestDeferredUnchangedRepublishKeepsRetryState(test *testing.T) {
+	t := NewGomegaWithT(test)
+	sender := newFakeSender()
+	sender.respond(testURL, fakeOutcome{statusCode: http.StatusServiceUnavailable})
+	queue := newTestQueue(sender, nil)
+
+	const payload = "app is running"
+	queue.SetDeferred("appInfo", bytes.NewBufferString(payload), testURL, nil,
+		DeferredItemOpts{BailOnHTTPErr: true})
+	t.Expect(queue.handleDeferred()).To(BeFalse())
+	item := queue.queuedItem("appInfo")
+	t.Expect(item.attempts).To(Equal(1))
+	retryAt := item.retryAt
+
+	// Same bytes: the queued message is unchanged, so its retry state stands.
+	queue.SetDeferred("appInfo", bytes.NewBufferString(payload), testURL, nil,
+		DeferredItemOpts{BailOnHTTPErr: true})
+	item = queue.queuedItem("appInfo")
+	t.Expect(item.attempts).To(Equal(1))
+	t.Expect(item.retryAt).To(Equal(retryAt))
+	// And it is not attempted again while the delay stands.
+	t.Expect(queue.handleDeferred()).To(BeFalse())
+	t.Expect(sender.sends()).To(HaveLen(1))
+
+	// Different bytes: a new message, which deserves an immediate attempt.
+	queue.SetDeferred("appInfo", bytes.NewBufferString("app is halting"),
+		testURL, nil, DeferredItemOpts{BailOnHTTPErr: true})
+	item = queue.queuedItem("appInfo")
+	t.Expect(item.attempts).To(BeZero())
+	t.Expect(item.retryAt).To(BeZero())
+	t.Expect(queue.handleDeferred()).To(BeFalse())
+	t.Expect(sender.sends()).To(HaveLen(2))
+}
+
+// A long backlog of undelivered messages is called out once per pass.
+func TestDeferredWarnsAboutBacklog(test *testing.T) {
+	t := NewGomegaWithT(test)
+	sender := newFakeSender()
+	sender.respond(testURL, fakeOutcome{statusCode: http.StatusServiceUnavailable})
+	queue, recorder := newTestQueueWithLog(test, sender)
+
+	for i := 0; i <= queueBacklogWarn; i++ {
+		queue.SetDeferred(fmt.Sprintf("appInfo%d", i),
+			bytes.NewBufferString("state"), testURL, nil,
+			DeferredItemOpts{BailOnHTTPErr: true})
+	}
+	queue.handleDeferred()
+
+	var backlogWarnings []string
+	for _, msg := range recorder.at(logrus.WarnLevel) {
+		if strings.Contains(msg, "the rest to be sent") {
+			backlogWarnings = append(backlogWarnings, msg)
+		}
+	}
+	t.Expect(backlogWarnings).To(HaveLen(1))
+	t.Expect(backlogWarnings[0]).To(ContainSubstring(
+		fmt.Sprintf("%d", queueBacklogWarn+1)))
+}
+
+// An airgapped device is not expected to reach a controller, so its backlog is
+// not an anomaly worth warning about.
+func TestDeferredBacklogQuietWhenLogsSuppressed(test *testing.T) {
+	t := NewGomegaWithT(test)
+	sender := newFakeSender()
+	sender.respond(testURL, fakeOutcome{statusCode: http.StatusServiceUnavailable})
+	queue, recorder := newTestQueueWithLog(test, sender)
+
+	for i := 0; i <= queueBacklogWarn; i++ {
+		queue.SetDeferred(fmt.Sprintf("appInfo%d", i),
+			bytes.NewBufferString("state"), testURL, nil,
+			DeferredItemOpts{BailOnHTTPErr: true, SuppressLogs: true})
+	}
+	queue.handleDeferred()
+
+	for _, msg := range recorder.at(logrus.WarnLevel) {
+		t.Expect(msg).ToNot(ContainSubstring("the rest to be sent"))
+	}
+	t.Expect(recorder.at(logrus.ErrorLevel)).To(BeEmpty())
+}
+
+func TestRetriableHTTPStatus(test *testing.T) {
+	t := NewGomegaWithT(test)
+	for _, code := range []int{
+		http.StatusBadRequest, http.StatusNotFound, http.StatusMethodNotAllowed,
+		http.StatusConflict, http.StatusGone, http.StatusRequestEntityTooLarge,
+		http.StatusUnsupportedMediaType, http.StatusUnprocessableEntity,
+	} {
+		t.Expect(retriableHTTPStatus(code)).To(BeFalse(),
+			"%d %s should not be retried", code, http.StatusText(code))
+	}
+	for _, code := range []int{
+		// EVE renews what the controller refused and expects the same payload
+		// to be accepted afterwards.
+		http.StatusUnauthorized, http.StatusForbidden,
+		http.StatusProxyAuthRequired,
+		http.StatusRequestTimeout, http.StatusTooManyRequests,
+		http.StatusInternalServerError, http.StatusNotImplemented,
+		http.StatusBadGateway, http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+	} {
+		t.Expect(retriableHTTPStatus(code)).To(BeTrue(),
+			"%d %s should be retried", code, http.StatusText(code))
+	}
+}
+
+func TestRetryDelayGrowsToItsCeiling(test *testing.T) {
+	t := NewGomegaWithT(test)
+	t.Expect(retryDelay(1)).To(Equal(minRetryDelay))
+	t.Expect(retryDelay(2)).To(Equal(2 * minRetryDelay))
+	t.Expect(retryDelay(3)).To(Equal(4 * minRetryDelay))
+	t.Expect(retryDelay(1000)).To(Equal(maxRetryDelay))
+}

--- a/pkg/pillar/controllerconn/deferred_test.go
+++ b/pkg/pillar/controllerconn/deferred_test.go
@@ -82,7 +82,7 @@ func TestDeferredQueue(test *testing.T) {
 		controllerconn.DeferredItemOpts{
 			BailOnHTTPErr:    false,
 			WithNetTracing:   false,
-			IgnoreErr:        false,
+			DiscardOnFailure: false,
 			SuppressLogs:     false,
 			AllowLoopbackDNS: true,
 		})
@@ -152,7 +152,7 @@ func TestDeferredQueue_NoUsablePorts(test *testing.T) {
 			BailOnHTTPErr:  false,
 			WithNetTracing: false,
 			// We will ignore errors (but we will check the sendOp.result value below)
-			IgnoreErr:        true,
+			DiscardOnFailure: true,
 			SuppressLogs:     false,
 			AllowLoopbackDNS: true,
 		})

--- a/pkg/pillar/controllerconn/send.go
+++ b/pkg/pillar/controllerconn/send.go
@@ -142,7 +142,9 @@ type RequestOptions struct {
 	// actually sending the data.
 	DryRun bool
 	// BailOnHTTPErr causes SendOnAllIntf to stop trying other interfaces if a 4xx or 5xx
-	// HTTP error is received from the server.
+	// HTTP error is received from the server. The response is still handed back to the
+	// caller; the option only limits how many ports are tried and says nothing about
+	// whether the request is worth repeating later.
 	BailOnHTTPErr bool
 	// Accept4xxErrors allows VerifyAllIntf to treat 4xx HTTP status codes as a valid
 	// indication of port connectivity.
@@ -228,6 +230,17 @@ type SendRetval struct {
 	HTTPResp     *http.Response
 	RespContents []byte
 	TracedReqs   []netdump.TracedNetRequest
+	// LastHTTPStatusCode is the status code of the most recent response received
+	// from the server, or zero if the server never responded. Unlike HTTPResp it
+	// is also set when the request ultimately failed on every port, so that
+	// a caller can tell a rejection by the controller apart from a connectivity
+	// failure.
+	//
+	// It is the code from the port which answered last, not a summary: should
+	// several ports answer with different codes, the earlier ones are not
+	// reported. Ports are tried in a rotating order, so a caller repeating the
+	// request may well be told about a different one next time.
+	LastHTTPStatusCode int
 }
 
 // VerifyRetval is returned from connectivity verification (VerifyAllIntf).
@@ -346,6 +359,9 @@ func (c *Client) SendOnAllIntf(ctx context.Context, url string, b *bytes.Buffer,
 		sendOnIntfOpts.UseOnboard = false
 		rv, err := c.SendOnIntf(ctx, url, intf, b, sendOnIntfOpts)
 		combinedRV.TracedReqs = append(combinedRV.TracedReqs, rv.TracedReqs...)
+		if rv.LastHTTPStatusCode != 0 {
+			combinedRV.LastHTTPStatusCode = rv.LastHTTPStatusCode
+		}
 		// This changes original boolean logic a little in V2 API.
 		// Basically the last status non-zero enum would overwrite the previous one
 		// in the loop if they differ.
@@ -863,6 +879,8 @@ func (c *Client) SendOnIntf(ctx context.Context, destURL string, intf string,
 			c.AgentMetrics.RecordSuccess(
 				c.log, intf, reqURL, reqlen, resplen, totalTimeMillis, sessionResume)
 		}
+
+		rv.LastHTTPStatusCode = resp.StatusCode
 
 		switch resp.StatusCode {
 		case http.StatusOK, http.StatusCreated, http.StatusNotModified, http.StatusNoContent:

--- a/pkg/pillar/controllerconn/send.go
+++ b/pkg/pillar/controllerconn/send.go
@@ -404,6 +404,14 @@ func (c *Client) SendOnAllIntf(ctx context.Context, url string, b *bytes.Buffer,
 		}
 		combinedRV.HTTPResp = rv.HTTPResp
 		combinedRV.RespContents = rv.RespContents
+		// The request was delivered by this port, so report its status rather
+		// than one collected from a port which failed to deliver it. A non-2xx
+		// can reach this point through Accept4xxErrors, and there the status
+		// derived from the response above is the answer the caller wants.
+		if rv.HTTPResp != nil && rv.HTTPResp.StatusCode >= 200 &&
+			rv.HTTPResp.StatusCode < 300 {
+			combinedRV.Status = rv.Status
+		}
 		return combinedRV, nil
 	}
 	errStr := fmt.Sprintf("All attempts to connect to %s failed: %s",
@@ -887,6 +895,9 @@ func (c *Client) SendOnIntf(ctx context.Context, destURL string, intf string,
 			c.log.Tracef("SendOnIntf to %s, response %s\n", reqURL, resp.Status)
 			rv.HTTPResp = resp
 			rv.RespContents = contents
+			// This source address delivered the request, so do not report
+			// a problem hit with one of the addresses tried before it.
+			rv.Status = types.SenderStatusNone
 			return rv, nil
 		default:
 			// Get caller to schedule a retry based on StatusCode

--- a/pkg/pillar/controllerconn/send_multiport_test.go
+++ b/pkg/pillar/controllerconn/send_multiport_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerconn_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// loopbackPort describes a management port which reaches the test server from
+// a distinct loopback source address, so that the handler can tell the ports
+// apart and answer each differently.
+func loopbackPort(ifName string, srcIP string, cost uint8) types.NetworkPortStatus {
+	return types.NetworkPortStatus{
+		IfName:       ifName,
+		Phylabel:     ifName,
+		Logicallabel: ifName,
+		IsMgmt:       true,
+		IsL3Port:     true,
+		Up:           true,
+		Cost:         cost,
+		AddrInfoList: []types.AddrInfo{{Addr: net.ParseIP(srcIP)}},
+		// Any DNS server will do, the request goes to a literal IP address.
+		DNSServers:     []net.IP{net.ParseIP("127.0.0.1")},
+		DefaultRouters: []net.IP{net.ParseIP("127.0.0.1")},
+	}
+}
+
+// The status reported to the caller must describe the port which delivered the
+// request, not one that failed before it. Otherwise a message that reached the
+// controller looks like a failure and gets sent a second time.
+func TestSendOnAllIntfStatusComesFromDeliveringPort(test *testing.T) {
+	t := NewGomegaWithT(test)
+
+	const failingSrcIP = "127.0.0.2"
+	const workingSrcIP = "127.0.0.1"
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			host, _, err := net.SplitHostPort(r.RemoteAddr)
+			if err == nil && host == failingSrcIP {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+	defer server.Close()
+
+	// The cheaper port is tried first and is the one answered with a 503.
+	var dns types.DeviceNetworkStatus
+	dns.Ports = []types.NetworkPortStatus{
+		loopbackPort("fakefail", failingSrcIP, 0),
+		loopbackPort("fakework", workingSrcIP, 1),
+	}
+	client := makeControllerClient(test, &dns, controllerconn.NewAgentMetrics())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	rv, err := client.SendOnAllIntf(ctx, server.URL+"/info", nil,
+		controllerconn.RequestOptions{AllowLoopbackDNS: true})
+
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(rv.HTTPResp).ToNot(BeNil())
+	t.Expect(rv.HTTPResp.StatusCode).To(Equal(http.StatusOK))
+	t.Expect(rv.LastHTTPStatusCode).To(Equal(http.StatusOK))
+	t.Expect(rv.Status).To(Equal(types.SenderStatusNone))
+}
+
+// When no port delivers the request, the status code the controller did answer
+// with has to survive, so that the caller can tell a rejection from a link that
+// never reached the controller.
+func TestSendOnAllIntfReportsStatusCodeWhenAllPortsFail(test *testing.T) {
+	t := NewGomegaWithT(test)
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+	defer server.Close()
+
+	var dns types.DeviceNetworkStatus
+	dns.Ports = []types.NetworkPortStatus{
+		loopbackPort("fakefail", "127.0.0.2", 0),
+		loopbackPort("fakefail2", "127.0.0.1", 1),
+	}
+	client := makeControllerClient(test, &dns, controllerconn.NewAgentMetrics())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	rv, err := client.SendOnAllIntf(ctx, server.URL+"/info", nil,
+		controllerconn.RequestOptions{AllowLoopbackDNS: true})
+
+	t.Expect(err).To(HaveOccurred())
+	t.Expect(rv.HTTPResp).To(BeNil())
+	t.Expect(rv.LastHTTPStatusCode).To(Equal(http.StatusServiceUnavailable))
+	t.Expect(rv.Status).To(Equal(types.SenderStatusUpgrade))
+}

--- a/pkg/pillar/docs/zedagent.md
+++ b/pkg/pillar/docs/zedagent.md
@@ -236,7 +236,7 @@ connectivity gaps. `zedagent` maintains three deferred queues:
 | Queue | Policy | Used for |
 |---|---|---|
 | `deferredEventQueue` | Reliable – retried on connectivity restore; has a priority function and a sent-callback. | Info messages, attestation escrow, EdgeNodeCerts – messages that must eventually reach the controller. |
-| `deferredPeriodicQueue` | Best-effort – dropped on failure without retry; no callback. | Metrics, hardware health, NTP sources – periodic data where a missed report is acceptable. |
+| `deferredPeriodicQueue` | Best-effort – dropped on failure without retry; no callback. | Location info, the one report published on a recurring timer where a missed one is acceptable. Metrics and hardware health do not go through a queue at all; NTP sources deliberately use the event queue so that every update is delivered. |
 | `deferredLOCPeriodicQueue` | Best-effort (same as above) | Periodic publishes to LOC. |
 
 When connectivity is restored (detected via `DeviceNetworkStatus`), the main event

--- a/pkg/pillar/docs/zedagent.md
+++ b/pkg/pillar/docs/zedagent.md
@@ -242,6 +242,18 @@ connectivity gaps. `zedagent` maintains three deferred queues:
 When connectivity is restored (detected via `DeviceNetworkStatus`), the main event
 loop kicks `deferredEventQueue` to flush any pending reliable messages.
 
+"Reliable" is bounded by what the controller answers. A message on the event
+queue survives connectivity loss and controller-side failures (5xx, 429), being
+re-offered with a per-item backoff, but it is given up on when the controller
+rejects the request itself (e.g. 400 or 404 for an object it no longer knows
+about) — retrying identical bytes it has already refused would be a hot loop.
+Such a drop is logged at error severity, because for the info types that reach
+this queue nothing re-asserts the state later: they are published on change
+only, so a lost message leaves the controller's view stale until the object
+changes again. A message the controller keeps failing to accept is moved behind
+its peers rather than retried first, so one object cannot hold up the reports
+for all the others.
+
 ## Source File Map
 
 | File | Responsibility |


### PR DESCRIPTION
# Description

This bug has been present for a while, and I discovered it by chance due to long running sequence of old tests running and one failing and that failure correlated with the controller being updated and restarted. Turns out that the app INFO message with its latest RUNNING status was never delivered to the controller even though those should be reliably delivered. Details below.

Note that this deferrred queue has been a source of issues in the past so this is a somewhat risky fix. To balance that, the fix relaxed the ordering so that if some message sees failures from the controller (due to some bug), it should not result in blocking the sending of the other info messages.

Separately there is an EVE API PR https://github.com/lf-edge/eve-api/pull/154 to add some more metrics around these failures and deferred queuing to get better visibility in production systems.

----

A device tells the controller about an application, volume, content tree,
blob, network instance, hardware or cluster change only when that change
happens; nothing re-asserts the state afterwards. Yet the deferred queue
treated **any** HTTP status from 400 to 599 as a reason to throw the message
away, logging a single line at the lowest severity and then counting the
message as sent. A few seconds of controller-side trouble was therefore
enough to leave the controller's view of an object wrong until that object
next changed - for a steady-state application, possibly never.

A case in point is a 503 error when the controller is updating; post update the controller will have missed any updates for these object.

The discard was introduced in 2018 for a controller that no longer knows
about an object and rejects the request itself (`return400`, matching exactly
400). Server errors were swept into it in 2020 by a commit whose subject was
about not trying the other ports on a 503; the same commit attached the
comment "Return 4xx and 5xx without trying other interfaces" to the shared
flag, which is why the field has documented the port-selection behavior while
the queue silently discarded data ever since.

This PR decides retention from the status code:

- A rejection of the request is still given up on - 400, 404, 405, 409, 410,
  413, 415, 422 - and is now logged as an error, since the state it carried is
  lost for good.
- Anything the controller may yet accept keeps the message queued: server
  errors, rate limiting, request timeout, and a refusal to authenticate or
  authorize the device, which EVE itself answers by restarting attestation and
  by fetching new controller certificates. There is no attempt limit; a
  message this queue carries has no other route to the controller, so the only
  alternative to retrying is losing it.

Retrying safely required fixing the queue ordering as well, which is the
larger half of the change. A status code means the controller was reached, so
the failure belongs to that one message: the pass now continues instead of
aborting for every remaining message and every lower-priority class, and a
message waiting out its retry delay moves behind its peers rather than being
retried ahead of them. Without this, converting the discard into a retry would
have traded data loss for one object blocking the reports of all the others.

Because retrying forever must not be silent, a long backlog of undelivered
messages and an individual message the controller keeps refusing are both
raised as warnings. Reporting an object again with unchanged content keeps the
retry state of the queued message, so a device republishing identical bytes
neither restarts the delay nor hides how long a message has been stuck.

Two smaller things fall out of the above. `SendOnAllIntf` now reports the
sender status of the port that actually delivered a request rather than a
complaint collected from a port that did not, so a delivered report is no
longer kept and sent a second time. And the first edgeview status no longer
takes a special path: it was routed to the best-effort queue in the hope of
getting it delivered, which had the opposite effect, since that queue discards
a message whose send fails.

Fixes #6302

## How to test and validate this PR

Covered by automated unit tests in `pkg/pillar/controllerconn`: 30 tests, run
with `make -C pkg/pillar test` or `go test -race ./controllerconn/...`. They
cover the status classification, the per-item delay, the demotion behind peers,
the interaction with the attest / app-info / hardware-info priority classes,
the two warnings, the retry state of a republished payload, and the queue
length staying bounded by the number of objects. Each was checked against the
pre-change behavior: reverting the classification or the pass-continuation
makes them fail on their assertions rather than pass silently.

It is also covered end to end. `evetest` can put the controller behind a proxy
which answers, delays or drops selected device requests - asked for with
`EVETEST_CONTROLLER_FAULTS=true`, and out of the path otherwise. Then
`evetest/tests/controllerfaults` uses that: an application's state is changed
while the controller fails the info messages reporting it, and the controller
then has to catch up on its own. Run with

```
EVETEST_CONTROLLER_FAULTS=true make evetest NAME=TestControllerFaultsSuite
```

Without the variable the controller is reached directly and these tests skip.

The outcome is measured rather than argued. `TestInfoRetriedAfterServerError`
**fails** against an EVE built without this change - the proxy answered every
info message with 503, so the device did try, and then nothing arrived in the
eight minutes after the controller started accepting messages again, the report
being gone for good - and **passes** against one built with it. The suite is
green as a whole on amd64 under QEMU:

```
--- PASS: TestControllerFaultsSuite (897.91s)
    --- PASS: .../TestInfoRetriedAfterServerError (501.83s)
    --- PASS: .../TestInfoRetriedAfterLostController (211.87s)
    --- PASS: .../TestInfoDroppedOnRejectionKeepsDeviceReporting (180.73s)
```

Only the first of the three distinguishes this change; the other two guard
behavior it deliberately preserves - a controller which cannot be reached keeps
the message queued, and one which rejects it drops the message without leaving
the queue unable to deliver what follows.

## Changelog notes

Device state updates - application, volume, content tree, network instance,
hardware and cluster information - are no longer discarded when the controller
answers with a temporary error such as a 503 during an upgrade or an overload.
They are retried until the controller accepts them, so its view of a device no
longer stays stale after a brief interruption. Messages the controller rejects
outright are still discarded, now with an error logged.

## PR Backports

The bug is present on all four branches, but the queue-ordering half of the fix
changes behavior in code which has been fragile before, so the backports wait
until this has soaked on master for a while. Review asked for the same.

- 17.0-stable: after soak on master
- 16.0-stable: after soak on master
- 14.5-stable: after soak on master
- 13.4-stable: after soak on master

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them: the tests above ran on an amd64 QEMU device rather than hardware,
  and the arm64 box is unchecked for want of one. Nothing here is architecture
  specific.



