### PR TITLE
[13.4-stable] zedagent: preserve newlines between bootstrap SSH authorized_keys

### DIFF
--- a/pkg/pillar/cmd/upgradeconverter/applydefaultconfigitem.go
+++ b/pkg/pillar/cmd/upgradeconverter/applydefaultconfigitem.go
@@ -212,31 +212,34 @@ func readAuthorizedKeys(filename string) (string, bool) {
 	}
 
 	fileDesc, err := os.Open(filename)
-	keyData := ""
 	if err != nil {
 		log.Warnf("readAuthorizedKeys: File (%s) open error: %s", filename, err)
-	} else {
-		reader := bufio.NewReader(fileDesc)
-		for {
-			line, err := reader.ReadString('\n')
-			if err != nil {
-				log.Traceln(err)
-				if err != io.EOF {
-					log.Errorf("readAuthorizedKeys: ReadString (%s) error: %s", filename, err)
-					return "", false
-				}
-				break
-			}
-			// remove trailing "\n" from line
-			line = line[0 : len(line)-1]
-
-			// Is it a comment or a key?
-			if strings.HasPrefix(line, "#") {
-				continue
-			}
-			keyData += string(line)
-		}
+		return "", false
 	}
+	defer fileDesc.Close()
+
+	// Collect keys and join them with newlines. sshd requires one key
+	// per line, so the separator must be preserved: concatenating the
+	// keys directly would mash them into a single invalid line.
+	var keys []string
+	scanner := bufio.NewScanner(fileDesc)
+	for scanner.Scan() {
+		// bufio.Scanner strips the trailing newline (and a trailing
+		// "\r"), and yields the final line even without a trailing
+		// newline.
+		line := scanner.Text()
+
+		// Skip comments and blank lines.
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		keys = append(keys, line)
+	}
+	if err := scanner.Err(); err != nil {
+		log.Errorf("readAuthorizedKeys: scan (%s) error: %s", filename, err)
+		return "", false
+	}
+	keyData := strings.Join(keys, "\n")
 	if len(keyData) != 0 {
 		return keyData, true
 	}

--- a/pkg/pillar/cmd/upgradeconverter/applydefaultconfigitem_test.go
+++ b/pkg/pillar/cmd/upgradeconverter/applydefaultconfigitem_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package upgradeconverter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_ReadAuthorizedKeys verifies that multiple keys in authorized_keys are
+// preserved as separate newline-separated lines. sshd requires one key per
+// line, so concatenating them without a separator produces a single invalid
+// line. Also exercises comment/blank-line skipping and a final key with no
+// trailing newline, which the previous ReadString-based loop silently dropped.
+func Test_ReadAuthorizedKeys(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+	log = base.NewSourceLogObject(logrus.StandardLogger(), "test", 1234)
+
+	const firstKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKey test@example.com"
+	const secondKey = "ssh-rsa AAAAB3NzaC1yc2ESecondTestKey second@example.com"
+
+	type readTestEntry struct {
+		contents string
+		expected string
+		expectOK bool
+	}
+
+	testMatrix := map[string]readTestEntry{
+		"single key with trailing newline": {
+			contents: firstKey + "\n",
+			expected: firstKey,
+			expectOK: true,
+		},
+		"multiple keys stay newline-separated": {
+			contents: firstKey + "\n" + secondKey + "\n",
+			expected: firstKey + "\n" + secondKey,
+			expectOK: true,
+		},
+		"comments and blank lines skipped, last key has no newline": {
+			contents: "# a comment\n" + firstKey + "\n\n" + secondKey,
+			expected: firstKey + "\n" + secondKey,
+			expectOK: true,
+		},
+		"only comments yields nothing": {
+			contents: "# just a comment\n",
+			expected: "",
+			expectOK: false,
+		},
+		"empty file yields nothing": {
+			contents: "",
+			expected: "",
+			expectOK: false,
+		},
+	}
+
+	for testname, test := range testMatrix {
+		t.Logf("Running test case %s", testname)
+		authKeysFile := filepath.Join(t.TempDir(), "authorized_keys")
+		if err := os.WriteFile(authKeysFile, []byte(test.contents), 0644); err != nil {
+			t.Fatalf("cannot write %s: %s", authKeysFile, err)
+		}
+		keyData, keyDataValid := readAuthorizedKeys(authKeysFile)
+		assert.Equal(t, test.expected, keyData)
+		assert.Equal(t, test.expectOK, keyDataValid)
+	}
+
+	// A missing file must not be reported as valid key data.
+	keyData, keyDataValid := readAuthorizedKeys(
+		filepath.Join(t.TempDir(), "absent"))
+	assert.Equal(t, "", keyData)
+	assert.False(t, keyDataValid)
+}


### PR DESCRIPTION
# Description

Backport of #6159 to `13.4-stable`.

**This one is not a straight cherry-pick**, because the code lives somewhere
else on this branch. Upstream (#6159) patched `readAuthorizedKeys` in
`pkg/pillar/cmd/zedagent/handleconfig.go`. On `13.4-stable` that function
does not exist in `zedagent` at all — the bootstrap `authorized_keys`
parsing lives in `pkg/pillar/cmd/upgradeconverter/applydefaultconfigitem.go`
instead, where it feeds the ingested keys into the persisted
`ConfigItemValueMap`. The function body there is character-for-character the
same buggy parser, so the branch has the same bug in a different place.

What was adapted:

- The parser rewrite is applied to the `upgradeconverter` copy. The new
  `readAuthorizedKeys` body is identical to the one merged on `master`.
- The `"io"` import is **kept** here (unlike the upstream commit, which
  dropped it) because this file still uses `io.ReadAll` elsewhere.
- The regression test is written against this package
  (`Test_ReadAuthorizedKeys` in `applydefaultconfigitem_test.go`), since the
  `loadGlobalConfigImpl` test scaffolding the upstream test builds on does
  not exist on this branch.

The original bug description follows.

`readAuthorizedKeys` stripped the trailing newline from every line of
`/config/authorized_keys` and concatenated the keys with **no separator**,
collapsing all keys onto a single line. Because each key already contains
spaces (`keytype base64 comment`), the result looked space-separated and was
rejected by sshd, which requires one key per line — so only the (mangled)
first key, if any, was usable. The value is fed into the `debug.enable.ssh`
global setting and ends up written verbatim to `/run/authorized_keys`.

The parser is rewritten using `bufio.Scanner`:

- keys are joined with `"\n"` (one key per line, as sshd expects);
- comment (`#`) and blank lines are skipped;
- the file descriptor is now closed (the old code leaked it).

This also fixes a second, latent bug in the same function: the old
`ReadString`-based loop broke on `io.EOF` *before* appending the final line,
so a last key without a trailing newline was silently dropped.
`bufio.Scanner` yields that final line correctly.

## How to test and validate this PR

Automated: `Test_ReadAuthorizedKeys` in
`pkg/pillar/cmd/upgradeconverter/applydefaultconfigitem_test.go`. It covers a
single key, multiple keys, comment and blank lines, a final key with no
trailing newline, a comments-only file, an empty file, and a missing file.

This was verified to be a real regression test: run against the **old**
parser it fails, reproducing both bugs —

```
expected: "ssh-ed25519 …test@example.com\nssh-rsa …second@example.com"
actual  : "ssh-ed25519 …test@example.comssh-rsa …second@example.com"   # no separator
actual  : "ssh-ed25519 …test@example.com"                              # last key dropped
```

— and passes with the fix. The full `cmd/upgradeconverter` package
(pre-existing tests included) and `go vet` are green.

Manual (device) validation:

1. Build an installer whose config partition contains a
   `/config/authorized_keys` file with **two or more** distinct SSH public
   keys, one per line.
2. Install and boot a fresh (un-onboarded) device from it.
3. On the device, inspect `/run/authorized_keys` — it must contain each key
   on its own line (previously all keys were mashed onto one line).
4. `ssh` into the device using **each** of the provisioned keys and confirm
   all of them are accepted.

## Changelog notes

Fixed a bug where providing multiple SSH public keys via the initial
`/config/authorized_keys` file produced an invalid single-line
`authorized_keys` on the device, preventing SSH debug access. Multiple keys
are now handled correctly.

## PR Backports

This *is* the backport to `13.4-stable`. The original is #6159 (merged to
`master`).

## Checklist

For backport PRs:

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
