### PR TITLE
zfs: serialize libzfs namespace enumeration to avoid panic

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -292,8 +292,11 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext, wdName string) {
 		}
 	}
 
-	// If we have ZFS dataset, report their info from the ZFS perspective
+	// If we have ZFS dataset, report their info from the ZFS perspective.
+	// The enumeration waits for any other agent already inside libzfs, so
+	// report liveness before entering it rather than only after publishing.
 	if handler := volumehandlers.GetZFSVolumeHandler(log, ctx); handler != nil {
+		ctx.ps.StillRunning(wdName, warningTime, errorTime)
 		items, err := handler.GetAllDataSets()
 		if err != nil {
 			log.Error(err)

--- a/pkg/pillar/cmd/zfsmanager/zfsmanager.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsmanager.go
@@ -55,7 +55,6 @@ type zfsContext struct {
 	subVolumeStatus        pubsub.Subscription
 	disksProcessingTrigger chan interface{}
 	zVolDeviceEvents       *base.LockedStringMap // stores device->zVolDeviceEvent mapping to check and publish
-	zfsIterLock            sync.Mutex
 	globalConfig           *types.ConfigItemValueMap
 	GCInitialized          bool
 	// trimMu guards trimStatus and the cached trimCron, which are read from

--- a/pkg/pillar/cmd/zfsmanager/zfsstoragemetrics.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsstoragemetrics.go
@@ -6,7 +6,6 @@ package zfsmanager
 import (
 	"time"
 
-	libzfs "github.com/andrewd-zededa/go-libzfs"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
@@ -34,9 +33,7 @@ func storageMetricsPublisher(ctxPtr *zfsContext) {
 
 func collectAndPublishStorageMetrics(ctxPtr *zfsContext) {
 	log.Functionf("collectAndPublishStorageMetrics start")
-	ctxPtr.zfsIterLock.Lock()
-	defer ctxPtr.zfsIterLock.Unlock()
-	zpoolList, err := libzfs.PoolOpenAll()
+	zpoolList, err := zfs.PoolOpenAll()
 	if err != nil {
 		log.Errorf("get zpool list for collect metrics failed %v", err)
 	} else {

--- a/pkg/pillar/cmd/zfsmanager/zfsstoragestatus.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsstoragestatus.go
@@ -34,14 +34,12 @@ func storageStatusPublisher(ctxPtr *zfsContext) {
 
 func collectAndPublishStorageStatus(ctxPtr *zfsContext) {
 	log.Functionf("collectAndPublishStorageStatus start")
-	ctxPtr.zfsIterLock.Lock()
-	defer ctxPtr.zfsIterLock.Unlock()
 	zfsVersion, err := zfs.GetZfsVersion()
 	if err != nil {
 		log.Errorf("error: %v", err)
 	}
 
-	zpoolList, err := libzfs.PoolOpenAll()
+	zpoolList, err := zfs.PoolOpenAll()
 	if err != nil {
 		log.Errorf("get zpool list failed %v", err)
 	} else {

--- a/pkg/pillar/zfs/namespace.go
+++ b/pkg/pillar/zfs/namespace.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zfs
+
+import (
+	"sync"
+
+	libzfs "github.com/andrewd-zededa/go-libzfs"
+)
+
+// namespaceLock serializes the two libzfs entry points that rebuild the userland
+// pool namespace. libzfs keeps that namespace in a single AVL tree per library
+// handle, and go-libzfs shares one handle across the whole process, so two agents
+// enumerating at once tear the tree down under each other. libzfs asserts on the
+// resulting duplicate insert and calls abort(), which kills every agent in zedbox:
+// a SIGABRT raised inside C cannot be recovered by the Go runtime.
+//
+// Only zpool_iter() and zfs_iter_root() reach that tree, and both walk it after
+// reloading it, so the lock is held across a whole enumeration. The handles an
+// enumeration returns do not refer to the tree, so callers hold no lock while
+// working with them.
+var namespaceLock sync.Mutex
+
+// PoolOpenAll enumerates the pools. Every caller must reach libzfs through this
+// wrapper rather than calling the binding directly, so that enumerations
+// serialize process-wide; namespace_test.go enforces that.
+func PoolOpenAll() ([]libzfs.Pool, error) {
+	namespaceLock.Lock()
+	defer namespaceLock.Unlock()
+	return libzfs.PoolOpenAll()
+}
+
+// DatasetOpenAll enumerates the datasets, under the same contract as PoolOpenAll.
+// The caller owns the returned handles and releases them with
+// libzfs.DatasetCloseAll.
+func DatasetOpenAll() ([]libzfs.Dataset, error) {
+	namespaceLock.Lock()
+	defer namespaceLock.Unlock()
+	return libzfs.DatasetOpenAll()
+}

--- a/pkg/pillar/zfs/namespace_test.go
+++ b/pkg/pillar/zfs/namespace_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zfs
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoDirectEnumeration fails when pillar calls a libzfs enumeration outside
+// the wrappers in namespace.go. The serialization those wrappers provide is
+// process-wide, so a single caller reaching the binding directly defeats it for
+// every agent, and nothing else in the build reports that.
+func TestNoDirectEnumeration(t *testing.T) {
+	banned := []string{"libzfs.PoolOpenAll(", "libzfs.DatasetOpenAll("}
+	exempt := map[string]bool{"namespace.go": true, "namespace_test.go": true}
+
+	var offenders []string
+	err := filepath.WalkDir("..", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == "vendor" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || exempt[d.Name()] {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, call := range banned {
+			if strings.Contains(string(content), call) {
+				offenders = append(offenders, path+": "+call)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking pillar sources: %v", err)
+	}
+	for _, offender := range offenders {
+		t.Errorf("%s must go through the zfs package wrapper so enumerations serialize", offender)
+	}
+}

--- a/pkg/pillar/zfs/zfs.go
+++ b/pkg/pillar/zfs/zfs.go
@@ -1049,7 +1049,7 @@ func GetVDevAuxMsgStr(state types.VDevAux) string {
 
 // GetAllZFSVolumeInfo returns an ImgInfo for each ZFS dataset
 func GetAllZFSVolumeInfo() ([]types.ImgInfo, error) {
-	list, err := libzfs.DatasetOpenAll()
+	list, err := DatasetOpenAll()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

I've seen this panic once, but it causes zedbox to exit hence a device reboot, so it is important to fix.

Enumerating ZFS pools or datasets makes libzfs rebuild the pool namespace it keeps in a single AVL tree per library handle, and the binding shares one handle across the whole process. Two agents enumerating at the same time tear that tree down under each other; libzfs answers the resulting duplicate insert with an assertion that calls `abort()`. A SIGABRT raised inside C cannot be recovered by the Go runtime, so this takes down every agent in zedbox at once and the device reboots with no reboot reason and no stack — #6299.

A lock for exactly this assertion was added in 2022 (`dcc3c4dc5`), but it lives in zfsmanager and so only ever covered that agent's two pool enumerations, even though its commit message names the dataset one too. The dataset enumeration in volumemgr's disk-metrics pass was added in 2024 (`673788fba`), in a different agent, and has run unprotected since.

This moves the lock to the `zfs` package, where it can cover every caller, and routes all three enumerations through it. `zfsmanager`'s private lock is removed. A test fails the build if a caller reaches the binding directly again — that is precisely how the 2022 fix decayed, silently, for two years.

The lock is deliberately scoped to the enumeration alone. Only `zpool_iter()` and `zfs_iter_root()` reach the shared tree, and both walk it after reloading it, so the whole call must be covered — but the handles they return do not refer to the tree, so no lock is held while callers work with them.

Waiting for the lock lands in volumemgr's metrics pass at a point that was already silent towards the watchdog (no `StillRunning` between the large-file walk and publishing), so that pass now reports liveness before it enumerates. This interacts with #6300 / #6301, which keep the same pass from going silent during the directory walks, but does not depend on them: with the heartbeat added here the wait starts against a fresh watchdog interval either way.

## How to test and validate this PR

Automated, in `pkg/pillar/zfs/namespace_test.go`:

* `TestNoDirectEnumeration` walks the pillar sources and fails on any `libzfs.PoolOpenAll(` / `libzfs.DatasetOpenAll(` outside the wrappers. Validated against the pre-change tree: it fails there on its assertions — not on compilation — naming all three call sites, including the one in `zfs/zfs.go`.

The race itself needs a ZFS device and two agents colliding inside libzfs, so it is not reproducible in a unit test; a test that only exercised the mutex would assert nothing about the bug. On a device the check is negative: a node with a ZFS `persist` pool should no longer abort in `namespace_reload()`. Note the window that makes this possible opens roughly every five minutes on any such node, because the cachefile write fails permanently and ZFS retries it every 300 s, bumping the config generation each time (measured on hardware, detail in #6299).

`gofmt`, `go vet` (with and without `-tags k`) and `make mini-yetus` are clean.

## Changelog notes

Fixes a rare crash where collecting storage metrics on a device using ZFS could abort all EVE services at once, rebooting the device without recording a reason.

## PR Backports

All four stable branches carry the same unprotected dataset enumeration alongside the agent-local lock:

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — no doc change; the locking is internal to the `zfs` package
- [ ] I've tested my PR on amd64 device — not yet; the failure is rare in the field and the fix is not directly observable
- [ ] I've tested my PR on arm64 device — not run; the change is architecture-independent
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
