### PR TITLE
[16.0-stable] pillar: resolve ifname to the deepest PCI address

### DIFF
--- a/pkg/pillar/types/ifnametopci.go
+++ b/pkg/pillar/types/ifnametopci.go
@@ -126,10 +126,14 @@ func IfNameToPciAndUsbAddr(log *base.LogObject, ifName string) (string, string, 
 	}
 	link = path.Clean(link)
 	components := strings.Split(link, "/")
-	for _, c := range components {
-		if re.MatchString(c) {
-			log.Noticef("Fallback found %s", c)
-			return c, usbAddr, nil
+	// The path may contain several PCI addresses when the NIC sits behind
+	// PCI(e) bridges (e.g. behind a pcie-root-port in a VM): take the last
+	// match, which is the device itself -- the earlier matches are its
+	// upstream bridges, and assigning a bridge to vfio-pci fails (-EINVAL).
+	for i := len(components) - 1; i >= 0; i-- {
+		if re.MatchString(components[i]) {
+			log.Noticef("Fallback found %s", components[i])
+			return components[i], usbAddr, nil
 		}
 	}
 	return target, usbAddr, fmt.Errorf("Not PCI %s", target)


### PR DESCRIPTION
# Description

Backport of #6384

The nested-virtualization fallback of `IoBundleToPci` walks the sysfs
path of a network interface and returned the first PCI address found
in it. When the NIC sits behind a PCI(e) bridge -- e.g. behind a
pcie-root-port in a VM -- the path contains the addresses of all
upstream bridges before the device itself, so the fallback resolved
the adapter to its root port. domainmgr then tried to bind the root
port to vfio-pci, which the kernel refuses for bridges (probe error
-22), and an application with the NIC directly assigned never started.

Return the last match instead: the deepest PCI address on the path is
the device itself.

## How to test and validate this PR

Same as the original PR #6384: `TestNetworkAdapterPassthrough` on the evetest
proxmox provider deploys an application with a network adapter directly
assigned, and the provider's VMs attach NICs behind dedicated PCIe root ports,
which exercises exactly the fallback path fixed here.

To validate manually: run EVE as a VM with a NIC attached behind a PCIe root
port (nested virtualization) and assign that adapter directly to an
application instance. Without this fix, domainmgr resolves the adapter to the
root port and fails to bind it to vfio-pci (kernel probe error -22), so the
application never starts; with the fix, the NIC itself is bound and the
application starts.

## Changelog notes

Fixed direct assignment (passthrough) of a network adapter to an application
when the NIC sits behind a PCI(e) bridge (e.g. behind a PCIe root port in
nested virtualization): EVE resolved the adapter to the upstream bridge
instead of the NIC itself and the application failed to start.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (no documentation changes needed: internal bug fix with no user-facing configuration or API change)
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs:

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
