### PR TITLE
[17.0-stable] pkg/kube: fix multus NAD apply ordering and unreachable retry back-off

### DIFF
--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -129,14 +129,27 @@ check_for_multus_link_request() {
 }
 
 apply_multus_cni() {
+        local apply_out
         # remove get_default_intf_IP_prefix
         #get_default_intf_IP_prefix
         if ! kubectl get namespace eve-kube-app > /dev/null 2>&1; then
                 kubectl create namespace eve-kube-app
         fi
         logmsg "Apply multus-daemonset-new.yaml"
-        if ! kubectl apply -f /etc/multus-daemonset-new.yaml > /dev/null 2>&1; then
-                logmsg "Apply Multus, has failed, jump out now"
+        # The manifest carries both the NetworkAttachmentDefinition CRD and an
+        # instance of it. kubectl does not wait for a CRD to be established
+        # before creating a CR of that kind, so the instance can fail with
+        # 'no matches for kind "NetworkAttachmentDefinition"' while everything
+        # else applies. Establish the CRD, then re-apply to pick up whatever
+        # lost that race; apply is idempotent.
+        apply_out=$(kubectl apply -f /etc/multus-daemonset-new.yaml 2>&1)
+        if ! kubectl wait --for condition=established --timeout=60s \
+                crd/network-attachment-definitions.k8s.cni.cncf.io > /dev/null 2>&1; then
+                logmsg "Apply Multus, NAD CRD not established: $apply_out"
+                return 1
+        fi
+        if ! apply_out=$(kubectl apply -f /etc/multus-daemonset-new.yaml 2>&1); then
+                logmsg "Apply Multus, has failed, jump out now: $apply_out"
                 return 1
         fi
         logmsg "Done applying Multus"

--- a/pkg/kube/cluster-init.sh
+++ b/pkg/kube/cluster-init.sh
@@ -1515,12 +1515,11 @@ if [ ! -f /var/lib/all_components_initialized ]; then
                         assign_multus_nodeip "$cluster_node_ip"
                 fi
                 apply_multus_cni
-                continue
                 if [ ! -f /var/lib/multus_initialized ]; then
                         logmsg "Failed to apply multus cni, wait a while"
                         sleep 10
-                        continue
                 fi
+                continue
         fi
         check_for_multus_link_request
         if ! pidof dhcp; then


### PR DESCRIPTION
# Description

Backport of #6242 to `17.0-stable`.

The multus NAD instance was applied before its CRD was established, and the retry
back-off that was supposed to cover that was unreachable, so a slow CRD
registration left the network-attachment definition unapplied.

Cherry-picked with `-x` from master: `ae5468b10606` then `c9e902f72f17`.

### Adaptations

None; both picks are clean.

## PR dependencies

None.

## How to test and validate this PR

`shellcheck -S warning pkg/kube/cluster-init.sh` is clean. On an EVE-k device,
cluster init should establish the NAD CRD before applying its instance, and retry
with back-off if the CRD is not ready yet.

## Changelog notes

Fixes EVE-k cluster initialization occasionally leaving the multus network-attachment definition unapplied.

## PR Backports

- 17.0-stable: this PR.
- 16.0-stable: No, EVE-k is not usable before 17.0.
- 14.5-stable: No, EVE-k is not usable before 17.0.
- 13.4-stable: No, EVE-k is not usable before 17.0.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Unit tests, `go vet` and `gofmt` were run on this branch; the device checkboxes
are left for QA.
