### PR TITLE
[14.5-stable] pkg/grub: fix dropped HTTP port in CoreOS merge patch

### DIFF
--- a/pkg/grub/patches/0000-core-os-merge.patch
+++ b/pkg/grub/patches/0000-core-os-merge.patch
@@ -4468,7 +4468,11 @@ index 10773fc34..5e3704831 100644
        if (comma)
  	{
  	  protnamelen = comma - name;
-@@ -1313,8 +1324,13 @@ grub_net_open_real (const char *name)
+@@ -1310,11 +1321,17 @@ grub_net_open_real (const char *name)
+ 	    if (!ret)
+ 	      return NULL;
+ 	    ret->protocol = proto;
++	    ret->port = port;
  	    ret->server = grub_strdup (server);
  	    if (!ret->server)
  	      {


### PR DESCRIPTION
# Description

Backport of #6305, first commit only.

**A non-default HTTP port is parsed and then silently ignored (amd64)**

The port support that `patches/0000-core-os-merge.patch` backports into
`grub_net_open_real()` reads a `":port"` suffix off the network device name, but
assigns it to `grub_net_t` only inside the "`grub_strdup()` failed" error
branch, where it also repeats the `grub_strdup()` call that has just failed:

```c
	    ret->server = grub_strdup (server);
	    if (!ret->server)
	      {
		ret->server = grub_strdup (server);
		ret->port = port;               /* only reached when out of memory */
		if (!ret->server)
		  {
		    grub_free (ret);
		    return NULL;
		  }
	      }
```

`ret` comes from `grub_zalloc()`, so on every normal path `net->port` stays 0
and `http_establish()` falls back to `HTTP_PORT`, i.e. 80. The port digits are
parsed and stripped off the server address, and the connection then goes to
port 80 anyway, without any error message. This is how it manifests: netbooting
the installer from an HTTP server that does not listen on port 80 never reaches
that server.

The fix assigns the port on the success path. It is deliberately kept to a
single added line, leaving the odd error branch exactly as it is today, so that
the diff of the patch file stays reviewable.

`pkg/grub/patches/0000-core-os-merge.patch` is byte-for-byte the same blob
(`f274c64fac90`) on 12.0-stable, 13.4-stable, 14.5-stable and 16.0-stable, so
the cherry-pick applies without conflict and produces a file identical to the
one in #6305 (blob `6815e73c2d21`).

Unlike 16.0-stable, this branch needs only this one commit of #6305: it already
fetches the GRUB source with git instead of a cgit snapshot tarball, via
`5914ce1c3c` (backport of #5589), and cgit no longer serves those tarballs.

Not affected: 17.0 and master, which build GRUB 2.12 and carry upstream commit
`26cfaa8a90f5` ("net: Read bracketed IPv6 addrs and port numbers") instead of
this backport; and arm64/riscv64 on this branch, which build GRUB 2.06 and have
no port support at all.

## How to test and validate this PR

**Build**

```sh
make pkg/grub
```

It should clone the GRUB source, apply all 15 patches with `git am`, compile for
both `efi` and `pc`, and run `grub-mkimage`. The `patches/` directory is
identical on 13.4-stable and 14.5-stable, so one build covers both.

**Quick functional check of the port fix, from the GRUB command line**

1. Serve any directory over HTTP on a non-default port, e.g.
   `python3 -m http.server 8080`.
2. Boot a device far enough to get a GRUB prompt with networking (the netboot
   installer gives you one with `c`), and if the card has no address yet run
   `net_bootp`.
3. Run `ls (http,<server-ip>:8080)/`.

- Before: the listing fails, because GRUB connects to port 80 on that host
  (visible as a connection timeout, or as whatever port 80 happens to serve).
- After: the directory listing succeeds.

**Full netboot scenario (the reported failure)**

1. `make installer-net`, untar `dist/<arch>/current/installer.net` into the
   document root of an HTTP server that listens on a port other than 80, e.g.
   8080.
2. In `EFI/BOOT/grub.cfg`, replace the generated device reference with an
   explicit HTTP device including the port:
   `loopback loop0 (http,<server-ip>:8080)/installer.iso`
   (the generated file uses `($cmddevice)`, which GRUB derives from the DHCP
   ack and which therefore names the TFTP next-server, not the HTTP server).
3. Netboot the target with iPXE pointed at that server.

- Before: GRUB prints "Downloading installer..." and then fails to fetch
  `installer.iso`, because it talks to port 80.
- After: `installer.iso` is downloaded and the installer boots.

Not covered by an automated test: there is no test coverage for `pkg/grub`.

## Changelog notes

Fixed the EVE installer being unable to netboot from an HTTP server that
listens on a port other than 80 (amd64). The port given in the GRUB device
name, as in `(http,server:8080)`, was parsed and then discarded, so GRUB always
connected to port 80.

## PR Backports

Original PR: #6305 (16.0-stable).

- 14.5-stable: This PR.
- 13.4-stable: #6308.

12.0-stable has the same bug, and additionally still uses the dead cgit tarball
URL, but it has had no commits since 2024-12-28 and is not in the LTS list
above, so no backport is proposed for it.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Reasons for the unchecked boxes:

- Documentation: no EVE document describes the GRUB device syntax or the netboot
  server layout in enough detail for a port to be mentioned, so there is nothing
  to update. `docs/DEPLOYMENT.md` only covers the iPXE side.
- amd64 device: `make pkg/grub` builds clean and the resulting source was
  verified by applying the full patch series and reading
  `grub_net_open_real()`/`http_establish()`, but the change has not yet been
  netbooted on hardware.
- arm64 device: not applicable. This patch directory is used for amd64 only;
  arm64 builds GRUB 2.06 from `patches-2.06`, which has no port support to fix.
