### PR TITLE
Give every device a unique soft serial

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -78,6 +78,16 @@ the number in the INVENTORY partition as a newly created folder, where the folde
 that soft serial number. Simply plug the USB stick back into a computer to view the contents
 of the INVENTORY partition to read the number.
 
+When a live image is written directly to a device the installer never runs, so EVE-OS
+provisions the soft serial number itself the first time it boots, before it creates its
+device certificate and contacts the controller. It uses the ```eve_soft_serial``` kernel
+argument if one is present and generates a unique one otherwise, and reports the value on
+the console and in the log. A live image therefore leaves its soft serial number empty —
+one image written to many devices would give all of them the same soft serial — unless you
+deliberately build a single-use image for one device by placing the number in the CONFIG
+partition (```conf/soft_serial``` in this repository), in which case that value is used
+as it is for the installer.
+
 ## Deploying EVE-OS in physical environments (aka onto bare metal)
 
 Deploying EVE-OS in a physical environment assumes it will be installed to run directly on an actual,

--- a/docs/SECURITY-ARCHITECTURE.md
+++ b/docs/SECURITY-ARCHITECTURE.md
@@ -107,7 +107,7 @@ openssl x509 -in conf/onboard.cert.pem -text | grep CN
 
 The [generate-onboard.sh](../pkg/pillar/scripts/generate-onboard.sh) script can be used to generate such onboarding certificates.
 
-A variant of that approach is to use a random soft serial number. When EVE is installed it generates a /config/soft_serial which is a random 128-bit UUID. If installed from a USB stick this serial number (together with the less random hardware serial number) are written to a directory on the USB installer stick.
+A variant of that approach is to use a random soft serial number. When EVE is installed it generates a /config/soft_serial which is a random 128-bit UUID. If installed from a USB stick this serial number (together with the less random hardware serial number) are written to a directory on the USB installer stick. A device that boots a live image directly, without ever running the installer, generates the same random 128-bit UUID on its first boot instead, before it creates its device certificate, and reports it on the console. An image written to more than one device leaves /config/soft_serial empty for that reason, since a value carried in the image would make every device written from it present the same one.
 
 When EVE is calling the register API it will present both the hardware serial and soft serial, hence if the controller has been told of the random soft serial for the device we avoid depending on guessable hardware serial numbers.
 

--- a/pkg/eve/runme.sh
+++ b/pkg/eve/runme.sh
@@ -151,19 +151,24 @@ do_build_config() {
 
 do_live() {
   PART_SPEC="efi efi_b conf imga"
-  # each live image is expected to have a soft serial number that
-  # typically gets provisioned by an installer -- since we're
-  # shortcutting the installer step here we need to generate it
-  # if it is missing in CONFIG partition
-  if mcopy -o -i /bits/config.img ::/soft_serial /tmp; then
-     IMAGE_UUID=$(cat /tmp/soft_serial)
-  else
-     IMAGE_UUID=$(uuidgen | tee /tmp/soft_serial)
+  # A live image may be written to any number of devices, so it must not carry a
+  # soft serial number that the build invents: every device would report the same
+  # one. The file is left empty for the benefit of anything downstream that
+  # expects it to exist, and each device fills it in on its first boot. A serial
+  # deliberately placed in the CONFIG partition, for a single-use image, is
+  # passed through and reported.
+  if ! mcopy -o -i /bits/config.img ::/soft_serial /tmp; then
+     : > /tmp/soft_serial
      mcopy -o -i /bits/config.img /tmp/soft_serial ::/soft_serial
   fi
+  IMAGE_UUID=$(cat /tmp/soft_serial)
   create_efi_raw "${1:-${DEFAULT_LIVE_IMG_SIZE}}" "$PART_SPEC"
   dump "$OUTPUT_IMG" live.raw
-  echo "$IMAGE_UUID" >&2
+  if [ -n "$IMAGE_UUID" ]; then
+     echo "$IMAGE_UUID" >&2
+  else
+     echo "no soft serial in CONFIG partition; each device generates its own on first boot" >&2
+  fi
 }
 
 do_installer_raw() {

--- a/pkg/pillar/scripts/onboot.sh
+++ b/pkg/pillar/scripts/onboot.sh
@@ -9,6 +9,9 @@ CONFIGDIR=/config
 PERSISTDIR=/persist
 PERSIST_CERTS="$PERSISTDIR/certs"
 DEVICE_KEY_NAME="$CONFIGDIR/device.key.pem"
+DEVICE_CERT_NAME="$CONFIGDIR/device.cert.pem"
+SOFT_SERIAL_NAME="$CONFIGDIR/soft_serial"
+CONFIGDIR_TMPMOUNT=/tmp/config_tmpmount
 PERSIST_AGENT_DEBUG=$PERSISTDIR/agentdebug
 BINDIR=/opt/zededa/bin
 TMPDIR="${PERSISTDIR}/tmp"
@@ -94,6 +97,49 @@ if [ -d /persist/status ]; then
     echo "$(date -Ins -u) Saving copy of /persist/status in /persist/agentdebug"
     cp -rp /persist/status $PERSIST_AGENT_DEBUG/
 fi
+
+# Give the device a soft serial number if it does not have one, from an
+# eve_soft_serial= kernel argument if present and a random UUID otherwise,
+# updating both the CONFIG partition and its copy in RAM. Never fails; leaves
+# the device without a soft serial if the partition cannot be written.
+#
+# Only on a first boot with no device certificate: measure-config extends PCR 14
+# with whether /config/soft_serial exists and PCR 14 seals the vault, so a
+# device that may already have a sealed vault must not gain the file.
+create_soft_serial() {
+    if [ -z "$FIRSTBOOT" ] || [ -s "$SOFT_SERIAL_NAME" ] || [ -f "$DEVICE_CERT_NAME" ]; then
+        return
+    fi
+    configdev=$(zboot partdev CONFIG)
+    if [ -z "$configdev" ]; then
+        echo "$(date -Ins -u) No CONFIG partition; not creating a soft serial number"
+        return
+    fi
+    soft_serial=$(tr ' ' '\012' < /proc/cmdline | sed -n '/^eve_soft_serial=/s#eve_soft_serial=##p')
+    [ -n "$soft_serial" ] || soft_serial=$(uuidgen)
+    if [ -z "$soft_serial" ]; then
+        echo "$(date -Ins -u) Failed to generate a soft serial number"
+        return
+    fi
+
+    mkdir -p $CONFIGDIR_TMPMOUNT
+    if ! mount -t vfat -o flush,dirsync,noatime,rw "$configdev" $CONFIGDIR_TMPMOUNT; then
+        echo "$(date -Ins -u) Failed to mount $configdev; not creating a soft serial number"
+        return
+    fi
+    echo "$soft_serial" > "$CONFIGDIR_TMPMOUNT/soft_serial"
+    sync
+    blockdev --flushbufs "$configdev"
+    umount $CONFIGDIR_TMPMOUNT
+
+    mount -o remount,rw $CONFIGDIR
+    echo "$soft_serial" > "$SOFT_SERIAL_NAME"
+    mount -o remount,ro $CONFIGDIR
+
+    echo "$(date -Ins -u) Soft serial number is $soft_serial" | tee /dev/console
+}
+
+create_soft_serial
 
 echo "$(date -Ins -u) Configuration from factory/install:"
 (cd $CONFIGDIR || return; ls -l)


### PR DESCRIPTION
# Description

Fixes #6346.

Only the installer provisioned `/config/soft_serial`, so a device that boots a live image directly registered with an empty soft serial and onboarding had to fall back on the hardware serial number — which is exactly what the soft serial exists to avoid depending on. Worse, a live image built by the eve container carried a soft serial generated at build time, so every device written from one image reported the same one: non-unique, but indistinguishable from a real device identifier. This PR ensures that all newly installed devices have a unique soft serial (unless PXE or user at grup prompt feeds in a non-unique one). That can be used in follow-up work to create device certificate for new devices with the soft serial as identifying information, which can help manage the device certificates and make them conform with 802.1AR etc.

EVE now provisions its own soft serial on its first boot, taking the value from an `eve_soft_serial=` kernel argument when present and generating a random UUID otherwise, and reports it on the console since a live image has no INVENTORY partition to deposit it on.

This happens in pillar's onboot phase, which is early enough that the device certificate does not yet exist and `client` has not yet registered, and which is also the last point at which the CONFIG partition may change. That second constraint is the load-bearing one: `measure-config` runs after every onboot container and extends PCR 14 with *whether* `/config/soft_serial` exists (its content is excluded from measurement, its existence is not), and PCR 14 is part of the default vault sealing policy. A file appearing later in the boot would therefore change PCR 14 on the following boot and break the vault unseal. Requiring a first boot with no device certificate keeps this away from any device that could already have a sealed vault to invalidate — a device that has booted before has a certificate, and one whose `/persist` was wiped still has the certificate in its CONFIG partition.

Because `/config` is a RAM copy of the CONFIG partition, the value is written to both, the partition first, so a failed persist leaves nothing behind in the copy that gets measured.

Building a live image no longer invents a soft serial for it. Without this the on-device change would never fire for images produced by `docker run lfedge/eve live`: the baked-in file exists, so the first-boot path skips. A serial deliberately placed in the CONFIG partition for a single-use image is still passed through and reported.

## How to test and validate this PR

We need to validate that a live image created by our clonezilla instructions do not get confused by a soft serial appearing in /config/ where today there is no such file.

Not covered by an automated test — it only fires on a device's very first boot, which the Eden and evetest harnesses reach only via a fresh onboarding cycle.

Manual validation, on a device or QEMU VM booting a freshly built live image:

1. Confirm the image itself carries no serial: `mdir -i <config.img> ::/` shows no `soft_serial`, and the `live` build prints `no soft serial in CONFIG partition; ...` instead of a UUID.
2. Boot it and check the console or `onboot.004-pillar-onboot.out` in the log for `Soft serial number is <uuid>`.
3. Confirm it reached the controller: the `register` call carries that value as the soft serial, and later requests carry it in the `X-Requested-By-Device-Soft-Serial` header. `eve exec pillar cat /config/soft_serial` should match.
4. Reboot and confirm the value survived (it was written to the CONFIG partition, not just the RAM copy) and that no second serial was generated.
5. On a TPM device, confirm the vault still unlocks across that reboot — `VaultStatus.UnlockMethod` should stay TPM-based. This is the case the first-boot gate exists to protect: the file must be present before `measure-config` extends PCR 14, so PCR 14 is identical on boot 1 and boot 2.
6. Negative control on an already-onboarded device: upgrade it to this build and confirm `/config/soft_serial` is *not* created and the vault still unlocks.
7. Command-line override: boot with `eve_soft_serial=lab-node-07` on the kernel command line and confirm that value is used verbatim rather than a UUID.

What has been verified so far: `shellcheck -x` clean on both scripts, no new markdownlint findings, `make check-docker-hashes-consistency` clean, and the new shell function exercised against stubbed `zboot`/`mount`/`uuidgen` for all seven paths (generates; command-line override; existing serial untouched; device-certificate gate; not-a-first-boot gate; mount failure writes nothing; no CONFIG partition writes nothing), each confirmed to fail when the corresponding condition is removed. It has **not** yet been booted on hardware or under QEMU.

## Changelog notes

A device installed by writing a live image directly to its disk, rather than by running the installer, now gets its own unique soft serial number on first boot, so it can be onboarded by soft serial like any installed device. Live images no longer carry a soft serial number of their own, which previously made every device written from the same image report an identical one.

## PR Backports

The defect predates all current LTS branches, and the first-boot and device-certificate conditions make the change a no-op on any already-deployed device, so it is a safe backport. Deferring to maintainers on whether it is wanted there:

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

Not checked, with reasons: the change has not been booted on an amd64 or arm64 device yet — it is opened as a draft for that reason, and the validation steps above are what needs running. Labels are left to the maintainers, including whether `stable` applies given the backport question above.
