### PR TITLE
[16.0-stable] pillar: reserve newlog space in bytes, not megabytes

### DIFF
--- a/pkg/pillar/diskmetrics/usage.go
+++ b/pkg/pillar/diskmetrics/usage.go
@@ -271,7 +271,11 @@ func Dom0DiskReservedSize(log *base.LogObject, globalConfig *types.ConfigItemVal
 		(float64(dom0MinDiskUsagePercent) * 0.01))
 	staticMaxDom0DiskSize := uint64(globalConfig.GlobalValueInt(
 		types.Dom0DiskUsageMaxBytes))
-	newlogReserved := uint64(globalConfig.GlobalValueInt(types.LogRemainToSendMBytes))
+	// The config item is in MBytes. newlogd clamps its own quota to a tenth
+	// of /persist, so anything above that could never be used.
+	newlogReserved := min(
+		1000000*uint64(globalConfig.GlobalValueInt(types.LogRemainToSendMBytes)),
+		deviceDiskSize/10)
 	// Always leave space for /persist/newlogd
 	maxDom0DiskSize := newlogReserved
 	// Select the larger of the current overhead usage and the configured

--- a/pkg/pillar/diskmetrics/usage_test.go
+++ b/pkg/pillar/diskmetrics/usage_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/containerd/containerd/mount"
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/sirupsen/logrus"
 )
 
@@ -189,5 +190,58 @@ func TestStatAllocatedBytes(t *testing.T) {
 	// check if the allocated bytes are 100% of 1MB
 	if allocatedBytes != 1024*1024 {
 		t.Fatalf("Test File should be fully allocated")
+	}
+}
+
+func TestDom0DiskReservedSizeNewlogTerm(t *testing.T) {
+	log := base.NewSourceLogObject(logrus.StandardLogger(), t.Name(), 0) //nolint:staticcheck
+
+	// The newlog term is one of several summands, and which of the others
+	// applies depends on the disk size. Difference against a zero quota to
+	// isolate it.
+	newlogTerm := func(deviceDiskSize uint64, quotaMBytes uint32) uint64 {
+		reserved := func(quota uint32) uint64 {
+			gc := types.DefaultConfigItemValueMap()
+			gc.SetGlobalValueInt(types.LogRemainToSendMBytes, quota)
+			return Dom0DiskReservedSize(log, gc, deviceDiskSize, 0)
+		}
+		return reserved(quotaMBytes) - reserved(0)
+	}
+
+	tests := []struct {
+		name           string
+		deviceDiskSize uint64
+		quotaMBytes    uint32
+		want           uint64
+	}{
+		{
+			// newlogd clamps its own quota to a tenth of /persist, so the
+			// default 2048 MBytes is unreachable on a 4 GByte /persist.
+			name:           "quota above newlogd's tenth-of-persist clamp",
+			deviceDiskSize: 4037619712,
+			quotaMBytes:    2048,
+			want:           403761971,
+		},
+		{
+			name:           "quota below the clamp is converted from MBytes",
+			deviceDiskSize: 32000000000,
+			quotaMBytes:    2048,
+			want:           2048000000,
+		},
+		{
+			name:           "minimum quota",
+			deviceDiskSize: 32000000000,
+			quotaMBytes:    10,
+			want:           10000000,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := newlogTerm(tc.deviceDiskSize, tc.quotaMBytes)
+			if got != tc.want {
+				t.Errorf("newlog reserve on %d bytes of /persist with a %d MByte quota = %d, want %d",
+					tc.deviceDiskSize, tc.quotaMBytes, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Backport of #6388

- #6388 — pillar: reserve newlog space in bytes, not megabytes

# Description

`Dom0DiskReservedSize` seeded a byte total with
`newlog.gzipfiles.ondisk.maxmegabytes` straight from the config map, so the
reserve for /persist/newlogd was 2048 bytes rather than ~2 GB. The fix converts
from MBytes and applies the same ceiling newlogd puts on its own quota, a tenth
of /persist.

Confirmed on this branch that the fix is semantically correct here: `newlogd.go`
applies the identical tenth-of-/persist cap to `limitGzipFilesMbyts`, and
`Dom0DiskReservedSize` has the same signature and body as on master.

Adaptation during the cherry-pick: the hunk appending to
`pkg/pillar/diskmetrics/usage_test.go` conflicted because master's copy of that
file also carries `TestParseLsblkPartitions`, which does not exist on this
branch. Resolved by taking only `TestDom0DiskReservedSizeNewlogTerm`; the
unrelated test was not pulled in. The resulting diff is byte-identical to the
one on master.

## How to test and validate this PR

See original PR.

## Changelog notes

See original PR.

## Checklist

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
