### PR TITLE
eve-k volumemgr: accept a cluster PVC instead of re-downloading its source

### DIFF
--- a/evetest/diskimages.go
+++ b/evetest/diskimages.go
@@ -4,16 +4,24 @@
 package evetest
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	eveconfig "github.com/lf-edge/eve-api/go/config"
 )
+
+// fetchImageTimeout bounds downloading one image in FetchAndServeImageFile.
+// Generous: some pinned cloud images run into the hundreds of megabytes.
+const fetchImageTimeout = 5 * time.Minute
 
 // CreateBlankImageFile creates an empty disk image of the given format and
 // size, served by evetest's built-in image server (both over HTTP and
@@ -76,6 +84,39 @@ func AddImageServerFile(name string, content []byte) string {
 		th.t.Fatalf("failed to write image server file %s: %v", name, err)
 	}
 	return name
+}
+
+// FetchAndServeImageFile downloads url over the evetest container's own
+// network and re-serves it from evetest's built-in image server, so a
+// device with no outbound Internet reachability can still download it as a
+// normal HTTP datastore -- just a local one instead of the remote url.
+// Returns name, for use as HTTPStorage.ImageRelativePath.
+func FetchAndServeImageFile(url, name, sha256Hex string) string {
+	th := getTestHarness()
+	ctx, cancel := context.WithTimeout(th.ctx, fetchImageTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		th.t.Fatalf("FetchAndServeImageFile: build request for %s: %v", url, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		th.t.Fatalf("FetchAndServeImageFile: GET %s: %v", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		th.t.Fatalf("FetchAndServeImageFile: GET %s: unexpected status %s", url, resp.Status)
+	}
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		th.t.Fatalf("FetchAndServeImageFile: read body from %s: %v", url, err)
+	}
+	sum := sha256.Sum256(content)
+	if got := hex.EncodeToString(sum[:]); got != sha256Hex {
+		th.t.Fatalf("FetchAndServeImageFile: %s: SHA256 mismatch: got %s, want %s",
+			url, got, sha256Hex)
+	}
+	return AddImageServerFile(name, content)
 }
 
 // qemuImgFormat maps an eveconfig.Format to the "-f" format name accepted by

--- a/evetest/edgedevice.go
+++ b/evetest/edgedevice.go
@@ -830,6 +830,21 @@ func (d *EdgeDevice) RequestReboot(waitUntilRebooted bool) {
 	})
 }
 
+// PrepareShutdown signals a graceful shutdown via EdgeDevConfig.Shutdown:
+// pillar deactivates every app instance on the device in response. Unlike
+// Reboot/PowerOff, this has no power effect of its own -- the device stays
+// up, which is why callers pair it with a separate power-off step.
+func (d *EdgeDevice) PrepareShutdown() {
+	config := d.getConfig(true)
+	shutdown := config.GetShutdown()
+	if shutdown == nil {
+		config.Shutdown = &eveconfig.DeviceOpsCmd{Counter: 1, DesiredState: true}
+	} else {
+		config.Shutdown = &eveconfig.DeviceOpsCmd{Counter: shutdown.GetCounter() + 1, DesiredState: true}
+	}
+	d.ApplyConfig(config, false, false)
+}
+
 // SoftReboot reboots the device from the console/SSH.
 func (d *EdgeDevice) SoftReboot(waitUntilRebooted bool) {
 	d.th.incExpectedRebootCount(d.devName)

--- a/evetest/edgedevice.go
+++ b/evetest/edgedevice.go
@@ -197,13 +197,17 @@ func (d *EdgeDevice) ApplyConfig(config *EdgeDeviceConfig, waitUntilFetched bool
 	// Set default global configuration properties.
 	newConfig.setDefaultConfigProperties()
 
-	// Preserve device reboot counter and per-app restart/purge counters from
-	// the previous config when the new config does not set them explicitly.
-	// This prevents a subsequent RequestReboot or Reboot/PurgeApplication
-	// call from re-issuing a command the device has already processed.
+	// Preserve device reboot/shutdown counters and per-app restart/purge
+	// counters from the previous config when the new config does not set
+	// them explicitly. This prevents a subsequent RequestReboot,
+	// PrepareShutdown, or Reboot/PurgeApplication call from re-issuing a
+	// command the device has already processed.
 	if prevConfig != nil {
 		if newConfig.Reboot == nil {
 			newConfig.Reboot = prevConfig.GetReboot()
+		}
+		if newConfig.Shutdown == nil {
+			newConfig.Shutdown = prevConfig.GetShutdown()
 		}
 		prevApps := make(map[string]*eveconfig.AppInstanceConfig,
 			len(prevConfig.GetApps()))
@@ -224,12 +228,16 @@ func (d *EdgeDevice) ApplyConfig(config *EdgeDeviceConfig, waitUntilFetched bool
 		}
 	}
 
-	// Always keep a non-nil Reboot command in the config so EVE records a baseline
-	// counter on first boot. Without this, the first RequestReboot call lands when
-	// EVE has no saved counter (opCfg == nil) and EVE's "first boot" guard skips the
-	// reboot, saving the counter but never triggering the operation.
+	// Always keep non-nil Reboot/Shutdown commands in the config so EVE records a
+	// baseline counter on first boot. Without this, the first RequestReboot or
+	// PrepareShutdown call lands when EVE has no saved counter (opCfg == nil) and
+	// EVE's "first boot" guard skips the operation, saving the counter but never
+	// triggering it.
 	if newConfig.Reboot == nil {
 		newConfig.Reboot = &eveconfig.DeviceOpsCmd{Counter: 0, DesiredState: false}
+	}
+	if newConfig.Shutdown == nil {
+		newConfig.Shutdown = &eveconfig.DeviceOpsCmd{Counter: 0, DesiredState: false}
 	}
 
 	// Preserve cipher contexts. The list is taken from the harness-held config

--- a/evetest/tests/cluster/cluster_test.go
+++ b/evetest/tests/cluster/cluster_test.go
@@ -57,6 +57,21 @@ func clusterDeviceRequirements(devName string, withTPM bool,
 	}
 }
 
+// clusterDeviceRequirementsForVMApp is clusterDeviceRequirements without the
+// vCPU caps above. Those caps constrain the eve/pillar and k3s-control-plane
+// cgroups (not Kubernetes pods, which kubelet places under the unconstrained
+// kubepods cgroup), so a real CDI disk import -- whose RolloutDiskToPVC calls
+// repeatedly hit that same constrained control plane while it is also doing
+// first-time Longhorn/CDI bring-up -- can starve and fail retries that never
+// hit a resource ceiling on a single, uncapped device. tests/apps/vnc_test.go
+// uploads this same image successfully with no such caps.
+func clusterDeviceRequirementsForVMApp(
+	devName string, withTPM bool, filesystem evetest.Filesystem) evetest.RequireEdgeDevice {
+	req := clusterDeviceRequirements(devName, withTPM, filesystem, false)
+	req.WithGrubOptions = nil
+	return req
+}
+
 // TestSingleNodeCluster verifies that an EVE-K device boots, forms a
 // healthy single-node K3s cluster, accepts an application deployment, and
 // that the deployed container is reachable both from outside (via port

--- a/evetest/tests/cluster/pvcredownload_test.go
+++ b/evetest/tests/cluster/pvcredownload_test.go
@@ -1,0 +1,389 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	api "github.com/lf-edge/eve/evetest/grpcapi/go"
+	"google.golang.org/protobuf/proto"
+
+	eveconfig "github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve-api/go/evecommon"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/netmodels"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+const (
+	// pvcRedownloadRebootTimeout bounds waiting for a node to reboot and,
+	// for the two surviving nodes, rejoin the cluster. Generous: a full
+	// device reboot plus k3s/etcd rejoin is slow.
+	pvcRedownloadRebootTimeout = 30 * time.Minute
+
+	pvcRedownloadPollInterval = 15 * time.Second
+)
+
+// TestClusterPVCRedownload is a stress test of combined failure modes: a
+// cluster maintenance event, a node severed from the cluster, and a
+// datastore cut off, all at once. It checks that EVE does not re-download
+// a VM's multi-GB qcow2 source image when the Longhorn PVC that image
+// exists to fill is already Bound and CDI-complete -- a needless download
+// that would block the app if the datastore stayed slow or unreachable.
+//
+// Neither VM here is ever re-designated: ContentTreeStatus and
+// ContentTreeConfig both publish non-persistent, so a plain reboot --
+// volumemgr is its own process -- wipes its cache and resets every
+// locally-owned content tree to INITIAL regardless of DesignatedNodeID.
+//
+// Reported steps, and how each maps to this test:
+//  1. Shutdown all apps -- DeactivateApplication on both VMs.
+//  2. Prepare power off Node1 and the tie-breaker -- EdgeDevConfig.Shutdown
+//     on those two devices only, not Node2. Real controller mechanism
+//     (drains and deactivates every app on the device), redundant with
+//     step 1 for vm1, same as it would be in the field.
+//  3. Shutdown 3x nodes -- hard PowerOff on all three, unconditionally.
+//  4. Shutdown the datastore -- an SDN firewall rule drops traffic to
+//     evetest's image server, for every node, left in place for the rest
+//     of the test.
+//  5. Disable Node2's cluster interface -- AdminUp=false on its
+//     cluster-interconnect port, applied together with step 4 (one
+//     NetworkModel update; a second UpdateNetworkModel call would replace
+//     the whole model, undoing whichever change came first).
+//  6. Bring the 3 nodes up -- Node1 and the tie-breaker rejoin; Node2
+//     keeps mgmt/app connectivity but never rejoins the cluster.
+//  7. Activate the 2 VMs -- VM1 (Node1) is waited on, since it's this
+//     test's subject; VM2 (the isolated Node2) is fire-and-forget.
+//  8. Verify VM1 comes online on Node1.
+//  9. Verify it still attempts to download its content tree despite being
+//     online -- asserted as the fixed behavior (REMOTELOADED), not the
+//     reported bug, so this passes on the fix and fails on master.
+//
+// Network model
+// -------------
+//   - netmodels.SeparateClusterPort -- the same model TestThreeNodesCluster
+//     and TestTieBreakerCluster use, cloned once to add the firewall rule
+//     and port change above.
+//
+// Device configuration
+// --------------------
+//   - clusterDeviceRequirementsForVMApp (top of cluster_test.go): the same
+//     three devices as clusterDeviceRequirements, minus its vCPU caps --
+//     see that function's doc comment for why a real CDI import needs
+//     them absent. edge-dev1 is the bootstrap node and hosts VM1;
+//     edge-dev2 hosts VM2 and is the node isolated in step 5; edge-dev3
+//     is the tie-breaker.
+//
+// Test params
+// -----------
+//   - TPM (bool), FILESYSTEM.
+//
+// Suite placement
+// ---------------
+//   - Not in TestNodeClusterSuite yet. This is the first test to combine
+//     multi-node power-cycling, network-model changes mid-test, and a VM
+//     app in one sequence; it needs a real run before its timing and
+//     failure modes are understood well enough to place it.
+func TestClusterPVCRedownload(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	evetest.DefineTestParameters(
+		evetest.TPMParameter(),
+		evetest.FilesystemParameter(),
+	)
+	withTPM := evetest.GetTPMParameterValue()
+	filesystem := evetest.GetFilesystemParameterValue()
+
+	var requiredDevices [3]evetest.Requirement
+	var devName [3]string
+	for i := 0; i < 3; i++ {
+		devName[i] = fmt.Sprintf("edge-dev%d", i+1)
+		requiredDevices[i] = clusterDeviceRequirementsForVMApp(devName[i], withTPM, filesystem)
+	}
+	requiredNetModel := evetest.RequireNetworkModel{
+		NetworkModel: netmodels.SeparateClusterPort,
+	}
+	var requirements []evetest.Requirement
+	requirements = append(requirements, requiredDevices[:]...)
+	requirements = append(requirements, requiredNetModel)
+	evetest.Setup(requirements...)
+	evetest.Checkpoint("setup-done")
+
+	const tieBreakerIdx = 2
+	// Fixed layout for this test, always: devName[0] (Node A) and
+	// devName[1] (Node B) are plain cluster members; devName[2] (Node C)
+	// is always the tie-breaker. Node A hosts vm1 and is the bootstrap
+	// node; Node B hosts vm2 and is the node isolated in step 5.
+	var nodes [3]evetest.ClusterNode
+	for i := 0; i < 3; i++ {
+		clusterIP := evetest.IPAddressWithPrefix(fmt.Sprintf("10.244.244.%d/24", i+2))
+		nodes[i] = evetest.ClusterNode{
+			DevName:          devName[i],
+			ClusterIP:        clusterIP,
+			ClusterInterface: "ethernet1",
+			BootstrapNode:    i == 0,
+			TieBreaker:       i == tieBreakerIdx,
+		}
+	}
+	clusterConfig := evetest.NewEdgeClusterConfig(
+		eveconfig.ClusterType_CLUSTER_TYPE_REPLICATED_STORAGE,
+		nodes[:]...,
+	)
+
+	dhcpNet := clusterConfig.AddNetwork(
+		evetest.DHCPNetworkConfig{NetworkType: evecommon.NetworkType_V4Only})
+	noIPNet := clusterConfig.AddNetwork(evetest.NoIPNetworkConfig{})
+	clusterConfig.AddNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel: "ethernet0", PhysicalLabel: "eth0", InterfaceName: "eth0",
+		NetworkUUID: dhcpNet, Usage: evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+	})
+	clusterConfig.AddNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel: "ethernet1", PhysicalLabel: "eth1", InterfaceName: "eth1",
+		NetworkUUID: noIPNet, Usage: evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+	})
+
+	cluster := evetest.NewEdgeCluster("test-cluster")
+	cluster.ApplyConfig(clusterConfig, true, true)
+	evetest.Checkpoint("initial-config-applied")
+
+	cluster.WaitUntilNodesAreReady(30 * time.Minute)
+	evetest.Checkpoint("nodes-are-ready")
+
+	// Nodes reporting Ready doesn't mean Longhorn/CDI/the k3s control
+	// plane are done with their own first-time bring-up churn; hitting
+	// them immediately with a real CDI import competes with that churn.
+	time.Sleep(2 * time.Minute)
+	evetest.Checkpoint("cluster-settled")
+
+	log := evetest.Logger()
+	dev1 := evetest.GetEdgeDevice(devName[0])
+	dev2 := evetest.GetEdgeDevice(devName[1])
+	dev3 := evetest.GetEdgeDevice(devName[2])
+
+	// Both VMs share one source image; PVCs are per-volume, so that's fine.
+	image, ok := vmAppAlpineImages[dev1.GetArch()]
+	t.Expect(ok).To(BeTrue(), "no pinned Alpine image for arch %q", dev1.GetArch())
+	imagePath := evetest.FetchAndServeImageFile(
+		"https://dl-cdn.alpinelinux.org"+image.relativePath,
+		"pvc-redownload-alpine.qcow2", image.sha256)
+	evetest.Checkpoint("image-fetched")
+
+	vmImage := func() evetest.HTTPStorage {
+		return evetest.HTTPStorage{
+			ImageFormat:       eveconfig.Format_QCOW2,
+			ImageSHA256:       image.sha256,
+			MaxDownloadBytes:  image.sizeBytes,
+			ImageRelativePath: imagePath,
+			ServerAddress:     evetest.GetImageServerIPv4().String(),
+			ServerPort:        evetest.GetImageServerPort(),
+		}
+	}
+
+	niUUID := clusterConfig.AddNetworkInstance(evetest.LocalNetworkInstanceConfig{
+		DisplayName: "local-ni",
+		Port:        "ethernet0",
+		Subnet:      evetest.IPSubnet("10.11.12.0/24"),
+		DHCPRange: types.IPRange{
+			Start: evetest.IPAddress("10.11.12.2"),
+			End:   evetest.IPAddress("10.11.12.254"),
+		},
+		Gateway:       evetest.IPAddress("10.11.12.1"),
+		EnableFlowlog: true,
+		MTU:           1500,
+		ForwardLLDP:   false,
+	})
+
+	newVMApp := func(displayName, designatedNode string) evetest.ClusterApplicationInstanceConfig {
+		return evetest.ClusterApplicationInstanceConfig{
+			ApplicationInstanceConfig: evetest.ApplicationInstanceConfig{
+				DisplayName: displayName,
+				Activate:    true,
+				Image:       vmImage(),
+				// Left unset, the target PVC is sized to exactly the
+				// image's own virtual size, leaving no room for CDI's
+				// scratch-space qcow2->raw conversion.
+				DiskBytes:          1 * evetest.GiB,
+				VirtualizationMode: eveconfig.VmMode_HVM,
+				CPUs:               1,
+				MemoryBytes:        512 * evetest.MiB,
+				NetworkAdapters: []evetest.AppNetworkAdapter{
+					evetest.VirtualNetworkAdapter{
+						LogicalLabel:        displayName + "-vif0",
+						NetworkInstanceUUID: niUUID,
+					},
+				},
+			},
+			DesignatedNodeName: designatedNode,
+			Affinity:           eveconfig.AffinityType_AFFINITY_TYPE_PREFERRED,
+		}
+	}
+	// Precondition the bug depends on: both PVCs Bound and CDI-complete.
+	// Deployed one at a time, not in one ApplyConfig, so a failure here
+	// names exactly which app failed rather than leaving two concurrent
+	// CDI imports to disentangle.
+	vm1UUID := clusterConfig.AddApplication(newVMApp("vm1", devName[0]))
+	cluster.ApplyConfig(clusterConfig, true, true)
+	log.Infof("Waiting for vm1 to reach RUNNING for the first time")
+	dev1.WaitUntilAppIsRunning(vm1UUID, pvcRedownloadRebootTimeout)
+	evetest.Checkpoint("vm1-initially-running")
+
+	vm2UUID := clusterConfig.AddApplication(newVMApp("vm2", devName[1]))
+	cluster.ApplyConfig(clusterConfig, true, true)
+	log.Infof("Waiting for vm2 to reach RUNNING for the first time")
+	dev2.WaitUntilAppIsRunning(vm2UUID, pvcRedownloadRebootTimeout)
+	evetest.Checkpoint("vms-initially-running")
+
+	// Step 1: shut down both apps from the controller.
+	dev1.DeactivateApplication(vm1UUID, true, pvcRedownloadRebootTimeout)
+	dev2.DeactivateApplication(vm2UUID, true, pvcRedownloadRebootTimeout)
+	evetest.Checkpoint("apps-deactivated")
+
+	// Step 2: prepare Node A and the tie-breaker (Node C) for power off.
+	// EdgeDevConfig.Shutdown drains and deactivates every app instance on
+	// each -- redundant with step 1 above for vm1, but that redundancy is
+	// the real controller behavior being modeled. Node B is deliberately
+	// excluded: it gets no shutdown-prepare of its own, only the hard
+	// power loss below.
+	dev1.PrepareShutdown()
+	dev3.PrepareShutdown()
+	evetest.Checkpoint("shutdown-prepared")
+
+	// Wait for EVE's own reported device state, rather than a fixed sleep:
+	// zedagent reports PREPARED_POWEROFF once ctx.allDomainsHalted is true,
+	// so this confirms the app instances are actually down instead of
+	// guessing how long that takes.
+	for _, d := range []*evetest.EdgeDevice{dev1, dev3} {
+		t.Eventually(d.GetState, pvcRedownloadRebootTimeout, pvcRedownloadPollInterval).
+			Should(Equal(api.EVEDeviceState_EVE_DEVICE_STATE_PREPARED_POWEROFF),
+				"device did not report prepared-poweroff before power-off")
+	}
+	evetest.Checkpoint("drains-begun")
+
+	// Step 3: hard power loss on all three nodes, regardless of which
+	// ones were prepared above.
+	clusterDevices := []*evetest.EdgeDevice{dev1, dev2, dev3}
+	evetest.RunParallel(3, func(i int) {
+		clusterDevices[i].PowerOff()
+	})
+	evetest.Checkpoint("nodes-powered-off")
+
+	// Steps 4+5, as one model update -- a second UpdateNetworkModel call
+	// would replace the whole model, undoing whichever change came first.
+	//
+	// Step 4: drop traffic to the image server from every node (SrcSubnet
+	// 0.0.0.0/0). Everything else -- mgmt, cluster interconnect -- keeps
+	// working, since the SDN's firewall is default-allow and only this
+	// one destination is matched.
+	//
+	// Step 5: bring down only Node B's cluster-interconnect port
+	// (dev2-eth1). Node A and Node C keep their own cluster ports up and
+	// reform the cluster between themselves; Node B's isolation is what
+	// keeps it out.
+	restrictedModel := proto.Clone(netmodels.SeparateClusterPort).(*api.NetworkModel)
+	restrictedModel.Firewall = &api.Firewall{
+		Rules: []*api.FwRule{
+			{
+				SrcSubnet: "0.0.0.0/0",
+				DstSubnet: evetest.GetImageServerIPv4().String() + "/32",
+				Action:    api.FwAction_FW_DROP,
+			},
+		},
+	}
+	for _, p := range restrictedModel.Ports {
+		if p.LogicalLabel == "dev2-eth1" {
+			p.AdminUp = false
+		}
+	}
+	evetest.UpdateNetworkModel(restrictedModel)
+	evetest.Checkpoint("datastore-severed-node2-isolated")
+
+	// Step 6. waitUntilOnline=false per PowerOn's own caveat about
+	// LastRebootTime not reliably republishing after a hard power-off;
+	// recovery is confirmed below via cluster membership instead.
+	evetest.RunParallel(3, func(i int) {
+		clusterDevices[i].PowerOn(false)
+	})
+	evetest.Checkpoint("nodes-powered-on")
+
+	// cluster.WaitUntilNodesAreReady is not usable here: it waits for
+	// every originally-configured node, and Node2 never rejoins.
+	log.Infof("Waiting for %s and %s to reform the cluster without %s",
+		devName[0], devName[tieBreakerIdx], devName[1])
+	t.Eventually(func() (int, error) {
+		out, err := runKubectl(dev1, `get nodes`+
+			` -o jsonpath="{range .items[*]}{.status.conditions[?(@.type=='Ready')].status}{'\n'}{end}"`)
+		if err != nil {
+			return 0, err
+		}
+		ready := 0
+		for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+			if strings.TrimSpace(line) == "True" {
+				ready++
+			}
+		}
+		return ready, nil
+	}, pvcRedownloadRebootTimeout, pvcRedownloadPollInterval).Should(Equal(2),
+		"expected exactly the two surviving nodes to report Ready; "+
+			"Node2's cluster interconnect is down and it cannot rejoin")
+	evetest.Checkpoint("cluster-reformed")
+
+	// Steps 7+8. VM2's outcome on the departed Node2 is a different
+	// question than the one this test asks, hence fire-and-forget.
+	dev2.ActivateApplication(vm2UUID, false, 0)
+	log.Infof("Waiting for vm1 to come back online on %s", devName[0])
+	dev1.ActivateApplication(vm1UUID, true, pvcRedownloadRebootTimeout)
+	evetest.Checkpoint("vm1-reactivated")
+
+	hostDevice := cluster.FindDeviceHostingApp(vm1UUID, 2*time.Minute)
+	t.Expect(hostDevice).NotTo(BeNil(), "no cluster device reports hosting vm1")
+	t.Expect(hostDevice.GetConfig().GetDeviceName()).To(Equal(devName[0]),
+		"vm1 landed on a node other than its DesignatedNodeName")
+	evetest.Checkpoint("vm1-online")
+
+	// Step 9. The datastore has been unreachable since step 4, so vm1
+	// getting this far already rules out a real download; this asserts it
+	// explicitly, on the fixed-behavior side (REMOTELOADED).
+	var contentTrees []types.ContentTreeStatus
+	t.Eventually(func() error {
+		var err error
+		contentTrees, err = evetest.ReadAllPublications[types.ContentTreeStatus](
+			dev1, "volumemgr", false)
+		return err
+	}, 2*time.Minute, pvcRedownloadPollInterval).Should(Succeed())
+
+	// vm1 and vm2 share one source image, so matching on ContentSha256
+	// alone is ambiguous: dev1 also carries a synced-but-not-local
+	// ContentTreeStatus for vm2, parked at LOADED by an unrelated
+	// !IsLocal shortcut that never touches the download pipeline. IsLocal
+	// is what actually picks out vm1's own tree on this device.
+	var vm1Tree *types.ContentTreeStatus
+	for i := range contentTrees {
+		if contentTrees[i].ContentSha256 == image.sha256 && contentTrees[i].IsLocal {
+			vm1Tree = &contentTrees[i]
+			break
+		}
+	}
+	t.Expect(vm1Tree).NotTo(BeNil(),
+		"no local ContentTreeStatus on %s matches vm1's image SHA256 %s", devName[0], image.sha256)
+	t.Expect(vm1Tree.State).To(Equal(types.REMOTELOADED),
+		"vm1's content tree is in state %v, not REMOTELOADED -- "+
+			"it was re-downloaded despite the PVC already being complete", vm1Tree.State)
+
+	downloaderConfigs, err := evetest.ReadAllPublications[types.DownloaderConfig](
+		dev1, "volumemgr", false)
+	t.Expect(err).NotTo(HaveOccurred())
+	for _, dc := range downloaderConfigs {
+		t.Expect(dc.ImageSha256).NotTo(Equal(image.sha256),
+			"volumemgr published a DownloaderConfig for vm1's image despite its PVC being complete")
+	}
+	evetest.Checkpoint("no-redownload-verified")
+}

--- a/evetest/tests/cluster/vmapp_test.go
+++ b/evetest/tests/cluster/vmapp_test.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	eveconfig "github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve-api/go/evecommon"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/netmodels"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// vmAppAlpineImage describes the pinned Alpine Linux cloud-init qcow2 image
+// used to boot the VM app in this test. Kept as its own copy rather than a
+// shared reference to tests/apps/vnc_test.go's identical map -- the same
+// duplication already exists between that file and
+// tests/security/vcom_test.go.
+type vmAppAlpineImage struct {
+	relativePath string
+	sha256       string
+	sizeBytes    uint64
+}
+
+// Alpine 3.24.1 cloud images, pinned by release version (not a rolling
+// "latest" alias) so the SHA256 below stays valid indefinitely. See
+// https://alpinelinux.org/cloud/ for the full image list.
+var vmAppAlpineImages = map[string]vmAppAlpineImage{
+	"amd64": {
+		relativePath: "/alpine/v3.24/releases/cloud/generic_alpine-3.24.1-x86_64-bios-cloudinit-r0.qcow2",
+		sha256:       "6e2e6fe0572b6632527f268d3659e8fccebda4e1ee470fafe2c4d7b85b6a4df6",
+		sizeBytes:    183697408,
+	},
+	"arm64": {
+		relativePath: "/alpine/v3.24/releases/cloud/generic_alpine-3.24.1-aarch64-uefi-cloudinit-r0.qcow2",
+		sha256:       "3059a6280977c2122982632e0317c5ddbd39069d46ca1e60480de283091f720f",
+		sizeBytes:    239271936,
+	},
+}
+
+// TestClusterVMApp verifies that a qcow2 VM app -- not a container -- boots
+// on an EVE-K cluster node and reaches RUNNING. Every existing cluster test
+// uses a container, which under Kubevirt runs in a shim VM but never boots
+// a real guest disk; this is the first cluster-suite coverage of that path.
+//
+// No failover, DNID re-designation, or node isolation here -- just proving
+// the VM app primitive works in a cluster at all.
+//
+// Network model
+// -------------
+//   - netmodels.SeparateClusterPort -- the same model TestThreeNodesCluster
+//     uses. It grants EVE no outbound Internet reachability, hence
+//     evetest.FetchAndServeImageFile rather than the public Alpine CDN
+//     tests/apps/vnc_test.go points a device at directly.
+//
+// Device configuration
+// --------------------
+//   - clusterDeviceRequirementsForVMApp (top of cluster_test.go): the same
+//     three devices as clusterDeviceRequirements, minus its vCPU caps --
+//     see that function's doc comment for why a real CDI import needs
+//     them absent. edge-dev1 is the bootstrap node and hosts the app.
+//
+// Test params
+// -----------
+//   - TPM (bool), FILESYSTEM.
+//
+// Suite placement
+// ---------------
+//   - Not in TestNodeClusterSuite yet: this is the first VM app ever
+//     deployed in the cluster suite, and the boot timing/failure modes
+//     (image fetch, CDI import, VMI creation) need a real run to pin down
+//     before it belongs alongside the suite's other tests.
+func TestClusterVMApp(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	evetest.DefineTestParameters(
+		evetest.TPMParameter(),
+		evetest.FilesystemParameter(),
+	)
+	withTPM := evetest.GetTPMParameterValue()
+	filesystem := evetest.GetFilesystemParameterValue()
+
+	var requiredDevices [3]evetest.Requirement
+	var devName [3]string
+	for i := 0; i < 3; i++ {
+		devName[i] = fmt.Sprintf("edge-dev%d", i+1)
+		requiredDevices[i] = clusterDeviceRequirementsForVMApp(devName[i], withTPM, filesystem)
+	}
+
+	requiredNetModel := evetest.RequireNetworkModel{
+		NetworkModel: netmodels.SeparateClusterPort,
+	}
+	var requirements []evetest.Requirement
+	requirements = append(requirements, requiredDevices[:]...)
+	requirements = append(requirements, requiredNetModel)
+	evetest.Setup(requirements...)
+	evetest.Checkpoint("setup-done")
+
+	var nodes [3]evetest.ClusterNode
+	for i := 0; i < 3; i++ {
+		clusterIP := evetest.IPAddressWithPrefix(fmt.Sprintf("10.244.244.%d/24", i+2))
+		nodes[i] = evetest.ClusterNode{
+			DevName:          devName[i],
+			ClusterIP:        clusterIP,
+			ClusterInterface: "ethernet1",
+			BootstrapNode:    i == 0,
+		}
+	}
+	clusterConfig := evetest.NewEdgeClusterConfig(
+		eveconfig.ClusterType_CLUSTER_TYPE_REPLICATED_STORAGE,
+		nodes[:]...,
+	)
+
+	dhcpNet := clusterConfig.AddNetwork(
+		evetest.DHCPNetworkConfig{
+			NetworkType: evecommon.NetworkType_V4Only,
+		})
+	noIPNet := clusterConfig.AddNetwork(evetest.NoIPNetworkConfig{})
+	clusterConfig.AddNetworkAdapter(
+		evetest.NetworkAdapterConfig{
+			LogicalLabel:  "ethernet0",
+			PhysicalLabel: "eth0",
+			InterfaceName: "eth0",
+			NetworkUUID:   dhcpNet,
+			Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+		})
+	clusterConfig.AddNetworkAdapter(
+		evetest.NetworkAdapterConfig{
+			LogicalLabel:  "ethernet1",
+			PhysicalLabel: "eth1",
+			InterfaceName: "eth1",
+			NetworkUUID:   noIPNet,
+			Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+		})
+
+	cluster := evetest.NewEdgeCluster("test-cluster")
+	cluster.ApplyConfig(clusterConfig, true, true)
+	evetest.Checkpoint("initial-config-applied")
+
+	cluster.WaitUntilNodesAreReady(30 * time.Minute)
+	evetest.Checkpoint("nodes-are-ready")
+
+	// Nodes reporting Ready doesn't mean Longhorn/CDI/the k3s control
+	// plane are done with their own first-time bring-up churn; hitting
+	// them immediately with a real CDI import competes with that churn.
+	time.Sleep(2 * time.Minute)
+	evetest.Checkpoint("cluster-settled")
+
+	log := evetest.Logger()
+
+	device := evetest.GetEdgeDevice(devName[0])
+	image, ok := vmAppAlpineImages[device.GetArch()]
+	t.Expect(ok).To(BeTrue(), "no pinned Alpine image for arch %q", device.GetArch())
+	imagePath := evetest.FetchAndServeImageFile(
+		"https://dl-cdn.alpinelinux.org"+image.relativePath,
+		"vmapp-alpine.qcow2", image.sha256)
+	evetest.Checkpoint("image-fetched")
+
+	niUUID := clusterConfig.AddNetworkInstance(evetest.LocalNetworkInstanceConfig{
+		DisplayName: "local-ni",
+		Port:        "ethernet0",
+		Subnet:      evetest.IPSubnet("10.11.12.0/24"),
+		DHCPRange: types.IPRange{
+			Start: evetest.IPAddress("10.11.12.2"),
+			End:   evetest.IPAddress("10.11.12.254"),
+		},
+		Gateway:       evetest.IPAddress("10.11.12.1"),
+		EnableFlowlog: true,
+		MTU:           1500,
+		ForwardLLDP:   false,
+	})
+	appUUID := clusterConfig.AddApplication(evetest.ClusterApplicationInstanceConfig{
+		ApplicationInstanceConfig: evetest.ApplicationInstanceConfig{
+			DisplayName: "cluster-vm-app",
+			Activate:    true,
+			Image: evetest.HTTPStorage{
+				ImageFormat:       eveconfig.Format_QCOW2,
+				ImageSHA256:       image.sha256,
+				MaxDownloadBytes:  image.sizeBytes,
+				ImageRelativePath: imagePath,
+				ServerAddress:     evetest.GetImageServerIPv4().String(),
+				ServerPort:        evetest.GetImageServerPort(),
+			},
+			// Left unset, the target PVC is sized to exactly the image's
+			// own virtual size, leaving no room for CDI's scratch-space
+			// qcow2->raw conversion. Comfortably above that virtual size.
+			DiskBytes:          1 * evetest.GiB,
+			VirtualizationMode: eveconfig.VmMode_HVM,
+			CPUs:               1,
+			MemoryBytes:        512 * evetest.MiB,
+			NetworkAdapters: []evetest.AppNetworkAdapter{
+				evetest.VirtualNetworkAdapter{
+					LogicalLabel:        "vif0",
+					NetworkInstanceUUID: niUUID,
+				},
+			},
+		},
+		DesignatedNodeName: devName[0],
+		Affinity:           eveconfig.AffinityType_AFFINITY_TYPE_PREFERRED,
+	})
+	cluster.ApplyConfig(clusterConfig, true, true)
+	evetest.Checkpoint("vm-app-submitted")
+
+	log.Infof("Waiting for VM app %v to reach RUNNING", appUUID)
+	cluster.WaitUntilAppIsRunning(appUUID, 30*time.Minute)
+	evetest.Checkpoint("vm-app-running")
+
+	hostDevice := cluster.FindDeviceHostingApp(appUUID, 2*time.Minute)
+	t.Expect(hostDevice).NotTo(BeNil(), "no cluster device reports hosting the VM app")
+	t.Expect(hostDevice.GetConfig().GetDeviceName()).To(Equal(devName[0]),
+		"the VM app landed on a node other than its DesignatedNodeName")
+	evetest.Checkpoint("vm-app-placement-verified")
+}

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1961,6 +1961,14 @@ func doActivate(ctx *domainContext, config types.DomainConfig,
 			}
 			if err != nil {
 				log.Errorf("Failed to check disk format: %v", err.Error())
+				// The disk format can still be settling. DiskConfig carries
+				// the format that volumemgr had recorded when zedmanager
+				// published this config, and a cluster volume reads as its
+				// content format until the PVC exists. So this is not final:
+				// mark it, and maybeRetryConfig reads the disks again and
+				// retries. Without this the app stays down for good, even
+				// after the format is right.
+				status.ConfigFailed = true
 				status.SetErrorNow(err.Error())
 				releaseCPUs(ctx, &config, status)
 				return

--- a/pkg/pillar/cmd/volumemgr/acceptclustercontenttree.go
+++ b/pkg/pillar/cmd/volumemgr/acceptclustercontenttree.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// maxFreshPVCProbesPerCheck bounds live PVC checks per call: each is a
+// kubeAPITimeout-bounded Kubernetes call, and enough of them chained in one
+// doUpdateContentTree call, with no watchdog touch in between, could starve
+// volumemgr's watchdog budget. reevaluatePendingContentTrees picks up
+// whatever a capped call defers.
+const maxFreshPVCProbesPerCheck = 2
+
+// contentTreeSatisfiedByPVCs reports whether every volume this node is
+// responsible for that references this content tree already has a Bound,
+// upload-complete Longhorn PVC at its requested generation.
+//
+// Background: EVE only has two ways to reach LOADED -- download the source,
+// or learn this node isn't the designated one (IsLocal false, parked at
+// LOADED with no blobs). Neither covers the case after a cluster event,
+// where the source isn't here but the PVC it exists to fill already is --
+// so without this check the node re-downloads a multi-GB image nothing will
+// ever read again, since CDI already populated the PVC and KubeVirt attaches
+// it directly.
+//
+// Conservative by construction:
+//   - EVE-k only; classic hypervisors have no PVC to be satisfied by.
+//   - Volumes owned by another node (IsReplicated) are skipped: this node is
+//     not the one that would download for them.
+//   - Requires at least one referencing volume. A content tree with no volume
+//     yet has nothing to judge by, so it downloads exactly as it does today.
+//   - Requires *every* referencing volume to be satisfied. One volume at a new
+//     generation (a purge) has a different PVC name, will not be found, and so
+//     holds the whole tree on the normal download path.
+//   - Any API error is "not satisfied": callers keep the existing behaviour.
+func contentTreeSatisfiedByPVCs(ctx *volumemgrContext, status *types.ContentTreeStatus) bool {
+	if !ctx.hvTypeKube {
+		return false
+	}
+	key := status.Key()
+
+	refs := 0
+	freshProbes := 0
+	for _, c := range ctx.subVolumeConfig.GetAll() {
+		vc := c.(types.VolumeConfig)
+		if vc.ContentID != status.ContentID {
+			continue
+		}
+		if vc.IsReplicated {
+			// Another node is the designated owner; it downloads, not us.
+			continue
+		}
+		if freshProbes >= maxFreshPVCProbesPerCheck {
+			// Live-probe budget spent this call. Whatever volumes remain
+			// unchecked stay that way until reevaluatePendingContentTrees
+			// drives this content tree again, rather than chaining more
+			// blocking calls into this one reconcile pass.
+			log.Functionf("contentTreeSatisfiedByPVCs(%s): live-probe budget spent, deferring the rest",
+				key)
+			return false
+		}
+		refs++
+		pvcName := vc.GetPVCName()
+		state, fresh := probePVCAdoption(pvcName)
+		if fresh {
+			freshProbes++
+		}
+		if state != kubeapi.PVCStateReady {
+			log.Functionf("contentTreeSatisfiedByPVCs(%s): PVC %s not yet ready for adoption",
+				key, pvcName)
+			return false
+		}
+	}
+	if refs == 0 {
+		log.Functionf("contentTreeSatisfiedByPVCs(%s): no local volumes reference this content tree", key)
+		return false
+	}
+	log.Noticef("contentTreeSatisfiedByPVCs(%s) name %s: all %d referencing volume(s) already have "+
+		"complete PVCs; the source image is not needed on this node",
+		key, status.DisplayName, refs)
+	return true
+}
+
+// reevaluatePendingContentTrees re-drives every ContentTreeStatus still below
+// VERIFIED, so a check maxFreshPVCProbesPerCheck deferred gets finished on a
+// later pass -- the same role reevaluatePendingVolumes plays for volumes.
+// Called from the periodic gc handler.
+func reevaluatePendingContentTrees(ctx *volumemgrContext) {
+	if !ctx.hvTypeKube {
+		// The accept-from-PVCs path this re-drives is EVE-k only.
+		return
+	}
+	for _, s := range ctx.pubContentTreeStatus.GetAll() {
+		status := s.(types.ContentTreeStatus)
+		if status.State >= types.VERIFIED {
+			continue
+		}
+		changed, _ := doUpdateContentTree(ctx, &status)
+		if changed {
+			publishContentTreeStatus(ctx, &status)
+		}
+	}
+}
+
+// acceptContentTreeFromPVCs marks a content tree satisfied without
+// downloading it. REMOTELOADED maps back to LOADED at the API layer, so the
+// controller still shows the content online.
+func acceptContentTreeFromPVCs(ctx *volumemgrContext, status *types.ContentTreeStatus) {
+	log.Noticef("acceptContentTreeFromPVCs(%s) name %s: accepting content tree from existing "+
+		"cluster PVCs, skipping download of %s",
+		status.Key(), status.DisplayName, status.RelativeURL)
+	// A losing earlier call to doUpdateContentTree -- the PVC probe not yet
+	// caught up right after a reboot is the common case -- can have already
+	// reserved a blob and DownloaderConfig reference before this check
+	// started passing. Release whatever was reserved so a download this
+	// content tree never needed does not outlive it: a no-op when nothing
+	// was reserved, since status.Blobs is empty on the ordinary path.
+	RemoveAllBlobsFromContentTreeStatus(ctx, status)
+	status.State = types.REMOTELOADED
+	status.ClearErrorWithSource()
+}
+
+// revokeContentTreeAcceptance undoes an acceptance a volume's own state
+// disproved (a new generation after a purge, or a PVC that's since gone): it
+// deletes and recreates the tree the same way handleContentTreeModify does
+// when a node becomes newly responsible, re-entering the download pipeline
+// from INITIAL.
+//
+// Does not call updateContentTree: the only caller is already inside
+// doUpdateVol for the volume that triggered this, and updateContentTree
+// would just fan back out to it via updateVolumeStatusFromContentID. The
+// recreated tree publishes its own status; downloader/verifier drive it
+// forward from there like any other download.
+func revokeContentTreeAcceptance(ctx *volumemgrContext, status *types.ContentTreeStatus) {
+	key := status.Key()
+	config := lookupContentTreeConfig(ctx, key)
+	if config == nil {
+		log.Warnf("revokeContentTreeAcceptance(%s): no ContentTreeConfig, cannot re-drive download", key)
+		return
+	}
+	log.Noticef("revokeContentTreeAcceptance(%s) name %s: a referencing volume needs content no PVC "+
+		"provides; re-entering the download pipeline", key, status.DisplayName)
+	deleteContentTree(ctx, status, 0) // immediate; nothing was downloaded to keep
+	newStatus := createContentTreeStatus(ctx, *config)
+	if changed, _ := doUpdateContentTree(ctx, newStatus); changed {
+		publishContentTreeStatus(ctx, newStatus)
+	}
+}
+
+// contentTreeNotLocallyUsable reports whether a volume cannot be created from
+// this content tree's local content right now: it is missing, still working
+// its way through download/verify, or was accepted from existing PVCs and so
+// has no local content at all. In every one of those cases a volume whose PVC
+// already exists should adopt it rather than wait.
+func contentTreeNotLocallyUsable(ctStatus *types.ContentTreeStatus) bool {
+	if ctStatus == nil {
+		return true
+	}
+	return ctStatus.State < types.LOADED || ctStatus.State == types.REMOTELOADED
+}

--- a/pkg/pillar/cmd/volumemgr/acceptclustercontenttree_test.go
+++ b/pkg/pillar/cmd/volumemgr/acceptclustercontenttree_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// TestContentTreeNotLocallyUsable pins which content-tree states mean "a volume
+// cannot be built from local content right now, so a volume whose PVC already
+// exists should adopt it instead of waiting".
+//
+// The REMOTELOADED case is the one worth pinning deliberately: it sorts above
+// LOADED numerically, so a plain "State < LOADED" test would call an
+// accepted-from-PVC tree usable and send the volume down the path that looks
+// the image up in CAS -- where it does not exist, because an accepted tree
+// downloaded nothing.
+func TestContentTreeNotLocallyUsable(t *testing.T) {
+	cases := []struct {
+		name string
+		ct   *types.ContentTreeStatus
+		want bool
+	}{
+		{"nil (no content tree published yet)", nil, true},
+		{"INITIAL", &types.ContentTreeStatus{State: types.INITIAL}, true},
+		{"DOWNLOADING", &types.ContentTreeStatus{State: types.DOWNLOADING}, true},
+		{"VERIFIED but not loaded", &types.ContentTreeStatus{State: types.VERIFIED}, true},
+		{"LOADED (real local content)", &types.ContentTreeStatus{State: types.LOADED}, false},
+		{"CREATING_VOLUME", &types.ContentTreeStatus{State: types.CREATING_VOLUME}, false},
+		{"REMOTELOADED (accepted from PVCs)", &types.ContentTreeStatus{State: types.REMOTELOADED}, true},
+	}
+	for _, c := range cases {
+		if got := contentTreeNotLocallyUsable(c.ct); got != c.want {
+			t.Errorf("%s: got %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestRemoteLoadedSortsAboveLoaded guards the assumption the previous test
+// depends on: REMOTELOADED is numerically greater than LOADED, which is why it
+// needs its own explicit check rather than falling out of a "< LOADED"
+// comparison. If the enum is ever reordered this fails loudly here instead of
+// silently changing which branch doUpdateVol takes.
+func TestRemoteLoadedSortsAboveLoaded(t *testing.T) {
+	if types.REMOTELOADED <= types.LOADED {
+		t.Fatalf("REMOTELOADED (%d) is no longer above LOADED (%d); revisit contentTreeNotLocallyUsable",
+			types.REMOTELOADED, types.LOADED)
+	}
+}

--- a/pkg/pillar/cmd/volumemgr/adoptclustervolume.go
+++ b/pkg/pillar/cmd/volumemgr/adoptclustervolume.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// tryAdoptExistingClusterPVC is the EVE-k/Longhorn cluster-failover fast path.
+//
+// Background: on a DNID reassignment (an app re-designated to a healthy node
+// after the original node became unavailable), the new node's VolumeConfig
+// flips IsReplicated false->true->false as ownership moves (see
+// handleVolumeModify), but the ContentTree backing this volume may be missing
+// entirely on the new node, or fighting a slow/unreachable datastore -- while
+// the Longhorn PVC for this exact volume generation is already Bound and fully
+// populated cluster-wide via replication. There is no reason to make the app
+// wait on re-establishing that source image: hand off straight to
+// CreateVolume(), whose existing FindPVC/upload-complete check (csihandler.go)
+// adopts the PVC in place instead of re-driving a download/import.
+//
+// Guarded to EVE-k only: classic hypervisors have no PVC/Longhorn concept, so
+// ctx.hvTypeKube false always short-circuits to false here, leaving that path
+// completely unchanged. On EVE-k, every persistent volume is CSI/Longhorn
+// backed, so that one guard is sufficient scoping -- no separate "is this a
+// Longhorn PVC" check is needed.
+//
+// This does not weaken the existing safety checks, it only adds a second way
+// to reach them sooner:
+//   - Generation matching is implicit: VolumeStatus.GetPVCName() embeds the
+//     generation counter in the PVC name itself, so this can only ever match
+//     the PVC for the exact generation being requested.
+//   - Completeness is still required: kubeapi.ProbePVCAdoption checks the PVC
+//     is Bound and CDI's own "Upload Complete" annotations are present, the
+//     same signal the existing (already-present) adopt-on-create logic in
+//     csihandler.go relies on.
+//
+// Returns the PVC's adoption state (see kubeapi.PVCAdoptionState). Callers
+// must only treat PVCStateAbsent as evidence this volume needs a real
+// download -- PVCStateUnknown and PVCStateNotReady both mean the volume
+// keeps waiting on the ContentTree exactly as it does today, not that it
+// should start over.
+func tryAdoptExistingClusterPVC(ctx *volumemgrContext, status *types.VolumeStatus) kubeapi.PVCAdoptionState {
+	if !ctx.hvTypeKube {
+		return kubeapi.PVCStateUnknown
+	}
+	key := status.Key()
+	pvcName := status.GetPVCName()
+	// This function makes at most one probe, so the live-call budget
+	// probePVCAdoption's second return value guards (see
+	// maxFreshPVCProbesPerCheck) does not apply here; reevaluatePendingVolumes
+	// already re-drives doUpdateVol every gc tick regardless.
+	state, _ := probePVCAdoption(pvcName)
+	switch state {
+	case kubeapi.PVCStateReady:
+		log.Noticef("tryAdoptExistingClusterPVC(%s): found existing Bound, upload-complete PVC %s "+
+			"at this volume's generation; adopting instead of waiting on ContentTree %s",
+			key, pvcName, status.ContentID)
+	case kubeapi.PVCStateAbsent:
+		log.Functionf("tryAdoptExistingClusterPVC(%s): PVC %s confirmed absent", key, pvcName)
+	default:
+		log.Functionf("tryAdoptExistingClusterPVC(%s): PVC %s not yet known ready", key, pvcName)
+	}
+	return state
+}

--- a/pkg/pillar/cmd/volumemgr/pvcadoptprobe.go
+++ b/pkg/pillar/cmd/volumemgr/pvcadoptprobe.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+)
+
+// pvcAdoptProbeTTL throttles repeat "is this PVC ready to adopt" checks
+// against the same PVC name. contentTreeSatisfiedByPVCs and
+// tryAdoptExistingClusterPVC can both ask about the same PVC on the same
+// reconcile pass, and doUpdateVol/doUpdateContentTree can each be re-driven
+// many times a second while a download retries -- probe at a bounded rate
+// rather than every reconcile.
+const pvcAdoptProbeTTL = 15 * time.Second
+
+// pvcAdoptCacheEntry is the last known adoption state of one PVC and when it
+// was determined.
+type pvcAdoptCacheEntry struct {
+	state   kubeapi.PVCAdoptionState
+	checked time.Time
+}
+
+// pvcAdoptCache is keyed by PVC name, not by ContentTreeStatus.Key() or
+// VolumeStatus.Key(). Those two keys can name the same underlying PVC, and
+// giving each caller its own throttle timer let one caller's stale
+// "not checked yet" outrank the other's fresh answer -- a probe throttled on
+// the volume side could report false moments after an unthrottled probe on
+// the content-tree side had confirmed the same PVC ready, and doUpdateVol
+// read that false as grounds to revoke the acceptance it had just granted.
+// Keying by PVC name gives both callers the same answer.
+//
+// Single-threaded volumemgr main loop, so no lock needed (same pattern as
+// clusterStorageReadyCache in retryclustervolume.go).
+var pvcAdoptCache = make(map[string]pvcAdoptCacheEntry)
+
+// probePVCAdoption returns the current adoption state of the named PVC, and
+// whether reaching that answer required a live Kubernetes call just now
+// (false when served from cache within pvcAdoptProbeTTL). A cached state is
+// returned as-is, not downgraded to PVCStateUnknown -- the point of the
+// cache is to keep serving the last real answer between checks, not to hide
+// it until the next unthrottled probe.
+//
+// Callers that probe several PVCs in one pass use fresh to bound how many
+// live, kubeAPITimeout-bounded calls a single reconcile makes -- see
+// maxFreshPVCProbesPerCheck in acceptclustercontenttree.go for why that
+// bound exists.
+func probePVCAdoption(pvcName string) (state kubeapi.PVCAdoptionState, fresh bool) {
+	if entry, ok := pvcAdoptCache[pvcName]; ok && time.Since(entry.checked) < pvcAdoptProbeTTL {
+		return entry.state, false
+	}
+	state = kubeapi.ProbePVCAdoption(pvcName, log)
+	pvcAdoptCache[pvcName] = pvcAdoptCacheEntry{state: state, checked: time.Now()}
+	return state, true
+}

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -42,6 +42,19 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 	}
 
 	if status.State < types.VERIFIED {
+		// EVE-k: before doing anything that costs a download, ask whether the
+		// artifact this content tree exists to produce is already present.
+		// If every volume this node owns that references this tree already has
+		// a complete, replicated PVC, the source image has no remaining
+		// consumer on this node -- accept the tree instead of fetching it.
+		// See contentTreeSatisfiedByPVCs for the (deliberately narrow)
+		// conditions, and revokeContentTreeAcceptance for how this is undone
+		// if a volume later turns out to need real content.
+		if contentTreeSatisfiedByPVCs(ctx, status) {
+			acceptContentTreeFromPVCs(ctx, status)
+			return true, true
+		}
+
 		if !status.AllDatastoresResolved {
 			log.Functionf("contentTreeStatus(%s) does not have a datastore type yet, deferring", status.ContentID)
 			return false, false
@@ -607,6 +620,50 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 		}
 	case zconfig.VolumeContentOriginType_VCOT_DOWNLOAD:
 		ctStatus := ctx.LookupContentTreeStatus(status.ContentID.String())
+
+		// EVE-k/Longhorn cluster-failover fast path: a volume whose
+		// ContentTree is missing, stuck (e.g. re-designated to a node
+		// that lost its local download, or fighting a slow/unreachable
+		// datastore), or accepted-without-download may already have a Bound,
+		// fully-populated Longhorn PVC for this exact generation, replicated
+		// cluster-wide. Don't make the app wait on re-establishing that
+		// source image in that case -- see tryAdoptExistingClusterPVC for the
+		// full rationale and the safety argument (generation matching,
+		// upload-complete check).
+		if !verifyOnly && status.State < types.CREATING_VOLUME &&
+			contentTreeNotLocallyUsable(ctStatus) {
+			switch tryAdoptExistingClusterPVC(ctx, status) {
+			case kubeapi.PVCStateReady:
+				if !clusterStorageReady(ctx) {
+					log.Noticef("doUpdateVol(%s): deferring adopted-volume create until cluster storage (longhorn/CDI) ready",
+						status.Key())
+					return changed, false
+				}
+				status.State = types.CREATING_VOLUME
+				changed = true
+				log.Noticef("doUpdateVol(%s): adopting existing cluster PVC, bypassing ContentTree wait", status.Key())
+				// Asynch preparation; ensure we have requested it
+				AddWorkPrepare(ctx, status)
+				return changed, false
+			case kubeapi.PVCStateAbsent:
+				if ctStatus != nil && ctStatus.State == types.REMOTELOADED {
+					// The tree was accepted on the strength of other
+					// volumes' PVCs, but Kubernetes confirms this volume's
+					// own PVC does not exist (e.g. a purge moved it to a
+					// new generation). Put the tree back on the download
+					// path so this volume can actually be built.
+					//
+					// PVCStateUnknown/PVCStateNotReady must never reach
+					// this branch: neither is evidence the PVC is gone,
+					// only that this check did not confirm it either way,
+					// and revoking on that would re-trigger the very
+					// download this fast path exists to avoid.
+					revokeContentTreeAcceptance(ctx, ctStatus)
+					return changed, false
+				}
+			}
+		}
+
 		if ctStatus == nil {
 			// Content tree not yet available
 			log.Errorf("doUpdateVol(%s) name %s: waiting for content tree status %v",
@@ -617,6 +674,21 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 			log.Functionf("doUpdate: Clearing volume error %s", status.Error)
 			status.ClearErrorWithSource()
 			changed = true
+		}
+		if ctStatus.State == types.REMOTELOADED {
+			// The content tree was accepted from existing cluster PVCs, so
+			// there is no local content to build from -- and none is needed:
+			// a volume that genuinely required content has already revoked the
+			// acceptance above, and one that did not has already been sent
+			// down the adoption path. Report the volume as LOADED (rather than
+			// copying REMOTELOADED down into it) so a VerifyOnly volume, and
+			// the app waiting on it, can proceed. Progress/size are not copied
+			// because an accepted tree downloaded nothing.
+			if status.State != types.LOADED && status.State < types.CREATING_VOLUME {
+				status.State = types.LOADED
+				changed = true
+			}
+			return changed, false
 		}
 		if status.Progress != ctStatus.Progress ||
 			status.TotalSize != ctStatus.TotalSize ||

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -873,6 +873,11 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			if ctx.hvTypeKube {
 				reevaluatePendingVolumes(&ctx)
 			}
+			// Re-drive content trees whose accept-from-PVCs check
+			// (contentTreeSatisfiedByPVCs) deferred after spending its
+			// per-call live-probe budget; nothing else re-evaluates a
+			// content tree sitting idle on that check.
+			reevaluatePendingContentTrees(&ctx)
 			ps.CheckMaxTimeTopic(agentName, "gc", start,
 				warningTime, errorTime)
 

--- a/pkg/pillar/kubeapi/cdiupload.go
+++ b/pkg/pillar/kubeapi/cdiupload.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -93,4 +94,67 @@ func IsPVCUploadComplete(pvcName string, log *base.LogObject) (bool, error) {
 		return false, fmt.Errorf("failed to get PVC %s: %v", pvcName, err)
 	}
 	return cdiUploadIsComplete(log, pvc), nil
+}
+
+// PVCAdoptionState is the outcome of checking whether an existing PVC can be
+// adopted in place of downloading/creating a volume's content from scratch.
+// Callers must not treat every non-ready state alike: only PVCStateAbsent is
+// evidence that no PVC will ever answer this check, and it is the only
+// verdict safe to act on as if the volume needs a real download.
+type PVCAdoptionState int
+
+const (
+	// PVCStateUnknown means the check did not complete: the API server was
+	// unreachable, or some other transient error occurred. This is not
+	// evidence the PVC is gone -- callers should keep waiting and probe
+	// again later.
+	PVCStateUnknown PVCAdoptionState = iota
+	// PVCStateReady means the PVC exists, is Bound, and its CDI image
+	// upload has completed. Safe to adopt.
+	PVCStateReady
+	// PVCStateNotReady means the PVC exists but is not yet Bound, or its
+	// upload has not finished. Keep waiting; this is still in progress,
+	// not gone.
+	PVCStateNotReady
+	// PVCStateAbsent means Kubernetes confirmed no PVC by this name
+	// exists (a real NotFound, not a transient error). This is the only
+	// state that means the volume actually needs a download.
+	PVCStateAbsent
+)
+
+// ProbePVCAdoption reports the current adoption state of a PVC with this
+// exact name -- i.e. whether it is safe to adopt in place of waiting on (or
+// re-driving) a source ContentTree download. See PVCAdoptionState for what
+// each outcome means and how callers should react to it.
+//
+// This is the cluster-failover fast path: VolumeStatus.GetPVCName() embeds the
+// volume's generation counter in the PVC name itself, so a match here can only
+// be the PVC for this exact generation -- a stale or newer generation simply
+// will not be found under this name, and this function does not need (and does
+// not do) any separate generation comparison.
+func ProbePVCAdoption(pvcName string, log *base.LogObject) PVCAdoptionState {
+	clientset, err := GetClientSet()
+	if err != nil {
+		log.Functionf("ProbePVCAdoption: get clientset: %v", err)
+		return PVCStateUnknown
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeAPITimeout)
+	defer cancel()
+	pvc, err := clientset.CoreV1().PersistentVolumeClaims(EVEKubeNameSpace).
+		Get(ctx, pvcName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return PVCStateAbsent
+		}
+		log.Functionf("ProbePVCAdoption: get PVC %s: %v", pvcName, err)
+		return PVCStateUnknown
+	}
+	if pvc.Status.Phase != corev1.ClaimBound {
+		log.Functionf("ProbePVCAdoption: pvc %s phase is %s, not Bound", pvcName, pvc.Status.Phase)
+		return PVCStateNotReady
+	}
+	if cdiUploadIsComplete(log, pvc) {
+		return PVCStateReady
+	}
+	return PVCStateNotReady
 }

--- a/pkg/pillar/kubeapi/nokube.go
+++ b/pkg/pillar/kubeapi/nokube.go
@@ -74,6 +74,27 @@ func ClusterStorageReadyForVolumes(*base.LogObject, string) bool {
 	return true
 }
 
+// PVCAdoptionState mirrors the k-build type, with the same four values in
+// the same order, so callers can reference it without a build tag. See the
+// k-build definition for what each value means. Only PVCStateUnknown is ever
+// returned on this build: there is no PVC/Longhorn concept to adopt from on
+// classic hypervisors, so there is never anything to adopt and callers fall
+// through to the normal ContentTree-gated path.
+type PVCAdoptionState int
+
+// These states mirror the k-build's meanings; see cdiupload.go there.
+const (
+	PVCStateUnknown PVCAdoptionState = iota
+	PVCStateReady
+	PVCStateNotReady
+	PVCStateAbsent
+)
+
+// ProbePVCAdoption is a stub for non EVE-k builds.
+func ProbePVCAdoption(string, *base.LogObject) PVCAdoptionState {
+	return PVCStateUnknown
+}
+
 // EnsureVMsDeschedulerAnnotated is a stub for non EVE-k builds.
 func EnsureVMsDeschedulerAnnotated(*base.LogObject) error {
 	return nil

--- a/pkg/pillar/kubeapi/vitoapiserver.go
+++ b/pkg/pillar/kubeapi/vitoapiserver.go
@@ -443,7 +443,11 @@ func RolloutDiskToPVC(ctx context.Context, log *base.LogObject, exists bool,
 	// virtctl image-upload -n eve-kube-app pvc pvcname  --no-create --storage-class longhorn --image-path=<diskfile>
 	// --insecure --uploadproxy-url https://10.43.31.180:8443  --access-mode RWO --block-volume --size 1000M
 
-	uploadPodServerStartTimeBase := int64(600) // First upload may need to wait for image download of the uploader itself
+	// Doubled from the original 600/300 floor: a busy multi-node cluster
+	// (k3s control plane, Longhorn, CDI all still settling from their own
+	// bring-up) is slower to service the upload-wait/status-poll calls
+	// below than the single-node case these floors were sized for.
+	uploadPodServerStartTimeBase := int64(1200) // First upload may need to wait for image download of the uploader itself
 	virtctlUploadServerRetryMax := int64(10)
 	args := []string{"image-upload", "-n", EVEKubeNameSpace, "pvc", pvcName,
 		"--storage-class", "longhorn", "--image-path", diskfile, "--insecure",
@@ -471,11 +475,14 @@ func RolloutDiskToPVC(ctx context.Context, log *base.LogObject, exists bool,
 
 	uploadTry := 0
 	maxRetries := 10
-	timeoutBaseSeconds := int64(300) // 5 min
+	timeoutBaseSeconds := int64(600) // 10 min
 	volSizeGB := int64(pvcSize / 1024 / 1024 / 1024)
 	timeoutPer1GBSeconds := int64(120)
 	timeout := time.Duration(uploadPodServerStartTimeBase + timeoutBaseSeconds + (volSizeGB * timeoutPer1GBSeconds))
-	log.Noticef("RolloutDiskToPVC pvc:%s calculated timeout to %d seconds due to volume size %d GB", pvcName, timeout, volSizeGB)
+	// volSizeGB truncates to 0 for any volume under 1 GiB -- report the
+	// actual size too, so a sub-1-GiB volume doesn't read as empty.
+	log.Noticef("RolloutDiskToPVC pvc:%s calculated timeout to %d seconds for a %.1f MiB volume (%d whole GB bonus)",
+		pvcName, timeout, float64(pvcSize)/1024/1024, volSizeGB)
 
 	startTimeOverall := time.Now()
 

--- a/pkg/pillar/types/volumetypes.go
+++ b/pkg/pillar/types/volumetypes.go
@@ -41,6 +41,15 @@ func (config VolumeConfig) Key() string {
 		config.GenerationCounter+config.LocalGenerationCounter)
 }
 
+// GetPVCName : returns the kubernetes(longhorn) PVC name for this volume.
+// Must produce the same name as VolumeStatus.GetPVCName() for the same volume
+// and generation; callers rely on the generation being embedded in the name so
+// that a lookup by name can only ever match this exact generation.
+func (config VolumeConfig) GetPVCName() string {
+	return fmt.Sprintf("%s-pvc-%d", config.VolumeID.String(),
+		config.GenerationCounter+config.LocalGenerationCounter)
+}
+
 // LogCreate :
 func (config VolumeConfig) LogCreate(logBase *base.LogObject) {
 	logObject := base.NewLogObject(logBase, base.VolumeConfigLogType, config.DisplayName,

--- a/pkg/pillar/types/volumetypes_test.go
+++ b/pkg/pillar/types/volumetypes_test.go
@@ -63,6 +63,39 @@ func TestVolumeRefConfigGetPVCNameMatchesStatus(t *testing.T) {
 	assert.Equal(t, ref.GetPVCName(), other.GetPVCName())
 }
 
+// TestVolumeConfigGetPVCNameMatchesStatus pins the invariant the EVE-k PVC
+// adoption path rests on: the name derived from a VolumeConfig must be the same
+// name derived from the corresponding VolumeStatus. Adoption looks a PVC up by
+// this name and treats a hit as proof that the PVC belongs to this volume at
+// this exact generation, so the two derivations drifting apart would let one
+// side look up a PVC the other never wrote.
+func TestVolumeConfigGetPVCNameMatchesStatus(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	for _, gen := range []struct{ generation, local int64 }{
+		{0, 0},
+		{2, 1},
+		{5, 0},
+		{0, 7},
+	} {
+		config := VolumeConfig{
+			VolumeID:               id,
+			GenerationCounter:      gen.generation,
+			LocalGenerationCounter: gen.local,
+		}
+		status := VolumeStatus{
+			VolumeID:               id,
+			GenerationCounter:      gen.generation,
+			LocalGenerationCounter: gen.local,
+		}
+		assert.Equal(t, status.GetPVCName(), config.GetPVCName(),
+			"generation=%d local=%d", gen.generation, gen.local)
+		// The generation must be part of the name, so a different generation
+		// can never resolve to the same PVC.
+		assert.Equal(t, fmt.Sprintf("%s-pvc-%d", id.String(), gen.generation+gen.local),
+			config.GetPVCName())
+	}
+}
+
 // VolumesSnapshotAction.String
 
 func TestVolumesSnapshotActionString(t *testing.T) {


### PR DESCRIPTION
# Description

**`volumemgr: accept a cluster PVC instead of re-downloading its source`**
— the actual fix. After a cluster maintenance event (reboot, failover),
EVE was re-downloading a VM's multi-GB qcow2 source image even though the
Longhorn PVC that image exists to fill was already Bound and CDI-complete.
Root cause: ContentTreeStatus and ContentTreeConfig are both published
non-persistent, so any process restart — every device reboot, since
volumemgr is its own process — wipes volumemgr's cache and resets every
locally-owned content tree to INITIAL, regardless of whether its
DesignatedNodeID ever changed. The fix checks, before the download path,
whether every volume referencing a content tree already has a complete
PVC; if so, the tree jumps straight to REMOTELOADED instead of
downloading. Each check is `kubeAPITimeout`-bounded and capped per call to
avoid starving volumemgr's watchdog budget, with a new periodic pass
picking up whatever a capped call defers.

**`evetest: add a cluster VM app test and a PVC re-download repro`** — new
coverage. 
`TestClusterVMApp` is the first qcow2 VM app deployed in the
cluster test suite (existing cluster tests use containers, which run in a
shim VM but never boot a real guest disk). 

`TestClusterPVCRedownload`
reproduces an end to end scenario: shut down
two VM apps, power off all three nodes, sever the datastore, isolate one
node's cluster interface, power back on (the isolated node can't rejoin),
reactivate the surviving app, and assert its content tree shows
REMOTELOADED rather than a re-download attempt.

## PR dependencies

#6309 

## How to test and validate this PR

Run the new evetest coverage:
```
    EVETEST_LOG_LEVEL=debug make evetest NAME=TestClusterVMApp
    EVETEST_LOG_LEVEL=debug make evetest NAME=TestClusterPVCRedownload
```

## Changelog notes

Fixed a bug where an EVE-K node could re-download a VM's multi-gigabyte
source image after a cluster maintenance event (reboot, failover) even
though the image's Longhorn PVC was already complete, needlessly delaying
app startup when the datastore was slow or unreachable. No other
user-facing changes; the evetest additions are test-framework only.

## PR Backports


- 17.0-stable: To be backported.
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
