### PR TITLE
pillar: reserve newlog space in bytes, not megabytes

### DIFF
--- a/pkg/pillar/diskmetrics/usage.go
+++ b/pkg/pillar/diskmetrics/usage.go
@@ -313,7 +313,11 @@ func Dom0DiskReservedSize(log *base.LogObject, globalConfig *types.ConfigItemVal
 		(float64(dom0MinDiskUsagePercent) * 0.01))
 	staticMaxDom0DiskSize := uint64(globalConfig.GlobalValueInt(
 		types.Dom0DiskUsageMaxBytes))
-	newlogReserved := uint64(globalConfig.GlobalValueInt(types.LogRemainToSendMBytes))
+	// The config item is in MBytes. newlogd clamps its own quota to a tenth
+	// of /persist, so anything above that could never be used.
+	newlogReserved := min(
+		1000000*uint64(globalConfig.GlobalValueInt(types.LogRemainToSendMBytes)),
+		deviceDiskSize/10)
 	// Always leave space for /persist/newlogd
 	maxDom0DiskSize := newlogReserved
 	// Select the larger of the current overhead usage and the configured

--- a/pkg/pillar/diskmetrics/usage_test.go
+++ b/pkg/pillar/diskmetrics/usage_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/containerd/containerd/mount"
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/sirupsen/logrus"
 )
 
@@ -270,6 +271,59 @@ func TestParseLsblkPartitions(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Fatalf("parseLsblkPartitions mismatch\n got: %+v\nwant: %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDom0DiskReservedSizeNewlogTerm(t *testing.T) {
+	log := base.NewSourceLogObject(logrus.StandardLogger(), t.Name(), 0) //nolint:staticcheck
+
+	// The newlog term is one of several summands, and which of the others
+	// applies depends on the disk size. Difference against a zero quota to
+	// isolate it.
+	newlogTerm := func(deviceDiskSize uint64, quotaMBytes uint32) uint64 {
+		reserved := func(quota uint32) uint64 {
+			gc := types.DefaultConfigItemValueMap()
+			gc.SetGlobalValueInt(types.LogRemainToSendMBytes, quota)
+			return Dom0DiskReservedSize(log, gc, deviceDiskSize, 0)
+		}
+		return reserved(quotaMBytes) - reserved(0)
+	}
+
+	tests := []struct {
+		name           string
+		deviceDiskSize uint64
+		quotaMBytes    uint32
+		want           uint64
+	}{
+		{
+			// newlogd clamps its own quota to a tenth of /persist, so the
+			// default 2048 MBytes is unreachable on a 4 GByte /persist.
+			name:           "quota above newlogd's tenth-of-persist clamp",
+			deviceDiskSize: 4037619712,
+			quotaMBytes:    2048,
+			want:           403761971,
+		},
+		{
+			name:           "quota below the clamp is converted from MBytes",
+			deviceDiskSize: 32000000000,
+			quotaMBytes:    2048,
+			want:           2048000000,
+		},
+		{
+			name:           "minimum quota",
+			deviceDiskSize: 32000000000,
+			quotaMBytes:    10,
+			want:           10000000,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := newlogTerm(tc.deviceDiskSize, tc.quotaMBytes)
+			if got != tc.want {
+				t.Errorf("newlog reserve on %d bytes of /persist with a %d MByte quota = %d, want %d",
+					tc.deviceDiskSize, tc.quotaMBytes, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
# Description

`Dom0DiskReservedSize` builds a byte total, but seeded it with
`newlog.gzipfiles.ondisk.maxmegabytes` straight from the config map. That item
is in MBytes, so the "always leave space for /persist/newlogd" reserve was 2048
bytes instead of ~2 GB. `getRemainingDiskSpace` subtracts this value from the
size of /persist to decide how much app volumes may claim, so apps were allowed
to fill ~2 GB more of /persist than intended.

Two things are needed to make the reserve correct:

1. Convert with `1000000`, matching the accounting newlogd itself uses to
   enforce the quota.
2. Apply newlogd's own ceiling on that quota. `newlogd.go` clamps
   `limitGzipFilesMbyts` to a tenth of /persist, so reserving the full
   configured value holds back space newlogd can never occupy. On a 4 GB
   /persist the default 2048 MBytes would reserve half the partition while
   newlogd stops at 403 MB — and with the 20% dom0 overhead reserve on top,
   apps would be left 29% of /persist.

Point 2 is not theoretical: with only point 1 in place, the Eden `Storage
(ext4)` job failed. That device has a 3851 MB /persist, and `volumes_test.txt`
sizes `blank-vol-1` from raw reported free space, which volumemgr then refused:

```
blank-vol-1 ... INITIAL: "Remaining disk space 1076153460 volume needs 1996488704"
                retry_condition:"Will retry when more space will be available"
```

Replaying that device's real numbers through the whole test sequence:

| | newlog reserve | remaining | blank-vol-1 |
| --- | --- | --- | --- |
| before this PR | 2,048 | 3,124,151,412 | fits |
| conversion only | 2,048,000,000 | 1,076,153,460 | rejected |
| conversion + clamp | 403,761,971 | 2,720,391,489 | fits |

With the clamp the later steps keep their intended outcomes too: once
`blank-vol-1` is placed, remaining falls to 723,902,785, so `blank-vol-2`
(2,018,508,800) is still correctly rejected with the "Remaining" error the test
waits for, and fits again after `blank-vol-1` is deleted.

Note that the clamp takes the /persist size from `PersistUsageStat` whereas
newlogd uses `statfs`. The two agree on ext4; on ZFS `PersistUsageStat` is
`LogicalUsed`-based and net of the reserved dataset, so the bound is approximate
there. That is acceptable for a reserve, but worth knowing.

## How to test and validate this PR

Covered by a unit test: `TestDom0DiskReservedSizeNewlogTerm` in
`pkg/pillar/diskmetrics/usage_test.go` pins both unit conversions. Run with
`make -C pkg/pillar test`. It fails against either mistake this reserve has
carried — the unconverted MBytes value, and the unclamped quota.

The Eden `Storage (ext4)` job exercises the end-to-end effect and must pass.

On a device, the volumemgr log line `getRemainingDiskSpace device total ...
allowed ...` must show `allowed` drop by `min(newlog.gzipfiles.ondisk.maxmegabytes
* 1000000, size_of_persist / 10)`, and follow that config item when it is
changed from the controller, up to the ceiling. An app volume above the new
limit must be rejected with "Will retry when more space will be available"
instead of being admitted.

## Changelog notes

EVE now reserves space on /persist for log files not yet uploaded to the
controller. Previously that reserve was effectively zero, so applications could
consume up to ~2 GB more of /persist than intended. The reserve never exceeds a
tenth of /persist, which is the same ceiling the log writer applies to itself.

## PR Backports

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

The affected line is identical on all four branches, so the cherry-picks apply
cleanly. 17.0-stable is not in the template's LTS list above but is active and
affected.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

No doc change needed: the behaviour now matches what `docs/CONFIG-PROPERTIES.md`
already documents. Not run on hardware — the change is a unit conversion and a
bound in a pure function, verified by the new unit test plus `go build`/`go vet`
on `diskmetrics` and `cmd/volumemgr`, and by the Eden storage suite.
