### PR TITLE
[13.4-stable] zfs: serialize libzfs namespace enumeration to avoid panic

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -288,8 +288,11 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext, wdName string) {
 		}
 	}
 
-	// If we have ZFS dataset, report their info from the ZFS perspective
+	// If we have ZFS dataset, report their info from the ZFS perspective.
+	// The enumeration waits for any other agent already inside libzfs, so
+	// report liveness before entering it rather than only after publishing.
 	if handler := volumehandlers.GetZFSVolumeHandler(log, ctx); handler != nil {
+		ctx.ps.StillRunning(wdName, warningTime, errorTime)
 		items, err := handler.GetAllDataSets()
 		if err != nil {
 			log.Error(err)

--- a/pkg/pillar/cmd/zfsmanager/zfsmanager.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsmanager.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -56,7 +55,6 @@ type zfsContext struct {
 	subVolumeStatus        pubsub.Subscription
 	disksProcessingTrigger chan interface{}
 	zVolDeviceEvents       *base.LockedStringMap // stores device->zVolDeviceEvent mapping to check and publish
-	zfsIterLock            sync.Mutex
 	globalConfig           *types.ConfigItemValueMap
 	GCInitialized          bool
 }

--- a/pkg/pillar/cmd/zfsmanager/zfsstoragemetrics.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsstoragemetrics.go
@@ -6,7 +6,6 @@ package zfsmanager
 import (
 	"time"
 
-	libzfs "github.com/andrewd-zededa/go-libzfs"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils/persist"
 	"github.com/lf-edge/eve/pkg/pillar/zfs"
@@ -33,9 +32,7 @@ func storageMetricsPublisher(ctxPtr *zfsContext) {
 
 func collectAndPublishStorageMetrics(ctxPtr *zfsContext) {
 	log.Functionf("collectAndPublishStorageMetrics start")
-	ctxPtr.zfsIterLock.Lock()
-	defer ctxPtr.zfsIterLock.Unlock()
-	zpoolList, err := libzfs.PoolOpenAll()
+	zpoolList, err := zfs.PoolOpenAll()
 	if err != nil {
 		log.Errorf("get zpool list for collect metrics failed %v", err)
 	} else {

--- a/pkg/pillar/cmd/zfsmanager/zfsstoragestatus.go
+++ b/pkg/pillar/cmd/zfsmanager/zfsstoragestatus.go
@@ -34,14 +34,12 @@ func storageStatusPublisher(ctxPtr *zfsContext) {
 
 func collectAndPublishStorageStatus(ctxPtr *zfsContext) {
 	log.Functionf("collectAndPublishStorageStatus start")
-	ctxPtr.zfsIterLock.Lock()
-	defer ctxPtr.zfsIterLock.Unlock()
 	zfsVersion, err := zfs.GetZfsVersion()
 	if err != nil {
 		log.Errorf("error: %v", err)
 	}
 
-	zpoolList, err := libzfs.PoolOpenAll()
+	zpoolList, err := zfs.PoolOpenAll()
 	if err != nil {
 		log.Errorf("get zpool list failed %v", err)
 	} else {

--- a/pkg/pillar/zfs/namespace.go
+++ b/pkg/pillar/zfs/namespace.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zfs
+
+import (
+	"sync"
+
+	libzfs "github.com/andrewd-zededa/go-libzfs"
+)
+
+// namespaceLock serializes the two libzfs entry points that rebuild the userland
+// pool namespace. libzfs keeps that namespace in a single AVL tree per library
+// handle, and go-libzfs shares one handle across the whole process, so two agents
+// enumerating at once tear the tree down under each other. libzfs asserts on the
+// resulting duplicate insert and calls abort(), which kills every agent in zedbox:
+// a SIGABRT raised inside C cannot be recovered by the Go runtime.
+//
+// Only zpool_iter() and zfs_iter_root() reach that tree, and both walk it after
+// reloading it, so the lock is held across a whole enumeration. The handles an
+// enumeration returns do not refer to the tree, so callers hold no lock while
+// working with them.
+var namespaceLock sync.Mutex
+
+// PoolOpenAll enumerates the pools. Every caller must reach libzfs through this
+// wrapper rather than calling the binding directly, so that enumerations
+// serialize process-wide; namespace_test.go enforces that.
+func PoolOpenAll() ([]libzfs.Pool, error) {
+	namespaceLock.Lock()
+	defer namespaceLock.Unlock()
+	return libzfs.PoolOpenAll()
+}
+
+// DatasetOpenAll enumerates the datasets, under the same contract as PoolOpenAll.
+// The caller owns the returned handles and releases them with
+// libzfs.DatasetCloseAll.
+func DatasetOpenAll() ([]libzfs.Dataset, error) {
+	namespaceLock.Lock()
+	defer namespaceLock.Unlock()
+	return libzfs.DatasetOpenAll()
+}

--- a/pkg/pillar/zfs/namespace_test.go
+++ b/pkg/pillar/zfs/namespace_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zfs
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoDirectEnumeration fails when pillar calls a libzfs enumeration outside
+// the wrappers in namespace.go. The serialization those wrappers provide is
+// process-wide, so a single caller reaching the binding directly defeats it for
+// every agent, and nothing else in the build reports that.
+func TestNoDirectEnumeration(t *testing.T) {
+	banned := []string{"libzfs.PoolOpenAll(", "libzfs.DatasetOpenAll("}
+	exempt := map[string]bool{"namespace.go": true, "namespace_test.go": true}
+
+	var offenders []string
+	err := filepath.WalkDir("..", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == "vendor" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || exempt[d.Name()] {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, call := range banned {
+			if strings.Contains(string(content), call) {
+				offenders = append(offenders, path+": "+call)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking pillar sources: %v", err)
+	}
+	for _, offender := range offenders {
+		t.Errorf("%s must go through the zfs package wrapper so enumerations serialize", offender)
+	}
+}

--- a/pkg/pillar/zfs/zfs.go
+++ b/pkg/pillar/zfs/zfs.go
@@ -1040,7 +1040,7 @@ func GetVDevAuxMsgStr(state types.VDevAux) string {
 
 // GetAllZFSVolumeInfo returns an ImgInfo for each ZFS dataset
 func GetAllZFSVolumeInfo() ([]types.ImgInfo, error) {
-	list, err := libzfs.DatasetOpenAll()
+	list, err := DatasetOpenAll()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

Backport of #6310 to `13.4-stable`.

Enumerating ZFS pools or datasets makes libzfs rebuild the pool namespace it keeps
per library handle, and the binding shares one handle process-wide. Two agents
enumerating at once tear that tree down under each other and libzfs aborts, which
kills every agent in zedbox and reboots the device with no reboot reason and no
stack. The 2022 lock only covered zfsmanager; volumemgr's disk-metrics dataset
enumeration has been unprotected since 2024. The lock moves into the zfs package
so it covers every caller.

Cherry-picked with `-x` from master: `38c2deb257d1`.

### Adaptations

Two adaptations. The import block of `cmd/zfsmanager/zfsstoragemetrics.go` conflicted: this branch imports `libzfs "github.com/andrewd-zededa/go-libzfs"` where master's post-change file imports `base`. This branch never used `base`, and `libzfs` is unused once the enumeration goes through the zfs package, so both sides were dropped. Also dropped the now-unused `"sync"` import from `cmd/zfsmanager/zfsmanager.go`, as on the other branches.

## PR dependencies

**#6301's backport before #6310's** — that is #6369 before this PR.

#6369 (the #6301 backport to `13.4-stable`) also touches `cmd/volumemgr/handlediskmetrics.go`, and #6310 was written on top of #6301 on
master. If this PR lands first it will need a rebase.

## How to test and validate this PR

`go test ./zfs/ ./cmd/zfsmanager/ ./cmd/volumemgr/` in `pkg/pillar`. The new
`pkg/pillar/zfs/namespace_test.go` fails the build if a caller reaches the
binding directly again. On a ZFS device, storage metrics and disk metrics should
keep being reported with no zedbox restart.

## Changelog notes

Fixes a device reboot with no reboot reason on ZFS systems, caused by two agents enumerating ZFS pools at the same time.

## PR Backports

- 17.0-stable: #6358
- 16.0-stable: #6359
- 14.5-stable: #6360
- 13.4-stable: this PR.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Unit tests, `go vet` and `gofmt` were run on this branch; the device checkboxes
are left for QA.

