### PR TITLE
evetest: port the Eden controller certificate change tests

### DIFF
--- a/evetest/VERSION
+++ b/evetest/VERSION
@@ -1,2 +1,2 @@
 # Evetest version. Increment this manually whenever changes are made to the evetest framework.
-1.3
+1.4

--- a/evetest/cipherdata.go
+++ b/evetest/cipherdata.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
+	eveconfig "github.com/lf-edge/eve-api/go/config"
 	"github.com/lf-edge/eve-api/go/evecommon"
 	"github.com/lf-edge/eve/evetest/utils"
 )
@@ -41,6 +42,12 @@ func (th *TestHarness) encryptCipherData(
 }
 
 // addCipherCtxToDevice associates or de-duplicates a cipher context for a device.
+//
+// The context is recorded in the harness-held device config, which is the single
+// owner of the cipher-context list: ApplyConfig always republishes the list found
+// there, ignoring the one in the config passed to it (see edgedevice.go).
+// Contexts are never removed, so cipher blocks tagged with a retired controller
+// certificate keep decrypting for as long as the device holds that certificate.
 func (th *TestHarness) addCipherCtxToDevice(devName string,
 	cipherCtx *evecommon.CipherContext) (*evecommon.CipherContext, error) {
 	th.devicesM.Lock()
@@ -48,7 +55,6 @@ func (th *TestHarness) addCipherCtxToDevice(devName string,
 
 	devState, found := th.devices[devName]
 	if !found {
-		th.devicesM.Unlock()
 		return nil, fmt.Errorf("unknown device %q", devName)
 	}
 
@@ -70,64 +76,177 @@ func (th *TestHarness) addCipherCtxToDevice(devName string,
 	return cipherCtx, nil
 }
 
-/*
-// reEncryptCipherData re-encrypts all cipher blocks in an EdgeDevConfig using a new signing cert.
-func (th *TestHarness) reEncryptCipherData(devName string, edgeDevConfig *eveconfig.EdgeDevConfig,
-	newCtrlECDHCert *x509.Certificate) error {
+// cipherBlockSite is a cipher block found in a device configuration, together
+// with a description of its owner for error messages.
+type cipherBlockSite struct {
+	what  string
+	block *evecommon.CipherBlock
+}
 
-	th.devicesM.Lock()
-	devState, found := th.devices[devName]
-	if !found {
-		th.devicesM.Unlock()
-		return nil, fmt.Errorf("unknown device %q", devName)
-	}
-	devECDHCert := devState.ecdhCert
-	th.devicesM.Unlock()
-
-	oldCtrlECDHCert, ctrlECDHKey := th.adamClient.GetECDHCertAndKey()
-
-	oldCfg, err := utils.NewCryptoConfig(devCert, oldCtrlECDHCert, ctrlECDHKey)
-	if err != nil {
-		return fmt.Errorf("getCommonCryptoConfig (old): %w", err)
-	}
-	newCfg, err := utils.NewCryptoConfig(devCert, newCtrlECDHCert, ctrlECDHKey)
-	if err != nil {
-		return fmt.Errorf("getCommonCryptoConfig (new): %w", err)
-	}
-	cipherCtx, err := utils.CreateCipherCtx(newCfg)
-	if err != nil {
-		return fmt.Errorf("createCipherCtx: %w", err)
-	}
-	cipherCtx = addCipherCtxToDevice(devName, cipherCtx)
-
-	for _, cfg := range edgeDevConfig.Apps {
-		if err := utils.ReEncryptCipherData(cfg, oldCfg, newCfg, cipherCtx); err != nil {
-			return fmt.Errorf("reencrypt app config: %w", err)
+// cipherBlockSites returns every cipher block of a device configuration.
+//
+// Every site in this package that creates a cipher block must be listed here
+// (grep for encryptCipherData) and in clearCipherBlocks. The last two are held
+// in fields not named CipherData, which is why this walks the configuration
+// explicitly instead of relying on a getter interface.
+func cipherBlockSites(config *eveconfig.EdgeDevConfig) []cipherBlockSite {
+	var sites []cipherBlockSite
+	add := func(what string, block *evecommon.CipherBlock) {
+		if block != nil {
+			sites = append(sites, cipherBlockSite{what: what, block: block})
 		}
 	}
-	for _, cfg := range edgeDevConfig.Datastores {
-		if err := utils.ReEncryptCipherData(cfg, oldCfg, newCfg, cipherCtx); err != nil {
-			return fmt.Errorf("reencrypt datastore config: %w", err)
-		}
+
+	for _, app := range config.GetApps() {
+		add("application "+app.GetDisplayname(), app.GetCipherData())
 	}
-	for _, netCfg := range edgeDevConfig.GetNetworks() {
-		if netCfg.Wireless == nil {
+	for _, ds := range config.GetDatastores() {
+		add("datastore "+ds.GetId(), ds.GetCipherData())
+	}
+	for _, netCfg := range config.GetNetworks() {
+		wireless := netCfg.GetWireless()
+		if wireless == nil {
 			continue
 		}
-		for _, cell := range netCfg.Wireless.CellularCfg {
-			for _, ap := range cell.AccessPoints {
-				if err := utils.ReEncryptCipherData(ap, oldCfg, newCfg, cipherCtx); err != nil {
-					return fmt.Errorf("reencrypt cellular config: %w", err)
+		for _, wifi := range wireless.GetWifiCfg() {
+			add("WiFi network "+wifi.GetWifiSSID(), wifi.GetCipherData())
+		}
+		for _, cellular := range wireless.GetCellularCfg() {
+			for _, ap := range cellular.GetAccessPoints() {
+				add("cellular access point "+ap.GetApn(), ap.GetCipherData())
+			}
+		}
+	}
+	for _, scep := range config.GetScepProfiles() {
+		add("SCEP profile "+scep.GetProfileName(), scep.GetScepChallengePassword())
+	}
+	add("cluster join token", config.GetCluster().GetEncryptedClusterToken())
+	return sites
+}
+
+// clearCipherBlocks removes every cipher block from a device configuration.
+//
+// The owners are listed here as well as in cipherBlockSites, because a reader
+// cannot unset the field it read from. The closing check is what keeps the two
+// lists honest: a newly added cipher block that this function forgets would
+// otherwise survive a device reset silently, still encrypted against whatever
+// certificate the previous test used.
+func clearCipherBlocks(config *eveconfig.EdgeDevConfig) error {
+	for _, app := range config.GetApps() {
+		if app != nil {
+			app.CipherData = nil
+		}
+	}
+	for _, ds := range config.GetDatastores() {
+		if ds != nil {
+			ds.CipherData = nil
+		}
+	}
+	for _, netCfg := range config.GetNetworks() {
+		wireless := netCfg.GetWireless()
+		if wireless == nil {
+			continue
+		}
+		for _, wifi := range wireless.GetWifiCfg() {
+			if wifi != nil {
+				wifi.CipherData = nil
+			}
+		}
+		for _, cellular := range wireless.GetCellularCfg() {
+			for _, ap := range cellular.GetAccessPoints() {
+				if ap != nil {
+					ap.CipherData = nil
 				}
 			}
 		}
-		for _, wifi := range netCfg.Wireless.WifiCfg {
-			if err := utils.ReEncryptCipherData(wifi, oldCfg, newCfg, cipherCtx); err != nil {
-				return fmt.Errorf("reencrypt wifi config: %w", err)
-			}
+	}
+	for _, scep := range config.GetScepProfiles() {
+		if scep != nil {
+			scep.ScepChallengePassword = nil
+		}
+	}
+	if config.GetCluster() != nil {
+		config.Cluster.EncryptedClusterToken = nil
+	}
+
+	if left := cipherBlockSites(config); len(left) > 0 {
+		return fmt.Errorf("failed to clear the cipher block of %s; "+
+			"clearCipherBlocks must be extended whenever a new cipher block "+
+			"is added to the configuration", left[0].what)
+	}
+	return nil
+}
+
+// hasCipherBlocks reports whether a device configuration contains at least one
+// cipher block, i.e. whether it has anything to migrate when the controller's
+// ECDH certificate is rotated.
+func hasCipherBlocks(config *eveconfig.EdgeDevConfig) bool {
+	return len(cipherBlockSites(config)) > 0
+}
+
+// reEncryptCipherBlocks re-encrypts every cipher block of a device
+// configuration from oldCfg to newCfg and re-tags it with cipherCtx.
+// Blocks already tagged with cipherCtx are skipped, making the function
+// idempotent.
+func reEncryptCipherBlocks(config *eveconfig.EdgeDevConfig,
+	oldCfg, newCfg *utils.CryptoConfig, cipherCtx *evecommon.CipherContext) error {
+
+	for _, site := range cipherBlockSites(config) {
+		if site.block.GetCipherContextId() == cipherCtx.GetContextId() {
+			continue
+		}
+		err := utils.ReEncryptCipherBlock(site.block, oldCfg, newCfg, cipherCtx)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to re-encrypt cipher block of %s: %w", site.what, err)
 		}
 	}
 	return nil
 }
 
-*/
+// checkCipherBlocksUseCurrentECDHCert reports an error for the first cipher block
+// in the configuration that is not encrypted against the controller's current
+// ECDH certificate. cipherCtxs is the cipher-context list the configuration will
+// be pushed with.
+//
+// This exists to make one silent regression loud. RotateControllerEncryptCert
+// re-encrypts the configuration builders handed to it; a test that keeps a
+// builder the rotation never saw will push blocks encrypted against the retired
+// certificate on its next ApplyConfig. Nothing fails at that moment - pillar
+// keeps a controller certificate alive while a cipher context still references
+// it, and evetest never removes contexts - so the regression would only surface
+// after a reboot, or not at all in a test that never reboots.
+func (th *TestHarness) checkCipherBlocksUseCurrentECDHCert(
+	config *eveconfig.EdgeDevConfig, cipherCtxs []*evecommon.CipherContext) error {
+
+	ctrlECDHCert, _ := th.adamClient.GetECDHCertAndKey()
+	if ctrlECDHCert == nil {
+		return nil
+	}
+	currentHash := utils.ControllerCertHash(ctrlECDHCert)[:16]
+
+	for _, site := range cipherBlockSites(config) {
+		ctxID := site.block.GetCipherContextId()
+		var blockCtx *evecommon.CipherContext
+		for _, cipherCtx := range cipherCtxs {
+			if cipherCtx.GetContextId() == ctxID {
+				blockCtx = cipherCtx
+				break
+			}
+		}
+		if blockCtx == nil {
+			// The context list is owned by the harness-held config, so a block can
+			// only name a context missing from it if the block was built outside
+			// encryptCipherData or copied from another device's config.
+			return fmt.Errorf("cipher block of %s names cipher context %s, which "+
+				"is not among the contexts registered for this device",
+				site.what, ctxID)
+		}
+		if !bytes.Equal(blockCtx.GetControllerCertHash(), currentHash) {
+			return fmt.Errorf("cipher block of %s uses cipher context %s, which "+
+				"references a retired controller ECDH certificate; pass this "+
+				"configuration to RotateControllerEncryptCert", site.what, ctxID)
+		}
+	}
+	return nil
+}

--- a/evetest/controller/adam.go
+++ b/evetest/controller/adam.go
@@ -79,11 +79,19 @@ type AdamClient struct {
 	listenIPs  []net.IP
 	listenPort uint16
 
-	// certificates and their corresponding private keys
-	caCert      *x509.Certificate
-	caKey       *rsa.PrivateKey
-	tlsCert     *x509.Certificate
-	tlsKey      *ecdsa.PrivateKey
+	// Certificates and their corresponding private keys that are never rotated:
+	// the CA is set at construction, the TLS pair once in generateCerts.
+	caCert  *x509.Certificate
+	caKey   *rsa.PrivateKey
+	tlsCert *x509.Certificate
+	tlsKey  *ecdsa.PrivateKey
+
+	// certsM guards the fields below: the signing and ECDH keypairs are
+	// rotatable at runtime (see RotateSigningKeyPair, RotateECDHKeyPair) while
+	// tests and per-device setup goroutines read them concurrently.
+	certsM      sync.RWMutex
+	certDir     string // directory holding the certificate files Adam reads
+	certSerial  int64  // serial number for the next generated certificate
 	signingCert *x509.Certificate
 	signingKey  *ecdsa.PrivateKey
 	ecdhCert    *x509.Certificate
@@ -364,16 +372,124 @@ func (ac *AdamClient) openStream(ctx context.Context, url string) (*http.Respons
 	return resp, nil
 }
 
+// KeyPair is a controller certificate together with its private key.
+type KeyPair struct {
+	Cert *x509.Certificate
+	Key  *ecdsa.PrivateKey
+}
+
 // GetSigningCertAndKey returns certificate+key used by the controller to sign payload
 // send to a device wrapped inside AuthContainer.
 func (ac *AdamClient) GetSigningCertAndKey() (*x509.Certificate, *ecdsa.PrivateKey) {
+	ac.certsM.RLock()
+	defer ac.certsM.RUnlock()
 	return ac.signingCert, ac.signingKey
 }
 
 // GetECDHCertAndKey returns certificate+key used by the controller for object-level
 // encryption (e.g., for WiFi password).
 func (ac *AdamClient) GetECDHCertAndKey() (*x509.Certificate, *ecdsa.PrivateKey) {
+	ac.certsM.RLock()
+	defer ac.certsM.RUnlock()
 	return ac.ecdhCert, ac.ecdhKey
+}
+
+// RotateSigningKeyPair generates a fresh keypair for the controller signing
+// certificate, installs it into Adam's certificate directory and makes it the
+// pair returned by GetSigningCertAndKey. It returns the new pair and the pair it
+// replaced.
+//
+// Adam must not be restarted for this to take effect -- it re-reads signing.pem
+// and signing-key.pem from disk on every API request. A restart would in fact
+// undo the rotation, because Start unconditionally regenerates all keypairs.
+func (ac *AdamClient) RotateSigningKeyPair() (newPair, oldPair KeyPair, err error) {
+	ac.certsM.Lock()
+	defer ac.certsM.Unlock()
+
+	oldPair = KeyPair{Cert: ac.signingCert, Key: ac.signingKey}
+	newPair, err = ac.rotateKeyPair("signing", "signing.pem", "signing-key.pem")
+	if err != nil {
+		return KeyPair{}, oldPair, err
+	}
+	ac.signingCert, ac.signingKey = newPair.Cert, newPair.Key
+	return newPair, oldPair, nil
+}
+
+// RotateECDHKeyPair generates a fresh keypair for the controller ECDH
+// (object-level encryption) certificate, installs it into Adam's certificate
+// directory and makes it the pair returned by GetECDHCertAndKey. It returns the
+// new pair and the pair it replaced; the old private key is needed to decrypt
+// cipher blocks that are being migrated onto the new certificate.
+//
+// As with RotateSigningKeyPair, Adam picks the change up without a restart.
+func (ac *AdamClient) RotateECDHKeyPair() (newPair, oldPair KeyPair, err error) {
+	ac.certsM.Lock()
+	defer ac.certsM.Unlock()
+
+	oldPair = KeyPair{Cert: ac.ecdhCert, Key: ac.ecdhKey}
+	newPair, err = ac.rotateKeyPair("ECDH", "ecdh.pem", "ecdh-key.pem")
+	if err != nil {
+		return KeyPair{}, oldPair, err
+	}
+	ac.ecdhCert, ac.ecdhKey = newPair.Cert, newPair.Key
+	return newPair, oldPair, nil
+}
+
+// rotateKeyPair generates an ECDSA keypair signed by the harness CA and installs
+// it into Adam's certificate directory under the given file names. The file names
+// are evetest's own, not Adam's defaults (which are encrypt.pem/encrypt-key.pem
+// for the ECDH pair); Start passes them explicitly via --encrypt-cert et al.
+//
+// The two files cannot be replaced as one, so a failure after the first write
+// would leave Adam holding a mismatched pair, answering 500 to every request
+// needing a signed response. That would break not only the test that asked for
+// the rotation but every later test sharing the harness, so the previous
+// contents are restored before the error is returned.
+//
+// The caller must hold certsM for writing.
+func (ac *AdamClient) rotateKeyPair(
+	desc, certFilename, keyFilename string) (KeyPair, error) {
+	if ac.certDir == "" {
+		return KeyPair{}, errors.New(
+			"the Adam certificate directory is not known yet")
+	}
+	certPath := filepath.Join(ac.certDir, certFilename)
+	keyPath := filepath.Join(ac.certDir, keyFilename)
+	prevCert, prevCertErr := os.ReadFile(certPath)
+	prevKey, prevKeyErr := os.ReadFile(keyPath)
+	restorePrevious := func() {
+		if prevCertErr != nil || prevKeyErr != nil {
+			ac.log.Errorf("Cannot restore the previous Adam %s pair, it was not "+
+				"readable (cert: %v, key: %v)", desc, prevCertErr, prevKeyErr)
+			return
+		}
+		if err := utils.WriteFileAtomic(keyPath, prevKey, 0o600); err != nil {
+			ac.log.Errorf("Failed to restore the previous Adam %s key: %v", desc, err)
+			return
+		}
+		if err := utils.WriteFileAtomic(certPath, prevCert, 0o644); err != nil {
+			ac.log.Errorf("Failed to restore the previous Adam %s certificate: %v",
+				desc, err)
+			return
+		}
+		ac.log.Warnf("Restored the previous Adam %s certificate and key", desc)
+	}
+
+	serial := big.NewInt(ac.certSerial)
+	ac.certSerial++
+	cert, key, err := utils.GenServerCertElliptic(ac.caCert, ac.caKey, serial,
+		ac.listenIPs, []string{ac.hostname}, ac.hostname)
+	if err != nil {
+		return KeyPair{}, fmt.Errorf(
+			"failed to generate Adam %s certificate: %w", desc, err)
+	}
+	if err := utils.OutputCertAndKeyAtomic(cert, key, certPath, keyPath); err != nil {
+		restorePrevious()
+		return KeyPair{}, fmt.Errorf(
+			"failed to install Adam %s certificate: %w", desc, err)
+	}
+	ac.log.Infof("Installed a new Adam %s certificate (serial %s)", desc, serial)
+	return KeyPair{Cert: cert, Key: key}, nil
 }
 
 // RegisterDevice directly registers a device certificate with Adam,
@@ -2073,12 +2189,24 @@ func (ac *AdamClient) findDeviceByOnboard(ctx context.Context, httpClient *http.
 }
 
 // Generate server, signing and encryption certificates for Adam.
+// The directory is remembered on the client so that the signing and ECDH
+// keypairs can later be rotated in place (see RotateSigningKeyPair).
 func (ac *AdamClient) generateCerts() (certDir string, err error) {
+	ac.certsM.Lock()
+	defer ac.certsM.Unlock()
+
 	certDir = filepath.Join(ac.runDir, "adam-certs")
 	if err := os.MkdirAll(certDir, 0o755); err != nil {
 		err = fmt.Errorf("failed to create Adam cert directory: %w", err)
 		return certDir, err
 	}
+	ac.certDir = certDir
+	// Start past the serials hardcoded below. Uniqueness within the CA is not
+	// achieved and not needed: the harness issues 2 for every device onboarding
+	// certificate and 3 for the image server from the same CA, and nothing
+	// consumes (issuer, serial) -- Adam identifies certificates by PEM hash.
+	// The counter exists only so that a rotation is visible in logs.
+	ac.certSerial = 4
 
 	ac.log.Debug("Generating Adam TLS certificate")
 	ac.tlsCert, ac.tlsKey, err = utils.GenServerCertElliptic(

--- a/evetest/devconfig.go
+++ b/evetest/devconfig.go
@@ -1073,6 +1073,11 @@ func (config ApplicationInstanceConfig) toProto(th *TestHarness, devName string,
 				th.t.Fatalf("Failed to encrypt user data for application %v: %v",
 					config.DisplayName, err)
 			}
+			// Deliberately leaves UserData unset. domainmgr's getCloudInitUserData
+			// silently falls back to the plaintext field when the decrypt fails,
+			// booting the application with cleartext and reporting no error at all
+			// - so setting both would make every encrypted-user-data assertion
+			// unable to fail.
 			appInstConfig.CipherData = cipherData
 		} else {
 			// This is initial device configuration.
@@ -1933,6 +1938,10 @@ func (dc *EdgeDeviceConfig) setDefaultConfigProperties() {
 		{Key: string(pillartypes.LocationCloudInterval), Value: "300"},
 		{Key: string(pillartypes.AllowLogFastupload), Value: "true"},
 		{Key: string(pillartypes.DownloadRetryTime), Value: "60"},
+
+		// timer.cert.interval is deliberately left at its 24h default: lowering it
+		// would make EVE refetch /certs on a timer, which is exactly the fallback
+		// the certificate rotation tests must not be able to rely on.
 
 		// Reduce the post-upgrade testing period so upgrades complete faster in tests.
 		{Key: string(pillartypes.MintimeUpdateSuccess), Value: "60"},

--- a/evetest/edgedevice.go
+++ b/evetest/edgedevice.go
@@ -6,6 +6,7 @@ package evetest
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -17,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	evecerts "github.com/lf-edge/eve-api/go/certs"
 	eveconfig "github.com/lf-edge/eve-api/go/config"
 	eveflowlog "github.com/lf-edge/eve-api/go/flowlog"
 	eveinfo "github.com/lf-edge/eve-api/go/info"
@@ -26,6 +28,7 @@ import (
 	api "github.com/lf-edge/eve/evetest/grpcapi/go"
 	"github.com/lf-edge/eve/evetest/logger"
 	"github.com/lf-edge/eve/evetest/utils"
+	pillartypes "github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
 	uuid "github.com/satori/go.uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -229,9 +232,23 @@ func (d *EdgeDevice) ApplyConfig(config *EdgeDeviceConfig, waitUntilFetched bool
 		newConfig.Reboot = &eveconfig.DeviceOpsCmd{Counter: 0, DesiredState: false}
 	}
 
-	// Preserve cipher contexts.
+	// Preserve cipher contexts. The list is taken from the harness-held config
+	// and not from the caller's, which makes the harness-held config the single
+	// owner of the cipher-context list: addCipherCtxToDevice appends there and
+	// every ApplyConfig republishes whatever it finds. Anything that changes the
+	// cipher contexts (e.g. RotateControllerEncryptCert) must therefore mutate
+	// the harness-held config, not just the config it is about to apply.
 	if prevConfig != nil {
 		newConfig.CipherContexts = prevConfig.GetCipherContexts()
+	}
+
+	// Never push a cipher block encrypted against a retired controller
+	// certificate; see checkCipherBlocksUseCurrentECDHCert for why that failure
+	// would otherwise stay invisible until a reboot.
+	if err := d.th.checkCipherBlocksUseCurrentECDHCert(
+		newConfig.EdgeDevConfig, newConfig.GetCipherContexts()); err != nil {
+		d.th.t.Fatalf("Refusing to apply configuration (version %s) for device %q: %v",
+			configVer, d.devName, err)
 	}
 
 	ctx, cancel := context.WithTimeout(d.th.ctx, adamApplyConfigTimeout)
@@ -2938,6 +2955,70 @@ func ReadAllPublications[T any](d *EdgeDevice, fromAgent string,
 		results = append(results, item)
 	}
 	return results, nil
+}
+
+// WaitUntilHasControllerCert blocks until the device publishes the given
+// controller certificate of the given type.
+//
+// The device side is the only place this can be observed: /certs is an
+// unauthenticated pull carrying no device UUID, so the controller does not even
+// record the request, and the device never acknowledges which certificates it
+// accepted. The ControllerCert publication is ephemeral (/run), which makes the
+// observation inherently fresh across a reboot.
+//
+// Certificates are matched on the PEM rather than on the hash, because the hash
+// is truncated on its way to the device (Adam serves only the first 16 bytes,
+// flagged SHA256_16BYTES) and comparing lengths that differ by truncation is easy
+// to get wrong. The PEM is compared trimmed, matching Adam's own normalization.
+// The type is part of the match because a certificate is only ever meaningful for
+// the role it was served under.
+func (d *EdgeDevice) WaitUntilHasControllerCert(
+	certType evecerts.ZCertType, certPEM []byte, timeout time.Duration) {
+
+	expectedPEM := strings.TrimSpace(string(certPEM))
+	d.th.log.Infof("Waiting for device %q to publish a controller certificate "+
+		"of type %v...", d.devName, certType)
+
+	deadline := time.Now().Add(timeout)
+	for {
+		certs, readErr := ReadAllPublications[pillartypes.ControllerCert](
+			d, "zedagent", false)
+		if readErr != nil {
+			// Warn, not Debug: a read path broken for an unrelated reason would
+			// otherwise burn the whole timeout without a trace.
+			d.th.log.Warnf("Reading ControllerCert from device %q failed: %v",
+				d.devName, readErr)
+		}
+		var published []string
+		for _, ctrlCert := range certs {
+			if ctrlCert.Type == certType &&
+				strings.TrimSpace(string(ctrlCert.Cert)) == expectedPEM {
+				d.th.log.Infof("Device %q published the expected controller "+
+					"certificate of type %v", d.devName, certType)
+				return
+			}
+			published = append(published, fmt.Sprintf("type=%v hash=%s",
+				ctrlCert.Type, hex.EncodeToString(ctrlCert.CertHash)))
+		}
+		if time.Now().After(deadline) {
+			// Naming the path matters: the topic only became ephemeral in EVE
+			// 16.9.3, so on an older build the certificates are published under
+			// /persist/status and an empty list here does not mean the device
+			// holds none.
+			d.th.t.Fatalf("Device %q did not publish the expected controller "+
+				"certificate of type %v within %v; certificates found under "+
+				"/run/zedagent/ControllerCert (EVE >= 16.9.3): [%s]; "+
+				"last read error: %v",
+				d.devName, certType, timeout, strings.Join(published, ", "), readErr)
+		}
+		select {
+		case <-time.After(deviceCertPollInterval):
+		case <-d.th.ctx.Done():
+			d.th.t.Fatalf("Interrupted while waiting for device %q to publish "+
+				"the expected controller certificate of type %v",
+				d.devName, certType)
+		}
+	}
 }
 
 // getDevUUID returns the device UUID, calling t.Fatalf if not found/onboarded.

--- a/evetest/grpcserver.go
+++ b/evetest/grpcserver.go
@@ -25,6 +25,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 )
 
 type infoMsgGrpcIterator[T any] struct {
@@ -230,7 +231,10 @@ func (th *TestHarness) GetEVEConfig(
 	if th.devices[devName].config == nil {
 		return nil, fmt.Errorf("no config submitted for device %s", devName)
 	}
-	config := th.devices[devName].config.EdgeDevConfig
+	// Cloned, not aliased: gRPC marshals the response only after this handler has
+	// released devicesM, so returning the live message would race with any writer
+	// that mutates the harness-held config in place.
+	config := proto.CloneOf(th.devices[devName].config.EdgeDevConfig)
 	return &api.EVEConfigResponse{Config: config}, nil
 }
 

--- a/evetest/harness.go
+++ b/evetest/harness.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -24,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	evecerts "github.com/lf-edge/eve-api/go/certs"
 	eveinfo "github.com/lf-edge/eve-api/go/info"
 	"github.com/lf-edge/eve/evetest/constants"
 	"github.com/lf-edge/eve/evetest/controller"
@@ -96,6 +98,17 @@ const (
 
 	// Timeout for a device to fetch the latest configuration from Adam.
 	deviceApplyConfigTimeout = 2 * time.Minute
+
+	// Timeout for a device to pick up a rotated controller certificate: notice
+	// the changed controllercert_confighash in a config response, refetch /certs
+	// and republish ControllerCert. Generous because a single failed fetch is
+	// never re-triggered by config and recovery then falls to zedagent's
+	// post-failure retry, which waits shortTime=120s.
+	deviceCertRefetchTimeout = 5 * time.Minute
+
+	// Polling interval while waiting for a controller certificate to appear on
+	// a device.
+	deviceCertPollInterval = 5 * time.Second
 
 	// Timeout for a device to be removed from the Adam controller.
 	deviceRemoveTimeout = 20 * time.Second
@@ -1269,13 +1282,202 @@ func UpdateNetworkModel(netModel *api.NetworkModel) {
 	th.log.Info("Successfully applied the new network model")
 }
 
-// ChangeSigningCert replaces the controller signing certificate
-// with the provided one.
-func ChangeSigningCert(newSignCertPEM string) error {
+// RotateControllerSigningCert rotates the certificate and private key with which
+// the controller signs the AuthContainer that wraps every API response.
+//
+// Nothing has to be re-encrypted and no configuration has to be pushed: evetest
+// always derives cipher contexts from the controller's ECDH certificate, never
+// from the signing certificate (see encryptCipherData), so object-level
+// encryption is untouched. Use RotateControllerEncryptCert for that.
+//
+// Unlike RotateControllerEncryptCert this does not wait for the device to pick
+// the new certificate up; the caller decides what to wait for.
+//
+// Adam is deliberately not restarted: it re-reads the signing certificate and key
+// from disk on every request, whereas a restart would regenerate all keypairs and
+// undo the rotation.
+func RotateControllerSigningCert() {
 	th := getTestHarness()
-	// TODO
-	th.t.Fatalf("ChangeSigningCert is not implemented")
-	return nil
+	newPair, oldPair, err := th.adamClient.RotateSigningKeyPair()
+	if err != nil {
+		th.t.Fatalf("Failed to rotate the controller signing certificate: %v", err)
+	}
+	th.log.Infof("Rotated the controller signing certificate (serial %s -> %s)",
+		oldPair.Cert.SerialNumber, newPair.Cert.SerialNumber)
+}
+
+// RotateControllerEncryptCert rotates the controller's ECDH certificate and
+// private key -- the material every evetest cipher context is derived from --
+// and migrates the deployed configuration onto it: for every onboarded device it
+// registers a cipher context derived from the new certificate, re-encrypts every
+// cipher block from the retired context to the new one, and re-applies the
+// configuration.
+//
+// Pass the EdgeDeviceConfig builders the test still holds, and pass the ones it
+// has been applying: configurations are pushed as they are, and EVE config is
+// declarative, so a builder that is a subset of what the device has deployed
+// silently un-deploys the difference. A builder left out keeps blocks encrypted
+// against the retired certificate; a device with no builder given has its
+// harness-held configuration migrated instead, and only if it holds cipher blocks.
+//
+// Ordering is load-bearing: install the certificates, wait for the device to
+// publish the new one, only then push. Reversed, the device parses a cipher
+// context for a certificate it does not have yet and takes a failed decrypt plus
+// domainmgr's 30s retry. The wait is on EVE's ControllerCert publication because
+// the /certs refetch is only triggered asynchronously, by
+// controllercert_confighash (Adam >= 0.0.81), and a fetch that fails is not
+// re-triggered. The push is required even though nothing else changed: zedagent
+// skips re-parsing cipher contexts while the hash over the set is unchanged.
+//
+// Not safe to call while devices are still being set up: it mutates the
+// harness-held configuration, which ApplyConfig also reads outside devicesM.
+func RotateControllerEncryptCert(deviceConfigs ...*EdgeDeviceConfig) {
+	th := getTestHarness()
+
+	configByDevice := make(map[string]*EdgeDeviceConfig, len(deviceConfigs))
+	for _, config := range deviceConfigs {
+		if config == nil {
+			continue
+		}
+		configByDevice[config.GetDeviceName()] = config
+	}
+	th.devicesM.Lock()
+	for devName := range configByDevice {
+		if _, found := th.devices[devName]; !found {
+			th.devicesM.Unlock()
+			th.t.Fatalf("RotateControllerEncryptCert was given a configuration "+
+				"for unknown device %q", devName)
+		}
+	}
+	th.devicesM.Unlock()
+
+	// Snapshot the devices to migrate; crypto and HTTP below must not run with
+	// devicesM held. A device the caller did not pass a builder for is only
+	// migrated if its harness-held config actually contains cipher blocks:
+	// otherwise it would get a cipher context it has no use for, and the resulting
+	// config push would flip zedagent's cipher-context-set hash and force a
+	// pointless re-parse of its app, network and datastore config. Devices whose
+	// builder was passed explicitly are always processed, so a caller can force a
+	// push. Sorted by name to keep the order of pushes deterministic.
+	type rotationTarget struct {
+		devName     string
+		devECDHCert *x509.Certificate
+		config      *EdgeDeviceConfig
+	}
+	var targets []rotationTarget
+	var onboarded []string
+	th.devicesM.Lock()
+	for devName, devState := range th.devices {
+		if devState.ID == NilUUID {
+			continue
+		}
+		onboarded = append(onboarded, devName)
+		if devState.ecdhCert == nil {
+			continue
+		}
+		config, explicit := configByDevice[devName]
+		if !explicit {
+			config = devState.config
+			if config == nil || !hasCipherBlocks(config.EdgeDevConfig) {
+				continue
+			}
+		}
+		targets = append(targets, rotationTarget{
+			devName:     devName,
+			devECDHCert: devState.ecdhCert,
+			config:      config,
+		})
+	}
+	th.devicesM.Unlock()
+	sort.Slice(targets, func(i, j int) bool {
+		return targets[i].devName < targets[j].devName
+	})
+	sort.Strings(onboarded)
+
+	newPair, oldPair, err := th.adamClient.RotateECDHKeyPair()
+	if err != nil {
+		th.t.Fatalf("Failed to rotate the controller ECDH certificate: %v", err)
+	}
+	th.log.Infof("Rotated the controller ECDH certificate (serial %s -> %s)",
+		oldPair.Cert.SerialNumber, newPair.Cert.SerialNumber)
+
+	// Every onboarded device is waited for, not just the ones being migrated: a
+	// device skipped for having nothing encrypted still holds only the retired
+	// certificate when this returns, so a later ApplyConfig that does introduce a
+	// cipher block would reference a certificate the device does not have yet.
+	for _, devName := range onboarded {
+		GetEdgeDevice(devName).WaitUntilHasControllerCert(
+			evecerts.ZCertType_CERT_TYPE_CONTROLLER_ECDH_EXCHANGE,
+			utils.CertToPEM(newPair.Cert), deviceCertRefetchTimeout)
+	}
+
+	for _, target := range targets {
+		oldCryptoCfg, err := utils.NewCryptoConfig(
+			target.devECDHCert, oldPair.Cert, oldPair.Key)
+		if err != nil {
+			th.t.Fatalf("Failed to create crypto config for the retired "+
+				"controller ECDH certificate (device %q): %v", target.devName, err)
+		}
+		newCryptoCfg, err := utils.NewCryptoConfig(
+			target.devECDHCert, newPair.Cert, newPair.Key)
+		if err != nil {
+			th.t.Fatalf("Failed to create crypto config for the new "+
+				"controller ECDH certificate (device %q): %v", target.devName, err)
+		}
+		cipherCtx, err := utils.CreateCipherCtx(newCryptoCfg)
+		if err != nil {
+			th.t.Fatalf("Failed to create cipher context for device %q: %v",
+				target.devName, err)
+		}
+		cipherCtx, err = th.addCipherCtxToDevice(target.devName, cipherCtx)
+		if err != nil {
+			th.t.Fatalf("Failed to add cipher context to device %q: %v",
+				target.devName, err)
+		}
+
+		// Under devicesM: on the implicit path target.config *is* the harness-held
+		// config, which readers holding the lock (GetEVEConfig, getConfig) must not
+		// observe half-migrated. Only the re-encryption is covered -- it is
+		// CPU-only, whereas the push below does I/O and waits on the device.
+		th.devicesM.Lock()
+		err = reEncryptCipherBlocks(
+			target.config.EdgeDevConfig, oldCryptoCfg, newCryptoCfg, cipherCtx)
+		th.devicesM.Unlock()
+		if err != nil {
+			th.t.Fatalf("Failed to re-encrypt configuration of device %q: %v",
+				target.devName, err)
+		}
+		GetEdgeDevice(target.devName).ApplyConfig(target.config, true, true)
+		th.log.Infof("Device %q configuration migrated to the new controller "+
+			"ECDH certificate", target.devName)
+	}
+}
+
+// GetControllerSigningCertPEM returns the PEM encoding of the certificate the
+// controller currently uses to sign API responses (see
+// RotateControllerSigningCert). The device receives the same certificate via
+// /certs as CERT_TYPE_CONTROLLER_SIGNING.
+func GetControllerSigningCertPEM() []byte {
+	th := getTestHarness()
+	cert, _ := th.adamClient.GetSigningCertAndKey()
+	if cert == nil {
+		th.t.Fatalf("The controller signing certificate is not available yet; " +
+			"the controller has not been started")
+	}
+	return utils.CertToPEM(cert)
+}
+
+// GetControllerEncryptCertPEM returns the PEM encoding of the controller's
+// current ECDH certificate (see RotateControllerEncryptCert). The device receives
+// the same certificate via /certs as CERT_TYPE_CONTROLLER_ECDH_EXCHANGE.
+func GetControllerEncryptCertPEM() []byte {
+	th := getTestHarness()
+	cert, _ := th.adamClient.GetECDHCertAndKey()
+	if cert == nil {
+		th.t.Fatalf("The controller ECDH certificate is not available yet; " +
+			"the controller has not been started")
+	}
+	return utils.CertToPEM(cert)
 }
 
 // GetControllerHostname returns the controller hostname (stored inside /config/server)

--- a/evetest/setup.go
+++ b/evetest/setup.go
@@ -1504,8 +1504,9 @@ func (th *TestHarness) forceDeviceReonboarding(dev deviceState) error {
 // only the network settings. All application-level state (apps, network instances,
 // datastores, content info, volumes, patch envelopes, profile settings, and config items)
 // is cleared so the next test starts from a clean application baseline without disrupting
-// the device's network connectivity. The new config is versioned, applied via the
-// controller, and saved in the harness's in-memory device record.
+// the device's network connectivity. Everything encrypted is cleared as well, so that no
+// test can inherit a cipher block from its predecessor. The new config is versioned,
+// applied via the controller, and saved in the harness's in-memory device record.
 func (th *TestHarness) resetDeviceConfig(dev deviceState) error {
 	th.devicesM.Lock()
 	if dev.config == nil {
@@ -1526,6 +1527,19 @@ func (th *TestHarness) resetDeviceConfig(dev deviceState) error {
 	newConfig.LocalProfileServer = ""
 	newConfig.GlobalProfile = ""
 	newConfig.ProfileServerToken = ""
+
+	// Cipher blocks also hide in retained objects (wireless credentials, the SCEP
+	// challenge password, the cluster join token), and one encrypted against a
+	// certificate the next device does not hold is undetectable until it fails to
+	// decrypt. Dropping the cipher contexts along with them is safe: no block
+	// survives the reset, and ApplyConfig republishes the context list from the
+	// harness-held config, so encryptCipherData re-adds a context on demand.
+	// This also makes the direct ApplyDeviceConfig push below (which bypasses
+	// ApplyConfig's checkCipherBlocksUseCurrentECDHCert guard) trivially valid.
+	if err := clearCipherBlocks(newConfig.EdgeDevConfig); err != nil {
+		return err
+	}
+	newConfig.CipherContexts = nil
 
 	// Set config ID.
 	configVer := th.nextConfigVersion(newConfig)

--- a/evetest/tests/security/apparmor_test.go
+++ b/evetest/tests/security/apparmor_test.go
@@ -39,7 +39,6 @@ func TestAppArmorEnabled(test *testing.T) {
 	)
 	hypervisor := evetest.GetHypervisorParameterValue()
 
-	devName := "edge-dev"
 	evetest.Setup(
 		evetest.RequireEdgeDevice{
 			Name:              devName,

--- a/evetest/tests/security/cert_change_test.go
+++ b/evetest/tests/security/cert_change_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test rotation of the controller certificate that signs API responses.
+
+package security
+
+import (
+	"fmt"
+	"testing"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	evecerts "github.com/lf-edge/eve-api/go/certs"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/netmodels"
+)
+
+// TestControllerSigningCertChange verifies that a device recovers on its own when
+// the controller rotates the certificate and private key it uses to sign the
+// AuthContainer wrapping every API response. After the rotation every API response
+// fails verification on the device until it refetches /certs, and nothing tells it
+// to do so other than the failure itself.
+//
+// A signing-cert rotation must leave object-level encryption alone: evetest cipher
+// contexts are derived from the controller's ECDH certificate, never from the
+// signing one. See TestControllerEncryptCertChange for that side.
+//
+// Phases / assertions
+// -------------------
+//  1. setup-done -> config-applied.
+//  2. app-1-running: baseline proof that object-encrypted user data decrypts.
+//  3. signing-cert-rotated-1: the confirmed ApplyConfig is the assertion that can
+//     fail. LastProcessedConfig must reach the timestamp of a config created after
+//     the rotation, which the device can only report once it has verified an
+//     AuthContainer signed with the new key.
+//  4. signing-cert-rotated-2: same code path, but over state a rotation itself
+//     produced -- the installed certificate no longer matches controllercerts.bak.
+//     A stale cached serverSigningCertHash shows up here, not in phase 3.
+//  5. app-2-running: a cipher block minted after both rotations. Reaching RUNNING
+//     proves nothing about decryption, see assertCipherDecryptionSucceeded.
+//  6. device-rebooted -> apps-running-after-reboot: the ControllerCert publication
+//     is ephemeral (/run) and the reboot wiped it, so both certificates must be
+//     there again. Not a checkpoint check -- zedagent refetches /certs
+//     unconditionally at startup, so a corrupt checkpoint passes too. The marker
+//     reads prove the recreated containers decrypted their blocks again.
+//  7. Delete both applications and wait until the device reports them gone.
+//
+// Test params: HYPERVISOR (defaults to KVM).
+// Suite placement: TestSecuritySuite.
+func TestControllerSigningCertChange(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	// Define configurable parameters available for the test.
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+	)
+
+	// Get parameter values set for this test execution.
+	hypervisor := evetest.GetHypervisorParameterValue()
+
+	// Set up the test harness and specify the test prerequisites.
+	evetest.Setup(
+		evetest.RequireEdgeDevice{
+			Name:           devName,
+			WithHypervisor: hypervisor,
+			// Decryption then runs through the TPM (evetpm.getDecryptKey), and it
+			// matches the other tests in the suite, so the device VM is reused.
+			WithTPM:           true,
+			DeviceReusePolicy: evetest.ResetDeviceConfig,
+		},
+		evetest.RequireNetworkModel{
+			NetworkModel: netmodels.SingleEthWithDHCP,
+		},
+	)
+	device := evetest.GetEdgeDevice(devName)
+	evetest.Checkpoint("setup-done")
+
+	log := evetest.Logger()
+	devConfig, niUUID := singleMgmtPortWithLocalNI(device, hypervisor)
+	evetest.Checkpoint("config-applied")
+
+	// Phase 2: baseline, before any certificate change.
+	const firstAppMarker = "before-signing-cert-rotation"
+	firstAppUUID := deployEncryptedUserDataApp(t, device, devConfig, niUUID,
+		"signing-cert-app1", 2222, firstAppMarker)
+	evetest.Checkpoint("app-1-running")
+
+	// Phases 3 and 4.
+	for rotation := 1; rotation <= 2; rotation++ {
+		log.Infof("Rotating the controller signing certificate (%d of 2)...", rotation)
+		evetest.RotateControllerSigningCert()
+
+		// Config processing must resume with no nudge but the verification failure.
+		device.ApplyConfig(devConfig, true, true)
+		assertDeviceHasControllerCert(t, device,
+			evecerts.ZCertType_CERT_TYPE_CONTROLLER_SIGNING,
+			evetest.GetControllerSigningCertPEM())
+		evetest.Checkpoint(fmt.Sprintf("signing-cert-rotated-%d", rotation))
+	}
+	assertCipherDecryptionSucceeded(t, device)
+
+	// Phase 5: a cipher block created after both rotations.
+	const secondAppMarker = "after-signing-cert-rotation"
+	secondAppUUID := deployEncryptedUserDataApp(t, device, devConfig, niUUID,
+		"signing-cert-app2", 2223, secondAppMarker)
+	evetest.Checkpoint("app-2-running")
+
+	// Phase 6: the device must repopulate its ephemeral controller certificates.
+	log.Infof("Rebooting the device...")
+	device.SoftReboot(true)
+	evetest.Checkpoint("device-rebooted")
+
+	assertDeviceHasControllerCert(t, device,
+		evecerts.ZCertType_CERT_TYPE_CONTROLLER_SIGNING,
+		evetest.GetControllerSigningCertPEM())
+	assertDeviceHasControllerCert(t, device,
+		evecerts.ZCertType_CERT_TYPE_CONTROLLER_ECDH_EXCHANGE,
+		evetest.GetControllerEncryptCertPEM())
+
+	device.WaitUntilAppIsRunning(firstAppUUID, appRunningTimeout)
+	assertUserDataDecrypted(t, device, firstAppUUID, firstAppMarker)
+	device.WaitUntilAppIsRunning(secondAppUUID, appRunningTimeout)
+	assertUserDataDecrypted(t, device, secondAppUUID, secondAppMarker)
+	evetest.Checkpoint("apps-running-after-reboot")
+
+	// Phase 7: clean up.
+	deleteAppAndWait(t, device, devConfig, firstAppUUID)
+	deleteAppAndWait(t, device, devConfig, secondAppUUID)
+}

--- a/evetest/tests/security/encrypt_cert_change_test.go
+++ b/evetest/tests/security/encrypt_cert_change_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test rotation of the controller ECDH certificate used for object encryption.
+
+package security
+
+import (
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	uuid "github.com/satori/go.uuid"
+
+	evecerts "github.com/lf-edge/eve-api/go/certs"
+	eveinfo "github.com/lf-edge/eve-api/go/info"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/netmodels"
+)
+
+// TestControllerEncryptCertChange verifies that object-level encryption survives a
+// rotation of the controller's ECDH certificate -- the certificate every evetest
+// cipher context is derived from, and the one EVE needs in order to decrypt user
+// data, datastore credentials, WiFi and cellular secrets and the join token. The
+// rotation also migrates deployed state: the harness re-encrypts the running
+// configuration's cipher blocks and re-applies it.
+//
+// Unlike the signing certificate, the ECDH certificate is not part of the
+// AuthContainer, so rotating raises no verification failure and no self-triggered
+// recovery; the /certs refetch is driven by controllercert_confighash instead. See
+// RotateControllerEncryptCert for the ordering and controller version implied.
+//
+// Phases / assertions
+// -------------------
+//  1. setup-done -> config-applied.
+//  2. app-1-running: baseline proof that the block decrypts with the pre-rotation
+//     certificate. Reaching RUNNING proves nothing about decryption, see
+//     assertCipherDecryptionSucceeded.
+//  3. encrypt-cert-rotated-1: the migration must not break the deployed
+//     application, see assertAppsNotDisruptedByRotation.
+//  4. app-2-running: a block encrypted against the new key from the start, so the
+//     marker read is the primary proof that the device got the new certificate and
+//     can use it -- no fallback to a retained old one produces that marker.
+//  5. encrypt-cert-rotated-2: decryption now needs a keypair a rotation itself
+//     installed, so a controller that mixed up which keypair it retired fails here
+//     and not in phase 3. A third application would only repeat phase 4.
+//  6. device-rebooted -> apps-running-after-reboot: the ControllerCert publication
+//     is ephemeral (/run) and the reboot wiped it, so the ECDH certificate must be
+//     there again before anything decrypts. Not a checkpoint check -- zedagent
+//     refetches /certs unconditionally at startup. The marker reads then prove the
+//     recreated containers decrypted their blocks again.
+//  7. Delete both applications and wait until the device reports them gone.
+//
+// Test params: HYPERVISOR (defaults to KVM).
+// Suite placement: TestSecuritySuite.
+func TestControllerEncryptCertChange(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	// Define configurable parameters available for the test.
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+	)
+
+	// Get parameter values set for this test execution.
+	hypervisor := evetest.GetHypervisorParameterValue()
+
+	// Set up the test harness and specify the test prerequisites.
+	evetest.Setup(
+		evetest.RequireEdgeDevice{
+			Name:           devName,
+			WithHypervisor: hypervisor,
+			// Load-bearing: the rotated controller point is fed to the TPM's ECDH
+			// rather than to a software one (evetpm.getDecryptKey), so with TPM off
+			// this test covers a different path. Also keeps the VM reusable.
+			WithTPM:           true,
+			DeviceReusePolicy: evetest.ResetDeviceConfig,
+		},
+		evetest.RequireNetworkModel{
+			NetworkModel: netmodels.SingleEthWithDHCP,
+		},
+	)
+	device := evetest.GetEdgeDevice(devName)
+	evetest.Checkpoint("setup-done")
+
+	log := evetest.Logger()
+	devConfig, niUUID := singleMgmtPortWithLocalNI(device, hypervisor)
+	evetest.Checkpoint("config-applied")
+
+	// Phase 2: encrypted against the pre-rotation certificate.
+	markers := []string{
+		"before-encrypt-cert-rotation",
+		"after-first-encrypt-cert-rotation",
+	}
+	appUUIDs := []uuid.UUID{
+		deployEncryptedUserDataApp(t, device, devConfig, niUUID,
+			"encrypt-cert-app1", 2222, markers[0]),
+	}
+	bootTimes := []time.Time{appBootTime(t, device, appUUIDs[0])}
+	evetest.Checkpoint("app-1-running")
+
+	// Phase 3: first rotation. RotateControllerEncryptCert blocks until the device
+	// publishes the new certificate, hence no ControllerCert assertion here.
+	log.Infof("Rotating the controller ECDH certificate (1 of 2)...")
+	evetest.RotateControllerEncryptCert(devConfig)
+	assertAppsNotDisruptedByRotation(t, device, appUUIDs, markers, bootTimes)
+	assertCipherDecryptionSucceeded(t, device)
+	evetest.Checkpoint("encrypt-cert-rotated-1")
+
+	// Phase 4: a block encrypted against the new key from the start.
+	appUUIDs = append(appUUIDs, deployEncryptedUserDataApp(t, device, devConfig,
+		niUUID, "encrypt-cert-app2", 2223, markers[1]))
+	bootTimes = append(bootTimes, appBootTime(t, device, appUUIDs[1]))
+	evetest.Checkpoint("app-2-running")
+
+	// Phase 5: second rotation, decrypting with a keypair a rotation installed.
+	log.Infof("Rotating the controller ECDH certificate (2 of 2)...")
+	evetest.RotateControllerEncryptCert(devConfig)
+	assertAppsNotDisruptedByRotation(t, device, appUUIDs, markers, bootTimes)
+	assertCipherDecryptionSucceeded(t, device)
+	evetest.Checkpoint("encrypt-cert-rotated-2")
+
+	// Phase 6: after the reboot the device only knows the current certificate.
+	log.Infof("Rebooting the device...")
+	device.SoftReboot(true)
+	evetest.Checkpoint("device-rebooted")
+
+	assertDeviceHasControllerCert(t, device,
+		evecerts.ZCertType_CERT_TYPE_CONTROLLER_ECDH_EXCHANGE,
+		evetest.GetControllerEncryptCertPEM())
+
+	for i, appUUID := range appUUIDs {
+		device.WaitUntilAppIsRunning(appUUID, appRunningTimeout)
+		assertUserDataDecrypted(t, device, appUUID, markers[i])
+	}
+	evetest.Checkpoint("apps-running-after-reboot")
+
+	// Phase 7: clean up.
+	for _, appUUID := range appUUIDs {
+		deleteAppAndWait(t, device, devConfig, appUUID)
+	}
+}
+
+// assertAppsNotDisruptedByRotation asserts that applications deployed before a
+// certificate rotation were not restarted by it. markers and bootTimes hold one
+// entry per application, in the same order as appUUIDs.
+//
+// The boot time is what proves it. For an already-activated domain domainmgr never
+// re-runs configToStatus: the marker read returns the environment planted at the
+// pre-rotation create whatever the migration did to the block, and only proves the
+// container is alive.
+//
+// The SSH round trip runs first, so any disruption has had time to reach the
+// controller before the reported state is read.
+func assertAppsNotDisruptedByRotation(t *WithT, device *evetest.EdgeDevice,
+	appUUIDs []uuid.UUID, markers []string, bootTimes []time.Time) {
+
+	for i, appUUID := range appUUIDs {
+		assertUserDataDecrypted(t, device, appUUID, markers[i])
+		info := device.GetAppInfo(appUUID)
+		t.Expect(info).ToNot(BeNil())
+		t.Expect(info.GetState()).To(Equal(eveinfo.ZSwState_RUNNING))
+		t.Expect(info.GetAppErr()).To(BeEmpty())
+		t.Expect(info.GetBootTime().AsTime()).To(BeTemporally("==", bootTimes[i]),
+			"the rotation recreated application %v", appUUID)
+	}
+}

--- a/evetest/tests/security/helpers_test.go
+++ b/evetest/tests/security/helpers_test.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared constants and helpers for the device-security tests.
+
+package security
+
+import (
+	"encoding/base64"
+	"strings"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	uuid "github.com/satori/go.uuid"
+
+	evecerts "github.com/lf-edge/eve-api/go/certs"
+	eveconfig "github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve-api/go/evecommon"
+	eveinfo "github.com/lf-edge/eve-api/go/info"
+	evemetrics "github.com/lf-edge/eve-api/go/metrics"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/matchers"
+	pillartypes "github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+const (
+	devName = "edge-dev"
+
+	// General-purpose test container image (ships sshd).
+	ubuntuCtrImage = "lfedge/evetest-ubuntu-ctr"
+	ubuntuCtrTag   = "1.0"
+
+	niDisplayName = "local-ni"
+	niSubnet      = "10.11.12.0/24"
+	niGateway     = "10.11.12.1"
+
+	// EVE turns plain "key=value" user data into environment variables of the
+	// container's init process, so finding it there proves the block was decrypted.
+	userDataMarkerKey = "EVETEST_CERT_ROTATION_MARKER"
+
+	appRunningTimeout = 10 * time.Minute
+
+	appMarkerReadTimeout = 5 * time.Minute
+
+	appSSHTimeout = 20 * time.Second
+
+	controllerCertTimeout = 3 * time.Minute
+
+	// The framework lowers the metric publishing interval to 20s.
+	cipherMetricsTimeout = 2 * time.Minute
+
+	pollingInterval = 5 * time.Second
+)
+
+// Credentials baked into the evetest-ubuntu-ctr image.
+var appAuth = evetest.UsernamePasswordAuth{
+	Username: "root",
+	Password: "testpassword",
+}
+
+// addLocalNI adds the network instance shared by this package's applications.
+func addLocalNI(devConfig *evetest.EdgeDeviceConfig) uuid.UUID {
+	return devConfig.AddNetworkInstance(evetest.LocalNetworkInstanceConfig{
+		DisplayName: niDisplayName,
+		Port:        "ethernet0",
+		Subnet:      evetest.IPSubnet(niSubnet),
+		DHCPRange: pillartypes.IPRange{
+			Start: evetest.IPAddress("10.11.12.2"),
+			End:   evetest.IPAddress("10.11.12.254"),
+		},
+		Gateway: evetest.IPAddress(niGateway),
+		MTU:     1500,
+	})
+}
+
+// deployEncryptedUserDataApp adds a container application whose user data is
+// delivered inside a CipherBlock (encrypted against the controller's current ECDH
+// certificate). sshFwdPort must be unique: it identifies the application's sshd.
+func deployEncryptedUserDataApp(t *WithT, device *evetest.EdgeDevice,
+	devConfig *evetest.EdgeDeviceConfig, niUUID uuid.UUID, appName string,
+	sshFwdPort uint16, marker string) uuid.UUID {
+
+	appUUID := devConfig.AddApplication(evetest.ApplicationInstanceConfig{
+		DisplayName: appName,
+		Activate:    true,
+		Image: evetest.DockerContainer{
+			ImageName: ubuntuCtrImage,
+			Tag:       ubuntuCtrTag,
+		},
+		VirtualizationMode: eveconfig.VmMode_HVM, // PV does not work in xen
+		CPUs:               1,
+		MemoryBytes:        512 * evetest.MiB,
+		NetworkAdapters: []evetest.AppNetworkAdapter{
+			evetest.VirtualNetworkAdapter{
+				LogicalLabel:        "vif0",
+				NetworkInstanceUUID: niUUID,
+				PortFwdRules: []evetest.PortFwdRule{
+					{
+						Protocol:     evetest.NetworkProtocolTCP,
+						EdgeNodePort: sshFwdPort,
+						AppPort:      22,
+					},
+				},
+				ACLAllowRules: []evetest.ACLAllowRule{
+					{
+						Protocol:     evetest.NetworkProtocolAny,
+						RemoteSubnet: evetest.IPSubnet("0.0.0.0/0"),
+					},
+				},
+			},
+		},
+		// EVE base64-decodes user data on the object-encrypted path too.
+		UserData: base64.StdEncoding.EncodeToString(
+			[]byte(userDataMarkerKey + "=" + marker + "\n")),
+	})
+	device.ApplyConfig(devConfig, true, true)
+	device.WaitUntilAppIsRunning(appUUID, appRunningTimeout)
+	assertUserDataDecrypted(t, device, appUUID, marker)
+	return appUUID
+}
+
+// assertUserDataDecrypted asserts that the container's init-process environment
+// carries the marker from the object-encrypted user data. /proc/1/environ rather
+// than the session environment, which sshd sanitizes. Retried as a whole: RUNNING
+// only means the domain was created, sshd needs longer, and the port-forward can
+// fail transiently.
+func assertUserDataDecrypted(t *WithT, device *evetest.EdgeDevice,
+	appUUID uuid.UUID, marker string) {
+
+	evetest.Logger().Infof("Reading back the user-data marker of app %q...", appUUID)
+	t.Eventually(func(g Gomega) {
+		environ, _, err := device.RunShellScriptInsideApp(appUUID, appAuth,
+			"tr '\\0' '\\n' < /proc/1/environ", appSSHTimeout, 0)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(strings.Split(environ, "\n")).To(
+			ContainElement(userDataMarkerKey+"="+marker),
+			"the application's object-encrypted user data was not decrypted")
+	}, appMarkerReadTimeout, pollingInterval).Should(Succeed())
+}
+
+// assertDeviceHasControllerCert reads EVE's ephemeral (/run) ControllerCert
+// publication and so requires EVE >= 16.9.3, where the topic stopped being
+// persisted; on older builds it fails as if the device held no certificate.
+func assertDeviceHasControllerCert(t *WithT, device *evetest.EdgeDevice,
+	certType evecerts.ZCertType, expectedCertPEM []byte) {
+
+	device.WaitUntilHasControllerCert(certType, expectedCertPEM,
+		controllerCertTimeout)
+}
+
+// assertCipherDecryptionSucceeded checks domainmgr's cipher counters in a
+// DeviceMetric published after this call. This is the only assertion in these
+// tests that fails when decryption silently does nothing: a failed decrypt leaves
+// no error on the cipher block, none on the application, and boots it with an
+// empty environment -- but it does increment these counters.
+//
+// Tc carries only the non-zero counters, and none may be non-zero: domainmgr
+// enters the cipher path only for applications carrying user data, which the
+// framework always encrypts once onboarded, so even CIPHER_ERROR_NO_CIPHER is a
+// failure here.
+func assertCipherDecryptionSucceeded(t *WithT, device *evetest.EdgeDevice) {
+	metricUpdates, stopMetricWatch := device.WatchDeviceMetrics()
+	defer stopMetricWatch()
+	evetest.Logger().Infof("Waiting for domainmgr cipher metrics...")
+	var cipherMetric *evemetrics.CipherMetric
+	t.Eventually(metricUpdates, cipherMetricsTimeout).Should(
+		Receive(matchers.SatisfyPredicate(
+			"Device reports cipher metrics for domainmgr",
+			func(dm *evemetrics.DeviceMetric) bool {
+				for _, cm := range dm.GetCipher() {
+					if cm.GetAgentName() == "domainmgr" {
+						cipherMetric = cm
+						return true
+					}
+				}
+				return false
+			})))
+	t.Expect(cipherMetric.GetSuccessCount()).To(BeNumerically(">", 0),
+		"domainmgr did not decrypt a single cipher block")
+	t.Expect(cipherMetric.GetFailureCount()).To(BeZero())
+	t.Expect(cipherMetric.GetTc()).To(BeEmpty(),
+		"domainmgr recorded cipher errors: %v", cipherMetric.GetTc())
+}
+
+// appBootTime returns the boot time the controller reports for the application.
+// EVE stamps it anew on every domain create, so unlike liveness it tells a
+// recreated application apart from an undisturbed one.
+func appBootTime(t *WithT, device *evetest.EdgeDevice, appUUID uuid.UUID) time.Time {
+	info := device.GetAppInfo(appUUID)
+	t.Expect(info).ToNot(BeNil())
+	t.Expect(info.GetBootTime().IsValid()).To(BeTrue(),
+		"the device reports no boot time for application %v", appUUID)
+	return info.GetBootTime().AsTime()
+}
+
+// singleMgmtPortWithLocalNI builds and applies the device configuration shared by
+// the certificate rotation tests.
+func singleMgmtPortWithLocalNI(device *evetest.EdgeDevice,
+	hypervisor evetest.Hypervisor) (*evetest.EdgeDeviceConfig, uuid.UUID) {
+
+	devConfig := evetest.NewEdgeDeviceConfig(devName)
+
+	// Pin the periodic /certs refetch to EVE's 24h default, so the fast trigger is
+	// the only path that can satisfy these tests.
+	cfgProps := pillartypes.NewConfigItemValueMap()
+	cfgProps.SetGlobalValueInt(pillartypes.CertInterval, 86400)
+	devConfig.SetConfigProperties(cfgProps)
+
+	dhcpNet := devConfig.AddNetwork(evetest.DHCPNetworkConfig{
+		NetworkType: evecommon.NetworkType_V4Only,
+	})
+	devConfig.AddNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  "ethernet0",
+		PhysicalLabel: "eth0",
+		InterfaceName: "eth0",
+		NetworkUUID:   dhcpNet,
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+	})
+	device.ApplyConfig(devConfig, true, true)
+	if hypervisor == evetest.HypervisorKubevirt {
+		device.WaitForClusterNodeIsReady(20 * time.Minute)
+	}
+	return devConfig, addLocalNI(devConfig)
+}
+
+// deleteAppAndWait removes the application and blocks until the device reports the
+// instance gone, so teardown cannot race the next test's device-config reset.
+func deleteAppAndWait(t *WithT, device *evetest.EdgeDevice,
+	devConfig *evetest.EdgeDeviceConfig, appUUID uuid.UUID) {
+	const timeout = 5 * time.Minute
+	appUpdates, stopAppWatch := device.WatchAppInfo(appUUID)
+	defer stopAppWatch()
+	devConfig.DeleteApplication(appUUID)
+	device.ApplyConfig(devConfig, false, false)
+	t.Eventually(appUpdates, timeout).Should(Receive(matchers.SatisfyPredicate(
+		"Application instance is deleted",
+		func(info *eveinfo.ZInfoApp) bool {
+			return info.GetState() == eveinfo.ZSwState_INVALID
+		})))
+}

--- a/evetest/tests/security/testsuite_test.go
+++ b/evetest/tests/security/testsuite_test.go
@@ -17,6 +17,8 @@ import (
 //   - TestVCom -- vcomlink (TPM-over-vsock) request/response from inside a VM app.
 //   - TestControllerSigningCertChange -- rotation of the controller certificate
 //     signing API responses; device must recover config processing on its own.
+//   - TestControllerEncryptCertChange -- rotation of the controller ECDH
+//     certificate; object-encrypted configuration must be migrated and survive.
 func TestSecuritySuite(test *testing.T) {
 	evetest.Init(test)
 	defer evetest.Close()
@@ -34,6 +36,9 @@ func TestSecuritySuite(test *testing.T) {
 		},
 		evetest.TestCase{
 			Test: TestControllerSigningCertChange,
+		},
+		evetest.TestCase{
+			Test: TestControllerEncryptCertChange,
 		},
 	)
 }

--- a/evetest/tests/security/testsuite_test.go
+++ b/evetest/tests/security/testsuite_test.go
@@ -15,6 +15,8 @@ import (
 // --------
 //   - TestAppArmorEnabled -- kernel AppArmor status flag.
 //   - TestVCom -- vcomlink (TPM-over-vsock) request/response from inside a VM app.
+//   - TestControllerSigningCertChange -- rotation of the controller certificate
+//     signing API responses; device must recover config processing on its own.
 func TestSecuritySuite(test *testing.T) {
 	evetest.Init(test)
 	defer evetest.Close()
@@ -29,6 +31,9 @@ func TestSecuritySuite(test *testing.T) {
 		},
 		evetest.TestCase{
 			Test: TestVCom,
+		},
+		evetest.TestCase{
+			Test: TestControllerSigningCertChange,
 		},
 	)
 }

--- a/evetest/tests/security/vcom_test.go
+++ b/evetest/tests/security/vcom_test.go
@@ -176,7 +176,6 @@ func TestVCom(test *testing.T) {
 	evetest.DefineTestParameters(evetest.HypervisorParameter())
 	hypervisor := evetest.GetHypervisorParameterValue()
 
-	devName := "edge-dev"
 	evetest.Setup(
 		evetest.RequireEdgeDevice{
 			Name:              devName,
@@ -231,7 +230,7 @@ func TestVCom(test *testing.T) {
 	})
 
 	image := alpineCloudImages[device.GetArch()]
-	appAuth := evetest.UsernamePasswordAuth{
+	vmAuth := evetest.UsernamePasswordAuth{
 		Username: "root",
 		Password: "testpassword",
 	}
@@ -247,7 +246,7 @@ write_files:
       PermitRootLogin yes
 runcmd:
   - rc-service sshd restart
-`, appAuth.Password)
+`, vmAuth.Password)
 	appUUID := devConfig.AddApplication(evetest.ApplicationInstanceConfig{
 		DisplayName: "vcom-test-vm",
 		Activate:    true,
@@ -291,7 +290,7 @@ runcmd:
 	polling := 5 * time.Second
 	log.Infof("Waiting for VM SSH to become reachable...")
 	t.Eventually(func(gt Gomega) {
-		_, _, err := device.RunShellScriptInsideApp(appUUID, appAuth,
+		_, _, err := device.RunShellScriptInsideApp(appUUID, vmAuth,
 			"echo ok", sshTimeout, 0)
 		gt.Expect(err).ToNot(HaveOccurred())
 	}, 5*time.Minute, polling).Should(Succeed())
@@ -301,7 +300,7 @@ runcmd:
 	encoded := base64.StdEncoding.EncodeToString([]byte(vcomCheckScript))
 	script := "echo " + encoded + " | base64 -d > vcomcheck.py && python3 vcomcheck.py"
 	checkOut, checkErr, err := device.RunShellScriptInsideApp(
-		appUUID, appAuth, script, 60*time.Second, 0)
+		appUUID, vmAuth, script, 60*time.Second, 0)
 	t.Expect(err).ToNot(HaveOccurred(), "vComLink check script failed: %s", checkErr)
 	t.Expect(checkOut).To(
 		ContainSubstring("STATUS=200"), "unexpected vComLink response: %s", checkOut)

--- a/evetest/utils/cipherdata.go
+++ b/evetest/utils/cipherdata.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"fmt"
+	"slices"
 	"strings"
 
 	googleuuid "github.com/google/uuid"
@@ -31,9 +32,6 @@ type CryptoConfig struct {
 // certificate's public key and the controller's private key.
 func NewCryptoConfig(devECDHCert, controllerECDHCert *x509.Certificate,
 	controllerECDHKey *ecdsa.PrivateKey) (*CryptoConfig, error) {
-	// Adam trims whitespace characters before calculating hash.
-	pem := strings.TrimSpace(string(CertToPEM(controllerECDHCert)))
-	ctrlHash := sha256.Sum256([]byte(pem))
 	// EVE (tpmmgr) calculates cert hash without trimming whitespace characters.
 	devHash := sha256.Sum256(CertToPEM(devECDHCert))
 	symmetricKey, err := calculateSymmetricKeyForEcdhAES(devECDHCert, controllerECDHKey)
@@ -41,10 +39,26 @@ func NewCryptoConfig(devECDHCert, controllerECDHCert *x509.Certificate,
 		return nil, err
 	}
 	return &CryptoConfig{
-		ControllerEncCertHash: ctrlHash[:],
+		ControllerEncCertHash: ControllerCertHash(controllerECDHCert),
 		DevCertHash:           devHash[:],
 		SymmetricKey:          symmetricKey,
 	}, nil
+}
+
+// ControllerCertHash returns the full SHA-256 of a controller certificate,
+// computed the way Adam computes it: over the PEM encoding with surrounding
+// whitespace trimmed. The full 32-byte value is what Adam puts into
+// AuthContainer.SenderCertHash.
+//
+// Nothing on the device ever holds the full value. /certs truncates it to 16
+// bytes (flagged HashAlgo=SHA256_16BYTES), which is what lands in
+// types.ControllerCert.CertHash, and CreateCipherCtx likewise stores only the
+// first 16 bytes in CipherContext.ControllerCertHash. Truncate before comparing
+// against anything device-side.
+func ControllerCertHash(cert *x509.Certificate) []byte {
+	trimmed := strings.TrimSpace(string(CertToPEM(cert)))
+	sum := sha256.Sum256([]byte(trimmed))
+	return sum[:]
 }
 
 // CreateCipherCtx constructs a CipherContext using certificate hashes to
@@ -53,7 +67,9 @@ func CreateCipherCtx(cfg *CryptoConfig) (*evecommon.CipherContext, error) {
 	if len(cfg.DevCertHash) == 0 {
 		return nil, fmt.Errorf("missing device cert hash")
 	}
-	hashSeed := append(cfg.ControllerEncCertHash[:16], cfg.DevCertHash[:16]...)
+	// slices.Concat, not append: ControllerCertHash returns a full 32-byte array
+	// slice, so appending into it would overwrite the caller's own bytes 16-31.
+	hashSeed := slices.Concat(cfg.ControllerEncCertHash[:16], cfg.DevCertHash[:16])
 	ctxID := googleuuid.NewSHA1(googleuuid.UUID{}, hashSeed).String()
 
 	return &evecommon.CipherContext{
@@ -92,16 +108,16 @@ func DecryptBlock(cipher *evecommon.CipherBlock,
 	return &block, nil
 }
 
-// CipherDataHolder represents an object that contains CipherData.
-type CipherDataHolder interface {
-	GetCipherData() *evecommon.CipherBlock
-}
-
-// ReEncryptCipherData decrypts cipher data using the old CryptoConfig and
-// re-encrypts it using the new CryptoConfig and CipherContext.
-func ReEncryptCipherData(holder CipherDataHolder, oldCfg, newCfg *CryptoConfig,
-	cipherCtx *evecommon.CipherContext) error {
-	cipherData := holder.GetCipherData()
+// ReEncryptCipherBlock decrypts a CipherBlock using the old CryptoConfig and
+// re-encrypts it in place using the new CryptoConfig and CipherContext.
+// A nil block is a no-op, so callers can pass an optional field directly.
+//
+// This deliberately takes the block rather than its owner: not every cipher
+// block in the EVE API lives in a field named CipherData (the SCEP challenge
+// password and the cluster join token do not), so an owner-based interface would
+// silently exclude them.
+func ReEncryptCipherBlock(cipherData *evecommon.CipherBlock,
+	oldCfg, newCfg *CryptoConfig, cipherCtx *evecommon.CipherContext) error {
 	if cipherData == nil {
 		return nil
 	}

--- a/evetest/utils/x509.go
+++ b/evetest/utils/x509.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"time"
 
 	"crypto/ecdsa"
@@ -20,6 +21,7 @@ import (
 	"math/big"
 
 	"github.com/lf-edge/eve-api/go/certs"
+	"github.com/lf-edge/eve-api/go/evecommon"
 )
 
 // CertToPEM returns the PEM encoding of the certificate.
@@ -43,14 +45,19 @@ func ECDSAPrivateKeyToPEM(key *ecdsa.PrivateKey) ([]byte, error) {
 }
 
 // ConvertToZCert converts X.509 certificate to ZCert proto message.
+//
+// The hash must be encoded exactly as Adam encodes it when serving the same
+// certificate from /certs -- SHA-256 over the trimmed PEM, truncated to 16 bytes,
+// flagged SHA256_16BYTES -- because pillar keys types.ControllerCert on
+// hex(CertHash): any other encoding would make the device hold one certificate
+// under two keys.
 func ConvertToZCert(cert *x509.Certificate, certType certs.ZCertType) *certs.ZCert {
-	certPEM := CertToPEM(cert)
-	shaOfCert := sha256.Sum256(certPEM)
-	zcert := &certs.ZCert{}
-	zcert.Cert = certPEM
-	zcert.CertHash = shaOfCert[:]
-	zcert.Type = certType
-	return zcert
+	return &certs.ZCert{
+		Cert:     CertToPEM(cert),
+		CertHash: ControllerCertHash(cert)[:16],
+		HashAlgo: evecommon.HashAlgorithm_HASH_ALGORITHM_SHA256_16BYTES,
+		Type:     certType,
+	}
 }
 
 // ValidatePEMCerts parses PEM-encoded certificates and validates them as X.509.
@@ -196,53 +203,151 @@ func generateCertificate(
 	return cert, nil
 }
 
+// certAndKeyPEM returns the PEM encodings of a certificate and its private key
+// in the on-disk form expected by the Adam controller: RSA keys as PKCS#8
+// ("PRIVATE KEY"), ECDSA keys as SEC 1 ("EC PRIVATE KEY").
+func certAndKeyPEM(crt *x509.Certificate, key any) (certPEM, keyPEM []byte, err error) {
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: crt.Raw})
+	if certPEM == nil {
+		return nil, nil, fmt.Errorf("failed to PEM-encode certificate")
+	}
+
+	var block *pem.Block
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		der, err := x509.MarshalPKCS8PrivateKey(k)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal key to PKCS #8: %w", err)
+		}
+		block = &pem.Block{Type: "PRIVATE KEY", Bytes: der}
+	case *ecdsa.PrivateKey:
+		der, err := x509.MarshalECPrivateKey(k)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal EC key: %w", err)
+		}
+		block = &pem.Block{Type: "EC PRIVATE KEY", Bytes: der}
+	default:
+		return nil, nil, fmt.Errorf("unsupported key type: %T", key)
+	}
+	keyPEM = pem.EncodeToMemory(block)
+	if keyPEM == nil {
+		return nil, nil, fmt.Errorf("failed to PEM-encode key")
+	}
+	return certPEM, keyPEM, nil
+}
+
 // OutputCertAndKey writes an X.509 certificate and private key to disk in PEM format.
 func OutputCertAndKey(
 	crt *x509.Certificate, key any, certFile string, keyFile string,
 ) error {
-	cf, err := os.Create(certFile)
+	certPEM, keyPEM, err := certAndKeyPEM(crt, key)
 	if err != nil {
-		return fmt.Errorf("failed to create cert file %s: %w", certFile, err)
+		return err
 	}
-	defer cf.Close()
+	if err := os.WriteFile(certFile, certPEM, 0o644); err != nil {
+		return fmt.Errorf("failed to write cert file %s: %w", certFile, err)
+	}
+	if err := os.WriteFile(keyFile, keyPEM, 0o600); err != nil {
+		return fmt.Errorf("failed to write key file %s: %w", keyFile, err)
+	}
+	return nil
+}
 
-	err = pem.Encode(cf, &pem.Block{Type: "CERTIFICATE", Bytes: crt.Raw})
+// OutputCertAndKeyAtomic is OutputCertAndKey for a keypair that is replaced while
+// a reader is running: the Adam controller re-reads the signing certificate and
+// key on every signed response, and the encryption certificate on every /certs
+// request and config-hash computation, so a truncate-then-write would let it read
+// a half-written or empty file. The encryption *key* is read only at startup,
+// which is why the mismatch window below concerns the signing pair alone.
+//
+// The certificate and the key are separate files and cannot be swapped as one, so
+// a request landing between the two renames sees a mismatched signing pair. Adam
+// detects that itself -- it loads the pair through tls.X509KeyPair, whose
+// public-key equality check fails -- and answers HTTP 500, which the device
+// retries on its next poll. The check is symmetric, so the write order does not
+// change the outcome; the key is renamed first only to follow the convention of
+// installing a secret before the certificate that advertises it.
+//
+// Both files are fully staged before either is published, so the mismatch is
+// transient (bounded by one rename) rather than permanent: nothing that can fail
+// for a resource reason -- creating, writing, fsyncing or chmodding a temp file --
+// happens once the first rename has landed.
+func OutputCertAndKeyAtomic(
+	crt *x509.Certificate, key any, certFile string, keyFile string,
+) error {
+	certPEM, keyPEM, err := certAndKeyPEM(crt, key)
 	if err != nil {
-		return fmt.Errorf("failed to PEM-encode certificate: %w", err)
+		return err
 	}
-
-	kf, err := os.OpenFile(keyFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	keyTmp, err := stageFileAtomic(keyFile, keyPEM, 0o600)
 	if err != nil {
-		return fmt.Errorf("failed to create key file %s: %w", keyFile, err)
+		return fmt.Errorf("failed to write key file %s: %w", keyFile, err)
 	}
-	defer kf.Close()
-
-	switch k := key.(type) {
-	case *rsa.PrivateKey:
-		b, err := x509.MarshalPKCS8PrivateKey(k)
-		if err != nil {
-			return fmt.Errorf("failed to marshal key to PKCS #8: %w", err)
-		}
-		err = pem.Encode(kf, &pem.Block{Type: "PRIVATE KEY", Bytes: b})
-		if err != nil {
-			return fmt.Errorf("failed to PEM-encode key: %w", err)
-		}
-		return nil
-
-	case *ecdsa.PrivateKey:
-		b, err := x509.MarshalECPrivateKey(k)
-		if err != nil {
-			return fmt.Errorf("failed to marshal key to PKCS #8: %w", err)
-		}
-		err = pem.Encode(kf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: b})
-		if err != nil {
-			return fmt.Errorf("failed to PEM-encode key: %w", err)
-		}
-		return nil
-
-	default:
-		return fmt.Errorf("unsupported key type: %T", key)
+	// Both are no-ops after a successful rename.
+	defer func() { _ = os.Remove(keyTmp) }()
+	certTmp, err := stageFileAtomic(certFile, certPEM, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to write cert file %s: %w", certFile, err)
 	}
+	defer func() { _ = os.Remove(certTmp) }()
+
+	if err := os.Rename(keyTmp, keyFile); err != nil {
+		return fmt.Errorf("failed to rename %s to %s: %w", keyTmp, keyFile, err)
+	}
+	if err := os.Rename(certTmp, certFile); err != nil {
+		return fmt.Errorf("failed to rename %s to %s: %w", certTmp, certFile, err)
+	}
+	return nil
+}
+
+// WriteFileAtomic writes data into a temporary file in the same directory as
+// path, fsyncs it and renames it over path. A concurrent reader therefore
+// observes either the old or the new content, never a partially written file.
+// The mode of the resulting file is perm regardless of the umask.
+func WriteFileAtomic(path string, data []byte, perm os.FileMode) error {
+	tmpName, err := stageFileAtomic(path, data, perm)
+	if err != nil {
+		return err
+	}
+	// A no-op after a successful rename.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("failed to rename %s to %s: %w", tmpName, path, err)
+	}
+	return nil
+}
+
+// stageFileAtomic writes data into a temporary file next to path, fsyncs it and
+// gives it mode perm, leaving a rename over path as the only remaining step.
+// The temp file is removed on every error path; on success the caller owns it.
+func stageFileAtomic(path string, data []byte, perm os.FileMode) (string, error) {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file in %s: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	fail := func(err error) (string, error) {
+		_ = os.Remove(tmpName)
+		return "", err
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fail(fmt.Errorf("failed to write %s: %w", tmpName, err))
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fail(fmt.Errorf("failed to sync %s: %w", tmpName, err))
+	}
+	if err := tmp.Close(); err != nil {
+		return fail(fmt.Errorf("failed to close %s: %w", tmpName, err))
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return fail(fmt.Errorf("failed to set mode %o on %s: %w", perm, tmpName, err))
+	}
+	return tmpName, nil
 }
 
 // computeEcdsaSignature signs the payload using the given ECDSA private key


### PR DESCRIPTION
# Description

Ports Eden's `ctrl_cert_change` and `ctrl_encrypt_cert_change` to evetest, into
the **security** suite (Eden keeps both in smoke). Three commits: framework
support for rotating either controller certificate, then one test each.

Tests could not rotate either certificate before this. The only entry point was
a `ChangeSigningCert` stub that could not be implemented as declared — it took a
certificate with no private key, while the controller signs with
`signing-key.pem`.

Two differences from the Eden originals are worth calling out, because they
change what the tests prove.

**A pure encrypt-cert rotation is now possible.** Eden had to rotate the signing
certificate alongside every encrypt rotation, because the only fast trigger for
a `/certs` refetch was a signing-cert mismatch in the auth envelope and the
controller did not populate `EdgeDevConfig.controllercert_confighash`. It does
now, so the encrypt test rotates one certificate in isolation, and Eden's
cipher-context-cert-hash filter — which existed only to keep the two rotations
from clobbering each other — is dropped with it.

**A signing rotation no longer re-encrypts anything.** Eden derived cipher
contexts from the *signing* certificate, so a signing rotation there genuinely
re-encrypted every block. evetest always derives from the ECDH certificate, so
the rotation must leave object-encrypted data alone. The applications in the
signing test therefore changed role from subject to control, which means
liveness is no longer an adequate assertion — see below.

**`timer.cert.interval` is left at its 24 h default and pinned high in both
tests.** Shortening it globally would give every rotation a second way to
succeed and make the trigger these tests are named after unfalsifiable. As
pushed, the fast trigger is the only live path, and both tests pass — which is
the evidence that it works, rather than an assumption.

## What proves decryption, and what does not

Reaching RUNNING proves nothing about decryption. On a failed
`DecryptCipherBlock`, `pkg/pillar/cipher/cipher.go` passes a literal `nil` as
the error into `handleCipherBlockCredError`, whose `if err != nil` guard then
skips `SetErrorNow`; the caller sees success with an empty `EncryptionBlock`,
and the application boots with an empty environment, `AppErr` and
`CipherBlockStatus.Error` both empty. Nothing anywhere reports a failure.

So both tests read a marker back out of `/proc/1/environ` and assert domainmgr's
entry in `DeviceMetric.Cipher` — successes, no failure of any type. The counters
are the one place the silent path *is* visible (`RecordFailure` runs before that
guard), and they additionally catch a builder regression to plaintext user data,
which every other assertion here would pass. This is controller-observable; no
SSH read of on-device metrics is involved.

For applications that were already running when the rotation happened, liveness
is doubly inadequate: for an activated application domainmgr recomputes nothing
and never recreates the domain, so a marker read returns the environment planted
at the original create either way. Their `BootTime` is captured before the
rotation and required to be unchanged after.

## A correction to the Eden tests' stated rationale

Both Eden tests say the first rotation runs before
`/persist/checkpoint/controllercerts.bak` exists, so only the second exercises
the backup fallback. That was true when written and stopped being true at
`213e2c8dc` ("persist: create controllercerts.bak on first save", EVE 17.1.0),
which backfills the backup on the very first save. On 17.1.0 and later both
rotations take the identical device-side path.

Both tests still rotate twice, and the commit messages say why in each case
rather than repeating Eden's reason. In the signing test it is repeatability from
a state a rotation itself produced, and it costs 9 s. In the encrypt test the
blocks end up depending on a keypair that was itself installed by a rotation.

## Framework notes for reviewers

- Rotation overwrites the files in Adam's certificate directory. Adam must
  **not** be restarted — it re-reads them per request, and a restart regenerates
  all keypairs and undoes the rotation.
- Both files are staged before either is renamed, and the previous pair is
  restored if a rename fails. A mismatched pair makes Adam answer 500 to every
  request needing a signed response, which would strand every later test in the
  run, not just the one that asked for the rotation.
- Certificates are installed first and the device is waited for to publish the
  new one before anything is pushed. The reverse order hands the device a cipher
  context naming a certificate it does not have; domainmgr fails the decrypt,
  marks the domain `ConfigFailed` and retries only on its own 30 s timer.
- The configuration must be re-pushed even when nothing else changed:
  `parseCipherContext` returns early while the hash over the cipher-context set
  is unchanged, so re-encrypted blocks would never be re-parsed. A consequence
  worth knowing: passing a builder that is a subset of what is deployed silently
  un-deploys the difference, since EVE config is declarative.
- `resetDeviceConfig` previously retained wireless credentials, the SCEP
  challenge password and the cluster join token, so a block encrypted against a
  retired certificate could cross into the next test and stay undetectable until
  it failed to decrypt. It now clears every cipher block and the cipher contexts
  with them.
- `ApplyConfig` refuses to push a block whose context does not reference the
  current ECDH certificate. This used to regress silently: pillar keeps a
  certificate alive while a context still references it, so a stale block breaks
  nothing until the next reboot, or never.
- `EdgeDevice.WaitUntilHasControllerCert` replaces two copies of the same poll
  loop, neither of which filtered on certificate type.

`evetest/VERSION` goes 1.3 → 1.4 because the harness container must be rebuilt
for framework changes to take effect (only `tests/`, `netmodels/` and
`matchers/` are bind-mounted). Without the bump a cached or pulled
`lfedge/evetest:1.3` would supply master's framework to these tests and fail in
ways that point nowhere near the cause. That version also tags the broker image,
so publishing it needs `make build-broker-container` as well.

## PR dependencies

None. Depends on Adam >= 0.0.81 for `controllercert_confighash`, which is the
version evetest already pins.

## How to test and validate this PR

Fully covered by automated tests. From the repository root:

```sh
EVETEST_EVE_VERSION=17.2.1 make evetest NAME=TestSecuritySuite
```

Either test also runs on its own, e.g.
`make evetest NAME=TestControllerEncryptCertChange`.

Validated on amd64/KVM against EVE **17.2.1**, framework 1.4, rebased on
`30cbb56ac` — the whole security suite passes in ~15 min on a single device VM:

| Subtest | Time |
|---|---|
| `TestAppArmorEnabled` | 152 s |
| `TestVCom` | 112 s |
| `TestControllerSigningCertChange` | 331 s |
| `TestControllerEncryptCertChange` | 325 s |
| **total** | **921 s** |

`golangci-lint` deserves a note, since it caught three findings here that a
local run had missed. Two things silence it locally: a cached
`lfedge/eve-yetus:0.15.1-eve-2` predating `f1a39de2a` still passes the removed
`--out-format` flag, and any package that fails to type-check — an unrelated
stale file in the working tree is enough — makes it abandon the whole analysis
and report nothing. `docker pull` the yetus image and lint an explicit package
list if you want a trustworthy local result.

**Minimum EVE version:** the cert cross-check reads the ephemeral (`/run`)
`ControllerCert` publication, which requires EVE >= 16.9.3 — the topic was
persistent before that, and on an older build the test fails as though the
device held no controller certificates. The failure message names the path it
looked at.

Only exercised on amd64/KVM. The hypervisor is a parameter, so an eve-k or xen
run is possible, but nothing here has been run that way and I am not claiming it
passes. The first thing I would expect to need attention is the
`/proc/1/environ` read: environment delivery is hypervisor-specific
(`spec.UpdateEnvVar` exists only on the containerd path, HVM uses an
`/environment` mount, and under `HV=k` a different `cloudinit-nocloud` payload
is synthesized).

## Changelog notes

No user-facing changes.

## PR Backports

- 17.0-stable: No, test-only change; the Eden equivalents still cover this area
  on the stable branches.
- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device (KVM)
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Not tested on arm64, xen or kubevirt: this is a test-only addition and the
evetest suites are not currently run on those targets by CI. See the note above
on the one assertion I would expect to need attention off KVM.



