### PR TITLE
kernel: move amd64 to eve-kernel 6.18.46, hwe flavour for HV=k

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -474,7 +474,7 @@ else
         PKGS_$(ZARCH)=$(shell find pkg -maxdepth 1 -type d | grep -Ev "eve|alpine|sources|kube|external-boot-image$$")
         # nvidia platform requires more space
         ifeq (, $(findstring nvidia,$(PLATFORM)))
-            ROOTFS_MAXSIZE_MB=290
+            ROOTFS_MAXSIZE_MB=295
         else
             ROOTFS_MAXSIZE_MB=10240
         endif

--- a/kernel-commits.mk
+++ b/kernel-commits.mk
@@ -1,5 +1,6 @@
 KERNEL_COMMIT_amd64_next_generic = a65e45508b45
 KERNEL_COMMIT_amd64_v6.12.96_generic = 5ec53c5d956c
+KERNEL_COMMIT_amd64_v6.18.46_generic = daa483f487da
 KERNEL_COMMIT_arm64_v5.10.192_nvidia-jp5 = 2e0dcfd3260d
 KERNEL_COMMIT_arm64_v5.15.136_nvidia-jp6 = 4929f15eda41
 KERNEL_COMMIT_arm64_v6.1.155_generic = 417a12ac3d50

--- a/kernel-version.mk
+++ b/kernel-version.mk
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # This file is included by the main Makefile.
-# Four variables are used as input for the kernel build:
+# Five variables are used as input for the kernel build:
 #   ZARCH - architecture (amd64, arm64)
 #   PLATFORM - platform (generic, nvidia, rt, imx*) based on these two
 #              variables we set kernel version, commit hash and branch
 #              when new kernel is built and pushed to the corresponding
 #              dockerhub
+#   HV - hypervisor (kvm, k, xen, mini)
 #   KERNEL_COMMIT_xxx variable must be manually updated
 #   KERNEL_CONFIG_FLAVOR - optional, used to select kernel's docker tag
 #                          which corresponds to the kernel config file
@@ -35,10 +36,12 @@ ifeq (, $(filter $(PLATFORM), $(PLATFORMS_$(ZARCH))))
 endif
 
 ifeq ($(ZARCH), amd64)
-    KERNEL_VERSION=v6.12.96
+    KERNEL_VERSION=v6.18.46
     KERNEL_FLAVOR=generic
     ifeq ($(PLATFORM), rt)
         KERNEL_CONFIG_FLAVOR=rt
+    else ifeq ($(HV), k)
+        KERNEL_CONFIG_FLAVOR=hwe
     else
         KERNEL_CONFIG_FLAVOR=core
     endif


### PR DESCRIPTION
# Description

Moves every amd64 build to the new `eve-kernel-amd64-v6.18.46-generic` branch, and introduces the `hwe` config flavour for `HV=k`.

`HV` becomes an input to kernel selection alongside `ZARCH` and `PLATFORM`. It is already set in the main `Makefile` well before `kernel-version.mk` is included, so no reordering was needed. The resulting mapping:

| `ZARCH` / `PLATFORM` / `HV` | config flavour | previously |
|---|---|---|
| amd64, generic, `k` | `hwe` | **new** |
| amd64, generic, `kvm` / `xen` / `mini` | `core` | v6.12.96 `core` |
| amd64, `rt`, any `HV` | `rt` | v6.12.96 `rt` |
| arm64, riscv64, any | unchanged | unchanged |

`hwe` is an Ubuntu-generic derivation carrying the full module set (~4400 modules), which is what `HV=k` wants for broad server/edge hardware coverage. `PLATFORM=rt` deliberately still wins over `HV`, so an `rt` build never silently loses `PREEMPT_RT` by being built as `hwe`. arm64 and riscv64 are untouched — there is no 6.18 branch for them.

The kernel is pinned at `daa483f487da`, which is on `lf-edge/eve-kernel-amd64-v6.18.46-generic`; the `core`, `rt` and `hwe` flavour images are all published, so this requires no kernel rebuild.

### Rootfs size cap

`ROOTFS_MAXSIZE_MB` is raised from 290 to 295 for the non-`k`, non-nvidia builds. The 6.18 `core` rootfs measures 306,147,328 B (291.96 MiB), roughly 2 MiB over the historical 290 MiB assertion, so `HV=kvm` fails that check without this. The binding constraint is the 300 MB rootfs partition on devices installed by pre-10.2.0 EVE, so 295 keeps 5 MB of margin against it rather than consuming the whole partition. `HV=k` is unaffected — it is already exempt at 10 GB — and its `hwe` rootfs measures 563,175,424 B (537.09 MiB).

## How to test and validate this PR

Check that the flavour selection resolves correctly:

```sh
make HV=k   ZARCH=amd64 PLATFORM=generic kernel-tag   # ...-v6.18.46-generic-hwe-daa483f487da-gcc
make HV=kvm ZARCH=amd64 PLATFORM=generic kernel-tag   # ...-v6.18.46-generic-core-daa483f487da-gcc
make HV=kvm ZARCH=amd64 PLATFORM=rt      kernel-tag   # ...-v6.18.46-generic-rt-daa483f487da-gcc
make HV=kvm ZARCH=arm64 PLATFORM=generic kernel-tag   # unchanged: arm64 v6.1.155
```

Build and boot both amd64 flavours:

```sh
make HV=kvm ZARCH=amd64 live && make ACCEL=1 HV=kvm run-live
make HV=k   ZARCH=amd64 live && make ACCEL=1 HV=k   run-live
```

Both should reach a login shell with no kernel panic. Confirm the running kernel is the expected flavour — the console banner reads `6.18.46-linuxkit-core-daa483f487da` for `kvm` and `6.18.46-hwe-daa483f487da` for `k`.

Note that `bridge` and `veth` are `=m` in `hwe` where `core` has them `=y`. Both autoload on demand; on a booted `HV=k` system this can be confirmed with:

```sh
ip link add brtest type bridge && ip link add v0 type veth peer name v1
lsmod | grep -E '^(bridge|veth)'
```

### What was verified, and what was not

Verified: both flavours build; both boot to a login shell under QEMU with zero panics/oops; `bridge` and `veth` autoload on the `hwe` kernel; the `kvm` rootfs fits the raised cap with 3 MB spare.

Not verified: `HV=k` was not driven far enough to exercise k3s / kubevirt / Longhorn convergence or EVE-created network instances, which needs a controller (Eden). `PLATFORM=rt` was checked only for correct tag resolution — it was not built or booted. Testing was QEMU-only; no real hardware.

## Changelog notes

The amd64 kernel moves to 6.18.46. `HV=k` amd64 builds now use a large hardware-enablement kernel configuration derived from Ubuntu's generic config, substantially widening driver coverage. The rootfs size limit for non-`k`, non-nvidia amd64/arm64 builds rises from 290 MB to 295 MB, still within the 300 MB rootfs partition used by pre-10.2.0 installations.

## PR Backports

- 16.0-stable: No — moves the default amd64 kernel version and raises a shipping rootfs size guardrail; too invasive for a stable branch, and the 6.18 kernel branch is new.
- 14.5-stable: No — same reason.
- 13.4-stable: No — same reason.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.

Both amd64 flavours were built and booted under QEMU rather than on physical hardware, so the amd64 device box is left unchecked. arm64 is not touched by this change. No documentation change seemed warranted for a kernel pin plus a size-cap constant, but happy to add a note if a reviewer wants one.
