### PR TITLE
[17.0-stable] Kernel update - [amd64-generic]

### DIFF
--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,5 +1,5 @@
 KERNEL_COMMIT_amd64_next_generic = a65e45508b45
-KERNEL_COMMIT_amd64_v6.12.96_generic = bfc617435842
+KERNEL_COMMIT_amd64_v6.12.96_generic = 5ec53c5d956c
 KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = 2e0dcfd3260d
 KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 4929f15eda41
 KERNEL_COMMIT_arm64_v6.1.155_generic = 417a12ac3d50


### PR DESCRIPTION
# Description

Backport of #6339

Kernel Update to get a fix for watchdog driver.

This commit changes:
eve-kernel-amd64-v6.12.96-generic
    5ec53c5d956c: watchdog: wdat_wdt: map registers that fall inside ACPI NVS

## How to test and validate this PR

Requires a OnLogic Karbon 524: Enable hardware watchdog in the BIOS and check it works correctly on EVE (it should not reboot within 4.5 hours)

## Changelog notes

Fix ACPI watchdog driver in kernel to work with hardware watchdog from a OnLogic Karbon 524 device.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.