### PR TITLE
[16.0-stable] pkg/grub: fix dropped HTTP port and grub source fetch

### DIFF
--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile-upstream:1.5.0-rc2-labs
-# Copyright (c) 2025 Zededa, Inc.
+# Copyright (c) 2025-2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 FROM lfedge/eve-alpine:745ae9066273c73b0fd879c4ba4ff626a8392d04 AS grub-build-base
@@ -40,20 +40,20 @@ ENV GRUB_PLATFORM="efi pc:--disable-efiemu"
 
 FROM grub-build-base AS grub-build-arm64
 ENV GRUB_MODULES="xen_boot efi_gop gpt gcry_sha256 measurefs efinet"
-ENV GRUB_COMMIT=2.06
-ENV GRUB_PATCHES="patches-${GRUB_COMMIT} patches-aarch64-${GRUB_COMMIT}"
+ENV GRUB_COMMIT=grub-2.06
+ENV GRUB_PATCHES="patches-2.06 patches-aarch64-2.06"
 ENV GRUB_PLATFORM=efi
 
 FROM grub-build-base AS grub-build-riscv64
 ENV GRUB_MODULES="efinet"
-ENV GRUB_COMMIT=2.06
-ENV GRUB_PATCHES="patches-${GRUB_COMMIT} patches-riscv64-${GRUB_COMMIT}"
+ENV GRUB_COMMIT=grub-2.06
+ENV GRUB_PATCHES="patches-2.06 patches-riscv64-2.06"
 ENV GRUB_PLATFORM=efi
 
 # hadolint ignore=DL3006
 FROM grub-build-${TARGETARCH} AS grub-build
 
-ENV GRUB_REPO=https://cgit.git.savannah.gnu.org/cgit/grub.git
+ENV GRUB_REPO=git://git.git.savannah.gnu.org/grub.git
 
 COPY patches /patches
 COPY patches-2.06  /patches-2.06
@@ -63,27 +63,19 @@ COPY patches-riscv64-2.06 /patches-riscv64-2.06
 RUN ln -s python3 /usr/bin/python && \
     mkdir /grub-lib
 
-ADD ${GRUB_REPO}/snapshot/grub-${GRUB_COMMIT}.tar.gz /grub.tar.gz
+ADD --keep-git-dir ${GRUB_REPO}#${GRUB_COMMIT} /grub
 ENV GNULIB_REVISION=d271f868a8df9bbec29049d01e056481b7a1a263
 ADD --keep-git-dir https://github.com/coreutils/gnulib.git#${GNULIB_REVISION} /gnulib
 
-# the below does a weird init of a git repo, because we are not cloning the
-# repo, yet we need to be in a repo to apply patches with `git am`.
 # hadolint ignore=DL3003,SC2086
-RUN if [ ! -d "grub" ]; then \
-        tar -xzf /grub.tar.gz && \
-        mv "grub-${GRUB_COMMIT}" grub && \
-        rm -f /grub.tar.gz && \
-        cd grub && \
-        mkdir -p /apply/patches && \
-        for dir in ${GRUB_PATCHES}; do \
-            cp -r /${dir}/* /apply/patches; \
-        done && \
-        git config --global user.name "Your Name" && \
-        git config --global user.email "you@example.com" && \
-        git init . && git add . && git commit -m "init" && \
-        git am /apply/patches/*; \
-    fi
+RUN cd /grub && \
+      mkdir -p /apply/patches && \
+      for dir in ${GRUB_PATCHES}; do \
+          cp -r /${dir}/* /apply/patches; \
+      done && \
+      git config --global user.name 'Project EVE' && \
+      git config --global user.email 'builder@projecteve.dev' && \
+      git am /apply/patches/*
 
 WORKDIR /grub
 

--- a/pkg/grub/Dockerfile
+++ b/pkg/grub/Dockerfile
@@ -53,7 +53,7 @@ ENV GRUB_PLATFORM=efi
 # hadolint ignore=DL3006
 FROM grub-build-${TARGETARCH} AS grub-build
 
-ENV GRUB_REPO=git://git.git.savannah.gnu.org/grub.git
+ENV GRUB_REPO=https://gitlab.freedesktop.org/gnu-grub/grub.git
 
 COPY patches /patches
 COPY patches-2.06  /patches-2.06

--- a/pkg/grub/patches/0000-core-os-merge.patch
+++ b/pkg/grub/patches/0000-core-os-merge.patch
@@ -4468,7 +4468,11 @@ index 10773fc34..5e3704831 100644
        if (comma)
  	{
  	  protnamelen = comma - name;
-@@ -1313,8 +1324,13 @@ grub_net_open_real (const char *name)
+@@ -1310,11 +1321,17 @@ grub_net_open_real (const char *name)
+ 	    if (!ret)
+ 	      return NULL;
+ 	    ret->protocol = proto;
++	    ret->port = port;
  	    ret->server = grub_strdup (server);
  	    if (!ret->server)
  	      {


### PR DESCRIPTION
# Description

Two independent problems in `pkg/grub` on this branch: one that silently
misroutes HTTP traffic in GRUB, and one that prevents the package from being
built at all.

**1. A non-default HTTP port is parsed and then silently ignored (amd64)**

The port support that `patches/0000-core-os-merge.patch` backports into
`grub_net_open_real()` reads a `":port"` suffix off the network device name, but
assigns it to `grub_net_t` only inside the "`grub_strdup()` failed" error
branch, where it also repeats the `grub_strdup()` call that has just failed:

```c
	    ret->server = grub_strdup (server);
	    if (!ret->server)
	      {
		ret->server = grub_strdup (server);
		ret->port = port;               /* only reached when out of memory */
		if (!ret->server)
		  {
		    grub_free (ret);
		    return NULL;
		  }
	      }
```

`ret` comes from `grub_zalloc()`, so on every normal path `net->port` stays 0
and `http_establish()` falls back to `HTTP_PORT`, i.e. 80. The port digits are
parsed and stripped off the server address, and the connection then goes to
port 80 anyway, without any error message. This is how it manifests: netbooting
the installer from an HTTP server that does not listen on port 80 never reaches
that server.

The first commit assigns the port on the success path. It is deliberately kept
to a single added line, leaving the odd error branch exactly as it is today, so
that the diff of the patch file stays reviewable.

Not affected: 17.0 and master, which build GRUB 2.12 and carry upstream commit
`26cfaa8a90f5` ("net: Read bracketed IPv6 addrs and port numbers") instead of
this backport; and arm64/riscv64 on this branch, which build GRUB 2.06 and have
no port support at all.

**2. `make pkg/grub` cannot fetch the GRUB source**

`git.savannah.gnu.org` no longer serves cgit snapshot tarballs, so the `ADD` of

```text
https://cgit.git.savannah.gnu.org/cgit/grub.git/snapshot/grub-71f9e4ac44142af52c3fc1860436cf9e432bf764.tar.gz
```

fails the build with `invalid response status 502`, then `400`, and now a plain
`404`. The second commit is a cherry-pick of #5589, which replaced the tarball
with a git clone; it applies to this branch unchanged. The third commit points
the clone at the `gitlab.freedesktop.org` mirror, because
`git.savannah.gnu.org` refuses to serve unadvertised objects and amd64 pins a
commit SHA rather than a tag:

```text
fatal: Not a valid object name 71f9e4ac44142af52c3fc1860436cf9e432bf764^{commit}
```

BuildKit recovers from that by cloning the entire repository, but the mirror
serves the pinned commit directly, over https rather than the plaintext git
protocol on port 9418 that tends to be blocked in CI and corporate networks. It
is also the repository master uses since the migration to GRUB 2.12, and its
content for this commit is identical (verified with `diff -r` against
`git archive` of the same SHA).

## How to test and validate this PR

**Build (covers commits 2 and 3, and is a prerequisite for everything else)**

```sh
make pkg/grub
```

On this branch without the fixes this fails while fetching the GRUB source. It
should now clone from `gitlab.freedesktop.org`, apply all 16 patches with
`git am`, compile for both `efi` and `pc`, and run `grub-mkimage`.

**Quick functional check of the port fix, from the GRUB command line**

1. Serve any directory over HTTP on a non-default port, e.g.
   `python3 -m http.server 8080`.
2. Boot a device far enough to get a GRUB prompt with networking (the netboot
   installer gives you one with `c`), and if the card has no address yet run
   `net_bootp`.
3. Run `ls (http,<server-ip>:8080)/`.

- Before: the listing fails, because GRUB connects to port 80 on that host
  (visible as a connection timeout, or as whatever port 80 happens to serve).
- After: the directory listing succeeds.

**Full netboot scenario (the reported failure)**

1. `make installer-net`, untar `dist/<arch>/current/installer.net` into the
   document root of an HTTP server that listens on a port other than 80, e.g.
   8080.
2. In `EFI/BOOT/grub.cfg`, replace the generated device reference with an
   explicit HTTP device including the port:
   `loopback loop0 (http,<server-ip>:8080)/installer.iso`
   (the generated file uses `($cmddevice)`, which GRUB derives from the DHCP
   ack and which therefore names the TFTP next-server, not the HTTP server).
3. Netboot the target with iPXE pointed at that server.

- Before: GRUB prints "Downloading installer..." and then fails to fetch
  `installer.iso`, because it talks to port 80.
- After: `installer.iso` is downloaded and the installer boots.

Not covered by an automated test: there is no test coverage for `pkg/grub`.

## Changelog notes

Fixed the EVE installer being unable to netboot from an HTTP server that
listens on a port other than 80 (amd64). The port given in the GRUB device
name, as in `(http,server:8080)`, was parsed and then discarded, so GRUB always
connected to port 80.

## PR Backports

The bug is identical on every branch before 17.0: the patch file
`pkg/grub/patches/0000-core-os-merge.patch` is byte-for-byte the same blob
(`f274c64fac90`) on 12.0-stable, 13.4-stable, 14.5-stable and 16.0-stable, so
the first commit cherry-picks onto all of them without conflict.

- 14.5-stable: Backported in #6307. Only the first commit is needed; the source
  fetch fix is already there as `5914ce1c3c` (backport of #5589). The mirror
  switch is optional there.
- 13.4-stable: Backported in #6308, same as 14.5-stable; it has #5589 as
  `be7043bc21`.

12.0-stable is not in the LTS list above, but for the record it has both
problems, and its snapshot URL now 301-redirects to the same dead endpoint.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Reasons for the unchecked boxes:

- Documentation: no EVE document describes the GRUB device syntax or the netboot
  server layout in enough detail for a port to be mentioned, so there is nothing
  to update. `docs/DEPLOYMENT.md` only covers the iPXE side.
- amd64 device: `make pkg/grub` builds clean and the resulting source was
  verified by applying the full patch series and reading
  `grub_net_open_real()`/`http_establish()`, but the change has not yet been
  netbooted on hardware.
- arm64 device: not applicable. This patch directory is used for amd64 only;
  arm64 builds GRUB 2.06 from `patches-2.06`, which has no port support to fix.
