### PR TITLE
docs/KEYS-AND-CERTS.md: fix typo

### DIFF
--- a/docs/KEYS-AND-CERTS.md
+++ b/docs/KEYS-AND-CERTS.md
@@ -16,7 +16,7 @@ If EVE is running on hardware with a trusted platform module (TPM), then these k
 | Device cert  | Secure identity of the device | ECC (P-256) | /config/device.cert.pem | [Identity of EVE](SECURITY-ARCHITECTURE.md#identity-of-eves-instance) |
 | ECDH key | For API object encryption | ECC (P-256) | TPM or /persist/certs/ecdh.key.pem | [Config object encryption](OBJECT-LEVEL-ENCRYPTION.md) |
 | ECDH cert | For API object encryption | ECC (P-256) | /persist/certs/ecdh.cert.pem | [Config object encryption](OBJECT-LEVEL-ENCRYPTION.md) |
-| Attestation key | Sign the attestation | ECC (P-256) | TPM or /persist/certs/attest.cert.pem | [Measured Boot and Remote Attestation](https://wiki.lfedge.org/display/EVE/Measured+Boot+and+Remote+Attestation) |
+| Attestation key | Sign the attestation | ECC (P-256) | TPM or /persist/certs/attest.key.pem | [Measured Boot and Remote Attestation](https://wiki.lfedge.org/display/EVE/Measured+Boot+and+Remote+Attestation) |
 | Attestation cert | Sign the attestation | ECC (P-256) | /persist/certs/attest.cert.pem | [Measured Boot and Remote Attestation](https://wiki.lfedge.org/display/EVE/Measured+Boot+and+Remote+Attestation) |
 | Onboarding key | Used initially for onboarding | ECC (P-256) | /config/onboard.key.pem | [Registration](REGISTRATION.md) |
 | Onboarding cert | Used initially for onboarding | ECC (P-256) | /config/onboard.cert.pem |  [Registration](REGISTRATION.md) |


### PR DESCRIPTION
# Description

The key/cert table in `docs/KEYS-AND-CERTS.md` listed `/persist/certs/attest.cert.pem`
as the location of the *attestation key*, duplicating the row below it. The key is
stored as `attest.key.pem` (see `quoteKeyFile` in `pkg/pillar/cmd/tpmmgr/tpmmgr.go`);
this corrects the table entry.

## How to test and validate this PR

Documentation only — no code or build changes. Verify by reading the table in
`docs/KEYS-AND-CERTS.md` and comparing the attestation key path against the
filenames used by tpmmgr.

## Changelog notes

No user-facing changes.

## PR Backports

- 17.0-stable: No, documentation-only typo.
- 16.0-stable: No, documentation-only typo.
- 14.5-stable: No, documentation-only typo.
- 13.4-stable: No, documentation-only typo.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

Documentation-only change, so no device testing applies.
