### PR TITLE
[16.0-stable] Honor the hostname declared in an app instance cloud-init config

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -2984,8 +2984,12 @@ func createCloudInitISO(ctx *domainContext,
 		metafile.WriteString(fmt.Sprintf("instance-id: %s/%s\n",
 			config.UUIDandVersion.UUID.String(),
 			getCloudInitVersion(config)))
-		metafile.WriteString(fmt.Sprintf("local-hostname: %s\n",
-			config.UUIDandVersion.UUID.String()))
+		// Provide local-hostname only in case there isn't any hostname
+		// declared in the cloud config
+		if !cloudconfig.DeclaresHostname(ciStr) {
+			metafile.WriteString(fmt.Sprintf("local-hostname: %s\n",
+				config.UUIDandVersion.UUID.String()))
+		}
 		metafile.Close()
 
 		// Handle normal user-data

--- a/pkg/pillar/utils/cloudconfig/cloudconfig.go
+++ b/pkg/pillar/utils/cloudconfig/cloudconfig.go
@@ -33,6 +33,14 @@ type WritableFile struct {
 	Owner       string `yaml:"owner"`
 }
 
+// hostnameConfig holds only the cloud-config keys through which the user
+// takes charge of the guest hostname.
+type hostnameConfig struct {
+	Hostname         string `yaml:"hostname"`
+	FQDN             string `yaml:"fqdn"`
+	PreserveHostname bool   `yaml:"preserve_hostname"` //nolint:tagliatelle // cloud-init standard uses snake_case
+}
+
 var validate = validator.New()
 
 // MaxDecompressedContentSize is the maximum size of a file that can be written to disk after decompression.
@@ -128,6 +136,21 @@ func WriteFile(log *base.LogObject, file WritableFile, rootPath string) error {
 	}
 
 	return nil
+}
+
+// DeclaresHostname reports whether the given user-data is a cloud-config in
+// which the user has taken charge of the guest hostname, via any of the
+// `hostname`, `fqdn` or `preserve_hostname` directives.
+func DeclaresHostname(ci string) bool {
+	if !IsCloudConfig(ci) {
+		return false
+	}
+	var hc hostnameConfig
+	if err := yaml.Unmarshal([]byte(ci), &hc); err != nil {
+		// Not parseable as cloud-config; no hostname directive to honour.
+		return false
+	}
+	return hc.Hostname != "" || hc.FQDN != "" || hc.PreserveHostname
 }
 
 func decodeGzipContent(content string) ([]byte, error) {


### PR DESCRIPTION
# Description

Backport of #6336

## How to test and validate this PR

1. Create an Edge Application (Virtual Machine) with cloud-init configuration
2. Try different approaches on cloud-init config that sets a hostname, e.g.:

```cloud-config
#cloud-config
fqdn: pocusedr-fqdn.localdomain
```

```cloud-config
hostname: pocuser
```

For these situations, EVE should honor the hostname and not inject `local-hostname` to the config. The VM hostname should be set to the one pointed in the cloud-config.

3. Do not set any hostname in the cloud-config:

In this case, the VM will have Edge App's ID as its hostname

## Changelog notes

EVE no longer overrides the hostname declared in an application's cloud-init configuration.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.