### PR TITLE
Add functionality to retrieve EVE origin version

### DIFF
--- a/pkg/pillar/cmd/zedagent/attesttask.go
+++ b/pkg/pillar/cmd/zedagent/attesttask.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync/atomic"
@@ -216,7 +217,17 @@ func combineBiosFields(biosVendor, biosVersion, biosReleaseDate string) string {
 	return biosStr
 }
 
-// encodeVersions fetches EVE, UEFI versions
+// getEveOriginVersion returns the basename of the origin file matching pattern,
+// e.g. "origin.2024-01-15.13.4.0", or an empty string if there is no such file.
+func getEveOriginVersion(pattern string) string {
+	matches, _ := filepath.Glob(pattern)
+	if len(matches) == 0 {
+		return ""
+	}
+	return filepath.Base(matches[0])
+}
+
+// encodeVersions fetches EVE, EVE origin and UEFI versions
 func encodeVersions(quoteMsg *attest.ZAttestQuote) error {
 	quoteMsg.Versions = make([]*attest.AttestVersionInfo, 0)
 	eveVersion := new(attest.AttestVersionInfo)
@@ -227,6 +238,15 @@ func encodeVersions(quoteMsg *attest.ZAttestQuote) error {
 	}
 	eveVersion.Version = strings.TrimSpace(string(eveRelease))
 	quoteMsg.Versions = append(quoteMsg.Versions, eveVersion)
+
+	if originStr := getEveOriginVersion(types.EveOriginVersionPattern); originStr != "" {
+		originVersion := new(attest.AttestVersionInfo)
+		originVersion.VersionType = attest.AttestVersionType_ATTEST_VERSION_TYPE_EVE_ORIGIN
+		originVersion.Version = originStr
+		quoteMsg.Versions = append(quoteMsg.Versions, originVersion)
+	} else {
+		log.Warnf("No origin version file matching %s", types.EveOriginVersionPattern)
+	}
 
 	//GetDeviceBios returns empty values on ARM64, check for them
 	bVendor, bVersion, bReleaseDate := hardware.GetDeviceBios(log)
@@ -239,7 +259,6 @@ func encodeVersions(quoteMsg *attest.ZAttestQuote) error {
 		uefiVersion.VersionType = attest.AttestVersionType_ATTEST_VERSION_TYPE_FIRMWARE
 		uefiVersion.Version = biosStr
 		quoteMsg.Versions = append(quoteMsg.Versions, uefiVersion)
-		log.Functionf("quoteMsg.Versions %s %s", eveVersion.Version, uefiVersion.Version)
 	}
 	return nil
 }

--- a/pkg/pillar/types/locationconsts.go
+++ b/pkg/pillar/types/locationconsts.go
@@ -84,6 +84,9 @@ const (
 	ITokenFile = "/run/eve.integrity_token"
 	//EveVersionFile contains the running version of EVE
 	EveVersionFile = "/run/eve-release"
+	//EveOriginVersionPattern matches the origin.<date>.<version> file created in
+	//the config partition at install time.
+	EveOriginVersionPattern = IdentityDirname + "/origin.*"
 	//DefaultVaultName is the name of the default vault
 	DefaultVaultName = "Application Data Store"
 


### PR DESCRIPTION
# Description

Retrieve EVE origin version and send it to controller as part of the attest task. This used by controller to properly predict post update PCR 14.

## PR dependencies
N/A

## How to test and validate this PR
Wait for Adam [PR Comming]

## Changelog notes

None.

## PR Backports

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
