### PR TITLE
[17.0-stable] eve-k: fix purge leaving stale VMIRS generations and volume refs

### DIFF
--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -429,11 +429,23 @@ func doInstall(ctx *zedmanagerContext,
 			MaybeRemoveVolumeRefConfig(ctx, config.UUIDandVersion.UUID,
 				vrs.VolumeID, vrs.GenerationCounter, vrs.LocalGenerationCounter)
 			if !vrs.PendingAdd {
-				vrs.PendingAdd = true
-				// Keep in VolumeRefStatus until we get an update
-				// from volumemgr
-				newVrs = append(newVrs, *vrs)
-				removed = true
+				if lookupVolumeRefStatus(ctx, vrs.Key()) == nil {
+					// volumemgr has no live VolumeRefStatus for this key
+					// at all, so there is nothing to wait for: either it
+					// was already deleted, or (e.g. after a reboot wiped
+					// ephemeral state) it was never republished this
+					// boot to begin with, in which case no delete event
+					// will ever arrive. Drop it now instead of parking
+					// on PendingAdd forever.
+					log.Functionf("No volumemgr VolumeRefStatus for %s; dropping immediately",
+						vrs.Key())
+				} else {
+					vrs.PendingAdd = true
+					// Keep in VolumeRefStatus until we get an update
+					// from volumemgr
+					newVrs = append(newVrs, *vrs)
+					removed = true
+				}
 			}
 		}
 		log.Functionf("purge inactive (%s) volumeRefStatus from %d to %d",

--- a/pkg/pillar/cmd/zedmanager/updatestatus_test.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zedmanager
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+// newDoInstallTestContext builds a zedmanagerContext wired up with just
+// enough pub/sub plumbing for doInstall: an (empty) DomainConfig
+// publication - no domain owns any volume - zedmanager's own outgoing
+// VolumeRefConfig publication, and a VolumeRefStatus subscription seeded
+// with whatever volumemgr is pretending to have live status for.
+func newDoInstallTestContext(t *testing.T, liveVolumeRefStatus []types.VolumeRefStatus) *zedmanagerContext {
+	t.Helper()
+	logger := logrus.StandardLogger()
+	log = base.NewSourceLogObject(logger, agentName, 0)
+	ps := pubsub.New(pubsub.NewMemoryDriver(), logger, log)
+
+	pubDomainConfig, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.DomainConfig{},
+	})
+	assert.NoError(t, err)
+
+	pubVolumeRefConfig, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.VolumeRefConfig{},
+	})
+	assert.NoError(t, err)
+
+	volumemgrPub, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: "volumemgr",
+		TopicType: types.VolumeRefStatus{},
+	})
+	assert.NoError(t, err)
+	for _, vrs := range liveVolumeRefStatus {
+		assert.NoError(t, volumemgrPub.Publish(vrs.Key(), vrs))
+	}
+
+	subVolumeRefStatus, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName:   "volumemgr",
+		MyAgentName: agentName,
+		TopicImpl:   types.VolumeRefStatus{},
+		Persistent:  true,
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, subVolumeRefStatus.Activate())
+
+	return &zedmanagerContext{
+		pubDomainConfig:    pubDomainConfig,
+		pubVolumeRefConfig: pubVolumeRefConfig,
+		subVolumeRefStatus: subVolumeRefStatus,
+	}
+}
+
+// TestDoInstallDropsStaleVolumeRefWithNoLiveStatus is the regression test
+// for the reboot-purge wedge: a VolumeRefStatus entry that the current
+// AppInstanceConfig no longer wants, and that volumemgr has no live status
+// for at all (never republished this boot, or already deleted), must be
+// dropped immediately instead of parked on PendingAdd waiting for a delete
+// event that can never arrive - which previously left doInstall returning
+// early forever, never even requesting the newly desired volume.
+func TestDoInstallDropsStaleVolumeRefWithNoLiveStatus(t *testing.T) {
+	appUUID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
+	staleVolumeID := uuid.Must(uuid.FromString("22222222-2222-2222-2222-222222222222"))
+	newVolumeID := uuid.Must(uuid.FromString("33333333-3333-3333-3333-333333333333"))
+
+	// volumemgr has nothing live for the stale volume at all.
+	ctx := newDoInstallTestContext(t, nil)
+
+	// zedmanager itself still has a live VolumeRefConfig request out for the
+	// stale volume (as it would across a reboot, if that publication is what
+	// survived while volumemgr's own side did not) - doInstall must still
+	// unpublish it, even though it drops the status entry immediately.
+	staleVrc := types.VolumeRefConfig{VolumeID: staleVolumeID, AppUUID: appUUID, VerifyOnly: true}
+	assert.NoError(t, ctx.pubVolumeRefConfig.Publish(staleVrc.Key(), staleVrc))
+
+	config := types.AppInstanceConfig{
+		UUIDandVersion: types.UUIDandVersion{UUID: appUUID, Version: "1"},
+		VolumeRefConfigList: []types.VolumeRefConfig{
+			{VolumeID: newVolumeID, AppUUID: appUUID, VerifyOnly: true},
+		},
+	}
+	status := &types.AppInstanceStatus{
+		UUIDandVersion:  config.UUIDandVersion,
+		PurgeInprogress: types.DownloadAndVerify,
+		VolumeRefStatusList: []types.VolumeRefStatus{
+			{
+				VolumeID:   staleVolumeID,
+				AppUUID:    appUUID,
+				State:      types.LOADED,
+				PendingAdd: false,
+				VerifyOnly: true,
+			},
+		},
+	}
+
+	doInstall(ctx, config, status)
+
+	for _, vrs := range status.VolumeRefStatusList {
+		assert.NotEqual(t, staleVolumeID, vrs.VolumeID,
+			"stale VolumeRefStatus must be dropped once volumemgr has no live status for it")
+	}
+	if assert.Len(t, status.VolumeRefStatusList, 1) {
+		assert.Equal(t, newVolumeID, status.VolumeRefStatusList[0].VolumeID)
+	}
+	staleVrcAfter, _ := ctx.pubVolumeRefConfig.Get(staleVrc.Key())
+	assert.Nil(t, staleVrcAfter,
+		"the stale VolumeRefConfig request to volumemgr must still be unpublished")
+}
+
+// TestDoInstallWaitsForStaleVolumeRefWithLiveStatus pins the other half of
+// the same invariant: if volumemgr still has a live VolumeRefStatus for the
+// stale ref, doInstall must not drop it out from under an in-flight async
+// removal - it should mark it PendingAdd and wait for volumemgr's delete,
+// exactly as before this fix.
+func TestDoInstallWaitsForStaleVolumeRefWithLiveStatus(t *testing.T) {
+	appUUID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
+	staleVolumeID := uuid.Must(uuid.FromString("22222222-2222-2222-2222-222222222222"))
+	newVolumeID := uuid.Must(uuid.FromString("33333333-3333-3333-3333-333333333333"))
+
+	staleVrs := types.VolumeRefStatus{
+		VolumeID:   staleVolumeID,
+		AppUUID:    appUUID,
+		State:      types.LOADED,
+		PendingAdd: false,
+		VerifyOnly: true,
+	}
+	// volumemgr still reports this volume as live.
+	ctx := newDoInstallTestContext(t, []types.VolumeRefStatus{staleVrs})
+
+	config := types.AppInstanceConfig{
+		UUIDandVersion: types.UUIDandVersion{UUID: appUUID, Version: "1"},
+		VolumeRefConfigList: []types.VolumeRefConfig{
+			{VolumeID: newVolumeID, AppUUID: appUUID, VerifyOnly: true},
+		},
+	}
+	status := &types.AppInstanceStatus{
+		UUIDandVersion:      config.UUIDandVersion,
+		PurgeInprogress:     types.DownloadAndVerify,
+		VolumeRefStatusList: []types.VolumeRefStatus{staleVrs},
+	}
+
+	doInstall(ctx, config, status)
+
+	if assert.Len(t, status.VolumeRefStatusList, 1) {
+		assert.Equal(t, staleVolumeID, status.VolumeRefStatusList[0].VolumeID)
+		assert.True(t, status.VolumeRefStatusList[0].PendingAdd,
+			"must be marked pending removal while waiting for volumemgr's delete")
+	}
+}

--- a/pkg/pillar/docs/zedkube.md
+++ b/pkg/pillar/docs/zedkube.md
@@ -112,7 +112,51 @@ This collection is specific for the kubernetes status and stats. Although EVE ha
 
 ### Handle Domain Apps Status in domainmgr
 
-When the application is launched and managed in KubeVirt mode, the Kubernetes cluster is provisioned for this application, being a VMI (Virtual Machine Instance) replicaSet object or a Pod replicaSet object. It uses a declarative approach to manage the desired state of the applications. The configurations are saved in the Kubernetes database for the Kubernetes controller to use to ensure the objects eventually achieve the correct state if possible. Any particular VMI/Pod state of a domain may not be in working condition at the time when EVE domainmgr checks. In the domainmgr code running in KubeVirt mode, if it can not contact the Kubernetes API server to query about the application, or if the application itself has not be started yet in the cluster, the kubervirt.go will return the 'Unknown' status back. It will keep a 'Unknown' status starting timestamp per application. If the 'Unknown' status lasts longer then 5 minutes, the status functions in kubevirt.go will return 'Halting' status back to domainmgr. The timestamp will be cleared once it can get the application status from the kubernetes.
+When the application is launched and managed in KubeVirt mode, the Kubernetes cluster is provisioned for this application, being a VMI (Virtual Machine Instance) replicaSet object or a Pod replicaSet object. It uses a declarative approach to manage the desired state of the applications. The configurations are saved in the Kubernetes database for the Kubernetes controller to use to ensure the objects eventually achieve the correct state if possible. Any particular VMI/Pod state of a domain may not be in working condition at the time when EVE domainmgr checks.
+
+`hypervisor/kubevirt.go`'s `Info` reports back to domainmgr on every poll. It is the only place that decides `DomainId` and `SwState` for a kube app, and every downstream consumer - `doInactivate`'s teardown gates, `doCleanup`'s success test, `verifyStatus` - trusts what it returns without re-deriving anything itself. The contract:
+
+> **`DomainId` is zero if and only if the VMIRS (or, for a NOHYPER app, its plain container ReplicaSet) is confirmed absent.** It is never zero merely because the answer is unknown or unattributable.
+
+`Info` confirms existence directly with a `Get` on the object by name, rather than inferring it from where a replica happens to be running:
+
+| Situation | `DomainId` | `SwState` |
+| --- | --- | --- |
+| object found, a replica is running on this node | derived from the object's UID | `RUNNING` (or whatever its mapped phase is) |
+| object found, no replica attributable to any node yet (mid-restart, mid-failover) | derived from the object's UID | `SCHEDULING` |
+| object found, replica reports an unmapped phase | derived from the object's UID | `SCHEDULING` (escalates to `HALTING` only after 30+ minutes stuck unmapped) |
+| object found, running on a *different* node | derived from the object's UID | `UNKNOWN` (deliberately not `SCHEDULING` - see below) |
+| **object confirmed absent (`Get` -> `NotFound`)** | **`0`** | `HALTED` |
+| existence could not be confirmed (API unreachable, or any other error) | the caller's last-known `DomainId`, unchanged | `UNKNOWN` |
+
+The "running on a different node" row is deliberately not `SCHEDULING`: that would send domainmgr's rescheduling logic into a path that expects a boot in progress, and an app that is healthy on another node would report `BOOTING` forever. The id changing from 0 to a real, derived value is the fix that row needs; the `SwState` itself is left as `UNKNOWN`, matching what a generic id-only change already does downstream.
+
+The derived, non-zero id (`workloadID` in `hypervisor/kubevirt.go`) is an FNV-1a hash of the object's `metadata.uid`, falling back to hashing its Kubernetes name before the object exists (there is no UID to read yet between `Create` and `Start`). It plays the same role kvm/xen give a qemu pid - a `DomainId` change signals a new generation - but it is never used as a cross-app key, so a hash collision between two different apps' ids is harmless.
+
+### Naming, purge generations, and why they collide
+
+Every kube app object - the VMIRS (or plain ReplicaSet, for a NOHYPER app), and its virt-launcher/app pods - is named `<display-name>-<uuid5>-<purge-counter>` (`base.GetAppKubeNameWithPurge`), where `<uuid5>` is the first 5 characters of the app's UUID and `<purge-counter>` is the sum of the controller's purge and local-purge counters. The counter is embedded in the name specifically so that a purge's old and new generations never collide on the object name in the Kubernetes API - without it, a new VMIRS could not be created while the old one, even if already deleted, was still terminating.
+
+The object *name* is therefore unique per generation, but almost everything a generation configures is derived deterministically from the app's config and is **not** generation-scoped: MAC addresses, the RWO disk backing the VM, and pod interface (veth) names are all the same across every generation of the same app. Two generations that are ever briefly both alive - even just the old one's pod still tearing down while the new one's pod comes up - collide on all of these, which is what produces failures like `cannot set "eve-bridge" interface name to "podif2": interface name already exists`. This is why a purge must never let two generations exist at once, and why confirming a deleted generation is *actually* gone (not just its own object, but its pods) has to happen before the next generation is created, not just before the next generation is deleted.
+
+### The stale-generation sweep
+
+`Setup`/`Start` run an unconditional sweep before creating each app's object:
+
+1. List every VMIRS (or plain ReplicaSet) in the cluster and filter to this app's, by the `App-Domain-Name` label prefix (`<uuid>.`) on the VMIRS's `Spec.Selector.MatchLabels` (a plain ReplicaSet carries the same label directly on `ObjectMeta.Labels`, since its own selector has nothing UUID-scoped to filter on).
+2. Select every generation whose trailing purge-counter suffix is strictly less than the one about to be created. Name inequality, not label or version comparison, is what matters here: a non-purge config edit bumps the config version embedded in the label without renaming the object, so a version-only rule would misclassify the current generation as stale.
+3. Delete each stale generation, then confirm it is actually gone - the object *and* any of its pods - before moving on. Deleting the object returns quickly, but Kubernetes' garbage collection of the pod it owns is asynchronous and can take tens of seconds; proceeding to create the next generation as soon as the object itself is gone is exactly the race described above.
+4. Only once every stale generation is confirmed gone does `Start` create the new one. If confirming absence times out, `Start` fails outright rather than risk creating a second generation alongside one that might still exist.
+
+Running this sweep unconditionally, on every `Start`, matters specifically for a reboot mid-purge: `/run` is tmpfs, so a reboot drops domainmgr's own state, and zedmanager's purge bookkeeping lives in `/persist` and is keyed by a counter, not by "does an old generation still exist" - a purge that was in progress across a reboot is not always re-detected as a purge on the next boot. The sweep doesn't depend on detecting a purge at all: it just enumerates what actually exists in the cluster and reconciles against the counter it is about to create, every time.
+
+The sweep does not touch the stale generation's PVC. It reconciles VMIRS/ReplicaSet objects and their pods only, so a disk left behind by a stale generation is not reclaimed by this mechanism at all; that gap is still open.
+
+### Why the sweep alone does not guarantee a stuck purge recovers
+
+The sweep only runs when `Start` is actually called for the app - it is not a periodic or independently-triggered check. If zedmanager itself never gets far enough to ask domainmgr to bring the app back up, `Start` is never invoked and the sweep never gets a chance to run, no matter how correct it is on its own terms.
+
+This is not hypothetical: a purge issued while the device is off can leave zedmanager (`cmd/zedmanager/updatestatus.go`) waiting indefinitely on a `VolumeRefStatus` deletion from volumemgr that confirms a stale volume reference is gone, before it will move on to requesting the new generation's volume. If volumemgr's own state for that reference was also wiped by the same reboot, and it never gets asked about that reference again this boot, no such deletion will ever arrive - zedmanager stays parked in its purge-download phase forever, and `domainmgr`'s `Start` for the new generation is never called. `doInstall` now checks whether volumemgr has any live status for the stale reference at all before deciding to wait on it, and drops it immediately if not, so this no longer depends on an event that might never come. The two fixes are complementary: this one gets zedmanager to actually call `Start` again after a stalled removal; the sweep is what makes that `Start` safe once it happens.
 
 ## Kubernetes Node Draining
 

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
 	"net"
 	"net/http"
 	"os"
@@ -59,6 +58,30 @@ const (
 	unknownToHaltMinutes   = 30 // If VMI is unknown for 30 minutes, return halt state
 )
 
+// newKubevirtClient and newK8sClient wrap the kubevirt/k8s client
+// constructors as package-level vars so unit tests can swap in a fake
+// client. kubecli's documented mock hook only covers
+// GetKubevirtClientFromClientConfig, while this file calls
+// GetKubevirtClientFromRESTConfig directly; wrapping it here is what makes
+// it swappable at all. Tests that reassign these must not run with
+// t.Parallel.
+// newK8sClient is declared against the kubernetes.Interface, not
+// kubernetes.NewForConfig's own concrete *kubernetes.Clientset return type,
+// specifically so tests can substitute k8s.io/client-go/kubernetes/fake's
+// Clientset (which implements the interface but is not that concrete type).
+var (
+	newKubevirtClient = kubecli.GetKubevirtClientFromRESTConfig
+	newK8sClient      = func(c *rest.Config) (kubernetes.Interface, error) {
+		return kubernetes.NewForConfig(c)
+	}
+	// getKubeConfig wraps kubeapi.GetKubeConfig, which a couple of call
+	// sites (getVMIStatus, GetDomsCPUMem) read directly instead of going
+	// through ctx.kubeConfig/getConfig. Wrapping it here for the same
+	// swap-in-tests reason as the two vars above - without it, those call
+	// sites always try to read the real kubeconfig file from disk.
+	getKubeConfig = kubeapi.GetKubeConfig
+)
+
 // MetaDataType is a type for different Domain types
 // We only support ReplicaSet for VMI and Pod for now.
 type MetaDataType int
@@ -75,7 +98,7 @@ const (
 type vmiMetaData struct {
 	repPod              *appsv1.ReplicaSet                   // Handle to the replicaSetof pod
 	repVMI              *v1.VirtualMachineInstanceReplicaSet // Handle to the replicaSet of VMI
-	domainID            int                                  // DomainID understood by domainmgr in EVE
+	domainID            int                                  // Cached types.DomainStatus.DomainId - see workloadID and its doc comment
 	mtype               MetaDataType                         // switch on is ReplicaSet, Pod or is VMI
 	name                string                               // Display-Name(all lower case) + first 5 bytes of domainName
 	cputotal            uint64                               // total CPU in NS so far
@@ -140,6 +163,7 @@ var stateMap = map[string]types.SwState{
 	"suspended":  types.PAUSED,
 	"Pending":    types.PENDING,
 	"Scheduling": types.SCHEDULING,
+	"Scheduled":  types.SCHEDULING,
 	"Failed":     types.FAILED,
 	"Halting":    types.HALTING,
 	"Succeeded":  types.SCHEDULING,
@@ -259,8 +283,38 @@ func (ctx kubevirtContext) Name() string {
 	return KubevirtHypervisorName
 }
 
+// kubevirtTask wraps kubevirtContext with the DomainStatus that produced
+// it, so that a Task's identity can be derived from the status instead of
+// depending only on the domainName string a caller happens to pass to each
+// method. Embedding kubevirtContext means every types.Task method not
+// overridden here is served, unchanged, by the existing domainName-keyed
+// implementation.
+type kubevirtTask struct {
+	kubevirtContext
+	status *types.DomainStatus
+}
+
 func (ctx kubevirtContext) Task(status *types.DomainStatus) types.Task {
-	return ctx
+	return kubevirtTask{ctx, status}
+}
+
+// kubeName derives the Kubernetes object name for t.status's app and purge
+// generation. Setup/Start populate vmiList using this exact derivation (see
+// CreateReplicaVMIConfig/CreateReplicaPodConfig), so it always names the
+// same object a freshly-run Setup/Start would.
+func (t kubevirtTask) kubeName() string {
+	return base.GetAppKubeNameWithPurge(t.status.DisplayName,
+		t.status.UUIDandVersion.UUID, t.status.PurgeCounter)
+}
+
+// metaType mirrors the NOHYPER check in Setup: a NOHYPER app runs as a
+// plain container ReplicaSet (IsMetaReplicaPod); anything else runs as a
+// VMI ReplicaSet (IsMetaReplicaVMI).
+func (t kubevirtTask) metaType() MetaDataType {
+	if t.status.VirtualizationMode == types.NOHYPER {
+		return IsMetaReplicaPod
+	}
+	return IsMetaReplicaVMI
 }
 
 // uuidPrefixOfDomainName returns the "uuid." prefix from a domainName of the
@@ -356,7 +410,7 @@ func (ctx kubevirtContext) CreateReplicaVMIConfig(domainName string, config type
 		return err
 	}
 
-	kvClient, err := kubecli.GetKubevirtClientFromRESTConfig(ctx.kubeConfig)
+	kvClient, err := newKubevirtClient(ctx.kubeConfig)
 	if err != nil {
 		logrus.Errorf("couldn't get the kubernetes client API config: %v", err)
 		return err
@@ -738,10 +792,14 @@ func (ctx kubevirtContext) CreateReplicaVMIConfig(domainName string, config type
 		}
 	}
 	meta := vmiMetaData{
-		repVMI:      replicaSet,
-		name:        kubeName,
-		mtype:       IsMetaReplicaVMI,
-		domainID:    int(rand.Uint32()),
+		repVMI: replicaSet,
+		name:   kubeName,
+		mtype:  IsMetaReplicaVMI,
+		// The VMIRS doesn't exist yet (Create runs before Start creates it),
+		// so there is no UID to hash; workloadID falls back to kubeName. A
+		// real, stable id is captured from Start's own Create response and
+		// re-derived on every subsequent Info call.
+		domainID:    workloadID("", kubeName),
 		memOverhead: uint64(overhead),
 		sriovVFs:    sriovVFs,
 	}
@@ -753,6 +811,199 @@ func (ctx kubevirtContext) CreateReplicaVMIConfig(domainName string, config type
 	// write to config file
 	file.WriteString(repvmiStr)
 
+	return nil
+}
+
+// sweepConfirmRetries/sweepConfirmInterval bound how long
+// sweepStaleGenerations will wait for a deleted stale generation to
+// actually disappear (object and pods) before giving up. This reuses
+// Start's own pre-existing 5x10s retry budget (see the Create retry loop
+// below) rather than inventing a new one: an unreachable API must not
+// block activation indefinitely.
+//
+// sweepConfirmInterval is a var, not a const, solely so unit tests can
+// shrink it and exercise the timeout path without a real 50-second wait.
+const sweepConfirmRetries = 5
+
+var sweepConfirmInterval = 10 * time.Second
+
+// appUUIDFromDomainName extracts the app UUID from a domainName of the
+// form "uuid.version.appnum".
+func appUUIDFromDomainName(domainName string) (uuid.UUID, error) {
+	prefix := uuidPrefixOfDomainName(domainName)
+	return uuid.FromString(strings.TrimSuffix(prefix, "."))
+}
+
+// confirmVMIRSGone waits for a deleted VMIRS - and its virt-launcher pod -
+// to actually disappear from the cluster. Deleting the VMIRS returns
+// quickly, but Kubernetes' garbage collection of the owned VMI and pod is
+// asynchronous and can take tens of seconds; since generations share veth
+// names and the RWO disk, proceeding to create the next generation as soon
+// as the VMIRS object itself is gone races the old pod's own network
+// teardown - the exact "interface name already exists" sandbox failure
+// this is guarding against.
+func confirmVMIRSGone(kubeconfig *rest.Config, name, domainNameLabel string) error {
+	virtClient, err := newKubevirtClient(kubeconfig)
+	if err != nil {
+		return err
+	}
+	podclientset, err := newK8sClient(kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	for retry := 0; ; retry++ {
+		getCtx, getCancel := apiCtx()
+		_, getErr := virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).
+			Get(getCtx, name, metav1.GetOptions{})
+		getCancel()
+		objGone := errors.IsNotFound(getErr)
+		if getErr != nil && !objGone {
+			return fmt.Errorf("confirmVMIRSGone(%s): %w", name, getErr)
+		}
+
+		podsGone := true
+		if domainNameLabel != "" {
+			listCtx, listCancel := apiCtx()
+			pods, listErr := podclientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).
+				List(listCtx, metav1.ListOptions{
+					LabelSelector: "kubevirt.io=virt-launcher," + eveLabelKey + "=" + domainNameLabel,
+				})
+			listCancel()
+			if listErr != nil {
+				return fmt.Errorf("confirmVMIRSGone(%s): %w", name, listErr)
+			}
+			podsGone = len(pods.Items) == 0
+		}
+
+		if objGone && podsGone {
+			logrus.Infof("confirmVMIRSGone(%s): confirmed gone", name)
+			return nil
+		}
+		if retry >= sweepConfirmRetries-1 {
+			return fmt.Errorf("timed out waiting for stale VMIRS %s to be gone "+
+				"(object gone:%t pods gone:%t)", name, objGone, podsGone)
+		}
+		logrus.Infof("confirmVMIRSGone(%s): not yet gone (object gone:%t pods gone:%t), retrying in %v",
+			name, objGone, podsGone, sweepConfirmInterval)
+		time.Sleep(sweepConfirmInterval)
+	}
+}
+
+// confirmPodReplicaSetGone is confirmVMIRSGone's analogue for a NOHYPER
+// app's plain container ReplicaSet. Its pods are labeled "app=<name>"
+// (CreateReplicaPodConfig), which already is generation-specific, so no
+// separate domainName label is needed to scope the pod check.
+func confirmPodReplicaSetGone(kubeconfig *rest.Config, name string) error {
+	clientset, err := newK8sClient(kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	for retry := 0; ; retry++ {
+		getCtx, getCancel := apiCtx()
+		_, getErr := clientset.AppsV1().ReplicaSets(kubeapi.EVEKubeNameSpace).
+			Get(getCtx, name, metav1.GetOptions{})
+		getCancel()
+		objGone := errors.IsNotFound(getErr)
+		if getErr != nil && !objGone {
+			return fmt.Errorf("confirmPodReplicaSetGone(%s): %w", name, getErr)
+		}
+
+		listCtx, listCancel := apiCtx()
+		pods, listErr := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).
+			List(listCtx, metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("app=%s", name),
+			})
+		listCancel()
+		if listErr != nil {
+			return fmt.Errorf("confirmPodReplicaSetGone(%s): %w", name, listErr)
+		}
+		podsGone := len(pods.Items) == 0
+
+		if objGone && podsGone {
+			logrus.Infof("confirmPodReplicaSetGone(%s): confirmed gone", name)
+			return nil
+		}
+		if retry >= sweepConfirmRetries-1 {
+			return fmt.Errorf("timed out waiting for stale ReplicaSet %s to be gone "+
+				"(object gone:%t pods gone:%t)", name, objGone, podsGone)
+		}
+		logrus.Infof("confirmPodReplicaSetGone(%s): not yet gone (object gone:%t pods gone:%t), retrying in %v",
+			name, objGone, podsGone, sweepConfirmInterval)
+		time.Sleep(sweepConfirmInterval)
+	}
+}
+
+// sweepStaleGenerations deletes every VMIRS/ReplicaSet belonging to this
+// app whose purge counter is strictly less than desiredCounter, and
+// confirms each one is actually gone - object and pods - before returning.
+// It runs unconditionally on every Start, because a reboot mid-purge means
+// no purge is ever *detected* on the boot path that recreates the domain
+// (zedmanager sees only /run, which the reboot emptied); only an
+// unconditional sweep catches that case. A confirm-absence failure here
+// fails Start outright - the caller must never proceed to create the new
+// generation while an old one may still exist.
+func (ctx kubevirtContext) sweepStaleGenerations(
+	appUUID uuid.UUID, desiredName string, desiredCounter uint32, mtype MetaDataType) error {
+	// Do not depend on the caller for kubeConfig. The receiver is a value,
+	// so a getConfig call up the stack can fill in a different copy.
+	if err := getConfig(&ctx); err != nil {
+		return err
+	}
+	kubeconfig := ctx.kubeConfig
+
+	if mtype == IsMetaReplicaPod {
+		clientset, err := newK8sClient(kubeconfig)
+		if err != nil {
+			return err
+		}
+		listCtx, listCancel := apiCtx()
+		list, err := clientset.AppsV1().ReplicaSets(kubeapi.EVEKubeNameSpace).
+			List(listCtx, metav1.ListOptions{})
+		listCancel()
+		if err != nil {
+			return err
+		}
+		for _, name := range stalePodReplicaSetNames(list.Items, appUUID, desiredName, desiredCounter) {
+			logrus.Infof("sweepStaleGenerations: tearing down stale ReplicaSet %s before creating %s",
+				name, desiredName)
+			if err := StopReplicaPodContainer(kubeconfig, name); err != nil {
+				return fmt.Errorf("sweepStaleGenerations: failed to delete %s: %w", name, err)
+			}
+			if err := confirmPodReplicaSetGone(kubeconfig, name); err != nil {
+				return fmt.Errorf("sweepStaleGenerations: %w", err)
+			}
+		}
+		return nil
+	}
+
+	virtClient, err := newKubevirtClient(kubeconfig)
+	if err != nil {
+		return err
+	}
+	listCtx, listCancel := apiCtx()
+	list, err := virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).List(listCtx, metav1.ListOptions{})
+	listCancel()
+	if err != nil {
+		return err
+	}
+	domainNameByName := make(map[string]string, len(list.Items))
+	for _, vmirs := range list.Items {
+		if vmirs.Spec.Selector != nil {
+			domainNameByName[vmirs.GetName()] = vmirs.Spec.Selector.MatchLabels[eveLabelKey]
+		}
+	}
+	for _, name := range staleVMIRSNames(list.Items, appUUID, desiredName, desiredCounter) {
+		logrus.Infof("sweepStaleGenerations: tearing down stale VMIRS %s before creating %s",
+			name, desiredName)
+		if err := StopReplicaVMI(kubeconfig, name); err != nil {
+			return fmt.Errorf("sweepStaleGenerations: failed to delete %s: %w", name, err)
+		}
+		if err := confirmVMIRSGone(kubeconfig, name, domainNameByName[name]); err != nil {
+			return fmt.Errorf("sweepStaleGenerations: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -776,6 +1027,18 @@ func (ctx kubevirtContext) Start(domainName string) error {
 	}
 	logrus.Infof("Starting Kubevirt domain %s, devicename nodename %d nodeName:%s vmis:%v", domainName, len(ctx.nodeNameMap), nodeName, vmis)
 
+	appUUID, err := appUUIDFromDomainName(domainName)
+	if err != nil {
+		return logError("Start domain %s: could not parse app UUID: %v", domainName, err)
+	}
+	desiredCounter, ok := trailingCounter(vmis.name)
+	if !ok {
+		return logError("Start domain %s: could not parse purge counter from %s", domainName, vmis.name)
+	}
+	if err := ctx.sweepStaleGenerations(appUUID, vmis.name, desiredCounter, vmis.mtype); err != nil {
+		return logError("Start domain %s: stale-generation sweep failed: %v", domainName, err)
+	}
+
 	// Start the Pod ReplicaSet
 	if vmis.mtype == IsMetaReplicaPod {
 		err := StartReplicaPodContiner(ctx, vmis)
@@ -786,7 +1049,7 @@ func (ctx kubevirtContext) Start(domainName string) error {
 
 	// Start the VMI ReplicaSet
 	repvmi := vmis.repVMI
-	virtClient, err := kubecli.GetKubevirtClientFromRESTConfig(kubeconfig)
+	virtClient, err := newKubevirtClient(kubeconfig)
 	if err != nil {
 		logrus.Errorf("couldn't get the kubernetes client API config: %v", err)
 		return err
@@ -794,8 +1057,11 @@ func (ctx kubevirtContext) Start(domainName string) error {
 
 	// Create the VMI ReplicaSet, retrying on transient kube API server errors.
 	const maxRetries = 5
+	var created *v1.VirtualMachineInstanceReplicaSet
 	for retries := maxRetries; ; retries-- {
-		_, err = virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).Create(context.Background(), repvmi, metav1.CreateOptions{})
+		createCtx, createCancel := apiCtx()
+		created, err = virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).Create(createCtx, repvmi, metav1.CreateOptions{})
+		createCancel()
 		if err == nil {
 			break
 		}
@@ -803,6 +1069,10 @@ func (ctx kubevirtContext) Start(domainName string) error {
 			// VMI could have been already started, for example failover from
 			// other node. An interrupted DetachUtilVmirsReplicaReset can leave
 			// the existing object scaled to 0 replicas; ensure it is not.
+			//
+			// The response on this branch carries no object, so the placeholder
+			// id from Setup stands until the next Info call re-derives it from a
+			// fresh Get.
 			logrus.Warnf("VMI replicaset %v already exists", repvmi)
 			if ensureErr := ensureVmirsReplicas(virtClient, vmis.name); ensureErr != nil {
 				return logError("Start domain %s: failed to ensure vmirs %s replicas: %v", domainName, vmis.name, ensureErr)
@@ -816,15 +1086,34 @@ func (ctx kubevirtContext) Start(domainName string) error {
 		logrus.Errorf("Start VMI replicaset failed, retrying (%d left): %v", retries-1, err)
 		time.Sleep(10 * time.Second)
 	}
+	if created != nil {
+		newID := workloadID(string(created.UID), vmis.name)
+		if newID != vmis.domainID {
+			logrus.Infof("Start(%s): domainID changed from %d to %d", domainName, vmis.domainID, newID)
+			vmis.domainID = newID
+		}
+	}
 	logrus.Infof("Started Kubevirt domain replicaset %s, VMI replicaset %s", domainName, vmis.name)
 
 	// Start() returns as soon as VMIRS is created; cluster drives VMI scheduling.
 	return nil
 }
 
-// Create is no-op for kubevirt, just return the domainID we already have.
+// Create is a no-op for kubevirt: it just returns an id for the domain that
+// Setup already built (and Start is about to create the VMIRS/pod for).
+//
+// This runs before the object exists in the cluster - Start creates it
+// afterwards - so if vmiList already has an entry (the normal case; Setup
+// just populated it) its cached id is returned unchanged. If not, config
+// carries everything needed to derive the exact same kubeName-based
+// fallback id Setup would have used, so this never has to dereference a
+// missing map entry.
 func (ctx kubevirtContext) Create(domainName string, cfgFilename string, config *types.DomainConfig) (int, error) {
-	return ctx.vmiList[domainName].domainID, nil
+	if vmis, ok := ctx.vmiList[domainName]; ok {
+		return vmis.domainID, nil
+	}
+	kubeName := base.GetAppKubeNameWithPurge(config.DisplayName, config.UUIDandVersion.UUID, config.PurgeCounter)
+	return workloadID("", kubeName), nil
 }
 
 // podListToSchedulingState derives the node-placement decision from a
@@ -832,13 +1121,24 @@ func (ctx kubevirtContext) Create(domainName string, cfgFilename string, config 
 // signal for node assignment; Status.Phase is deliberately not used because a
 // pod in Init:0/1 carries Phase="Pending" even after it has been bound to a
 // node by the scheduler.
-func podListToSchedulingState(pods []k8sv1.Pod, nodeName string) (onMe bool, anyNode bool, err error) {
+//
+// scheduledOnNone means "no non-terminating replica is bound to any node" -
+// i.e. the first non-terminating pod's own Spec.NodeName is empty. This is
+// the same definition the VMI-list path (replicaVmiScheduledOnMe) uses for
+// its own scheduledOnNone; a bound-but-elsewhere pod (Spec.NodeName set to
+// something other than nodeName) is neither onMe nor scheduledOnNone.
+func podListToSchedulingState(pods []k8sv1.Pod, nodeName string) (onMe bool, scheduledOnNone bool, err error) {
 	for _, p := range pods {
 		if p.ObjectMeta.DeletionTimestamp != nil {
 			continue
 		}
-		return p.Spec.NodeName == nodeName, true, nil
+		onMe = p.Spec.NodeName == nodeName
+		scheduledOnNone = p.Spec.NodeName == ""
+		logrus.Infof("podListToSchedulingState: pod %s Spec.NodeName:%q onMe:%t scheduledOnNone:%t",
+			p.ObjectMeta.Name, p.Spec.NodeName, onMe, scheduledOnNone)
+		return onMe, scheduledOnNone, nil
 	}
+	logrus.Infof("podListToSchedulingState: no non-terminating pod among %d", len(pods))
 	return false, false, fmt.Errorf("unhandled scheduling state")
 }
 
@@ -849,7 +1149,7 @@ func (ctx kubevirtContext) replicaVmiScheduledOnMe(vmirsName string) (scheduledO
 		return false, false, err
 	}
 
-	virtClient, err := kubecli.GetKubevirtClientFromRESTConfig(ctx.kubeConfig)
+	virtClient, err := newKubevirtClient(ctx.kubeConfig)
 	if err != nil {
 		logrus.Errorf("couldn't get the kubernetes client API config: %v", err)
 		return false, false, err
@@ -892,16 +1192,23 @@ func (ctx kubevirtContext) vmiScheduledOnMeFromVmirs(virtClient kubecli.Kubevirt
 			}
 			if vmi.Status.NodeName == "" {
 				// Not scheduled yet, move on
+				logrus.Infof("vmiScheduledOnMeFromVmirs(%s): vmi %s not yet scheduled anywhere",
+					vmirs.Name, vmi.ObjectMeta.Name)
 				continue
 			}
-			return (vmi.Status.NodeName == nodeName), false, nil
+			onMe := vmi.Status.NodeName == nodeName
+			logrus.Infof("vmiScheduledOnMeFromVmirs(%s): vmi %s scheduled on %q onMe:%t",
+				vmirs.Name, vmi.ObjectMeta.Name, vmi.Status.NodeName, onMe)
+			return onMe, false, nil
 		}
 		// Intentional fallback to looking at a virt-launcher pod
 		// One or both VMI objects may be either terminating or not scheduled to any node.
+		logrus.Infof("vmiScheduledOnMeFromVmirs(%s): no attributable vmi among %d, "+
+			"falling back to pod list", vmirs.Name, len(vmis.Items))
 	}
 
 	// No VMI, look for a Virt-launcher pod instead, it will start earlier
-	podclientset, err := kubernetes.NewForConfig(ctx.kubeConfig)
+	podclientset, err := newK8sClient(ctx.kubeConfig)
 	if err != nil {
 		return false, false, fmt.Errorf("no kube config")
 	}
@@ -909,6 +1216,7 @@ func (ctx kubevirtContext) vmiScheduledOnMeFromVmirs(virtClient kubecli.Kubevirt
 		LabelSelector: "kubevirt.io=virt-launcher," + appDomainNameSelector,
 	})
 	if len(vlPods.Items) == 0 {
+		logrus.Infof("vmiScheduledOnMeFromVmirs(%s): no virt-launcher pod found", vmirs.Name)
 		return false, false, nil
 	}
 	return podListToSchedulingState(vlPods.Items, nodeName)
@@ -926,7 +1234,7 @@ func (ctx kubevirtContext) replicaPodScheduledOnMe(rsName string) (onMe bool, sc
 		return false, false, fmt.Errorf("Failed to get nodeName")
 	}
 
-	podclientset, err := kubernetes.NewForConfig(ctx.kubeConfig)
+	podclientset, err := newK8sClient(ctx.kubeConfig)
 	if err != nil {
 		return false, false, fmt.Errorf("no kube config")
 	}
@@ -1101,7 +1409,7 @@ func (ctx kubevirtContext) Delete(domainName string) (result error) {
 
 // StopReplicaVMI stops the VMI ReplicaSet
 func StopReplicaVMI(kubeconfig *rest.Config, repVmiName string) error {
-	virtClient, err := kubecli.GetKubevirtClientFromRESTConfig(kubeconfig)
+	virtClient, err := newKubevirtClient(kubeconfig)
 	if err != nil {
 		logrus.Errorf("couldn't get the kubernetes client API config: %v", err)
 		return err
@@ -1205,29 +1513,111 @@ func ensureVmirsReplicas(virtClient kubecli.KubevirtClient, vmiRsName string) er
 		ensureVmirsReplicaRetries, vmiRsName)
 }
 
-func (ctx kubevirtContext) Info(domainName string) (int, types.SwState, error) {
+// apiCtx bounds a single Kubernetes API request with kubeapi.KubeAPITimeout,
+// the budget the rest of pillar already uses - see getVmirs just below, and the
+// kubeapi and cmd/zedkube packages. It exists as a helper because several of
+// these calls sit inside retry loops, where a deferred cancel would hold every
+// context until the loop finished.
+//
+// This matters more here than elsewhere: domainmgr's runHandler calls Info on a
+// 9-30s ticker and Start synchronously, and zedbox's watchdog reboots the device
+// if that handler stops checking in. A request that blocks forever on an
+// unhealthy API server therefore takes the node down. With a deadline it fails
+// instead, which Info reports as UNKNOWN with the caller's id preserved -
+// exactly the contract documented on types.DomainStatus.DomainId.
+func apiCtx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), kubeapi.KubeAPITimeout())
+}
 
+// replicaSetUID confirms existence of the app's VMIRS (or, for a NOHYPER
+// app, its plain ReplicaSet) directly via Get, rather than inferring
+// existence from replica placement, and returns its metadata.uid.
+//
+// err is the raw API error. Callers must check errors.IsNotFound(err) to
+// distinguish "confirmed absent" from "could not confirm" (e.g. the API is
+// unreachable) - only the former may ever produce the zero id.
+func (t kubevirtTask) replicaSetUID(kubeName string) (uid string, err error) {
+	if err := getConfig(&t.kubevirtContext); err != nil {
+		return "", err
+	}
+	if t.metaType() == IsMetaReplicaPod {
+		clientset, err := newK8sClient(t.kubeConfig)
+		if err != nil {
+			return "", err
+		}
+		getCtx, getCancel := apiCtx()
+		rs, err := clientset.AppsV1().ReplicaSets(kubeapi.EVEKubeNameSpace).
+			Get(getCtx, kubeName, metav1.GetOptions{})
+		getCancel()
+		if err != nil {
+			return "", err
+		}
+		return string(rs.UID), nil
+	}
+	virtClient, err := newKubevirtClient(t.kubeConfig)
+	if err != nil {
+		return "", err
+	}
+	getCtx, getCancel := apiCtx()
+	vmirs, err := virtClient.ReplicaSet(kubeapi.EVEKubeNameSpace).
+		Get(getCtx, kubeName, metav1.GetOptions{})
+	getCancel()
+	if err != nil {
+		return "", err
+	}
+	return string(vmirs.UID), nil
+}
+
+// Info's contract: DomainId is zero if and only if the VMIRS (or plain
+// ReplicaSet, for a NOHYPER app) is confirmed absent (Get -> NotFound).
+// Every other outcome - found, found-but-unattributed, found-with-an-
+// unmapped-phase, or the existence check itself failing - returns a
+// non-zero id, because a zero id is what tells domainmgr's doInactivate/
+// doCleanup that a teardown already happened.
+func (t kubevirtTask) Info(domainName string) (int, types.SwState, error) {
 	logrus.Debugf("Info called for Domain: %s", domainName)
-	nodeName, ok := ctx.nodeNameMap["nodename"]
+	nodeName, ok := t.nodeNameMap["nodename"]
 	if !ok {
 		return 0, types.BROKEN, logError("Failed to get nodeName")
 	}
 
-	var res string
-	var err error
-	err = getConfig(&ctx)
-	if err != nil {
-		return 0, types.BROKEN, err
+	// Fill in kubeConfig here. The receiver is a value, so the getConfig
+	// call in replicaSetUID fills in a copy and leaves t.kubeConfig nil.
+	// A nil *rest.Config panics newKubevirtClient below.
+	if err := getConfig(&t.kubevirtContext); err != nil {
+		return t.status.DomainId, types.UNKNOWN, logError(
+			"Info(%s): can not get kubeconfig: %v", domainName, err)
 	}
-	vmis, ok := ctx.vmiList[domainName]
-	if !ok {
-		if stale, oldKey := ctx.lookupVMIByUUIDPrefix(domainName); stale != nil {
-			logrus.Warnf("Info: domainName %s not in vmiList; using stale entry under %s",
-				domainName, oldKey)
-			vmis = stale
-		} else {
-			return 0, types.HALTED, logError("info domain %s failed to get vmlist", domainName)
+
+	kubeName := t.kubeName()
+
+	uid, err := t.replicaSetUID(kubeName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logrus.Infof("Info(%s): %s confirmed absent", domainName, kubeName)
+			return 0, types.HALTED, nil
 		}
+		// Existence could not be confirmed one way or the other (API
+		// unreachable, or some other error): never produce the "confirmed
+		// absent" token while the answer is unknown, so keep whatever id
+		// the caller already had.
+		logrus.Infof("Info(%s): existence check for %s failed: %v", domainName, kubeName, err)
+		return t.status.DomainId, types.UNKNOWN, err
+	}
+	id := workloadID(uid, kubeName)
+
+	// Note: unlike Stop/Delete/Cleanup, a miss here does not fall back to
+	// lookupVMIByUUIDPrefix's stale entry. That fallback's cached name can
+	// belong to an older generation than the kubeName whose existence was
+	// just confirmed above, which would make the phase-reading calls below
+	// silently query the wrong object. Since existence no longer depends on
+	// vmiList at all, a miss here can safely just hold (SCHEDULING) rather
+	// than risk that mismatch.
+	vmis, ok := t.vmiList[domainName]
+	if !ok {
+		logrus.Infof("Info(%s): %s exists but there is no local vmiList entry for it",
+			domainName, kubeName)
+		return id, types.SCHEDULING, nil
 	}
 
 	// Check for a stranded VMIRS before the scheduledOnMe/!onMe short-circuit
@@ -1235,69 +1625,110 @@ func (ctx kubevirtContext) Info(domainName string) (int, types.SwState, error) {
 	// onMe would be false and this domain would otherwise be reported as
 	// UNKNOWN forever instead of recovering. The VMIRS fetched here is reused
 	// for the scheduling check below instead of fetching it a second time.
+	//
+	// Note the object queried is kubeName, derived from DomainStatus, not
+	// vmis.name from the cache: vmiList can still name an older generation
+	// after a purge, and checking that one's replica count would report on the
+	// wrong object.
 	var vmirs *v1.VirtualMachineInstanceReplicaSet
 	var virtClient kubecli.KubevirtClient
 	if vmis.mtype == IsMetaReplicaVMI {
 		var verr error
-		virtClient, verr = kubecli.GetKubevirtClientFromRESTConfig(ctx.kubeConfig)
+		virtClient, verr = newKubevirtClient(t.kubeConfig)
 		if verr != nil {
 			return 0, types.BROKEN, logError("couldn't get the kubernetes client API config: %v", verr)
 		}
 		var rerr error
-		vmirs, rerr = getVmirs(virtClient, vmis.name)
+		vmirs, rerr = getVmirs(virtClient, kubeName)
 		if rerr != nil {
 			if isK3sUnreachable(rerr) {
-				return 0, types.UNKNOWN, nil
+				// Unknown, not absent: hold the caller's id rather than
+				// emitting the "confirmed gone" token.
+				return t.status.DomainId, types.UNKNOWN, nil
 			}
 			// Non-unreachable Get failure: fall through to scheduledOnMe's own
 			// independent fetch attempt below, same as before this reuse was
 			// added -- vmirs stays nil so the generic dispatch runs.
 			vmirs = nil
 		} else if vmirsStranded(vmirsDesiredReplicas(vmirs)) {
-			return 0, types.HALTED, logError("domain %s vmirs %s scaled to 0 replicas", domainName, vmis.name)
+			// The object exists, so the id stays non-zero (zero means
+			// confirmed absent, see types.DomainStatus.DomainId); HALTED is
+			// what tells domainmgr the workload is down and to recreate it,
+			// which Start's ensureVmirsReplicas then repairs.
+			return id, types.HALTED, logError("domain %s vmirs %s scaled to 0 replicas",
+				domainName, kubeName)
 		}
 	}
 
-	var onMe bool
+	var onMe, scheduledOnNone bool
 	if vmirs != nil {
-		onMe, _, err = ctx.vmiScheduledOnMeFromVmirs(virtClient, vmirs)
+		onMe, scheduledOnNone, err = t.vmiScheduledOnMeFromVmirs(virtClient, vmirs)
 	} else {
-		onMe, _, err = ctx.scheduledOnMe(vmis.mtype, vmis.name)
+		onMe, scheduledOnNone, err = t.scheduledOnMe(vmis.mtype, kubeName)
 	}
 	if err != nil {
 		if isK3sUnreachable(err) {
-			return 0, types.UNKNOWN, nil
+			logrus.Infof("Info(%s): k3s unreachable while determining scheduled node: %v",
+				domainName, err)
+			return t.status.DomainId, types.UNKNOWN, err
 		}
-		return 0, types.BROKEN, logError("Failed to determine scheduled node: %s", err)
+		logrus.Infof("Info(%s): failed to determine scheduled node for %s: %v",
+			domainName, kubeName, err)
+		return id, types.SCHEDULING, err
 	}
 	if !onMe {
-		return 0, types.UNKNOWN, nil
+		if scheduledOnNone {
+			// Exists, but no non-terminating replica is bound to any node
+			// yet (mid-restart, mid-failover) - this is the case that used
+			// to fall through to a false zero via !onMe.
+			logrus.Infof("Info(%s): %s exists but is not yet scheduled anywhere", domainName, kubeName)
+			return id, types.SCHEDULING, nil
+		}
+		// Bound to a different node: healthy elsewhere, just not here.
+		// Returning SCHEDULING here would send verifyStatus into its
+		// rescheduling arm and make an app that is healthy on another node
+		// report BOOTING forever, so this stays UNKNOWN - only the id
+		// changes from 0 to a real, non-zero value.
+		logrus.Infof("Info(%s): %s scheduled on a different node", domainName, kubeName)
+		return id, types.UNKNOWN, nil
 	}
 
+	var res string
 	if vmis.mtype == IsMetaReplicaPod {
-		res, err = InfoReplicaSetContainer(ctx, vmis)
+		res, err = InfoReplicaSetContainer(t.kubevirtContext, vmis)
 	} else {
 		res, err = getVMIStatus(vmis, nodeName)
 	}
 	if err != nil {
 		if isK3sUnreachable(err) {
-			return 0, types.UNKNOWN, nil
+			logrus.Infof("Info(%s): k3s unreachable while getting status: %v", domainName, err)
+			return t.status.DomainId, types.UNKNOWN, err
 		}
-		return 0, types.BROKEN, logError("domain %s failed to get info: %v", domainName, err)
+		logrus.Infof("Info(%s): failed to get status for %s: %v", domainName, kubeName, err)
+		return id, types.SCHEDULING, err
 	}
 
-	if effectiveDomainState, matched := stateMap[res]; !matched {
-		// Received undefined state in our map, return UNKNOWN instead
-		retStatus, err := checkAndReturnStatus(vmis, true)
+	effectiveDomainState, matched := stateMap[res]
+	if !matched {
+		// Received an undefined phase string. Object presence is already
+		// confirmed, so the default is SCHEDULING (held), not the old
+		// HALTING-by-default (which zeroed DomainId via domainmgr's own
+		// HALTED/HALTING branch and skipped a teardown that had not
+		// actually happened). checkAndReturnStatus's own 30+ minute
+		// escalation to "Halting" for a workload stuck unmapped that long
+		// is unrelated to this and is preserved unchanged.
+		retStatus, statusErr := checkAndReturnStatus(vmis, true)
 		logrus.Infof("domain %s reported to be in unexpected state %s", domainName, res)
-		effectiveDomainState = types.HALTING
-		if retStatus == "Unknown" {
-			effectiveDomainState = types.UNKNOWN
+		effectiveDomainState = types.SCHEDULING
+		if retStatus != "Unknown" {
+			effectiveDomainState = types.HALTING
 		}
-		return vmis.domainID, effectiveDomainState, err
-	} else {
-		return vmis.domainID, effectiveDomainState, err
+		logrus.Infof("Info(%s): unmapped state %q -> %s, id:%d", domainName, res,
+			effectiveDomainState.String(), id)
+		return id, effectiveDomainState, statusErr
 	}
+	logrus.Infof("Info(%s): state %q -> %s, id:%d", domainName, res, effectiveDomainState.String(), id)
+	return id, effectiveDomainState, nil
 }
 
 func (ctx kubevirtContext) Cleanup(domainName string) error {
@@ -1357,12 +1788,12 @@ func convertToKubernetesFormat(b int) string {
 func getVMIStatus(vmis *vmiMetaData, nodeName string) (string, error) {
 
 	repVmiName := vmis.name
-	kubeconfig, err := kubeapi.GetKubeConfig()
+	kubeconfig, err := getKubeConfig()
 	if err != nil {
 		return "", logError("couldn't get the Kube Config: %v", err)
 	}
 
-	virtClient, err := kubecli.GetKubevirtClientFromRESTConfig(kubeconfig)
+	virtClient, err := newKubevirtClient(kubeconfig)
 
 	if err != nil {
 		return "", logError("couldn't get the Kube client Config: %v", err)
@@ -1387,12 +1818,21 @@ func getVMIStatus(vmis *vmiMetaData, nodeName string) (string, error) {
 		return retStatus, err2
 	}
 
-	// Use the first VMI in the list
+	// Use the first non-terminating VMI in the list. Skipping terminating
+	// copies matters when a replica is being replaced on the same node: the
+	// old (terminating) and new VMI briefly coexist with the same
+	// GenerateName and NodeName, and picking whichever the API happened to
+	// list first - rather than the live one - is what made a confirm-absence
+	// wait latch onto the object that was already on its way out instead of
+	// the one it actually needed to watch.
 	var nonLocalStatus string
 	var targetVMI *v1.VirtualMachineInstance
 	for _, vmi := range vmiList.Items {
 		logrus.Debugf("getVMIStatus: repVmi:%s nodeName:%s vmiList vmi.ObjectMeta.Name:%s vmi.Status.NodeName:%s vmi.ObjectMeta.DeletionTimestamp:%v vmi.Status.Phase:%s",
 			repVmiName, nodeName, vmi.ObjectMeta.Name, vmi.Status.NodeName, vmi.ObjectMeta.DeletionTimestamp, vmi.Status.Phase)
+		if vmi.ObjectMeta.DeletionTimestamp != nil {
+			continue
+		}
 		if vmi.Status.NodeName == nodeName {
 			if vmi.GenerateName == repVmiName {
 				targetVMI = &vmi
@@ -1760,6 +2200,12 @@ func (ctx kubevirtContext) CreateReplicaPodConfig(domainName string, config type
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kubeName,
 			Namespace: kubeapi.EVEKubeNameSpace,
+			// Mirrors the VMIRS path's own top-level label (CreateReplicaVMIConfig):
+			// lets a stale-generation sweep find every ReplicaSet belonging to this
+			// app, across purge generations, by UUID prefix alone.
+			Labels: map[string]string{
+				eveLabelKey: domainName,
+			},
 		},
 		Spec: appsv1.ReplicaSetSpec{
 			Replicas: repNum,
@@ -1857,10 +2303,11 @@ func (ctx kubevirtContext) CreateReplicaPodConfig(domainName string, config type
 		}
 	}
 	meta := vmiMetaData{
-		repPod:      replicaSet,
-		mtype:       IsMetaReplicaPod,
-		name:        kubeName,
-		domainID:    int(rand.Uint32()),
+		repPod: replicaSet,
+		mtype:  IsMetaReplicaPod,
+		name:   kubeName,
+		// See the identical comment in CreateReplicaVMIConfig.
+		domainID:    workloadID("", kubeName),
 		memOverhead: uint64(overhead),
 	}
 	ctx.evictStaleVMIByUUIDPrefix(domainName)
@@ -1933,7 +2380,7 @@ func StartReplicaPodContiner(ctx kubevirtContext, vmis *vmiMetaData) error {
 	if err != nil {
 		return err
 	}
-	clientset, err := kubernetes.NewForConfig(ctx.kubeConfig)
+	clientset, err := newK8sClient(ctx.kubeConfig)
 	if err != nil {
 		logrus.Errorf("StartReplicaPodContiner: can't get clientset %v", err)
 		return err
@@ -1945,8 +2392,16 @@ func StartReplicaPodContiner(ctx kubevirtContext, vmis *vmiMetaData) error {
 		if !errors.IsAlreadyExists(err) {
 			logrus.Errorf("StartReplicaPodContiner: replicaset create failed: %v", err)
 			return err
-		} else {
-			opStr = "already exists"
+		}
+		// The response on this branch carries no object, so the placeholder id
+		// from Setup stands until the next Info call re-derives it from a fresh Get.
+		opStr = "already exists"
+	} else if result != nil {
+		newID := workloadID(string(result.UID), vmis.name)
+		if newID != vmis.domainID {
+			logrus.Infof("StartReplicaPodContiner(%s): domainID changed from %d to %d",
+				rep.ObjectMeta.Name, vmis.domainID, newID)
+			vmis.domainID = newID
 		}
 	}
 
@@ -1998,7 +2453,7 @@ func InfoReplicaSetContainer(ctx kubevirtContext, vmis *vmiMetaData) (string, er
 	if err != nil {
 		return "", err
 	}
-	podclientset, err := kubernetes.NewForConfig(ctx.kubeConfig)
+	podclientset, err := newK8sClient(ctx.kubeConfig)
 	if err != nil {
 		return "", logError("InfoReplicaSetContainer: couldn't get the pod Config: %v", err)
 	}
@@ -2050,7 +2505,7 @@ func checkReplicaPodMetrics(ctx kubevirtContext, res map[string]types.DomainMetr
 		return
 	}
 	kubeconfig := ctx.kubeConfig
-	podclientset, err := kubernetes.NewForConfig(kubeconfig)
+	podclientset, err := newK8sClient(kubeconfig)
 	if err != nil {
 		logrus.Errorf("checkReplicaPodMetrics: can not get pod client %v", err)
 		return
@@ -2168,7 +2623,7 @@ func getPodMetrics(clientset *metricsv.Clientset, pod k8sv1.Pod, vmis *vmiMetaDa
 // StopReplicaPodContainer stops the ReplicaSet pod
 func StopReplicaPodContainer(kubeconfig *rest.Config, repName string) error {
 
-	clientset, err := kubernetes.NewForConfig(kubeconfig)
+	clientset, err := newK8sClient(kubeconfig)
 	if err != nil {
 		logrus.Errorf("StopReplicaPodContainer: can't get clientset %v", err)
 		return err
@@ -2200,7 +2655,7 @@ func InfoPodContainer(ctx kubevirtContext, podName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	podclientset, err := kubernetes.NewForConfig(ctx.kubeConfig)
+	podclientset, err := newK8sClient(ctx.kubeConfig)
 	if err != nil {
 		return "", logError("InfoPodContainer: couldn't get the pod Config: %v", err)
 	}
@@ -2253,7 +2708,7 @@ func calculateMemoryUsagePercent(usedMemory, allocatedMemory int64) float64 {
 
 func getConfig(ctx *kubevirtContext) error {
 	if ctx.kubeConfig == nil {
-		kubeconfig, err := kubeapi.GetKubeConfig()
+		kubeconfig, err := getKubeConfig()
 		if err != nil {
 			logrus.Error("getConfig: can not get kubeconfig")
 			return err

--- a/pkg/pillar/hypervisor/kubevirt_identity.go
+++ b/pkg/pillar/hypervisor/kubevirt_identity.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package hypervisor
+
+import "hash/fnv"
+
+// workloadID derives a stable, non-zero identifier for a kube workload from
+// its cluster object UID, falling back to its Kubernetes name when the UID
+// is not yet known (e.g. before the object has been created - Create runs
+// before Start creates the VMIRS, so there is no UID to read yet).
+//
+// This is the kube-mode analogue of a pid: DomainId is only ever compared
+// against the same app's own previous value, or against zero, never used
+// as a cross-app key, so a hash collision between two different apps is
+// harmless.
+//
+// 0 is reserved exclusively for "confirmed absent" (see Info's contract),
+// so a hash that happens to land on exactly 0 is mapped to 1.
+func workloadID(uid, kubeName string) int {
+	key := uid
+	if key == "" {
+		key = kubeName
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(key))
+	// Mask to 63 bits so the result is always a non-negative int (int is
+	// 64-bit on every platform EVE builds for), then guard the one masked
+	// value that lands on zero.
+	id := int64(h.Sum64() & 0x7FFFFFFFFFFFFFFF)
+	if id == 0 {
+		return 1
+	}
+	return int(id)
+}

--- a/pkg/pillar/hypervisor/kubevirt_identity_test.go
+++ b/pkg/pillar/hypervisor/kubevirt_identity_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package hypervisor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorkloadID(t *testing.T) {
+	t.Run("deterministic per UID", func(t *testing.T) {
+		id1 := workloadID("11111111-1111-1111-1111-111111111111", "myapp-a1b2c-1")
+		id2 := workloadID("11111111-1111-1111-1111-111111111111", "myapp-a1b2c-1")
+		assert.Equal(t, id1, id2)
+	})
+
+	t.Run("differs across UIDs", func(t *testing.T) {
+		id1 := workloadID("11111111-1111-1111-1111-111111111111", "myapp-a1b2c-1")
+		id2 := workloadID("22222222-2222-2222-2222-222222222222", "myapp-a1b2c-1")
+		assert.NotEqual(t, id1, id2)
+	})
+
+	t.Run("never zero", func(t *testing.T) {
+		// A broad sweep of inputs, including ones hand-picked to be more
+		// likely to collide with a masking edge case, none of which may
+		// ever produce exactly 0.
+		inputs := []string{"", "0", "a", "myapp-a1b2c-1", "11111111-1111-1111-1111-111111111111"}
+		for _, in := range inputs {
+			assert.NotZero(t, workloadID(in, "fallback-name"))
+			assert.NotZero(t, workloadID("", in))
+		}
+	})
+
+	t.Run("falls back to kubeName when UID is unavailable", func(t *testing.T) {
+		idFromUID := workloadID("11111111-1111-1111-1111-111111111111", "myapp-a1b2c-1")
+		idFromNameAsUID := workloadID("myapp-a1b2c-1", "unused")
+		idFromFallback := workloadID("", "myapp-a1b2c-1")
+		assert.NotEqual(t, idFromUID, idFromNameAsUID,
+			"a UID and an unrelated kubeName must not coincidentally hash the same input")
+		assert.Equal(t, idFromNameAsUID, idFromFallback,
+			"an empty UID must fall back to hashing kubeName, i.e. the exact same input "+
+				"as passing kubeName in the UID slot")
+	})
+}

--- a/pkg/pillar/hypervisor/kubevirt_info_test.go
+++ b/pkg/pillar/hypervisor/kubevirt_info_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package hypervisor
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+)
+
+// newInfoTestTask builds a kubevirtTask ready to call Info/replicaSetUID
+// against a mocked kubevirt client, with an arbitrary non-zero
+// status.DomainId sentinel so tests can tell whether Info preserved it.
+func newInfoTestTask(t *testing.T, lastKnownID int) (kubevirtTask, *types.DomainStatus) {
+	t.Helper()
+	appUUID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
+	status := &types.DomainStatus{
+		UUIDandVersion: types.UUIDandVersion{UUID: appUUID},
+		DisplayName:    "myapp",
+		DomainName:     "myapp." + appUUID.String(),
+		PurgeCounter:   1,
+		DomainId:       lastKnownID,
+	}
+	status.VirtualizationMode = types.HVM // -> IsMetaReplicaVMI
+
+	var ctx kubevirtContext
+	ctx.nodeNameMap = map[string]string{"nodename": "node1"}
+
+	// Leave ctx.kubeConfig nil, as domainmgr does, and stub only the
+	// kubeconfig read. Info must then call getConfig itself. An earlier
+	// version of this helper set kubeConfig here and hid a nil-pointer
+	// panic in Info.
+	swapGetKubeConfig(t)
+
+	return ctx.Task(status).(kubevirtTask), status
+}
+
+// TestInfoContract pins the main invariant in Info's contract (see its doc
+// comment in kubevirt.go): a zero DomainId means the VMIRS is confirmed
+// absent, and nothing else. Every other outcome must return a non-zero id.
+//
+// It covers the two rows the existence check decides alone (NotFound, and
+// unreachable) plus the stranded-VMIRS row. The remaining "found" rows need
+// VMI and pod listing as well, so the evetest purge tests cover those.
+func TestInfoContract(t *testing.T) {
+	const lastKnownID = 918273645
+
+	t.Run("NotFound is the only case that returns zero", func(t *testing.T) {
+		task, _ := newInfoTestTask(t, lastKnownID)
+
+		ctrl := gomock.NewController(t)
+		mockClient := kubecli.NewMockKubevirtClient(ctrl)
+		mockRS := kubecli.NewMockReplicaSetInterface(ctrl)
+		mockClient.EXPECT().ReplicaSet(gomock.Any()).Return(mockRS).AnyTimes()
+		mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			nil, apierrors.NewNotFound(
+				schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineinstancereplicasets"},
+				task.kubeName()))
+		swapKubevirtClient(t, mockClient)
+
+		id, state, err := task.Info(task.status.DomainName)
+		assert.NoError(t, err)
+		assert.Equal(t, types.HALTED, state)
+		assert.Zero(t, id)
+	})
+
+	t.Run("an unreachable API never returns zero and keeps the last known id", func(t *testing.T) {
+		task, _ := newInfoTestTask(t, lastKnownID)
+
+		ctrl := gomock.NewController(t)
+		mockClient := kubecli.NewMockKubevirtClient(ctrl)
+		mockRS := kubecli.NewMockReplicaSetInterface(ctrl)
+		mockClient.EXPECT().ReplicaSet(gomock.Any()).Return(mockRS).AnyTimes()
+		mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			nil, assert.AnError)
+		swapKubevirtClient(t, mockClient)
+
+		id, state, err := task.Info(task.status.DomainName)
+		assert.Error(t, err)
+		assert.Equal(t, types.UNKNOWN, state)
+		assert.Equal(t, lastKnownID, id, "must preserve the caller's last known id, not fabricate a new one")
+		assert.NotZero(t, id)
+	})
+
+	// The two rows above return before Info builds a client. This row is the
+	// shortest path to that line, which panicked on a device. HALTED with a
+	// non-zero id tells domainmgr to recreate the workload.
+	t.Run("a stranded VMIRS is HALTED with a non-zero id", func(t *testing.T) {
+		task, _ := newInfoTestTask(t, lastKnownID)
+		domainName := task.status.DomainName
+		task.vmiList = map[string]*vmiMetaData{
+			domainName: {mtype: IsMetaReplicaVMI, name: task.kubeName()},
+		}
+
+		noReplicas := int32(0)
+		stranded := &v1.VirtualMachineInstanceReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{Name: task.kubeName(), UID: "stranded-uid"},
+			Spec:       v1.VirtualMachineInstanceReplicaSetSpec{Replicas: &noReplicas},
+		}
+
+		ctrl := gomock.NewController(t)
+		mockClient := kubecli.NewMockKubevirtClient(ctrl)
+		mockRS := kubecli.NewMockReplicaSetInterface(ctrl)
+		mockClient.EXPECT().ReplicaSet(gomock.Any()).Return(mockRS).AnyTimes()
+		// Two Gets: the existence check in replicaSetUID, then getVmirs.
+		mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(stranded, nil).AnyTimes()
+		swapKubevirtClient(t, mockClient)
+
+		id, state, err := task.Info(domainName)
+		assert.Error(t, err, "a stranded VMIRS is logged as an error")
+		assert.Equal(t, types.HALTED, state)
+		assert.NotZero(t, id, "the object exists, so zero would falsely mean confirmed-absent")
+	})
+}
+
+// TestInfoUnreachableKeepsLastID is a focused restatement of the second
+// case in TestInfoContract: a range of different last-known ids must all
+// survive an existence-check failure unchanged.
+func TestInfoUnreachableKeepsLastID(t *testing.T) {
+	for _, lastKnownID := range []int{1, 42, 918273645} {
+		task, _ := newInfoTestTask(t, lastKnownID)
+
+		ctrl := gomock.NewController(t)
+		mockClient := kubecli.NewMockKubevirtClient(ctrl)
+		mockRS := kubecli.NewMockReplicaSetInterface(ctrl)
+		mockClient.EXPECT().ReplicaSet(gomock.Any()).Return(mockRS).AnyTimes()
+		mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
+		swapKubevirtClient(t, mockClient)
+
+		id, state, err := task.Info(task.status.DomainName)
+		assert.Error(t, err)
+		assert.Equal(t, types.UNKNOWN, state)
+		assert.Equal(t, lastKnownID, id)
+	}
+}
+
+// TestCreateReturnsNonZero pins the pre-Start sequencing invariant: Create
+// runs before the VMIRS exists, so vmiList has no entry for it yet, but
+// Create must still return a non-zero id derived from config - never a nil
+// dereference (the map access this replaced) and never zero.
+func TestCreateReturnsNonZero(t *testing.T) {
+	var ctx kubevirtContext // zero value: nil vmiList
+	appUUID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
+	config := &types.DomainConfig{
+		UUIDandVersion: types.UUIDandVersion{UUID: appUUID},
+		DisplayName:    "myapp",
+		PurgeCounter:   1,
+	}
+
+	id, err := ctx.Create("some-domain-name", "", config)
+	assert.NoError(t, err)
+	assert.NotZero(t, id)
+}

--- a/pkg/pillar/hypervisor/kubevirt_staleness.go
+++ b/pkg/pillar/hypervisor/kubevirt_staleness.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package hypervisor
+
+import (
+	"strconv"
+	"strings"
+
+	uuid "github.com/satori/go.uuid"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "kubevirt.io/api/core/v1"
+)
+
+// staleVMIRSGeneration reports whether vmirs is a superseded generation of
+// the given app's VMIRS: it carries the app's App-Domain-Name label prefix
+// ("<uuid>."), its object name differs from the desired generation's name,
+// and its trailing purge-counter suffix parses as strictly less than
+// desiredCounter.
+//
+// The label lives on Spec.Selector.MatchLabels (and the pod template),
+// not on the VMIRS object's own ObjectMeta.Labels - CreateReplicaVMIConfig
+// never sets that field at all - so this reads the selector, not
+// vmirs.GetLabels().
+//
+// Name inequality, not label or version comparison, is what distinguishes
+// "this generation" from "an older one": a non-purge config edit bumps the
+// label's embedded config version without renaming the object, so a
+// version-only rule would misclassify the current generation as stale.
+//
+// An unparsable or missing counter suffix is never considered stale, since
+// there is nothing to safely compare it against.
+func staleVMIRSGeneration(
+	vmirs v1.VirtualMachineInstanceReplicaSet, appUUID uuid.UUID,
+	desiredName string, desiredCounter uint32) bool {
+	var label string
+	if vmirs.Spec.Selector != nil {
+		label = vmirs.Spec.Selector.MatchLabels[eveLabelKey]
+	}
+	if !strings.HasPrefix(label, appUUID.String()+".") {
+		return false
+	}
+	name := vmirs.GetName()
+	if name == desiredName {
+		return false
+	}
+	counter, ok := trailingCounter(name)
+	if !ok {
+		return false
+	}
+	return counter < desiredCounter
+}
+
+// stalePodReplicaSetGeneration is staleVMIRSGeneration's analogue for a
+// NOHYPER app's plain container ReplicaSet. Unlike the VMIRS case, this
+// object's own ObjectMeta.Labels does carry the App-Domain-Name label -
+// see CreateReplicaPodConfig - because there is no pre-existing convention
+// on this type to follow instead.
+func stalePodReplicaSetGeneration(
+	rs appsv1.ReplicaSet, appUUID uuid.UUID, desiredName string, desiredCounter uint32) bool {
+	label := rs.GetLabels()[eveLabelKey]
+	if !strings.HasPrefix(label, appUUID.String()+".") {
+		return false
+	}
+	name := rs.GetName()
+	if name == desiredName {
+		return false
+	}
+	counter, ok := trailingCounter(name)
+	if !ok {
+		return false
+	}
+	return counter < desiredCounter
+}
+
+// stalePodReplicaSetNames is staleVMIRSNames's ReplicaSet-Pod analogue.
+func stalePodReplicaSetNames(
+	list []appsv1.ReplicaSet, appUUID uuid.UUID, desiredName string, desiredCounter uint32) []string {
+	var names []string
+	for _, rs := range list {
+		if stalePodReplicaSetGeneration(rs, appUUID, desiredName, desiredCounter) {
+			names = append(names, rs.GetName())
+		}
+	}
+	return names
+}
+
+// trailingCounter extracts the purge-counter suffix from a name of the form
+// "<anything>-<counter>" (see base.GetAppKubeNameWithPurge), i.e. the
+// digits after the last hyphen. ok is false if there is no hyphen or the
+// suffix is not a valid non-negative integer.
+func trailingCounter(name string) (counter uint32, ok bool) {
+	idx := strings.LastIndex(name, "-")
+	if idx < 0 || idx == len(name)-1 {
+		return 0, false
+	}
+	n, err := strconv.ParseUint(name[idx+1:], 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(n), true
+}
+
+// staleVMIRSNames returns the names of every VMIRS in vmirsList that is a
+// stale generation of appUUID's app, per staleVMIRSGeneration. Pure and
+// side-effect free; callers are responsible for actually enumerating
+// vmirsList from the cluster and for deleting whatever it returns.
+func staleVMIRSNames(
+	vmirsList []v1.VirtualMachineInstanceReplicaSet, appUUID uuid.UUID,
+	desiredName string, desiredCounter uint32) []string {
+	var names []string
+	for _, vmirs := range vmirsList {
+		if staleVMIRSGeneration(vmirs, appUUID, desiredName, desiredCounter) {
+			names = append(names, vmirs.GetName())
+		}
+	}
+	return names
+}

--- a/pkg/pillar/hypervisor/kubevirt_staleness_test.go
+++ b/pkg/pillar/hypervisor/kubevirt_staleness_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package hypervisor
+
+import (
+	"testing"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "kubevirt.io/api/core/v1"
+)
+
+// mkVMIRS builds a fixture matching what CreateReplicaVMIConfig actually
+// creates: the App-Domain-Name label lives on Spec.Selector.MatchLabels,
+// not on the object's own ObjectMeta.Labels (which CreateReplicaVMIConfig
+// never sets).
+func mkVMIRS(name, domainNameLabel string) v1.VirtualMachineInstanceReplicaSet {
+	return v1.VirtualMachineInstanceReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1.VirtualMachineInstanceReplicaSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{eveLabelKey: domainNameLabel},
+			},
+		},
+	}
+}
+
+// mkPodReplicaSet builds a fixture matching CreateReplicaPodConfig, which
+// (unlike the VMIRS case) does set the App-Domain-Name label directly on
+// ObjectMeta.Labels.
+func mkPodReplicaSet(name, domainNameLabel string) appsv1.ReplicaSet {
+	return appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{eveLabelKey: domainNameLabel},
+		},
+	}
+}
+
+func TestStaleGenerationPredicate(t *testing.T) {
+	appUUID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
+	otherUUID := uuid.Must(uuid.FromString("22222222-2222-2222-2222-222222222222"))
+	domainName := appUUID.String() + ".1.0"
+	const desiredName = "myapp-a1b2c-2"
+	const desiredCounter = uint32(2)
+
+	tests := []struct {
+		name   string
+		vmirs  v1.VirtualMachineInstanceReplicaSet
+		wantOK bool
+	}{
+		{
+			name:   "older generation of this app is stale",
+			vmirs:  mkVMIRS("myapp-a1b2c-1", domainName),
+			wantOK: true,
+		},
+		{
+			name:   "much older generation of this app is stale",
+			vmirs:  mkVMIRS("myapp-a1b2c-0", domainName),
+			wantOK: true,
+		},
+		{
+			name:   "the desired generation itself is never stale",
+			vmirs:  mkVMIRS(desiredName, domainName),
+			wantOK: false,
+		},
+		{
+			name:   "a differently-named object at the same counter is never stale (not strictly less)",
+			vmirs:  mkVMIRS("myapp-old-2", domainName),
+			wantOK: false,
+		},
+		{
+			name:   "a newer generation is never stale",
+			vmirs:  mkVMIRS("myapp-a1b2c-3", domainName),
+			wantOK: false,
+		},
+		{
+			name:   "a different app's older-numbered generation is ignored",
+			vmirs:  mkVMIRS("otherapp-x9y8z-1", otherUUID.String()+".1.0"),
+			wantOK: false,
+		},
+		{
+			name:   "unparsable (non-numeric) trailing suffix is never stale",
+			vmirs:  mkVMIRS("myapp-a1b2c-abc", domainName),
+			wantOK: false,
+		},
+		{
+			name:   "name with no hyphen is never stale",
+			vmirs:  mkVMIRS("myappa1b2c1", domainName),
+			wantOK: false,
+		},
+		{
+			name:   "empty App-Domain-Name label is ignored",
+			vmirs:  mkVMIRS("myapp-a1b2c-1", ""),
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := staleVMIRSGeneration(tc.vmirs, appUUID, desiredName, desiredCounter)
+			assert.Equal(t, tc.wantOK, got)
+		})
+	}
+}
+
+func TestStaleVMIRSNames(t *testing.T) {
+	appUUID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
+	otherUUID := uuid.Must(uuid.FromString("22222222-2222-2222-2222-222222222222"))
+	domainName := appUUID.String() + ".1.0"
+	const desiredName = "myapp-a1b2c-2"
+
+	list := []v1.VirtualMachineInstanceReplicaSet{
+		mkVMIRS("myapp-a1b2c-0", domainName),
+		mkVMIRS("myapp-a1b2c-1", domainName),
+		mkVMIRS(desiredName, domainName),
+		mkVMIRS("otherapp-x9y8z-0", otherUUID.String()+".1.0"),
+	}
+
+	got := staleVMIRSNames(list, appUUID, desiredName, 2)
+	assert.ElementsMatch(t, []string{"myapp-a1b2c-0", "myapp-a1b2c-1"}, got)
+}
+
+func TestStalePodReplicaSetNames(t *testing.T) {
+	appUUID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
+	otherUUID := uuid.Must(uuid.FromString("22222222-2222-2222-2222-222222222222"))
+	domainName := appUUID.String() + ".1.0"
+	const desiredName = "myapp-a1b2c-2"
+
+	list := []appsv1.ReplicaSet{
+		mkPodReplicaSet("myapp-a1b2c-0", domainName),
+		mkPodReplicaSet("myapp-a1b2c-1", domainName),
+		mkPodReplicaSet(desiredName, domainName),
+		mkPodReplicaSet("otherapp-x9y8z-0", otherUUID.String()+".1.0"),
+	}
+
+	got := stalePodReplicaSetNames(list, appUUID, desiredName, 2)
+	assert.ElementsMatch(t, []string{"myapp-a1b2c-0", "myapp-a1b2c-1"}, got)
+}
+
+func TestTrailingCounter(t *testing.T) {
+	tests := []struct {
+		name        string
+		wantCounter uint32
+		wantOK      bool
+	}{
+		{name: "myapp-a1b2c-2", wantCounter: 2, wantOK: true},
+		{name: "myapp-a1b2c-0", wantCounter: 0, wantOK: true},
+		{name: "myapp-a1b2c-", wantOK: false},
+		{name: "myapp-a1b2c-abc", wantOK: false},
+		{name: "noseparator", wantOK: false},
+		{name: "", wantOK: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			counter, ok := trailingCounter(tc.name)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.wantCounter, counter)
+			}
+		})
+	}
+}

--- a/pkg/pillar/hypervisor/kubevirt_stopreplicavmi_test.go
+++ b/pkg/pillar/hypervisor/kubevirt_stopreplicavmi_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package hypervisor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"kubevirt.io/client-go/kubecli"
+)
+
+// swapKubevirtClient overrides newKubevirtClient to always return client,
+// restoring the original constructor when the test ends. Tests using this
+// must not run with t.Parallel, since the override is a shared
+// package-level var.
+//
+// The override rejects a nil *rest.Config, because the real constructor
+// panics on one. A stub that ignores its argument hides a caller that never
+// filled in kubeConfig.
+func swapKubevirtClient(t *testing.T, client kubecli.KubevirtClient) {
+	t.Helper()
+	orig := newKubevirtClient
+	newKubevirtClient = func(cfg *rest.Config) (kubecli.KubevirtClient, error) {
+		if cfg == nil {
+			t.Errorf("newKubevirtClient called with a nil *rest.Config: " +
+				"the caller did not populate kubeConfig (getConfig on a value " +
+				"receiver fills in a copy); this panics in production")
+		}
+		return client, nil
+	}
+	t.Cleanup(func() { newKubevirtClient = orig })
+}
+
+// TestStopReplicaVMIErrorHandling pins the fix to the inverted IsNotFound
+// check in StopReplicaVMI: success and NotFound must both return nil, and
+// only a real API error should be returned (and logged as an error).
+func TestStopReplicaVMIErrorHandling(t *testing.T) {
+	tests := []struct {
+		name    string
+		delErr  error
+		wantErr bool
+	}{
+		{
+			name:    "success",
+			delErr:  nil,
+			wantErr: false,
+		},
+		{
+			name: "not found is not an error",
+			delErr: apierrors.NewNotFound(
+				schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineinstancereplicasets"},
+				"myapp-a1b2c-1"),
+			wantErr: false,
+		},
+		{
+			name:    "a real API error is returned",
+			delErr:  apierrors.NewInternalError(assert.AnError),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockClient := kubecli.NewMockKubevirtClient(ctrl)
+			mockRS := kubecli.NewMockReplicaSetInterface(ctrl)
+			mockClient.EXPECT().ReplicaSet(gomock.Any()).Return(mockRS).AnyTimes()
+			mockRS.EXPECT().
+				Delete(gomock.Any(), "myapp-a1b2c-1", gomock.Any()).
+				Return(tc.delErr)
+
+			swapKubevirtClient(t, mockClient)
+
+			err := StopReplicaVMI(&rest.Config{}, "myapp-a1b2c-1")
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/pillar/hypervisor/kubevirt_sweep_test.go
+++ b/pkg/pillar/hypervisor/kubevirt_sweep_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package hypervisor
+
+import (
+	"testing"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+)
+
+// swapK8sClientNoPods overrides newK8sClient to return a fake clientset
+// with no pods in it, i.e. every pod-list confirm-absence check reports
+// "gone" immediately. Sufficient for sweep tests, which are exercising the
+// VMIRS/ReplicaSet object side of confirm-absence, not pod teardown timing.
+// It asserts a non-nil config for the reason given on swapKubevirtClient.
+func swapK8sClientNoPods(t *testing.T) {
+	t.Helper()
+	orig := newK8sClient
+	fakeClientset := fake.NewSimpleClientset()
+	newK8sClient = func(cfg *rest.Config) (kubernetes.Interface, error) {
+		if cfg == nil {
+			t.Errorf("newK8sClient called with a nil *rest.Config: " +
+				"the caller did not populate kubeConfig")
+		}
+		return fakeClientset, nil
+	}
+	t.Cleanup(func() { newK8sClient = orig })
+}
+
+// swapSweepConfirmInterval shrinks the confirm-absence retry interval for
+// the duration of a test, so a deliberately-never-gone timeout test does
+// not have to wait out the real ~50s budget.
+func swapSweepConfirmInterval(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := sweepConfirmInterval
+	sweepConfirmInterval = d
+	t.Cleanup(func() { sweepConfirmInterval = orig })
+}
+
+// TestSweepDeletesOnlyOlderGenerations pins the sweep's core selection
+// invariant: given a mix of older, current, and another app's generations,
+// only the strictly-older generations of the target app are deleted - the
+// current generation and the other app's generation must survive untouched.
+func TestSweepDeletesOnlyOlderGenerations(t *testing.T) {
+	appUUID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
+	otherUUID := uuid.Must(uuid.FromString("22222222-2222-2222-2222-222222222222"))
+	domainName := appUUID.String() + ".1.0"
+	const desiredName = "myapp-a1b2c-2"
+	const desiredCounter = uint32(2)
+
+	list := &v1.VirtualMachineInstanceReplicaSetList{
+		Items: []v1.VirtualMachineInstanceReplicaSet{
+			mkVMIRS("myapp-a1b2c-0", domainName),
+			mkVMIRS("myapp-a1b2c-1", domainName),
+			mkVMIRS(desiredName, domainName),
+			mkVMIRS("otherapp-x9y8z-1", otherUUID.String()+".1.0"),
+		},
+	}
+	notFoundErr := apierrors.NewNotFound(
+		schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineinstancereplicasets"}, "")
+
+	ctrl := gomock.NewController(t)
+	mockClient := kubecli.NewMockKubevirtClient(ctrl)
+	mockRS := kubecli.NewMockReplicaSetInterface(ctrl)
+	mockClient.EXPECT().ReplicaSet(gomock.Any()).Return(mockRS).AnyTimes()
+	mockRS.EXPECT().List(gomock.Any(), gomock.Any()).Return(list, nil)
+
+	deleted := map[string]bool{}
+	mockRS.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ interface{}, name interface{}, _ interface{}) error {
+			deleted[name.(string)] = true
+			return nil
+		}).Times(2)
+	// Confirm-absence: object already gone by the time we check.
+	mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, notFoundErr).Times(2)
+
+	swapKubevirtClient(t, mockClient)
+	swapK8sClientNoPods(t)
+
+	var ctx kubevirtContext
+	ctx.kubeConfig = &rest.Config{}
+
+	err := ctx.sweepStaleGenerations(appUUID, desiredName, desiredCounter, IsMetaReplicaVMI)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]bool{"myapp-a1b2c-0": true, "myapp-a1b2c-1": true}, deleted)
+}
+
+// TestSweepConfirmAbsenceTimeoutFails: if a stale generation is deleted but
+// never actually confirmed gone, the sweep must return an error (which
+// Start propagates, refusing to create the new
+// generation) rather than give up silently or hang indefinitely.
+func TestSweepConfirmAbsenceTimeoutFails(t *testing.T) {
+	appUUID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
+	domainName := appUUID.String() + ".1.0"
+
+	list := &v1.VirtualMachineInstanceReplicaSetList{
+		Items: []v1.VirtualMachineInstanceReplicaSet{
+			mkVMIRS("myapp-a1b2c-1", domainName),
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	mockClient := kubecli.NewMockKubevirtClient(ctrl)
+	mockRS := kubecli.NewMockReplicaSetInterface(ctrl)
+	mockClient.EXPECT().ReplicaSet(gomock.Any()).Return(mockRS).AnyTimes()
+	mockRS.EXPECT().List(gomock.Any(), gomock.Any()).Return(list, nil)
+	mockRS.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	// The object is never confirmed gone: every Get keeps succeeding (still there).
+	mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&v1.VirtualMachineInstanceReplicaSet{}, nil).
+		Times(sweepConfirmRetries)
+
+	swapKubevirtClient(t, mockClient)
+	swapK8sClientNoPods(t)
+	swapSweepConfirmInterval(t, time.Millisecond)
+
+	var ctx kubevirtContext
+	ctx.kubeConfig = &rest.Config{}
+
+	err := ctx.sweepStaleGenerations(appUUID, "myapp-a1b2c-2", 2, IsMetaReplicaVMI)
+	assert.Error(t, err)
+}

--- a/pkg/pillar/hypervisor/kubevirt_task_test.go
+++ b/pkg/pillar/hypervisor/kubevirt_task_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package hypervisor
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTaskDerivesKubeName constructs a Task from a DomainStatus whose
+// DisplayName/PurgeCounter match no vmiList entry, and asserts that the
+// kubeName it derives is exactly what CreateReplicaVMIConfig/
+// CreateReplicaPodConfig would have named the same generation.
+func TestTaskDerivesKubeName(t *testing.T) {
+	var ctx kubevirtContext // zero value: nil vmiList, no entries whatsoever
+
+	appUUID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
+	status := &types.DomainStatus{
+		UUIDandVersion: types.UUIDandVersion{UUID: appUUID},
+		DisplayName:    "myapp",
+		PurgeCounter:   3,
+	}
+
+	task := ctx.Task(status)
+	kt, ok := task.(kubevirtTask)
+	assert.True(t, ok, "Task() must return a kubevirtTask")
+
+	// The derivation must not depend on any vmiList entry existing.
+	_, found := kt.vmiList[kt.kubeName()]
+	assert.False(t, found)
+
+	want := base.GetAppKubeNameWithPurge("myapp", appUUID, 3)
+	assert.Equal(t, want, kt.kubeName())
+}
+
+func TestTaskMetaType(t *testing.T) {
+	var ctx kubevirtContext
+
+	tests := []struct {
+		name string
+		mode types.VmMode
+		want MetaDataType
+	}{
+		{name: "NOHYPER runs as a plain container ReplicaSet", mode: types.NOHYPER, want: IsMetaReplicaPod},
+		{name: "HVM runs as a VMI ReplicaSet", mode: types.HVM, want: IsMetaReplicaVMI},
+		{name: "PV (zero value) runs as a VMI ReplicaSet", mode: types.PV, want: IsMetaReplicaVMI},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status := &types.DomainStatus{}
+			status.VirtualizationMode = tc.mode
+			kt := ctx.Task(status).(kubevirtTask)
+			assert.Equal(t, tc.want, kt.metaType())
+		})
+	}
+}

--- a/pkg/pillar/hypervisor/kubevirt_test.go
+++ b/pkg/pillar/hypervisor/kubevirt_test.go
@@ -56,41 +56,44 @@ func TestPodListToSchedulingState(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		pods        []corev1.Pod
-		wantOnMe    bool
-		wantAnyNode bool
-		wantErr     bool
+		name                string
+		pods                []corev1.Pod
+		wantOnMe            bool
+		wantScheduledOnNone bool
+		wantErr             bool
 	}{
 		{
-			name:        "Pending phase with NodeName set (Init:0/1) on this node",
-			pods:        []corev1.Pod{mkPod(node, corev1.PodPending)},
-			wantOnMe:    true,
-			wantAnyNode: true,
+			name:     "Pending phase with NodeName set (Init:0/1) on this node",
+			pods:     []corev1.Pod{mkPod(node, corev1.PodPending)},
+			wantOnMe: true,
+			// Bound to a node (this one), so nothing about "scheduled on none" applies.
+			wantScheduledOnNone: false,
 		},
 		{
-			name:        "Pending phase with NodeName set (Init:0/1) on another node",
-			pods:        []corev1.Pod{mkPod("other-node", corev1.PodPending)},
-			wantOnMe:    false,
-			wantAnyNode: true,
+			name:     "Pending phase with NodeName set (Init:0/1) on another node",
+			pods:     []corev1.Pod{mkPod("other-node", corev1.PodPending)},
+			wantOnMe: false,
+			// Bound to a node, just not this one - neither onMe nor scheduledOnNone.
+			wantScheduledOnNone: false,
 		},
 		{
-			name:        "Running pod on this node",
-			pods:        []corev1.Pod{mkPod(node, corev1.PodRunning)},
-			wantOnMe:    true,
-			wantAnyNode: true,
+			name:                "Running pod on this node",
+			pods:                []corev1.Pod{mkPod(node, corev1.PodRunning)},
+			wantOnMe:            true,
+			wantScheduledOnNone: false,
 		},
 		{
-			name:        "Running pod on another node",
-			pods:        []corev1.Pod{mkPod("other-node", corev1.PodRunning)},
-			wantOnMe:    false,
-			wantAnyNode: true,
+			name:                "Running pod on another node",
+			pods:                []corev1.Pod{mkPod("other-node", corev1.PodRunning)},
+			wantOnMe:            false,
+			wantScheduledOnNone: false,
 		},
 		{
-			name:        "Pending pod with NodeName empty (not yet scheduled)",
-			pods:        []corev1.Pod{mkPod("", corev1.PodPending)},
-			wantOnMe:    false,
-			wantAnyNode: true,
+			name:     "Pending pod with NodeName empty (not yet scheduled)",
+			pods:     []corev1.Pod{mkPod("", corev1.PodPending)},
+			wantOnMe: false,
+			// Not bound to any node at all.
+			wantScheduledOnNone: true,
 		},
 		{
 			name:    "No pods",
@@ -110,14 +113,14 @@ func TestPodListToSchedulingState(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			onMe, anyNode, err := podListToSchedulingState(tc.pods, node)
+			onMe, scheduledOnNone, err := podListToSchedulingState(tc.pods, node)
 			if tc.wantErr {
 				assert.Error(t, err)
 				return
 			}
 			assert.NoError(t, err)
 			assert.Equal(t, tc.wantOnMe, onMe)
-			assert.Equal(t, tc.wantAnyNode, anyNode)
+			assert.Equal(t, tc.wantScheduledOnNone, scheduledOnNone)
 		})
 	}
 }

--- a/pkg/pillar/hypervisor/kubevirt_waitforvmi_test.go
+++ b/pkg/pillar/hypervisor/kubevirt_waitforvmi_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package hypervisor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+)
+
+// swapGetKubeConfig overrides getKubeConfig (the wrapper around
+// kubeapi.GetKubeConfig) to return a dummy, non-nil *rest.Config instead of
+// reading the real kubeconfig file from disk, restoring the original when
+// the test ends.
+func swapGetKubeConfig(t *testing.T) {
+	t.Helper()
+	orig := getKubeConfig
+	getKubeConfig = func() (*rest.Config, error) {
+		return &rest.Config{}, nil
+	}
+	t.Cleanup(func() { getKubeConfig = orig })
+}
+
+// TestWaitForVMITargetsCorrectObject is the regression test for the
+// terminating-replica confusion seen in the field: when a same-node
+// replica restart briefly leaves both the outgoing and incoming VMI
+// matching the same GenerateName and NodeName, getVMIStatus (the primitive
+// waitForVMI polls) must report the live one's phase, not the terminating
+// one's - previously the loop picked whichever the API happened to list
+// first.
+func TestWaitForVMITargetsCorrectObject(t *testing.T) {
+	const nodeName = "node1"
+	const repVmiName = "myapp-a1b2c-1"
+
+	now := metav1.Now()
+	terminating := v1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "myapp-a1b2c-1bbbbb",
+			GenerateName:      repVmiName,
+			DeletionTimestamp: &now,
+		},
+		Status: v1.VirtualMachineInstanceStatus{
+			NodeName: nodeName,
+			Phase:    v1.Running,
+		},
+	}
+	live := v1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         "myapp-a1b2c-1ccccc",
+			GenerateName: repVmiName,
+		},
+		Status: v1.VirtualMachineInstanceStatus{
+			NodeName: nodeName,
+			Phase:    v1.Scheduling,
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	mockClient := kubecli.NewMockKubevirtClient(ctrl)
+	mockVMI := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
+	mockClient.EXPECT().VirtualMachineInstance(gomock.Any()).Return(mockVMI).AnyTimes()
+	// Deliberately list the terminating copy first, matching what the
+	// field trace showed: picking by list order rather than skipping
+	// terminating entries is exactly the bug this pins.
+	mockVMI.EXPECT().List(gomock.Any(), gomock.Any()).Return(&v1.VirtualMachineInstanceList{
+		Items: []v1.VirtualMachineInstance{terminating, live},
+	}, nil)
+
+	swapKubevirtClient(t, mockClient)
+	swapGetKubeConfig(t)
+
+	vmis := &vmiMetaData{name: repVmiName}
+	state, err := getVMIStatus(vmis, nodeName)
+	assert.NoError(t, err)
+	assert.Equal(t, "Scheduling", state,
+		"must report the live replica's phase, not the terminating one's")
+}

--- a/pkg/pillar/types/domainmgrtypes.go
+++ b/pkg/pillar/types/domainmgrtypes.go
@@ -394,6 +394,19 @@ type DomainStatus struct {
 	PendingModify  bool
 	PendingDelete  bool
 	DomainName     string // Name of Xen domain
+	// DomainId identifies the running domain, with hypervisor-specific meaning:
+	// for xen/kvm it is the underlying qemu process's pid; for kubevirt (HV=k)
+	// it is a value derived from the app's current VMIRS/ReplicaSet identity
+	// (see hypervisor/kubevirt.go's workloadID), since there is no pid.
+	//
+	// The one invariant every hypervisor backend must uphold, and every
+	// consumer relies on: DomainId is zero if and only if the domain is
+	// confirmed not present (no process for xen/kvm; VMIRS/ReplicaSet
+	// confirmed absent for kubevirt). It must never be zero merely because
+	// the answer is unknown or unattributable - doInactivate's teardown
+	// gates and doCleanup's success test both key on zero meaning "already
+	// gone", so a zero returned for any other reason skips a teardown that
+	// never happened and reports it as done.
 	DomainId       int
 	BootTime       time.Time
 	DiskStatusList []DiskStatus


### PR DESCRIPTION
# Description

Backport of #6257

Partial backport: the pillar fix only. The two evetest commits from the
original PR are **not** included — see "Scope" below.

## Purge leaves the old app generation running on the kube path

A purge must delete the app's previous generation before it creates the
new one. On the kube path it does not: the old VMIRS keeps running, and
EVE reports the purge complete anyway.

### Root cause (three defects, all in `pkg/pillar`)

1. **`Info()` reports "gone" when it only can't see the domain.** It
   returned domain ID 0 whenever it found no replica on this node.
   `domainmgr` copies that 0 into `DomainStatus`; `zedmanager` reads 0 as
   "no domain," skips the teardown, and releases the purge anyway.
   `Info()` now gets identity and existence from the cluster instead of
   a random ID, and returns 0 only when the VMIRS is confirmed absent —
   never when it merely can't confirm one way or the other.

2. **Nothing deletes the old generation after a reboot.** `/run` is
   tmpfs, so a reboot drops the purge state pillar was tracking, but the
   VMIRS survives in etcd. `zedmanager` finds no local domain to halt,
   advances the counter anyway, and a new generation starts beside the
   old one. `Start()` now sweeps the cluster first: it finds every older
   generation, deletes it, and confirms the object and its pods are
   gone before proceeding. A failed sweep fails the start — safer than
   two generations sharing MACs, veth names, and one RWO disk.

3. **`zedmanager` can wait forever for a volume-ref removal.** A purge
   parks the old `VolumeRefStatus` and waits for `volumemgr` to confirm
   the delete. If `volumemgr` has no live status for that reference in
   the current boot, the confirmation never arrives, and the app is
   stuck in `DownloadAndVerify` forever. `zedmanager` now checks
   `volumemgr`'s live status first and drops the reference if it's
   already gone.

## Scope of this backport

Only `pillar: keep purges from leaving the old app generation behind`
(9c2eecf8def94423bd6bf29a6abba2ada9ebd242) is backported. It cherry-picks
cleanly onto 17.0-stable with no adaptation.

The original PR's two evetest commits are omitted because they cannot be
cherry-picked to this branch: the evetest framework here is a different
generation (`evetest/VERSION` v0.0.1 vs 1.4 on master, with 79 evetest
commits on master not present on 17.0-stable). Both commits modify files
that do not exist on this branch — `evetest/tests/apps/testsuite_test.go`
(the whole `tests/apps/` suite is absent) and three
`evetest/tests/cluster/` files — and the new tests call harness helpers
this branch's `edgedevice.go`/`harness.go` do not have. Porting that
purge coverage to the v0.0.1 harness would be a hand-written change, not
a backport, so it is deliberately left out of this PR.

## PR dependencies

None. This does not conflict with #6353 (the #6100 backport); the two
were verified to apply cleanly in either order.

## How to test and validate this PR

The automated purge tests are not available on this branch (see Scope),
so validate manually on an eve-k device — purging a container app, which
runs in a VMIRS via a shim VM:

- **Baseline** — purge a healthy, undisturbed app. Exactly one VMIRS and
  one volume must exist before and after, and the survivor must be named
  for the new generation.
- **Purge across a power cycle** — purge while the device is powered off,
  then power it back on. This reproduces the failure customers saw. On
  coming back up there must be exactly one VMIRS (the new generation),
  no leftover PVC from the old one, and the app must reach running
  rather than sticking in `DownloadAndVerify`.

Useful checks on the device:

```sh
kubectl -n eve-kube-app get vmirs
kubectl -n eve-kube-app get pvc
```

A kvm-hypervisor purge across a power cycle is a useful control: a kvm
domain is a local qemu process with no cluster-side object to lose track
of, so the duplicate-generation defect is structurally impossible there.

Unit coverage picked up with the fix: `go test -tags k
./cmd/zedmanager/... ./hypervisor/...` (includes the new
`updatestatus_test.go`, `kubevirt_staleness_test.go`,
`kubevirt_identity_test.go`, `kubevirt_info_test.go` and others).

## Changelog notes

Fixes a bug on eve-k (kubevirt hypervisor) where purging an application around a
device reboot could leave a duplicate/stale VM instance running alongside the new
one, or leave the purge stuck indefinitely instead of completing. No other
user-facing changes.

## PR Backports

This is the backport

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
