### PR TITLE
[17.0-stable] zedagent: re-read config after maintenance mode change/clear

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -1015,12 +1015,28 @@ func needRequestLocConfig(getconfigCtx *getconfigContext,
 		getconfigCtx.locConfig.LocURL != ""
 }
 
+// forgetConfigHashOnLeavingMaintenanceMode discards the remembered config hash once
+// the device has left maintenance mode, so the next request fetches the configuration
+// in full. parseConfig applied nothing while maintenance mode was set, yet the hash was
+// already recorded and the controller answers "not modified" while it matches; the local
+// reasons are lifted by nodeagent rather than by a configuration change, so nothing else
+// re-drives the dropped configuration.
+func forgetConfigHashOnLeavingMaintenanceMode(getconfigCtx *getconfigContext) {
+	maintenanceMode := getconfigCtx.zedagentCtx.maintenanceMode
+	if prevMaintenanceMode && !maintenanceMode {
+		log.Notice("Left maintenance mode; re-reading the configuration")
+		prevConfigHash = ""
+	}
+	prevMaintenanceMode = maintenanceMode
+}
+
 func getLatestConfig(getconfigCtx *getconfigContext, iteration int,
 	withNetTracing bool) (configProcessingRetval, []netdump.TracedNetRequest) {
 
 	if ctrlClient == nil {
 		log.Fatal("nil ctrlClient in getLatestConfig")
 	}
+	forgetConfigHashOnLeavingMaintenanceMode(getconfigCtx)
 	url := controllerconn.URLPathString(serverNameAndPort,
 		devUUID, "config")
 
@@ -1120,6 +1136,12 @@ func readSavedProtoMessageConfig(ctrlClient *controllerconn.Client, URL string,
 
 // The most recent config hash we received. Starts empty
 var prevConfigHash string
+
+// Value of zedagentContext.maintenanceMode as last seen by the config goroutine, which
+// is the only one to touch this and prevConfigHash, so neither needs a lock. Other
+// goroutines change maintenanceMode itself, hence sampling it here rather than acting
+// where it is set.
+var prevMaintenanceMode bool
 
 func generateConfigRequest(getconfigCtx *getconfigContext, isCompoundConfig bool) (
 	[]byte, error) {

--- a/pkg/pillar/cmd/zedagent/parseconfig.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig.go
@@ -3250,6 +3250,11 @@ func mergeMaintenanceMode(ctx *zedagentContext, caller string) {
 		log.Noticef("%s changed maintenanceMode to %t, with reason as %s, considering {%v, %v, %v}",
 			caller, ctx.maintenanceMode, ctx.maintModeReasons.String(), ctx.gcpMaintenanceMode,
 			ctx.apiMaintenanceMode, ctx.localMaintenanceMode)
+		if !ctx.maintenanceMode && ctx.getconfigCtx.configTickerHandle != nil {
+			// Fetch at once rather than waiting out timer.config.interval, which can
+			// be as high as a day. Only a hint; the fetch discards the hash itself.
+			triggerGetConfig(ctx.getconfigCtx.configTickerHandle)
+		}
 	}
 	publishZedAgentStatus(ctx.getconfigCtx)
 }

--- a/pkg/pillar/cmd/zedagent/parseconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/parseconfig_test.go
@@ -2380,3 +2380,41 @@ func TestBondMemberSwap(t *testing.T) {
 	g.Expect(bond2Port).ToNot(BeNil())
 	g.Expect(bond2Port.L2LinkConfig.Bond.AggregatedPorts).To(ConsistOf("eth1", "eth3"))
 }
+
+// TestForgetConfigHashOnLeavingMaintenanceMode checks that only the leaving edge
+// discards the config hash. The other three transitions must keep it, so that an
+// unchanged configuration is still answered with "not modified".
+func TestForgetConfigHashOnLeavingMaintenanceMode(t *testing.T) {
+	tests := []struct {
+		name       string
+		before     bool
+		now        bool
+		wantForget bool
+	}{
+		{name: "entering", before: false, now: true, wantForget: false},
+		{name: "still-in", before: true, now: true, wantForget: false},
+		{name: "leaving", before: true, now: false, wantForget: true},
+		{name: "still-out", before: false, now: false, wantForget: false},
+	}
+
+	const hash = "6ba7b8109dad11d180b400c04fd430c8"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			getconfigCtx := initGetConfigCtx(g)
+			prevConfigHash = hash
+			prevMaintenanceMode = tt.before
+			getconfigCtx.zedagentCtx.maintenanceMode = tt.now
+
+			forgetConfigHashOnLeavingMaintenanceMode(getconfigCtx)
+
+			if tt.wantForget {
+				g.Expect(prevConfigHash).To(BeEmpty())
+			} else {
+				g.Expect(prevConfigHash).To(Equal(hash))
+			}
+			// Otherwise the leaving edge would fire on every fetch.
+			g.Expect(prevMaintenanceMode).To(Equal(tt.now))
+		})
+	}
+}

--- a/pkg/pillar/docs/zedagent-internals.md
+++ b/pkg/pillar/docs/zedagent-internals.md
@@ -176,6 +176,10 @@ When `maintenanceMode` is set:
   maintenance mode remotely.
 - New application deployments and base OS updates are deferred until maintenance mode
   is cleared.
+- Leaving maintenance mode discards the remembered config hash, so the following fetch
+  re-reads the configuration in full and applies what was deferred. The local reasons
+  are cleared by `nodeagent` rather than by a configuration change, so nothing else
+  would re-drive it.
 
 ## Eden Test Coverage Map
 


### PR DESCRIPTION
# Description

Backport of #6298 to `17.0-stable`.

While maintenance mode is set the config fetch records the received config's hash
but does not process the config, so once maintenance mode goes away the
controller keeps answering "not modified" and that config is never applied —
until an unrelated controller-side change alters the hash, or zedagent restarts.
A base OS upgrade dropped this way never starts. The local reasons for
maintenance mode are lifted by nodeagent rather than by a config change, so
nothing prompts a re-read. The hash is now forgotten on leaving maintenance mode,
and the config timer is poked so the re-read happens at once.

Cherry-picked with `-x` from master: `df6bdd01fd92`.

### Adaptations

The added test calls `newFuzzGetConfigCtx`, a fuzzing harness that does not exist
on this branch and that depends on many master-only context fields. The test uses
this branch's existing `initGetConfigCtx(g)` helper instead; its four transition
cases and assertions are unchanged.

## PR dependencies

None.

## How to test and validate this PR

`go test ./cmd/zedagent/` in `pkg/pillar`;
`TestForgetConfigHashOnLeavingMaintenanceMode` covers all four transitions, only
the leaving edge discarding the hash. On a device: put it into maintenance mode,
change the config (a base OS upgrade is the interesting case), clear maintenance
mode, and the new config should be applied within seconds instead of waiting out
`timer.config.interval`.

## Changelog notes

A configuration change made while the device was in maintenance mode, such as a base OS upgrade, is now applied as soon as maintenance mode is cleared instead of being ignored.

## PR Backports

- 17.0-stable: this PR.
- 16.0-stable: #6371
- 14.5-stable: #6372
- 13.4-stable: #6373

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Unit tests, `go vet` and `gofmt` were run on this branch; the device checkboxes
are left for QA.
