### PR TITLE
eve-k volumemgr: reclaim orphaned PVCs after a stale generation is swept

### DIFF
--- a/evetest/VERSION
+++ b/evetest/VERSION
@@ -1,2 +1,2 @@
 # Evetest version. Increment this manually whenever changes are made to the evetest framework.
-1.5
+1.6

--- a/evetest/edgedevice.go
+++ b/evetest/edgedevice.go
@@ -2001,6 +2001,66 @@ func (d *EdgeDevice) SyncDisks() {
 	}
 }
 
+// EVEKubeAppNamespace is the namespace EVE runs app workloads in. VMIRS
+// objects, their pods and their PVCs live there. It mirrors
+// pkg/pillar/kubeapi.EVEKubeNameSpace.
+const EVEKubeAppNamespace = "eve-kube-app"
+
+// KubeItemList is the part of `kubectl get <resource> -o json` that tests use:
+// the name, the labels, the selector labels and the status phase.
+//
+// Each resource fills in different fields. EVE puts the App-Domain-Name label
+// in a VMIRS selector only. A PVC has no labels or selector, but reports a
+// phase. A field the resource does not carry stays at its zero value.
+type KubeItemList struct {
+	Items []struct {
+		Metadata struct {
+			Name   string            `json:"name"`
+			Labels map[string]string `json:"labels"`
+		} `json:"metadata"`
+		Spec struct {
+			Selector struct {
+				MatchLabels map[string]string `json:"matchLabels"`
+			} `json:"selector"`
+		} `json:"spec"`
+		Status struct {
+			Phase string `json:"phase"`
+		} `json:"status"`
+	} `json:"items"`
+}
+
+// RunKubectl runs one kubectl command in EVE's kube container, against the app
+// namespace. Pass everything after "kubectl", such as `get pvc -o json`.
+//
+// This is an exception to the guideline "assert against the EVE API, not
+// internal state" (README, "Writing Tests -> Guidelines"). Some cluster facts
+// have no EVE API form, such as how many generations of a workload exist. Use
+// an EVE API assertion when one exists.
+//
+// The method returns the error and does not fail the test. A booting node
+// reports one until k3s is up, and a caller in Eventually must retry it.
+func (d *EdgeDevice) RunKubectl(args string) (stdout, stderr string, err error) {
+	return d.RunShellScript(
+		"eve exec kube kubectl -n "+EVEKubeAppNamespace+" "+args,
+		kubectlCommandTimeout, 0)
+}
+
+// KubectlListItems lists one resource type from the EVE app namespace. An
+// error means the device was unreachable, k3s was down, or the output did not
+// parse. A caller in Eventually must retry each of these.
+func (d *EdgeDevice) KubectlListItems(resource string) (KubeItemList, error) {
+	var list KubeItemList
+	stdout, stderr, err := d.RunKubectl("get " + resource + " -o json")
+	if err != nil {
+		return list, fmt.Errorf("KubectlListItems: get %s failed: %w (stderr: %s)",
+			resource, err, stderr)
+	}
+	if err := json.Unmarshal([]byte(stdout), &list); err != nil {
+		return list, fmt.Errorf("KubectlListItems: parsing %s output: %w", resource, err)
+	}
+	return list, nil
+}
+
 // GetDeviceInfo returns the last recorded device information,
 // or nil if no info message has been received yet.
 func (d *EdgeDevice) GetDeviceInfo() *eveinfo.ZInfoDevice {

--- a/evetest/harness.go
+++ b/evetest/harness.go
@@ -150,6 +150,11 @@ const (
 	// to finish quickly.
 	quickSSHCommandTimeout = 5 * time.Second
 
+	// Timeout for one kubectl command on the device (see
+	// EdgeDevice.RunKubectl). Longer than a quick SSH command: `eve exec`
+	// enters the kube container first, and a settling node answers slowly.
+	kubectlCommandTimeout = 20 * time.Second
+
 	// Timeout for flushing the device's filesystem caches
 	// (see EdgeDevice.SyncDisks). Far more generous than a quick SSH command:
 	// a sync issued right after an app's image layers were unpacked has tens

--- a/evetest/tests/apps/appvolumes_helpers_test.go
+++ b/evetest/tests/apps/appvolumes_helpers_test.go
@@ -59,11 +59,13 @@ func soleVolumeStatus(g Gomega, dev *evetest.EdgeDevice) types.VolumeStatus {
 // listPVCNames returns the names of every PVC in the namespace EVE runs app
 // workloads in, regardless of which app or generation it belongs to - see
 // assertNoOrphanedPVCs, which is what attributes them.
-func listPVCNames(dev *evetest.EdgeDevice) []string {
-	list, ok := kubectlListItems(dev, "pvc")
-	if !ok {
-		return nil
-	}
+//
+// A kubectl failure fails the assertion. It does not return an empty list. An
+// empty list satisfies an absence check for the wrong reason, and a booting
+// node reports one until k3s is up - the window the caller polls through.
+func listPVCNames(g Gomega, dev *evetest.EdgeDevice) []string {
+	list, err := dev.KubectlListItems("pvc")
+	g.Expect(err).ToNot(HaveOccurred(), "listing PVCs")
 	var names []string
 	for _, item := range list.Items {
 		names = append(names, item.Metadata.Name)
@@ -71,24 +73,45 @@ func listPVCNames(dev *evetest.EdgeDevice) []string {
 	return names
 }
 
-// assertNoOrphanedPVCs cross-checks every PVC actually present in the cluster
-// against the PVC name volumemgr's own current VolumeStatus publications would
-// produce (VolumeStatus.GetPVCName): "<volume-id>-pvc-<generation>". A PVC that
-// exists in Kubernetes but that no published VolumeStatus would name is orphaned
-// - Kubernetes still has the disk, but EVE no longer references it.
+// assertNoOrphanedPVCs cross-checks the PVCs actually present in the cluster
+// against the PVC names volumemgr's own current VolumeStatus publications would
+// produce (VolumeStatus.GetPVCName): "<volume-id>-pvc-<generation>".
 //
-// This is strictly stronger than a volume count: the stale-generation sweep in
-// hypervisor/kubevirt.go reconciles the VMIRS/ReplicaSet and its pods only, not
-// PVCs, so a purge that otherwise completes cleanly can still leave a stale
-// generation's disk behind indefinitely and nothing else here would catch it.
+// Each direction catches an opposite failure:
+//
+//   - A PVC that no published VolumeStatus names is orphaned. Kubernetes keeps
+//     the disk, but EVE no longer refers to it. The sweep in
+//     hypervisor/kubevirt.go deletes a stale generation's VMIRS and pods, but
+//     not its PVC, so only this check finds that disk.
+//   - A created volume with no PVC is the reverse. volumemgr's own GC reclaimed
+//     a disk the node still refers to. Without this half, a cluster with no
+//     PVCs passes, which is what a GC that reaps too much produces.
+//
+// Only a volume in CREATED_VOLUME state must have a PVC. A volume still being
+// built has none yet, and a caller in Eventually converges through that state.
 func assertNoOrphanedPVCs(g Gomega, dev *evetest.EdgeDevice) {
 	vols, err := evetest.ReadAllPublications[types.VolumeStatus](dev, "volumemgr", false)
 	g.Expect(err).ToNot(HaveOccurred(), "reading volumemgr's VolumeStatus publications")
 	expected := make(map[string]bool, len(vols))
+	required := make(map[string]bool, len(vols))
 	for _, v := range vols {
 		expected[v.GetPVCName()] = true
+		if v.State == types.CREATED_VOLUME {
+			required[v.GetPVCName()] = true
+		}
 	}
-	for _, name := range listPVCNames(dev) {
+
+	present := make(map[string]bool)
+	for _, name := range listPVCNames(g, dev) {
+		present[name] = true
+	}
+
+	for name := range required {
+		g.Expect(present).To(HaveKey(name),
+			"volumemgr publishes a created VolumeStatus naming PVC %q, but no such "+
+				"PVC exists - the live generation's disk was reclaimed underneath it", name)
+	}
+	for name := range present {
 		g.Expect(expected).To(HaveKey(name),
 			"PVC %q exists in the cluster but no currently published VolumeStatus "+
 				"would produce it - orphaned disk left behind by a stale generation", name)

--- a/evetest/tests/apps/appworkload_helpers_test.go
+++ b/evetest/tests/apps/appworkload_helpers_test.go
@@ -4,18 +4,17 @@
 // Where and whether the app is actually running, as the hypervisor itself sees
 // it: VMIRS objects on eve-k, qemu domain state directories on kvm/xen.
 //
-// Rule for this file: readers that enumerate the app's WORKLOAD instances, plus
-// the kubectl plumbing they are built on. This is the one place a stale
-// generation is observable, because pillar's own DomainStatus is keyed by app
-// UUID and so can only ever describe one (appstate_helpers_test.go).
+// Rule for this file: readers that enumerate the app's WORKLOAD instances. This
+// is the one place a stale generation is observable, because pillar's own
+// DomainStatus is keyed by app UUID and so can only ever describe one
+// (appstate_helpers_test.go).
 //
 // Everything generic - reading a file, listing a directory, testing for a path,
-// flushing caches - is an EdgeDevice method in the framework
+// flushing caches, running kubectl - is an EdgeDevice method in the framework
 // (evetest/edgedevice.go); this file only adds what is specific to EVE's
-// workload objects. Note the two error conventions that follow from that:
-// helpers backed by a framework method surface its error to Gomega, because an
-// error there is a transport failure, while a failed kubectl call is reported as
-// found=false, because "k3s is not up yet" is an expected transient state a
+// workload objects. Note the two error conventions that follow from that: a
+// transport failure surfaces to Gomega, while a failed kubectl call is reported
+// as found=false, because "k3s is not up yet" is an expected transient state a
 // caller inside Eventually should retry on rather than fail.
 //
 // Split trigger: if a xen-specific reader is ever needed, break this into
@@ -26,13 +25,11 @@
 package apps_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"path"
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	// revive:disable:dot-imports
 	. "github.com/onsi/gomega"
@@ -42,14 +39,6 @@ import (
 )
 
 const (
-	// sshCmdTimeout bounds a single kubectl invocation run over SSH.
-	sshCmdTimeout = 20 * time.Second
-
-	// eveKubeAppNamespace is the Kubernetes namespace EVE runs app workloads in;
-	// both VMIRS objects and their PVCs live there. See
-	// pkg/pillar/kubeapi.EVEKubeNameSpace.
-	eveKubeAppNamespace = "eve-kube-app"
-
 	// appDomainNameLabel holds the owning app's DomainName,
 	// "<uuid>.<version>.<appnum>". See the eveLabelKey constant in
 	// hypervisor/kubevirt.go.
@@ -66,61 +55,6 @@ const (
 	kvmDomainStateDir = "/run/hypervisor/kvm"
 )
 
-// kubeItemList is the minimal shape needed from any `kubectl get <resource>
-// -o json`: a name per item, the item's own labels, and the selector labels.
-// A VMIRS is attributed by its selector, which is the only place EVE puts the
-// App-Domain-Name label. A PVC has neither field.
-type kubeItemList struct {
-	Items []struct {
-		Metadata struct {
-			Name   string            `json:"name"`
-			Labels map[string]string `json:"labels"`
-		} `json:"metadata"`
-		Spec struct {
-			Selector struct {
-				MatchLabels map[string]string `json:"matchLabels"`
-			} `json:"selector"`
-		} `json:"spec"`
-	} `json:"items"`
-}
-
-// kubectlListItems lists one Kubernetes resource type from the EVE app
-// namespace. found is false, with a warning logged, if the device is
-// unreachable, k3s is not up, or the output does not parse - all of which are
-// transient states a caller inside Eventually should retry rather than fail on.
-//
-// Reaching into Kubernetes at all is a deliberate exception to the framework
-// guideline "assert against the EVE API, not internal state" (README "Writing
-// Tests -> Guidelines"): there is no EVE-API-exposed signal for "how many
-// generations of this app's workload exist" - the cluster-status topic zedkube
-// publishes carries only the single name of the desired generation. Until that
-// gap is closed, this is the only vantage point from which a stale generation
-// surviving a purge is observable at all.
-//
-// Promotion trigger: when a second suite needs kubectl access, move this to an
-// EdgeDevice method in evetest/edgedevice.go. Do not copy it. It is kept local
-// for now because tests/cluster has no kubectl calls at all, so the shape is
-// unsettled after two consumers, and because the framework has no non-fatal
-// read family to fit it into yet.
-func kubectlListItems(
-	dev *evetest.EdgeDevice, resource string) (list kubeItemList, found bool) {
-	stdout, stderr, err := dev.RunShellScript(
-		"eve exec kube kubectl -n "+eveKubeAppNamespace+" get "+resource+" -o json",
-		sshCmdTimeout, 0)
-	if err != nil {
-		evetest.Logger().Warnf(
-			"kubectlListItems: kubectl get %s failed: %v (stderr: %s)",
-			resource, err, stderr)
-		return list, false
-	}
-	if err := json.Unmarshal([]byte(stdout), &list); err != nil {
-		evetest.Logger().Warnf(
-			"kubectlListItems: failed to parse kubectl %s output: %v", resource, err)
-		return list, false
-	}
-	return list, true
-}
-
 // listAppVMIRS returns the names of every VMIRS (any generation) that belongs to
 // appUUID. It matches the prefix "<uuid>." on the App-Domain-Name selector
 // label, because the label value also carries a version and an appnum that do
@@ -130,8 +64,10 @@ func kubectlListItems(
 // VMIRS", and not "the device did not answer".
 func listAppVMIRS(
 	dev *evetest.EdgeDevice, appUUID uuid.UUID) (names []string, found bool) {
-	list, ok := kubectlListItems(dev, "vmirs")
-	if !ok {
+	list, err := dev.KubectlListItems("vmirs")
+	if err != nil {
+		// k3s may still be starting; a caller inside Eventually retries.
+		evetest.Logger().Warnf("listAppVMIRS: %v", err)
 		return nil, false
 	}
 	prefix := appUUID.String() + "."

--- a/evetest/tests/apps/purge_after_power_cycle_test.go
+++ b/evetest/tests/apps/purge_after_power_cycle_test.go
@@ -138,6 +138,11 @@ func TestVMAppPurgeAfterPowerCycle(test *testing.T) {
 	evetest.Checkpoint("setup-done")
 
 	devConfig := evetest.NewEdgeDeviceConfig(devName)
+	// The GC ticker is timer.gc.vdisk/10, an hour by default. At the 60s floor
+	// a pass runs every six seconds, so the reclaim assertion does not wait.
+	cfgProps := types.NewConfigItemValueMap()
+	cfgProps.SetGlobalValueInt(types.VdiskGCTime, 60)
+	devConfig.SetConfigProperties(cfgProps)
 	dhcpNet := devConfig.AddNetwork(
 		evetest.DHCPNetworkConfig{
 			NetworkType: evecommon.NetworkType_V4Only,
@@ -233,19 +238,21 @@ func TestVMAppPurgeAfterPowerCycle(test *testing.T) {
 	}, purgeEndStateTimeout, assertPollInterval).Should(Succeed())
 	evetest.Checkpoint("purge-verified")
 
-	// The old generation's storage is reclaimed on its own schedule, minutes
-	// after the purge itself completes - see assertOldVolumeReclaimed.
+	// The old generation's storage is reclaimed on its own schedule, after the
+	// purge itself completes - see assertOldVolumeReclaimed. This test set
+	// timer.gc.vdisk to its 60s floor above, so fastStorageReclaimTimeout
+	// bounds the wait, not storageReclaimTimeout.
 	//
-	// assertNoOrphanedPVCs is disabled on Kubevirt for now: sweepStaleGenerations
-	// deletes the old VMIRS and its pod but not its PVC, so the old generation's
-	// disk stays behind. That is a pillar fix, not a test bug - re-enable this
-	// once sweepStaleGenerations deletes the PVC too.
+	// On Kubevirt, sweepStaleGenerations deletes the old VMIRS and its pod, but
+	// not its PVC. volumemgr's gcPVCs reclaims that PVC. assertNoOrphanedPVCs
+	// also checks that the live generation's PVC stays, so a GC that reaps too
+	// much fails here.
 	t.Eventually(func(g Gomega) {
 		if hypervisor == evetest.HypervisorKubevirt {
-			// assertNoOrphanedPVCs(g, device)
+			assertNoOrphanedPVCs(g, device)
 		} else {
 			assertOldVolumeReclaimed(g, device, baselineVolPath)
 		}
-	}, storageReclaimTimeout, storageReclaimPollInterval).Should(Succeed())
+	}, fastStorageReclaimTimeout, storageReclaimPollInterval).Should(Succeed())
 	evetest.Checkpoint("old-storage-reclaimed")
 }

--- a/evetest/tests/apps/purge_helpers_test.go
+++ b/evetest/tests/apps/purge_helpers_test.go
@@ -56,16 +56,22 @@ const (
 	// workload. Observed to settle within about a minute of the app coming back.
 	purgeEndStateTimeout = 5 * time.Minute
 
-	// storageReclaimTimeout bounds removal of the OLD generation's disk, which
-	// is a separate concern on a separate clock: the purge is complete once the
-	// app runs on the new generation, and volumemgr reclaims the previous
-	// artifact afterwards - observed at roughly five minutes, far short of the
-	// one-hour VdiskGCTime but far longer than the purge itself.
+	// storageReclaimTimeout bounds removal of the OLD generation's disk on the
+	// default timer.gc.vdisk clock. TestVMAppPurgeReplacesVMIRS does not
+	// override that clock, so its GC pass ticks every six minutes and reclaim
+	// settles within about five. See fastStorageReclaimTimeout for a test that
+	// speeds the clock up itself.
 	storageReclaimTimeout = 15 * time.Minute
 
 	// storageReclaimPollInterval is deliberately coarse: each poll shells out to
-	// the device, and nothing is expected to change for minutes.
+	// the device.
 	storageReclaimPollInterval = 15 * time.Second
+
+	// fastStorageReclaimTimeout is storageReclaimTimeout's counterpart for
+	// TestVMAppPurgeAfterPowerCycle, which sets timer.gc.vdisk to its 60s
+	// floor. A GC pass then ticks every six seconds, so reclaim settles within
+	// a handful of ticks, not within five minutes.
+	fastStorageReclaimTimeout = 5 * time.Minute
 
 	// clusterReadyTimeout bounds a single eve-k node becoming Ready. k3s and
 	// Longhorn take minutes to come up, and an app deployed before that sits in
@@ -276,9 +282,8 @@ func assertLocalDomainPurgeEndState(g Gomega, dev *evetest.EdgeDevice,
 // assertOldVolumeReclaimed asserts the previous generation's disk is eventually
 // removed. Deliberately separate from the purge's end state: the purge is
 // complete once the app runs on the new generation, while reclaiming the old
-// artifact happens minutes later on volumemgr's own schedule (well before the
-// one-hour VdiskGCTime, but far outside the purge window). Give it its own,
-// longer Eventually.
+// artifact happens later, on volumemgr's own timer.gc.vdisk schedule. Give it
+// its own Eventually, sized to whatever clock the caller's test configured.
 func assertOldVolumeReclaimed(
 	g Gomega, dev *evetest.EdgeDevice, baselineVolPath string) {
 	assertVolumeArtifactGone(g, dev, baselineVolPath)

--- a/evetest/tests/cluster/pvcgc_test.go
+++ b/evetest/tests/cluster/pvcgc_test.go
@@ -1,0 +1,353 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	eveconfig "github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve-api/go/evecommon"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/netmodels"
+	pillartypes "github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// Timeouts for this test. An Eventually stops as soon as its condition holds,
+// so a large bound only delays a true failure.
+const (
+	// pvcGCClusterTimeout bounds three nodes forming a cluster.
+	pvcGCClusterTimeout = 30 * time.Minute
+
+	// pvcGCAppReadyTimeout bounds the app reaching RUNNING, excluding download.
+	pvcGCAppReadyTimeout = 15 * time.Minute
+
+	// pvcGCPurgeTimeout bounds the purge.
+	pvcGCPurgeTimeout = 10 * time.Minute
+
+	// pvcGCReclaimTimeout bounds the old PVC disappearing. A GC pass runs every
+	// six seconds here, so this absorbs the Longhorn delete behind it.
+	pvcGCReclaimTimeout = 5 * time.Minute
+
+	// pvcGCPollInterval is coarse because each poll runs kubectl on the device.
+	pvcGCPollInterval = 10 * time.Second
+
+	// pvcGCSettleWindow holds the survival assertion for many GC passes. That
+	// repetition is the subject of this test.
+	pvcGCSettleWindow = 90 * time.Second
+
+	// pvcGCSettleInterval is how often the survival assertion re-checks.
+	pvcGCSettleInterval = 15 * time.Second
+
+	// pvcGCVdiskGCTime is timer.gc.vdisk's floor. The GC ticker is
+	// vdiskGCTime/10, so a pass runs every six seconds.
+	pvcGCVdiskGCTime = 60
+)
+
+// clusterPVCNames returns every PVC name in the EVE app namespace, as one node
+// sees it. A kubectl failure fails the assertion. An empty set would satisfy
+// the absence half of this test for the wrong reason.
+func clusterPVCNames(g Gomega, dev *evetest.EdgeDevice) map[string]bool {
+	list, err := dev.KubectlListItems("pvc")
+	g.Expect(err).ToNot(HaveOccurred(),
+		"listing PVCs from device %q", dev.Name())
+	names := make(map[string]bool, len(list.Items))
+	for _, item := range list.Items {
+		names[item.Metadata.Name] = true
+	}
+	return names
+}
+
+// nodeVolumeConfigs returns the VolumeConfigs zedagent publishes on one node.
+// The designated node gets IsReplicated false. Every other node gets true.
+// See cmd/zedagent/handlevolume.go.
+func nodeVolumeConfigs(g Gomega, dev *evetest.EdgeDevice) []pillartypes.VolumeConfig {
+	configs, err := evetest.ReadAllPublications[pillartypes.VolumeConfig](
+		dev, "zedagent", false)
+	g.Expect(err).ToNot(HaveOccurred(),
+		"reading zedagent's VolumeConfig publications from %q", dev.Name())
+	return configs
+}
+
+// nodeVolumeStatuses returns the VolumeStatuses volumemgr publishes on one
+// node. gcPVCs reaps any PVC that no entry here names. This set is therefore
+// the only protection against that node's own GC pass.
+func nodeVolumeStatuses(g Gomega, dev *evetest.EdgeDevice) []pillartypes.VolumeStatus {
+	statuses, err := evetest.ReadAllPublications[pillartypes.VolumeStatus](
+		dev, "volumemgr", false)
+	g.Expect(err).ToNot(HaveOccurred(),
+		"reading volumemgr's VolumeStatus publications from %q", dev.Name())
+	return statuses
+}
+
+// TestClusterPVCGCPreservesLiveVolumes checks that volumemgr's PVC garbage
+// collection keeps a PVC that a live VolumeConfig still refers to. It must keep
+// it on every node, whether that node owns the volume or replicates it.
+//
+// The test needs a cluster. IsReplicated is true only on a node that does not
+// own the volume, so one node shows one case. Three nodes with one app show
+// both at once, and each node runs its own GC pass.
+//
+// One check protects a live PVC: gcPVCs reaps a PVC when no VolumeStatus on
+// that node names it. The IsReplicated guard beside it never fires here,
+// because a PVC name carries no replication bit. The test therefore asserts
+// per node that the VolumeStatus is present.
+//
+// A purge supplies the positive control. "The PVC is still there" also passes
+// when GC never runs. The purge moves the app to a new generation and orphans
+// the old PVC. The old PVC disappears, which proves GC runs. The new PVC stays,
+// which is the property under test.
+//
+// Network model
+// -------------
+//   - netmodels.SeparateClusterPort -- eth0 on a management+app bridge with
+//     DHCP, eth1 on a cluster-only bridge for K3s traffic.
+//
+// Device configuration
+// --------------------
+//   - Three clusterDeviceRequirements devices (Kubevirt, fresh image,
+//     filesystem per FILESYSTEM).
+//   - ClusterConfig (REPLICATED_STORAGE) over three nodes, node 1 bootstrap.
+//   - timer.gc.vdisk at its 60s floor, so a GC pass runs every six seconds.
+//   - One Local NI "local-ni" (10.11.15.0/24) and one app designated to node 1.
+//
+// Test parameters
+// ---------------
+//   - TPM via evetest.TPMParameter().
+//   - FILESYSTEM (ext4|zfs, defaults to ext4) via evetest.FilesystemParameter().
+//
+// Phases
+// ------
+//  1. setup-done -> nodes-are-ready: bring up the cluster.
+//  2. app-is-running: deploy the app and wait for RUNNING.
+//  3. ownership-asserted: node 1 reports IsReplicated false, nodes 2 and 3
+//     report true. Without this the test can cover one case only.
+//  4. purge-complete: purge the app, which orphans the old generation's PVC.
+//  5. old-pvc-reclaimed: the old PVC goes away and the new PVC stays.
+//  6. live-pvc-survives: the new PVC stays for many more GC passes on each
+//     node, and the app stays RUNNING.
+//
+// Suite placement
+// ---------------
+//   - TestNodeClusterSuite (cluster tests are pinned to Kubevirt).
+func TestClusterPVCGCPreservesLiveVolumes(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	evetest.DefineTestParameters(
+		evetest.TPMParameter(),
+		evetest.FilesystemParameter(),
+	)
+	withTPM := evetest.GetTPMParameterValue()
+	filesystem := evetest.GetFilesystemParameterValue()
+
+	var requiredDevices [3]evetest.Requirement
+	var devName [3]string
+	for i := 0; i < 3; i++ {
+		devName[i] = fmt.Sprintf("edge-dev%d", i+1)
+		requiredDevices[i] = clusterDeviceRequirements(
+			devName[i], withTPM, filesystem, false)
+	}
+	requiredNetModel := evetest.RequireNetworkModel{
+		NetworkModel: netmodels.SeparateClusterPort,
+	}
+	var requirements []evetest.Requirement
+	requirements = append(requirements, requiredDevices[:]...)
+	requirements = append(requirements, requiredNetModel)
+	evetest.Setup(requirements...)
+	evetest.Checkpoint("setup-done")
+
+	var nodes [3]evetest.ClusterNode
+	for i := 0; i < 3; i++ {
+		clusterIP := evetest.IPAddressWithPrefix(fmt.Sprintf("10.244.244.%d/24", i+2))
+		nodes[i] = evetest.ClusterNode{
+			DevName:          devName[i],
+			ClusterIP:        clusterIP,
+			ClusterInterface: "ethernet1",
+			BootstrapNode:    i == 0,
+		}
+	}
+	clusterConfig := evetest.NewEdgeClusterConfig(
+		eveconfig.ClusterType_CLUSTER_TYPE_REPLICATED_STORAGE,
+		nodes[:]...,
+	)
+
+	cfgProps := pillartypes.NewConfigItemValueMap()
+	cfgProps.SetGlobalValueInt(pillartypes.VdiskGCTime, pvcGCVdiskGCTime)
+	clusterConfig.SetConfigProperties(cfgProps)
+
+	dhcpNet := clusterConfig.AddNetwork(
+		evetest.DHCPNetworkConfig{
+			NetworkType: evecommon.NetworkType_V4Only,
+		})
+	noIPNet := clusterConfig.AddNetwork(evetest.NoIPNetworkConfig{})
+	clusterConfig.AddNetworkAdapter(
+		evetest.NetworkAdapterConfig{
+			LogicalLabel:  "ethernet0",
+			PhysicalLabel: "eth0",
+			InterfaceName: "eth0",
+			NetworkUUID:   dhcpNet,
+			Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+		})
+	clusterConfig.AddNetworkAdapter(
+		evetest.NetworkAdapterConfig{
+			LogicalLabel:  "ethernet1",
+			PhysicalLabel: "eth1",
+			InterfaceName: "eth1",
+			NetworkUUID:   noIPNet,
+			Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+		})
+
+	cluster := evetest.NewEdgeCluster("pvc-gc-cluster")
+	cluster.ApplyConfig(clusterConfig, true, true)
+	evetest.Checkpoint("initial-config-applied")
+
+	cluster.WaitUntilNodesAreReady(pvcGCClusterTimeout)
+	evetest.Checkpoint("nodes-are-ready")
+
+	niUUID := clusterConfig.AddNetworkInstance(evetest.LocalNetworkInstanceConfig{
+		DisplayName: "local-ni",
+		Port:        "ethernet0",
+		Subnet:      evetest.IPSubnet("10.11.15.0/24"),
+		DHCPRange: pillartypes.IPRange{
+			Start: evetest.IPAddress("10.11.15.2"),
+			End:   evetest.IPAddress("10.11.15.254"),
+		},
+		Gateway:       evetest.IPAddress("10.11.15.1"),
+		EnableFlowlog: true,
+		MTU:           1500,
+		ForwardLLDP:   false,
+	})
+	appUUID := clusterConfig.AddApplication(evetest.ClusterApplicationInstanceConfig{
+		ApplicationInstanceConfig: evetest.ApplicationInstanceConfig{
+			DisplayName: "pvc-gc-app",
+			Activate:    true,
+			Image: evetest.DockerContainer{
+				ImageName: "lfedge/evetest-ubuntu-ctr",
+				Tag:       "1.0",
+			},
+			CPUs:        1,
+			MemoryBytes: 500 * evetest.MiB,
+			NetworkAdapters: []evetest.AppNetworkAdapter{
+				evetest.VirtualNetworkAdapter{
+					LogicalLabel:        "vif0",
+					NetworkInstanceUUID: niUUID,
+				},
+			},
+		},
+		DesignatedNodeName: devName[0],
+		Affinity:           eveconfig.AffinityType_AFFINITY_TYPE_PREFERRED,
+	})
+	cluster.ApplyConfig(clusterConfig, true, true)
+	log := evetest.Logger()
+	log.Infof("Submitted config with application UUID=%v, designated node %q",
+		appUUID, devName[0])
+	evetest.Checkpoint("app-config-is-submitted")
+
+	cluster.WaitUntilAppIsRunning(appUUID, pvcGCAppReadyTimeout)
+	evetest.Checkpoint("app-is-running")
+
+	// Read from the owner. That node built the disk.
+	owner := evetest.GetEdgeDevice(devName[0])
+	oldPVCName := ""
+	t.Eventually(func(g Gomega) {
+		statuses := nodeVolumeStatuses(g, owner)
+		g.Expect(statuses).To(HaveLen(1),
+			"expected exactly one volume on the designated node, found %d",
+			len(statuses))
+		oldPVCName = statuses[0].GetPVCName()
+	}, pvcGCAppReadyTimeout, pvcGCPollInterval).Should(Succeed())
+	log.Infof("Pre-purge PVC is %q", oldPVCName)
+
+	// Assert the ownership split. If it stops holding, this test covers one
+	// case only, and says nothing about the other.
+	t.Eventually(func(g Gomega) {
+		for i, name := range devName {
+			dev := evetest.GetEdgeDevice(name)
+			configs := nodeVolumeConfigs(g, dev)
+			g.Expect(configs).ToNot(BeEmpty(),
+				"node %q publishes no VolumeConfig at all", name)
+			for _, vc := range configs {
+				if i == 0 {
+					g.Expect(vc.IsReplicated).To(BeFalse(),
+						"the designated node %q must own volume %s, not replicate it",
+						name, vc.Key())
+				} else {
+					g.Expect(vc.IsReplicated).To(BeTrue(),
+						"non-designated node %q must see volume %s as replicated",
+						name, vc.Key())
+				}
+			}
+		}
+	}, pvcGCAppReadyTimeout, pvcGCPollInterval).Should(Succeed())
+	evetest.Checkpoint("ownership-asserted")
+
+	// The purge moves the app to a new generation. Nothing then refers to the
+	// old generation's PVC. This is the positive control below.
+	cluster.PurgeApplication(appUUID, true, pvcGCPurgeTimeout)
+	evetest.Checkpoint("purge-complete")
+
+	cluster.WaitUntilAppIsRunning(appUUID, pvcGCAppReadyTimeout)
+
+	newPVCName := ""
+	t.Eventually(func(g Gomega) {
+		statuses := nodeVolumeStatuses(g, owner)
+		g.Expect(statuses).To(HaveLen(1),
+			"expected exactly one volume after the purge, found %d", len(statuses))
+		newPVCName = statuses[0].GetPVCName()
+		g.Expect(newPVCName).ToNot(Equal(oldPVCName),
+			"the purge must have moved the app to a new volume generation")
+	}, pvcGCAppReadyTimeout, pvcGCPollInterval).Should(Succeed())
+	log.Infof("Post-purge PVC is %q (was %q)", newPVCName, oldPVCName)
+
+	// The old PVC must go away. This proves gcPVCs runs. The new PVC must stay
+	// while that happens.
+	t.Eventually(func(g Gomega) {
+		present := clusterPVCNames(g, owner)
+		g.Expect(present).ToNot(HaveKey(oldPVCName),
+			"the superseded generation's PVC %q must be reclaimed", oldPVCName)
+		g.Expect(present).To(HaveKey(newPVCName),
+			"the live generation's PVC %q must not be reclaimed with it", newPVCName)
+	}, pvcGCReclaimTimeout, pvcGCPollInterval).Should(Succeed())
+	evetest.Checkpoint("old-pvc-reclaimed")
+
+	// The property under test. Each node runs a GC pass every six seconds. Hold
+	// for many more passes. Each node must still see the live PVC, and must
+	// still publish the VolumeStatus that protects it.
+	t.Consistently(func(g Gomega) {
+		for _, name := range devName {
+			dev := evetest.GetEdgeDevice(name)
+			g.Expect(clusterPVCNames(g, dev)).To(HaveKey(newPVCName),
+				"node %q no longer sees the live PVC %q - a GC pass reclaimed a "+
+					"disk that a live VolumeConfig still refers to", name, newPVCName)
+
+			named := false
+			for _, vs := range nodeVolumeStatuses(g, dev) {
+				if vs.GetPVCName() == newPVCName {
+					named = true
+					break
+				}
+			}
+			g.Expect(named).To(BeTrue(),
+				"node %q publishes no VolumeStatus naming %q, so nothing there "+
+					"protects it from that node's own gcPVCs pass", name, newPVCName)
+		}
+	}, pvcGCSettleWindow, pvcGCSettleInterval).Should(Succeed())
+	evetest.Checkpoint("live-pvc-survives")
+
+	// A reclaimed disk does not always show as an app error at once. This check
+	// is therefore weak alone. A failure here means the damage reached the
+	// guest. Ask the node that hosts the app.
+	host := cluster.FindDeviceHostingApp(appUUID, pvcGCPollInterval)
+	appInfo := host.GetAppInfo(appUUID)
+	t.Expect(appInfo).ToNot(BeNil(),
+		"expected app info from host %q after the settle window", host.Name())
+	t.Expect(appInfo.GetAppErr()).To(BeEmpty(),
+		"the app must still be healthy after repeated GC passes")
+}

--- a/evetest/tests/cluster/testsuite_test.go
+++ b/evetest/tests/cluster/testsuite_test.go
@@ -18,6 +18,11 @@ import (
 // purge runs before the fault-injecting VMIRS test, so a failure in the
 // ordinary app lifecycle is not masked by chaos.
 //
+// TestClusterPVCGCPreservesLiveVolumes runs last: it lowers timer.gc.vdisk to
+// its floor to make volumemgr's PVC garbage collection run continuously, which
+// is not a configuration the other subtests should inherit if that ordering
+// ever changes.
+//
 // Every cluster subtest re-creates its devices, because
 // clusterDeviceRequirements sets CreateFromScratchWithLiveImage, which
 // maybeReuseDevices always rejects. No subtest inherits cluster state from
@@ -54,6 +59,9 @@ func TestNodeClusterSuite(test *testing.T) {
 		},
 		evetest.TestCase{
 			Test: TestClusterToSingleConversion,
+		},
+		evetest.TestCase{
+			Test: TestClusterPVCGCPreservesLiveVolumes,
 		},
 	)
 }

--- a/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
+++ b/pkg/pillar/cmd/volumemgr/initialvolumestatus.go
@@ -109,7 +109,7 @@ func gcObjects(ctx *volumemgrContext, dirName string) {
 		}
 		locations = append(locations, filepath.Join(dirName, location.Name()))
 	}
-	gcVolumes(ctx, locations)
+	gcVolumes(ctx, locations, getVolumeStatusByLocation)
 	log.Tracef("gcObjects(%s) Done", dirName)
 }
 
@@ -122,30 +122,72 @@ func gcDatasets(ctx *volumemgrContext, dataset string) {
 			dataset, err)
 		return
 	}
-	gcVolumes(ctx, locations)
+	gcVolumes(ctx, locations, getVolumeStatusByLocation)
 	log.Tracef("gcDatasets(%s) Done", dataset)
 }
 
-func gcVolumes(ctx *volumemgrContext, locations []string) {
-	for _, location := range locations {
-		tempVolumeStatus, err := getVolumeStatusByLocation(location)
+// getPVCList is kubeapi.GetPVCList behind a package-level var, so a test can
+// supply a fixed PVC list without a real Kubernetes API server. See
+// hypervisor/kubevirt.go's newKubevirtClient for the same pattern.
+var getPVCList = kubeapi.GetPVCList
+
+// gcPVCs is gcObjects' counterpart for PVC-backed volumes: it garbage
+// collects any PVC with no currently-published VolumeStatus. The hypervisor's
+// own purge sweep (kubevirt.go's sweepStaleGenerations) deletes a stale
+// generation's VMIRS and pod but not its PVC; this periodic pass is what
+// reclaims it instead. Call only when base.IsHVTypeKube().
+func gcPVCs(ctx *volumemgrContext) {
+	log.Tracef("gcPVCs")
+	names, err := getPVCList(log)
+	if err != nil {
+		log.Errorf("gcPVCs: GetPVCList failed: %v", err)
+		return
+	}
+	gcVolumes(ctx, names, getVolumeStatusByPVC)
+	log.Tracef("gcPVCs Done")
+}
+
+// resolveVolumeStatus turns one GC candidate - a file/dataset path or a PVC
+// name - into the VolumeStatus it would have if it were still in use.
+type resolveVolumeStatus func(candidate string) (*types.VolumeStatus, error)
+
+// volumesToReap resolves each candidate and returns those with no
+// currently-published VolumeStatus - the ones gcVolumes will destroy.
+//
+// Split out from gcVolumes so this decision is testable on its own. For
+// PVC-backed volumes, destroying is a real Kubernetes API call; this
+// function makes none.
+func volumesToReap(ctx *volumemgrContext, candidates []string,
+	resolve resolveVolumeStatus) []*types.VolumeStatus {
+	var reap []*types.VolumeStatus
+	for _, candidate := range candidates {
+		vs, err := resolve(candidate)
 		if err != nil {
-			log.Errorf("gcVolumes: getVolumeStatusByLocation '%s' failed: %v",
-				location, err)
+			log.Errorf("volumesToReap: resolve %q failed: %v", candidate, err)
 			continue
 		}
-		// Do not GC a replicated volume.
-		if tempVolumeStatus != nil && tempVolumeStatus.IsReplicated {
+		// Do not GC a replicated volume: it may be tracked here only because
+		// this node is a failover candidate, not because it is unused.
+		if vs != nil && vs.IsReplicated {
 			continue
 		}
-		vs := ctx.LookupVolumeStatus(tempVolumeStatus.Key())
-		if vs == nil {
-			log.Functionf("gcVolumes: Found unused volume %s. Deleting it.",
-				location)
-			if _, err := volumehandlers.GetVolumeHandler(log, ctx, tempVolumeStatus).DestroyVolume(); err != nil {
-				log.Errorf("gcVolumes: destroyVolume '%s' failed: %v",
-					location, err)
-			}
+		if ctx.LookupVolumeStatus(vs.Key()) == nil {
+			reap = append(reap, vs)
+		}
+	}
+	return reap
+}
+
+// gcVolumes destroys every candidate volumesToReap finds unused. candidates
+// may be filesystem paths, ZFS dataset names, or PVC names; resolve is what
+// tells them apart.
+func gcVolumes(ctx *volumemgrContext, candidates []string, resolve resolveVolumeStatus) {
+	for _, vs := range volumesToReap(ctx, candidates, resolve) {
+		log.Functionf("gcVolumes: Found unused volume %s. Deleting it.",
+			vs.FileLocation)
+		if _, err := volumehandlers.GetVolumeHandler(log, ctx, vs).DestroyVolume(); err != nil {
+			log.Errorf("gcVolumes: destroyVolume '%s' failed: %v",
+				vs.FileLocation, err)
 		}
 	}
 }

--- a/pkg/pillar/cmd/volumemgr/initialvolumestatus_test.go
+++ b/pkg/pillar/cmd/volumemgr/initialvolumestatus_test.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetVolumeStatusByPVC(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	pvcName := fmt.Sprintf("%s-pvc-3", id.String())
+
+	vs, err := getVolumeStatusByPVC(pvcName)
+	assert.NoError(t, err)
+	assert.Equal(t, id, vs.VolumeID)
+	assert.Equal(t, int64(3), vs.GenerationCounter)
+	assert.Equal(t, pvcName, vs.FileLocation)
+	// getPVCList/getVolumeStatusByPVC cannot recover LocalGenerationCounter
+	// from the PVC name alone, so GetPVCName must round-trip against the
+	// GenerationCounter this parsed - otherwise volumesToReap would compute
+	// the wrong Key() and reap a live volume.
+	assert.Equal(t, pvcName, vs.GetPVCName())
+}
+
+func TestGetVolumeStatusByPVCInvalid(t *testing.T) {
+	cases := []string{
+		"not-a-uuid-pvc-3",
+		"11111111-1111-1111-1111-111111111111-pvc-notanumber",
+		"11111111-1111-1111-1111-111111111111", // no "-pvc-" separator
+	}
+	for _, name := range cases {
+		_, err := getVolumeStatusByPVC(name)
+		assert.Error(t, err, "expected an error for PVC name %q", name)
+	}
+}
+
+// TestVolumesToReapSkipsLiveVolume pins the safety property this whole
+// change depends on: a volume this node still tracks - including one it
+// tracks only because it is a failover candidate for an app running
+// elsewhere in the cluster, not because it is unused - must never be
+// reaped, regardless of what resolve() reconstructs from its name alone.
+func TestVolumesToReapSkipsLiveVolume(t *testing.T) {
+	ctx := initStatusCtx(t)
+	live := types.VolumeStatus{
+		VolumeID:          uuid.Must(uuid.NewV4()),
+		GenerationCounter: 0,
+	}
+	publishVolumeStatus(&ctx, &live)
+
+	pvcName := live.GetPVCName()
+	reap := volumesToReap(&ctx, []string{pvcName}, getVolumeStatusByPVC)
+	assert.Empty(t, reap, "a currently-published volume must never be reaped")
+}
+
+// TestVolumesToReapSkipsLiveVolumeWithLocalGeneration shows why
+// getVolumeStatusByPVC can assume LocalGenerationCounter is zero.
+//
+// A PVC name carries one number, not two. The reconstruction puts it all in
+// GenerationCounter, which is a different split than the live volume uses.
+// Key() and GetPVCName() both use the sum of the two counters, so gen=2/local=3
+// and gen=5/local=0 produce the same key. If either function starts to use the
+// counters apart, this test fails, and a live volume would be reaped.
+func TestVolumesToReapSkipsLiveVolumeWithLocalGeneration(t *testing.T) {
+	ctx := initStatusCtx(t)
+	live := types.VolumeStatus{
+		VolumeID:               uuid.Must(uuid.NewV4()),
+		GenerationCounter:      2,
+		LocalGenerationCounter: 3,
+	}
+	publishVolumeStatus(&ctx, &live)
+
+	pvcName := live.GetPVCName()
+	// The name must carry the sum, not either counter on its own.
+	assert.Equal(t, fmt.Sprintf("%s-pvc-5", live.VolumeID.String()), pvcName)
+
+	rebuilt, err := getVolumeStatusByPVC(pvcName)
+	assert.NoError(t, err)
+	assert.Equal(t, live.Key(), rebuilt.Key(),
+		"the key rebuilt from a PVC name must match the live volume's, "+
+			"whatever split of generation counters produced it")
+
+	reap := volumesToReap(&ctx, []string{pvcName}, getVolumeStatusByPVC)
+	assert.Empty(t, reap,
+		"a live volume with a non-zero LocalGenerationCounter must never be reaped")
+}
+
+// TestVolumesToReapIncludesSupersededGeneration covers the purge case. The app
+// moved to a new generation. No published VolumeStatus names the old PVC, so
+// the pass reaps that one only.
+func TestVolumesToReapIncludesSupersededGeneration(t *testing.T) {
+	ctx := initStatusCtx(t)
+	volID := uuid.Must(uuid.NewV4())
+	live := types.VolumeStatus{
+		VolumeID:          volID,
+		GenerationCounter: 1,
+	}
+	publishVolumeStatus(&ctx, &live)
+
+	stale := types.VolumeStatus{
+		VolumeID:          volID,
+		GenerationCounter: 0,
+	}
+	reap := volumesToReap(&ctx,
+		[]string{stale.GetPVCName(), live.GetPVCName()}, getVolumeStatusByPVC)
+	assert.Len(t, reap, 1)
+	assert.Equal(t, stale.GetPVCName(), reap[0].FileLocation,
+		"only the superseded generation's PVC may be reaped")
+}
+
+// TestVolumesToReapIncludesUnknownVolume is the positive case: a candidate
+// with no published VolumeStatus at all is exactly what this pass exists to
+// find.
+func TestVolumesToReapIncludesUnknownVolume(t *testing.T) {
+	ctx := initStatusCtx(t)
+	orphanID := uuid.Must(uuid.NewV4())
+	pvcName := fmt.Sprintf("%s-pvc-0", orphanID.String())
+
+	reap := volumesToReap(&ctx, []string{pvcName}, getVolumeStatusByPVC)
+	assert.Len(t, reap, 1)
+	assert.Equal(t, orphanID, reap[0].VolumeID)
+}
+
+// TestVolumesToReapSkipsReplicated pins the defence-in-depth check: even if
+// a resolver ever reconstructs IsReplicated=true for a candidate with no
+// published VolumeStatus, it must still not be reaped. getVolumeStatusByPVC
+// itself can never produce this today (a PVC name carries no such bit), but
+// gcVolumes is shared with the file/dataset paths, where the same combination
+// is possible.
+func TestVolumesToReapSkipsReplicated(t *testing.T) {
+	ctx := initStatusCtx(t)
+	resolve := func(string) (*types.VolumeStatus, error) {
+		return &types.VolumeStatus{
+			VolumeID:     uuid.Must(uuid.NewV4()),
+			IsReplicated: true,
+		}, nil
+	}
+
+	reap := volumesToReap(&ctx, []string{"whatever"}, resolve)
+	assert.Empty(t, reap, "a replicated volume must never be reaped")
+}
+
+// TestVolumesToReapSkipsUnresolvable confirms one bad candidate - a PVC name
+// this node cannot parse - is logged and skipped rather than stopping the
+// whole pass or reaping something by mistake.
+func TestVolumesToReapSkipsUnresolvable(t *testing.T) {
+	ctx := initStatusCtx(t)
+	orphanID := uuid.Must(uuid.NewV4())
+	goodName := fmt.Sprintf("%s-pvc-0", orphanID.String())
+
+	reap := volumesToReap(&ctx,
+		[]string{"not-a-valid-pvc-name", goodName}, getVolumeStatusByPVC)
+	assert.Len(t, reap, 1)
+	assert.Equal(t, orphanID, reap[0].VolumeID)
+}
+
+// TestGcPVCsSkipsLiveVolumes exercises gcPVCs end to end through the
+// swappable getPVCList seam. Every name it returns matches a published
+// VolumeStatus, so volumesToReap's result is empty and gcVolumes never
+// reaches DestroyVolume - the real Kubernetes delete call, which this test
+// does not want to invoke.
+func TestGcPVCsSkipsLiveVolumes(t *testing.T) {
+	ctx := initStatusCtx(t)
+	live := types.VolumeStatus{
+		VolumeID:          uuid.Must(uuid.NewV4()),
+		GenerationCounter: 1,
+	}
+	publishVolumeStatus(&ctx, &live)
+
+	origGetPVCList := getPVCList
+	getPVCList = func(*base.LogObject) ([]string, error) {
+		return []string{live.GetPVCName()}, nil
+	}
+	t.Cleanup(func() { getPVCList = origGetPVCList })
+
+	assert.NotPanics(t, func() { gcPVCs(&ctx) })
+	assert.NotNil(t, ctx.LookupVolumeStatus(live.Key()),
+		"gcPVCs must not have touched the still-published volume")
+}

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -854,6 +854,9 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 				gcDatasets(&ctx, types.VolumeEncryptedZFSDataset)
 				gcDatasets(&ctx, types.VolumeClearZFSDataset)
 			}
+			if base.IsHVTypeKube() {
+				gcPVCs(&ctx)
+			}
 			if !ctx.initGced {
 				gcUnusedInitObjects(&ctx)
 				ctx.initGced = true


### PR DESCRIPTION
# Description

**`pillar: reclaim orphaned PVCs after a stale generation is swept`** — the
fix. `sweepStaleGenerations` (added in #6257) deletes a stale purge
generation's VMIRS and its pod, but not its PVC. The old disk stays in the
cluster and nothing points at it. volumemgr already collects unused files and
ZFS volumes on a timer; this adds the same pass for PVCs. `gcPVCs` lists each
PVC, and the existing `gcVolumes` deletes the ones that no live `VolumeStatus`
names. The pass is not specific to a purge: it reclaims each PVC that no
`VolumeStatus` names, whatever left it behind.

The safety question is which PVCs the pass must keep. A node publishes a live
`VolumeStatus` for a volume it does not run, when that volume's app can fail
over to it. `LookupVolumeStatus` is the only check that protects such a PVC.
The `IsReplicated` guard beside it never fires on this path, because a PVC name
carries no replication bit.

A second question is the generation counter. A PVC name carries one number,
but a volume has two counters. `getVolumeStatusByPVC` puts the whole value in
`GenerationCounter` and leaves `LocalGenerationCounter` at zero, which is a
different split than the live volume uses. This is safe because `Key()` and
`GetPVCName()` both use the sum of the two counters, so both splits give the
same key. Unit tests hold this.

**`evetest: cover PVC garbage collection, on one node and across a cluster`** —
new coverage, plus a fix to an assertion that could pass without checking
anything.

`assertNoOrphanedPVCs` asked only that each PVC present was expected. An empty
list satisfies that, and `listPVCNames` returned an empty list on any kubectl
error, so the assertion passed while k3s was down. That is the state right
after the reboot the caller polls through. It now fails on a kubectl error and
checks the other direction as well: a volume in `CREATED_VOLUME` state must
still have its PVC.

`TestClusterPVCGCPreservesLiveVolumes` covers the case that needs a cluster.
`IsReplicated` is true only on a node that does not own the volume, so one node
shows one case and three nodes with one app show both. The test asserts that
split, then purges the app to orphan the old generation's PVC. The old PVC
disappearing proves the GC pass runs. The new PVC surviving on each node,
through many more passes, is the property under test.

kubectl access moves from `tests/apps` to `EdgeDevice` (`RunKubectl`,
`KubectlListItems`, `KubeItemList`, `EVEKubeAppNamespace`), because a second
suite now needs it. The framework version goes to 1.6.

## PR dependencies

None. #6257 is already merged; this completes the PVC half of that sweep.

## How to test and validate this PR

Automated coverage:

```sh
# volumemgr unit tests (25 pass, -race -tags k)
make -C pkg/pillar test TESTPKGS=./cmd/volumemgr/

# the cluster safety property: a live PVC survives repeated GC passes on the
# owner node and on both replica nodes
make evetest NAME=TestClusterPVCGCPreservesLiveVolumes

# the single-node reclaim path, with the hardened orphan assertion
make evetest NAME=TestVMAppPurgeAfterPowerCycle
```

Manual check on an eve-k node, if you want to see the reclaim directly:

1. Deploy an app, then purge it.
2. `eve exec kube kubectl -n eve-kube-app get pvc` — two PVCs appear briefly,
   one per generation.
3. Wait for volumemgr's GC ticker (`timer.gc.vdisk`/10, six minutes by
   default; the tests lower `timer.gc.vdisk` to its 60s floor).
4. List the PVCs again. Only the new generation's PVC remains, and the app
   stays RUNNING.

Validation status: the unit tests pass in the builder image. The two evetest
tests have not yet been run on hardware, and
`TestClusterPVCGCPreservesLiveVolumes` is new and has never been executed.
## Changelog notes

Fixed a bug where an EVE-K node kept the old disk of an application after a
purge. The stale PersistentVolumeClaim stayed in the cluster and consumed
storage, although nothing used it. EVE now reclaims it.

## PR Backports

- 17.0-stable: To be backported.
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
