### PR TITLE
netboot: stop transferring the installer ISO twice

### DIFF
--- a/docs/BOOT-INSTALLER.md
+++ b/docs/BOOT-INSTALLER.md
@@ -119,5 +119,38 @@ The boot process then is:
 1. `grub.cfg` hands control to `(loop)/EFI/BOOT/grub.cfg` from the loop mounted ISO **V**
 1. `grub.cfg` recognizes that it is a network boot, sets:
    * `kernel /boot/kernel`
-   * `initrd /boot/initrd.img newc:/installer.iso:($install_part)/installer.iso` - this loads the `installer.iso` in the initramfs as a file
-1. `initrd.img` mounts the `/installer.iso` and calls `switch_root`.
+   * `initrd /boot/initrd.img newc:/rootfs_installer.img:($root)/rootfs_installer.img` - this loads the installer rootfs
+     in the initramfs as a file, read out of the loop mounted ISO. If the ISO carries a top-level `config.img`
+     override, it is loaded the same way and passed as `rootaddmount=/config.img:/config.img`
+1. `initrd.img` mounts `/rootfs_installer.img` and calls `switch_root`.
+
+Note that the payload is read from the ISO that grub already has open as `loop`, rather than by naming
+`($install_part)/installer.iso` as the initrd source. The latter is a second URL, so it makes the whole ISO
+cross the network twice - once for grub to read the kernel and initrd out of, and once as the initramfs payload.
+
+For the same reason, prefer serving the netboot directory over HTTP rather than TFTP. Grub's HTTP transport
+implements `seek` with a `Range` request, so grub only transfers the ISO extents it actually reads; its TFTP
+transport has no `seek`, so every backward seek restarts the transfer from byte 0 and discards forward, which
+for a ~500MB ISO means several full transfers before the kernel even starts.
+
+#### Fetching the ISO over HTTP
+
+Grub inherits its device from whatever chainloaded it, so when iPXE loads `BOOT*.EFI` over TFTP,
+`$cmddevice` is `tftp,<server>` and the ISO is read over TFTP as well. To read it over HTTP instead,
+override `$cmddevice` in the `EFI/BOOT/grub.cfg` of the served directory, before the `loopback` line:
+
+```grub
+set cmddevice=http,192.168.1.1
+loopback loop0 ($cmddevice)/installer.iso
+set root=loop0
+set isnetboot=true
+export isnetboot
+configfile ($root)/EFI/BOOT/grub.cfg
+```
+
+A non-default port is given as `http,192.168.1.1:8080`.
+
+Note that `($cmddevice)/installer.iso` resolves from the root of that device, i.e.
+`http://192.168.1.1/installer.iso`, and *not* relative to the directory grub itself was loaded from.
+If the netboot tarball is served from a subdirectory, spell the path out instead, e.g.
+`loopback loop0 (http,192.168.1.1)/eve/installer.iso`.

--- a/pkg/eve/installer/grub_installer.cfg
+++ b/pkg/eve/installer/grub_installer.cfg
@@ -56,8 +56,17 @@ set_global eve_flavor kvm
 probe --set rootlabel --label $root
 if [ "$rootlabel" = "EVEISO" ]; then
    if [ "$isnetboot" = "true" ]; then
-      set_global initrd "/boot/initrd.img newc:/installer.iso:($install_part)/installer.iso" # add a simple custom initrd that will find the CD based on the label on the next line
-      set_global rootfs_root "/installer.iso rootimg=/rootfs_installer.img rootaddmount=/config.img:/config.img"
+      # $root is the ISO, already open over the network by the netboot grub.cfg.
+      # Take the payload out of it instead of naming the ISO itself as the initrd
+      # source, which would transfer the whole image over the network a second time.
+      set_global initrd "/boot/initrd.img newc:/rootfs_installer.img:($root)/rootfs_installer.img"
+      set_global rootfs_root "/rootfs_installer.img"
+      # an ISO carrying a config override has it at the top level; without one the
+      # installer rootfs keeps its own /config.img
+      if [ -f "($root)/config.img" ]; then
+         set_global initrd "$initrd newc:/config.img:($root)/config.img"
+         set_global rootfs_root "$rootfs_root rootaddmount=/config.img:/config.img"
+      fi
    else
       set_global initrd "/boot/initrd.img" # add a simple custom initrd that will find the CD based on the label on the next line
       set_global rootfs_root "LABEL=$rootlabel rootimg=/rootfs_installer.img rootaddmount=/config.img:/config.img"

--- a/pkg/mkimage-iso-efi/README.md
+++ b/pkg/mkimage-iso-efi/README.md
@@ -117,3 +117,12 @@ It accepts the following `isoroot=` flags:
 * `UUID=` - filesystem UUID
 * `PARTUUID=` - GPT partition UUID
 * `*` - anything else is a device path, or even a file path, e.g. `/dev/sr0` or `/installer.iso`
+
+## Additional root flags
+
+* `rootimg=` - a filesystem image *inside* `root=`, which is mounted and switched into instead of `root=`
+  itself. Use it when `root=` is a carrier, e.g. an ISO holding the real rootfs image.
+* `rootaddmount=<source>:<target>` - bind-mount `<source>` at `<target>` inside the filesystem being
+  switched into, before switching. May be repeated. `<target>` must already exist in that filesystem.
+  `<source>` is resolved relative to `root=` when `rootimg=` is set, and relative to the initramfs
+  otherwise - so an image placed in the initramfs by the bootloader can be used as a source.

--- a/pkg/mkimage-iso-efi/initrd.sh
+++ b/pkg/mkimage-iso-efi/initrd.sh
@@ -31,7 +31,53 @@ root_img=${rootimg_param#rootimg=}
 # Search for the rootaddmount= cmdline property
 # shellcheck disable=SC2002
 rootaddmount_param=$(cat /proc/cmdline | tr ' ' '\n' | grep '^rootaddmount=')
-# remove the leading "rootaddmount="  to get the actual value
+
+# staging area for bind mount sources that live in the initramfs, see add_mounts
+stagedir=/addmounts
+
+# add_mounts <source prefix> <target root>
+# bind-mounts every rootaddmount=<source>:<target> pair, resolving the source
+# under the given prefix (empty for the initramfs itself) and the target inside
+# the filesystem we are about to switch into
+add_mounts() {
+    src_prefix="$1"
+    target_root="$2"
+    for mountpair in $rootaddmount_param; do
+        # remove the leading "rootaddmount=" to get the actual value
+        mount=${mountpair#rootaddmount=}
+        if [ -z "$mount" ]; then
+            continue
+        fi
+        mount_source=$(echo "$mount" | cut -d':' -f1)
+        mount_target=$(echo "$mount" | cut -d':' -f2)
+        # make sure the mount target exists, after stripping leading slashes
+        mount_target="${mount_target#/}"
+        targetpath="$target_root/$mount_target"
+        mount_source="${mount_source#/}"
+        sourcepath="$src_prefix/$mount_source"
+        if [ ! -e "$sourcepath" ]; then
+            echo "Source path $mount_source does not exist, skipping mount"
+            continue
+        fi
+        if [ -z "$src_prefix" ]; then
+            # switch_root unlinks the whole initramfs. The bind mount itself
+            # survives that, but its source dentry is then deleted, and the
+            # kernel refuses a deleted dentry as the source of a further bind
+            # mount - which is exactly what the onboot containers do with these
+            # files. Move the source onto a tmpfs, which switch_root skips, so
+            # that it stays linked.
+            if [ ! -d "$stagedir" ]; then
+                mkdir -p "$stagedir"
+                mount -t tmpfs tmpfs "$stagedir"
+            fi
+            staged="$stagedir/$mount_source"
+            mkdir -p "$(dirname "$staged")"
+            mv "$sourcepath" "$staged"
+            sourcepath="$staged"
+        fi
+        mount --bind "${sourcepath}" "${targetpath}"
+    done
+}
 
 # Check if root_value is set
 if [ -z "$root_value" ]; then
@@ -43,9 +89,16 @@ echo "searching for root filesystem with value: $root_value"
 
 rootdev=""
 
-# Some emulated CD/DVD-ROM devices might take some time to appear in the
-# system, set a maximum number of retries (one per second) until give up
-cnt=10
+# a root= naming a file needs no device lookup at all: netboot hands us the
+# root image inside the initramfs
+if [ -f "$root_value" ]; then
+    rootdev="$root_value"
+    cnt=0
+else
+    # Some emulated CD/DVD-ROM devices might take some time to appear in the
+    # system, set a maximum number of retries (one per second) until give up
+    cnt=10
+fi
 while [ "$cnt" -gt 0 ]; do
     # Determine if the root_value is a LABEL, UUID, or direct device path
     while read -r line; do
@@ -99,35 +152,16 @@ if [ -n "$rootdev" ]; then
             # Mount the image and call switch_root
             mkdir -p /installer_root
             mount "$rootfsimg" /installer_root
-            # check if the rootaddmount parameter is set and add those mounts
-            if [ -n "$rootaddmount_param" ]; then
-                # remove the leading "rootaddmount=" to get the actual value
-                for mountpair in $rootaddmount_param; do
-                    mount=${mountpair#rootaddmount=}
-                    if [ -z "$mount" ]; then
-                        continue
-                    fi
-                    mount_source=$(echo "$mount" | cut -d':' -f1)
-                    mount_target=$(echo "$mount" | cut -d':' -f2)
-                    # make sure the mount target exists, after stripping leading slashes
-                    mount_target="${mount_target#/}"
-                    targetpath="/installer_root/$mount_target"
-                    mount_source="${mount_source#/}"
-                    sourcepath="/newroot/$mount_source"
-                    if [ ! -e "$sourcepath" ]; then
-                        echo "Source path $mount_source does not exist, skipping mount"
-                        continue
-                    fi
-                    mount --bind "${sourcepath}" "${targetpath}"
-                done
-            fi
+            add_mounts /newroot /installer_root
             exec switch_root /installer_root /sbin/init
         else
             echo "$root_img image not found!"
             exec sh
         fi
     else
-        # No image provided, let's just switch root
+        # No image provided, the root filesystem is what we switch into, so any
+        # additional mounts have to come from the initramfs
+        add_mounts "" /newroot
         exec switch_root /newroot /sbin/init
     fi
 else


### PR DESCRIPTION
# Description

Booting the EVE installer over iPXE transfers `installer.iso` twice. The netboot
`grub.cfg` loopback mounts the ISO so grub can read the kernel, initrd and
configs out of it, and `grub_installer.cfg` then named
`($install_part)/installer.iso` as the initrd source - a second URL, so the whole
~500MB image crossed the network again just to reach the initramfs.

This reads the payload out of the ISO grub already has open instead:

```grub
set_global initrd "/boot/initrd.img newc:/rootfs_installer.img:($root)/rootfs_installer.img"
set_global rootfs_root "/rootfs_installer.img"
```

The kernel now gets root=/rootfs_installer.img and mounts it directly, dropping
the nested iso9660 loop mount. The installer.net tarball is unchanged -
same files, same layout - so nothing changes for anyone serving it.

config.img is now conditional, because the two ISO builders differ:
tools/makeiso.sh leaves none at the ISO root (the unconditional
rootaddmount=/config.img was silently skipped there), while
create_installer_iso in pkg/eve/runme.sh puts one there so that
docker run -v /path/to/conf:/in ... installer_net overrides reach the
installer. Both behaviours are preserved.

initrd.sh gains an add_mounts helper so both layouts resolve rootaddmount
sources - under root= when rootimg= is set, in the initramfs otherwise - and
skips the blkid device hunt when root= names a file, which has nothing to
find there.

Related, and now in docs/BOOT-INSTALLER.md: serve the netboot directory over
HTTP, not TFTP. Grub's HTTP transport implements seek with a Range request,
so it only fetches the extents it reads; its TFTP transport has no seek and
restarts from byte 0 on every backward seek. The small boot files sit both
before and after the 470MB squashfs in this ISO, so over TFTP it is effectively
streamed several times.

## How to test and validate this PR

Should be covered by any ipxe test batch. However, the manual workflow for testing is:

1. `make ZARCH=amd64 HV=kvm installer-net`
1. Untar `dist/amd64/current/installer.net` into a directory served over HTTP,
   set `set url http://<server>/<path>/` in `ipxe.efi.cfg`, and iPXE boot a
   target at it. `make run-installer-net` also works (it serves over QEMU's
   built-in TFTP, so expect it to be slow for the reason described above).
1. Expected: the grub menu appears, the installer boots and installs EVE
   normally - i.e. no functional change from before.
1. The actual fix is visible in the web server access log. Before this change
   there are two full-length `GET /installer.iso` requests, the second one
   without a `Range` header. After it there is one connection plus ranged
   requests, and no second full sequential fetch. Total bytes transferred drop
   by roughly the size of the ISO.

**Optional**

**Config override path** (exercises the `[ -f ($root)/config.img ]` branch,
which is the one used by the ISO that `pkg/eve/runme.sh` builds):

1. `docker run -v /path/to/eve/conf:/in --rm lfedge/eve:<tag> installer_net > installer.net`
1. Netboot it as above and confirm the installer picked up the overridden
   config (e.g. a custom `server` file), which verifies `config.img` was carried
   into the initramfs and bind mounted over the one inside the squashfs.

**Regressions to check** - both go through the untouched `else` branch of
`grub_installer.cfg` and must behave exactly as before:

1. `make installer-iso`, then boot the ISO from virtual/physical media.
1. `make installer-raw`, then boot the raw installer from a USB stick.

## Changelog notes

Booting the EVE installer over the network no longer downloads the installer image twice, roughly halving the data transferred for a netboot install. For best results serve the netboot directory over HTTP rather than TFTP.

## PR Backports

This is an optimization rather than a bug fix, so I'd say to not backport. However, the netboot code is identical on all four branches and the change is self-contained, so it applies as-is.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR (`stable`, per the backport section)
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.