### PR TITLE
pkg/debug: report USB-attached UARTs as COM ports

### DIFF
--- a/pkg/debug/spec.sh
+++ b/pkg/debug/spec.sh
@@ -27,6 +27,10 @@
 #
 # Note that handling of wlan and other network interfaces sitting on USB buses
 # does not set the correct assignment group.
+#
+# A serial port behind a USB-to-UART converter is reported as a COM port. Ports
+# of a cellular modem are left out, but only modems driven by one of the wwan
+# serial drivers below, or exposing a QMI/MBIM interface, are recognized as such.
 
 verbose=
 usb_devices=
@@ -437,11 +441,44 @@ __EOT__
     COMMA="},"
 done
 
+# Drivers that give a cellular modem away: the serial drivers its AT and data
+# ports come up under, and the net drivers of its control interface. A converter
+# whose driver is not listed is still reported, since missing a COM port is the
+# worse outcome for a hardware model.
+MODEM_DRIVERS='option|qcserial|sierra|usb_wwan|cdc_mbim|qmi_wwan'
+
+# usb_uart_device($TTY_SYSFS_DIR) prints the sysfs directory of the USB device
+# providing a tty, or nothing when the tty is not on the USB bus or belongs to a
+# cellular modem. Modem ports are enumerated as IO_TYPE_WWAN and EVE itself
+# talks to them.
+usb_uart_device() {
+    local dev
+    local parent
+    local subsystem
+    dev=$(realpath "$1/device" 2>/dev/null) || return 0
+    while true; do
+        subsystem=$(readlink -f "$dev/subsystem" 2>/dev/null)
+        # the USB device is the closest ancestor on the usb bus carrying
+        # idVendor; the interfaces below it are on that bus but have no idVendor
+        if [ "${subsystem##*/}" = usb ] && [ -f "$dev/idVendor" ]; then
+            break
+        fi
+        parent=$(dirname "$dev")
+        [ "$parent" = "$dev" ] && return 0
+        dev="$parent"
+    done
+    # the interface of the tty is one of these, so this catches both a modem
+    # serial port and a serial port next to a modem control interface
+    grep -qE "^DRIVER=(${MODEM_DRIVERS})$" "$dev"/*/uevent 2>/dev/null && return 0
+    echo "$dev"
+}
+
 #enumerate serial ports
 ID="1"
 for TTY in /sys/class/tty/*; do
    IO=""
    IRQ=""
+   USB_UART=""
    if [ -f "$TTY/irq" ]; then
       IRQ=$(cat "$TTY/irq")
       [ "${IRQ:-0}" -gt 0 ] || IRQ=""
@@ -458,8 +495,12 @@ for TTY in /sys/class/tty/*; do
          IRQ=""
       fi
    fi
+   # A UART behind a USB converter has no port or irq of its own
+   if [ -z "$IO" ] && [ -z "$IRQ" ]; then
+      USB_UART=$(usb_uart_device "$TTY")
+   fi
    TTY=$(echo "$TTY" | cut -f5 -d/)
-   if [ -n "$IO" ] || [ -n "$IRQ" ]; then
+   if [ -n "$IO" ] || [ -n "$IRQ" ] || [ -n "$USB_UART" ]; then
 cat <<__EOT__
     ${COMMA}
     {

--- a/pkg/installer/Dockerfile
+++ b/pkg/installer/Dockerfile
@@ -28,7 +28,7 @@ RUN cargo sbom > sbom.spdx.json
 
 RUN cp "/usr/local/my-installer/target/$CARGO_BUILD_TARGET/release/installer" /usr/local/my-installer/target/installer
 
-FROM lfedge/eve-debug:d1461b73753e42bf288cc3e35514fa0a9d1061a2 AS debug
+FROM lfedge/eve-debug:4d8ad0e15ba78e278db9fc158c3c3c740757ceeb AS debug
 
 # Dockerfile to build installer img initrd
 FROM lfedge/eve-alpine:d075dd224fa7a7540817d224cc28d3cd998ad04c AS build


### PR DESCRIPTION
# Description

A UART reached through a USB-to-serial converter never appeared in the generated
hardware model as a COM port. Boxes whose only serial port is an internal
converter therefore produced a model with no serial port at all; the converter
showed up solely as an `IO_TYPE_USB_DEVICE` entry.

The COM entry was emitted only for ttys with an IO port range or an IRQ. Both
come from sysfs attributes that the serial core creates, and `usb-serial` does
not use the serial core, so such a tty has neither file and could never pass the
check. On a 6.12 kernel:

```text
/sys/class/tty/ttyUSB0   dev device power subsystem uevent          <- no port, no irq
/sys/class/tty/ttyS0     ... irq port io_type type line ...         port=0x3F8 irq=4
```

Presence of the `device` symlink is not usable as the criterion instead:
platforms commonly advertise 8250 ports they do not populate — one test machine
exposes 32, of which 28 read `port=0x0` — and all of them have that symlink, so
they would turn into phantom COM ports. The tty is therefore classified by
climbing to the USB device it hangs off: the closest ancestor on the `usb` bus
that carries `idVendor`.

**Modem ports** are kept out, since they are enumerated as `IO_TYPE_WWAN` and
EVE's own wwan service talks to them. A port counts as a modem port when the
driver bound to it is one of `option|qcserial|sierra|usb_wwan`, or when the USB
device also exposes a QMI/MBIM interface. Neither test is exhaustive and this
cannot be made fully reliable from sysfs alone, so the limitation is stated in
the script header. Note the driver list deliberately does **not** include
`cdc_acm`: that driver serves plain USB serial devices too (Arduino-class), and
excluding it would drop the very ports this PR adds. A modem's ACM control port
is instead caught by the QMI/MBIM interface sitting next to it on the same
device — covered by a test case below.

**Assignment groups.** The converter is described twice when `-u` is given, once
as a COM port and once as a USB device, each in its own assignment group. Nothing
stops the two from being assigned to different app instances — but that hazard
already exists between the USB controller and USB device entries, and preventing
it is a pillar-side change rather than something the model generator can express,
so it is deliberately not addressed here. See the thread below for what I found
while looking into it.

Only `Serial` is reported for such a port, no `usbaddr`/`usbproduct`. Those
fields on an `IO_TYPE_COM` entry would point domainmgr at the USB passthrough
path instead of opening the tty.

The second commit updates the `eve-debug` hash pinned by `pkg/installer`, which
the new `pkg/debug` content hash requires. It is separate because the value is
branch-specific: a backport has to recompute it with
`linuxkit pkg show-tag pkg/debug` rather than cherry-pick that commit.

## How to test and validate this PR

### With an emulated converter, no hardware needed

EVE's kernel ships `ftdi_sio`, and QEMU can emulate an FTDI FT232BM, which gives
a genuine `/dev/ttyUSB0`. Boot EVE's kernel (the `kernel` file at the root of the
`lfedge/eve-kernel` image, modules in its `kernel.tar`) with a busybox initramfs:

```sh
qemu-system-x86_64 -nographic -no-reboot -m 1024 \
  -kernel kernel -initrd initrd.gz -append "console=ttyS0" \
  -device qemu-xhci,id=xhci \
  -chardev file,path=ftdi.out,id=sp \
  -device usb-serial,chardev=sp,bus=xhci.0 \
  -serial mon:stdio
```

The converter attaches only once its chardev reports an open, so a `null` or
`pty` chardev leaves it detached with no error message — use a `file` chardev.

Then run `spec.sh` in the guest and compare the `"ztype": 3` entries:

```text
before:  /dev/ttyS0  /dev/ttyS1  /dev/ttyS2  /dev/ttyS3
after:   /dev/ttyS0  /dev/ttyS1  /dev/ttyS2  /dev/ttyS3  /dev/ttyUSB0
```

Checked as well on a physical amd64 machine with 32 advertised and 4 populated
8250 ports: output identical before and after, i.e. the unpopulated ports do not
become COM ports.

### Automated check

Not added to the tree, to keep this to the two files. The script below builds a
synthetic sysfs tree and bind-mounts it over `/sys` inside an unprivileged mount
namespace, so it needs neither root nor hardware. Cases covered: populated 8250,
unpopulated 8250, USB converter, modem recognised by its port driver, modem whose
`cdc_acm` control port is recognised only by the MBIM interface beside it, a
non-modem `cdc_acm` device that must stay reported, and a virtual tty. It fails
on current master with

```text
FAIL: expected COM ports '/dev/ttyACM1 /dev/ttyS0 /dev/ttyUSB0 ', got '/dev/ttyS0 '
```

and passes with this change. Drop it in `pkg/debug/tests/` and run
`sh tests/spec-serial-test.sh`. It has to run on the host — a docker build has no
`CAP_SYS_ADMIN` and cannot bind-mount over `/sys`. Happy to land it here instead
if reviewers prefer it in the tree.

<details>
<summary>spec-serial-test.sh</summary>

```sh
#!/bin/sh
# Copyright (c) 2026 Zededa, Inc.
# SPDX-License-Identifier: Apache-2.0

# Checks which serial ports spec.sh reports, using a synthetic sysfs tree
# bind-mounted over /sys inside a private mount namespace.
#
# The tree mirrors what a 6.12 kernel exposes. To refresh it, boot the kernel
# with an emulated FTDI converter and read /sys/class/tty there:
#   qemu-system-x86_64 -kernel <eve-kernel> -initrd <initramfs> \
#     -device qemu-xhci,id=xhci -chardev file,path=ftdi.out,id=sp \
#     -device usb-serial,chardev=sp,bus=xhci.0
# The converter only attaches once its chardev reports an open, which a null or
# pty chardev never does.

set -eu

SPEC=${SPEC:-$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)/spec.sh}
WORK=$(mktemp -d)
trap 'rm -rf "$WORK"' EXIT

# modems are enumerated even without -u, so assertions about the COM entries
# have to look at the serial section rather than the whole model
com_section() {
    sed -n '/"ztype": 3/,/usagePolicy/p' "$WORK/out"
}

fail() {
    echo "FAIL: $*" >&2
    echo "--- spec.sh serial output ---" >&2
    com_section >&2
    echo "--- spec.sh stderr ---" >&2
    cat "$WORK/err" >&2
    exit 1
}

USB1=sys/devices/pci0000:00/0000:00:14.0/usb1

# A tty exposes its UART registers only when the serial core drives it; a port
# the platform advertises but does not populate reports 0x0.
add_serial8250_tty() {
    tty="$1"; port="$2"; irq="$3"; idx="$4"
    dir="$WORK/sys/devices/platform/serial8250/serial8250:0/serial8250:0.$idx"
    mkdir -p "$dir/tty/$tty"
    printf '%s\n' "$port" > "$dir/tty/$tty/port"
    printf '%s\n' "$irq" > "$dir/tty/$tty/irq"
    printf '0\n' > "$dir/tty/$tty/io_type"
    ln -s "../../../serial8250:0.$idx" "$dir/tty/$tty/device"
    ln -s "../../devices/platform/serial8250/serial8250:0/serial8250:0.$idx/tty/$tty" \
        "$WORK/sys/class/tty/$tty"
}

# $1 USB bus-port, $2 idVendor, $3 idProduct, $4 driver of interface .0
add_usb_device() {
    busport="$1"
    mkdir -p "$WORK/$USB1/$busport/$busport:1.0"
    printf '%s\n' "$2" > "$WORK/$USB1/$busport/idVendor"
    printf '%s\n' "$3" > "$WORK/$USB1/$busport/idProduct"
    printf 'DEVTYPE=usb_device\n' > "$WORK/$USB1/$busport/uevent"
    ln -s ../../../../../bus/usb "$WORK/$USB1/$busport/subsystem"
    printf 'DEVTYPE=usb_interface\nDRIVER=%s\n' "$4" \
        > "$WORK/$USB1/$busport/$busport:1.0/uevent"
    ln -s ../../../../../../bus/usb "$WORK/$USB1/$busport/$busport:1.0/subsystem"
}

# a usb-serial port hangs one level below its interface; $1 tty, $2 bus-port,
# $3 interface number, $4 driver bound to that interface
add_usbserial_tty() {
    tty="$1"; busport="$2"; intf="$3"
    iface="$WORK/$USB1/$busport/$busport:1.$intf"
    mkdir -p "$iface/$tty/tty/$tty"
    printf 'DEVTYPE=usb_interface\nDRIVER=%s\n' "$4" > "$iface/uevent"
    ln -s ../../../../../../bus/usb "$iface/subsystem"
    printf 'DEVTYPE=usb_serial_port\nDRIVER=%s\n' "$4" > "$iface/$tty/uevent"
    ln -s "../../../$tty" "$iface/$tty/tty/$tty/device"
    ln -s "../../devices/pci0000:00/0000:00:14.0/usb1/$busport/$busport:1.$intf/$tty/tty/$tty" \
        "$WORK/sys/class/tty/$tty"
}

# cdc_acm registers its tty directly under the USB interface
add_acm_tty() {
    tty="$1"; busport="$2"; intf="$3"
    iface="$WORK/$USB1/$busport/$busport:1.$intf"
    mkdir -p "$iface/tty/$tty"
    printf 'DEVTYPE=usb_interface\nDRIVER=cdc_acm\n' > "$iface/uevent"
    ln -s ../../../../../../bus/usb "$iface/subsystem"
    ln -s ../.. "$iface/tty/$tty/device"
    ln -s "../../devices/pci0000:00/0000:00:14.0/usb1/$busport/$busport:1.$intf/tty/$tty" \
        "$WORK/sys/class/tty/$tty"
}

make_fixture() {
    mkdir -p "$WORK/sys/class/tty" "$WORK/sys/class/net" "$WORK/sys/bus/usb" \
        "$WORK/sys/bus/pci/devices" "$WORK/sys/kernel/iommu_groups" \
        "$WORK/sys/devices/virtual/tty/tty0"

    # a real 8250 port, and one the platform advertises but does not populate
    add_serial8250_tty ttyS0 0x3f8 4 0
    add_serial8250_tty ttyS1 0x0 0 1

    # an internal USB-to-UART converter: the port this whole change is about
    add_usb_device 1-1 0403 6001 ftdi_sio
    add_usbserial_tty ttyUSB0 1-1 0 ftdi_sio

    # a modem recognised by the driver bound to its port
    add_usb_device 1-2 2c7c 0125 qcserial
    add_usbserial_tty ttyUSB1 1-2 2 option

    # a modem whose control port is plain cdc_acm, recognised only by the MBIM
    # interface sitting next to it on the same device
    add_usb_device 1-3 1546 1102 cdc_mbim
    add_acm_tty ttyACM0 1-3 2

    # a non-modem CDC device, which must keep being reported
    add_usb_device 1-4 2341 0043 cdc_acm
    add_acm_tty ttyACM1 1-4 1

    # a virtual tty has no device at all
    ln -s ../../devices/virtual/tty/tty0 "$WORK/sys/class/tty/tty0"
}

run_spec() {
    # the fixture holds no PCI, block or network devices, so the tools
    # inspecting those complain on stderr; only the serial section is under test
    unshare --mount --map-root-user sh -c \
        "mount --bind '$WORK/sys' /sys && '$SPEC' $1" > "$WORK/out" 2> "$WORK/err"
}

make_fixture

if ! unshare --mount --map-root-user true 2>/dev/null; then
    echo "SKIP: unprivileged mount namespaces unavailable" >&2
    exit 0
fi

run_spec ""

serials=$(sed -n 's/.*"Serial": "\(.*\)".*/\1/p' "$WORK/out" | tr '\n' ' ')
[ "$serials" = "/dev/ttyACM1 /dev/ttyS0 /dev/ttyUSB0 " ] ||
    fail "expected COM ports '/dev/ttyACM1 /dev/ttyS0 /dev/ttyUSB0 ', got '$serials'"

# a USB UART has no register window to report
grep -A1 '"phyaddrs": {' "$WORK/out" | grep -q '"Serial": "/dev/ttyUSB0"' ||
    fail "ttyUSB0 reported with Ioports/Irq it does not have"

if command -v jq > /dev/null 2>&1; then
    jq . < "$WORK/out" > /dev/null || fail "output is not valid json"
fi

echo "PASS: spec.sh serial port enumeration"
```

</details>

## Changelog notes

A serial port connected through an internal USB-to-UART converter is now
included as a COM port in the hardware model generated by `spec.sh`.

## PR Backports

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Documentation: the limitation of the modem heuristic is documented in the
`spec.sh` header; there are no other user-facing docs for this script. arm64: not
tested on a board — the added code is architecture-independent (the `x86_64`-only
IO-port branch is untouched) and no arm64 machine with a USB UART was at hand;
the amd64 QEMU run exercises the same code path.
