### PR TITLE
kubeapi: round a PVC request to Longhorn's granularity

### DIFF
--- a/pkg/pillar/kubeapi/vitoapiserver.go
+++ b/pkg/pillar/kubeapi/vitoapiserver.go
@@ -25,6 +25,35 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Granularity Longhorn rounds a claim up to: longhorn-manager util.SizeAlignment,
+// duplicated rather than imported because that package costs 42 dependencies.
+const longhornVolumeBlockSize = 2 * 1024 * 1024
+
+// Smallest PVC size Longhorn supports.
+const pvcMinSize = 10 * 1024 * 1024
+
+// pvcRequestSize returns the size to ask for in a PVC claim: at least
+// pvcMinSize, rounded up to the granularity Longhorn provisions at. Longhorn
+// rounds a claim up to longhornVolumeBlockSize while CDI validates an upload
+// against the size the claim asked for, so a request that is not already such a
+// multiple produces a volume bigger than the claim and CDI refuses the import.
+// The result is never smaller than size, so the image always fits; a size within
+// one block of overflowing uint64 is returned unrounded rather than wrapping.
+func pvcRequestSize(size uint64) uint64 {
+	if size < pvcMinSize {
+		size = pvcMinSize
+	}
+	rem := size % longhornVolumeBlockSize
+	if rem == 0 {
+		return size
+	}
+	pad := longhornVolumeBlockSize - rem
+	if size > math.MaxUint64-pad {
+		return size
+	}
+	return size + pad
+}
+
 // CreatePVC : creates a Persistent volume of given name and size.
 func CreatePVC(pvcName string, size uint64, log *base.LogObject, storageClass string) error {
 	// Get the Kubernetes clientset
@@ -35,10 +64,8 @@ func CreatePVC(pvcName string, size uint64, log *base.LogObject, storageClass st
 		return err
 	}
 
-	// PVC minimum supported size is 10MB
-	if size < 10*1024*1024 {
-		size = 10 * 1024 * 1024
-	}
+	size = pvcRequestSize(size)
+
 	// Define the Longhorn PVC object
 	pvc := NewPVCDefinition(pvcName, fmt.Sprint(size), nil, nil, storageClass)
 

--- a/pkg/pillar/kubeapi/vitoapiserver_test.go
+++ b/pkg/pillar/kubeapi/vitoapiserver_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package kubeapi
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TestPVCRequestSize checks the sizes a claim is allowed to ask for. The
+// decimal-unit cases are the ones seen in the field (lf-edge/eve#6331): a size
+// expressed in MB/GB is never a multiple of Longhorn's 2 MiB granularity, so
+// without rounding the provisioned volume exceeds the claim and CDI rejects the
+// import.
+func TestPVCRequestSize(t *testing.T) {
+	tests := []struct {
+		name string
+		size uint64
+		want uint64
+	}{
+		{"1GB decimal", 1000000000, 1000341504},
+		{"100MB decimal", 100000000, 100663296},
+		{"5GB decimal above 4GiB", 5000000000, 5001707520},
+		{"12MB decimal", 12000000, 12582912},
+		{"1GiB already aligned", 1073741824, 1073741824},
+		{"minimum already aligned", 10485760, 10485760},
+		{"one byte below minimum", 10485759, 10485760},
+		{"below minimum and unaligned", 2097153, 10485760},
+		{"one byte below a block boundary", 4194303, 10485760},
+		{"zero", 0, 10485760},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pvcRequestSize(tt.size); got != tt.want {
+				t.Errorf("pvcRequestSize(%d) = %d, want %d", tt.size, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPVCRequestSizeAppliesMinimumBeforeRounding pins the order of the two
+// adjustments. Rounding an unaligned sub-minimum size first would yield a claim
+// below the minimum Longhorn accepts, which the table above cannot distinguish
+// from a correct result for aligned inputs.
+func TestPVCRequestSizeAppliesMinimumBeforeRounding(t *testing.T) {
+	const justOverOneBlock = longhornVolumeBlockSize + 1
+	got := pvcRequestSize(justOverOneBlock)
+	if got != pvcMinSize {
+		t.Errorf("pvcRequestSize(%d) = %d, want the minimum %d; the minimum must be applied before rounding",
+			justOverOneBlock, got, pvcMinSize)
+	}
+}
+
+// TestPVCRequestSizeInvariants asserts the properties every claim size must
+// satisfy: it is aligned to Longhorn's granularity (the reason the rounding
+// exists), it never shrinks (a smaller claim would truncate the image), it never
+// drops below the supported minimum, and it is stable under a second
+// application -- RolloutDiskToPVC raises the size to the image's virtual size
+// before calling CreatePVC, so a size can pass through this more than once.
+func TestPVCRequestSizeInvariants(t *testing.T) {
+	sizes := []uint64{
+		0, 1, 512, 4096, pvcMinSize - 1, pvcMinSize, pvcMinSize + 1,
+		12000000, 100000000, 1000000000, 1073741824, 5000000000,
+		longhornVolumeBlockSize - 1, longhornVolumeBlockSize, longhornVolumeBlockSize + 1,
+		1 << 40, (1 << 40) + 1, 1<<44 - 3,
+	}
+	for i := uint64(1); i <= 64; i++ {
+		sizes = append(sizes, i*7919999)
+	}
+	for _, size := range sizes {
+		got := pvcRequestSize(size)
+		if got%longhornVolumeBlockSize != 0 {
+			t.Errorf("pvcRequestSize(%d) = %d, not a multiple of %d", size, got, longhornVolumeBlockSize)
+		}
+		if got < size {
+			t.Errorf("pvcRequestSize(%d) = %d, must never shrink the request", size, got)
+		}
+		if got < pvcMinSize {
+			t.Errorf("pvcRequestSize(%d) = %d, below the minimum %d", size, got, pvcMinSize)
+		}
+		if again := pvcRequestSize(got); again != got {
+			t.Errorf("pvcRequestSize(%d) = %d, applying it again gave %d; must be idempotent", size, got, again)
+		}
+	}
+}
+
+// TestPVCRequestSizeNoOverflow covers the sizes within one block of the uint64
+// range, where padding up to the next multiple would wrap and hand back a claim
+// far smaller than requested.
+func TestPVCRequestSizeNoOverflow(t *testing.T) {
+	for _, size := range []uint64{math.MaxUint64, math.MaxUint64 - 1, math.MaxUint64 - longhornVolumeBlockSize + 1} {
+		if got := pvcRequestSize(size); got < size {
+			t.Errorf("pvcRequestSize(%d) = %d, overflowed instead of leaving the size alone", size, got)
+		}
+	}
+}
+
+// TestNewPVCDefinitionRequestsRoundedSize checks the value that actually reaches
+// Longhorn and CDI: the storage quantity in the claim spec, after the size has
+// been through the string formatting CreatePVC applies.
+func TestNewPVCDefinitionRequestsRoundedSize(t *testing.T) {
+	const requested = 1000000000
+	rounded := pvcRequestSize(requested)
+
+	pvc := NewPVCDefinition("test-pvc", fmt.Sprint(rounded), nil, nil, "longhorn")
+	quantity, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	if !ok {
+		t.Fatal("NewPVCDefinition produced no storage request")
+	}
+	got := quantity.Value()
+	if got != int64(rounded) {
+		t.Errorf("claim requests %d bytes, want %d", got, rounded)
+	}
+	if got%longhornVolumeBlockSize != 0 {
+		t.Errorf("claim requests %d bytes, not a multiple of %d", got, longhornVolumeBlockSize)
+	}
+}


### PR DESCRIPTION
# Description

On EVE-k an image-backed volume whose size is not a multiple of 2 MiB is never
delivered. Longhorn provisions a volume rounded up to a 2 MiB multiple, while CDI
validates its upload against the size the claim asked for, so an unrounded request
produces a volume larger than the target. CDI then rejects the import as needing a
larger PVC and retries on a ninety-second loop indefinitely: the volume never
reaches `CREATED_VOLUME` and an app referencing it never runs. Sizes given in
decimal units are routinely affected — 1 GB, 500 MB and 100 MB are all unrounded.

Round the request to the granularity Longhorn uses, so the claim and the volume it
produces agree. Requests that are already a multiple are unchanged, and the
rounding sits where both the plain and the image-import paths create their claims.

Fixes #6331.

## How to test and validate this PR

Automated: `TestVolumeSizeAlignment` declares two image-backed volumes on an
ordinary EVE-k device that differ only in whether the size is a multiple of 2 MiB,
and requires both to be delivered. It lives in `eriknordmark/eve@appvol-verify`
pending its own PR.

Manually, on an EVE-k device: deploy an app with an image-backed volume whose size
is not a multiple of 2 MiB — 100000000 bytes, or anything expressed in decimal
units such as 1 GB — and confirm the volume reaches `CREATED_VOLUME` and the app
reaches `RUNNING`. Before this change the volume never arrives; the CDI upload
server logs

```
Virtual image size <V> is larger than the reported available storage <T>.
A larger PVC is required.
```

and repeats it every ninety seconds indefinitely. A volume whose size already is a
multiple of 2 MiB works either way and is the control.

Measured before and after, same test and sizes, only the image differing:

| | before | after |
|---|---|---|
| 100663296 bytes (a 2 MiB multiple) | delivered | delivered |
| 100000000 bytes | never delivered, 900 s timeout | delivered |

The kvm→k conversion test also goes from refusing the import to completing it: its
migrated volumes are sized from the file's allocation on `/persist` and so are
unrounded on every run. With this change the claim's requested and provisioned
sizes are equal (2149580800 and 2050Mi) and no rejection is logged.

## Changelog notes

Fixed a failure where an app volume whose size was not a multiple of 2 MiB would
never become available on a kubevirt-enabled device, leaving the app unable to
start.

## PR Backports

- 17.0-stable: To be backported.
- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No, as EVE-k volume import is not available there.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — no user-facing documentation changes;
      the behaviour is a bug fix, not a new interface
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device — not tested; the change is architecture
      independent
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR — draft; labels to be set before review

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
