### PR TITLE
xen-tools: fix gen12 iGPU passthrough scanout corruption (GSMBASE/BGSM)

### DIFF
--- a/pkg/xen-tools/patches-4.21.1/x86_64/16-vfio-igd-gsmbase-emulation.patch
+++ b/pkg/xen-tools/patches-4.21.1/x86_64/16-vfio-igd-gsmbase-emulation.patch
@@ -1,0 +1,168 @@
+From 90fb2a1995181eab89dd155cdf7133fedae2e219 Mon Sep 17 00:00:00 2001
+From: Mikhail Malyshev <mike.malyshev@gmail.com>
+Date: Tue, 25 Aug 2026 16:16:09 +0000
+Subject: [PATCH] vfio/igd: emulate GSMBASE for gen12 iGPU passthrough
+
+The gen12 (Iris Xe) graphics driver locates its Graphics Stolen Memory
+(which holds the GGTT and graphics-stolen surfaces) via the MMIO-only
+GSMBASE register at BAR0 offset 0x108100.  Unlike DSMBASE/BDSM there is
+no PCI config-space counterpart, so the existing BDSM mirror cannot
+sanitize it and the guest reads the host physical base.  The driver then
+programs GTT entries pointing at host stolen memory, which is not in the
+guest's IOMMU domain, so the GPU's scanout DMA faults ("PTE Read access
+is not set") part-way through the frame and the lower portion of the
+display goes black.
+
+Emulate GSMBASE to point at guest RAM placed immediately above the guest
+DSM: enlarge the etc/igd-bdsm-size fw_cfg reservation by GGMS so the
+range [BDSM+GMS, BDSM+GMS+GGMS) is reserved guest RAM, and return
+BDSM+GMS from the 0x108100 MMIO register.  Both the DSM and GSM then live
+in mapped guest RAM and the GTT no longer references host physical
+addresses.
+
+Applies to gen12+ (offset and behaviour are gen12-specific).  GSM is
+placed above the DSM rather than below it (as on real hardware) so the
+guest BDSM written by firmware does not have to move; this keeps the fix
+entirely in QEMU with no OVMF change.
+
+Signed-off-by: Mikhail Malyshev <mike.malyshev@gmail.com>
+---
+ hw/vfio/igd.c | 108 ++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 108 insertions(+)
+
+diff --git a/tools/qemu-xen/hw/vfio/igd.c b/tools/qemu-xen/hw/vfio/igd.c
+index 8997611920..0b492b857d 100644
+--- a/tools/qemu-xen/hw/vfio/igd.c
++++ b/tools/qemu-xen/hw/vfio/igd.c
+@@ -439,6 +439,64 @@ static const MemoryRegionOps igd_bdsm_mirror_ops = {
+ #define IGD_BDSM_GEN11 0xc0
+ #endif
+ 
++/*
++ * IGD GSMBASE (Graphics Stolen Memory base) emulation.
++ *
++ * On gen12 (GEN12_GSMBASE) the base of the Graphics Stolen Memory that holds
++ * the GGTT and graphics-stolen surfaces is exposed via MMIO at BAR0 0x108100
++ * (64-bit).  Unlike DSMBASE/BDSM there is no PCI config counterpart, so it
++ * cannot be redirected to emulated config space like the BDSM mirror above.
++ *
++ * The gen12 (Iris Xe) guest driver reads GSMBASE to locate graphics stolen
++ * memory and writes GTT entries accordingly.  Left un-emulated it returns the
++ * host physical address, so the GPU DMAs into host stolen memory that is not in
++ * the guest's IOMMU domain -> "PTE Read access is not set" DMAR faults and a
++ * black band across the lower part of the scanned-out frame.
++ *
++ * Emulate it to point at guest RAM placed immediately above the guest DSM.  The
++ * fw_cfg reservation (etc/igd-bdsm-size) is enlarged by GGMS so the range
++ * [BDSM+GMS, BDSM+GMS+GGMS) is reserved guest RAM; GSMBASE returns BDSM+GMS.
++ */
++#define IGD_GSMBASE_MMIO_OFFSET 0x108100
++
++typedef struct IGDGsmBaseQuirk {
++    VFIOPCIDevice *vdev;
++    uint32_t bdsm_config_offset; /* emulated guest BDSM lives here (0xC0) */
++    uint8_t  bdsm_size;          /* BDSM width in bytes (8 on gen11+) */
++    uint64_t gms_bytes;          /* DSM size; GSM sits just above the DSM */
++    MemoryRegion mem;
++} IGDGsmBaseQuirk;
++
++static uint64_t igd_gsmbase_read(void *opaque, hwaddr addr, unsigned size)
++{
++    IGDGsmBaseQuirk *gsm = opaque;
++    VFIOPCIDevice *vdev = gsm->vdev;
++    uint64_t bdsm = vfio_pci_read_config(&vdev->pdev, gsm->bdsm_config_offset,
++                                         gsm->bdsm_size);
++    /* Place GSM just above the guest DSM and set the low "lock/valid" bit. */
++    uint64_t gsmbase = ((bdsm & ~0xfffULL) + gsm->gms_bytes) | 0x1;
++    uint64_t val = gsmbase >> (addr * 8);
++
++    if (size < 8) {
++        val &= (1ULL << (size * 8)) - 1;
++    }
++    return val;
++}
++
++static void igd_gsmbase_write(void *opaque, hwaddr addr,
++                              uint64_t data, unsigned size)
++{
++    /* Read-only emulation: GSMBASE is derived from BDSM, ignore guest writes. */
++    error_report("IGD GSMBASE emul: ignoring write off=0x%" PRIx64
++                 " data=0x%" PRIx64, (uint64_t)addr, data);
++}
++
++static const MemoryRegionOps igd_gsmbase_ops = {
++    .read = igd_gsmbase_read,
++    .write = igd_gsmbase_write,
++    .endianness = DEVICE_LITTLE_ENDIAN,
++};
++
+ /*
+  * IGD BAR0 DBUF_CTL sanitize quirk.
+  *
+@@ -577,6 +635,43 @@ void vfio_probe_igd_bar0_quirk(VFIOPCIDevice *vdev, int nr)
+ 
+     QLIST_INSERT_HEAD(&vdev->bars[nr].quirks, quirk, next);
+ 
++    /*
++     * GSMBASE (Graphics Stolen Memory base) emulation (gen12+).  MMIO-only at
++     * 0x108100 (64-bit) with no config counterpart to mirror, so emulate it to
++     * point at guest RAM just above the DSM (see igd_gsmbase_read()).  This is
++     * the companion to the enlarged etc/igd-bdsm-size reservation in
++     * vfio_probe_igd_bar4_quirk() and prevents the guest driver from writing
++     * host-physical addresses into the GTT (IOMMU DMA-read faults).
++     */
++    if (gen >= 12) {
++        uint32_t gmch = vfio_pci_read_config(&vdev->pdev, IGD_GMCH, 4);
++        uint32_t gms = (gmch >> 8) & 0xff;
++        uint64_t gms_bytes = (gms < 0xf0) ? (uint64_t)gms * 32 * MiB
++                                          : (uint64_t)(gms - 0xf0 + 1) * 4 * MiB;
++
++        if (gms) {
++            VFIOQuirk *gsm_quirk = vfio_quirk_alloc(1);
++            IGDGsmBaseQuirk *gsm = g_malloc0(sizeof(*gsm));
++
++            gsm->vdev = vdev;
++            gsm->bdsm_config_offset = IGD_BDSM_GEN11;
++            gsm->bdsm_size = 8;
++            gsm->gms_bytes = gms_bytes;
++
++            memory_region_init_io(&gsm_quirk->mem[0], OBJECT(vdev),
++                                  &igd_gsmbase_ops, gsm,
++                                  "vfio-igd-gsmbase-quirk", 8);
++            memory_region_add_subregion_overlap(vdev->bars[nr].region.mem,
++                                                IGD_GSMBASE_MMIO_OFFSET,
++                                                &gsm_quirk->mem[0], 1);
++
++            QLIST_INSERT_HEAD(&vdev->bars[nr].quirks, gsm_quirk, next);
++
++            error_report("IGD GSMBASE emul: enabled, GSM at guest BDSM+0x%"
++                         PRIx64 " bytes (GMS)", gms_bytes);
++        }
++    }
++
+     /*
+      * DBUF_CTL sanitize quirk (gen9+): trap the DBUF_CTL slice registers so
+      * POWER_STATE is reported consistently with POWER_REQUEST (see
+@@ -665,6 +760,19 @@ void vfio_probe_igd_bar4_quirk(VFIOPCIDevice *vdev, int nr)
+         } else {
+             bdsm_bytes = (uint64_t)(gms - 0xf0 + 1) * 4 * MiB;
+         }
++        /*
++         * On gen12+ also reserve the Graphics Stolen Memory (GTT stolen, GGMS)
++         * so the emulated GSMBASE (BAR0 0x108100, see vfio_probe_igd_bar0_quirk)
++         * can point at guest RAM just above the DSM.  Without this the guest
++         * driver reads the host GSMBASE and programs GTT entries with host
++         * physical addresses, causing IOMMU DMA-read faults (black-band scanout
++         * corruption on Iris Xe).
++         */
++        if (gen >= 12) {
++            uint32_t ggms = (gmch >> 6) & 0x3;
++            ggms = 1 << ggms;
++            bdsm_bytes += (uint64_t)ggms * MiB;
++        }
+         error_report("IGD bdsm-size: device %04x gen=%d gmch=0x%08x "
+                      "gms=%u bdsm_bytes=%" PRIu64,
+                      vdev->device_id, gen, gmch, gms, bdsm_bytes);
+-- 
+2.43.0
+

--- a/pkg/xen-tools/patches-4.21.1/x86_64/17-vfio-igd-stolen-reserved.patch
+++ b/pkg/xen-tools/patches-4.21.1/x86_64/17-vfio-igd-stolen-reserved.patch
@@ -1,0 +1,203 @@
+From 557de921290b079e7fdc21cd2af758faedd950a6 Mon Sep 17 00:00:00 2001
+From: Mikhail Malyshev <mike.malyshev@gmail.com>
+Date: Tue, 25 Aug 2026 18:21:20 +0000
+Subject: [PATCH] vfio/igd: emulate STOLEN_RESERVED for gen12 iGPU passthrough
+
+Companion to the GSMBASE emulation.  The gen12 (Iris Xe) graphics driver
+reads the reserved stolen-memory base (GEN6_STOLEN_RESERVED) both from PCI
+config offset 0xf0 and from its BAR0 MMIO alias at 0x1082C0, and programs
+the GTT with it.  Left un-emulated these return the host physical base, so
+the GPU DMAs into host stolen memory that is not mapped in the guest IOMMU
+domain, producing "PTE Read access is not set" DMAR faults and intermittent
+scanout corruption even once BDSM and GSMBASE are handled.
+
+Emulate the config-space register read-only and keep it consistent with the
+guest BDSM: it sits at a fixed host offset above BDSM, so whenever the
+firmware programs the relocated guest BDSM (config 0xC0), recompute it by
+the same host->guest delta from vfio_pci_write_config().  Also mirror the
+BAR0 0x1082C0 alias to the emulated config 0xf0, the same way the BDSM MMIO
+mirror redirects 0x1080C0 to config 0xC0.  The value then lands inside the
+already-reserved guest stolen region, so no extra reservation is required.
+
+Signed-off-by: Mikhail Malyshev <mike.malyshev@gmail.com>
+---
+ hw/vfio/igd.c | 97 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ hw/vfio/pci.c |  5 +++
+ hw/vfio/pci.h |  2 ++
+ 3 files changed, 104 insertions(+)
+
+diff --git a/tools/qemu-xen/hw/vfio/igd.c b/tools/qemu-xen/hw/vfio/igd.c
+index 0b492b857d..811ae93261 100644
+--- a/tools/qemu-xen/hw/vfio/igd.c
++++ b/tools/qemu-xen/hw/vfio/igd.c
+@@ -12,6 +12,7 @@
+ 
+ #include "qemu/osdep.h"
+ #include "qemu/units.h"
++#include "qemu/range.h"
+ #include "qemu/error-report.h"
+ #include "qapi/error.h"
+ #include "hw/hw.h"
+@@ -115,6 +116,11 @@ typedef struct VFIOIGDQuirk {
+ #define IGD_GMCH 0x50 /* Graphics Control Register */
+ #define IGD_BDSM 0x5c /* Base Data of Stolen Memory (32-bit, Gen6-Gen10) */
+ #define IGD_BDSM_GEN11 0xc0 /* Base Data of Stolen Memory (64-bit, Gen11+) */
++/*
++ * Stolen Reserved base (GEN6_STOLEN_RESERVED, 64-bit, Gen11+); the gen12
++ * Windows driver also reads it from config space.
++ */
++#define IGD_STOLEN_RESERVED 0xf0
+ 
+ 
+ /*
+@@ -433,6 +439,9 @@ static const MemoryRegionOps igd_bdsm_mirror_ops = {
+ };
+ 
+ #define IGD_BDSM_MMIO_OFFSET 0x1080C0
++/* STOLEN_RESERVED is also aliased in BAR0 MMIO at 0x1082C0 (64-bit); the gen12
++ * driver reads it there too, so mirror it to the emulated config 0xf0. */
++#define IGD_STOLEN_RESERVED_MMIO_OFFSET 0x1082C0
+ /* PCI config offset of the 64-bit BDSM on Gen11+ iGPUs (not defined in
+  * qemu-xen 4.21.0; introduced in upstream qemu after 9.1.0). */
+ #ifndef IGD_BDSM_GEN11
+@@ -585,6 +594,54 @@ static const MemoryRegionOps igd_dbuf_ctl_ops = {
+     .endianness = DEVICE_LITTLE_ENDIAN,
+ };
+ 
++/*
++ * Keep the emulated STOLEN_RESERVED (config 0xf0) consistent with BDSM.
++ *
++ * Called from vfio_pci_write_config() after every guest config write.  When
++ * the guest firmware (IgdAssignmentDxe) programs the relocated guest BDSM, the
++ * reserved-stolen base must move by the same host->guest delta so it too points
++ * at reserved guest RAM instead of the host stolen region.  It keeps its fixed
++ * offset above BDSM and its low/lock bits.  No-op for non-IGD devices and for
++ * writes that do not touch BDSM.
++ */
++void vfio_igd_update_stolen_reserved(VFIOPCIDevice *vdev, uint32_t addr,
++                                     int len)
++{
++    uint64_t host_bdsm = 0, host_sr = 0, guest_bdsm, guest_sr;
++
++    if (!vfio_pci_is(vdev, PCI_VENDOR_ID_INTEL, PCI_ANY_ID) ||
++        !vfio_is_vga(vdev) || igd_gen(vdev) < 11 ||
++        !ranges_overlap(addr, len, IGD_BDSM_GEN11, 8)) {
++        return;
++    }
++
++    /* Host BDSM and STOLEN_RESERVED are read-only bases; read from hardware. */
++    if (pread(vdev->vbasedev.fd, &host_bdsm, 8,
++              vdev->config_offset + IGD_BDSM_GEN11) != 8 ||
++        pread(vdev->vbasedev.fd, &host_sr, 8,
++              vdev->config_offset + IGD_STOLEN_RESERVED) != 8) {
++        return;
++    }
++    host_bdsm = le64_to_cpu(host_bdsm) & ~0xfffULL;
++    host_sr = le64_to_cpu(host_sr);
++    if (!host_bdsm || !(host_sr & ~0xfffULL)) {
++        return;
++    }
++
++    /* Guest BDSM the firmware just programmed (emulated config). */
++    guest_bdsm = pci_get_quad(vdev->pdev.config + IGD_BDSM_GEN11) & ~0xfffULL;
++    if (!guest_bdsm) {
++        return;
++    }
++
++    guest_sr = (guest_bdsm + ((host_sr & ~0xfffULL) - host_bdsm)) |
++               (host_sr & 0xfffULL);
++    pci_set_quad(vdev->pdev.config + IGD_STOLEN_RESERVED, guest_sr);
++
++    error_report("IGD STOLEN_RESERVED emul: BDSM=0x%" PRIx64 " -> 0x%" PRIx64
++                 " (host 0x%" PRIx64 ")", guest_bdsm, guest_sr, host_sr);
++}
++
+ void vfio_probe_igd_bar0_quirk(VFIOPCIDevice *vdev, int nr)
+ {
+     IGDBdsmMirrorQuirk *mirror;
+@@ -635,6 +692,32 @@ void vfio_probe_igd_bar0_quirk(VFIOPCIDevice *vdev, int nr)
+ 
+     QLIST_INSERT_HEAD(&vdev->bars[nr].quirks, quirk, next);
+ 
++    /*
++     * STOLEN_RESERVED is also exposed as a 64-bit MMIO register at BAR0
++     * 0x1082C0.  The gen12 driver reads it there in addition to config space,
++     * so mirror it to the emulated config 0xf0 (kept in sync with BDSM by
++     * vfio_igd_update_stolen_reserved()); without this the driver reads the
++     * host base and programs the GTT with it -> residual IOMMU DMA faults.
++     */
++    if (gen >= 11) {
++        VFIOQuirk *sr_quirk = vfio_quirk_alloc(1);
++        IGDBdsmMirrorQuirk *sr_mirror = g_malloc0(sizeof(*sr_mirror));
++
++        sr_mirror->vdev = vdev;
++        sr_mirror->bar = nr;
++        sr_mirror->bar_offset = IGD_STOLEN_RESERVED_MMIO_OFFSET;
++        sr_mirror->config_offset = IGD_STOLEN_RESERVED;
++
++        memory_region_init_io(&sr_quirk->mem[0], OBJECT(vdev),
++                              &igd_bdsm_mirror_ops, sr_mirror,
++                              "vfio-igd-stolen-reserved-mirror", 8);
++        memory_region_add_subregion_overlap(vdev->bars[nr].region.mem,
++                                             IGD_STOLEN_RESERVED_MMIO_OFFSET,
++                                             &sr_quirk->mem[0], 1);
++
++        QLIST_INSERT_HEAD(&vdev->bars[nr].quirks, sr_quirk, next);
++    }
++
+     /*
+      * GSMBASE (Graphics Stolen Memory base) emulation (gen12+).  MMIO-only at
+      * 0x108100 (64-bit) with no config counterpart to mirror, so emulate it to
+@@ -879,6 +962,20 @@ void vfio_probe_igd_bar4_quirk(VFIOPCIDevice *vdev, int nr)
+         pci_set_quad(vdev->pdev.config + IGD_BDSM_GEN11, 0);
+         pci_set_quad(vdev->pdev.wmask + IGD_BDSM_GEN11, ~0ULL);
+         pci_set_quad(vdev->emulated_config_bits + IGD_BDSM_GEN11, ~0ULL);
++
++        /*
++         * STOLEN_RESERVED (0xf0, 64-bit) is the reserved stolen-memory base
++         * (top of stolen, e.g. WOPCM).  Like BDSM it holds a host physical
++         * address by default; the gen12 Windows driver reads it from config
++         * space and programs the GTT with it, causing IOMMU DMA faults (host-PA
++         * not in the guest domain).  Emulate it read-only and keep its value
++         * tracking the guest BDSM: whenever the firmware programs BDSM,
++         * vfio_igd_update_stolen_reserved() recomputes it by the same
++         * host->guest relocation (see below).  Initialize to 0.
++         */
++        pci_set_quad(vdev->pdev.config + IGD_STOLEN_RESERVED, 0);
++        pci_set_quad(vdev->emulated_config_bits + IGD_STOLEN_RESERVED, ~0ULL);
++        /* wmask stays 0: read-only to the guest. */
+     } else {
+         pci_set_long(vdev->pdev.config + IGD_BDSM, 0);
+         pci_set_long(vdev->pdev.wmask + IGD_BDSM, ~0);
+diff --git a/tools/qemu-xen/hw/vfio/pci.c b/tools/qemu-xen/hw/vfio/pci.c
+index 9069c674a2..d5db3ad821 100644
+--- a/tools/qemu-xen/hw/vfio/pci.c
++++ b/tools/qemu-xen/hw/vfio/pci.c
+@@ -1314,6 +1314,11 @@ void vfio_pci_write_config(PCIDevice *pdev,
+         /* Write everything to QEMU to keep emulated bits correct */
+         pci_default_write_config(pdev, addr, val, len);
+     }
++
++#ifdef CONFIG_VFIO_IGD
++    /* Keep the emulated IGD STOLEN_RESERVED (0xf0) in sync with BDSM. */
++    vfio_igd_update_stolen_reserved(vdev, addr, len);
++#endif
+ }
+ 
+ /*
+diff --git a/tools/qemu-xen/hw/vfio/pci.h b/tools/qemu-xen/hw/vfio/pci.h
+index 5ad090a229..1823b1bc05 100644
+--- a/tools/qemu-xen/hw/vfio/pci.h
++++ b/tools/qemu-xen/hw/vfio/pci.h
+@@ -217,6 +217,8 @@ void vfio_quirk_reset(VFIOPCIDevice *vdev);
+ VFIOQuirk *vfio_quirk_alloc(int nr_mem);
+ void vfio_probe_igd_bar0_quirk(VFIOPCIDevice *vdev, int nr);
+ void vfio_probe_igd_bar4_quirk(VFIOPCIDevice *vdev, int nr);
++void vfio_igd_update_stolen_reserved(VFIOPCIDevice *vdev, uint32_t addr,
++                                     int len);
+ 
+ extern const PropertyInfo qdev_prop_nv_gpudirect_clique;
+ 
+-- 
+2.43.0
+


### PR DESCRIPTION
# Description

Fixes black-band scanout corruption on gen12 (Iris Xe) Intel iGPU passthrough to a q35/UEFI guest.

The gen12 graphics driver locates its stolen graphics memory through three PCI/MMIO base registers — BDSM (Data Stolen Memory), GSMBASE and BGSM (GTT Stolen Memory) — and programs the GPU's GTT with the addresses it reads. qemu-xen's vfio-igd code already relocates the guest's stolen memory into guest RAM and sanitizes BDSM, but it leaves two of those bases returning the host physical address:

- GSMBASE, exposed MMIO-only at BAR0 `0x108100` (64-bit), has no PCI-config counterpart and so isn't covered by the existing BDSM config mirror.
- BGSM, exposed in PCI config space at offset `0xf0` (64-bit), is read by the gen12 Windows driver (i915 gets it via MMIO instead) and isn't sanitized at all.

When either returns the host base, the driver writes host-physical addresses into the GTT. Those addresses are not mapped in the guest's IOMMU domain, so the GPU's scanout DMA faults part-way through the frame (`DMAR: [DMA Read] ... PTE Read access is not set`), the lower portion of the display gets no data, and a black band appears across the bottom of the screen under redraw. It manifests on Iris Xe (dual-channel) because that driver reads these registers; the UHD (single-channel) variant does not.

This series adds two qemu-xen patches:

- **16** emulates GSMBASE as a BAR0 quirk pointing at guest RAM just above the guest DSM, and enlarges the `etc/igd-bdsm-size` reservation by GGMS so that region is reserved.
- **17** emulates BGSM (config `0xf0`) read-only and keeps it tracking the relocated guest BDSM by the same host→guest delta, so it lands inside the already-reserved guest stolen region.

With all three bases sanitized, the GTT no longer references host memory and the DMAR fault flood (~33k faults/s under the corruption) drops to zero.

## How to test and validate this PR

On a gen12/Iris Xe host with the iGPU passed through to a Windows guest (q35/UEFI):

- Before: the guest shows a black band across the lower part of the display under redraw (dragging a window, moving the mouse), and the host kernel log floods with `DMAR: ... Request device [00:02.0] ... PTE Read access is not set` faults.
- After: the display is clean under redraw and the host DMAR fault counter stays flat (`dmesg | grep -c 'PTE Read access is not set'` does not grow while the guest drives the display).
- The qemu logs show `IGD GSMBASE emul: enabled` and `IGD BGSM emul: ...` confirming both quirks fired.

## Changelog notes

Fix black-band scanout corruption on gen12 (Iris Xe) Intel iGPU passthrough by sanitizing the GSMBASE and BGSM stolen-memory base registers so the guest driver no longer programs host-physical addresses into the GPU's GTT.

## PR Backports

- 17.0-stable: Yes
- 16.0-stable: No — builds on the gen12 q35/UEFI iGPU passthrough support that is not present in the stable branches.
- 14.5-stable: No — same reason.
- 13.4-stable: No — same reason.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.
