### PR TITLE
[13.4-stable] Stop the disk-metrics walk from watchdogging

### DIFF
--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -153,6 +153,10 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext, wdName string) {
 	var diskMetricList []*types.DiskMetric
 	startPubTime := time.Now()
 
+	// Measuring a single directory can take longer than the watchdog tolerates,
+	// so the walks report progress as they go rather than only between paths.
+	wdTick := func() { ctx.ps.StillRunning(wdName, warningTime, errorTime) }
+
 	disks := diskmetrics.FindDisksPartitions(log)
 	for _, d := range disks {
 		ctx.ps.StillRunning(wdName, warningTime, errorTime)
@@ -226,7 +230,7 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext, wdName string) {
 
 	for _, path := range types.ReportDirPaths {
 		ctx.ps.StillRunning(wdName, warningTime, errorTime)
-		usage, err := diskmetrics.DirUsage(log, path)
+		usage, err := diskmetrics.DirUsage(log, path, wdTick)
 		log.Tracef("createOrUpdateDiskMetrics: ReportDirPath %s usage %d err %v", path, usage, err)
 		if err != nil {
 			// Do not report
@@ -249,7 +253,7 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext, wdName string) {
 
 	for _, path := range types.AppPersistPaths {
 		ctx.ps.StillRunning(wdName, warningTime, errorTime)
-		usage, err := diskmetrics.DirUsage(log, path)
+		usage, err := diskmetrics.DirUsage(log, path, wdTick)
 		log.Tracef("createOrUpdateDiskMetrics: AppPersistPath %s usage %d err %v", path, usage, err)
 		if err != nil {
 			// Do not report
@@ -274,7 +278,7 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext, wdName string) {
 	excludeDirs = append(excludeDirs, types.ReportDirPaths...)
 	excludeDirs = append(excludeDirs, types.AppPersistPaths...)
 	list, err := diskmetrics.FindLargeFiles(types.PersistDir, 1024*1024,
-		excludeDirs)
+		excludeDirs, wdTick)
 	if err != nil {
 		log.Errorf("FindLargeFiles Failed: %s", err)
 	} else {

--- a/pkg/pillar/diskmetrics/usage.go
+++ b/pkg/pillar/diskmetrics/usage.go
@@ -177,12 +177,11 @@ func FindLargestDisk(log *base.LogObject) string {
 	return maxdisk
 }
 
-// DirUsage calculates usage of directory
-// it checks if provided directory is zfs mountpoint and take usage from zfs in that case
+// DirUsage calculates usage of directory.
+// When dir holds a whole filesystem, usage comes from that filesystem - one
+// dataset query for ZFS, one statfs otherwise - rather than from walking the
+// tree. Anything else is walked with SizeFromDir.
 func DirUsage(log *base.LogObject, dir string) (uint64, error) {
-	if persist.ReadPersistType() != types.PersistZFS || !strings.HasPrefix(dir, types.PersistDir) {
-		return SizeFromDir(log, dir)
-	}
 	mi, err := mount.Lookup(dir)
 	if err != nil {
 		// Lookup do not return error in case of dir is not mountpoint
@@ -190,15 +189,33 @@ func DirUsage(log *base.LogObject, dir string) (uint64, error) {
 		log.Errorf("dirUsage: Lookup returns error (%s), fallback to SizeFromDir", err)
 		return SizeFromDir(log, dir)
 	}
-	// if it is zfs mountpoint and we mount exactly the directory of interest (not parent folder)
-	if mi.FSType == types.PersistZFS.String() && mi.Mountpoint == dir {
-		usageStat, err := zfs.GetDatasetUsageStat(strings.TrimPrefix(dir, "/"))
-		if err != nil {
-			return 0, err
+	if isWholeFilesystem(mi, dir) {
+		// The dataset name is derived from the path, which only holds inside
+		// the persist pool.
+		if mi.FSType == types.PersistZFS.String() &&
+			strings.HasPrefix(dir, types.PersistDir) {
+			usageStat, err := zfs.GetDatasetUsageStat(strings.TrimPrefix(dir, "/"))
+			if err != nil {
+				return 0, err
+			}
+			return usageStat.Used, nil
 		}
-		return usageStat.Used, nil
+		usage, err := disk.Usage(dir)
+		if err == nil {
+			return usage.Used, nil
+		}
+		log.Errorf("dirUsage: disk.Usage(%s) returns error (%s), fallback to SizeFromDir",
+			dir, err)
 	}
 	return SizeFromDir(log, dir)
+}
+
+// isWholeFilesystem reports whether mi describes a filesystem mounted in its
+// entirety at dir, so that filesystem-wide usage accounts for exactly the tree
+// under dir. A Root other than "/" is a bind mount of a subtree, whose backing
+// filesystem also holds data outside dir.
+func isWholeFilesystem(mi mount.Info, dir string) bool {
+	return mi.Mountpoint == dir && mi.Root == "/"
 }
 
 // Dom0DiskReservedSize returns reserved space for EVE-OS

--- a/pkg/pillar/diskmetrics/usage.go
+++ b/pkg/pillar/diskmetrics/usage.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/containerd/containerd/mount"
 	"github.com/lf-edge/eve/pkg/pillar/base"
@@ -39,10 +40,50 @@ func StatAllocatedBytes(path string) (uint64, error) {
 	return uint64(stat.Blocks * C.DEV_BSIZE), nil
 }
 
+// walkTickInterval bounds how often a walk reports progress. Reporting per
+// directory entry would cost more than the walk itself, while the watchdog
+// tolerates minutes of silence, so seconds of granularity are ample.
+const walkTickInterval = 5 * time.Second
+
+// walkHeartbeat rate-limits the progress callback threaded through a directory
+// walk. A nil *walkHeartbeat is usable and reports nothing.
+type walkHeartbeat struct {
+	tick func()
+	next time.Time
+}
+
+func newWalkHeartbeat(tick func()) *walkHeartbeat {
+	if tick == nil {
+		return nil
+	}
+	return &walkHeartbeat{tick: tick}
+}
+
+func (h *walkHeartbeat) beat() {
+	if h == nil {
+		return
+	}
+	now := time.Now()
+	if now.Before(h.next) {
+		return
+	}
+	h.next = now.Add(walkTickInterval)
+	h.tick()
+}
+
 // SizeFromDir performs a du -s equivalent operation.
 // Didn't use os.ReadDir and filepath.Walk because they sort (quick_sort) all files per directory
 // which is an unnecessary costly operation.
-func SizeFromDir(log *base.LogObject, dirname string) (uint64, error) {
+// tick, when not nil, is called as the walk advances, at most once every
+// walkTickInterval; a caller whose goroutine is watched by the watchdog uses it
+// to report liveness while measuring a tree that takes minutes. It fires only
+// after a directory read returns, so a walk stuck in the kernel stays silent and
+// the watchdog still catches it.
+func SizeFromDir(log *base.LogObject, dirname string, tick func()) (uint64, error) {
+	return sizeFromDir(log, dirname, newWalkHeartbeat(tick))
+}
+
+func sizeFromDir(log *base.LogObject, dirname string, hb *walkHeartbeat) (uint64, error) {
 	var totalUsed uint64
 	fileInfo, err := os.Stat(dirname)
 	if err != nil {
@@ -70,11 +111,12 @@ func SizeFromDir(log *base.LogObject, dirname string) (uint64, error) {
 		if err != nil {
 			return totalUsed, err
 		}
+		hb.beat()
 		for _, location := range locations {
 			filename := dirname + "/" + location.Name()
 			log.Tracef("Looking in %s\n", filename)
 			if location.IsDir() {
-				size, _ := SizeFromDir(log, filename)
+				size, _ := sizeFromDir(log, filename, hb)
 				log.Tracef("Dir %s size %d\n", filename, size)
 				totalUsed += size
 			} else {
@@ -180,14 +222,14 @@ func FindLargestDisk(log *base.LogObject) string {
 // DirUsage calculates usage of directory.
 // When dir holds a whole filesystem, usage comes from that filesystem - one
 // dataset query for ZFS, one statfs otherwise - rather than from walking the
-// tree. Anything else is walked with SizeFromDir.
-func DirUsage(log *base.LogObject, dir string) (uint64, error) {
+// tree. Anything else is walked with SizeFromDir, which is what tick is for.
+func DirUsage(log *base.LogObject, dir string, tick func()) (uint64, error) {
 	mi, err := mount.Lookup(dir)
 	if err != nil {
 		// Lookup do not return error in case of dir is not mountpoint
 		// it returns the longest found parent mountpoint for provided dir
 		log.Errorf("dirUsage: Lookup returns error (%s), fallback to SizeFromDir", err)
-		return SizeFromDir(log, dir)
+		return SizeFromDir(log, dir, tick)
 	}
 	if isWholeFilesystem(mi, dir) {
 		// The dataset name is derived from the path, which only holds inside
@@ -207,7 +249,7 @@ func DirUsage(log *base.LogObject, dir string) (uint64, error) {
 		log.Errorf("dirUsage: disk.Usage(%s) returns error (%s), fallback to SizeFromDir",
 			dir, err)
 	}
-	return SizeFromDir(log, dir)
+	return SizeFromDir(log, dir, tick)
 }
 
 // isWholeFilesystem reports whether mi describes a filesystem mounted in its
@@ -291,14 +333,18 @@ type PathAndSize struct {
 }
 
 // FindLargeFiles walks a directory and reports all files larger than minSize
-// unless they are in an excluded (sub)directory
-func FindLargeFiles(root string, minSize int64, excludePaths []string) ([]PathAndSize, error) {
+// unless they are in an excluded (sub)directory.
+// tick has the same meaning as in SizeFromDir.
+func FindLargeFiles(root string, minSize int64, excludePaths []string,
+	tick func()) ([]PathAndSize, error) {
 	var list []PathAndSize
+	hb := newWalkHeartbeat(tick)
 	walkErr := filepath.WalkDir(filepath.Clean(root), func(path string, di fs.DirEntry, err error) error {
 		// if there is any problem with path we stop
 		if err != nil {
 			return err
 		}
+		hb.beat()
 
 		// Part of excludePath?
 		for _, ex := range excludePaths {

--- a/pkg/pillar/diskmetrics/usage_test.go
+++ b/pkg/pillar/diskmetrics/usage_test.go
@@ -4,12 +4,80 @@
 package diskmetrics
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/containerd/containerd/mount"
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
 )
+
+func TestWalkHeartbeat(t *testing.T) {
+	beats := 0
+	hb := newWalkHeartbeat(func() { beats++ })
+
+	hb.beat()
+	hb.beat()
+	if beats != 1 {
+		t.Fatalf("beats = %d, want 1: beat() within walkTickInterval must be dropped", beats)
+	}
+
+	hb.next = time.Now().Add(-time.Second)
+	hb.beat()
+	if beats != 2 {
+		t.Fatalf("beats = %d, want 2: beat() after walkTickInterval must report", beats)
+	}
+
+	// A walk with no callback carries a nil heartbeat.
+	newWalkHeartbeat(nil).beat()
+}
+
+func TestSizeFromDirReportsProgress(t *testing.T) {
+	log := base.NewSourceLogObject(logrus.StandardLogger(), t.Name(), 0) //nolint:staticcheck
+	tmpdir := t.TempDir()
+
+	const (
+		dirs          = 3
+		filesPerDir   = 25
+		bytesPerFile  = 100
+		expectedTotal = dirs * filesPerDir * bytesPerFile
+	)
+	for d := 0; d < dirs; d++ {
+		subdir := fmt.Sprintf("%s/sub%d", tmpdir, d)
+		if err := os.Mkdir(subdir, 0755); err != nil {
+			t.Fatalf("os.Mkdir failed: %v", err)
+		}
+		for f := 0; f < filesPerDir; f++ {
+			name := fmt.Sprintf("%s/file%d", subdir, f)
+			if err := os.WriteFile(name, make([]byte, bytesPerFile), 0644); err != nil {
+				t.Fatalf("os.WriteFile failed: %v", err)
+			}
+		}
+	}
+
+	beats := 0
+	size, err := SizeFromDir(log, tmpdir, func() { beats++ })
+	if err != nil {
+		t.Fatalf("SizeFromDir failed: %v", err)
+	}
+	if size != expectedTotal {
+		t.Fatalf("SizeFromDir = %d, want %d", size, expectedTotal)
+	}
+	if beats == 0 {
+		t.Fatalf("SizeFromDir never reported progress")
+	}
+
+	size, err = SizeFromDir(log, tmpdir, nil)
+	if err != nil {
+		t.Fatalf("SizeFromDir with no callback failed: %v", err)
+	}
+	if size != expectedTotal {
+		t.Fatalf("SizeFromDir with no callback = %d, want %d", size, expectedTotal)
+	}
+}
 
 func TestIsWholeFilesystem(t *testing.T) {
 	tests := []struct {

--- a/pkg/pillar/diskmetrics/usage_test.go
+++ b/pkg/pillar/diskmetrics/usage_test.go
@@ -7,7 +7,58 @@ import (
 	"io"
 	"os"
 	"testing"
+
+	"github.com/containerd/containerd/mount"
 )
+
+func TestIsWholeFilesystem(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  string
+		mi   mount.Info
+		want bool
+	}{
+		{
+			name: "ext4 filesystem mounted at dir",
+			dir:  "/persist/vault",
+			mi:   mount.Info{Mountpoint: "/persist/vault", Root: "/", FSType: "ext4"},
+			want: true,
+		},
+		{
+			name: "zfs dataset mounted at dir",
+			dir:  "/persist/reserved",
+			mi:   mount.Info{Mountpoint: "/persist/reserved", Root: "/", FSType: "zfs"},
+			want: true,
+		},
+		{
+			name: "dir is a plain subdirectory of a mountpoint",
+			dir:  "/persist/vault/volumes",
+			mi:   mount.Info{Mountpoint: "/persist", Root: "/", FSType: "zfs"},
+			want: false,
+		},
+		{
+			name: "bind mount of a subtree",
+			dir:  "/persist/kubelog",
+			mi:   mount.Info{Mountpoint: "/persist/kubelog", Root: "/log", FSType: "ext4"},
+			want: false,
+		},
+		{
+			name: "mountpoint is a prefix of dir",
+			dir:  "/persist/vault2",
+			mi:   mount.Info{Mountpoint: "/persist/vault", Root: "/", FSType: "ext4"},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isWholeFilesystem(tc.mi, tc.dir); got != tc.want {
+				t.Fatalf("isWholeFilesystem(%+v, %s) = %v, want %v",
+					tc.mi, tc.dir, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestStatAllocatedBytes(t *testing.T) {
 	// Generate a tmpfile path

--- a/pkg/pillar/volumehandlers/containerhandler.go
+++ b/pkg/pillar/volumehandlers/containerhandler.go
@@ -40,7 +40,7 @@ func (handler *volumeHandlerContainer) GetVolumeDetails() (uint64, uint64, strin
 		// we did not create snapshot yet
 		handler.log.Warnf("GetVolumeSize: Failed get snapshot usage: %s for %s. Error %s",
 			snapshotID, handler.status.FileLocation, err)
-		size, err = diskmetrics.SizeFromDir(handler.log, handler.status.FileLocation)
+		size, err = diskmetrics.SizeFromDir(handler.log, handler.status.FileLocation, nil)
 	}
 	return size, size, "CONTAINER", false, err
 }


### PR DESCRIPTION
# Description

Backport of #6301 to `13.4-stable`.

The disk-metrics pass walked a whole filesystem to size it, which on a large
`/persist` takes long enough that the agent misses its watchdog deadline and the
device reboots. It now uses statfs for a whole filesystem and reports liveness
while walking in the cases that still need a walk.

Cherry-picked with `-x` from master: `a31bd73e2ea1` then `b43666461376`.

### Adaptations

None; both picks are clean.

## PR dependencies

**#6301's backport before #6310's** — that is this PR before #6361.

#6361 (the #6310 backport to `13.4-stable`) also touches `cmd/volumemgr/handlediskmetrics.go`, and #6310 was written on top of #6301 on
master. If #6361 lands first it will need a rebase.

## How to test and validate this PR

`go test ./diskmetrics/ ./cmd/volumemgr/ ./volumehandlers/` in `pkg/pillar`. On a
device with a large `/persist`, disk metrics should keep being reported without a
watchdog reboot of volumemgr.

## Changelog notes

Fixes a device reboot caused by the disk-metrics collection taking too long on a large persist partition.

## PR Backports

- 17.0-stable: #6366
- 16.0-stable: #6367
- 14.5-stable: #6368
- 13.4-stable: this PR.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Unit tests, `go vet` and `gofmt` were run on this branch; the device checkboxes
are left for QA.

