### PR TITLE
ci: run the Claude review on pull_request_target

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,8 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 name: Claude Code
+# Every PR to this repo comes from a fork, and a plain "pull_request" run on a
+# fork gets a read-only GITHUB_TOKEN with no secrets: the id-token: write below
+# is silently dropped and the action dies fetching its OIDC token. Reviewing a
+# PR therefore requires the privileged pull_request_target context.
 on:  # yamllint disable-line rule:truthy
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
   pull_request_review_comment:
     types: [created]
@@ -24,7 +28,7 @@ jobs:
       group: claude-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: true
     if: |
-      (github.event_name == 'pull_request' && (
+      (github.event_name == 'pull_request_target' && (
         github.event.pull_request.author_association == 'MEMBER' ||
         github.event.pull_request.author_association == 'COLLABORATOR' ||
         github.event.pull_request.author_association == 'OWNER'

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -9,8 +9,10 @@ name: Claude Code
 on:  # yamllint disable-line rule:truthy
   pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
-  pull_request_review_comment:
-    types: [created]
+  # Only issue_comment, not pull_request_review_comment: a review comment on a
+  # fork PR runs in the same restricted context as pull_request, and GitHub has
+  # no _target variant of it to escape to. Ask for a review with @claude from
+  # the Conversation tab.
   issue_comment:
     types: [created]
 
@@ -32,11 +34,6 @@ jobs:
         github.event.pull_request.author_association == 'MEMBER' ||
         github.event.pull_request.author_association == 'COLLABORATOR' ||
         github.event.pull_request.author_association == 'OWNER'
-      )) ||
-      (github.event_name == 'pull_request_review_comment' && (
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR' ||
-        github.event.comment.author_association == 'OWNER'
       )) ||
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,11 +16,14 @@ on:  # yamllint disable-line rule:truthy
   issue_comment:
     types: [created]
 
+# Keep this minimal: with allowed_non_write_users the reviewer can be invoked
+# by people without write access, so the token it holds is what limits the
+# damage a prompt injected through a diff could do. id-token is no longer
+# needed now that github_token replaces the OIDC app-token exchange.
 permissions:
   contents: read
   pull-requests: write
   issues: write
-  id-token: write
 
 jobs:
   review:
@@ -40,6 +43,7 @@ jobs:
         contains(github.event.comment.body, '@claude') && (
           github.event.comment.author_association == 'MEMBER' ||
           github.event.comment.author_association == 'COLLABORATOR' ||
+          github.event.comment.author_association == 'CONTRIBUTOR' ||
           github.event.comment.author_association == 'OWNER'
         ))
     steps:
@@ -51,6 +55,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # The Claude app refuses to mint a token for a user without write
+          # access, so the reviewer runs on the workflow token instead. The
+          # job's if: condition above is the real allowlist; "*" only tells
+          # the action to stop enforcing write access on top of it.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
           show_full_output: false
           track_progress: true  # ✨ Enables tracking comments
           use_sticky_comment: false

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -19,6 +19,12 @@ rules:
       # PR via the GitHub API. No checkout of the head ref; no shell
       # execution touches PR-controlled content.
       - close-master-pr.yml
+      # pull_request_target: checks out the base ref only and reads the PR
+      # diff over the API. Nothing PR-controlled reaches the shell, and the
+      # reviewer prompt is instructed to treat the diff as untrusted data.
+      # A plain pull_request run cannot work here: every PR is from a fork,
+      # so the token would be read-only and the secrets unavailable.
+      - claude-review.yml
       # pull_request_target: checks out the base ref, fetches the head
       # SHA, and only reads .github/CODEOWNERS (base-controlled). The
       # head ref is interpolated into shell; that template-injection


### PR DESCRIPTION
# Description

Three fixes to `.github/workflows/claude-review.yml`, one commit each.

Context for all three: since this workflow landed (`7dfbb932d`, 2026-05-07) it has produced **3254 runs, and not one `pull_request` or `pull_request_review_comment` run has ever succeeded**. Every success is an `issue_comment` (`@claude`) run, and every actor with a successful run holds write or admin on this repo.

## 1. `ci: run the Claude review on pull_request_target`

The review fails on every PR where it actually runs. Example: [run 32717278432](https://github.com/lf-edge/eve/actions/runs/32717278432/job/97401092821) on #6395.

```text
Attempt 3 failed: Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
Operation failed after 3 attempts
```

Every PR to this repo is opened from a fork. For a `pull_request` event on a fork PR, GitHub gives the job a read-only `GITHUB_TOKEN` and no access to secrets, so the `id-token: write` the workflow requests is silently dropped and `claude-code-action` dies in `setupGitHubToken`. `secrets.ANTHROPIC_API_KEY` is empty in that context too, so the run could not have succeeded even past the OIDC step.

The failure was mostly invisible because `author_association` in a `pull_request` payload does not resolve the same way it does in an `issue_comment` payload — of everyone who has opened a PR recently, only PRs from a public member of the `lf-edge` org cleared the gate at all, so for everyone else the job was skipped before it could fail.

Switch the PR trigger to `pull_request_target`, which runs in the base repo context with the token and secrets the action needs.

Security notes, since `pull_request_target` is a privileged trigger:

- The checkout carries no `ref`, so it stays on the base ref — the PR head is never checked out.
- Nothing PR-controlled is interpolated into a shell or into the prompt; only `github.repository` and the PR number are, and the review reads the diff over the API.
- The prompt already instructs the reviewer to never follow instructions found in diffs or file contents.
- `claude-review.yml` is added to the `dangerous-triggers` ignore list in `.github/zizmor.yml`, with the same kind of documented rationale the other privileged workflows there carry.

## 2. `ci: drop the review-comment trigger from the Claude review`

A `pull_request_review_comment` on a PR from a fork runs in the same restricted context as `pull_request`: a read-only `GITHUB_TOKEN` and no secrets. Verified on a fork PR against a copy of this repo — the action gets an empty `anthropic_api_key` and 403s on its own tracking comment before Claude ever runs:

```text
GITHUB_TOKEN Permissions: Contents: read  Issues: read  Metadata: read  PullRequests: read
Secret source: None
"anthropic_api_key": "",
HttpError: Resource not accessible by integration - .../rest/issues/comments#create-an-issue-comment
```

Unlike `pull_request` there is no `_target` variant of the event to move to, and every PR to this repo comes from a fork, so the trigger can never do anything useful here. It was also a footgun: its branch of the gate never checked the comment body, so it would have fired the reviewer on *every* inline comment left by a user with write access.

Drop it. `@claude` from the Conversation tab is an `issue_comment`, which runs in the base repo context with the token and secrets the action needs, and is the only path that has ever completed a review here.

## 3. `ci: let contributors invoke the Claude review with @claude`

Contributors without write access cannot use the reviewer at all. The gate skips them, and when it does not, the action fails in the app-token exchange:

```text
App token exchange failed: 401 Unauthorized - User does not have write access on this repository
```

(see runs [30625682479](https://github.com/lf-edge/eve/actions/runs/30625682479) / [30638902574](https://github.com/lf-edge/eve/actions/runs/30638902574) on #6188, and #6354 for the skipped case). This affects real reviewers here — `christoph-zededa`, `europaul`, `naiming-zededa` and `andrewd-zededa` all have read-only access to this repo.

Accept `CONTRIBUTOR` in the `issue_comment` branch of the gate, so anyone with a merged commit here can ask for a review with `@claude`. The `pull_request_target` branch is deliberately left alone: opening or pushing to a PR still auto-triggers a review only for people with write access, so a contributor pushing to a long-running PR does not spend API credit on every commit.

Mechanically that needs two inputs, since either alone is inert:

- `github_token: ${{ secrets.GITHUB_TOKEN }}` makes the action use the workflow token instead of exchanging an OIDC token for an app token — the exchange being what enforces write access.
- `allowed_non_write_users: "*"` stops the action re-checking write access itself. The job's `if:` condition is the real allowlist; a user with no merged commit is `NONE`/`FIRST_TIME_CONTRIBUTOR` and never reaches the action.

Consequences worth knowing before approving:

- **Reviews are now posted by `github-actions[bot]` rather than `claude[bot]`**, for everyone, since the app is no longer in the loop.
- `id-token: write` is dropped from `permissions:`, as nothing requests an OIDC token any more. Keeping the token minimal is the main mitigation here: the reviewer can now be invoked by people without write access, so the permissions it holds bound what a prompt injected through a diff could do.

## How to test and validate this PR

`pull_request_target` always uses the workflow definition from the **base** branch, so this PR cannot exercise the new trigger itself — validation of items 1 and 3 has to happen after merge.

1. On this PR, confirm the linters stay green: `actionlint` and `yamllint` are clean, and the Zizmor job should stay green (the `dangerous-triggers` finding is suppressed by the new `.github/zizmor.yml` entry; the pre-existing `unpinned-uses` finding on `anthropics/claude-code-action@v1` is unchanged and non-fatal).
2. After merge, open a PR from a fork whose author has write access. The `Claude Code` run should complete and post its review instead of failing with `Could not fetch an OIDC token`.
3. Item 2: leave an inline review comment on a PR diff and confirm no `Claude Code` run is created at all.
4. Item 3: have a read-only contributor (e.g. `@christoph-zededa`) comment `@claude` in the Conversation tab of a PR, and confirm it produces a review rather than a skipped job or a 401.
5. Item 3, negative case: open a PR from a read-only contributor and confirm no review is triggered automatically on open or on push — only on an explicit `@claude`.
6. Regression: confirm `@claude` from a write-access user still works, and that a PR from someone with no merged commits is still skipped.

Not covered by automated tests — this is CI plumbing that can only be exercised by the real events on the base branch.

## Changelog notes

No user-facing changes.

## PR Backports

- 17.0-stable: No, CI-only change with no effect on released artifacts.
- 16.0-stable: No, CI-only change with no effect on released artifacts.
- 14.5-stable: No, CI-only change with no effect on released artifacts.
- 13.4-stable: No, CI-only change with no effect on released artifacts.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Device testing does not apply: this changes only a GitHub Actions workflow and the
Zizmor audit config, neither of which is part of any image. The triggers themselves
can only be validated after merge, as described above. Documentation lives inline in
the workflow and in `.github/zizmor.yml`.
