### PR TITLE
ci: add a security-focused Claude review of PRs

### DIFF
--- a/.github/workflows/claude-sec-review.yml
+++ b/.github/workflows/claude-sec-review.yml
@@ -1,0 +1,38 @@
+# Copyright (c) 2026, Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+name: Claude Security Review
+on:  # yamllint disable-line rule:truthy
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  security-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: claude-sec-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    if: |
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR' ||
+      github.event.pull_request.author_association == 'OWNER'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
+          persist-credentials: false
+      # fork of anthropics/claude-code-security-review: upstream refuses to
+      # run on pull_request_target, which this repo needs for fork PRs
+      - uses: shjala/claude-code-security-review@4d62096960937fdd393d3e4b15ac501ff1a77ede  # main
+        with:
+          claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude-model: claude-opus-4-8
+          comment-pr: true
+          upload-results: true
+          exclude-directories: vendor

--- a/.github/workflows/claude-sec-review.yml
+++ b/.github/workflows/claude-sec-review.yml
@@ -27,6 +27,19 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
           persist-credentials: false
+      # The action runs the claude CLI with its working directory set to this
+      # checked-out PR tree, and the CLI executes hooks from a .claude
+      # settings file and command servers from .mcp.json found there. On a
+      # pull_request_target run those secrets are in scope, so strip both
+      # before the CLI ever sees the tree. The author allowlist above is the
+      # primary gate; this removes the code-execution path a trusted-but-
+      # compromised branch would otherwise have.
+      - name: Strip in-tree tool configs from the PR checkout
+        run: |
+          find . -depth -type d -name .claude -exec rm -rf {} +
+          find . -type l -name .claude -delete
+          find . -type f -name .mcp.json -delete
+          find . -type l -name .mcp.json -delete
       # fork of anthropics/claude-code-security-review: upstream refuses to
       # run on pull_request_target, which this repo needs for fork PRs
       - uses: shjala/claude-code-security-review@4d62096960937fdd393d3e4b15ac501ff1a77ede  # main


### PR DESCRIPTION
# Description

Scan PRs with the claude-code-security-review action, run from a fork that accepts pull_request_target, which this repo needs since every PR comes from a fork and a plain pull_request run gets no secrets. The job is gated to PRs authored by members, collaborators and owners.

## PR dependencies

List all dependencies of this PR (when applicable, otherwise remove this
section).

## How to test and validate this PR

Please describe how the changes in this PR can be validated or verified. For
example:

- If your PR fixes a bug, outline the steps to confirm the issue is resolved.
- If your PR introduces a new feature, explain how to test and validate it.

This will be used

1. to provide test scenarios for the QA team
1. by a reviewer to validate the changes in this PR.

The first is especially important, so, please make sure to provide as much
detail as possible.

If it's covered by an automated test, please mention it here.

## Changelog notes

Text in this section will be used to generate the changelog entry for
release notes. The consumers of this are end users, not developers.
So, provide a clear and short description of what is changed in the PR from
the end user perspective. If it changes only tooling or some internal
implementation, put a note like "No user-facing changes" or "None".

## PR Backports

For all current LTS branches, please state explicitly if this PR should be
backported or not. This section is used by our scripts to track the backports,
so, please, do not omit it.

Here is the list of current LTS branches (it should be always up to date):

- 17.0-stable
- 16.0-stable
- 14.5-stable
- 13.4-stable

For example, if this PR fixes a bug in a feature that was introduced in 17.0,
you can write:

```text
- 17.0-stable: To be backported.
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.
```

Also, to the PRs that should be backported into any stable branch, please
add a label `stable`.

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
