### PR TITLE
[13.4-stable] domainmgr: fix two adapter-assignment regressions from #6169

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1464,8 +1464,8 @@ func doAssignIoAdaptersToDomain(ctx *domainContext, config types.DomainConfig,
 					status.DomainName)
 			}
 			// Also checked in reserveAdapters. Check here in case there was a late error.
-			if !ib.Error.Empty() {
-				return errors.New(ib.Error.String())
+			if errStr := ib.Error.HardErrorString(); errStr != "" {
+				return errors.New(errStr)
 			}
 			if ib.UsbAddr != "" {
 				log.Functionf("Assigning %s (%s) to %s",
@@ -2255,9 +2255,9 @@ func reserveAdapters(ctx *domainContext, config types.DomainConfig) *types.Error
 					adapter.Type, adapter.Name, ibp.Phylabel)
 				return &description
 			}
-			if !ibp.Error.Empty() {
+			if errStr := ibp.Error.HardErrorString(); errStr != "" {
 				description.Error = fmt.Sprintf("adapter %d %s phylabel %s has error: %s",
-					adapter.Type, adapter.Name, ibp.Phylabel, ibp.Error.String())
+					adapter.Type, adapter.Name, ibp.Phylabel, errStr)
 				return &description
 			}
 		}
@@ -3387,9 +3387,9 @@ func updatePortAndPciBackIoMember(ctx *domainContext, ib *types.IoBundle, isPort
 	}
 
 	if !ib.KeepInHost && !ib.IsPCIBack {
-		if !ib.Error.Empty() {
+		if errStr := ib.Error.HardErrorString(); errStr != "" {
 			log.Warningf("Not assigning %s (%s) to pciback due to error: %s at %s",
-				ib.Phylabel, ib.PciLong, ib.Error.String(), ib.Error.ErrorTime())
+				ib.Phylabel, ib.PciLong, errStr, ib.Error.ErrorTime())
 		} else if ctx.deviceNetworkStatus.Testing && ib.Type.IsNet() {
 			log.Noticef("Not assigning %s (%s) to pciback due to Testing",
 				ib.Phylabel, ib.PciLong)

--- a/pkg/pillar/cmd/domainmgr/domainmgr_test.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr_test.go
@@ -20,8 +20,10 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/hypervisor"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils/cloudconfig"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -700,4 +702,111 @@ func TestMistypedNetworkPortKeptInHost(t *testing.T) {
 			t.Fatalf("warning should identify the PCI address %s, got %q", pciLong, b.Error.String())
 		}
 	}
+}
+
+// TestReserveAdaptersWarningVsError checks that an advisory warning on an I/O
+// bundle leaves the adapter assignable, while a hard error refuses it and is
+// the only text reported back.
+func TestReserveAdaptersWarningVsError(t *testing.T) {
+	const hardErr = "device is missing"
+	const warnStr = "renamed to match the model"
+
+	newCtx := func(t *testing.T, aa *types.AssignableAdapters) *domainContext {
+		t.Helper()
+		ps := pubsub.New(pubsub.NewMemoryDriver(), logger, log)
+		pubAA, err := ps.NewPublication(pubsub.PublicationOptions{
+			AgentName: agentName,
+			TopicType: types.AssignableAdapters{},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		pubCap, err := ps.NewPublication(pubsub.PublicationOptions{
+			AgentName: agentName,
+			TopicType: types.Capabilities{},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := pubCap.Publish("global", types.Capabilities{IOVirtualization: true}); err != nil {
+			t.Fatal(err)
+		}
+		return &domainContext{
+			assignableAdapters:    aa,
+			pubAssignableAdapters: pubAA,
+			pubCapabilities:       pubCap,
+		}
+	}
+
+	newBundle := func() types.IoBundle {
+		return types.IoBundle{
+			Phylabel:        "eth1",
+			Logicallabel:    "eth1",
+			Type:            types.IoNetEth,
+			AssignmentGroup: "eth1",
+			PciLong:         "0000:06:00.0",
+		}
+	}
+
+	appUUID, err := uuid.FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := types.DomainConfig{
+		UUIDandVersion: types.UUIDandVersion{UUID: appUUID},
+		IoAdapterList:  []types.IoAdapter{{Type: types.IoNetEth, Name: "eth1"}},
+	}
+
+	t.Run("warning only", func(t *testing.T) {
+		ib := newBundle()
+		ib.Error.SetSourceErrors(types.ErrIoBundleRename{}, true, false, []string{warnStr})
+		aa := &types.AssignableAdapters{IoBundleList: []types.IoBundle{ib}}
+		ctx := newCtx(t, aa)
+
+		if d := reserveAdapters(ctx, config); d != nil {
+			t.Fatalf("adapter carrying only a warning must stay assignable, refused with %q", d.Error)
+		}
+		if aa.IoBundleList[0].UsedByUUID != appUUID {
+			t.Fatalf("adapter should be reserved for %s, got %s",
+				appUUID, aa.IoBundleList[0].UsedByUUID)
+		}
+	})
+
+	t.Run("hard error", func(t *testing.T) {
+		ib := newBundle()
+		ib.Error.SetSourceErrors(types.ErrIoBundleMissingDevice{}, false, false, []string{hardErr})
+		aa := &types.AssignableAdapters{IoBundleList: []types.IoBundle{ib}}
+		ctx := newCtx(t, aa)
+
+		d := reserveAdapters(ctx, config)
+		if d == nil {
+			t.Fatal("adapter carrying a hard error must be refused")
+		}
+		if !strings.Contains(d.Error, hardErr) {
+			t.Fatalf("refusal should quote %q, got %q", hardErr, d.Error)
+		}
+		if aa.IoBundleList[0].UsedByUUID != nilUUID {
+			t.Fatalf("refused adapter must not be reserved, got %s",
+				aa.IoBundleList[0].UsedByUUID)
+		}
+	})
+
+	t.Run("warning and hard error", func(t *testing.T) {
+		ib := newBundle()
+		ib.Error.SetSourceErrors(types.ErrIoBundleRename{}, true, false, []string{warnStr})
+		ib.Error.SetSourceErrors(types.ErrIoBundleMissingDevice{}, false, false, []string{hardErr})
+		aa := &types.AssignableAdapters{IoBundleList: []types.IoBundle{ib}}
+		ctx := newCtx(t, aa)
+
+		d := reserveAdapters(ctx, config)
+		if d == nil {
+			t.Fatal("adapter carrying a hard error must be refused")
+		}
+		if !strings.Contains(d.Error, hardErr) {
+			t.Fatalf("refusal should quote %q, got %q", hardErr, d.Error)
+		}
+		if strings.Contains(d.Error, warnStr) {
+			t.Fatalf("refusal should not quote the advisory warning, got %q", d.Error)
+		}
+	})
 }

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -903,12 +903,18 @@ func newIoBundleCollisionErr() ErrIOBundleCollision {
 	}
 }
 
-// CheckBadUSBBundles sets and clears ib.Error/ErrorTime if bundle collides in regards of USB
+// CheckBadUSBBundles sets and clears ib.Error/ErrorTime when several bundles
+// describe the same USB device, i.e. share a USB address and/or USB product
+// (plus PCI address and assignment group). Only bundles identifying a USB
+// device take part: a model may legitimately list several receptacles of one
+// USB controller as separate bundles of a single assignment group, which share
+// a PCI address without describing the same device. Bundles sharing a PCI
+// address across assignment groups are CheckBadAssignmentGroups' concern.
 func (aa *AssignableAdapters) CheckBadUSBBundles() {
 	usbProductsAddressMap := make(map[[4]string][]*IoBundle)
 	for i := range aa.IoBundleList {
 		ioBundle := &aa.IoBundleList[i]
-		if ioBundle.UsbAddr == "" && ioBundle.UsbProduct == "" && ioBundle.PciLong == "" {
+		if ioBundle.UsbAddr == "" && ioBundle.UsbProduct == "" {
 			continue
 		}
 

--- a/pkg/pillar/types/assignableadapters.go
+++ b/pkg/pillar/types/assignableadapters.go
@@ -168,6 +168,22 @@ func (iobe *IOBundleError) IsOnlyWarnings() bool {
 	return true
 }
 
+// HardErrorString returns the combined text of the entries that are not
+// advisory warnings, and "" when the bundle carries only warnings or nothing.
+// Callers deciding whether an adapter is usable must key on this rather than on
+// Empty(): a warning records a model inconsistency EVE worked around and
+// carried on from, so it must not by itself make the adapter unusable.
+func (iobe *IOBundleError) HardErrorString() string {
+	errorStrings := make([]string, 0, len(iobe.Errors))
+	for _, err := range iobe.Errors {
+		if err.Warning {
+			continue
+		}
+		errorStrings = append(errorStrings, err.Error())
+	}
+	return strings.Join(errorStrings, "; ")
+}
+
 // Empty returns true if no error has been added
 func (iobe *IOBundleError) Empty() bool {
 	if iobe.Errors == nil || len(iobe.Errors) == 0 {

--- a/pkg/pillar/types/assignableadapters_test.go
+++ b/pkg/pillar/types/assignableadapters_test.go
@@ -584,9 +584,15 @@ func TestSetSourceErrors(t *testing.T) {
 
 func alternativeCheckBadUSBBundlesImpl(bundles []IoBundle) {
 	for i := range bundles {
+		if bundles[i].UsbAddr == "" && bundles[i].UsbProduct == "" {
+			continue
+		}
 		for j := range bundles {
 			errStr := ""
 			if i == j {
+				continue
+			}
+			if bundles[j].UsbAddr == "" && bundles[j].UsbProduct == "" {
 				continue
 			}
 
@@ -928,6 +934,32 @@ func TestCheckBadUSBBundles(t *testing.T) {
 				},
 				{
 					bundle: IoBundle{Phylabel: "11", UsbAddr: "", UsbProduct: ""},
+				},
+			},
+		},
+		{
+			// Receptacles of one USB controller, which a model may list
+			// individually and put in a single assignment group. They share a
+			// PCI address but identify no USB device, so they do not collide.
+			bundleWithError: []bundleWithError{
+				{bundle: IoBundle{Phylabel: "USB0", Type: IoUSB, PciLong: "0000:00:15.0", AssignmentGroup: "USB-A"}},
+				{bundle: IoBundle{Phylabel: "USB1", Type: IoUSB, PciLong: "0000:00:15.0", AssignmentGroup: "USB-A"}},
+				{bundle: IoBundle{Phylabel: "USB2", Type: IoUSB, PciLong: "0000:00:15.0", AssignmentGroup: "USB-A"}},
+				{bundle: IoBundle{Phylabel: "USB3", Type: IoUSB, PciLong: "0000:00:15.0", AssignmentGroup: "USB-A"}},
+				{bundle: IoBundle{Phylabel: "USB4", Type: IoUSB, PciLong: "0000:00:15.0", AssignmentGroup: "USB-A"}},
+				{bundle: IoBundle{Phylabel: "USB5", Type: IoUSB, PciLong: "0000:00:15.0", AssignmentGroup: "USB-A"}},
+			},
+		},
+		{
+			// Grouping does not exempt bundles that do name the same USB device.
+			bundleWithError: []bundleWithError{
+				{
+					bundle:        IoBundle{Phylabel: "12", UsbAddr: "1:2", PciLong: "0000:00:15.0", AssignmentGroup: "USB-A"},
+					expectedError: "ioBundle collision: 12 (usbaddr 1:2, pcilong 0000:00:15.0, assigngrp USB-A); 13 (usbaddr 1:2, pcilong 0000:00:15.0, assigngrp USB-A)",
+				},
+				{
+					bundle:        IoBundle{Phylabel: "13", UsbAddr: "1:2", PciLong: "0000:00:15.0", AssignmentGroup: "USB-A"},
+					expectedError: "ioBundle collision: 12 (usbaddr 1:2, pcilong 0000:00:15.0, assigngrp USB-A); 13 (usbaddr 1:2, pcilong 0000:00:15.0, assigngrp USB-A)",
 				},
 			},
 		},

--- a/pkg/pillar/types/assignableadapters_test.go
+++ b/pkg/pillar/types/assignableadapters_test.go
@@ -582,6 +582,24 @@ func TestSetSourceErrors(t *testing.T) {
 	assert.False(t, e.TimeOfError.IsZero(), "still has the other source's error")
 }
 
+func TestHardErrorString(t *testing.T) {
+	t.Parallel()
+
+	var e IOBundleError
+	assert.Equal(t, "", e.HardErrorString(), "no entries")
+
+	e.SetSourceErrors(ErrIoBundleRename{}, true, false, []string{"renamed"})
+	assert.False(t, e.Empty(), "the warning is recorded")
+	assert.Equal(t, "", e.HardErrorString(), "a warning is not a hard error")
+
+	e.SetSourceErrors(ErrIoBundleMissingDevice{}, false, false, []string{"missing"})
+	assert.Equal(t, "missing", e.HardErrorString(), "only the hard error is returned")
+
+	e.SetSourceErrors(ErrIoBundleMissingDevice{}, false, false, nil)
+	assert.Equal(t, "", e.HardErrorString(), "hard error cleared, warning remains")
+	assert.False(t, e.Empty())
+}
+
 func alternativeCheckBadUSBBundlesImpl(bundles []IoBundle) {
 	for i := range bundles {
 		if bundles[i].UsbAddr == "" && bundles[i].UsbProduct == "" {


### PR DESCRIPTION
# Description

Backport of #6292 to `13.4-stable`.

Two regressions #6169 introduced. A device model may describe each receptacle of
a USB controller as its own I/O bundle in one assignment group; those share the
controller's PCI address and the USB collision check read that as several bundles
describing the same device, marking every member with an error so an application
assigned any one of them was refused its adapter. Separately, an I/O bundle
records both hard errors and advisory warnings, and domainmgr treated any
recorded entry as disqualifying, so a warning alone was enough to refuse an
adapter — reachable on exactly the devices that reporting was added for, where an
adapter renamed to match the model permanently carries the advisory.

Cherry-picked with `-x` from master: `9f9c797136c2` then `38e378177d0d`.

### Adaptations

The conflicting hunk in `cmd/domainmgr/domainmgr.go` had an incoming side that
bundles an `ib.UsedByUUID != nilUUID` guard from `77e345952` ("pillar: NOHYPE
direct-attach network interface passthrough"), a feature commit this branch does
not carry. Only this PR's own change was kept — the condition and the log
arguments — so the resulting difference from the master commit is exactly `if`
versus `} else if`.

## PR dependencies

Depends on #6169's backport to this branch, which has already merged.

## How to test and validate this PR

`go test ./cmd/domainmgr/ ./types/` in `pkg/pillar`; `TestCheckBadUSBBundles` and
`TestReserveAdaptersWarningVsError` guard the two fixes. On a device whose model
splits a USB controller into per-receptacle bundles, or whose kernel names an
interface differently from the model, an application assigned that adapter should
now come online.

## Changelog notes

Fixes applications being refused an assigned USB or network adapter after the I/O-bundle error reporting change.

## PR Backports

- 17.0-stable: #6377
- 16.0-stable: #6378
- 14.5-stable: #6374
- 13.4-stable: this PR.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Unit tests, `go vet` and `gofmt` were run on this branch; the device checkboxes
are left for QA.
