### PR TITLE
[14.5-stable] yetus: annotate only the patch's issues

### DIFF
--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -67,6 +67,20 @@ jobs:
           name: 'yetus-scan'
           path: ${{ github.workspace }}/out
 
+      - name: Publish Yetus vote table in the job summary
+        if: ${{ always() }}
+        run: |
+          console=${{ github.workspace }}/out/console.txt
+          if [ ! -s "${console}" ]; then
+            echo "No Yetus report to publish."
+            exit 0
+          fi
+          {
+            echo '```'
+            cat "${console}"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Annotate errors from Yetus
         if: ${{ always() }}
         run: |

--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -70,28 +70,27 @@ jobs:
       - name: Annotate errors from Yetus
         if: ${{ always() }}
         run: |
-          set +e
-          # Yetus writes patch-<plugin>.txt files for each plugin that found issues.
-          # Each line is in the format: filename:line:message
-          if [ -z "$(ls ${{ github.workspace }}/out/patch-*-result.txt 2> /dev/null || true)" ]; then
-            echo "No result files to annotate."
+          # Yetus collects the issues a patch *adds* - the ones it posts as
+          # inline review comments when it has PR access - into results-full.txt,
+          # one per line as file:line:column:plugin:message. This is the only
+          # output scoped to the patch: the branch-*/patch-*-result.txt files it
+          # derives that from are scans of the whole tree, so annotating those
+          # buries the patch's own issues under pre-existing ones.
+          results=${{ github.workspace }}/out/results-full.txt
+          if [ ! -s "${results}" ]; then
+            echo "No new issues to annotate."
             exit 0
           fi
-          for patch_file in ${{ github.workspace }}/out/patch-*-result.txt; do
-            plugin=$(basename "$patch_file" | sed "s/patch-\(.*\)-result.txt/\1/")
-            while read -r line; do
-              # Skip empty lines and header lines
-              [ -z "$line" ] && continue
-              # Parse filename:linenum:message
-              file=$(echo "$line" | awk -F: '{print $1}')
-              lineno=$(echo "$line" | awk -F: '{print $2}' | grep "^[0-9].*" || true)
-              message=$(echo "$line" | awk -F: '{start=($3~/^[0-9]+$/)?4:3; for(i=start;i<=NF;i++) printf "%s%s",(i>start?":":""),$i; print ""}')
-              # Only annotate if we got a valid file and line number
-              if [ -n "$file" ] && [ -n "$lineno" ]; then
-                echo "::error file=${file},line=${lineno},title=Yetus [${plugin}]::${message}"
-              else
-                # No file/line info, just print for visibility
-                echo "${line}"
-              fi
-            done < "$patch_file"
-          done
+          while IFS=: read -r file lineno column plugin message; do
+            case "${lineno}" in
+              ''|*[!0-9]*)
+                echo "${file}:${lineno}:${column}:${plugin}:${message}"
+                continue
+              ;;
+            esac
+            case "${column}" in
+              ''|0|*[!0-9]*) col='' ;;
+              *) col=",col=${column}" ;;
+            esac
+            echo "::error file=${file},line=${lineno}${col},title=Yetus [${plugin}]::${message}"
+          done < "${results}"


### PR DESCRIPTION
# Description

Backport of #6313 to `14.5-stable`.

The `Annotate errors from Yetus` step globs `out/patch-*-result.txt`, which are
Yetus's post-patch scans of the **whole tree**, and emits one annotation per
line. The delta Yetus actually computed — the issues the patch adds — lives in
`out/results-full.txt` as `file:line:column:plugin:message`, the same set Yetus
posts as inline review comments when it has PR access. This annotates that
instead, and additionally writes the vote table to the job summary since nothing
posts Yetus's verdict back to the PR.

Because the step runs under `if: always()`, the noise is not limited to
failures: on this branch a **passing** Yetus check still carries ten error-level
annotations, at least one on a file the PR never touched.

Cherry-picked with `-x`, oldest first, no conflicts and **no adaptations**:

1. `bcfed1129` yetus: annotate only the patch's issues
2. `bb22ef0c2` yetus: show the vote table in the job summary

The changed region does not overlap what differs between branches, so this
branch keeps its own `--buf-basedir`/`--user-plugins`/`permissions` state. The
diff is byte-identical to the master PR's once hunk-header line offsets are
stripped.

**Draft:** #6313 is not merged yet, so the `(cherry picked from commit …)`
trailers name pre-merge SHAs. If #6313 is squash- or rebase-merged these will be
rebuilt from the final master commits before this leaves draft.

## How to test and validate this PR

Evidence that this branch is affected, from its own recent `yetus-scan`
artifact — `patch-*-result.txt` is what the current step annotates,
`results-full.txt` is what this PR annotates:

Sample PR #6317: 329 whole-tree findings vs a delta of 0, Yetus verdict **success**,
10 annotations shown, at least one on a file #6317 never touched.

Validation on master (#6313): a temporary commit adding one misspelling produced
exactly **one** annotation, on the line it added, in
[run 31824696804](https://github.com/lf-edge/eve/actions/runs/31824696804), with
the vote table rendering correctly in the job summary and `golangcilint`
reporting "No new issues" after its whole-tree scan. `actionlint` with the
repo's own flags (`-shellcheck=-e=SC2086,SC2046,SC2035`) is clean on this
branch.

This PR's own Yetus run exercises the fixed step on `14.5-stable` (workflow changes take
effect for `pull_request` events), so it is a direct check on this branch: [run 31843746574](https://github.com/lf-edge/eve/actions/runs/31843746574) passed with
**0 annotations**, against 10 on this branch before the fix — with the same
few-hundred-finding whole-tree scan present.

To see it fail deliberately here, push a commit with a misspelled word and check
that the annotation lands on that line and nowhere else.

## Changelog notes

No user-facing changes.

## PR Backports

- 17.0-stable: #6321
- 16.0-stable: #6322
- 14.5-stable: this PR.
- 13.4-stable: #6324

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — n/a, no documented behavior changes
- [ ] I've tested my PR on amd64 device — n/a, CI-only change, no device involved
- [ ] I've tested my PR on arm64 device — n/a, same
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR — `bug` added
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
