### PR TITLE
ci: add .cve-ignore list for the CVE PR gate

### DIFF
--- a/.cve-ignore
+++ b/.cve-ignore
@@ -1,0 +1,24 @@
+# CVE ignore list for the CVE PR Gate (.github/workflows/cve-scan.yml).
+#
+# Vulnerability IDs listed here are excluded from the PR scan report and
+# will not fail CI. One ID per line (CVE-..., GHSA-..., ...), matching is
+# case-insensitive and also applies to a vulnerability's aliases.
+# '#' starts a comment, blank lines are skipped.
+#
+
+# Based on reachability report :
+# EVE-OS · master · amd64_v6.12.96_generic
+# Not reachable
+# confidence: high
+# package: linux-kernel
+# Last analyzed 21/08/2026, 14:14:21 on master
+# CVE-2026-68434 is version-applicable to this kernel (6.12.96), and the
+# vulnerable code pattern is present in drivers/tty/serial/8250/8250_mid.c
+# (NULL-able dnv callbacks with unconditional dereferences). However, in this
+# specific kernel build the decisive gate is CONFIG_SERIAL_8250_MID: the
+# driver object 8250_mid.o is only built under that option, and
+# eve-core_defconfig has it disabled (# CONFIG_SERIAL_8250_MID is not set).
+# Because the vulnerable driver is not compiled into this kernel variant,
+# there is no runtime entry path to mid8250_probe()/mid8250_remove() in this
+# shipped build, so the vulnerability is not reachable here.
+CVE-2026-68434


### PR DESCRIPTION
# Description
IDs listed in this file are excluded from the CVE scan report and do not fail CI.

Waive CVE-2026-68434, the vulnerable 8250_mid driver is not built into the EVE kernel (CONFIG_SERIAL_8250_MID is not set), so the bug is not reachable.


## PR dependencies

None.

## How to test and validate this PR
On CI, this is CI only.

## Changelog notes

None

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 17.0-stable
- 16.0-stable
- 14.5-stable
- 13.4-stable

For example, if this PR fixes a bug in a feature that was introduced in 17.0,
you can write:

```text
- 17.0-stable: To be backported.
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
