### PR TITLE
[16.0-stable] zedagent: report size of EFI and IMGx partitions

### DIFF
--- a/pkg/edgeview/vendor/github.com/lf-edge/eve/pkg/pillar/types/diskmetrics.go
+++ b/pkg/edgeview/vendor/github.com/lf-edge/eve/pkg/pillar/types/diskmetrics.go
@@ -70,6 +70,12 @@ type DiskMetric struct {
 	UsedBytes  uint64 // Value in Bytes. Total number of used Bytes by the disk.
 	FreeBytes  uint64 // Value in Bytes. Total number of free Bytes for the disk.
 	IsDir      bool   // Will be true if DiskPath is a mountPath, will false if it's a disk.
+
+	// GPT identity for block partitions. Empty when IsDir is true,
+	// for whole-disk entries, and for partitions on non-GPT disks.
+	PartitionLabel string // GPT PARTLABEL
+	PartitionType  string // GPT partition type GUID
+	PartitionUUID  string // GPT PARTUUID
 }
 
 // Key returns the pubsub Key.
@@ -92,6 +98,9 @@ func (status DiskMetric) LogCreate(logBase *base.LogObject) {
 		AddField("userbytes-int64", status.UsedBytes).
 		AddField("freebytes-int64", status.FreeBytes).
 		AddField("isdor", status.IsDir).
+		AddField("partition-label", status.PartitionLabel).
+		AddField("partition-type", status.PartitionType).
+		AddField("partition-uuid", status.PartitionUUID).
 		Metricf("DiskMetric status create")
 }
 
@@ -111,6 +120,9 @@ func (status DiskMetric) LogModify(logBase *base.LogObject, old interface{}) {
 		AddField("old-userbytes-int64", status.UsedBytes).
 		AddField("old-freebytes-int64", status.FreeBytes).
 		AddField("isdor", status.IsDir).
+		AddField("partition-label", status.PartitionLabel).
+		AddField("partition-type", status.PartitionType).
+		AddField("partition-uuid", status.PartitionUUID).
 		Metricf("DiskMetric status modify")
 }
 

--- a/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/types/diskmetrics.go
+++ b/pkg/newlog/vendor/github.com/lf-edge/eve/pkg/pillar/types/diskmetrics.go
@@ -70,6 +70,12 @@ type DiskMetric struct {
 	UsedBytes  uint64 // Value in Bytes. Total number of used Bytes by the disk.
 	FreeBytes  uint64 // Value in Bytes. Total number of free Bytes for the disk.
 	IsDir      bool   // Will be true if DiskPath is a mountPath, will false if it's a disk.
+
+	// GPT identity for block partitions. Empty when IsDir is true,
+	// for whole-disk entries, and for partitions on non-GPT disks.
+	PartitionLabel string // GPT PARTLABEL
+	PartitionType  string // GPT partition type GUID
+	PartitionUUID  string // GPT PARTUUID
 }
 
 // Key returns the pubsub Key.
@@ -92,6 +98,9 @@ func (status DiskMetric) LogCreate(logBase *base.LogObject) {
 		AddField("userbytes-int64", status.UsedBytes).
 		AddField("freebytes-int64", status.FreeBytes).
 		AddField("isdor", status.IsDir).
+		AddField("partition-label", status.PartitionLabel).
+		AddField("partition-type", status.PartitionType).
+		AddField("partition-uuid", status.PartitionUUID).
 		Metricf("DiskMetric status create")
 }
 
@@ -111,6 +120,9 @@ func (status DiskMetric) LogModify(logBase *base.LogObject, old interface{}) {
 		AddField("old-userbytes-int64", status.UsedBytes).
 		AddField("old-freebytes-int64", status.FreeBytes).
 		AddField("isdor", status.IsDir).
+		AddField("partition-label", status.PartitionLabel).
+		AddField("partition-type", status.PartitionType).
+		AddField("partition-uuid", status.PartitionUUID).
 		Metricf("DiskMetric status modify")
 }
 

--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -161,23 +161,26 @@ func createOrUpdateDiskMetrics(ctx *volumemgrContext, wdName string) {
 	disks := diskmetrics.FindDisksPartitions(log)
 	for _, d := range disks {
 		ctx.ps.StillRunning(wdName, warningTime, errorTime)
-		size, _ := diskmetrics.PartitionSize(log, d)
-		log.Tracef("createOrUpdateDiskMetrics: Disk/partition %s size %d", d, size)
+		size, _ := diskmetrics.PartitionSize(log, d.Name)
+		log.Tracef("createOrUpdateDiskMetrics: Disk/partition %s size %d", d.Name, size)
 		var metric *types.DiskMetric
-		metric = lookupDiskMetric(ctx, d)
+		metric = lookupDiskMetric(ctx, d.Name)
 		if metric == nil {
-			log.Functionf("createOrUpdateDiskMetrics: creating new DiskMetric for %s", d)
-			metric = &(types.DiskMetric{DiskPath: d, IsDir: false})
+			log.Functionf("createOrUpdateDiskMetrics: creating new DiskMetric for %s", d.Name)
+			metric = &(types.DiskMetric{DiskPath: d.Name, IsDir: false})
 		} else {
-			log.Functionf("createOrUpdateDiskMetrics: updating DiskMetric for %s", d)
+			log.Functionf("createOrUpdateDiskMetrics: updating DiskMetric for %s", d.Name)
 		}
 		metric.TotalBytes = size
-		stat, err := disk.IOCounters(d)
+		metric.PartitionLabel = d.PartitionLabel
+		metric.PartitionType = d.PartitionType
+		metric.PartitionUUID = d.PartitionUUID
+		stat, err := disk.IOCounters(d.Name)
 		if err == nil {
-			metric.ReadBytes = stat[d].ReadBytes
-			metric.WriteBytes = stat[d].WriteBytes
-			metric.ReadCount = stat[d].ReadCount
-			metric.WriteCount = stat[d].WriteCount
+			metric.ReadBytes = stat[d.Name].ReadBytes
+			metric.WriteBytes = stat[d.Name].WriteBytes
+			metric.ReadCount = stat[d.Name].ReadCount
+			metric.WriteCount = stat[d.Name].WriteCount
 		}
 		// XXX do we have a mountpath? Combine with paths below if same?
 		diskMetricList = append(diskMetricList, metric)

--- a/pkg/pillar/cmd/zedagent/reportinfo.go
+++ b/pkg/pillar/cmd/zedagent/reportinfo.go
@@ -262,9 +262,12 @@ func PublishDeviceInfoToZedCloud(ctx *zedagentContext, dest destinationBitset) {
 			diskPath = diskMetric.DiskPath
 		}
 		is := info.ZInfoStorage{
-			Device:    diskPath,
-			MountPath: mountPath,
-			Total:     utils.RoundToMbytes(diskMetric.TotalBytes),
+			Device:            diskPath,
+			MountPath:         mountPath,
+			Total:             utils.RoundToMbytes(diskMetric.TotalBytes),
+			PartitionLabel:    diskMetric.PartitionLabel,
+			PartitionTypeGuid: diskMetric.PartitionType,
+			PartitionUuid:     diskMetric.PartitionUUID,
 		}
 		if diskMetric.DiskPath == types.PersistDir {
 			is.StorageLocation = true

--- a/pkg/pillar/diskmetrics/usage.go
+++ b/pkg/pillar/diskmetrics/usage.go
@@ -205,6 +205,19 @@ func FindDisksPartitions(log *base.LogObject) []DiskPartition {
 		log.Errorf("lsblk -J -l -o NAME,PARTLABEL,PARTTYPE,PARTUUID failed: %s", err)
 		return nil
 	}
+	parts, err := parseLsblkPartitions(out)
+	if err != nil {
+		log.Errorf("lsblk JSON decode failed: %s", err)
+		return nil
+	}
+	return parts
+}
+
+// parseLsblkPartitions decodes the JSON produced by
+// `lsblk -J -l -o NAME,PARTLABEL,PARTTYPE,PARTUUID` into DiskPartition
+// records. Split out from FindDisksPartitions so the parsing can be
+// unit-tested without shelling out to lsblk.
+func parseLsblkPartitions(out []byte) ([]DiskPartition, error) {
 	var parsed struct {
 		BlockDevices []struct {
 			Name      string `json:"name"`
@@ -214,8 +227,7 @@ func FindDisksPartitions(log *base.LogObject) []DiskPartition {
 		} `json:"blockdevices"`
 	}
 	if err := json.Unmarshal(out, &parsed); err != nil {
-		log.Errorf("lsblk JSON decode failed: %s", err)
-		return nil
+		return nil, err
 	}
 	result := make([]DiskPartition, 0, len(parsed.BlockDevices))
 	for _, e := range parsed.BlockDevices {
@@ -226,7 +238,7 @@ func FindDisksPartitions(log *base.LogObject) []DiskPartition {
 			PartitionUUID:  e.PartUUID,
 		})
 	}
-	return result
+	return result, nil
 }
 
 // FindLargestDisk determines the name of the largest disk

--- a/pkg/pillar/diskmetrics/usage.go
+++ b/pkg/pillar/diskmetrics/usage.go
@@ -7,6 +7,7 @@ package diskmetrics
 import "C"
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -185,18 +186,47 @@ func diskType(log *base.LogObject, part string) string {
 	return strings.TrimSpace(string(out))
 }
 
-// FindDisksPartitions returns the names of all disks and all partitions
-// Return an array of names like "sda", "sdb1"
-func FindDisksPartitions(log *base.LogObject) []string {
-	out, err := base.Exec(log, "lsblk", "-nlo", "NAME").Output()
+// DiskPartition is a block device or partition discovered by lsblk,
+// optionally enriched with GPT identity fields.
+type DiskPartition struct {
+	Name           string // E.g., "sda3"
+	PartitionLabel string // GPT PARTLABEL; "" for non-GPT
+	PartitionType  string // GPT partition type GUID; "" for non-GPT
+	PartitionUUID  string // GPT PARTUUID; "" for non-GPT
+}
+
+// FindDisksPartitions returns every block device and partition the kernel
+// exposes, enriched with GPT identity when available. Whole-disk entries
+// and partitions on non-GPT disks leave the partition* fields empty.
+func FindDisksPartitions(log *base.LogObject) []DiskPartition {
+	out, err := base.Exec(log, "lsblk", "-J", "-l",
+		"-o", "NAME,PARTLABEL,PARTTYPE,PARTUUID").Output()
 	if err != nil {
-		log.Errorf("lsblk -nlo NAME failed %s", err)
+		log.Errorf("lsblk -J -l -o NAME,PARTLABEL,PARTTYPE,PARTUUID failed: %s", err)
 		return nil
 	}
-	res := strings.Split(string(out), "\n")
-	// Remove blank/empty string after last CR
-	res = res[:len(res)-1]
-	return res
+	var parsed struct {
+		BlockDevices []struct {
+			Name      string `json:"name"`
+			PartLabel string `json:"partlabel"`
+			PartType  string `json:"parttype"`
+			PartUUID  string `json:"partuuid"`
+		} `json:"blockdevices"`
+	}
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		log.Errorf("lsblk JSON decode failed: %s", err)
+		return nil
+	}
+	result := make([]DiskPartition, 0, len(parsed.BlockDevices))
+	for _, e := range parsed.BlockDevices {
+		result = append(result, DiskPartition{
+			Name:           e.Name,
+			PartitionLabel: e.PartLabel,
+			PartitionType:  e.PartType,
+			PartitionUUID:  e.PartUUID,
+		})
+	}
+	return result
 }
 
 // FindLargestDisk determines the name of the largest disk
@@ -208,13 +238,13 @@ func FindLargestDisk(log *base.LogObject) string {
 	var maxdisk string
 	disksAndPartitions := FindDisksPartitions(log)
 	for _, part := range disksAndPartitions {
-		if !strings.EqualFold(diskType(log, part), "disk") {
+		if !strings.EqualFold(diskType(log, part.Name), "disk") {
 			continue
 		}
-		size, _ := PartitionSize(log, part)
+		size, _ := PartitionSize(log, part.Name)
 		if size > maxsize {
 			maxsize = size
-			maxdisk = part
+			maxdisk = part.Name
 		}
 	}
 	return maxdisk

--- a/pkg/pillar/diskmetrics/usage_test.go
+++ b/pkg/pillar/diskmetrics/usage_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -241,6 +242,89 @@ func TestDom0DiskReservedSizeNewlogTerm(t *testing.T) {
 			if got != tc.want {
 				t.Errorf("newlog reserve on %d bytes of /persist with a %d MByte quota = %d, want %d",
 					tc.deviceDiskSize, tc.quotaMBytes, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseLsblkPartitions(t *testing.T) {
+	const linuxFSGUID = "0fc63daf-8483-4772-8e79-3d69d8477de4"
+	const efiGUID = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
+
+	tests := []struct {
+		name    string
+		input   string
+		want    []DiskPartition
+		wantErr bool
+	}{
+		{
+			name: "EVE GPT layout",
+			input: `{
+              "blockdevices": [
+                {"name":"sda","partlabel":null,"parttype":null,"partuuid":null},
+                {"name":"sda1","partlabel":"EFI System","parttype":"` + efiGUID + `","partuuid":"11111111-1111-1111-1111-111111111111"},
+                {"name":"sda2","partlabel":"CONFIG","parttype":"` + linuxFSGUID + `","partuuid":"22222222-2222-2222-2222-222222222222"},
+                {"name":"sda3","partlabel":"IMGA","parttype":"` + linuxFSGUID + `","partuuid":"33333333-3333-3333-3333-333333333333"},
+                {"name":"sda4","partlabel":"IMGB","parttype":"` + linuxFSGUID + `","partuuid":"44444444-4444-4444-4444-444444444444"},
+                {"name":"sda9","partlabel":"P3","parttype":"` + linuxFSGUID + `","partuuid":"99999999-9999-9999-9999-999999999999"}
+              ]
+            }`,
+			want: []DiskPartition{
+				{Name: "sda"},
+				{Name: "sda1", PartitionLabel: "EFI System", PartitionType: efiGUID, PartitionUUID: "11111111-1111-1111-1111-111111111111"},
+				{Name: "sda2", PartitionLabel: "CONFIG", PartitionType: linuxFSGUID, PartitionUUID: "22222222-2222-2222-2222-222222222222"},
+				{Name: "sda3", PartitionLabel: "IMGA", PartitionType: linuxFSGUID, PartitionUUID: "33333333-3333-3333-3333-333333333333"},
+				{Name: "sda4", PartitionLabel: "IMGB", PartitionType: linuxFSGUID, PartitionUUID: "44444444-4444-4444-4444-444444444444"},
+				{Name: "sda9", PartitionLabel: "P3", PartitionType: linuxFSGUID, PartitionUUID: "99999999-9999-9999-9999-999999999999"},
+			},
+		},
+		{
+			name: "MBR partitions leave PARTLABEL and PARTUUID empty",
+			input: `{
+              "blockdevices": [
+                {"name":"sdb","partlabel":null,"parttype":null,"partuuid":null},
+                {"name":"sdb1","partlabel":null,"parttype":"0x83","partuuid":null},
+                {"name":"sdb2","partlabel":null,"parttype":"0x82","partuuid":null}
+              ]
+            }`,
+			want: []DiskPartition{
+				{Name: "sdb"},
+				{Name: "sdb1", PartitionType: "0x83"},
+				{Name: "sdb2", PartitionType: "0x82"},
+			},
+		},
+		{
+			name:  "empty blockdevices list",
+			input: `{"blockdevices":[]}`,
+			want:  []DiskPartition{},
+		},
+		{
+			name:    "malformed JSON",
+			input:   `{"blockdevices":`,
+			wantErr: true,
+		},
+		{
+			name:    "empty input",
+			input:   ``,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseLsblkPartitions([]byte(tc.input))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil; result=%+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("parseLsblkPartitions mismatch\n got: %+v\nwant: %+v", got, tc.want)
+
 			}
 		})
 	}

--- a/pkg/pillar/types/diskmetrics.go
+++ b/pkg/pillar/types/diskmetrics.go
@@ -70,6 +70,12 @@ type DiskMetric struct {
 	UsedBytes  uint64 // Value in Bytes. Total number of used Bytes by the disk.
 	FreeBytes  uint64 // Value in Bytes. Total number of free Bytes for the disk.
 	IsDir      bool   // Will be true if DiskPath is a mountPath, will false if it's a disk.
+
+	// GPT identity for block partitions. Empty when IsDir is true,
+	// for whole-disk entries, and for partitions on non-GPT disks.
+	PartitionLabel string // GPT PARTLABEL
+	PartitionType  string // GPT partition type GUID
+	PartitionUUID  string // GPT PARTUUID
 }
 
 // Key returns the pubsub Key.
@@ -92,6 +98,9 @@ func (status DiskMetric) LogCreate(logBase *base.LogObject) {
 		AddField("userbytes-int64", status.UsedBytes).
 		AddField("freebytes-int64", status.FreeBytes).
 		AddField("isdor", status.IsDir).
+		AddField("partition-label", status.PartitionLabel).
+		AddField("partition-type", status.PartitionType).
+		AddField("partition-uuid", status.PartitionUUID).
 		Metricf("DiskMetric status create")
 }
 
@@ -111,6 +120,9 @@ func (status DiskMetric) LogModify(logBase *base.LogObject, old interface{}) {
 		AddField("old-userbytes-int64", status.UsedBytes).
 		AddField("old-freebytes-int64", status.FreeBytes).
 		AddField("isdor", status.IsDir).
+		AddField("partition-label", status.PartitionLabel).
+		AddField("partition-type", status.PartitionType).
+		AddField("partition-uuid", status.PartitionUUID).
 		Metricf("DiskMetric status modify")
 }
 

--- a/pkg/vtpm/swtpm-vtpm/vendor/github.com/lf-edge/eve/pkg/pillar/types/diskmetrics.go
+++ b/pkg/vtpm/swtpm-vtpm/vendor/github.com/lf-edge/eve/pkg/pillar/types/diskmetrics.go
@@ -70,6 +70,12 @@ type DiskMetric struct {
 	UsedBytes  uint64 // Value in Bytes. Total number of used Bytes by the disk.
 	FreeBytes  uint64 // Value in Bytes. Total number of free Bytes for the disk.
 	IsDir      bool   // Will be true if DiskPath is a mountPath, will false if it's a disk.
+
+	// GPT identity for block partitions. Empty when IsDir is true,
+	// for whole-disk entries, and for partitions on non-GPT disks.
+	PartitionLabel string // GPT PARTLABEL
+	PartitionType  string // GPT partition type GUID
+	PartitionUUID  string // GPT PARTUUID
 }
 
 // Key returns the pubsub Key.
@@ -92,6 +98,9 @@ func (status DiskMetric) LogCreate(logBase *base.LogObject) {
 		AddField("userbytes-int64", status.UsedBytes).
 		AddField("freebytes-int64", status.FreeBytes).
 		AddField("isdor", status.IsDir).
+		AddField("partition-label", status.PartitionLabel).
+		AddField("partition-type", status.PartitionType).
+		AddField("partition-uuid", status.PartitionUUID).
 		Metricf("DiskMetric status create")
 }
 
@@ -111,6 +120,9 @@ func (status DiskMetric) LogModify(logBase *base.LogObject, old interface{}) {
 		AddField("old-userbytes-int64", status.UsedBytes).
 		AddField("old-freebytes-int64", status.FreeBytes).
 		AddField("isdor", status.IsDir).
+		AddField("partition-label", status.PartitionLabel).
+		AddField("partition-type", status.PartitionType).
+		AddField("partition-uuid", status.PartitionUUID).
 		Metricf("DiskMetric status modify")
 }
 

--- a/pkg/wwan/mmagent/vendor/github.com/lf-edge/eve/pkg/pillar/types/diskmetrics.go
+++ b/pkg/wwan/mmagent/vendor/github.com/lf-edge/eve/pkg/pillar/types/diskmetrics.go
@@ -70,6 +70,12 @@ type DiskMetric struct {
 	UsedBytes  uint64 // Value in Bytes. Total number of used Bytes by the disk.
 	FreeBytes  uint64 // Value in Bytes. Total number of free Bytes for the disk.
 	IsDir      bool   // Will be true if DiskPath is a mountPath, will false if it's a disk.
+
+	// GPT identity for block partitions. Empty when IsDir is true,
+	// for whole-disk entries, and for partitions on non-GPT disks.
+	PartitionLabel string // GPT PARTLABEL
+	PartitionType  string // GPT partition type GUID
+	PartitionUUID  string // GPT PARTUUID
 }
 
 // Key returns the pubsub Key.
@@ -92,6 +98,9 @@ func (status DiskMetric) LogCreate(logBase *base.LogObject) {
 		AddField("userbytes-int64", status.UsedBytes).
 		AddField("freebytes-int64", status.FreeBytes).
 		AddField("isdor", status.IsDir).
+		AddField("partition-label", status.PartitionLabel).
+		AddField("partition-type", status.PartitionType).
+		AddField("partition-uuid", status.PartitionUUID).
 		Metricf("DiskMetric status create")
 }
 
@@ -111,6 +120,9 @@ func (status DiskMetric) LogModify(logBase *base.LogObject, old interface{}) {
 		AddField("old-userbytes-int64", status.UsedBytes).
 		AddField("old-freebytes-int64", status.FreeBytes).
 		AddField("isdor", status.IsDir).
+		AddField("partition-label", status.PartitionLabel).
+		AddField("partition-type", status.PartitionType).
+		AddField("partition-uuid", status.PartitionUUID).
 		Metricf("DiskMetric status modify")
 }
 


### PR DESCRIPTION
# Description

Backport of #5976 to `16.0-stable`.

This changes zedagent's storage reporting so it also reports the size of the
EFI system partition and the IMGx partitions, in addition to the volumes, so
the controller has the full picture of on-disk partition usage.

Commits picked with `-x`:
- `96f23b673` zedagent: report size of EFI and IMGx partitions
- `36a21f39d` diskmetrics: unit-test lsblk output parsing

Adaptations vs the source PR:
- None on the pillar source beyond what commits carry; `reportinfo.go` keeps
  the branch's `utils.RoundToMbytes` idiom (master uses `base.RoundToMbytes`
  there), adding only the three partition fields.
- `pkg/pillar/vendor/.../types/diskmetrics.go` re-vendored in edgeview,
  newlog, vtpm/swtpm-vtpm, and wwan/mmagent with the new GPT identity fields
  (additive).
- 16.0 already pins a sufficiently new eve-api; no API bump needed (unlike the
  14.5/13.4 backports).

## PR dependencies

None. This is a pure backport.

## How to test and validate this PR

The diskmetrics change is covered by an added unit test
(`TestParseLsblkPartitions`) added in `36a21f39d`.

Build and unit-test verification performed on this branch:
- `go build ./...` and `go vet ./...` in `pkg/pillar` exit 0
- `go test ./diskmetrics/...` passes
- `gofmt -l` clean on touched dirs
- `make check-docker-hashes-consistency` exits 0

## Changelog notes

zedagent now reports the sizes of the EFI and IMGx partitions together with
storage volumes.

## PR Backports

This PR is itself a backport of #5976.

- 16.0-stable: This PR.
- 14.5-stable: Backport PR #6430.
- 13.4-stable: Backport PR #6431.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs:

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
