### PR TITLE
[13.4-stable] newlog: capture cgo aborts and full tracebacks

### DIFF
--- a/pkg/newlog/cmd/newlogd.go
+++ b/pkg/newlog/cmd/newlogd.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -82,6 +83,9 @@ var (
 	persistMbytes uint64 // '/persist' disk space total in Mbytes
 	gzipFilesCnt  int64  // total gzip files written
 	panicBuf      []byte // buffer to save panic crash stack
+	// panicBuf is appended by the memlogd reader goroutine and drained by the
+	// main loop when panicWriteTimer fires.
+	panicBufLock sync.Mutex
 
 	limitGzipFilesMbyts uint32 // maximum Mbytes for gzip files remain to be sent up
 
@@ -342,10 +346,12 @@ func main() {
 			savePanicFiles(panicBuf)
 
 		case <-panicWriteTimer.C:
+			panicBufLock.Lock()
 			if len(panicBuf) > 0 {
 				savePanicFiles(panicBuf)
 				panicBuf = nil
 			}
+			panicBufLock.Unlock()
 
 		case <-schedResetTimer.C:
 			syncToFileCnt = defaultSyncCount
@@ -670,7 +676,7 @@ func getMemlogMsg(logChan chan inputEntry, panicFileChan chan []byte) {
 		}
 
 		// if we are in watchdog going down. fsync often
-		checkWatchdogRestart(&entry, &panicStackCount, string(bytes), panicFileChan)
+		checkWatchdogRestart(&entry, &panicStackCount, panicFileChan)
 
 		logChan <- entry
 	}
@@ -1462,8 +1468,40 @@ func cleanGzipTempfiles(dir string) {
 	}
 }
 
+const (
+	// panicQuietPeriod is how long the capture waits for more traceback lines
+	// before writing the panic files.
+	panicQuietPeriod = 2 * time.Second
+)
+
+var (
+	// Budget for one capture, kept in variables so tests can shrink it. zedbox
+	// dumps every goroutine as one memlogd record per line, which runs to
+	// thousands of records and hundreds of KiB, and the frames that explain a
+	// crash are rarely the first ones.
+	maxPanicRecords = 20000
+	maxPanicBufSize = 2 << 20
+
+	// Prefixes of the first stderr line of a fatal pillar failure. Signal
+	// banners appear both bare ("SIGABRT: abort") and inside a Go panic
+	// message ("[signal SIGSEGV: segmentation violation ...").
+	panicStartMarkers = []string{
+		"panic:",
+		"fatal error:",
+		"ASSERT at ",
+		"[signal SIG",
+		"SIGABRT:",
+		"SIGSEGV:",
+		"SIGBUS:",
+		"SIGFPE:",
+		"SIGILL:",
+		"SIGTRAP:",
+		"signal arrived during cgo execution",
+	}
+)
+
 // flush more often when we are going down by reading from watchdog log message itself
-func checkWatchdogRestart(entry *inputEntry, panicStackCount *int, origMsg string, panicFileChan chan []byte) {
+func checkWatchdogRestart(entry *inputEntry, panicStackCount *int, panicFileChan chan []byte) {
 	// source can be watchdog or watchdog.err
 	if strings.HasPrefix(entry.source, "watchdog") {
 		if strings.Contains(entry.content, "Retry timed-out at") {
@@ -1477,31 +1515,60 @@ func checkWatchdogRestart(entry *inputEntry, panicStackCount *int, origMsg strin
 	}
 
 	// the panic generated message can have the source either as 'pillar' or 'pillar.out'
-	// this origMsg is the raw message, the ";" is the deliminator between source and content.
-	if strings.Contains(entry.source, "pillar") && strings.Contains(origMsg, ";panic:") &&
-		!strings.Contains(entry.content, "rebootReason") {
-		*panicStackCount = 1
-		panicBuf = append(panicBuf, []byte(origMsg)...)
-		// in case there is only few log messages after this, kick off a timer to write the panic files
-		panicWriteTimer = time.NewTimer(2 * time.Second)
-	} else if *panicStackCount > 0 {
-		var done bool
-		if strings.Contains(entry.source, "pillar") {
-			panicBuf = append(panicBuf, []byte(origMsg)...)
-		} else {
-			// conclude the capture when log source is not 'pillar'
-			done = true
+	if !strings.Contains(entry.source, "pillar") {
+		return
+	}
+
+	panicBufLock.Lock()
+	defer panicBufLock.Unlock()
+
+	if *panicStackCount == 0 {
+		if !isPanicStart(entry.content) ||
+			strings.Contains(entry.content, "rebootReason") {
+			return
 		}
+		*panicStackCount = 1
+		appendPanicLine(entry.content)
+		panicWriteTimer.Reset(panicQuietPeriod)
+		return
+	}
 
-		*panicStackCount++
+	*panicStackCount++
+	appendPanicLine(entry.content)
 
-		if *panicStackCount > 15 || done {
-			panicWriteTimer.Stop()
-			*panicStackCount = 0
-			panicFileChan <- panicBuf
-			panicBuf = nil
+	// A traceback arrives as a burst of one record per line and other services
+	// keep logging in between, so the capture ends on a quiet period rather
+	// than on the first record from another source. The budget only bounds how
+	// much of a dying process's stack is kept.
+	if *panicStackCount >= maxPanicRecords || len(panicBuf) >= maxPanicBufSize {
+		panicWriteTimer.Stop()
+		*panicStackCount = 0
+		panicFileChan <- panicBuf
+		panicBuf = nil
+		return
+	}
+	panicWriteTimer.Reset(panicQuietPeriod)
+}
+
+// appendPanicLine adds one traceback line to panicBuf. Caller must hold
+// panicBufLock.
+func appendPanicLine(content string) {
+	panicBuf = append(panicBuf, content...)
+	panicBuf = append(panicBuf, '\n')
+}
+
+// isPanicStart reports whether a pillar stderr line begins a fatal failure.
+// Go panics and runtime throws print "panic:"/"fatal error:", while a C
+// assertion or fatal signal raised under cgo runs no Go panic machinery at all
+// and prints only the assert text followed by a signal banner.
+func isPanicStart(content string) bool {
+	content = strings.TrimLeft(content, " \t")
+	for _, marker := range panicStartMarkers {
+		if strings.HasPrefix(content, marker) {
+			return true
 		}
 	}
+	return false
 }
 
 func savePanicFiles(panicbuf []byte) {

--- a/pkg/newlog/cmd/paniccapture_test.go
+++ b/pkg/newlog/cmd/paniccapture_test.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// feedPanicRecords runs a sequence of memlogd records through
+// checkWatchdogRestart and returns whatever was sent to the panic file
+// channel, plus the buffer still being accumulated.
+func feedPanicRecords(t *testing.T, records []inputEntry) (sent []byte, pending string) {
+	t.Helper()
+
+	panicWriteTimer = time.NewTimer(time.Hour)
+	panicWriteTimer.Stop()
+	panicBuf = nil
+	t.Cleanup(func() { panicBuf = nil })
+
+	panicFileChan := make(chan []byte, 1)
+	var count int
+	for i := range records {
+		checkWatchdogRestart(&records[i], &count, panicFileChan)
+	}
+
+	select {
+	case sent = <-panicFileChan:
+	default:
+	}
+	panicBufLock.Lock()
+	defer panicBufLock.Unlock()
+	return sent, string(panicBuf)
+}
+
+// A C assertion failing under cgo, in the order the dying process prints it:
+// no "panic:" appears anywhere and Go's traceback only starts several lines in.
+var cgoAbortRecords = []string{
+	"ASSERT at lib/cgolib/tree.c:190:tree_reload()",
+	"avl_find(hdl->tree, node, &where) == NULL",
+	"  PID: 4280      COMM: zedbox",
+	"SIGABRT: abort",
+	"signal arrived during cgo execution",
+	"goroutine 4490 gp=0xc002b81500 m=13 mp=0xc0005f4808 [syscall]:",
+	"github.com/example/cgolib.OpenAll()",
+}
+
+func pillarRecords(lines []string) []inputEntry {
+	entries := make([]inputEntry, 0, len(lines))
+	for _, l := range lines {
+		entries = append(entries, inputEntry{source: "pillar", content: l})
+	}
+	return entries
+}
+
+func TestPanicCaptureStart(t *testing.T) {
+	t.Run("cgo abort is captured from its first line", func(t *testing.T) {
+		_, pending := feedPanicRecords(t, pillarRecords(cgoAbortRecords))
+		if !strings.HasPrefix(pending, "ASSERT at lib/cgolib/tree.c:190") {
+			t.Fatalf("capture must start at the C assert line, not at the Go traceback; got %q", pending)
+		}
+		if !strings.Contains(pending, "cgolib.OpenAll()") {
+			t.Errorf("traceback frames missing from capture: %q", pending)
+		}
+		if !strings.Contains(pending, "signal arrived during cgo execution") {
+			t.Errorf("signal banner missing from capture: %q", pending)
+		}
+	})
+
+	t.Run("go panic and runtime throw are captured", func(t *testing.T) {
+		for _, first := range []string{
+			"panic: runtime error: invalid memory address or nil pointer dereference",
+			"fatal error: concurrent map writes",
+			"[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x123]",
+		} {
+			_, pending := feedPanicRecords(t, pillarRecords([]string{first, "goroutine 1 [running]:"}))
+			if !strings.HasPrefix(pending, first) {
+				t.Errorf("should trigger on %q, got %q", first, pending)
+			}
+		}
+	})
+
+	t.Run("ordinary pillar logs do not trigger a capture", func(t *testing.T) {
+		_, pending := feedPanicRecords(t, pillarRecords([]string{
+			`{"level":"info","msg":"periodic metrics published","pid":4280}`,
+			`{"level":"error","msg":"handling panic: recovered"}`,
+		}))
+		if pending != "" {
+			t.Errorf("ordinary logs must not start a capture, got %q", pending)
+		}
+	})
+
+	t.Run("a reported rebootReason does not re-trigger", func(t *testing.T) {
+		_, pending := feedPanicRecords(t, pillarRecords([]string{
+			`panic: some old crash rebootReason from the previous boot`,
+		}))
+		if pending != "" {
+			t.Errorf("a reported rebootReason must not start a capture, got %q", pending)
+		}
+	})
+}
+
+func TestPanicCaptureSpansOtherSources(t *testing.T) {
+	// A traceback is a burst of thousands of records; other services keep
+	// logging in between, and those interleaved records must not end it.
+	records := pillarRecords(cgoAbortRecords[:4])
+	records = append(records, inputEntry{source: "zedbox", content: "some other service logged"})
+	records = append(records, inputEntry{source: "kube", content: "and another"})
+	records = append(records, pillarRecords(cgoAbortRecords[4:])...)
+
+	_, pending := feedPanicRecords(t, records)
+	if !strings.Contains(pending, "cgolib.OpenAll()") {
+		t.Errorf("records after an interleaved non-pillar record must still be captured, got %q", pending)
+	}
+	if strings.Contains(pending, "some other service logged") {
+		t.Errorf("non-pillar records must not be captured, got %q", pending)
+	}
+}
+
+func TestPanicCaptureBudget(t *testing.T) {
+	origRecords, origSize := maxPanicRecords, maxPanicBufSize
+	maxPanicRecords = 5
+	t.Cleanup(func() { maxPanicRecords, maxPanicBufSize = origRecords, origSize })
+
+	sent, _ := feedPanicRecords(t, pillarRecords(cgoAbortRecords))
+	if len(sent) == 0 {
+		t.Fatal("hitting the record budget must flush the capture")
+	}
+	if !strings.HasPrefix(string(sent), "ASSERT at") {
+		t.Errorf("flushed capture should start at the assert line, got %q", string(sent))
+	}
+	if got := strings.Count(string(sent), "\n"); got != 5 {
+		t.Errorf("flushed capture should hold %d records, got %d", 5, got)
+	}
+}


### PR DESCRIPTION
# Description

Backport of #6303 to `13.4-stable`.

A fatal pillar failure that is not a Go panic left no trail: when a C assertion
reached through cgo raises SIGABRT, the process dies before any Go panic
machinery runs, so the reboot afterwards had an empty reboot reason, an empty
reboot stack and no panicStacks entry. Detection keyed on a `source;content`
delimiter memlogd no longer sends, so no capture ran for any failure of this
kind. The capture now triggers on the parsed line and ends after a quiet period
rather than at the first record from another service, since a traceback is a
burst of thousands of records with other services logging in between.

Cherry-picked with `-x` from master: `517ed02d44e9`.

### Adaptations

Same as the 14.5-stable backport: the change goes into `newlogd.go` because
`getMemlogMsg.go` does not exist on this branch, and adding the 13-file
restructuring commit `8fea9dad5` that created it is out of scope. This branch
also needed `"sync"` added to `newlogd.go`'s imports.

The tests went into a new `pkg/newlog/cmd/paniccapture_test.go`, rewritten
against the standard library's `testing` package rather than gomega: this
branch's `pkg/newlog` module does not list gomega in `go.mod` at all, and
rewriting six assertions is cheaper than adding a dependency and its vendor tree
to an LTS branch. The cases and their intent are unchanged.

## PR dependencies

None.

## How to test and validate this PR

`go test ./cmd/` in `pkg/newlog`. The added tests cover a cgo abort, a Go panic,
a runtime throw, interleaved records from other services, and the record budget.
On a device, a pillar abort should leave a `panicStacks` entry holding the whole
traceback rather than the first few frames.

## Changelog notes

A fatal pillar crash caused by a C library abort is now recorded with its full stack, instead of rebooting with no reboot reason.

## PR Backports

- 17.0-stable: #6362
- 16.0-stable: #6363
- 14.5-stable: #6364
- 13.4-stable: this PR.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Unit tests, `go vet` and `gofmt` were run on this branch; the device checkboxes
are left for QA.
