### PR TITLE
cipher: report a failed decryption as a failure

### DIFF
--- a/pkg/pillar/cipher/cipher.go
+++ b/pkg/pillar/cipher/cipher.go
@@ -41,8 +41,8 @@ func GetCipherCredentials(ctx *DecryptCipherContext,
 	var decBlock types.EncryptionBlock
 	cipherBlock, clearBytes, err := GetCipherMarshalledData(ctx, status)
 	if err != nil {
-		return handleCipherBlockCredError(ctx, &cipherBlock,
-			decBlock, err, types.DecryptFailed)
+		// Already counted and marked in-error by GetCipherMarshalledData.
+		return cipherBlock, decBlock, err
 	}
 
 	var zconfigDecBlock zcommon.EncryptionBlock
@@ -91,7 +91,7 @@ func GetCipherMarshalledData(ctx *DecryptCipherContext,
 		ctx.Log.Errorf("%s, cipherblock decryption failed, %v\n",
 			cipherBlock.Key(), err)
 		cblock, _, err := handleCipherBlockCredError(ctx, cipherBlock,
-			decBlock, nil, types.Invalid)
+			decBlock, err, types.DecryptFailed)
 		return cblock, nil, err
 	}
 

--- a/pkg/pillar/cipher/cipher_test.go
+++ b/pkg/pillar/cipher/cipher_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cipher
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/sirupsen/logrus"
+)
+
+func testDecryptContext() *DecryptCipherContext {
+	return &DecryptCipherContext{
+		Log:          base.NewSourceLogObject(logrus.StandardLogger(), "test", 0),
+		AgentName:    "test",
+		AgentMetrics: NewAgentMetrics("test"),
+	}
+}
+
+// undecryptableBlock fails inside DecryptCipherBlock on the empty-payload check,
+// before any controller/edge-node cert lookup, so no subscriptions are needed.
+func undecryptableBlock() types.CipherBlockStatus {
+	return types.CipherBlockStatus{
+		CipherBlockID:   "test-block",
+		CipherContextID: "test-context",
+		IsCipher:        true,
+	}
+}
+
+func TestGetCipherMarshalledDataFailsClosed(t *testing.T) {
+	ctx := testDecryptContext()
+
+	status, clearBytes, err := GetCipherMarshalledData(ctx, undecryptableBlock())
+	if err == nil {
+		t.Fatalf("decryption failure reported as success (clearBytes=%v)", clearBytes)
+	}
+	if !status.HasError() {
+		t.Fatal("decryption failure left the cipher block status un-errored")
+	}
+}
+
+func TestGetCipherCredentialsFailsClosed(t *testing.T) {
+	ctx := testDecryptContext()
+
+	status, decBlock, err := GetCipherCredentials(ctx, undecryptableBlock())
+	if err == nil {
+		t.Fatalf("decryption failure reported as success (decBlock=%+v)", decBlock)
+	}
+	if !status.HasError() {
+		t.Fatal("decryption failure left the cipher block status un-errored")
+	}
+	if !reflect.DeepEqual(decBlock, types.EncryptionBlock{}) {
+		t.Fatalf("expected no plaintext on failure, got %+v", decBlock)
+	}
+}
+
+// The !IsCipher branch is a misuse guard, not a decryption failure: callers are
+// expected to check IsCipher and supply their own cleartext, so it stays
+// non-fatal.
+func TestGetCipherMarshalledDataNotCipher(t *testing.T) {
+	ctx := testDecryptContext()
+
+	status := types.CipherBlockStatus{CipherBlockID: "test-block"}
+	outStatus, _, err := GetCipherMarshalledData(ctx, status)
+	if err != nil {
+		t.Fatalf("expected no error for a non-cipher block, got %v", err)
+	}
+	if outStatus.HasError() {
+		t.Fatal("non-cipher block should not be marked in-error")
+	}
+}
+
+// A failed decrypt must be counted once: GetCipherMarshalledData records it and
+// GetCipherCredentials only propagates the error.
+func TestGetCipherCredentialsCountsFailureOnce(t *testing.T) {
+	ctx := testDecryptContext()
+
+	if _, _, err := GetCipherCredentials(ctx, undecryptableBlock()); err == nil {
+		t.Fatal("decryption failure reported as success")
+	}
+
+	m := ctx.AgentMetrics.metrics
+	if m.FailureCount != 1 {
+		t.Errorf("FailureCount = %d, want 1", m.FailureCount)
+	}
+	if m.SuccessCount != 0 {
+		t.Errorf("SuccessCount = %d, want 0", m.SuccessCount)
+	}
+	if got := m.TypeCounters[types.DecryptFailed]; got != 1 {
+		t.Errorf("TypeCounters[DecryptFailed] = %d, want 1", got)
+	}
+	if got := m.TypeCounters[types.Invalid]; got != 0 {
+		t.Errorf("TypeCounters[Invalid] = %d, want 0", got)
+	}
+}
+
+// A block that arrived already in error never reached decryption, so it counts
+// as NotReady and not as a decryption failure.
+func TestGetCipherCredentialsNotReadyCountedAsNotReady(t *testing.T) {
+	ctx := testDecryptContext()
+	status := undecryptableBlock()
+	status.SetErrorNow("cipher context not found")
+
+	if _, _, err := GetCipherCredentials(ctx, status); err == nil {
+		t.Fatal("not-ready cipher block reported as success")
+	}
+
+	m := ctx.AgentMetrics.metrics
+	if m.FailureCount != 1 {
+		t.Errorf("FailureCount = %d, want 1", m.FailureCount)
+	}
+	if got := m.TypeCounters[types.NotReady]; got != 1 {
+		t.Errorf("TypeCounters[NotReady] = %d, want 1", got)
+	}
+	if got := m.TypeCounters[types.DecryptFailed]; got != 0 {
+		t.Errorf("TypeCounters[DecryptFailed] = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
# Description

`GetCipherMarshalledData` passed a literal `nil` where
`handleCipherBlockCredError` expects the error that just occurred. That helper
only sets the object error when its `err` argument is non-nil, and it returns
that same argument, so a failed `DecryptCipherBlock` produced neither an error
nor an error state. `GetCipherCredentials` then unmarshalled a nil payload —
which `proto.Unmarshal` accepts as an empty message — recorded a **success**,
and handed the caller a zero `EncryptionBlock`.

A decryption failure was therefore indistinguishable from a decrypted empty
secret. An application with encrypted cloud-init user data reached RUNNING with
an empty environment, `AppErr` empty and `CipherBlockStatus.Error` empty. The
only trace anywhere was the cipher metrics, because `RecordFailure` runs before
the guard — and even those were wrong, since `SuccessCount` was incremented too.

This is a regression, not the original design. `786a54885` ("Handle the
Patch-Envelope Encrypted Artifacts", Mar 2025) split `GetCipherMarshalledData`
out of `GetCipherCredentials` and in the process changed this branch from
passing `err` to passing `nil`; before that commit the error was forwarded
correctly.

The fix is one token. The tests are the substance of the change.

## Why this does not remove a legitimate cleartext fallback

Worth stating explicitly, because it looks like a fail-closed change that could
break working devices, and it is closer to the opposite.

The lawful cleartext fallback lives in the *callers*, not in this package. Each
one records `CleartextFallback` or `MissingFallback` itself and decides whether
to proceed on cleartext — and every one of those paths is gated on `err != nil`,
so all of them were being skipped because the error never arrived. Passing `err`
through is what lets them run.

Call sites, and what changes when a decrypt now fails loudly:

| Caller | Before | After |
|---|---|---|
| `domainmgr` `getCloudInitUserData` | app boots RUNNING with an empty environment, no error | falls back to cleartext `CloudInitUserData` if present; otherwise a domain error surfaces in the API |
| `msrv` `getCloudInitUserData` | empty user data served over the metadata service | falls back, or errors with "no fallback data" |
| `dpcreconciler` `getWifiCredentials` | empty SSID credentials → silent association failure | falls back to `wifi.Identity`/`wifi.Password` |
| `downloader` `getDatastoreCredential` | empty API key → 403 on download | falls back to `dst.ApiKey`/`dst.Password` |
| `collectinfo` | empty credentials → upload fails | falls back to the datastore's cleartext fields |
| `zedkube` `decryptClusterTokenAndManifest` | empty cluster token published, join fails silently | `EdgeNodeClusterStatus.Error` set |
| `scepclient` `decryptChallengePassword` | empty challenge password → server rejects | error before the request |
| `msrv` `PopulateBinaryBlobFromCipher` | blob built from nil: empty filename, sha of `""` | error, logged and skipped by the caller |

**The one newly user-visible case** is the first: an application whose user data
is encrypted with no cleartext to fall back to now reports an error instead of
booting with an empty environment. That is the bug being fixed, but it is a
behaviour change on a device-management path and is the thing to review.

`SuccessCount` is no longer incremented for a failed decrypt. `FailureCount`
goes up, never down.

## Not included, deliberately

Three adjacent defects found while tracing this, each separable and none of them
this bug:

- `collectinfo` is the only caller that does not check `IsCipher`, so for a
  plain-cleartext datastore it takes the sibling `!IsCipher` branch (which still
  passes `nil`, correctly — it is a misuse guard) and silently drops
  `datastore.ApiKey`/`Password`. The fix belongs in `collectinfo`.
- `msrv` nests `if err != nil { return }` *inside* `if pub != nil` in two places,
  so it still discards the error when the publisher is absent.
- `handleCipherBlockCredError`'s `reflect.DeepEqual` branch that resets `err` to
  nil on valid data is dead code — no call site passes a non-zero `decBlock`.

## PR dependencies

None.

## How to test and validate this PR

The package had no tests. Three are added, all driving the failure through
`DecryptCipherBlock`'s empty-payload check so no controller or edge-node
certificate subscriptions are needed:

- `TestGetCipherMarshalledDataFailsClosed` — non-nil error and the block is
  marked in-error
- `TestGetCipherCredentialsFailsClosed` — the reported symptom: non-nil error,
  block in-error, and no plaintext
- `TestGetCipherMarshalledDataNotCipher` — pins the `!IsCipher` branch as
  deliberately non-fatal, so the distinction is not lost later

```sh
make -C pkg/pillar test
```

Two of the three fail without the one-token change and pass with it:

```
WITHOUT FIX: 1 passed, 2 failed
  [FAIL] TestGetCipherMarshalledDataFailsClosed: decryption failure reported as success (clearBytes=[])
  [FAIL] TestGetCipherCredentialsFailsClosed:    decryption failure reported as success (decBlock={...})
WITH FIX:    3 passed
```

Full dockerized pillar suite green: 1986 tests, 18 environment-dependent skips,
0 failures. Also `-race` on `./cipher/...`, and `go build` under both `-tags k`
and `-tags kvm`.

Not exercised on hardware: the behaviour change is reachable only with an
encrypted secret that genuinely fails to decrypt, which is what a controller
certificate rotation without re-encryption produces. #6333 adds evetest coverage
that asserts the cipher counters from the controller side, which is the
regression test for the success path.

## Changelog notes

A failed decryption of controller-supplied encrypted data (application user
data, WiFi or datastore credentials, SCEP challenge password, cluster token) is
now reported as an error instead of being treated as an empty successfully
decrypted value. Devices that were silently running with empty secrets will now
surface an error for the affected object.

## PR Backports

The regression ships in all three current stable branches (verified: the
`decBlock, nil, types.Invalid` call is present on `14.5-stable`, `16.0-stable`
and `17.0-stable`), so this wants backporting.

- 17.0-stable: Yes
- 16.0-stable: Yes
- 14.5-stable: Yes
- 13.4-stable: No, predates `786a54885`.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device (KVM)
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Covered by unit tests and the full pillar suite rather than by a hardware run;
the code is architecture-independent, so an arm64 run would exercise the same
path.
