### PR TITLE
tools: fix Docker Hub 403 in update_kernel_commits.py

### DIFF
--- a/tools/update_kernel_commits.py
+++ b/tools/update_kernel_commits.py
@@ -797,7 +797,7 @@ def find_updated_branches(old_commits, new_commits, token=None, verbose=False):
 
 
 def get_kernel_tags_from_dockerhub(
-    username, repository, search_pattern: str = "", verbose=False
+    username, repository, search_pattern: str = "", name_filter: str = "", verbose=False
 ):
     """
     Retrieves Docker tags from Docker Hub for a given repository.
@@ -807,6 +807,9 @@ def get_kernel_tags_from_dockerhub(
         repository (str): The name of the Docker repository.
         search_pattern (str, optional): A regular expression pattern to filter Docker tags.
         Defaults to None.
+        name_filter (str, optional): Substring passed to the Docker Hub API to filter tags
+        server-side. Anonymous requests are rejected with 403 once the pagination offset
+        exceeds ~1000 tags, so keep the result set small instead of listing every tag.
         verbose (bool, optional): Increase output verbosity if True. Defaults to False.
 
     Returns:
@@ -815,46 +818,33 @@ def get_kernel_tags_from_dockerhub(
     tags = []
     tags_url = (
         f"https://hub.docker.com/v2/repositories/{username}/{repository}/"
-        f"tags/?page_size=1000"
+        f"tags/?page_size=100&ordering=last_updated"
     )
-
-    total_tags_fetched = 0
-    regex_pattern = None
+    if name_filter:
+        tags_url += f"&name={name_filter}"
 
     # convert search patterns to gerexp
-    if search_pattern != "":
-        regex_pattern = pattern_to_regex(search_pattern)
+    regex_pattern = pattern_to_regex(search_pattern) if search_pattern else None
 
     while True:
         response = requests.get(tags_url, timeout=30)
 
         if response.status_code == 200:
             tags_json = response.json()
-            count = tags_json["count"]
             # pretty print tags_json
             if verbose:
                 print(json.dumps(tags_json, indent=4, sort_keys=True))
 
-            raw_results = tags_json["results"]
-            total_tags_fetched += len(raw_results)
-
-            for tag in raw_results:
-                if regex_pattern:
-                    if re.match(regex_pattern, tag["name"]):
-                        tags.append((tag["name"], tag["tag_last_pushed"]))
-                else:
-                    tags.append((tag["name"], tag["tag_last_pushed"]))
-
-            # print progress overwrite the same line
-            print(f"Fetching docker tags: {total_tags_fetched} / {count}", end="\r")
+            for tag in tags_json["results"]:
+                if regex_pattern and not re.match(regex_pattern, tag["name"]):
+                    continue
+                tags.append((tag["name"], tag["tag_last_pushed"]))
 
             if tags_json["next"]:
                 tags_url = tags_json["next"]
                 if verbose:
                     print(tags_url)
             else:
-                # to keep progress on the screen
-                print(f"Fetching docker tags: {total_tags_fetched} / {count}")
                 break
         else:
             print(
@@ -864,24 +854,47 @@ def get_kernel_tags_from_dockerhub(
     return tags
 
 
-def fetch_docker_tags(verbose=False):
+def _fetch_tags_per_branch(branches, verbose=False):
+    """
+    Fetches docker tags for each branch separately.
+
+    Args:
+        branches (iterable): Branch names to look up tags for.
+        verbose (bool, optional): Increase output verbosity if True. Defaults to False.
+
+    Returns:
+        list: A list of tuples containing Docker tags and their last push dates.
+    """
+    docker_username = "lfedge"
+    repository = "eve-kernel"
+    branch_search_pattern = "eve-kernel-*"
+    branches = list(branches)
+    tags = []
+    for num, branch in enumerate(branches, start=1):
+        print(f"Fetching docker tags: {num} / {len(branches)} branches", end="\r")
+        tags += get_kernel_tags_from_dockerhub(
+            docker_username, repository, branch_search_pattern, branch, verbose
+        )
+    # to keep progress on the screen
+    print(f"Fetching docker tags: {len(branches)} / {len(branches)} branches")
+    return tags
+
+
+def fetch_docker_tags(branches, verbose=False):
     """
     Fetches kernel commits from docker hub and returns them as a dictionary of
     (branch, commit) pairs.
 
     Args:
+        branches (iterable): Branch names to look up tags for. Each one is queried
+        separately so no single listing runs past the anonymous pagination limit.
         verbose (bool): If True, prints all tags with decoded dates and all kernel commits
         from docker hub.
 
     Returns:
         dict: A dictionary of (branch, commit) pairs.
     """
-    docker_username = "lfedge"
-    repository = "eve-kernel"
-    branch_search_pattern = "eve-kernel-*"
-    docker_tag_list = get_kernel_tags_from_dockerhub(
-        docker_username, repository, branch_search_pattern
-    )
+    docker_tag_list = _fetch_tags_per_branch(branches, verbose)
 
     # group tags by common capture group e.g. amd64-v6.1.38-generic
     tag_groups = {}
@@ -1123,7 +1136,8 @@ def adjust_branches_by_docker_tags(new_commits, updated_branches, docker_tags):
                     f"{branch} will not be updated."
                 )
                 del updated_branches[branch]
-                del new_commits[branch]
+                # a branch removed from github is not in new_commits at all
+                new_commits.pop(branch, None)
 
         return is_error
 
@@ -1221,9 +1235,15 @@ def main():
 
     print_updated_branches(updated_branches)
 
+    # branches gone from github are still in kernel-commits.mk and their docker tags
+    # linger, so query them too to have them reported as removed rather than untagged
+    queried_branches = list(new_commits) + [
+        branch for branch in updated_branches if branch not in new_commits
+    ]
+
     # fetch tags from docker hub and convert them to branch names
     if adjust_branches_by_docker_tags(
-        new_commits, updated_branches, fetch_docker_tags(args.verbose)
+        new_commits, updated_branches, fetch_docker_tags(queried_branches, args.verbose)
     ):
         print(
             Fore.RED


### PR DESCRIPTION
# Description

`tools/update_kernel_commits.py` currently fails at the Docker Hub stage with:

```text
Error: 403 {"message":"pagination offset too large for anonymous requests; sign in to page further","errinfo":{}}
```

The script listed *every* tag of `lfedge/eve-kernel` with `page_size=1000`.
Docker Hub silently clamps `page_size` to 100, so with the repository now
holding ~1350 tags the walk needed 14 pages, and Docker Hub rejects anonymous
requests once the pagination offset passes ~1000. The script used to work
simply because the repository had fewer tags; it now breaks unconditionally,
so no kernel update can be generated with it.

This queries the tags of one branch at a time instead, using the Docker Hub
API's server-side `name` substring filter together with
`ordering=last_updated`. Each branch has only a handful of tags, so no listing
ever approaches the anonymous pagination limit and no Docker Hub login is
required. As a side effect the lookup is faster: a dozen small requests
instead of fourteen full pages.

Concretely:

- `get_kernel_tags_from_dockerhub()` takes a `name_filter` argument and
  requests `page_size=100&ordering=last_updated`.
- `fetch_docker_tags()` takes the branch list and queries each branch
  separately; the progress line now counts branches instead of tags.
- `main()` passes the branches gathered from GitHub down to
  `fetch_docker_tags()`, so the set of queried branches is unchanged.

Behaviour is otherwise identical: the same tag-grouping regex and
"most recently pushed tag wins" logic decide the commit per branch, and
branches with no Docker tag are still reported and dropped as before.

## How to test and validate this PR

There is no automated test for the Docker Hub code path (the existing pytest
cases in the script cover only branch-name parsing). Validate manually:

1. Check out this branch and run the tool from the top of the repository:

   ```sh
   ./tools/update_kernel_commits.py -t <github-token>
   ```

2. It must run to completion and print the usual tips:

   ```text
   Fetching docker tags: 12 / 12 branches
   Commit message generated and saved to kernel-update-commit-message.txt
   ```

   No `403` and no `pagination offset too large` message.

3. Confirm the outputs are sane: `git diff kernel-commits.mk` shows the branch
   updates listed under "Updated branches:", and
   `kernel-update-commit-message.txt` contains the per-branch commit ranges.
   Discard both afterwards if you are only testing the tool.

4. To see the failure this fixes, run the same command on `master` — it stops
   at `Fetching docker tags: 1000 / 1349` with the 403 above.

Verified on this branch: the run completes and correctly reports
`eve-kernel-amd64-v6.12.96-generic` moving from `bfc617435842` to
`5ec53c5d956c`, plus the branches present on GitHub but missing from
`kernel-commits.mk`.

## Changelog notes

No user-facing changes. Tooling only: fixes the `update_kernel_commits.py`
helper used by maintainers to refresh `kernel-commits.mk`.

## PR Backports

All four LTS branches carry the same `page_size=1000` listing and are
therefore equally broken, and kernel updates are generated on stable branches
too, so the tool needs to work there:

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — not applicable, no documented
  behaviour or interface changes; the reason for the per-branch query is
  captured in the docstring and the commit message.
- [ ] I've tested my PR on amd64 device — not applicable, this is a host-side
  maintainer script that is not part of any EVE image. Tested by running it on
  an amd64 host.
- [ ] I've tested my PR on arm64 device — not applicable, same reason as above.
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
