### PR TITLE
[17.0-stable] Makefile: split bpftrace tests out of make test

### DIFF
--- a/.github/actions/run-make/action.yml
+++ b/.github/actions/run-make/action.yml
@@ -5,17 +5,13 @@ description: 'Fetch tags, login to dockerhub, build and push artifacts produced 
 inputs:
   command:
     required: true
-    type: string
   dockerhub-token:
     required: true
-    type: string
   dockerhub-account:
     required: true
-    type: string
   clean:
     required: false
-    type: boolean
-    default: true
+    default: 'true'
 
 runs:
   using: 'composite'

--- a/.github/workflows/bpftrace-tests.yml
+++ b/.github/workflows/bpftrace-tests.yml
@@ -1,7 +1,7 @@
-# Copyright (c) 2025, Zededa, Inc.
+# Copyright (c) 2026, Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 ---
-name: Go Tests
+name: BPFTrace Tests
 on:  # yamllint disable-line rule:truthy
   push:
     branches:
@@ -9,38 +9,35 @@ on:  # yamllint disable-line rule:truthy
       - "[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+-stable"
       - "feature/*"
-    paths-ignore:
-      - '**/*.md'
-      - '.github/**'
+    paths:
+      - 'pkg/bpftrace/**'
+      - 'eve-tools/bpftrace-compiler/**'
+      - 'kernel-commits.mk'
+      - '.github/workflows/bpftrace-tests.yml'
   pull_request:
     branches:
       - "master"
       - "[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+-stable"
       - "feature/*"
-    paths-ignore:
-      - '**/*.md'
-      - '.github/**'
+    paths:
+      - 'pkg/bpftrace/**'
+      - 'eve-tools/bpftrace-compiler/**'
+      - 'kernel-commits.mk'
+      - '.github/workflows/bpftrace-tests.yml'
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test:
+  test-bpftrace:
     runs-on: zededa-ubuntu-2204
-    env:
-      REPO_NAME: ${{ github.event.repository.full_name }}
-      GH_REF: ${{ github.ref }}
+    timeout-minutes: 180
     steps:
-      - name: Starting Report
-        run: |
-          echo Git Ref: ${GH_REF}
-          echo GitHub Event: ${{ github.event_name }}
-          echo Disk usage
-          df -h
-          echo Memory
-          free -m
       - name: Clear repository
         run: |
           sudo rm -fr "$GITHUB_WORKSPACE" && mkdir "$GITHUB_WORKSPACE"
@@ -51,33 +48,17 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Login to Docker Hub
         if: ${{ github.event.repository.full_name == 'lf-edge/eve' }}
         run: | # Runners must provide default credentials
           docker login
-      - name: Test (TPM Required)
-        run: |
-          bash tests/tpm/prep-and-test.sh
       - name: Test
         run: |
-          make test
-      - name: Report test results as Annotations
-        if: ${{ always() }}
-        uses: guyarb/golang-test-annoations@96fc379b171c49932041d6c789e73331a7bdeec1  # v0.9.0
-        with:
-          test-results: dist/amd64/results.json
-      - name: Store raw test results
-        if: ${{ always() }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
-        with:
-          name: 'test-report'
-          path: ${{ github.workspace }}/dist
-      - name: Get code coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+          make test-bpftrace
       - name: Clean
         if: ${{ always() }}
         run: |
           make clean || :
           docker system prune -f -a || :
-          docker rm -f $(docker ps -aq) && docker volume rm -f $(docker volume ls -q) || :
           rm -rf ~/.linuxkit || :

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -274,8 +274,6 @@ jobs:
           docker login
       - name: Test
         run: |
-          make pkg/bpftrace
-          make ZARCH=arm64 pkg/bpftrace
           make test
       - name: Report test results as Annotations
         if: ${{ always() }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,10 +52,12 @@ When running `make run-live` QEMU defaults to 8GB RAM and forwards ssh on port 2
 
 ## Tests
 
-`make test` is the umbrella target — it runs pillar tests *in Docker* plus several smaller test suites. The most useful per-component invocations:
+`make test` runs pillar tests *in Docker* plus several smaller test suites, all for the host architecture. `make test-all` is the umbrella target: it adds `test-bpftrace`, which boots QEMU for amd64 and arm64 and is slow enough that CI runs it in its own path-filtered workflow. The most useful per-component invocations:
 
 ```sh
-make test                                    # full suite (pillar + bpftrace-compiler + dnsmasq + debug + vtpm + newlog + edgeview)
+make test                                    # host-arch suite (pillar + dnstest + debug + vtpm + newlog + edgeview)
+make test-bpftrace                           # QEMU-based bpftrace-compiler tests for amd64 and arm64 (~1h)
+make test-all                                # both of the above
 make -C pkg/pillar test                      # pillar unit tests in docker (produces results.json/xml, coverage.txt)
 make -C pkg/pillar fuzz-test                 # fuzz tests
 make -C pkg/pillar fmt                       # gofmt -w -s
@@ -78,7 +80,7 @@ make mini-yetus                     # Yetus only on files changed vs. master (mu
 make check-docker-hashes-consistency # Check if packages are pointing to the latest version of dependency packages inside their Dockerfile. All packages should point to the same hashes of a common dependency (with a few exceptions)
 ```
 
-`mini-yetus` accepts `MYETUS_SBRANCH`, `MYETUS_DBRANCH`, `MYETUS_VERBOSE=Y`. CI workflows live under `.github/workflows/` — `pr-gate.yml`, `go-tests.yml`, `yetus.yml`, `codeql.yml`, `build.yml`. The shellcheck config (`shellcheckrc`) disables SC3043.
+`mini-yetus` accepts `MYETUS_SBRANCH`, `MYETUS_DBRANCH`, `MYETUS_VERBOSE=Y`. CI workflows live under `.github/workflows/` — `pr-gate.yml`, `go-tests.yml`, `bpftrace-tests.yml`, `yetus.yml`, `codeql.yml`, `build.yml`. The shellcheck config (`shellcheckrc`) disables SC3043.
 
 ## Pillar architecture (the part you'll touch most)
 

--- a/Makefile
+++ b/Makefile
@@ -519,12 +519,25 @@ test: $(LINUXKIT) pkg/pillar | $(DIST)
 	make -C pkg/pillar test
 	cp pkg/pillar/results.json $(DIST)/
 	cp pkg/pillar/results.xml $(DIST)/
-	make -C eve-tools/bpftrace-compiler test
 	make -C pkg/alpine/dnstest test
 	make -C pkg/debug test
 	make -C pkg/vtpm test
 	go test -C pkg/newlog/cmd/ -v -race
 	go test -C pkg/edgeview/src/ -v -race
+	$(QUIET): $@: Succeeded
+
+# The bpftrace-compiler tests boot QEMU for both amd64 and arm64, so they need
+# the eve-bpftrace package for each. A linuxkit cache entry holding a single
+# architecture shadows the registry's multi-arch manifest for every FROM naming
+# that tag, so --pull is needed to keep the entry complete. Everything reachable
+# from `test` above stays on the host architecture for the same reason.
+test-bpftrace:
+	$(MAKE) LINUXKIT_OPTS="$(strip $(LINUXKIT_OPTS) --pull)" pkg/bpftrace
+	$(MAKE) LINUXKIT_OPTS="$(strip $(LINUXKIT_OPTS) --pull)" ZARCH=arm64 pkg/bpftrace
+	make -C eve-tools/bpftrace-compiler test
+	$(QUIET): $@: Succeeded
+
+test-all: test test-bpftrace
 	$(QUIET): $@: Succeeded
 
 test-profiling:
@@ -1351,7 +1364,7 @@ kernel-tag:
 	@echo $(KERNEL_TAG)
 
 .PRECIOUS: rootfs-% $(ROOTFS)-%.img $(ROOTFS_COMPLETE)
-.PHONY: all clean test run pkgs help live rootfs config installer live current FORCE $(DIST) HOSTARCH image-set cache-export eden eden-cover coverage-merge
+.PHONY: all clean test test-bpftrace test-all run pkgs help live rootfs config installer live current FORCE $(DIST) HOSTARCH image-set cache-export eden eden-cover coverage-merge
 FORCE:
 
 .PHONY: evetest
@@ -1378,6 +1391,8 @@ help:
 	@echo "Commonly used maintenance and development targets:"
 	@echo "   build-vm                         prepare a build VM for EVE in qcow2 format"
 	@echo "   test                             run EVE tests"
+	@echo "   test-bpftrace                    run the QEMU-based bpftrace-compiler tests (slow, ~1h)"
+	@echo "   test-all                         run both of the above"
 	@echo "   test-profiling                   run pillar tests with memory profiler"
 	@echo "   clean                            clean build artifacts in a current directory (doesn't clean Docker)"
 	@echo "   release                          prepare branch for a release (VERSION=x.y.z required)"


### PR DESCRIPTION
# Description

Backport of #6329 to `17.0-stable`.

The bpftrace-compiler tests boot QEMU for amd64 and arm64 and take roughly 53
minutes, over half of the Go Tests workflow. Running them in the middle of the
`test` target also means a failure there skips every remaining suite along with
the coverage upload. They now live in `test-bpftrace`, reached from `test-all`,
with their own workflow triggered only by changes to `pkg/bpftrace`,
`eve-tools/bpftrace-compiler` or `kernel-commits.mk`.

`17.0-stable` is the only stable branch exposed to the second half of the fix.
Its `go-tests.yml` and `publish.yml` build the eve-bpftrace package for amd64
and then arm64 before `make test`; linuxkit matches a `FROM` against its local
cache by name alone, so an entry populated for one architecture hides the
registry's multi-arch manifest from the other, and a package published while the
job runs can leave the build resolving against an image it cannot find. `make
test` now stays on the host architecture throughout, and `test-bpftrace` passes
`--pull` so an already-published architecture is fetched into the cache rather
than skipped. On 16.0-stable and older those two pre-build lines were never
added, so the cache entry is never poisoned there and no backport is proposed.

Cherry-picked with `-x` from the merged commit `2c33bb174`; it applied cleanly
to all five files. One adaptation: master's new `CLAUDE.md` line lists
`kube-init` among the suites `make test` runs, but `17.0-stable`'s `test` target
ends at `pkg/edgeview` and has no `kube-init` step, so that entry is dropped
from the list. `.github/workflows/bpftrace-tests.yml` is byte-identical to
master's.

## PR dependencies

`7c4809f79` ("github/actions/run-make: drop invalid type keys on inputs") is
cherry-picked ahead of the backport as a prerequisite. `Workflow Lint` only runs
when a PR touches `.github/workflows/**`, so it had never been exercised on this
branch, and it fails here on `.github/actions/run-make/action.yml`: composite
action inputs cannot carry `type:`, which is reusable-workflow syntax. Master
fixed that in `7c4809f79`, and `git branch -r --contains` shows it on 17.2 and
17.3 but not on `17.0-stable`. Without it actionlint would fail on this PR and
on every future PR to this branch that edits a workflow. The resulting file is
byte-identical to master's.

## How to test and validate this PR

Covered by CI on this PR: Go Tests exercises the reduced `make test`, and the
new workflow's trigger paths include its own file, so `make test-bpftrace` runs
here too.

Locally, on this branch:

- `make -n test` — every `--platforms` line reads `linux/amd64`, with no
  `pkg/bpftrace` and no `bpftrace-compiler test` in the recipe. The same
  command on `17.0-stable` does contain `make -C eve-tools/bpftrace-compiler
  test`, which is what this change removes.
- `make -n test-bpftrace` — `--pull` on each linuxkit invocation,
  `pkg/bpftrace` for `linux/amd64` then `linux/arm64`, then
  `make -C eve-tools/bpftrace-compiler test`.
- `make -n test-all` — covers both, with the compiler test appearing once.
- `make help` — lists `test-bpftrace` and `test-all`.

`17.0-stable`'s `go-tests.yml` already runs on `zededa-ubuntu-2204` with the
same conditional `docker login` step, so the new workflow needs no runner
adaptation.

## Changelog notes

No user-facing changes.

## PR Backports

- 17.0-stable: this PR.
- 16.0-stable: No, the workflows there do not pre-build the eve-bpftrace
  package, so the cache-shadowing failure cannot occur.
- 14.5-stable: No, same reason as 16.0-stable.
- 13.4-stable: No, same reason as 16.0-stable.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

Device testing does not apply — this changes only build and CI targets and
produces no artifact that runs on a device.

No label applies here: #6329 carries only `stable`, which marks a change as
needing a backport rather than describing this one.
