### PR TITLE
evetest: stop the security suite rebuilding its VMs after the first test

### DIFF
--- a/evetest/tests/security/apparmor_test.go
+++ b/evetest/tests/security/apparmor_test.go
@@ -12,11 +12,19 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/netmodels"
 )
 
 // TestAppArmorEnabled verifies that EVE's kernel has AppArmor compiled in
 // and enabled, by reading the kernel's own status flag directly over the
 // device's management SSH.
+//
+// Network model
+// -------------
+//   - netmodels.SingleEthWithDHCP -- not needed by the check itself, but the
+//     network model is compared before device requirements are, so declaring the
+//     same one as the rest of the suite is what keeps the SDN and EVE VMs from
+//     being rebuilt after this test.
 //
 // Test params
 // -----------
@@ -38,6 +46,9 @@ func TestAppArmorEnabled(test *testing.T) {
 			WithHypervisor:    hypervisor,
 			WithTPM:           true,
 			DeviceReusePolicy: evetest.ResetDeviceConfig,
+		},
+		evetest.RequireNetworkModel{
+			NetworkModel: netmodels.SingleEthWithDHCP,
 		},
 	)
 	device := evetest.GetEdgeDevice(devName)


### PR DESCRIPTION
# Description

`TestAppArmorEnabled` declares no `RequireNetworkModel`, so `Setup` synthesizes
one for it. `maybeReuseDevices` compares the network model *before* it looks at
device requirements and gives up on reuse as soon as the models differ, so the
SDN and EVE VMs were torn down and rebuilt between this test and the next one on
every run of the security suite — for a check that reads one kernel flag.

Declaring the same model as the rest of the suite makes the device reusable. The
check itself does not care about network topology; the declaration exists only
to satisfy the comparison.

Found while porting the certificate-rotation tests into this suite (#6333),
which is what made the cost visible. Sent separately because it is unrelated to
those tests and helps the suite on its own.

## PR dependencies

None.

## How to test and validate this PR

```sh
EVETEST_EVE_VERSION=17.2.1 make evetest NAME=TestSecuritySuite
```

Measured on amd64/KVM against EVE 17.2.1, with the certificate-rotation tests
present in the suite so there is something after `TestAppArmorEnabled` to reuse
the device:

| | Runtime | EVE VMs | SDN VMs |
|---|---|---|---|
| without this change | 882 s | 2 | 2 |
| with this change | 783 s | 1 | 1 |

So it is worth ~99 s and one VM build per suite run. The saving grows with the
number of subtests placed after `TestAppArmorEnabled`.

The suite passes 4/4 either way — this is a runtime fix, not a correctness fix.

## Changelog notes

No user-facing changes.

## PR Backports

- 17.0-stable: No, test-only change.
- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device (KVM)
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Not tested on arm64: test-only change, and the evetest suites are not currently
run on that target by CI.
