### PR TITLE
yetus: annotate only the patch's issues

### DIFF
--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -74,6 +74,20 @@ jobs:
           name: 'yetus-scan'
           path: ${{ github.workspace }}/out
 
+      - name: Publish Yetus vote table in the job summary
+        if: ${{ always() }}
+        run: |
+          console=${{ github.workspace }}/out/console.txt
+          if [ ! -s "${console}" ]; then
+            echo "No Yetus report to publish."
+            exit 0
+          fi
+          {
+            echo '```'
+            cat "${console}"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Annotate errors from Yetus
         if: ${{ always() }}
         run: |

--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -77,28 +77,27 @@ jobs:
       - name: Annotate errors from Yetus
         if: ${{ always() }}
         run: |
-          set +e
-          # Yetus writes patch-<plugin>.txt files for each plugin that found issues.
-          # Each line is in the format: filename:line:message
-          if [ -z "$(ls ${{ github.workspace }}/out/patch-*-result.txt 2> /dev/null || true)" ]; then
-            echo "No result files to annotate."
+          # Yetus collects the issues a patch *adds* - the ones it posts as
+          # inline review comments when it has PR access - into results-full.txt,
+          # one per line as file:line:column:plugin:message. This is the only
+          # output scoped to the patch: the branch-*/patch-*-result.txt files it
+          # derives that from are scans of the whole tree, so annotating those
+          # buries the patch's own issues under pre-existing ones.
+          results=${{ github.workspace }}/out/results-full.txt
+          if [ ! -s "${results}" ]; then
+            echo "No new issues to annotate."
             exit 0
           fi
-          for patch_file in ${{ github.workspace }}/out/patch-*-result.txt; do
-            plugin=$(basename "$patch_file" | sed "s/patch-\(.*\)-result.txt/\1/")
-            while read -r line; do
-              # Skip empty lines and header lines
-              [ -z "$line" ] && continue
-              # Parse filename:linenum:message
-              file=$(echo "$line" | awk -F: '{print $1}')
-              lineno=$(echo "$line" | awk -F: '{print $2}' | grep "^[0-9].*" || true)
-              message=$(echo "$line" | awk -F: '{start=($3~/^[0-9]+$/)?4:3; for(i=start;i<=NF;i++) printf "%s%s",(i>start?":":""),$i; print ""}')
-              # Only annotate if we got a valid file and line number
-              if [ -n "$file" ] && [ -n "$lineno" ]; then
-                echo "::error file=${file},line=${lineno},title=Yetus [${plugin}]::${message}"
-              else
-                # No file/line info, just print for visibility
-                echo "${line}"
-              fi
-            done < "$patch_file"
-          done
+          while IFS=: read -r file lineno column plugin message; do
+            case "${lineno}" in
+              ''|*[!0-9]*)
+                echo "${file}:${lineno}:${column}:${plugin}:${message}"
+                continue
+              ;;
+            esac
+            case "${column}" in
+              ''|0|*[!0-9]*) col='' ;;
+              *) col=",col=${column}" ;;
+            esac
+            echo "::error file=${file},line=${lineno}${col},title=Yetus [${plugin}]::${message}"
+          done < "${results}"


### PR DESCRIPTION
# Description

When a Yetus check fails, the annotations and the failure summary list
pre-existing issues from all over the repo rather than the ones the PR
introduced, so the real findings are buried — GitHub's per-step annotation cap
means they are often not shown at all.

The step also runs under `if: always()`, so this is not limited to failures: a
Yetus check that **passes** still carries up to ten error-level annotations
pointing at files the PR never touched. That is the more common form on the
stable branches, where it reads as a green check with unexplained errors
attached.

The annotation step iterates `out/patch-*-result.txt`. Those are Yetus's
post-patch scans of the **whole tree** (`golangci-lint run ./...` and friends),
so they contain every pre-existing issue in the repo. Yetus reduces them to the
delta against the pre-patch scan and collects that — the same set it posts as
inline review comments when it has PR access — in `out/results-full.txt`, as
`file:line:column:plugin:message`. This PR annotates that file instead, which
also removes the per-line `awk`/`grep` field guessing since the fields are
fixed.

Second commit: nothing posts Yetus's verdict back to the PR, so the per-plugin
vote table is only reachable by downloading the `yetus-scan` artifact. It is now
also written to the job summary.

## How to test and validate this PR

Yetus runs on this PR, so a green check shows the step still works when there
are no new issues. To validate the fix itself, replay the step against a run
that failed: run 31628996866 (`[17.0-stable] hypervisor: recover a VMIRS
stranded at Spec.Replicas == 0`, touching 6 files under `pkg/pillar` and
`evetest`). Download its `yetus-scan` artifact and compare:

- `patch-*-result.txt` — 580 findings, spread over `pkg` (287), `evetest` (226),
  `eve-tools` (47), `tools` (14), `tests` (6). That is what the job annotated.
- `results-full.txt` — 1 finding, in `pkg/pillar/kubeapi/kubeapi.go`, a file the
  PR touches. It matches Yetus's own verdict for that run, which was `-1 revive`
  / "2 new + 0 unchanged - 0 fixed" and no other subsystem below +1.

This has also been verified end to end on a live run. A temporary commit adding
a single misspelling to a Go comment was pushed, which made Yetus fail with one
new issue while the `.go` change forced the full `golangci-lint` tree scan whose
findings used to flood the output. Result in
[run 31824696804](https://github.com/lf-edge/eve/actions/runs/31824696804):

- **Annotations:** exactly one, `Yetus [codespell]` on
  `pkg/pillar/types/zedroutertypes_linux.go:18` — the line the commit added.
  It renders inline against the diff in the *Files changed* view, so a reviewer
  sees the finding on the code that caused it. The only other annotation is
  GitHub's own "Process completed with exit code 1", which is unavoidable since
  Yetus exits non-zero on a `-1` vote. The equivalent baseline run emitted 507.
- **Job summary:** the vote table renders correctly in the GitHub UI, showing
  `-1 codespell` with "1 new + 0 unchanged - 0 fixed" and every other subsystem
  at `+1`, including `golangcilint` at "No new issues" after an 8m11s whole-tree
  scan.

The temporary commit has been dropped; only the two commits above remain.

## Changelog notes

No user-facing changes.

## PR Backports

All four are affected. The annotate step is byte-identical on every LTS branch
and the Yetus image is the same `0.15.1-eve-2`, but rather than rely on that, the
noise was measured per branch from a recent run's `yetus-scan` artifact —
`patch-*-result.txt` is what the current step annotates, `results-full.txt` is
what this PR annotates:

| Branch | Sample | Whole-tree findings | Delta | Yetus verdict | Annotations shown |
|---|---|---|---|---|---|
| master | run 31628996866 | 580 | 1 | failure | 10 (capped) |
| 17.0-stable | PR #6285 | 595 | 0 | **success** | 10 |
| 16.0-stable | PR #6316 | 354 | 0 | **success** | 10 |
| 14.5-stable | PR #6317 | 329 | 0 | **success** | 10 |
| 13.4-stable | PR #6288 | 327 | 0 | **success** | 10 |

Each of those four checks passed with zero new issues, yet showed ten error
annotations, at least one on a file the PR did not touch (e.g. #6285 was
annotated in `evetest/broker/broker.go`, #6288 in
`eve-tools/bpftrace-compiler/…`). So the older LTS branches are not healthier
than master here — the symptom is just less visible, because it shows up on
green checks.

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — n/a, no documented behavior changes
- [ ] I've tested my PR on amd64 device — n/a, CI-only change, no device involved
- [ ] I've tested my PR on arm64 device — n/a, same
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR — `stable` to be added


