### PR TITLE
tools: allow running mini-yetus from a git worktree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,10 +80,6 @@ make check-docker-hashes-consistency # Check if packages are pointing to the lat
 
 `mini-yetus` accepts `MYETUS_SBRANCH`, `MYETUS_DBRANCH`, `MYETUS_VERBOSE=Y`. CI workflows live under `.github/workflows/` — `pr-gate.yml`, `go-tests.yml`, `yetus.yml`, `codeql.yml`, `build.yml`. The shellcheck config (`shellcheckrc`) disables SC3043.
 
-**Do not run `mini-yetus` from a `git worktree` — it will destroy your branch.** `tools/mini-yetus.sh` copies the top-level dotfiles into a scratch directory and then runs `git init && git add . && git commit` there. In a worktree `.git` is a *file* holding a `gitdir:` pointer rather than a directory, so it gets copied along with the other dotfiles; `git init` then finds an existing repository through that pointer and the commit lands on your real checked-out branch, recording the sparse scratch copy as a deletion of nearly every file in the repo. In a normal clone `.git` is a directory, is not copied, and the scratch repo is created as intended.
-
-The same redirection also sends the script's `git config user.name`/`user.email` calls to the real repository, so it leaves `Your Name <you@example.com>` in `.git/config`, which silently overrides your global identity and unsigns every later commit. To recover: `git reset --hard` back to the last good commit from `git reflog` — the bogus commit (`Changes in the PR`) sits on top of your work rather than replacing it — then `git config --unset user.name && git config --unset user.email`, and check `git log` for commits that picked up the wrong `Signed-off-by`. Run `mini-yetus` from a normal clone instead.
-
 ## Debugging on a live device
 
 - `eve version`, `zboot curpart` — running version and active IMGA/IMGB partition.
@@ -183,7 +179,7 @@ From `CONTRIBUTING.md` / `.github/pull_request_template.md`:
 - When fixing a batch of independent findings (e.g. from an audit), make one commit per logical fix rather than one big commit.
 - When generating code, avoid excessive comments inside function bodies. In-function comments should be as summarized as possible — comment only non-obvious constraints or tricky logic, never narrate what each line does.
 - Backport PRs follow a specific title format `[<stable-branch>] Original title`, with a body line `Backport of #<original-PR-number>` and `git cherry-pick -x` to preserve the source SHA.
-- `mini-yetus` is the cheap pre-push check; full `make yetus` mirrors CI but is slow. Neither may be run from a `git worktree` (see "Linting / CI parity").
+- `mini-yetus` is the cheap pre-push check; full `make yetus` mirrors CI but is slow.
 - Any changes on vendor files should always be committed on a dedicated commit. For eve-api, eve-libs, edge-containers and pillar there are specific make targets to automate bumping versions:
 
 ```sh

--- a/tools/mini-yetus.sh
+++ b/tools/mini-yetus.sh
@@ -134,12 +134,25 @@ else
 fi
 cp -Rf .yetus "$SRC_DIR/"
 
-cd "$SRC_DIR" && \
-    git init >/dev/null 2>&1 && \
-    git add . >/dev/null 2>&1 && \
-    git config user.email "you@example.com" >/dev/null 2>&1 && \
-    git config user.name "Your Name" >/dev/null 2>&1 && \
-    git commit -m "Changes in the PR" >/dev/null 2>&1
+# In a git worktree .git is a *file* holding a gitdir: pointer, so the dot file
+# copy above drags it along. Left in place, it makes the git commands below
+# operate on the real repository instead of the scratch one.
+rm -rf "$SRC_DIR/.git"
+
+cd "$SRC_DIR" || { echo "[!] Error: Could not enter $SRC_DIR."; exit 1; }
+git init >/dev/null 2>&1 || { echo "[!] Error: Could not initialize the scratch repository."; exit 1; }
+# a leftover .git pointer keeps the toplevel here but sends every ref update to
+# the pointed-at repository, so the git directory is what has to be checked
+if [ "$(git rev-parse --absolute-git-dir 2>/dev/null)" != "$(pwd -P)/.git" ]; then
+    echo "[!] Error: The scratch repository resolves outside $SRC_DIR, refusing to commit."
+    exit 1
+fi
+# Failing here would leave an empty scratch repository, and yetus reports a clean
+# run on an empty diff, so a silent failure looks like a pass.
+git add . >/dev/null 2>&1 || { echo "[!] Error: Could not stage the changes."; exit 1; }
+git -c user.email="you@example.com" -c user.name="Your Name" \
+    commit -m "Changes in the PR" >/dev/null 2>&1 ||
+    { echo "[!] Error: Could not commit the changes."; exit 1; }
 
 echo "[+] Running yetus on the changes..."
 docker run --rm -v "$SRC_DIR":/src:delegated,z docker.io/lfedge/eve-yetus:0.15.1-eve-2 \


### PR DESCRIPTION
# Description

`mini-yetus` can now be run from a `git worktree`. It could not before: in a
worktree `.git` is a file holding a `gitdir:` pointer, so the script's dot-file
copy dragged it into the scratch directory, `git init` resolved through it, and
the commit landed on the real checked-out branch as a deletion of nearly every
file. The `git config` calls went to the same place, writing
`Your Name <you@example.com>` into `.git/config` and unsigning every later
commit.

The fix drops the copied pointer before `git init`, passes the commit identity
with `git -c` so nothing is written to a config file at all, and aborts loudly
if the scratch repository resolves elsewhere or the commit fails.

Also removes the CLAUDE.md passages that warned against running it from a
worktree.

## How to test and validate this PR

```sh
make mini-yetus   # from a git worktree
```

Verified in throwaway clones: run from a worktree, the unpatched script commits
16.1M deletions onto the branch and overwrites the git identity; patched, HEAD,
commit count and identity are all unchanged and the run completes normally. A
normal checkout behaves as before. `shellcheck` clean.

## Changelog notes

No user-facing changes. Developer tooling only.

## PR Backports

- 17.0-stable: No, developer tooling and not shipped to devices.
- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device (KVM)
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

No device testing: this is a developer lint helper that never runs on a device.
