### PR TITLE
evetest: stop failing healthy downloads as stalled

### DIFF
--- a/evetest/edgedevice.go
+++ b/evetest/edgedevice.go
@@ -1268,11 +1268,20 @@ func (d *EdgeDevice) WaitUntilAppIsRunning(
 			if vinfo == nil {
 				return false, nil
 			}
+			prev, hadPrev := volumes[vinfo.GetUuid()]
 			volumes[vinfo.GetUuid()] = vinfo
+			// A volume moving to another state is progress even when the
+			// percentage does not move: EVE reports 0/0 bytes for
+			// container-registry downloads (downloader's resp.Progress()),
+			// so the percentage is not a liveness signal for those at all.
+			stateChanged := !hadPrev || prev.GetState() != vinfo.GetState()
 			// If the app is in DOWNLOAD_STARTED state, a volume update may
 			// change the reported progress -- check and log.
 			if inDownload {
 				pct := appDownloadProgress(volumeRefs, volumes)
+				if stateChanged && timer != nil {
+					timer.Reset(downloadStalledTimeout)
+				}
 				if pct != lastDownloadPct {
 					lastDownloadPct = pct
 					if timer != nil {
@@ -3023,14 +3032,22 @@ func appDownloadProgress(
 			// No info received yet for this volume; treat as 0%.
 			continue
 		}
-		state := vol.GetState()
-		switch {
-		case state == eveinfo.ZSwState_INVALID || state == eveinfo.ZSwState_INITIAL:
-			// 0 -- nothing added
-		case state >= eveinfo.ZSwState_DOWNLOADED:
-			total += 100
-		default:
+		// ZSwState is NOT ordered by progress. The states appended after the
+		// original sequence carry higher numbers than DOWNLOADED (3) while
+		// happening earlier: RESOLVING_TAG is 12, RESOLVED_TAG 13. Comparing
+		// with >= therefore reported an image as 100% downloaded while its tag
+		// was still being resolved, and the figure then "fell" to 0% once the
+		// download genuinely started. Classify explicitly instead.
+		switch vol.GetState() {
+		case eveinfo.ZSwState_INVALID, eveinfo.ZSwState_INITIAL,
+			eveinfo.ZSwState_RESOLVING_TAG, eveinfo.ZSwState_RESOLVED_TAG:
+			// Nothing downloaded yet.
+		case eveinfo.ZSwState_DOWNLOAD_STARTED:
 			total += vol.GetProgressPercentage()
+		default:
+			// DOWNLOADED and every state past it (DELIVERED, INSTALLED,
+			// CREATING_VOLUME, VERIFYING, LOADING, LOADED, BOOTING, RUNNING...).
+			total += 100
 		}
 	}
 	return total / uint32(len(volumeRefs))

--- a/evetest/edgedevice.go
+++ b/evetest/edgedevice.go
@@ -1270,23 +1270,24 @@ func (d *EdgeDevice) WaitUntilAppIsRunning(
 			}
 			prev, hadPrev := volumes[vinfo.GetUuid()]
 			volumes[vinfo.GetUuid()] = vinfo
-			// A volume moving to another state is progress even when the
-			// percentage does not move: EVE reports 0/0 bytes for
-			// container-registry downloads (downloader's resp.Progress()),
-			// so the percentage is not a liveness signal for those at all.
-			stateChanged := !hadPrev || prev.GetState() != vinfo.GetState()
+			// A volume of THIS app moving to another state is progress even
+			// when the percentage does not move: EVE reports 0/0 bytes for
+			// container-registry downloads (downloader's resp.Progress()), so
+			// the percentage is not a liveness signal for those at all. The
+			// membership check matters: `volumes` accumulates every volume on
+			// the device, and an unrelated one flapping states would otherwise
+			// keep this app's stall timer alive forever.
+			stateChanged := isAppVolume(vinfo.GetUuid(), volumeRefs) &&
+				(!hadPrev || prev.GetState() != vinfo.GetState())
 			// If the app is in DOWNLOAD_STARTED state, a volume update may
 			// change the reported progress -- check and log.
 			if inDownload {
 				pct := appDownloadProgress(volumeRefs, volumes)
-				if stateChanged && timer != nil {
+				if timer != nil && (stateChanged || pct != lastDownloadPct) {
 					timer.Reset(downloadStalledTimeout)
 				}
 				if pct != lastDownloadPct {
 					lastDownloadPct = pct
-					if timer != nil {
-						timer.Reset(downloadStalledTimeout)
-					}
 					if live {
 						d.th.log.Infof("App %q (%s) on device %q state changed to %s (%d%%)",
 							appUUID, appName, d.devName, lastState, pct)
@@ -3015,11 +3016,25 @@ func (f flowMsgIterFn) Iterate(msg *eveflowlog.FlowMessage) (bool, error) { retu
 // appDownloadProgress returns the average download progress (0–100) across
 // the app's volumes. For each volume UUID listed in volumeRefs the progress
 // is taken from the latest ZInfoVolume in volumes:
-//   - INVALID or INITIAL state → 0%
-//   - DOWNLOADED or above      → 100%
-//   - any other state          → ProgressPercentage as reported
+//   - not started yet (INVALID, INITIAL, RESOLVING_TAG, RESOLVED_TAG) → 0%
+//   - failed (ERROR)                                                  → 0%
+//   - DOWNLOAD_STARTED → ProgressPercentage as reported by the device
+//   - anything past the download (DOWNLOADED, DELIVERED, INSTALLED,
+//     CREATING_VOLUME, VERIFYING, LOADING, LOADED, BOOTING, RUNNING, …) → 100%
+//
+// The classification is explicit because ZSwState is not ordered by progress.
 //
 // Returns 0 if volumeRefs is empty or no volume info has been received yet.
+// isAppVolume reports whether uuid is one of the app's own volumes.
+func isAppVolume(uuid string, volumeRefs []string) bool {
+	for _, ref := range volumeRefs {
+		if ref == uuid {
+			return true
+		}
+	}
+	return false
+}
+
 func appDownloadProgress(
 	volumeRefs []string, volumes map[string]*eveinfo.ZInfoVolume) uint32 {
 	if len(volumeRefs) == 0 {
@@ -3042,6 +3057,10 @@ func appDownloadProgress(
 		case eveinfo.ZSwState_INVALID, eveinfo.ZSwState_INITIAL,
 			eveinfo.ZSwState_RESOLVING_TAG, eveinfo.ZSwState_RESOLVED_TAG:
 			// Nothing downloaded yet.
+		case eveinfo.ZSwState_ERROR:
+			// A failed volume is not a downloaded one. Reporting 100% here
+			// would retire the stall timer and leave the app to fail against
+			// the (much longer) non-download budget instead.
 		case eveinfo.ZSwState_DOWNLOAD_STARTED:
 			total += vol.GetProgressPercentage()
 		default:

--- a/evetest/edgedevice_test.go
+++ b/evetest/edgedevice_test.go
@@ -40,6 +40,9 @@ func TestAppDownloadProgress(t *testing.T) {
 		{"downloading, partway", vol(eveinfo.ZSwState_DOWNLOAD_STARTED, 42), 42},
 		// After the download.
 		{"downloaded", vol(eveinfo.ZSwState_DOWNLOADED, 0), 100},
+		// A failed volume must not read as complete, or the stall timer is
+		// retired and the app fails against the wrong (much longer) budget.
+		{"error", vol(eveinfo.ZSwState_ERROR, 0), 0},
 		{"delivered", vol(eveinfo.ZSwState_DELIVERED, 0), 100},
 		{"installed", vol(eveinfo.ZSwState_INSTALLED, 0), 100},
 		{"creating volume", vol(eveinfo.ZSwState_CREATING_VOLUME, 0), 100},
@@ -75,5 +78,19 @@ func TestAppDownloadProgressAveraging(t *testing.T) {
 	}
 	if got := appDownloadProgress(nil, volumes); got != 0 {
 		t.Errorf("no volume refs = %d%%, want 0%%", got)
+	}
+}
+
+// TestIsAppVolume covers the membership check that keeps an unrelated
+// volume's state changes from resetting this app's stall timer.
+func TestIsAppVolume(t *testing.T) {
+	refs := []string{"a", "b"}
+	for uuid, want := range map[string]bool{"a": true, "b": true, "c": false, "": false} {
+		if got := isAppVolume(uuid, refs); got != want {
+			t.Errorf("isAppVolume(%q, %v) = %v, want %v", uuid, refs, got, want)
+		}
+	}
+	if isAppVolume("a", nil) {
+		t.Error("isAppVolume with no refs must be false")
 	}
 }

--- a/evetest/edgedevice_test.go
+++ b/evetest/edgedevice_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package evetest
+
+import (
+	"testing"
+
+	eveinfo "github.com/lf-edge/eve-api/go/info"
+)
+
+// TestAppDownloadProgress pins the classification of ZSwState values, which
+// is not derivable from their numeric order: RESOLVING_TAG (12) and
+// RESOLVED_TAG (13) are numerically greater than DOWNLOADED (3) but happen
+// before the download starts, while CREATING_VOLUME (14) and LOADED (19)
+// happen after it finishes.
+func TestAppDownloadProgress(t *testing.T) {
+	vol := func(state eveinfo.ZSwState, pct uint32) *eveinfo.ZInfoVolume {
+		return &eveinfo.ZInfoVolume{
+			Uuid:               "vol",
+			State:              state,
+			ProgressPercentage: pct,
+		}
+	}
+
+	tests := []struct {
+		name string
+		vol  *eveinfo.ZInfoVolume
+		want uint32
+	}{
+		// Before the download: must never report progress, however high the
+		// enum value is.
+		{"invalid", vol(eveinfo.ZSwState_INVALID, 0), 0},
+		{"initial", vol(eveinfo.ZSwState_INITIAL, 0), 0},
+		{"resolving tag", vol(eveinfo.ZSwState_RESOLVING_TAG, 0), 0},
+		{"resolved tag", vol(eveinfo.ZSwState_RESOLVED_TAG, 0), 0},
+		// During the download: whatever the device reports, including the 0
+		// that a container-registry pull reports throughout.
+		{"downloading, no bytes reported", vol(eveinfo.ZSwState_DOWNLOAD_STARTED, 0), 0},
+		{"downloading, partway", vol(eveinfo.ZSwState_DOWNLOAD_STARTED, 42), 42},
+		// After the download.
+		{"downloaded", vol(eveinfo.ZSwState_DOWNLOADED, 0), 100},
+		{"delivered", vol(eveinfo.ZSwState_DELIVERED, 0), 100},
+		{"installed", vol(eveinfo.ZSwState_INSTALLED, 0), 100},
+		{"creating volume", vol(eveinfo.ZSwState_CREATING_VOLUME, 0), 100},
+		{"verifying", vol(eveinfo.ZSwState_VERIFYING, 0), 100},
+		{"loaded", vol(eveinfo.ZSwState_LOADED, 0), 100},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := appDownloadProgress([]string{"vol"},
+				map[string]*eveinfo.ZInfoVolume{"vol": tc.vol})
+			if got != tc.want {
+				t.Errorf("appDownloadProgress(%v) = %d%%, want %d%%",
+					tc.vol.GetState(), got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAppDownloadProgressAveraging covers the multi-volume arithmetic,
+// including a volume the device has not reported on yet.
+func TestAppDownloadProgressAveraging(t *testing.T) {
+	volumes := map[string]*eveinfo.ZInfoVolume{
+		"a": {Uuid: "a", State: eveinfo.ZSwState_LOADED},
+		"b": {Uuid: "b", State: eveinfo.ZSwState_DOWNLOAD_STARTED, ProgressPercentage: 50},
+	}
+	if got := appDownloadProgress([]string{"a", "b"}, volumes); got != 75 {
+		t.Errorf("two volumes at 100%% and 50%% = %d%%, want 75%%", got)
+	}
+	// "c" has no info yet: counted as 0, not skipped, or an app would look
+	// complete while a volume of it had not been heard from at all.
+	if got := appDownloadProgress([]string{"a", "b", "c"}, volumes); got != 50 {
+		t.Errorf("unreported third volume = %d%%, want 50%%", got)
+	}
+	if got := appDownloadProgress(nil, volumes); got != 0 {
+		t.Errorf("no volume refs = %d%%, want 0%%", got)
+	}
+}

--- a/evetest/harness.go
+++ b/evetest/harness.go
@@ -151,7 +151,14 @@ const (
 	fileTransferTimeout = time.Minute
 
 	// If download progress does not advance for this long, WaitUntilAppIsRunning fails.
-	downloadStalledTimeout = time.Minute
+	// downloadStalledTimeout bounds how long an app may sit in
+	// DOWNLOAD_STARTED without any observable progress. Generous on purpose:
+	// for a container-registry pull EVE reports 0/0 bytes throughout (the
+	// downloader's resp.Progress() carries no size for OCI blobs), so the only
+	// liveness signals the controller ever sees are volume state changes and
+	// the occasional per-blob update. A minute here failed healthy pulls of
+	// images that were still downloading minutes later.
+	downloadStalledTimeout = 5 * time.Minute
 
 	// Timeout for pulling an EVE docker image and extracting its rootfs.
 	eveImagePullTimeout = 15 * time.Minute

--- a/evetest/tests/cluster/purge_test.go
+++ b/evetest/tests/cluster/purge_test.go
@@ -24,10 +24,18 @@ import (
 )
 
 // purgeMarkerPath is written into the app's root filesystem before the purge.
-// A purge keeps the app's existing volumes (zedmanager's doUpdate: "Keep the
-// old volumes in place"), so the marker is expected to SURVIVE. Only a
-// purge&update, where the controller sends volume refs with new generation
-// counters, causes volumemgr to build fresh volumes.
+// A purge recreates the boot disk, so the marker is expected to be GONE
+// afterwards: "The EVE behavior for a purge command is to restart the
+// application instance with the first drive/volumeRef recreated from its
+// origin" (eve-api, AppInstanceOpsCmd), and pkg/pillar/docs/zedmanager.md:
+// "The purge means replacing the first volume (the boot disk) with a copy
+// recreated from the immutable content". zedmanager's "Keep the old volumes in
+// place" refers to holding them while the old domain is brought down, which is
+// how purge minimizes downtime -- the app is then recreated on the new volume.
+//
+// Losing the marker is therefore what distinguishes a purge from a restart,
+// which reuses the volume untouched. Volumes other than the boot disk do
+// survive a purge, but this app has none.
 const purgeMarkerPath = "/root/purge-marker"
 
 // appPurgeMarkerState reports "PRESENT" or "ABSENT" for purgeMarkerPath inside
@@ -124,8 +132,9 @@ func clusterHasVMIWithPrefix(info *eveinfo.ZInfoKubeCluster, prefix string) bool
 //     VMIRS and none belonging to the purge-counter-0 one. This is what separates
 //     a purge from a plain restart -- a restart reuses the VMIRS name -- and it is
 //     the assertion that would catch the old VMIRS being left behind.
-//  9. volumes-preserved: purgeMarkerPath still reads PRESENT (see "Purge vs.
-//     purge&update" above).
+//  9. boot-disk-recreated: purgeMarkerPath reads ABSENT, proving the boot disk
+//     was replaced from its origin rather than the workload merely restarted
+//     (see purgeMarkerPath above).
 //
 // Suite placement
 // ---------------
@@ -295,12 +304,14 @@ func TestAppInstancePurge(test *testing.T) {
 		})))
 	evetest.Checkpoint("vmirs-renamed")
 
-	// A purge keeps the app's volumes, so the marker must still be there.
-	log.Infof("Checking that purge marker %s survived the purge", purgeMarkerPath)
+	// A purge recreates the boot disk from its origin, so the marker written
+	// into it before the purge must be gone. Checked last: it needs the app's
+	// SSH daemon, which comes up some time after the app reports RUNNING.
+	log.Infof("Checking that purge marker %s is gone after the purge", purgeMarkerPath)
 	t.Eventually(func(t Gomega) {
 		stdout, stderr, err := appPurgeMarkerState(device, appUUID, appAuth, sshTimeout)
 		t.Expect(err).ToNot(HaveOccurred(), stderr)
-		t.Expect(stdout).To(ContainSubstring("PRESENT"))
+		t.Expect(stdout).To(ContainSubstring("ABSENT"))
 	}, sshReadyTimeout, polling).Should(Succeed())
-	evetest.Checkpoint("volumes-preserved")
+	evetest.Checkpoint("boot-disk-recreated")
 }


### PR DESCRIPTION
# Description

Two independent evetest defects, both found by running `TestNodeClusterSuite` and then reading the device's own logs rather than the harness's account of them.

**A healthy download reported as stalled.** `TestSingleNodeCluster` failed with `download stalled at 0% for more than 1m0s`. The device was downloading normally: it finished the manifest blob 20 seconds before the test gave up and was still ingesting further blobs a minute later, ending in `IngestBlob(...): Loaded the blob successfully`. Two things combined to produce that verdict.

`appDownloadProgress` classified volume states with `state >= ZSwState_DOWNLOADED`, but `ZSwState` is not ordered by progress. The states appended after the original sequence carry higher numbers than `DOWNLOADED` (3) while happening earlier — `RESOLVING_TAG` is 12, `RESOLVED_TAG` 13. So an image whose tag was still being resolved reported **100%**, and the number then "fell" to 0% once the download actually began: the 100% was the wrong figure, not the 0%. The states are now classified explicitly, with a unit test pinning the grouping, because nothing in the numbering makes it evident — `CREATING_VOLUME` (14), `VERIFYING` (16) and `LOADED` (19) genuinely are past the download, while `RESOLVING_TAG` (12) is not.

The stall timer then used that percentage as its only liveness signal. For a container-registry download EVE reports `0/0` bytes for the whole transfer (the downloader's `resp.Progress()` carries no size for OCI blobs), so the percentage cannot move however healthy the pull is. The timer now also resets when a volume changes state, and the budget goes from one minute to five. It is the only bound on a genuinely stuck download — download time is excluded from the test's main timeout — but one minute of an unchanging percentage says nothing about a registry pull.

**A purge expected to preserve the boot disk.** `TestAppInstancePurge` wrote a marker into the app's root filesystem and asserted it survived, reasoning that a purge keeps the app's volumes. It does not: eve-api specifies that a purge restarts the instance "with the first drive/volumeRef recreated from its origin", and `pkg/pillar/docs/zedmanager.md` describes it as "replacing the first volume (the boot disk) with a copy recreated from the immutable content". zedmanager's "Keep the old volumes in place", which the test cited, refers to holding the old volumes while the running domain is brought down — that is how purge minimizes downtime; the instance is then recreated on the new volume. The test now asserts the marker is gone, which is the stronger property: it distinguishes a purge from a restart, and would catch a purge silently degrading into one.

Only the last of the test's nine phases was failing; the eight before it, including the VMIRS rename that proves the purge was carried out, were passing.

## How to test and validate this PR

The unit test covers the state classification without a device:

```
cd evetest && GOWORK=off go test -run TestAppDownloadProgress ./...
```

For the rest, run the cluster suite, which exercises both the download path and the purge:

```
make evetest NAME=TestNodeClusterSuite
```

`TestAppInstancePurge` should reach its final checkpoint, now named `boot-disk-recreated`. `TestSingleNodeCluster` should no longer fail on a slow registry pull; on the run that motivated this change the app image took over two minutes to download, with the harness previously giving up after one.

## Changelog notes

No user-facing changes. Test framework only.

## PR Backports

- 17.0-stable: To be backported -- evetest is there and carries the same defect (`state >= eveinfo.ZSwState_DOWNLOADED` in `appDownloadProgress`, `downloadStalledTimeout = time.Minute`). Only the download-progress commit applies; `evetest/tests/cluster/purge_test.go` does not exist on that branch.
- 16.0-stable: No, evetest does not exist there.
- 14.5-stable: No, evetest does not exist there.
- 13.4-stable: No, evetest does not exist there.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
