### PR TITLE
[16.0-stable] pkg/pillar: Bound URLCounters growth in downloader metrics

### DIFF
--- a/pkg/pillar/controllerconn/agentmetrics.go
+++ b/pkg/pillar/controllerconn/agentmetrics.go
@@ -8,6 +8,7 @@
 package controllerconn
 
 import (
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +17,11 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/pubsub"
 	"github.com/lf-edge/eve/pkg/pillar/types"
 )
+
+// urlCountersWiggle is headroom above types.MaxURLCounters: once the total
+// reaches MaxURLCounters+urlCountersWiggle, that many oldest entries are
+// evicted at once, amortizing the eviction scan across several new URLs.
+const urlCountersWiggle = 15
 
 // AgentMetrics stores controller related metrics for one agent (microservice).
 // Able to properly handle concurrent access.
@@ -58,28 +64,31 @@ func (am *AgentMetrics) RecordFailure(log *base.LogObject, ifname, url string,
 	defer release()
 	log.Tracef("RecordFailure(%s, %s, %d, %d, %t)",
 		ifname, url, reqLen, respLen, authenFail)
-	m := am.getInterfaceMetrics(ifname)
 
 	// if we have authen verify failure, the network part is success
 	if authenFail {
+		m := am.getInterfaceMetrics(ifname)
 		m.AuthFailCount++
-	} else {
-		m.FailureCount++
-		m.LastFailure = time.Now()
-
-		var u types.URLMetrics
-		var ok bool
-		if u, ok = m.URLCounters[url]; !ok {
-			u = types.URLMetrics{}
-		}
-		u.TryMsgCount++
-		u.TryByteCount += reqLen
-		if respLen != 0 {
-			u.RecvMsgCount++
-			u.RecvByteCount += respLen
-		}
-		m.URLCounters[url] = u
+		am.metrics[ifname] = m
+		return
 	}
+
+	if _, ok := am.getInterfaceMetrics(ifname).URLCounters[url]; !ok {
+		// Re-fetch below: eviction may update this ifname's entry too.
+		am.makeRoomForNewURL(log)
+	}
+	m := am.getInterfaceMetrics(ifname)
+	m.FailureCount++
+	m.LastFailure = time.Now()
+	u := m.URLCounters[url]
+	u.TryMsgCount++
+	u.TryByteCount += reqLen
+	if respLen != 0 {
+		u.RecvMsgCount++
+		u.RecvByteCount += respLen
+	}
+	u.LastUpdated = time.Now()
+	m.URLCounters[url] = u
 	am.metrics[ifname] = m
 }
 
@@ -90,15 +99,15 @@ func (am *AgentMetrics) RecordSuccess(log *base.LogObject, ifname, url string,
 	defer release()
 	log.Tracef("RecordSuccess(%s, %s, %d, %d, %d, %t)",
 		ifname, url, reqLen, respLen, timeSpent, resume)
-	m := am.getInterfaceMetrics(ifname)
 
+	if _, ok := am.getInterfaceMetrics(ifname).URLCounters[url]; !ok {
+		// Re-fetch below: eviction may update this ifname's entry too.
+		am.makeRoomForNewURL(log)
+	}
+	m := am.getInterfaceMetrics(ifname)
 	m.SuccessCount++
 	m.LastSuccess = time.Now()
-	var u types.URLMetrics
-	var ok bool
-	if u, ok = m.URLCounters[url]; !ok {
-		u = types.URLMetrics{}
-	}
+	u := m.URLCounters[url]
 	u.SentMsgCount++
 	u.SentByteCount += reqLen
 	u.RecvMsgCount++
@@ -107,8 +116,46 @@ func (am *AgentMetrics) RecordSuccess(log *base.LogObject, ifname, url string,
 	if resume {
 		u.SessionResume++
 	}
+	u.LastUpdated = time.Now()
 	m.URLCounters[url] = u
 	am.metrics[ifname] = m
+}
+
+// makeRoomForNewURL evicts urlCountersWiggle least recently used
+// URLMetrics entries, combined across all interfaces, once the high
+// watermark is reached. Caller must hold the AgentMetrics lock.
+func (am *AgentMetrics) makeRoomForNewURL(log *base.LogObject) {
+	var total int
+	for _, m := range am.metrics {
+		total += len(m.URLCounters)
+	}
+	if total < types.MaxURLCounters+urlCountersWiggle {
+		return
+	}
+
+	type urlEntry struct {
+		ifname, url string
+		lastUpdated time.Time
+	}
+	entries := make([]urlEntry, 0, total)
+	for ifname, m := range am.metrics {
+		for url, u := range m.URLCounters {
+			entries = append(entries, urlEntry{ifname, url, u.LastUpdated})
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].lastUpdated.Before(entries[j].lastUpdated)
+	})
+
+	for _, e := range entries[:urlCountersWiggle] {
+		m := am.metrics[e.ifname]
+		delete(m.URLCounters, e.url)
+		m.URLCounterRedactedCount++
+		am.metrics[e.ifname] = m
+	}
+	log.Warnf("AgentMetrics: URLCounters limit of %d reached; "+
+		"evicted %d least recently used entries",
+		types.MaxURLCounters, urlCountersWiggle)
 }
 
 // Publish the recorded metrics through the given publisher.

--- a/pkg/pillar/controllerconn/agentmetrics_test.go
+++ b/pkg/pillar/controllerconn/agentmetrics_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerconn_test
+
+import (
+	"fmt"
+	"testing"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/sirupsen/logrus"
+)
+
+// urlCountersWiggle mirrors the unexported constant of the same name in
+// controllerconn/agentmetrics.go: the amount of headroom above
+// types.MaxURLCounters that is let through before a batch of oldest
+// entries gets evicted.
+const urlCountersWiggle = 15
+
+func testLogObject() *base.LogObject {
+	logger := logrus.StandardLogger()
+	logger.SetLevel(logrus.TraceLevel)
+	return base.NewSourceLogObject(logger, "unittest", 1234)
+}
+
+func TestAgentMetricsURLCountersUnderLimit(t *testing.T) {
+	g := NewGomegaWithT(t)
+	log := testLogObject()
+	am := controllerconn.NewAgentMetrics()
+
+	am.RecordSuccess(log, "eth0", "/url/a", 10, 10, 1, false)
+	am.RecordFailure(log, "eth0", "/url/b", 10, 10, false)
+
+	toMap := types.MetricsMap{}
+	am.AddInto(log, toMap)
+	cm := toMap["eth0"]
+
+	g.Expect(len(cm.URLCounters)).To(Equal(2))
+	g.Expect(cm.URLCounterRedactedCount).To(Equal(uint64(0)))
+}
+
+func TestAgentMetricsURLCountersLimit(t *testing.T) {
+	g := NewGomegaWithT(t)
+	log := testLogObject()
+	am := controllerconn.NewAgentMetrics()
+
+	// Stay right at the high watermark: no eviction should have happened
+	// yet, and every recorded URL should still be present.
+	highWatermark := types.MaxURLCounters + urlCountersWiggle
+	for i := 0; i < highWatermark; i++ {
+		am.RecordSuccess(log, "eth0", fmt.Sprintf("/url/%d", i), 10, 10, 1, false)
+	}
+
+	toMap := types.MetricsMap{}
+	am.AddInto(log, toMap)
+	cm := toMap["eth0"]
+	g.Expect(len(cm.URLCounters)).To(Equal(highWatermark))
+	g.Expect(cm.URLCounterRedactedCount).To(Equal(uint64(0)))
+
+	// One more entry crosses the high watermark: a batch of the oldest
+	// (urlCountersWiggle) entries must be evicted, bringing the total back
+	// down to the low watermark (MaxURLCounters) plus the new entry.
+	am.RecordSuccess(log, "eth0", "/url/new", 10, 10, 1, false)
+
+	toMap = types.MetricsMap{}
+	am.AddInto(log, toMap)
+	cm = toMap["eth0"]
+	g.Expect(len(cm.URLCounters)).To(Equal(types.MaxURLCounters + 1))
+	g.Expect(cm.URLCounterRedactedCount).To(Equal(uint64(urlCountersWiggle)))
+
+	// The oldest entries (recorded first) must be the ones evicted.
+	for i := 0; i < urlCountersWiggle; i++ {
+		g.Expect(cm.URLCounters).NotTo(HaveKey(fmt.Sprintf("/url/%d", i)))
+	}
+	// The most recently recorded entries, including the new one, must
+	// still be present.
+	g.Expect(cm.URLCounters).To(HaveKey(fmt.Sprintf("/url/%d", highWatermark-1)))
+	g.Expect(cm.URLCounters).To(HaveKey("/url/new"))
+}
+
+func TestAgentMetricsURLCountersLimitAcrossInterfaces(t *testing.T) {
+	g := NewGomegaWithT(t)
+	log := testLogObject()
+	am := controllerconn.NewAgentMetrics()
+
+	// The limit is combined across all interfaces, not per interface.
+	// n0+n1 lands exactly on the high watermark, so the extra entry
+	// recorded below is the one that crosses it.
+	highWatermark := types.MaxURLCounters + urlCountersWiggle
+	n0 := highWatermark / 2
+	n1 := highWatermark - n0
+	for i := 0; i < n0; i++ {
+		am.RecordSuccess(log, "eth0", fmt.Sprintf("/eth0/%d", i), 10, 10, 1, false)
+	}
+	for i := 0; i < n1; i++ {
+		am.RecordSuccess(log, "eth1", fmt.Sprintf("/eth1/%d", i), 10, 10, 1, false)
+	}
+
+	total := func(m types.MetricsMap) int {
+		return len(m["eth0"].URLCounters) + len(m["eth1"].URLCounters)
+	}
+
+	toMap := types.MetricsMap{}
+	am.AddInto(log, toMap)
+	g.Expect(total(toMap)).To(Equal(highWatermark))
+
+	// One more entry, on either interface, must cross the combined high
+	// watermark and evict the globally oldest entries (recorded first, on
+	// eth0), not just entries local to eth1.
+	am.RecordSuccess(log, "eth1", "/eth1/new", 10, 10, 1, false)
+
+	toMap = types.MetricsMap{}
+	am.AddInto(log, toMap)
+	g.Expect(total(toMap)).To(Equal(types.MaxURLCounters + 1))
+	g.Expect(toMap["eth0"].URLCounters).NotTo(HaveKey("/eth0/0"))
+	g.Expect(toMap["eth1"].URLCounters).To(HaveKey("/eth1/new"))
+	g.Expect(toMap["eth0"].URLCounterRedactedCount).To(Equal(uint64(urlCountersWiggle)))
+}

--- a/pkg/pillar/types/zedcloudmetrics.go
+++ b/pkg/pillar/types/zedcloudmetrics.go
@@ -13,6 +13,12 @@ import (
 // when logging
 type MetricsMap map[string]ControllerConnMetrics
 
+// MaxURLCounters limits URLMetrics entries per MetricsMap (combined across
+// interfaces): agents like downloader/mgmtproxy can otherwise grow
+// URLCounters without bound and exceed the pubsub message size limit.
+// The actual count may transiently exceed this; see AgentMetrics.
+const MaxURLCounters = 100
+
 // ControllerConnMetrics holds communication statistics with the controller
 // for a single interface.
 // It tracks successes, failures, authentication failures, and per-URL metrics.
@@ -23,6 +29,9 @@ type ControllerConnMetrics struct {
 	LastSuccess   time.Time
 	URLCounters   map[string]URLMetrics
 	AuthFailCount uint64
+	// URLCounterRedactedCount counts URLMetrics entries evicted to stay
+	// within MaxURLCounters.
+	URLCounterRedactedCount uint64
 }
 
 // URLMetrics are metrics for a particular URL
@@ -35,6 +44,9 @@ type URLMetrics struct {
 	RecvByteCount  int64 // Based on content-length which could be off
 	TotalTimeSpent int64
 	SessionResume  int64
+	// LastUpdated determines which entries to evict once MaxURLCounters
+	// is reached.
+	LastUpdated time.Time
 }
 
 // AddInto adds metrics from this instance of MetricsMap
@@ -66,6 +78,7 @@ func (m MetricsMap) AddInto(toMap MetricsMap) {
 		dst.FailureCount += src.FailureCount
 		dst.SuccessCount += src.SuccessCount
 		dst.AuthFailCount += src.AuthFailCount
+		dst.URLCounterRedactedCount += src.URLCounterRedactedCount
 		if dst.URLCounters == nil {
 			dst.URLCounters = make(map[string]URLMetrics)
 		}
@@ -85,6 +98,9 @@ func (m MetricsMap) AddInto(toMap MetricsMap) {
 			dstURL.RecvByteCount += srcURL.RecvByteCount
 			dstURL.TotalTimeSpent += srcURL.TotalTimeSpent
 			dstURL.SessionResume += srcURL.SessionResume
+			if srcURL.LastUpdated.After(dstURL.LastUpdated) {
+				dstURL.LastUpdated = srcURL.LastUpdated
+			}
 			dstURLs[url] = dstURL
 		}
 		toMap[ifname] = dst

--- a/pkg/pillar/types/zedcloudmetrics_test.go
+++ b/pkg/pillar/types/zedcloudmetrics_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// MetricsMap.AddInto
+
+func TestMetricsMapAddInto(t *testing.T) {
+	now := time.Now()
+	earlier := now.Add(-time.Minute)
+
+	src := MetricsMap{
+		"eth0": ControllerConnMetrics{
+			FailureCount: 2,
+			SuccessCount: 5,
+			LastFailure:  now,
+			LastSuccess:  now,
+			URLCounters: map[string]URLMetrics{
+				"/v1/config": {TryMsgCount: 3, SentMsgCount: 3},
+			},
+		},
+	}
+
+	dst := MetricsMap{
+		"eth0": ControllerConnMetrics{
+			FailureCount: 1,
+			SuccessCount: 2,
+			LastFailure:  earlier,
+			LastSuccess:  earlier,
+		},
+	}
+
+	src.AddInto(dst)
+
+	got := dst["eth0"]
+	assert.Equal(t, uint64(3), got.FailureCount)
+	assert.Equal(t, uint64(7), got.SuccessCount)
+	// LastFailure should be updated to the more recent value
+	assert.Equal(t, now, got.LastFailure)
+	assert.Equal(t, now, got.LastSuccess)
+	// URL counters merged
+	assert.Equal(t, int64(3), got.URLCounters["/v1/config"].TryMsgCount)
+}
+
+func TestMetricsMapAddIntoNilSource(t *testing.T) {
+	// Nil source → no-op
+	var src MetricsMap
+	dst := MetricsMap{"eth0": {FailureCount: 1}}
+	src.AddInto(dst)
+	assert.Equal(t, uint64(1), dst["eth0"].FailureCount)
+}
+
+func TestMetricsMapAddIntoNewIfname(t *testing.T) {
+	src := MetricsMap{
+		"eth1": ControllerConnMetrics{SuccessCount: 10},
+	}
+	dst := MetricsMap{}
+	src.AddInto(dst)
+	assert.Equal(t, uint64(10), dst["eth1"].SuccessCount)
+}
+
+// AddInto — dst timestamp newer than src (else-if false path)
+
+func TestMetricsMapAddIntoDstNewerTimestamp(t *testing.T) {
+	now := time.Now()
+	older := now.Add(-time.Minute)
+
+	src := MetricsMap{
+		"eth0": ControllerConnMetrics{
+			LastFailure: older,
+			LastSuccess: older,
+		},
+	}
+	dst := MetricsMap{
+		"eth0": ControllerConnMetrics{
+			LastFailure: now,
+			LastSuccess: now,
+		},
+	}
+
+	src.AddInto(dst)
+
+	got := dst["eth0"]
+	// dst timestamps should be preserved (src is older)
+	assert.Equal(t, now, got.LastFailure)
+	assert.Equal(t, now, got.LastSuccess)
+}
+
+// AddInto — URL already in dst map (merge path)
+
+func TestMetricsMapAddIntoURLMerge(t *testing.T) {
+	src := MetricsMap{
+		"eth0": ControllerConnMetrics{
+			URLCounters: map[string]URLMetrics{
+				"/v1/config": {TryMsgCount: 5, SentMsgCount: 3, SessionResume: 1},
+			},
+		},
+	}
+	dst := MetricsMap{
+		"eth0": ControllerConnMetrics{
+			URLCounters: map[string]URLMetrics{
+				"/v1/config": {TryMsgCount: 2, SentMsgCount: 1},
+			},
+		},
+	}
+
+	src.AddInto(dst)
+
+	got := dst["eth0"].URLCounters["/v1/config"]
+	assert.Equal(t, int64(7), got.TryMsgCount)
+	assert.Equal(t, int64(4), got.SentMsgCount)
+	assert.Equal(t, int64(1), got.SessionResume)
+}
+
+func TestMetricsMapAddIntoRedactedCountAndLastUpdated(t *testing.T) {
+	now := time.Now()
+	earlier := now.Add(-time.Minute)
+
+	src := MetricsMap{
+		"eth0": ControllerConnMetrics{
+			URLCounterRedactedCount: 3,
+			URLCounters: map[string]URLMetrics{
+				"/v1/config": {TryMsgCount: 1, LastUpdated: earlier},
+			},
+		},
+	}
+	dst := MetricsMap{
+		"eth0": ControllerConnMetrics{
+			URLCounterRedactedCount: 2,
+			URLCounters: map[string]URLMetrics{
+				"/v1/config": {TryMsgCount: 1, LastUpdated: now},
+			},
+		},
+	}
+
+	// URLCounterRedactedCount is summed and LastUpdated takes the more recent
+	// of the two entries being merged.
+	src.AddInto(dst)
+
+	got := dst["eth0"]
+	assert.Equal(t, uint64(5), got.URLCounterRedactedCount)
+	assert.Equal(t, now, got.URLCounters["/v1/config"].LastUpdated)
+}


### PR DESCRIPTION
# Description

Backport of https://github.com/lf-edge/eve/pull/6389

## How to test and validate this PR

Deploy many container applications, each with an image consisting of multiple blobs. It was observed that with more than ~250 blobs (each contributing with one `URLMetrics` entry), the `MetricsMap` published by downloader would exceed the 64KB pubsub limit without this patch, triggering a panic and a device reboot.

## Changelog notes

Fixed: a device could unexpectedly reboot after downloading many app image blobs over its lifetime, due to internal connection-statistics growing without limit and exceeding an internal size cap. This metrics data is now automatically pruned, preventing the reboot.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.