### PR TITLE
[14.5-stable] zedagent: preserve newlines between bootstrap SSH authorized_keys

### DIFF
--- a/pkg/pillar/cmd/zedagent/handleconfig.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -423,31 +422,34 @@ func readAuthorizedKeys(filename string) (string, bool) {
 	}
 
 	fileDesc, err := os.Open(filename)
-	keyData := ""
 	if err != nil {
 		log.Warnf("readAuthorizedKeys: File (%s) open error: %s", filename, err)
-	} else {
-		reader := bufio.NewReader(fileDesc)
-		for {
-			line, err := reader.ReadString('\n')
-			if err != nil {
-				log.Traceln(err)
-				if err != io.EOF {
-					log.Errorf("readAuthorizedKeys: ReadString (%s) error: %s", filename, err)
-					return "", false
-				}
-				break
-			}
-			// remove trailing "\n" from line
-			line = line[0 : len(line)-1]
-
-			// Is it a comment or a key?
-			if strings.HasPrefix(line, "#") {
-				continue
-			}
-			keyData += string(line)
-		}
+		return "", false
 	}
+	defer fileDesc.Close()
+
+	// Collect keys and join them with newlines. sshd requires one key
+	// per line, so the separator must be preserved: concatenating the
+	// keys directly would mash them into a single invalid line.
+	var keys []string
+	scanner := bufio.NewScanner(fileDesc)
+	for scanner.Scan() {
+		// bufio.Scanner strips the trailing newline (and a trailing
+		// "\r"), and yields the final line even without a trailing
+		// newline.
+		line := scanner.Text()
+
+		// Skip comments and blank lines.
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		keys = append(keys, line)
+	}
+	if err := scanner.Err(); err != nil {
+		log.Errorf("readAuthorizedKeys: scan (%s) error: %s", filename, err)
+		return "", false
+	}
+	keyData := strings.Join(keys, "\n")
 	if len(keyData) != 0 {
 		return keyData, true
 	}

--- a/pkg/pillar/cmd/zedagent/handleconfig_test.go
+++ b/pkg/pillar/cmd/zedagent/handleconfig_test.go
@@ -102,6 +102,29 @@ func TestLoadGlobalConfigBootstrapFromAuthorizedKeys(t *testing.T) {
 		To(gomega.Equal(testSSHKey))
 }
 
+// TestLoadGlobalConfigBootstrapMultipleAuthorizedKeys: multiple keys in
+// authorized_keys must be preserved as separate newline-separated lines
+// (sshd requires one key per line). Also exercises comment/blank-line
+// skipping and a final key with no trailing newline.
+func TestLoadGlobalConfigBootstrapMultipleAuthorizedKeys(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctx := initGetConfigCtx(g)
+
+	const secondSSHKey = "ssh-rsa AAAAB3NzaC1yc2ESecondTestKey second@example.com"
+
+	dir := t.TempDir()
+	globalFile := filepath.Join(dir, "global.json") // intentionally absent
+	authKeysFile := filepath.Join(dir, "authorized_keys")
+	// A comment, a blank line, and a final key without a trailing newline.
+	contents := "# a comment\n" + testSSHKey + "\n\n" + secondSSHKey
+	g.Expect(os.WriteFile(authKeysFile, []byte(contents), 0644)).To(gomega.Succeed())
+
+	result := loadGlobalConfigImpl(ctx, globalFile, authKeysFile)
+	g.Expect(result).To(gomega.BeTrue())
+	g.Expect(ctx.zedagentCtx.globalConfig.GlobalValueString(types.SSHAuthorizedKeys)).
+		To(gomega.Equal(testSSHKey + "\n" + secondSSHKey))
+}
+
 // TestLoadGlobalConfigBootstrapEmptyAuthKeys: empty authorized_keys
 // with no GlobalConfig must not publish a default ConfigItemValueMap.
 func TestLoadGlobalConfigBootstrapEmptyAuthKeys(t *testing.T) {


### PR DESCRIPTION
# Description

Backport of #6159 to `14.5-stable`.

`git cherry-pick -x` of the original commit. `readAuthorizedKeys` and the
`loadGlobalConfigImpl` test scaffolding on `14.5-stable` are identical to
the pre-fix versions on `master`, so the change itself applied verbatim.

The only conflict was in the import block: `14.5-stable` has an extra
`"net"` import that `master` does not, which collided with the upstream
commit's removal of `"io"`. Resolved by dropping `"io"` (now unused —
only `bufio` remains) and keeping `"net"`. The resulting
`readAuthorizedKeys` body is byte-identical to the one on `master`.

For convenience, the original description:

The bootstrap-SSH path corrupted `/config/authorized_keys` when it
contained more than one key, silently breaking SSH debug access on
freshly-provisioned devices.

On first boot without a `GlobalConfig`/`bootstrap-config.pb`, zedagent
reads `/config/authorized_keys` (via `readAuthorizedKeys`) and feeds the
result into the `debug.enable.ssh` global setting, which is then written
verbatim to `/run/authorized_keys` and used by sshd. The parser stripped
the trailing newline from every line and concatenated the keys with **no
separator**, collapsing all keys onto a single line. Because each key
already contains spaces (`keytype base64 comment`), the result looked
space-separated and was rejected by sshd, which requires one key per
line — so only the (mangled) first key, if any, was usable.

`readAuthorizedKeys` is rewritten using `bufio.Scanner`:

- keys are joined with `"\n"` (one key per line, as sshd expects);
- comment (`#`) and blank lines are skipped;
- the file descriptor is now closed (the old code leaked it).

It also fixes a second, latent bug in the same function: the old
`ReadString`-based loop broke on `io.EOF` *before* appending the final
line, so a last key without a trailing newline was silently dropped.
`bufio.Scanner` yields that final line correctly.

Only the local bootstrap-file path was affected — the normal controller
config path already preserved newlines verbatim.

## How to test and validate this PR

Automated: `TestLoadGlobalConfigBootstrapMultipleAuthorizedKeys` in
`pkg/pillar/cmd/zedagent/handleconfig_test.go`. It writes an
`authorized_keys` file with a comment line, two keys, a blank line, and
a final key with no trailing newline, and asserts the resulting
`debug.enable.ssh` value is the keys joined by `"\n"`.

Verified on this branch by running the full `cmd/zedagent` package test
suite inside the pillar build image (all tests pass, `go vet` clean).

Manual (device) validation:

1. Build an installer whose config partition contains a
   `/config/authorized_keys` file with **two or more** distinct SSH
   public keys, one per line, and **no** `/config/GlobalConfig/global.json`.
2. Install and boot a fresh (un-onboarded) device from it.
3. On the device, inspect `/run/authorized_keys` — it must contain each
   key on its own line (previously all keys were mashed onto one line).
4. `ssh` into the device using **each** of the provisioned keys and
   confirm all of them are accepted.

## Changelog notes

Fixed a bug where providing multiple SSH public keys via the initial
`/config/authorized_keys` file produced an invalid single-line
`authorized_keys` on the device, preventing SSH debug access. Multiple
keys are now handled correctly.

## PR Backports

This *is* the backport to `14.5-stable`. The original is #6159 (merged to
`master`).

## Checklist

For backport PRs:

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
