### PR TITLE
evetest: port the Eden hardware inventory test

### DIFF
--- a/evetest/go.mod
+++ b/evetest/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/containerd/errdefs v1.0.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v29.6.2+incompatible
+	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.9
 	github.com/google/uuid v1.6.0
 	github.com/lf-edge/eve-api/go v0.0.0-20260812180240-99d02ddcfcb0
@@ -56,7 +57,6 @@ require (
 	github.com/go-playground/validator/v10 v10.15.5 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jinzhu/copier v0.4.0 // indirect

--- a/evetest/tests/telemetry/hwinventory_test.go
+++ b/evetest/tests/telemetry/hwinventory_test.go
@@ -1,0 +1,266 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test the hardware inventory (ZInfoHardware) that EVE reports to the controller.
+
+package telemetry_test
+
+import (
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	"github.com/google/go-cmp/cmp"
+	eveinfo "github.com/lf-edge/eve-api/go/info"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/constants"
+	"github.com/lf-edge/eve/evetest/matchers"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+const (
+	devInfoTimeout = 5 * time.Minute
+
+	// EVE publishes ZInfoHardware once per boot, at zedagent startup - i.e. long
+	// before this test starts - so the pre-reboot message is fetched from the
+	// controller's store rather than awaited on a watch. Polling Adam reloads
+	// every stored info message, hence the deliberately slow interval.
+	hwInfoTimeout      = 2 * time.Minute
+	hwInfoPollInterval = 5 * time.Second
+
+	// RequestReboot(true) returns only once the device is back and has reported a
+	// fresh LastRebootTime, so this covers just the gap between that device info
+	// message and the hardware info message - zedagent triggers both during
+	// startup, seconds apart.
+	postRebootHwInfoTimeout = 2 * time.Minute
+)
+
+// TestHardwareInventory verifies the hardware inventory EVE reports in
+// ZInfoHardware: that EVE advertises the capability, that the inventory
+// describes the device it actually runs on, and - the point of the test - that
+// it is a *stable* description of that hardware, unchanged by a reboot.
+//
+// zedagent collects the inventory once per boot, from ghw, before any controller
+// config is applied (hardware.GetInventoryInfo) - which is what makes a
+// difference across a reboot meaningful: it can only be a non-deterministic
+// collector or runtime state leaking into a pure hardware description.
+//
+// Two traps in the field assertions:
+//   - CpuInfo lists one entry per *physical core* while ZInfoDevice.Ncpu counts
+//     *logical* CPUs. Both are asserted against the vCPU count the harness gave
+//     the VM rather than against each other, so that EVE is not its own
+//     reference; the inventory side holds only while threads-per-core is 1, as
+//     it is for every provider the broker drives. Ids are not asserted unique:
+//     the id is a core id, unique only within a socket.
+//   - Several assertions are floor checks catching collection that failed
+//     outright, not cross-checks: HwInventorySupport is hardcoded true in
+//     getOptionalCapabilities, so it guards the API shape rather than a runtime
+//     capability; ghw falls TotalPhysicalBytes back to MemTotal; and
+//     TotalStorageBytes contains ZInfoDevice.Storage (the /persist partition) by
+//     construction. ghw also enumerates /sys/class/net irrespective of the
+//     applied config, so the entry for the configured port proves nothing about
+//     that config; it is asserted because a physical NIC is the one device whose
+//     properties the test knows in advance.
+//
+// Network model
+// -------------
+//   - netmodels.SingleEthWithDHCP -- the inventory is not about networking, so a
+//     single port need only give the device controller connectivity; it also
+//     gives the NetworkDevice assertion an unambiguous interface to look for.
+//
+// Device configuration
+// --------------------
+//   - SystemAdapter for eth0 (DHCP, mgmt+apps), nothing else: the inventory is
+//     collected before any config is applied, so the configuration exists only
+//     to get the device reporting to the controller.
+//
+// Phases / assertions
+// -------------------
+//
+//  1. setup-done -> config-applied.
+//
+//  2. inventory-support-reported: wait for a ZInfoDevice with Ncpu and Storage
+//     populated - they reach zedagent from other microservices via pubsub - then
+//     assert HwInventorySupport, rather than waiting for it, so that an EVE
+//     without the field fails immediately instead of timing out.
+//
+//  3. inventory-reported: the ZInfoHardware message EVE published at boot carries
+//     an inventory. Fetched with GetHardwareInfo rather than a watch, because it
+//     was published once during zedagent startup, so the controller's stored copy
+//     is by now the only one there is.
+//
+//  4. inventory-fields-checked: the field assertions.
+//
+//  5. device-rebooted -> inventory-stable-after-reboot: reboot via
+//     RequestReboot(true), then compare the two inventories. Here a watch is the
+//     right tool, opened *before* the reboot: it streams only messages arriving
+//     after subscribing, so what it delivers can only be the publish from the
+//     rebooted device's own startup, not the record the controller already held.
+//     The whole HardwareInventory is compared; the enclosing ZInfoHardware is
+//     not, since its Disks field carries S.M.A.R.T. attributes that legitimately
+//     change. The comment at the diff names the likely sources of a spurious one.
+//
+// Test params
+// -----------
+//   - TPM. Drives both whether the device VM gets an emulated TPM and the
+//     expected value of Inventory.Tpm.Present.
+//   - HYPERVISOR. Not asserted on; declared so that every test in the suite
+//     states the same device requirements and the framework can reuse one VM.
+//
+// Suite placement
+// ---------------
+//   - TestTelemetrySuite, among the subtests that reboot the device.
+func TestHardwareInventory(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	// Define configurable parameters available for the test.
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+		evetest.TPMParameter(),
+	)
+
+	// Get parameter values set for this test execution.
+	hypervisor := evetest.GetHypervisorParameterValue()
+	useTPM := evetest.GetTPMParameterValue()
+
+	// Set up the test harness and specify the test prerequisites.
+	device := setupTelemetryTestDevice(hypervisor, useTPM)
+	evetest.Checkpoint("setup-done")
+
+	// Build and apply the device configuration.
+	devConfig := singleMgmtPortConfig()
+	devUpdates, stopDevWatch := device.WatchDeviceInfo()
+	defer stopDevWatch()
+	device.ApplyConfig(devConfig, true, true)
+	evetest.Checkpoint("config-applied")
+	if hypervisor == evetest.HypervisorKubevirt {
+		device.WaitForClusterNodeIsReady(clusterNodeReadyTimeout)
+	}
+
+	// Phase 2: EVE advertises hardware inventory support and reports the summary
+	// quantities the inventory is checked alongside.
+	var devInfo *eveinfo.ZInfoDevice
+	t.Eventually(devUpdates, devInfoTimeout).Should(Receive(matchers.SatisfyPredicate(
+		"Device reports its CPU count and storage size",
+		func(info *eveinfo.ZInfoDevice) bool {
+			devInfo = info
+			return info.GetNcpu() > 0 && info.GetStorage() > 0
+		})))
+	t.Expect(devInfo.GetOptionalCapabilities()).ToNot(BeNil(),
+		"device info reports no optional capabilities")
+	t.Expect(devInfo.GetOptionalCapabilities().GetHwInventorySupport()).To(BeTrue(),
+		"device does not advertise hardware inventory support")
+	evetest.Checkpoint("inventory-support-reported")
+
+	// Phase 3: the hardware info message published at boot is on the controller
+	// and carries an inventory.
+	var hwInfo *eveinfo.ZInfoHardware
+	t.Eventually(func(g Gomega) {
+		hwInfo = device.GetHardwareInfo()
+		g.Expect(hwInfo).ToNot(BeNil(), "no ZInfoHardware message received")
+		g.Expect(hwInfo.GetInventory()).ToNot(BeNil(),
+			"ZInfoHardware message carries no hardware inventory")
+	}, hwInfoTimeout, hwInfoPollInterval).Should(Succeed())
+	inventory := hwInfo.GetInventory()
+	evetest.Logger().Infof("Hardware inventory reported by %s: %v", devName, inventory)
+	evetest.Checkpoint("inventory-reported")
+
+	// Phase 4: the inventory describes the device EVE actually runs on. Both CPU
+	// counts are compared against the vCPUs the harness provisioned, not against
+	// each other.
+	cpus := inventory.GetCpuInfo().GetCpus()
+	t.Expect(len(cpus)).To(Equal(constants.DefaultEVEDeviceCPUs),
+		"inventory reports %d CPU(s) for a %d-vCPU device",
+		len(cpus), constants.DefaultEVEDeviceCPUs)
+	t.Expect(devInfo.GetNcpu()).To(BeEquivalentTo(constants.DefaultEVEDeviceCPUs),
+		"device info reports %d CPU(s) for a %d-vCPU device",
+		devInfo.GetNcpu(), constants.DefaultEVEDeviceCPUs)
+	for i, cpu := range cpus {
+		t.Expect(cpu.GetVendor() != "" || cpu.GetModel() != "").To(BeTrue(),
+			"CPU %d is identified by neither vendor nor model", i)
+	}
+
+	t.Expect(inventory.GetTotalMemoryBytes()).To(BeNumerically(">", 0),
+		"inventory reports no system memory")
+	// Both sides in MiB; ZInfoDevice.Storage covers the /persist partition only.
+	t.Expect(inventory.GetTotalStorageBytes()>>20).To(
+		BeNumerically(">=", devInfo.GetStorage()),
+		"inventory reports less total storage than the /persist partition size "+
+			"reported in the device info")
+
+	var portDev *eveinfo.NetworkDevice
+	for _, netDev := range inventory.GetNetworkDevices() {
+		if netDev.GetIfname() == portIfName {
+			portDev = netDev
+			break
+		}
+	}
+	t.Expect(portDev).ToNot(BeNil(), "inventory has no network device %q", portIfName)
+	t.Expect(portDev.GetMacAddress()).ToNot(BeEmpty(),
+		"network device %q has no MAC address", portIfName)
+	t.Expect(portDev.GetType()).To(
+		Equal(eveinfo.NetworkDeviceType_NETWORK_DEVICE_TYPE_ETHERNET),
+		"network device %q is not classified as Ethernet", portIfName)
+
+	t.Expect(inventory.GetPciDevices()).ToNot(BeEmpty(),
+		"inventory reports no PCI devices")
+	for _, pciDev := range inventory.GetPciDevices() {
+		t.Expect(pciDev.GetAddress()).ToNot(BeNil(),
+			"PCI device %04x:%04x has no bus address",
+			pciDev.GetVendorId(), pciDev.GetDeviceId())
+	}
+
+	t.Expect(inventory.GetTpm()).ToNot(BeNil(), "inventory reports no TPM information")
+	t.Expect(inventory.GetTpm().GetPresent()).To(Equal(useTPM),
+		"inventory disagrees with the TPM the device was created with")
+	evetest.Checkpoint("inventory-fields-checked")
+
+	// Phase 5: the inventory survives a reboot unchanged. The watch is opened
+	// before the reboot, so the only message it can deliver is the one the
+	// rebooted device publishes during startup.
+	hwUpdates, stopHwWatch := device.WatchHardwareInfo()
+	defer stopHwWatch()
+	device.RequestReboot(true)
+	evetest.Checkpoint("device-rebooted")
+
+	var rebootedHwInfo *eveinfo.ZInfoHardware
+	t.Eventually(hwUpdates, postRebootHwInfoTimeout).Should(Receive(&rebootedHwInfo),
+		"the rebooted device did not report its hardware inventory")
+
+	// Should this ever produce a spurious diff, start with the fields whose value
+	// depends on when during the boot ghw sampled - the two boots are not
+	// symmetric, a cold first boot against a warm reboot:
+	//   - PciDevices[].Driver: driver binding is asynchronous, so a module
+	//     binding later on one boot leaves the driver symlink, and this, unset.
+	//   - NetworkDevices: ghw skips only lo and bonding_masters, so every netdev
+	//     alive at sample time counts (sit0, tunl0, app or NI leftovers).
+	//   - NetworkDevices[].SpeedMbps: raw /sys/class/net/<dev>/speed, which is
+	//     EINVAL while the carrier is down; constant on virtio, not on real NICs.
+	//   - TotalStorageBytes: sums every /sys/block entry unfiltered, so loop*,
+	//     dm-* and zram* count too.
+	diff := cmp.Diff(inventory, rebootedHwInfo.GetInventory(),
+		protocmp.Transform(), protocmp.SortRepeated(cpuLess))
+	t.Expect(diff).To(BeEmpty(),
+		"hardware inventory changed across a reboot (-before +after)")
+	evetest.Checkpoint("inventory-stable-after-reboot")
+}
+
+// cpuLess orders CPUs by their observable content so that CpuInfo.Cpus can be
+// compared as a multiset: ghw derives the list by ranging over a map keyed by
+// socket, so its order is stable only while the VM has a single socket.
+func cpuLess(a, b *eveinfo.CPU) bool {
+	switch {
+	case a.GetId() != b.GetId():
+		return a.GetId() < b.GetId()
+	case a.GetVendor() != b.GetVendor():
+		return a.GetVendor() < b.GetVendor()
+	case a.GetModel() != b.GetModel():
+		return a.GetModel() < b.GetModel()
+	default:
+		return a.GetFreq() < b.GetFreq()
+	}
+}

--- a/evetest/tests/telemetry/testsuite_test.go
+++ b/evetest/tests/telemetry/testsuite_test.go
@@ -20,19 +20,20 @@ import (
 // setupTelemetryTestDevice, which states the device requirements in one place.
 // That is what lets the framework reuse a single VM across the suite: it
 // compares the requirements field by field, so any divergence silently costs a
-// full device recreation. Only TestDeviceInfo asserts on the TPM (via
-// HSMStatus); for the others both parameters merely select the device flavor.
-// None of the subtests deploys an application, but the hypervisor is a parameter
-// regardless, so that the suite can be run against eve-k - where the log
-// pipeline and the reporting paths are worth covering even though nothing here
-// is hypervisor-specific. It has so far only been run under KVM.
+// full device recreation. TestDeviceInfo and TestHardwareInventory assert on the
+// TPM (via HSMStatus and Inventory.Tpm.Present); for the others both parameters
+// merely select the device flavor. None of the subtests deploys an application,
+// but the hypervisor is a parameter regardless, so that the suite can be run
+// against eve-k - where the log pipeline and the reporting paths are worth
+// covering even though nothing here is hypervisor-specific. It has so far only
+// been run under KVM.
 //
 // The subtests are grouped by subject - what EVE reports, then how the log
-// pipeline is configured - and TestRemoteLogLevelNone goes last because it is
-// the only one that reboots, which the others would otherwise pay for. Nothing
-// beyond that is load-bearing: the framework resets the device configuration
-// between subtests, and each subtest establishes the state it needs before it
-// asserts anything, so the order can be changed freely.
+// pipeline is configured - and the two that reboot the device go last so that
+// the others do not pay for a reboot. Nothing beyond that is load-bearing: the
+// framework resets the device configuration between subtests, and each subtest
+// establishes the state it needs before it asserts anything, so the order can be
+// changed freely.
 //
 // Subtests
 // --------
@@ -52,6 +53,8 @@ import (
 //     rejected by pillar and never reaches Vector.
 //   - TestRemoteLogLevelNone -- remote log levels set to "none" stop log upload
 //     without stopping the device or its local log collection.
+//   - TestHardwareInventory -- ZInfoHardware describes the device EVE runs on
+//     and stays identical across a reboot.
 func TestTelemetrySuite(test *testing.T) {
 	evetest.Init(test)
 	defer evetest.Close()
@@ -86,6 +89,9 @@ func TestTelemetrySuite(test *testing.T) {
 		},
 		evetest.TestCase{
 			Test: TestRemoteLogLevelNone,
+		},
+		evetest.TestCase{
+			Test: TestHardwareInventory,
 		},
 	)
 }


### PR DESCRIPTION
# Description

Replaces Eden's `eden_hw_inventory` with `TestHardwareInventory` in the
telemetry suite: EVE advertises the capability, publishes a `ZInfoHardware`
carrying an inventory that describes the device it runs on, and reports the same
inventory after a reboot.

Eden's original announced a step to "check some fields in the HW inventory
message" and then did not implement one, so the field assertions are new. They
are chosen for what is both populated and meaningful in a VM, and the doc comment
says for each whether it is a cross-check against something outside EVE or an
explicit floor check — several look stronger than they are.

Two notes on judgement calls, both explained in the test:

The CPU count is checked against the number of CPUs the harness provisioned
rather than against `ZInfoDevice.Ncpu`. Those are different quantities — the
inventory lists physical cores, `Ncpu` counts logical CPUs — so comparing them
was circular: a bug shared by both producers would pass, and a failure said only
that they disagreed. This does not remove the dependence on the VM having one
thread per core, which asserting a core count cannot avoid.

The reboot comparison covers the whole `HardwareInventory`, with the CPU list
sorted because ghw derives it from a map keyed by socket. The enclosing
`ZInfoHardware` is excluded: its `Disks` field carries S.M.A.R.T. attributes that
legitimately change. The message is not purely physical, so the fields that could
produce a spurious diff are listed at the comparison rather than left to be
re-derived by whoever debugs one.

**Not covered**, and stated in the test rather than left implicit: proof that the
post-reboot message belongs to the boot that followed the reboot. The argument is
that EVE publishes `ZInfoHardware` once per boot and the watch is opened before
the reboot. Establishing it directly would need the message timestamp, which the
framework does not expose, and content cannot serve because identical content is
what is being asserted.

## PR dependencies

Builds on #6296 (merged), which restructured `evetest/tests/telemetry` and added
the shared `setupTelemetryTestDevice` helper and the hypervisor parameter this
test uses.

## How to test and validate this PR

Fully covered by an automated test. From the repository root:

```sh
EVETEST_EVE_VERSION=17.0.0-lts make evetest NAME=TestTelemetrySuite
```

or the subtest alone with `make evetest NAME=TestHardwareInventory`.

Validated on amd64/KVM against EVE `17.0.0-lts` — the whole suite passes in
~14 minutes with one device VM provisioned, `TestHardwareInventory` taking 149 s
of that:

| Subtest | Time |
|---|---|
| `TestDeviceInfo` | 125 s |
| `TestDeviceMetrics` | 13 s |
| `TestDeviceLogs` | 20 s |
| `TestWorkingConfig` | 15 s |
| `TestFaultyConfig` | 105 s |
| `TestEmptyConfig` | 45 s |
| `TestInvalidBase64Config` | 91 s |
| `TestRemoteLogLevelNone` | 248 s |
| `TestHardwareInventory` | 149 s |

**Minimum EVE version:** `optionalCapabilities.hwInventorySupport` was added in
16.6.0, so this test needs EVE >= 16.6.0. It fails immediately and clearly on an
older build rather than timing out.

Only exercised on amd64/KVM. The hypervisor is a parameter, so an eve-k or xen
run is possible, but nothing here has been run that way and I am not claiming it
passes. On arm64 the per-CPU vendor/model assertion is the first thing I would
expect to need attention: ghw derives the vendor from the CPU implementer ID and
only for ARM Ltd, so a Marvell, Qualcomm, HiSilicon, Ampere or Apple part can
legitimately leave both fields empty.

## Changelog notes

No user-facing changes.

## PR Backports

- 17.0-stable: No, test-only change; the Eden equivalent still covers this area
  on the stable branches.
- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device (KVM)
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Not tested on arm64, xen or kubevirt: this is a test-only addition, and the
evetest suites are not currently run on those targets by CI. See the note above
on the one assertion I would expect to need attention on arm64.
