### PR TITLE
[17.0-stable] Resolve container USER name for EVE-k volumes and diagnose stuck EVE-k app bring-up

### DIFF
--- a/pkg/pillar/cas/containerd.go
+++ b/pkg/pillar/cas/containerd.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -18,6 +19,7 @@ import (
 	containerderrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/oci"
 	snapshot "github.com/containerd/containerd/snapshots"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	v1types "github.com/google/go-containerregistry/pkg/v1/types"
@@ -27,6 +29,7 @@ import (
 	"github.com/lf-edge/eve/pkg/pillar/types"
 	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"github.com/moby/sys/mountinfo"
+	"github.com/moby/sys/user"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
@@ -802,21 +805,66 @@ func (c *containerdCAS) prepareContainerRootDirForKubevirt(clientImageSpec *ocis
 		return err
 	}
 
-	// Userid and GID are same
-	ug := "0 0"
-	if user != "" {
-		uid, converr := strconv.Atoi(user)
-		if converr != nil {
-			return converr
-		}
-		ug = fmt.Sprintf("%d %d", uid, uid)
+	uid, gid, err := resolveUserGroup(GetRoofFsPath(rootPath), user)
+	if err != nil {
+		return fmt.Errorf("PrepareContainerRootDir: cannot resolve user %q: %w", user, err)
 	}
+	ug := fmt.Sprintf("%d %d", uid, gid)
 	if err := os.WriteFile(filepath.Join(rootPath, "ug"),
 		[]byte(ug), 0644); err != nil {
 		return err
 	}
 
 	return os.MkdirAll(filepath.Join(rootPath, "modules"), 0600)
+}
+
+// resolveUserGroup maps an OCI image Config.User string to numeric uid/gid.
+// User or group *names* are resolved against /etc/passwd and /etc/group in the
+// container's rootfs (rootfs must already be mounted). It accepts the same
+// forms as the OCI runtime and the HV=kvm/xen path (containerd's oci.WithUser):
+// "", "uid", "user", "uid:gid", "user:group", "uid:group", "user:gid". An empty
+// user yields 0/0. When only a numeric uid is given, gid defaults to that user's
+// primary group from /etc/passwd, falling back to 0 if the rootfs has no
+// matching entry.
+func resolveUserGroup(rootfs, userstr string) (uid, gid uint32, err error) {
+	if userstr == "" {
+		return 0, 0, nil
+	}
+	userPart, groupPart, hasGroup := strings.Cut(userstr, ":")
+
+	if v, aerr := strconv.Atoi(userPart); aerr == nil {
+		if v < 0 || v > math.MaxInt32 {
+			return 0, 0, fmt.Errorf("uid %q out of range", userPart)
+		}
+		uid = uint32(v)
+		// Default gid to the user's primary group; a missing rootfs entry
+		// is not an error for a numeric uid, matching oci.WithUserID.
+		if u, ferr := oci.UserFromPath(rootfs, func(u user.User) bool { return u.Uid == v }); ferr == nil {
+			gid = uint32(u.Gid)
+		}
+	} else {
+		u, ferr := oci.UserFromPath(rootfs, func(u user.User) bool { return u.Name == userPart })
+		if ferr != nil {
+			return 0, 0, ferr
+		}
+		uid, gid = uint32(u.Uid), uint32(u.Gid)
+	}
+
+	if hasGroup && groupPart != "" {
+		if v, aerr := strconv.Atoi(groupPart); aerr == nil {
+			if v < 0 || v > math.MaxInt32 {
+				return 0, 0, fmt.Errorf("gid %q out of range", groupPart)
+			}
+			gid = uint32(v)
+		} else {
+			g, ferr := oci.GIDFromPath(rootfs, func(g user.Group) bool { return g.Name == groupPart })
+			if ferr != nil {
+				return 0, 0, ferr
+			}
+			gid = g
+		}
+	}
+	return uid, gid, nil
 }
 
 // UnmountContainerRootDir unmounts container's rootPath

--- a/pkg/pillar/cas/containerd_test.go
+++ b/pkg/pillar/cas/containerd_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cas
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveUserGroup guards the EVE-k volume-preparation path that maps an
+// OCI image Config.User string to a numeric uid/gid pair.
+func TestResolveUserGroup(t *testing.T) {
+	rootfs := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(rootfs, "etc"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	passwd := "root:x:0:0:root:/root:/bin/bash\nzcli:x:1000:1000:Linux User:/home/zcli:/bin/bash\n"
+	group := "root:x:0:\nstaff:x:50:\nzcli:x:1000:\n"
+	if err := os.WriteFile(filepath.Join(rootfs, "etc", "passwd"), []byte(passwd), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rootfs, "etc", "group"), []byte(group), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		userstr  string
+		uid, gid uint32
+		wantErr  bool
+	}{
+		{userstr: "", uid: 0, gid: 0},
+		{userstr: "zcli", uid: 1000, gid: 1000},  // username resolved from /etc/passwd
+		{userstr: "1000", uid: 1000, gid: 1000},  // numeric uid; gid from passwd
+		{userstr: "1234", uid: 1234, gid: 0},     // uid absent from passwd; gid falls back to 0
+		{userstr: "1000:50", uid: 1000, gid: 50}, // numeric group overrides
+		{userstr: "zcli:staff", uid: 1000, gid: 50},
+		{userstr: "1000:staff", uid: 1000, gid: 50},
+		{userstr: "nobody", wantErr: true},
+		{userstr: "zcli:nogroup", wantErr: true},
+		{userstr: "2147483648", wantErr: true},      // uid > math.MaxInt32
+		{userstr: "1000:2147483648", wantErr: true}, // gid > math.MaxInt32
+	}
+	for _, tt := range tests {
+		uid, gid, err := resolveUserGroup(rootfs, tt.userstr)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("resolveUserGroup(%q): expected error, got uid=%d gid=%d", tt.userstr, uid, gid)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("resolveUserGroup(%q): unexpected error: %v", tt.userstr, err)
+			continue
+		}
+		if uid != tt.uid || gid != tt.gid {
+			t.Errorf("resolveUserGroup(%q) = %d/%d, want %d/%d", tt.userstr, uid, gid, tt.uid, tt.gid)
+		}
+	}
+}

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -732,7 +732,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 				break
 			}
 			if waitForKubevirtFlag {
-				log.Warnf("Domainmgr: WaitForKubernetes kubevirt not ready: %v, retrying", err)
+				log.Warnf("Domainmgr: WaitForKubernetes not satisfied: %v, retrying", err)
 				continue
 			}
 			log.Errorf("Domainmgr: WaitForKubernetes error %v", err)

--- a/pkg/pillar/go.mod
+++ b/pkg/pillar/go.mod
@@ -144,7 +144,7 @@ require (
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/signal v0.7.0 // indirect
-	github.com/moby/sys/user v0.4.0 // indirect
+	github.com/moby/sys/user v0.4.0
 	github.com/moby/term v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/pkg/pillar/kubeapi/kubeapi.go
+++ b/pkg/pillar/kubeapi/kubeapi.go
@@ -237,22 +237,28 @@ func WaitForKubernetes(agentName string, ps *pubsub.PubSub, stillRunning *time.T
 	// nodeName is the caller-supplied EVE-k node name (from EdgeNodeInfo.DeviceName),
 	// not os.Hostname().
 	var nodeReadyErr error
+	// Record the last failing sub-check; PollImmediate's timeout error alone does not say which of node/kubevirt/longhorn was unmet.
+	var lastUnmet error
 	doneCh := make(chan struct{}, 1)
 	go func() {
 		nodeReadyErr = wait.PollImmediate(time.Second, time.Minute*20, func() (bool, error) {
 			if err := nodeReadyByName(client, nodeName); err != nil {
+				lastUnmet = fmt.Errorf("node not ready: %w", err)
 				return false, nil
 			}
 			if opts.WaitForKubevirt {
 				if err := waitForKubevirtReady(config); err != nil {
+					lastUnmet = fmt.Errorf("kubevirt not ready: %w", err)
 					return false, nil
 				}
 			}
 			if opts.WaitForLonghorn {
 				if err := checkLonghornReady(client, nodeName); err != nil {
+					lastUnmet = fmt.Errorf("longhorn not ready: %w", err)
 					return false, nil
 				}
 			}
+			lastUnmet = nil
 			return true, nil
 		})
 		doneCh <- struct{}{}
@@ -268,6 +274,9 @@ func WaitForKubernetes(agentName string, ps *pubsub.PubSub, stillRunning *time.T
 	})
 	watches = append(watches, alsoWatch...)
 	pubsub.MultiChannelWatch(watches)
+	if nodeReadyErr != nil && lastUnmet != nil {
+		return fmt.Errorf("%w (last unmet condition: %v)", nodeReadyErr, lastUnmet)
+	}
 	return nodeReadyErr
 }
 

--- a/pkg/pillar/kubeapi/vitoapiserver.go
+++ b/pkg/pillar/kubeapi/vitoapiserver.go
@@ -513,6 +513,26 @@ func RolloutDiskToPVC(ctx context.Context, log *base.LogObject, exists bool,
 		return transientf("PVC Upload for pvc:%s attempts to upload image failed, upload pod:%s does not exist", pvcName, cdiUploadPodName)
 	}
 	uploadNodeName := pod.Spec.NodeName
+	// 3b. The upload pod can reach Ready yet get torn down by CDI (pod.phase Failed /
+	// ContainerStatusUnknown) with the local-path scratch PVC left stuck Terminating —
+	// a wedge the data-vol/PV/engine checks below do not surface, so log it explicitly.
+	log.Noticef("RolloutDiskToPVC pvc:%s upload pod:%s phase:%s cdi.pod.phase:%q cdi.running.reason:%q cdi.running.msg:%q",
+		pvcName, cdiUploadPodName, pod.Status.Phase,
+		pvc.ObjectMeta.Annotations["cdi.kubevirt.io/storage.pod.phase"],
+		pvc.ObjectMeta.Annotations["cdi.kubevirt.io/storage.condition.running.reason"],
+		pvc.ObjectMeta.Annotations["cdi.kubevirt.io/storage.condition.running.message"])
+	scratchName := pvcName + "-scratch"
+	if scratchPvc, scratchErr := PVCGet(scratchName, log); scratchErr != nil {
+		log.Noticef("RolloutDiskToPVC pvc:%s scratch PVC %s not found: %v", pvcName, scratchName, scratchErr)
+	} else {
+		scratchSC := ""
+		if scratchPvc.Spec.StorageClassName != nil {
+			scratchSC = *scratchPvc.Spec.StorageClassName
+		}
+		log.Noticef("RolloutDiskToPVC pvc:%s scratch PVC %s phase:%s terminating:%t storageClass:%q finalizers:%v",
+			pvcName, scratchName, scratchPvc.Status.Phase,
+			scratchPvc.ObjectMeta.DeletionTimestamp != nil, scratchSC, scratchPvc.ObjectMeta.Finalizers)
+	}
 	// 4. Did the PVC claim get a backing pv?
 	lhVol, err := lhVolGet(pvName)
 	if err != nil {


### PR DESCRIPTION
# Description

Backport of #6189 and #6200 to `17.0-stable`.

Both are EVE-k (kubevirt) app-bring-up fixes; EVE-k is only usable in 17.0 and later, so neither is relevant to the earlier LTS branches.

Commits picked with `-x`:
- `485098ca73` Resolve container USER name for EVE-k volumes (#6189)
- `7b12123fb8` kubeapi: log CDI upload-pod teardown state on rollout failure (#6200)
- `068aacf9e2` kubeapi: name the unmet WaitForKubernetes gate (#6200)

Adaptation: `pkg/pillar/cas/containerd_test.go` does not exist on 17.0-stable. Rather than import the whole master test file (which also carries two unrelated `TestIngestBlobMissingFile*` cases), only the regression-guarding `TestResolveUserGroup` is created, with an SPDX header using the current year. `go.mod` promotes `moby/sys/user` from indirect to direct (unversioned change; the vendored module was already present and consistent).

## PR dependencies

None.

## How to test and validate this PR

`TestResolveUserGroup` in `pkg/pillar/cas/containerd_test.go` guards the #6189 fix (username/numeric `USER` forms resolved against the container rootfs, unknown names error). #6200 is diagnostic-only logging and has no automated test; the `WaitForKubernetes` readiness-gate change compiles and vets cleanly (`gofmt`, `go vet`, `go build` incl. `-tags k`) on this branch.

## Changelog notes

Fix container apps failing to start on EVE-k when the image sets a non-numeric user (e.g. `USER appuser`); the username is now resolved to its uid/gid from the image, as it already was on EVE-kvm. The rest of this backport is diagnostic logging (no user-facing change).

## PR Backports

EVE-k (kubevirt) is only usable in 17.0 and later, so this is only relevant on 17.0.

- 17.0: This PR.
- 16.0-stable: No, EVE-k is not usable before 17.0.
- 14.5-stable: No, EVE-k is not usable before 17.0.
- 13.4-stable: No, EVE-k is not usable before 17.0.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs:

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
