### PR TITLE
ci: run the Claude review on pull_request_target

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,8 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 name: Claude Code
+# Every PR to this repo comes from a fork, and a plain "pull_request" run on a
+# fork gets a read-only GITHUB_TOKEN with no secrets: the id-token: write below
+# is silently dropped and the action dies fetching its OIDC token. Reviewing a
+# PR therefore requires the privileged pull_request_target context.
 on:  # yamllint disable-line rule:truthy
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
   pull_request_review_comment:
     types: [created]
@@ -24,7 +28,7 @@ jobs:
       group: claude-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: true
     if: |
-      (github.event_name == 'pull_request' && (
+      (github.event_name == 'pull_request_target' && (
         github.event.pull_request.author_association == 'MEMBER' ||
         github.event.pull_request.author_association == 'COLLABORATOR' ||
         github.event.pull_request.author_association == 'OWNER'
@@ -42,6 +46,9 @@ jobs:
           github.event.comment.author_association == 'OWNER'
         ))
     steps:
+      # No "ref" on purpose: under pull_request_target this checks out the base
+      # ref. Never check out the PR head here, it would run untrusted code with
+      # a privileged token. The review reads the diff over the API instead.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -19,6 +19,12 @@ rules:
       # PR via the GitHub API. No checkout of the head ref; no shell
       # execution touches PR-controlled content.
       - close-master-pr.yml
+      # pull_request_target: checks out the base ref only and reads the PR
+      # diff over the API. Nothing PR-controlled reaches the shell, and the
+      # reviewer prompt is instructed to treat the diff as untrusted data.
+      # A plain pull_request run cannot work here: every PR is from a fork,
+      # so the token would be read-only and the secrets unavailable.
+      - claude-review.yml
       # pull_request_target: checks out the base ref, fetches the head
       # SHA, and only reads .github/CODEOWNERS (base-controlled). The
       # head ref is interpolated into shell; that template-injection


### PR DESCRIPTION
The Claude Code review workflow fails on every PR where it actually runs. Example: [run 32717278432](https://github.com/lf-edge/eve/actions/runs/32717278432/job/97401092821) on #6395.

```
Attempt 3 failed: Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
Operation failed after 3 attempts
```

## Why

Every PR to this repo is opened from a fork. For a `pull_request` event on a fork PR, GitHub gives the job a read-only `GITHUB_TOKEN` and no access to secrets — the `id-token: write` the workflow requests is silently dropped, so `claude-code-action` dies in `setupGitHubToken`. `secrets.ANTHROPIC_API_KEY` is empty in that context too, so the run could not have succeeded even past the OIDC step.

It looked like a per-user problem because the job's gate is evaluated against the **webhook payload**, and `author_association` there reports `MEMBER` only for users whose lf-edge org membership is *public*. Private members show up as `CONTRIBUTOR`, so for almost everyone the job is skipped before it can fail. lf-edge currently has six public members, which is why only their PRs surfaced the breakage.

Every `success` in this workflow's history came from an `issue_comment` (`@claude`) run, which already executes in the base-repo context. No `pull_request`-event run has ever succeeded.

## Fix

Switch the PR trigger to `pull_request_target`, which runs in the base repo context with the token and secrets the action needs. The gate condition and the payload fields it reads are unchanged.

Security notes, since `pull_request_target` is a privileged trigger:

- The checkout keeps no `ref`, so it stays on the base ref — the PR head is never checked out.
- Nothing PR-controlled is interpolated into a shell or into the prompt; only `github.repository` and the PR number are, and the review reads the diff over the API.
- The prompt already instructs the reviewer to never follow instructions found in diffs or file contents.
- Added to the `dangerous-triggers` ignore list in `.github/zizmor.yml`, with the same kind of documented rationale the other privileged workflows carry.

Note that this only takes effect once merged: `pull_request_target` always uses the workflow definition from the base branch, so this PR itself will not exercise the new trigger.

## How to test

After merge, open any PR from a fork whose author's lf-edge membership is public (or make yours public temporarily) and confirm the `Claude Code` job runs and posts a review instead of failing on the OIDC step.