### PR TITLE
Makefile: split bpftrace tests out of make test

### DIFF
--- a/.github/workflows/bpftrace-tests.yml
+++ b/.github/workflows/bpftrace-tests.yml
@@ -1,7 +1,7 @@
-# Copyright (c) 2025, Zededa, Inc.
+# Copyright (c) 2026, Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 ---
-name: Go Tests
+name: BPFTrace Tests
 on:  # yamllint disable-line rule:truthy
   push:
     branches:
@@ -9,18 +9,22 @@ on:  # yamllint disable-line rule:truthy
       - "[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+-stable"
       - "feature/*"
-    paths-ignore:
-      - '**/*.md'
-      - '.github/**'
+    paths:
+      - 'pkg/bpftrace/**'
+      - 'eve-tools/bpftrace-compiler/**'
+      - 'kernel-commits.mk'
+      - '.github/workflows/bpftrace-tests.yml'
   pull_request:
     branches:
       - "master"
       - "[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+-stable"
       - "feature/*"
-    paths-ignore:
-      - '**/*.md'
-      - '.github/**'
+    paths:
+      - 'pkg/bpftrace/**'
+      - 'eve-tools/bpftrace-compiler/**'
+      - 'kernel-commits.mk'
+      - '.github/workflows/bpftrace-tests.yml'
 
 permissions:
   contents: read
@@ -30,20 +34,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  test-bpftrace:
     runs-on: zededa-ubuntu-2204
-    env:
-      REPO_NAME: ${{ github.event.repository.full_name }}
-      GH_REF: ${{ github.ref }}
+    timeout-minutes: 180
     steps:
-      - name: Starting Report
-        run: |
-          echo Git Ref: ${GH_REF}
-          echo GitHub Event: ${{ github.event_name }}
-          echo Disk usage
-          df -h
-          echo Memory
-          free -m
       - name: Clear repository
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
@@ -59,29 +53,12 @@ jobs:
         if: ${{ github.event.repository.full_name == 'lf-edge/eve' }}
         run: | # Runners must provide default credentials
           docker login
-      - name: Test (TPM Required)
-        run: |
-          bash tests/tpm/prep-and-test.sh
       - name: Test
         run: |
-          make test
-      - name: Report test results as Annotations
-        if: ${{ always() }}
-        uses: guyarb/golang-test-annoations@96fc379b171c49932041d6c789e73331a7bdeec1  # v0.9.0
-        with:
-          test-results: dist/amd64/results.json
-      - name: Store raw test results
-        if: ${{ always() }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
-        with:
-          name: 'test-report'
-          path: ${{ github.workspace }}/dist
-      - name: Get code coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+          make test-bpftrace
       - name: Clean
         if: ${{ always() }}
         run: |
           make clean || :
           docker system prune -f -a || :
-          docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
           rm -rf ~/.linuxkit || :

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -282,8 +282,6 @@ jobs:
           docker login
       - name: Test
         run: |
-          make pkg/bpftrace
-          make ZARCH=arm64 pkg/bpftrace
           make test
       - name: Report test results as Annotations
         if: ${{ always() }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,10 +52,12 @@ When running `make run-live` QEMU defaults to 8GB RAM and forwards ssh on port 2
 
 ## Tests
 
-`make test` is the umbrella target — it runs pillar tests *in Docker* plus several smaller test suites. The most useful per-component invocations:
+`make test` runs pillar tests *in Docker* plus several smaller test suites, all for the host architecture. `make test-all` is the umbrella target: it adds `test-bpftrace`, which boots QEMU for amd64 and arm64 and is slow enough that CI runs it in its own path-filtered workflow. The most useful per-component invocations:
 
 ```sh
-make test                                    # full suite (pillar + bpftrace-compiler + dnsmasq + debug + vtpm + newlog + edgeview)
+make test                                    # host-arch suite (pillar + dnstest + debug + vtpm + newlog + edgeview + kube-init)
+make test-bpftrace                           # QEMU-based bpftrace-compiler tests for amd64 and arm64 (~1h)
+make test-all                                # both of the above
 make -C pkg/pillar test                      # pillar unit tests in docker (produces results.json/xml, coverage.txt)
 make -C pkg/pillar fuzz-test                 # fuzz tests
 make -C pkg/pillar fmt                       # gofmt -w -s
@@ -78,7 +80,7 @@ make mini-yetus                     # Yetus only on files changed vs. master (mu
 make check-docker-hashes-consistency # Check if packages are pointing to the latest version of dependency packages inside their Dockerfile. All packages should point to the same hashes of a common dependency (with a few exceptions)
 ```
 
-`mini-yetus` accepts `MYETUS_SBRANCH`, `MYETUS_DBRANCH`, `MYETUS_VERBOSE=Y`. CI workflows live under `.github/workflows/` — `pr-gate.yml`, `go-tests.yml`, `yetus.yml`, `codeql.yml`, `build.yml`. The shellcheck config (`shellcheckrc`) disables SC3043.
+`mini-yetus` accepts `MYETUS_SBRANCH`, `MYETUS_DBRANCH`, `MYETUS_VERBOSE=Y`. CI workflows live under `.github/workflows/` — `pr-gate.yml`, `go-tests.yml`, `bpftrace-tests.yml`, `yetus.yml`, `codeql.yml`, `build.yml`. The shellcheck config (`shellcheckrc`) disables SC3043.
 
 **Do not run `mini-yetus` from a `git worktree` — it will destroy your branch.** `tools/mini-yetus.sh` copies the top-level dotfiles into a scratch directory and then runs `git init && git add . && git commit` there. In a worktree `.git` is a *file* holding a `gitdir:` pointer rather than a directory, so it gets copied along with the other dotfiles; `git init` then finds an existing repository through that pointer and the commit lands on your real checked-out branch, recording the sparse scratch copy as a deletion of nearly every file in the repo. In a normal clone `.git` is a directory, is not copied, and the scratch repo is created as intended.
 

--- a/Makefile
+++ b/Makefile
@@ -525,13 +525,26 @@ test: $(LINUXKIT) pkg/pillar | $(DIST)
 	make -C pkg/pillar test
 	cp pkg/pillar/results.json $(DIST)/
 	cp pkg/pillar/results.xml $(DIST)/
-	make -C eve-tools/bpftrace-compiler test
 	make -C pkg/alpine/dnstest test
 	make -C pkg/debug test
 	make -C pkg/vtpm test
 	go test -C pkg/newlog/cmd/ -v -race
 	go test -C pkg/edgeview/src/ -v -race
 	go test -C pkg/kube/kube-init/ -v -race ./...
+	$(QUIET): $@: Succeeded
+
+# The bpftrace-compiler tests boot QEMU for both amd64 and arm64, so they need
+# the eve-bpftrace package for each. A linuxkit cache entry holding a single
+# architecture shadows the registry's multi-arch manifest for every FROM naming
+# that tag, so --pull is needed to keep the entry complete. Everything reachable
+# from `test` above stays on the host architecture for the same reason.
+test-bpftrace:
+	$(MAKE) LINUXKIT_OPTS="$(strip $(LINUXKIT_OPTS) --pull)" pkg/bpftrace
+	$(MAKE) LINUXKIT_OPTS="$(strip $(LINUXKIT_OPTS) --pull)" ZARCH=arm64 pkg/bpftrace
+	make -C eve-tools/bpftrace-compiler test
+	$(QUIET): $@: Succeeded
+
+test-all: test test-bpftrace
 	$(QUIET): $@: Succeeded
 
 test-profiling:
@@ -1389,7 +1402,7 @@ kernel-tag:
 	@echo $(KERNEL_TAG)
 
 .PRECIOUS: rootfs-% $(ROOTFS)-%.img $(ROOTFS_COMPLETE)
-.PHONY: all clean test run pkgs help live rootfs config installer live current FORCE $(DIST) HOSTARCH image-set cache-export eden eden-cover coverage-merge
+.PHONY: all clean test test-bpftrace test-all run pkgs help live rootfs config installer live current FORCE $(DIST) HOSTARCH image-set cache-export eden eden-cover coverage-merge
 FORCE:
 
 .PHONY: evetest
@@ -1416,6 +1429,8 @@ help:
 	@echo "Commonly used maintenance and development targets:"
 	@echo "   build-vm                         prepare a build VM for EVE in qcow2 format"
 	@echo "   test                             run EVE tests"
+	@echo "   test-bpftrace                    run the QEMU-based bpftrace-compiler tests (slow, ~1h)"
+	@echo "   test-all                         run both of the above"
 	@echo "   test-profiling                   run pillar tests with memory profiler"
 	@echo "   clean                            clean build artifacts in a current directory (doesn't clean Docker)"
 	@echo "   release                          prepare branch for a release (VERSION=x.y.z required)"


### PR DESCRIPTION
# Description

The bpftrace-compiler tests boot QEMU for amd64 and arm64 and take roughly 53
minutes, over half of the Go Tests workflow. Running them in the middle of the
`test` target also means a failure there skips every remaining suite along with
the coverage upload. They now live in `test-bpftrace`, reached from `test-all`,
with their own workflow triggered only by changes to `pkg/bpftrace`,
`eve-tools/bpftrace-compiler` or `kernel-commits.mk` — the three inputs they can
regress from.

Building the arm64 eve-bpftrace package was also the only reason these jobs
touched a second architecture. linuxkit matches a `FROM` against its local cache
by name alone, so an entry populated for one architecture hides the registry's
multi-arch manifest from the other, and a package published while the job runs
can leave it building against an image it cannot resolve. `make test` now stays
on the host architecture throughout, and `test-bpftrace` passes `--pull` so an
already-published architecture is fetched into the cache rather than skipped.

That last failure mode is not hypothetical — it broke both workflows on master
earlier today. In [run
31879060486](https://github.com/lf-edge/eve/actions/runs/31879060486) the
`coverage` job built eve-bpftrace amd64 locally at 10:17 (not yet on the
registry), then at 10:26 found arm64 already published and skipped it, leaving
an amd64-only cache entry. `TestCompileArm64` then failed at 11:05 with `no
match for platform in manifest: not found` against an OCI-layout digest that
does not exist on Docker Hub. Go Tests
([31879060286](https://github.com/lf-edge/eve/actions/runs/31879060286)) failed
identically, and the preceding push
([31878627368](https://github.com/lf-edge/eve/actions/runs/31878627368)) failed
one layer down on eve-alpine. Because the failing step aborted mid-target, the
Codecov upload was skipped and those runs produced no coverage at all.

## How to test and validate this PR

`make test` and `make test-bpftrace` are both exercised by CI on this PR — the
latter because the trigger paths include the new workflow file itself.

Locally:

- `make -n test` — every `--platforms` line should read `linux/amd64` only, with
  no `pkg/bpftrace` and no `ZARCH=arm64` anywhere in the recipe.
- `make -n test-bpftrace` — should show `--pull` on each linuxkit invocation,
  `pkg/bpftrace` built for `linux/amd64` and then `linux/arm64`, followed by
  `make -C eve-tools/bpftrace-compiler test`.
- `make -n test-all` — should cover both.
- `make help` lists the two new targets.

The workflows were checked with `actionlint`, `yamllint -c .yamllint`, and
`zizmor --config .github/zizmor.yml` (no findings on the new file; unchanged
finding counts on the two edited ones).

## Changelog notes

No user-facing changes.

## PR Backports

- 17.0-stable: #6379
- 16.0-stable: No, the workflows there do not pre-build the eve-bpftrace
  package before `make test`, so the cache-shadowing failure cannot occur.
- 14.5-stable: No, same reason as 16.0-stable.
- 13.4-stable: No, same reason as 16.0-stable.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

Device testing does not apply — this changes only build and CI targets and
produces no artifact that runs on a device.

