### PR TITLE
zedmanager: apply staged adapter change once domain is down

### DIFF
--- a/pkg/pillar/cmd/zedmanager/handlezedrouter.go
+++ b/pkg/pillar/cmd/zedmanager/handlezedrouter.go
@@ -18,9 +18,10 @@ import (
 // network stack (bridge, dnsmasq, VIFs). While the application is running such
 // a change is withheld from
 // zedrouter (stageNetwork below) so the network is not reconfigured underneath
-// the running guest; it is published instead on the next restart (or when the
-// app is being started), so zedrouter reconfigures the network as part of the
-// (re)start. ACL and other field changes are applied live.
+// the running guest; it is published once the domain of a restarting app came
+// down (or when the app is being started), so zedrouter reconfigures the
+// network as part of the (re)start. ACL and other field changes are applied
+// live.
 func MaybeAddAppNetworkConfig(ctx *zedmanagerContext,
 	aiConfig types.AppInstanceConfig, aiStatus *types.AppInstanceStatus) {
 
@@ -77,12 +78,15 @@ func MaybeAddAppNetworkConfig(ctx *zedmanagerContext,
 		log.Functionf("MaybeAddAppNetworkConfig done (no change) for %s", key)
 		return
 	}
-	// Stage network-reconfiguring changes while the guest is running; they are
-	// applied on the next restart (when RestartInprogress is set). If the app is
-	// not currently activated it is being started, so there is no running guest
-	// to protect and the change is applied immediately.
+	// Stage network-reconfiguring changes while the guest owns its VIFs; they
+	// are applied during a restart, but only once the domain came down
+	// (BringUp). Handing them over any earlier (BringDown) makes zedrouter move
+	// a VIF that domainmgr is concurrently tearing down, and the reconciler
+	// then fails with "link not found", which is reported as an app error.
+	// If the app is not currently activated it is being started, so there is no
+	// running guest to protect and the change is applied immediately.
 	if stageNetwork && aiStatus.Activated &&
-		aiStatus.RestartInprogress == types.NotInprogress {
+		aiStatus.RestartInprogress != types.BringUp {
 		log.Noticef("MaybeAddAppNetworkConfig(%s): network adapter change staged; "+
 			"will be applied when the application is restarted", key)
 		return
@@ -100,6 +104,20 @@ func MaybeAddAppNetworkConfig(ctx *zedmanagerContext,
 	nc.AppNetAdapterList = slices.Clone(aiConfig.AppNetAdapterList)
 	publishAppNetworkConfig(ctx, &nc)
 	log.Functionf("MaybeAddAppNetworkConfig done for %s", key)
+}
+
+// appNetAdaptersApplied reports whether zedrouter has already taken over the
+// application's current set of network adapters. zedrouter copies the
+// AppNetAdapterConfig it was given into AppNetworkStatus, so a mismatch means
+// the staged adapters have not been applied yet and the VIFs described by the
+// status still belong to the previous adapter set.
+func appNetAdaptersApplied(aiConfig types.AppInstanceConfig,
+	ns types.AppNetworkStatus) bool {
+	return slices.EqualFunc(aiConfig.AppNetAdapterList, ns.AppNetAdapterList,
+		func(config types.AppNetAdapterConfig,
+			status types.AppNetAdapterStatus) bool {
+			return reflect.DeepEqual(config, status.AppNetAdapterConfig)
+		})
 }
 
 // adapterChangeNeedsRestart reports whether the difference between the old and

--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -797,6 +797,16 @@ func doActivate(ctx *zedmanagerContext, uuidStr string,
 		status.ClearErrorWithSource()
 		changed = true
 	}
+	// A staged set of network adapters is handed to zedrouter only once the
+	// domain came down (see MaybeAddAppNetworkConfig). Wait for zedrouter to
+	// apply it before re-creating the domain, whose VIFs would otherwise be
+	// built from the adapters that are being replaced.
+	if status.RestartInprogress == types.BringUp &&
+		!appNetAdaptersApplied(config, *ns) {
+		log.Noticef("RestartInprogress(%s) waiting for zedrouter to apply "+
+			"the new network adapters", status.Key())
+		return changed
+	}
 	log.Tracef("Done with AppNetworkStatus for %s", uuidStr)
 
 	// Do we try to activate an application earlier than it's configured to start?


### PR DESCRIPTION
# Description

A change to an application's network adapters is withheld from zedrouter
while the guest runs and applied on the next restart (4775e934e). The gate
released the change as soon as the restart began (`RestartInprogress` was no
longer `NotInprogress`), that is in the same `doActivate` pass which clears
`DomainConfig.Activate`. zedrouter therefore moved the VIF between bridges
while domainmgr was tearing the domain down:

```text
15:23:31.999 zedmanager  publishAppNetworkConfig()
15:23:32.031 zedmanager  RestartInprogress(...) Clear Activate
15:23:32.380 domainmgr   doInactivate(...) domainId 6748
15:23:33.311 zedrouter   failed items: BridgePort/bn1/nbu1x1
                         (failed to get link for interface nbu1x1)
15:23:34.296 zedmanager  Received error from zedrouter ... -> return
```

The failed item becomes an application error, and `doActivate` bails out on
it, so the domain is never re-created. zedrouter cannot clear the error
either, because that VIF only exists while the domain runs. The app is stuck
in HALTING until its configuration changes again.

This PR holds the change back until the domain came down (`BringUp`), where
there is no VIF to trip over: the bridge port stays pending, exactly as it
does while an application starts for the first time.

That removes the delay between handing the adapters over and re-creating the
domain — the ~30s teardown used to be, by accident, long enough for zedrouter
to finish first. `doActivate` now waits for the adapters to appear in
`AppNetworkStatus` before it publishes the `DomainConfig`. Otherwise the VIF
list is built from the adapters being replaced, and since domainmgr reads
`VifList` only while activating a domain, the guest keeps those adapters
until the next restart.

## How to test and validate this PR

The fix is covered by automated tests in `evetest/tests/networking`, runnable
from the repo root against a locally built image:

```sh
make evetest NAME=TestMoveAppBetweenNIs   # adapter moved between NIs, then app restart
make evetest NAME=TestNICCountChange     # NICs added/removed, guest must see them after restart
```

- `TestMoveAppBetweenNIs` (`netinst_test.go`) reproduces the race: without
  the fix the app ends up stuck in HALTING after the restart that applies the
  adapter change.
- `TestNICCountChange` (`nicchange_test.go`) guards the second half of the
  fix: without waiting for `AppNetworkStatus`, the guest comes back up
  without the newly added NIC (no `eth1`).

Results with evetest against a locally built live image (QEMU/KVM, amd64):

|             | TestMoveAppBetweenNIs | TestNICCountChange       |
|-------------|-----------------------|--------------------------|
| before      | FAIL (573s)           | PASS (677s)              |
| gate only   | PASS (542s)           | FAIL (guest has no eth1) |
| gate + wait | PASS (442s)           | PASS (648s)              |

Manual validation for QA:

1. Deploy an application with a network adapter on network instance A and
   wait for it to run.
2. Without purging, change the application's adapter to network instance B
   (requires a controller that uses the "allow adapter change" capability;
   the change is staged until the next app restart).
3. Restart the application.
4. Verify the app returns to RUNNING (previously it could get stuck in
   HALTING with a `BridgePort` error), its adapter is attached to network
   instance B, and the guest sees all expected interfaces.

## Changelog notes

Fixed: changing the network adapters of a running application (applied on
the next app restart) could leave the application stuck in a halting state,
or leave a newly added network adapter missing from the guest until another
restart.

## PR Backports

- 17.0-stable: No, the adapter-change-without-a-purge feature (4775e934e) is
  not available there. Should that feature ever be backported, this fix must
  accompany it.
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — no documentation changes needed:
  this is an internal ordering fix inside zedmanager; the documented behavior
  (adapter change applied on the next app restart) is unchanged.
- [x] I've tested my PR on amd64 device — via evetest against a locally
  built live image on QEMU/KVM (table above).
- [ ] I've tested my PR on arm64 device — not tested there: the change is
  architecture-independent zedmanager state-machine logic, validated via
  evetest on amd64.
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR — none applicable: not a stable
  backport candidate (see PR Backports).

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I
  didn't check them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
