### PR TITLE
[DO NOT MERGE] eve-k: reclaim the purged generation's PVC

### DIFF
--- a/evetest/tests/apps/appworkload_helpers_test.go
+++ b/evetest/tests/apps/appworkload_helpers_test.go
@@ -67,9 +67,10 @@ const (
 )
 
 // kubeItemList is the minimal shape needed from any `kubectl get <resource>
-// -o json`: a name per item, the item's own labels, and the selector labels.
-// A VMIRS is attributed by its selector, which is the only place EVE puts the
-// App-Domain-Name label. A PVC has neither field.
+// -o json`: a name per item, the item's own labels, the selector labels, and
+// its status phase. A VMIRS is attributed by its selector, which is the only
+// place EVE puts the App-Domain-Name label; a PVC has neither label field but
+// does have Status.Phase.
 type kubeItemList struct {
 	Items []struct {
 		Metadata struct {
@@ -81,6 +82,9 @@ type kubeItemList struct {
 				MatchLabels map[string]string `json:"matchLabels"`
 			} `json:"selector"`
 		} `json:"spec"`
+		Status struct {
+			Phase string `json:"phase"`
+		} `json:"status"`
 	} `json:"items"`
 }
 
@@ -119,6 +123,49 @@ func kubectlListItems(
 		return list, false
 	}
 	return list, true
+}
+
+// kubeEventList is the minimal shape needed from `kubectl get events -o json`:
+// the reason, the human-readable message, and the name of the object the
+// event is about.
+type kubeEventList struct {
+	Items []struct {
+		Reason         string `json:"reason"`
+		Message        string `json:"message"`
+		InvolvedObject struct {
+			Name string `json:"name"`
+		} `json:"involvedObject"`
+	} `json:"items"`
+}
+
+// kubectlEvents lists every event in the EVE app namespace. found is false on
+// the same conditions as kubectlListItems.
+func kubectlEvents(dev *evetest.EdgeDevice) (list kubeEventList, found bool) {
+	stdout, stderr, err := dev.RunShellScript(
+		"eve exec kube kubectl -n "+eveKubeAppNamespace+" get events -o json",
+		sshCmdTimeout, 0)
+	if err != nil {
+		evetest.Logger().Warnf(
+			"kubectlEvents: kubectl get events failed: %v (stderr: %s)", err, stderr)
+		return list, false
+	}
+	if err := json.Unmarshal([]byte(stdout), &list); err != nil {
+		evetest.Logger().Warnf(
+			"kubectlEvents: failed to parse kubectl events output: %v", err)
+		return list, false
+	}
+	return list, true
+}
+
+// restartCSIProvisioner deletes Longhorn's csi-provisioner pod(s), forcing a
+// fresh leader election and cache. See the REMOVE ME note atop
+// longhorn_provisioner_workaround_test.go for why this exists.
+func restartCSIProvisioner(dev *evetest.EdgeDevice) {
+	if _, stderr, err := dev.RunShellScript(
+		"eve exec kube kubectl -n longhorn-system delete pod -l app=csi-provisioner",
+		sshCmdTimeout, 0); err != nil {
+		evetest.Logger().Warnf("restartCSIProvisioner: delete failed: %v (stderr: %s)", err, stderr)
+	}
 }
 
 // listAppVMIRS returns the names of every VMIRS (any generation) that belongs to

--- a/evetest/tests/apps/longhorn_provisioner_workaround_test.go
+++ b/evetest/tests/apps/longhorn_provisioner_workaround_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// ============================================================================
+// REMOVE ME
+// ============================================================================
+//
+// This file works around an infra bug in Longhorn's CSI provisioner. It is
+// not related to anything this suite tests. Delete this file and the one
+// call to waitForAppRunningMitigatingPVCStall (grep for it, in
+// purge_during_failover_test.go) once Longhorn no longer needs a pod restart
+// to recover from a stuck PVC.
+//
+// Observed symptom: a PVC stays Pending indefinitely. Its ProvisioningFailed
+// events alternate "volume ... not found" (404) and "volume ... already
+// exists" (500) - the provisioner created the Longhorn backend volume once,
+// lost track of that success in its own cache, and keeps retrying against a
+// name it no longer recognizes.
+//
+// Confirmed live, on the current Longhorn version, with no EVE or pillar
+// change involved: deleting the csi-provisioner pod forces a fresh leader
+// election and cache, and the very next retry succeeds
+// (ProvisioningSucceeded within minutes).
+//
+// Only wired into TestVMAppPurgeDuringFailover: that is the one test this has
+// actually been observed to fail, and restarting a cluster-wide Longhorn pod
+// is not something to do reflexively from every test that creates a volume.
+//
+// Scope note: this deletes a cluster-wide Longhorn pod. Safe here because
+// each purge test gets its own freshly-created device/cluster
+// (purgeDeviceRequirements), so nothing else is using it. Do not call this
+// against a shared or long-lived cluster.
+package apps_test
+
+import (
+	"strings"
+	"time"
+
+	"github.com/lf-edge/eve/evetest"
+)
+
+// pvcStallSignature is the substring both ends of the failure oscillation
+// share. "not found" alone is not distinctive enough to key on - a PVC can
+// legitimately report "not found" for a moment during normal provisioning.
+const pvcStallSignature = "already exists"
+
+// pvcStallCheckInterval is how often waitForAppRunningMitigatingPVCStall
+// polls for the stuck-PVC signature while waitFn is blocked.
+const pvcStallCheckInterval = 30 * time.Second
+
+// pvcStallThreshold is how long a PVC must show the signature, continuously,
+// before this mitigation acts. A PVC that clears - becomes Bound, or simply
+// stops matching the signature - before this elapses is a normal, if slow,
+// provisioning retry; passing through and leaving it alone is the point.
+const pvcStallThreshold = 2 * time.Minute
+
+// waitForAppRunningMitigatingPVCStall wraps waitFn - normally
+// cluster.WaitUntilAppIsRunning - with a background watcher that restarts
+// Longhorn's csi-provisioner if a PVC shows the stuck-PVC signature for at
+// least pvcStallThreshold while waitFn is blocked.
+//
+// waitFn still Fatalf's on its own timeout exactly as it would unwrapped;
+// this only gives the provisioner a chance to recover before that timeout.
+// kubeDev is any device that can reach the cluster's kubectl - for a cluster
+// test, any member node.
+func waitForAppRunningMitigatingPVCStall(kubeDev *evetest.EdgeDevice, waitFn func()) {
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(pvcStallCheckInterval)
+		defer ticker.Stop()
+		firstSeenStalled := map[string]time.Time{}
+		kicked := false
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				if kicked {
+					// One restart per wait is enough. Retrying it on every
+					// tick would fight a genuinely slow (but healthy)
+					// provision with unnecessary leader-election churn.
+					continue
+				}
+				now := time.Now()
+				stalled := stalledPVCNames(kubeDev)
+				// A PVC no longer in the stalled set recovered on its own -
+				// forget it, so a later, unrelated stall starts its own
+				// clock rather than inheriting an old one.
+				for name := range firstSeenStalled {
+					if !stalled[name] {
+						delete(firstSeenStalled, name)
+					}
+				}
+				for name := range stalled {
+					if _, tracked := firstSeenStalled[name]; !tracked {
+						firstSeenStalled[name] = now
+					}
+				}
+				for name, since := range firstSeenStalled {
+					if now.Sub(since) < pvcStallThreshold {
+						continue
+					}
+					evetest.Logger().Warnf(
+						"waitForAppRunningMitigatingPVCStall: PVC %q stuck for over %s, "+
+							"restarting csi-provisioner - see the REMOVE ME note in "+
+							"longhorn_provisioner_workaround_test.go", name, pvcStallThreshold)
+					restartCSIProvisioner(kubeDev)
+					kicked = true
+					break
+				}
+			}
+		}
+	}()
+	waitFn()
+	close(stop)
+	<-done
+}
+
+// stalledPVCNames returns the names of PVCs that are currently Pending and
+// have a ProvisioningFailed event carrying pvcStallSignature. Checking events
+// against PVCs still Pending, rather than events alone, means a PVC that has
+// since become Bound is never counted, even though its old events persist
+// for a while - that is exactly the "passes through once bound" behavior
+// this mitigation is meant to have.
+//
+// Empty on any read failure - a transient kubectl error must never
+// contribute to the stall clock.
+func stalledPVCNames(dev *evetest.EdgeDevice) map[string]bool {
+	stalled := map[string]bool{}
+
+	pvcs, found := kubectlListItems(dev, "pvc")
+	if !found {
+		return stalled
+	}
+	pending := make(map[string]bool)
+	for _, item := range pvcs.Items {
+		if item.Status.Phase == "Pending" {
+			pending[item.Metadata.Name] = true
+		}
+	}
+	if len(pending) == 0 {
+		return stalled
+	}
+
+	events, found := kubectlEvents(dev)
+	if !found {
+		return stalled
+	}
+	for _, ev := range events.Items {
+		if ev.Reason != "ProvisioningFailed" || !pending[ev.InvolvedObject.Name] {
+			continue
+		}
+		if strings.Contains(ev.Message, pvcStallSignature) {
+			stalled[ev.InvolvedObject.Name] = true
+		}
+	}
+	return stalled
+}

--- a/evetest/tests/apps/purge_after_power_cycle_test.go
+++ b/evetest/tests/apps/purge_after_power_cycle_test.go
@@ -234,15 +234,13 @@ func TestVMAppPurgeAfterPowerCycle(test *testing.T) {
 	evetest.Checkpoint("purge-verified")
 
 	// The old generation's storage is reclaimed on its own schedule, minutes
-	// after the purge itself completes - see assertOldVolumeReclaimed.
-	//
-	// assertNoOrphanedPVCs is disabled on Kubevirt for now: sweepStaleGenerations
-	// deletes the old VMIRS and its pod but not its PVC, so the old generation's
-	// disk stays behind. That is a pillar fix, not a test bug - re-enable this
-	// once sweepStaleGenerations deletes the PVC too.
+	// after the purge itself completes - see assertOldVolumeReclaimed. On
+	// Kubevirt the reclaim is volumemgr's periodic GC pass rather than the
+	// purge: sweepStaleGenerations deletes the old VMIRS and its pod, and the
+	// PVC outlives both until that pass collects it.
 	t.Eventually(func(g Gomega) {
 		if hypervisor == evetest.HypervisorKubevirt {
-			// assertNoOrphanedPVCs(g, device)
+			assertNoOrphanedPVCs(g, device)
 		} else {
 			assertOldVolumeReclaimed(g, device, baselineVolPath)
 		}

--- a/evetest/tests/apps/purge_during_failover_test.go
+++ b/evetest/tests/apps/purge_during_failover_test.go
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package apps_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	eveconfig "github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve-api/go/evecommon"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/netmodels"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// TestVMAppPurgeDuringFailover exercises a purge issued after the app's
+// designated node has failed over: the app's designated node is powered
+// off, KubeVirt reschedules the replica onto a different node, and a purge
+// is then issued while the designated node is still down. The purge must
+// not wait on the dead node: gating the teardown on the app's designated
+// node, or on where a replica currently happens to be scheduled, would
+// deadlock exactly this case, because neither signal is both durable and
+// liveness-aware on its own.
+//
+// Network model
+// -------------
+//   - netmodels.SeparateClusterPort -- six ports (two per device): eth0
+//     ports share a management+app SDN bridge with DHCP and controller
+//     reachability; eth1 ports share a separate cluster-only bridge used
+//     for inter-node K3s traffic.
+//
+// Device configuration
+// --------------------
+//   - Three purgeDeviceRequirements (purge_helpers_test.go) devices, called
+//     with HypervisorKubevirt - same fresh-image/vcpu-cap setup as the other
+//     Kubevirt tests in this suite, following tests/cluster/cluster_test.go's
+//     TestThreeNodesCluster topology.
+//   - ClusterConfig (REPLICATED_STORAGE) with three ClusterNode entries on
+//     10.244.244.0/24; node 1 is the bootstrap node.
+//   - One Local NI "local-ni" (10.11.14.0/24) and one shim-VM app
+//     (vmShimApplication) with DesignatedNodeName=devName[0] (node 1) and
+//     Affinity=PREFERRED.
+//
+// Test parameters
+// ---------------
+//   - TPM via evetest.TPMParameter().
+//   - FILESYSTEM (ext4|zfs, defaults to ext4) via evetest.FilesystemParameter().
+//   - HYPERVISOR is read from the suite only to skip on anything but kubevirt;
+//     the three devices are always required as Kubevirt nodes, since a VMIRS
+//     and a replicated-storage cluster exist nowhere else.
+//
+// Phases
+// ------
+//  1. setup-done -> nodes-are-ready: bring up the three-node cluster.
+//  2. app-is-deployed: deploy the app; assert it is in fact running on its
+//     preferred (DNID) node, node 1, while node 1 is healthy.
+//  3. dnid-node-powered-off: EdgeDevice.PowerOff() on node 1.
+//  4. failed-over: EdgeCluster.FindDeviceHostingApp with node 1 excluded waits
+//     for KubeVirt to reschedule the replica onto node 2 or node 3. The
+//     exclusion matters: without it the powered-off node's own stale cluster
+//     info still names it as the host and would be returned immediately.
+//  5. purge-complete: EdgeCluster.PurgeApplication(waitUntilPurged=true) -
+//     this bumps the purge counter on every device (including the
+//     powered-off node 1 - EdgeDevice.ApplyConfig's push does not require
+//     device reachability) but waits only on the node actually hosting the
+//     app; there is no exclusive gate on the delete itself.
+//  6. End-state assertion: exactly one VMIRS, named for the NEW generation,
+//     observed from the node that now hosts the app. Unlike the other two
+//     tests in this suite, this one makes no volume or guest-level assertion
+//     (VolumeStatus is a per-node ephemeral publication and its
+//     clustered/replicated-storage semantics across a node failover have
+//     not been established for this suite; the app's forwarded SSH port on
+//     the new host has not been either).
+//  7. dnid-node-powered-on: power node 1 back on so cluster teardown does
+//     not have to reason about an already-off device.
+//
+// Suite placement
+// ---------------
+//   - TestAppsSuite, last: it is the only subtest needing three devices, so it
+//     is also the most expensive to set up.
+func TestVMAppPurgeDuringFailover(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+		evetest.TPMParameter(),
+		evetest.FilesystemParameter(),
+	)
+	if hypervisor := evetest.GetHypervisorParameterValue(); hypervisor != evetest.HypervisorKubevirt {
+		evetestT.Skipf("HYPERVISOR is %s: this test needs a replicated-storage "+
+			"cluster and asserts on VMIRS objects, which only exist on kubevirt",
+			hypervisor)
+	}
+	withTPM := evetest.GetTPMParameterValue()
+	filesystem := evetest.GetFilesystemParameterValue()
+
+	var requiredDevices [3]evetest.Requirement
+	var devName [3]string
+	for i := 0; i < 3; i++ {
+		devName[i] = fmt.Sprintf("edge-dev%d", i+1)
+		requiredDevices[i] = purgeDeviceRequirements(devName[i], withTPM, filesystem,
+			evetest.HypervisorKubevirt)
+	}
+	requiredNetModel := evetest.RequireNetworkModel{
+		NetworkModel: netmodels.SeparateClusterPort,
+	}
+	var requirements []evetest.Requirement
+	requirements = append(requirements, requiredDevices[:]...)
+	requirements = append(requirements, requiredNetModel)
+	evetest.Setup(requirements...)
+	evetest.Checkpoint("setup-done")
+
+	var nodes [3]evetest.ClusterNode
+	for i := 0; i < 3; i++ {
+		clusterIP := evetest.IPAddressWithPrefix(fmt.Sprintf("10.244.244.%d/24", i+2))
+		nodes[i] = evetest.ClusterNode{
+			DevName:          devName[i],
+			ClusterIP:        clusterIP,
+			ClusterInterface: "ethernet1",
+			BootstrapNode:    i == 0,
+		}
+	}
+	clusterConfig := evetest.NewEdgeClusterConfig(
+		eveconfig.ClusterType_CLUSTER_TYPE_REPLICATED_STORAGE,
+		nodes[:]...,
+	)
+
+	dhcpNet := clusterConfig.AddNetwork(
+		evetest.DHCPNetworkConfig{
+			NetworkType: evecommon.NetworkType_V4Only,
+		})
+	noIPNet := clusterConfig.AddNetwork(evetest.NoIPNetworkConfig{})
+	clusterConfig.AddNetworkAdapter(
+		evetest.NetworkAdapterConfig{
+			LogicalLabel:  "ethernet0",
+			PhysicalLabel: "eth0",
+			InterfaceName: "eth0",
+			NetworkUUID:   dhcpNet,
+			Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+		})
+	clusterConfig.AddNetworkAdapter(
+		evetest.NetworkAdapterConfig{
+			LogicalLabel:  "ethernet1",
+			PhysicalLabel: "eth1",
+			InterfaceName: "eth1",
+			NetworkUUID:   noIPNet,
+			Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+		})
+
+	cluster := evetest.NewEdgeCluster("purge-failover-cluster")
+	cluster.ApplyConfig(clusterConfig, true, true)
+	evetest.Checkpoint("initial-config-applied")
+
+	cluster.WaitUntilNodesAreReady(clusterFormationTimeout)
+	evetest.Checkpoint("nodes-are-ready")
+
+	niUUID := clusterConfig.AddNetworkInstance(evetest.LocalNetworkInstanceConfig{
+		DisplayName: "local-ni",
+		Port:        "ethernet0",
+		Subnet:      evetest.IPSubnet("10.11.14.0/24"),
+		DHCPRange: types.IPRange{
+			Start: evetest.IPAddress("10.11.14.2"),
+			End:   evetest.IPAddress("10.11.14.254"),
+		},
+		Gateway:       evetest.IPAddress("10.11.14.1"),
+		EnableFlowlog: true,
+		MTU:           1500,
+		ForwardLLDP:   false,
+	})
+	const appDisplayName = "purge-app"
+	appUUID := clusterConfig.AddApplication(evetest.ClusterApplicationInstanceConfig{
+		ApplicationInstanceConfig: vmShimApplication(appDisplayName, niUUID),
+		DesignatedNodeName:        devName[0],
+		Affinity:                  eveconfig.AffinityType_AFFINITY_TYPE_PREFERRED,
+	})
+	cluster.ApplyConfig(clusterConfig, true, true)
+	log := evetest.Logger()
+	log.Infof("Submitted config with application UUID=%v, DNID node=%q", appUUID, devName[0])
+	evetest.Checkpoint("app-config-is-submitted")
+
+	cluster.WaitUntilAppIsRunning(appUUID, appReadyTimeout)
+	evetest.Checkpoint("app-is-deployed")
+
+	initialHost := cluster.FindDeviceHostingApp(appUUID, time.Minute)
+	t.Expect(initialHost.Name()).To(Equal(devName[0]),
+		"app should have been scheduled onto its preferred (DNID) node while it is healthy")
+
+	dnidDevice := evetest.GetEdgeDevice(devName[0])
+	baselineCounter, _ := purgeCounter(dnidDevice, appUUID)
+
+	log.Infof("Powering off DNID node %q to force a failover", devName[0])
+	dnidDevice.PowerOff()
+	evetest.Checkpoint("dnid-node-powered-off")
+
+	failoverHost := cluster.FindDeviceHostingApp(appUUID, failoverTimeout, devName[0])
+	log.Infof("App failed over to device %q", failoverHost.Name())
+	evetest.Checkpoint("failed-over")
+
+	cluster.PurgeApplication(appUUID, true, purgeCompleteTimeout)
+	evetest.Checkpoint("purge-complete")
+
+	wantCounter := baselineCounter + 1
+	t.Eventually(func(g Gomega) {
+		assertExactlyOneVMIRSAtGeneration(g, failoverHost, appUUID, appDisplayName, wantCounter)
+	}, purgeEndStateTimeout, assertPollInterval).Should(Succeed())
+
+	log.Infof("Powering DNID node %q back on", devName[0])
+	dnidDevice.PowerOn(true)
+	evetest.Checkpoint("dnid-node-powered-on")
+}

--- a/evetest/tests/apps/purge_during_failover_test.go
+++ b/evetest/tests/apps/purge_during_failover_test.go
@@ -185,7 +185,12 @@ func TestVMAppPurgeDuringFailover(test *testing.T) {
 	log.Infof("Submitted config with application UUID=%v, DNID node=%q", appUUID, devName[0])
 	evetest.Checkpoint("app-config-is-submitted")
 
-	cluster.WaitUntilAppIsRunning(appUUID, appReadyTimeout)
+	// Any cluster member can reach kubectl; devName[0] is as good as any for
+	// the mitigation's own queries while the wait below is blocked.
+	kubeDev := evetest.GetEdgeDevice(devName[0])
+	waitForAppRunningMitigatingPVCStall(kubeDev, func() {
+		cluster.WaitUntilAppIsRunning(appUUID, appReadyTimeout)
+	})
 	evetest.Checkpoint("app-is-deployed")
 
 	initialHost := cluster.FindDeviceHostingApp(appUUID, time.Minute)

--- a/evetest/tests/apps/purge_helpers_test.go
+++ b/evetest/tests/apps/purge_helpers_test.go
@@ -73,6 +73,14 @@ const (
 	// Measured at about six minutes on a 4-vCPU node; every other test in this
 	// package allows twenty.
 	clusterReadyTimeout = 20 * time.Minute
+
+	// clusterFormationTimeout bounds a multi-node cluster forming, which is
+	// slower than one node joining itself.
+	clusterFormationTimeout = 30 * time.Minute
+
+	// failoverTimeout bounds KubeVirt rescheduling a replica after its node is
+	// powered off. Dominated by the node-not-ready detection, not by the pod.
+	failoverTimeout = 10 * time.Minute
 )
 
 // purgeDeviceRequirements returns the RequireEdgeDevice used by every test in

--- a/evetest/tests/apps/testsuite_test.go
+++ b/evetest/tests/apps/testsuite_test.go
@@ -25,6 +25,10 @@
 //	<topic>_helpers_test.go      what one topic's tests build before they run,
 //	                             plus the assertions meaningless outside it;
 //	                             purge_helpers_test.go is the worked example
+//	longhorn_provisioner_workaround_test.go
+//	                             REMOVE ME once resolved - works around a
+//	                             Longhorn CSI-provisioner bug unrelated to
+//	                             anything this suite tests
 //
 // Reading a file, listing a directory, testing for a path and flushing caches
 // are NOT here: they are EdgeDevice methods in the framework

--- a/evetest/tests/apps/testsuite_test.go
+++ b/evetest/tests/apps/testsuite_test.go
@@ -88,13 +88,17 @@ import (
 //   - TestVMAppPurgeAfterPowerCycle -- a purge issued while the device is
 //     powered off, which is where a reboot lands in the middle of the purge
 //     deterministically rather than by chance. Meaningful on every hypervisor.
+//   - TestVMAppPurgeDuringFailover -- a purge issued while the app's
+//     designated node is powered off and the workload has failed over to
+//     another node. Needs a three-node cluster; Kubevirt only.
 //
-// The two purge tests come last because they are the expensive ones: they
+// The three purge tests come last because they are the expensive ones: they
 // assert on which generation of a workload exists, so each needs a device
 // created from scratch (purgeDeviceRequirements) rather than the warm device
-// the earlier subtests reuse.
+// the earlier subtests reuse. The failover test is last of the three, being
+// the only one that needs three of them.
 //
-// Neither declares hypervisor variants. The whole suite is run once per
+// None declares hypervisor variants. The whole suite is run once per
 // hypervisor (EVETEST_HYPERVISOR=kvm|kubevirt), so a variant here would run
 // the same combination a second time; a test that cannot say anything on the
 // hypervisor it was given skips instead.
@@ -130,6 +134,9 @@ func TestAppsSuite(test *testing.T) {
 		},
 		evetest.TestCase{
 			Test: TestVMAppPurgeAfterPowerCycle,
+		},
+		evetest.TestCase{
+			Test: TestVMAppPurgeDuringFailover,
 		},
 	)
 }

--- a/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
+++ b/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
@@ -109,7 +109,7 @@ func gcObjects(ctx *volumemgrContext, dirName string) {
 		}
 		locations = append(locations, filepath.Join(dirName, location.Name()))
 	}
-	gcVolumes(ctx, locations)
+	gcVolumes(ctx, locations, getVolumeStatusByLocation)
 	log.Tracef("gcObjects(%s) Done", dirName)
 }
 
@@ -122,30 +122,72 @@ func gcDatasets(ctx *volumemgrContext, dataset string) {
 			dataset, err)
 		return
 	}
-	gcVolumes(ctx, locations)
+	gcVolumes(ctx, locations, getVolumeStatusByLocation)
 	log.Tracef("gcDatasets(%s) Done", dataset)
 }
 
-func gcVolumes(ctx *volumemgrContext, locations []string) {
-	for _, location := range locations {
-		tempVolumeStatus, err := getVolumeStatusByLocation(location)
+// getPVCList is kubeapi.GetPVCList behind a package-level var, so a test can
+// supply a fixed PVC list without a real Kubernetes API server. See
+// hypervisor/kubevirt.go's newKubevirtClient for the same pattern.
+var getPVCList = kubeapi.GetPVCList
+
+// gcPVCs is gcObjects' counterpart for PVC-backed volumes: it garbage
+// collects any PVC with no currently-published VolumeStatus. The hypervisor's
+// own purge sweep (kubevirt.go's sweepStaleGenerations) deletes a stale
+// generation's VMIRS and pod but not its PVC; this periodic pass is what
+// reclaims it instead. Call only when base.IsHVTypeKube().
+func gcPVCs(ctx *volumemgrContext) {
+	log.Tracef("gcPVCs")
+	names, err := getPVCList(log)
+	if err != nil {
+		log.Errorf("gcPVCs: GetPVCList failed: %v", err)
+		return
+	}
+	gcVolumes(ctx, names, getVolumeStatusByPVC)
+	log.Tracef("gcPVCs Done")
+}
+
+// resolveVolumeStatus turns one GC candidate - a file/dataset path or a PVC
+// name - into the VolumeStatus it would have if it were still in use.
+type resolveVolumeStatus func(candidate string) (*types.VolumeStatus, error)
+
+// volumesToReap resolves each candidate and returns those with no
+// currently-published VolumeStatus - the ones gcVolumes will destroy.
+//
+// Split out from gcVolumes so this decision is testable on its own. For
+// PVC-backed volumes, destroying is a real Kubernetes API call; this
+// function makes none.
+func volumesToReap(ctx *volumemgrContext, candidates []string,
+	resolve resolveVolumeStatus) []*types.VolumeStatus {
+	var reap []*types.VolumeStatus
+	for _, candidate := range candidates {
+		vs, err := resolve(candidate)
 		if err != nil {
-			log.Errorf("gcVolumes: getVolumeStatusByLocation '%s' failed: %v",
-				location, err)
+			log.Errorf("volumesToReap: resolve %q failed: %v", candidate, err)
 			continue
 		}
-		// Do not GC a replicated volume.
-		if tempVolumeStatus != nil && tempVolumeStatus.IsReplicated {
+		// Do not GC a replicated volume: it may be tracked here only because
+		// this node is a failover candidate, not because it is unused.
+		if vs != nil && vs.IsReplicated {
 			continue
 		}
-		vs := ctx.LookupVolumeStatus(tempVolumeStatus.Key())
-		if vs == nil {
-			log.Functionf("gcVolumes: Found unused volume %s. Deleting it.",
-				location)
-			if _, err := volumehandlers.GetVolumeHandler(log, ctx, tempVolumeStatus).DestroyVolume(); err != nil {
-				log.Errorf("gcVolumes: destroyVolume '%s' failed: %v",
-					location, err)
-			}
+		if ctx.LookupVolumeStatus(vs.Key()) == nil {
+			reap = append(reap, vs)
+		}
+	}
+	return reap
+}
+
+// gcVolumes destroys every candidate volumesToReap finds unused. candidates
+// may be filesystem paths, ZFS dataset names, or PVC names; resolve is what
+// tells them apart.
+func gcVolumes(ctx *volumemgrContext, candidates []string, resolve resolveVolumeStatus) {
+	for _, vs := range volumesToReap(ctx, candidates, resolve) {
+		log.Functionf("gcVolumes: Found unused volume %s. Deleting it.",
+			vs.FileLocation)
+		if _, err := volumehandlers.GetVolumeHandler(log, ctx, vs).DestroyVolume(); err != nil {
+			log.Errorf("gcVolumes: destroyVolume '%s' failed: %v",
+				vs.FileLocation, err)
 		}
 	}
 }

--- a/pkg/pillar/cmd/volumemgr/initialvolumestatus_test.go
+++ b/pkg/pillar/cmd/volumemgr/initialvolumestatus_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetVolumeStatusByPVC(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	pvcName := fmt.Sprintf("%s-pvc-3", id.String())
+
+	vs, err := getVolumeStatusByPVC(pvcName)
+	assert.NoError(t, err)
+	assert.Equal(t, id, vs.VolumeID)
+	assert.Equal(t, int64(3), vs.GenerationCounter)
+	assert.Equal(t, pvcName, vs.FileLocation)
+	// getPVCList/getVolumeStatusByPVC cannot recover LocalGenerationCounter
+	// from the PVC name alone, so GetPVCName must round-trip against the
+	// GenerationCounter this parsed - otherwise volumesToReap would compute
+	// the wrong Key() and reap a live volume.
+	assert.Equal(t, pvcName, vs.GetPVCName())
+}
+
+func TestGetVolumeStatusByPVCInvalid(t *testing.T) {
+	cases := []string{
+		"not-a-uuid-pvc-3",
+		"11111111-1111-1111-1111-111111111111-pvc-notanumber",
+		"11111111-1111-1111-1111-111111111111", // no "-pvc-" separator
+	}
+	for _, name := range cases {
+		_, err := getVolumeStatusByPVC(name)
+		assert.Error(t, err, "expected an error for PVC name %q", name)
+	}
+}
+
+// TestVolumesToReapSkipsLiveVolume pins the safety property this whole
+// change depends on: a volume this node still tracks - including one it
+// tracks only because it is a failover candidate for an app running
+// elsewhere in the cluster, not because it is unused - must never be
+// reaped, regardless of what resolve() reconstructs from its name alone.
+func TestVolumesToReapSkipsLiveVolume(t *testing.T) {
+	ctx := initStatusCtx(t)
+	live := types.VolumeStatus{
+		VolumeID:          uuid.Must(uuid.NewV4()),
+		GenerationCounter: 0,
+	}
+	publishVolumeStatus(&ctx, &live)
+
+	pvcName := live.GetPVCName()
+	reap := volumesToReap(&ctx, []string{pvcName}, getVolumeStatusByPVC)
+	assert.Empty(t, reap, "a currently-published volume must never be reaped")
+}
+
+// TestVolumesToReapIncludesUnknownVolume is the positive case: a candidate
+// with no published VolumeStatus at all is exactly what this pass exists to
+// find.
+func TestVolumesToReapIncludesUnknownVolume(t *testing.T) {
+	ctx := initStatusCtx(t)
+	orphanID := uuid.Must(uuid.NewV4())
+	pvcName := fmt.Sprintf("%s-pvc-0", orphanID.String())
+
+	reap := volumesToReap(&ctx, []string{pvcName}, getVolumeStatusByPVC)
+	assert.Len(t, reap, 1)
+	assert.Equal(t, orphanID, reap[0].VolumeID)
+}
+
+// TestVolumesToReapSkipsReplicated pins the defense-in-depth check: even if
+// a resolver ever reconstructs IsReplicated=true for a candidate with no
+// published VolumeStatus, it must still not be reaped. getVolumeStatusByPVC
+// itself can never produce this today (a PVC name carries no such bit), but
+// gcVolumes is shared with the file/dataset paths, where the same combination
+// is possible.
+func TestVolumesToReapSkipsReplicated(t *testing.T) {
+	ctx := initStatusCtx(t)
+	resolve := func(string) (*types.VolumeStatus, error) {
+		return &types.VolumeStatus{
+			VolumeID:     uuid.Must(uuid.NewV4()),
+			IsReplicated: true,
+		}, nil
+	}
+
+	reap := volumesToReap(&ctx, []string{"whatever"}, resolve)
+	assert.Empty(t, reap, "a replicated volume must never be reaped")
+}
+
+// TestVolumesToReapSkipsUnresolvable confirms one bad candidate - a PVC name
+// this node cannot parse - is logged and skipped rather than stopping the
+// whole pass or reaping something by mistake.
+func TestVolumesToReapSkipsUnresolvable(t *testing.T) {
+	ctx := initStatusCtx(t)
+	orphanID := uuid.Must(uuid.NewV4())
+	goodName := fmt.Sprintf("%s-pvc-0", orphanID.String())
+
+	reap := volumesToReap(&ctx,
+		[]string{"not-a-valid-pvc-name", goodName}, getVolumeStatusByPVC)
+	assert.Len(t, reap, 1)
+	assert.Equal(t, orphanID, reap[0].VolumeID)
+}
+
+// TestGcPVCsSkipsLiveVolumes exercises gcPVCs end to end through the
+// swappable getPVCList seam. Every name it returns matches a published
+// VolumeStatus, so volumesToReap's result is empty and gcVolumes never
+// reaches DestroyVolume - the real Kubernetes delete call, which this test
+// does not want to invoke.
+func TestGcPVCsSkipsLiveVolumes(t *testing.T) {
+	ctx := initStatusCtx(t)
+	live := types.VolumeStatus{
+		VolumeID:          uuid.Must(uuid.NewV4()),
+		GenerationCounter: 1,
+	}
+	publishVolumeStatus(&ctx, &live)
+
+	origGetPVCList := getPVCList
+	getPVCList = func(*base.LogObject) ([]string, error) {
+		return []string{live.GetPVCName()}, nil
+	}
+	t.Cleanup(func() { getPVCList = origGetPVCList })
+
+	assert.NotPanics(t, func() { gcPVCs(&ctx) })
+	assert.NotNil(t, ctx.LookupVolumeStatus(live.Key()),
+		"gcPVCs must not have touched the still-published volume")
+}

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -854,6 +854,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 				gcDatasets(&ctx, types.VolumeEncryptedZFSDataset)
 				gcDatasets(&ctx, types.VolumeClearZFSDataset)
 			}
+			if base.IsHVTypeKube() {
+				gcPVCs(&ctx)
+			}
 			if !ctx.initGced {
 				gcUnusedInitObjects(&ctx)
 				ctx.initGced = true


### PR DESCRIPTION
# Description

**Draft, for comparison — not competing for merge.** @andrewd-zededa is preparing
the production version of this work, which handles multi-node clusters and makes
the lifecycle consistent across the designated node and the rest of the cluster.
This branch is the single-node reference implementation that has been running on
a local integration branch, opened so the two can be read side by side. Prefer
his where they disagree.

## The leak

On EVE-k a purge deletes the stale generation's VMIRS and its pod, but not its
PVC. The Longhorn volume underneath is never reclaimed, so the space stays
consumed for the life of the device. #6257 fixed the duplicate-generation bug
and merged; `sweepStaleGenerations` there deletes the workload objects and stops
short of the disk.

An ordinary purge does not leak — it cleans up its own PVC. The orphan appears
when a purge is *interrupted* such that `sweepStaleGenerations` is what reaps the
stale generation, so accumulation tracks interruption frequency rather than purge
frequency.

## The fix

volumemgr's periodic garbage-collection pass already collects file- and
dataset-backed volumes with no currently-published `VolumeStatus`. Extend it to
PVC-backed ones on the same rule, running only on EVE-k. A volume this node
still tracks is never collected, including one it tracks only as a failover
candidate for an app running elsewhere in the cluster.

## Commits

1. **`volumemgr: reclaim orphaned PVCs on EVE-k`** — the fix, plus unit tests for
   the reap decision (which is separable from the Kubernetes delete call, so it
   is testable without one).
2. **`evetest: assert the purged PVC is reclaimed`** — `TestVMAppPurgeAfterPowerCycle`
   checks the old generation's disk is gone on the local-hypervisor path but
   skips the equivalent on Kubevirt, so the leak leaves it green. Enables the
   check on both paths.
3. **`evetest: purge with the designated node down`** — a three-node cluster
   test: app deployed with a preferred designated node, that node powered off so
   KubeVirt reschedules the replica, purge issued while it is still down. This is
   the case where gating the teardown on the designated node — or on wherever a
   replica currently happens to be scheduled — deadlocks. It is also the area
   Andrew's version addresses properly; treat it as a statement of the problem
   rather than as the answer.
4. **`evetest: work around a Longhorn CSI-provisioner stall`** — marked REMOVE ME
   in its own file. Works around infra, not anything this suite tests. Drop this
   commit if you would rather the test flake than carry it.

## PR dependencies

None. #6257 has merged; this applies on top of it.

## How to test and validate this PR

**Unit** — `make -C pkg/pillar test`. The reap decision is covered directly:
a published volume is never reaped, an unknown one is, a replicated one is not,
and one unparseable candidate is skipped rather than stopping the pass.

Negative control run locally: neutering the "still published" guard makes
`TestVolumesToReapSkipsLiveVolume` fail on its assertion, and it passes again
once restored — so the test can actually fail.

**e2e** — `EVETEST_HYPERVISOR=kubevirt make evetest NAME=TestVMAppPurgeAfterPowerCycle`.
Without the fix this now fails on the assertion enabled by commit 2:

```
PVC "<uuid>-pvc-0" exists in the cluster but no currently published VolumeStatus
would produce it - orphaned disk left behind by a stale generation
```

`-pvc-0` is generation 0 — the old generation's disk, the object
`sweepStaleGenerations` leaves behind. With the fix the same scenario passes.

That A/B was run locally, one image per leg differing only in the three
`cmd/volumemgr` files, both legs driven from the tree where the assertion is
live: power-cycle × no-reclaim failed, power-cycle × reclaim passed, and the
plain-purge baseline passed on both — which is what establishes that a healthy
purge does not leak and that the assertion is able to fire.

`TestVMAppPurgeDuringFailover` needs a three-node cluster and has not been run
against this branch.

**Not verified here:** the leak *rate* under repeated interrupted purges, and
whether accumulation causes Longhorn storage pressure or downstream volume
failures.

## Changelog notes

Fixes a bug on eve-k (kubevirt hypervisor) where a purge interrupted by a reboot
could leave the old application generation's disk behind indefinitely, consuming
storage for the life of the device. Adds automated tests for purge storage
reclaim.

## PR Backports

- 17.0-stable: To be backported.
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Notes on the unchecked boxes: `pkg/pillar/docs/volumemgr.md` is untouched — say
so if the GC pass gaining a third backend warrants a line there. The amd64 e2e
evidence is the A/B described above rather than a run of this exact branch;
arm64 has not been exercised. Labels are left for whoever picks this up, given
it is a draft.
