### PR TITLE
[17.0-stable] pkg/optee-client: Copy only optee-client files to the final image

### DIFF
--- a/pkg/optee-client/Dockerfile
+++ b/pkg/optee-client/Dockerfile
@@ -27,7 +27,7 @@ RUN git config --global user.name 'Project EVE' && \
     done
 
 # Build tee-supplicant
-RUN cmake -DCMAKE_INSTALL_PREFIX=/out/usr && \
+RUN cmake -DCMAKE_INSTALL_PREFIX=/build/usr && \
       make -j "$(getconf _NPROCESSORS_ONLN)" && \
       make install
 
@@ -41,7 +41,9 @@ FROM scratch AS output-arm64
 ENTRYPOINT []
 CMD []
 ADD rootfs/ /
-COPY --from=build-arm64 /out /
+COPY --from=build-arm64 /build/usr/etc/* /etc/
+COPY --from=build-arm64 /build/usr/lib/* /usr/lib/
+COPY --from=build-arm64 /build/usr/sbin/* /usr/sbin/
 
 ARG TARGETARCH
 FROM output-${TARGETARCH}


### PR DESCRIPTION
# Description

Backport of https://github.com/lf-edge/eve/pull/6275

## How to test and validate this PR

This must be validated on any supported NVIDIA device

1. Boot the device
3. From main console (or ssh - debug console), ensure `nsenter` doesn't point to busybox. It should be something like this:

```sh
ls -l /usr/bin/nsenter 
-rwxr-xr-x 1 root root 34712 Apr 15  2022 /usr/bin/nsenter
```
or from debug container (through ssh):
```sh
ls -l /hostfs/usr/bin/nsenter 
-rwxr-xr-x 1 root root 34712 Apr 15  2022 /hostfs/usr/bin/nsenter
```

## Changelog notes

Fix deployment of optee-client binaries that were impacting other system binaries on NVIDIA devices.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.