### PR TITLE
[16.0-stable] Disable LED disk enforcement

### DIFF
--- a/docs/LED-INDICATION.md
+++ b/docs/LED-INDICATION.md
@@ -1,6 +1,6 @@
 # LED Indication
 
-As EVE-OS boots and progresses through various intermediate states, the LED (by default the disk LED) blinking
+As EVE-OS boots and progresses through various intermediate states, the LED blinking
 pattern changes to indicate state transitions.
 To indicate a given state, LED blinks one or more times quickly in a row, then pauses for 1200ms and repeats continuously.
 By counting the number of successive blinks one may determine the current state of the edge device.

--- a/pkg/pillar/cmd/ledmanager/ledmanager.go
+++ b/pkg/pillar/cmd/ledmanager/ledmanager.go
@@ -17,18 +17,15 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/agentbase"
 	"github.com/lf-edge/eve/pkg/pillar/agentlog"
 	"github.com/lf-edge/eve/pkg/pillar/base"
-	"github.com/lf-edge/eve/pkg/pillar/diskmetrics"
 	"github.com/lf-edge/eve/pkg/pillar/hardware"
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -86,41 +83,6 @@ type modelToFuncs struct {
 }
 
 var mToF = []modelToFuncs{
-	{
-		model:       "Supermicro.SYS-E100-9APP",
-		initFunc:    InitForceDiskCmd,
-		displayFunc: ExecuteForceDiskCmd,
-	},
-	{
-		model:       "Supermicro.SYS-E100-9S",
-		initFunc:    InitForceDiskCmd,
-		displayFunc: ExecuteForceDiskCmd,
-	},
-	{
-		model:       "Supermicro.SYS-E50-9AP",
-		initFunc:    InitForceDiskCmd,
-		displayFunc: ExecuteForceDiskCmd,
-	},
-	{ // XXX temporary fix for old BIOS
-		model:       "Supermicro.Super Server",
-		initFunc:    InitForceDiskCmd,
-		displayFunc: ExecuteForceDiskCmd,
-	},
-	{
-		model:       "Supermicro.SYS-E300-8D",
-		initFunc:    InitForceDiskCmd,
-		displayFunc: ExecuteForceDiskCmd,
-	},
-	{
-		model:       "Supermicro.SYS-E300-9A-4CN10P",
-		initFunc:    InitForceDiskCmd,
-		displayFunc: ExecuteForceDiskCmd,
-	},
-	{
-		model:       "Supermicro.SYS-5018D-FN8T",
-		initFunc:    InitForceDiskCmd,
-		displayFunc: ExecuteForceDiskCmd,
-	},
 	{
 		model:       "PC Engines.apu2",
 		initFunc:    InitLedCmd,
@@ -266,8 +228,8 @@ var mToF = []modelToFuncs{
 	{
 		// Last in table as a default
 		model:       "",
-		initFunc:    InitForceDiskCmd,
-		displayFunc: ExecuteForceDiskCmd,
+		initFunc:    nil,
+		displayFunc: nil,
 	},
 }
 
@@ -568,86 +530,6 @@ var (
 	bufferLength = int64(256 * 1024) //256k buffer length
 	readBuffer   []byte
 )
-
-// InitForceDiskCmd determines the disk (using the largest disk) and measures
-// the repetition count to get to 200ms dd time.
-func InitForceDiskCmd(ledName string) string {
-	disk := diskmetrics.FindLargestDisk(log)
-	if disk == "" {
-		return ""
-	}
-	log.Functionf("InitForceDiskCmd using disk %s", disk)
-	readBuffer = make([]byte, bufferLength)
-	diskDevice := "/dev/" + disk
-	count := 100 * 16
-	// Prime before measuring
-	uncachedDiskRead(count, diskDevice)
-	uncachedDiskRead(count, diskDevice)
-	start := time.Now()
-	uncachedDiskRead(count, diskDevice)
-	elapsed := time.Since(start)
-	if elapsed == 0 {
-		log.Errorf("Measured 0 nanoseconds!")
-		return ""
-	}
-	// Adjust count but at least one
-	fl := time.Duration(count) * (200 * time.Millisecond) / elapsed
-	count = int(fl)
-	if count == 0 {
-		count = 1
-	}
-	log.Noticef("Measured %v; count %d", elapsed, count)
-	diskRepeatCount = count
-	return diskDevice
-}
-
-// ExecuteForceDiskCmd does counter number of 200ms blinks and returns
-// It assumes the init function has determined a diskRepeatCount and a disk.
-func ExecuteForceDiskCmd(deviceNetworkStatus *types.DeviceNetworkStatus,
-	diskDevice string, blinkCount types.LedBlinkCount) {
-	for i := 0; i < int(blinkCount); i++ {
-		doForceDiskBlink(diskDevice)
-		time.Sleep(200 * time.Millisecond)
-	}
-}
-
-// doForceDiskBlink assumes the init function has determined a diskRepeatCount
-// which makes the disk LED light up for 200ms
-// We do this with caching disabled since there might be a filesystem on the
-// device in which case the disk LED would otherwise not light up.
-func doForceDiskBlink(diskDevice string) {
-	if diskDevice == "" || diskRepeatCount == 0 {
-		DummyCmd()
-		return
-	}
-	uncachedDiskRead(diskRepeatCount, diskDevice)
-}
-
-func uncachedDiskRead(count int, diskDevice string) {
-	offset := int64(0)
-	handler, err := os.Open(diskDevice)
-	if err != nil {
-		err = fmt.Errorf("uncachedDiskRead: Failed on open: %s", err)
-		log.Error(err.Error())
-		return
-	}
-	defer handler.Close()
-	for i := 0; i < count; i++ {
-		unix.Fadvise(int(handler.Fd()), offset, bufferLength, 4) // 4 == POSIX_FADV_DONTNEED
-		readBytes, err := handler.Read(readBuffer)
-		if err != nil {
-			err = fmt.Errorf("uncachedDiskRead: Failed on read: %s", err)
-			log.Error(err.Error())
-		}
-		syscall.Madvise(readBuffer, 4) // 4 == MADV_DONTNEED
-		log.Tracef("uncachedDiskRead: size: %d", readBytes)
-		if int64(readBytes) < bufferLength {
-			log.Tracef("uncachedDiskRead: done")
-			break
-		}
-		offset += bufferLength
-	}
-}
 
 const (
 	// Time limits for event loop handlers


### PR DESCRIPTION
# Description

Backport of https://github.com/lf-edge/eve/pull/5614

## How to test and validate this PR

This is code removal, so there is nothing to test actually. Default test batch should provide coverage for regression detection.

## Changelog notes

Removal of disk LED enforcement. EVE will not enforce disk I/O operations to modulate status through the disk activity LED for devices that don't have a dedicated status LED.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.