### PR TITLE
Makefile: drop bogus comment from currentversion recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -517,7 +517,6 @@ $(CURRENT_DIR): $(BUILD_DIR)
 # if we ran a new build.
 .PHONY: currentversion
 currentversion:
-	#echo $(shell readlink $(CURRENT) | sed -E 's/rootfs-(.*)\.[^.]*$/\1/')
 	@cat $(CURRENT_DIR)/installer/eve_version
 
 test: $(LINUXKIT) pkg/pillar | $(DIST)


### PR DESCRIPTION
# Description

Every run of `make currentversion` printed error noise before the actual
version:

```
readlink: missing operand
Try 'readlink --help' for more information.
sed: -e expression #1, char 23: unterminated `s' command
#echo
0.0.0-master-abcd1234-kvm-amd64
```

The "commented-out" first line of the `currentversion` recipe starts with a
tab, so make treats it as a shell command, not a comment: the
`$(shell readlink $(CURRENT) | sed ...)` in it is expanded on every
invocation. `$(CURRENT)` has never been defined (only `CURRENT_DIR`) and the
unescaped `$` corrupts the sed expression. Since the expanded line is passed
to the shell starting with `#`, the shell then treats it as a comment, so the
target still exited 0 while spewing the errors above.

Broken since the target was introduced in 3588da9f2 ("save build version and
report it in make"). The comment block above the target already documents why
the version is read from `installer/eve_version` instead of being parsed out
of the symlink name, so dropping the dead line loses nothing.

## How to test and validate this PR

1. Build any image so that `dist/<arch>/current` exists, e.g. `make rootfs`
   or `make live`.
2. Run `make currentversion`.
3. Before this fix it printed the `readlink`/`sed` errors and a stray
   `#echo` line shown above; with this fix it prints only the version, e.g.:

   ```
   $ make currentversion
   0.0.0-master-abcd1234-kvm-amd64
   ```

Not covered by an automated test (top-level Makefile targets have none).

## Changelog notes

No user-facing changes (developer build tooling only).

## PR Backports

Cosmetic build-tooling fix, no functional impact, so no backports planned:

- 17.0-stable: No, cosmetic build-tooling fix only.
- 16.0-stable: No, cosmetic build-tooling fix only.
- 14.5-stable: No, cosmetic build-tooling fix only.
- 13.4-stable: No, cosmetic build-tooling fix only.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation (none needed: removes one dead
  Makefile line, behavior is documented in the commit message)
- [x] I've tested my PR on amd64 device (host-side build tooling, not a
  device-side change; verified `make currentversion` on an amd64 build host)
- [x] I've tested my PR on arm64 device (not applicable: host-side build
  tooling, arch-independent)
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I
  didn't check them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
