### PR TITLE
Allow I/O adapter change with restart

### DIFF
--- a/docs/APP-CONNECTIVITY.md
+++ b/docs/APP-CONNECTIVITY.md
@@ -78,6 +78,18 @@ to application domains:
 * [Xen PCI Passthrough](https://wiki.xenproject.org/wiki/Xen_PCI_Passthrough) for Xen
 * [QEMU/VFIO Passthrough](https://wiki.archlinux.org/index.php/PCI_passthrough_via_OVMF) for KVM
 
+Directly assigned network adapters can be added to, removed from, and moved between applications
+without purging them: EVE stages such a configuration change and applies it on the application's
+next restart (see [zedmanager.md](../pkg/pillar/docs/zedmanager.md) for details; the same applies
+to directly assigned I/O adapters of any type).
+
+Note that whenever a directly assigned device changes hands between applications, no matter
+whether the reassignment happens with a purge or just a restart, the new application receives the
+device in whatever state the previous guest driver left it.
+If the previous VM did not bring the device into a good state when shutting down (e.g. it crashed
+or was forcibly stopped, incomplete driver), the receiving application may run into problems with
+the device, such as driver initialization failures or device malfunction.
+
 ### SR-IOV VFs
 
 SR-IOV NIC VFs (virtual functions) combine the resource-sharing advantages of virtual interfaces

--- a/evetest/devconfig.go
+++ b/evetest/devconfig.go
@@ -967,10 +967,14 @@ func (config ApplicationInstanceConfig) toProto(th *TestHarness, devName string,
 	for i, netAdapter := range config.NetworkAdapters {
 		switch adapter := netAdapter.(type) {
 		case DirectlyAssignedNetworkAdapter:
+			interfaceOrder := uint32(i)
+			if adapter.InterfaceOrder != nil {
+				interfaceOrder = *adapter.InterfaceOrder
+			}
 			appInstConfig.Adapters = append(appInstConfig.Adapters, &eveconfig.Adapter{
 				Type:           evecommon.PhyIoType_PhyIoNetEth,
 				Name:           adapter.LogicalLabel,
-				InterfaceOrder: uint32(i),
+				InterfaceOrder: interfaceOrder,
 			})
 		case VirtualNetworkAdapter:
 			var ipAddr string
@@ -1391,7 +1395,8 @@ type AppNetworkAdapter interface {
 // DirectlyAssignedNetworkAdapter represents network adapter directly assigned
 // to an application (e.g. using PCI passthrough).
 type DirectlyAssignedNetworkAdapter struct {
-	LogicalLabel string
+	LogicalLabel   string
+	InterfaceOrder *uint32
 }
 
 func (DirectlyAssignedNetworkAdapter) isAppNetworkAdapter() {}

--- a/evetest/tests/networking/passthrough_test.go
+++ b/evetest/tests/networking/passthrough_test.go
@@ -179,6 +179,11 @@ func TestNetworkAdapterPassthrough(test *testing.T) {
 		},
 		Gateway: evetest.IPAddress("10.11.12.1"),
 	})
+	// Explicit interface order for the passthrough NIC: it must be unique
+	// among all network adapters of the app (EnforceNetIntfOrder), and the
+	// test later inserts virtual NICs with orders 1-3, so the passthrough
+	// NIC is placed at the end.
+	orderEthernet1 := uint32(4)
 	appConfig := evetest.ApplicationInstanceConfig{
 		DisplayName: "passthrough-app",
 		Activate:    true,
@@ -209,7 +214,8 @@ func TestNetworkAdapterPassthrough(test *testing.T) {
 				},
 			},
 			evetest.DirectlyAssignedNetworkAdapter{
-				LogicalLabel: "ethernet1",
+				LogicalLabel:   "ethernet1",
+				InterfaceOrder: &orderEthernet1,
 			},
 		},
 		EnforceNetIntfOrder: true,
@@ -387,7 +393,8 @@ func TestNetworkAdapterPassthrough(test *testing.T) {
 		t.Expect(stdout).To(ContainSubstring("00:09:5b:45:af:d3"))
 	}, timeout, polling).Should(Succeed())
 
-	ensureNetworkOrder(t, device, appUUID, []string{"vif0", "newvif1", "newvif2", "newvif3"})
+	ensureNetworkOrder(t, device, appUUID,
+		[]string{"vif0", "newvif1", "newvif2", "newvif3", "ethernet1"})
 }
 
 // lookupAssignableAdapter returns the ZioBundle with the given name from the
@@ -399,4 +406,183 @@ func lookupAssignableAdapter(dinfo *eveinfo.ZInfoDevice, name string) *eveinfo.Z
 		}
 	}
 	return nil
+}
+
+func TestNetworkAdapterPassthroughChange(test *testing.T) {
+	evetestT := evetest.Init(test)
+	log := evetest.Logger()
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	evetest.DefineTestParameters(evetest.HypervisorParameter())
+	hypervisor := evetest.GetHypervisorParameterValue()
+
+	devName := "edge-dev"
+	evetest.Setup(
+		evetest.RequireEdgeDevice{
+			Name:              devName,
+			WithHypervisor:    hypervisor,
+			DeviceReusePolicy: evetest.ResetDeviceConfig,
+		},
+		evetest.RequireNetworkModel{
+			NetworkModel: netmodels.TwoMgmtPorts,
+		})
+	device := evetest.GetEdgeDevice(devName)
+	evetest.Checkpoint("setup-done")
+
+	const (
+		timeout    = 5 * time.Minute
+		sshTimeout = 20 * time.Second
+		polling    = 3 * time.Second
+	)
+
+	// eth0 is the management port; eth1 is reserved for passthrough
+	// (dedicated usage, hence no network and no SystemAdapter).
+	devConfig := evetest.NewEdgeDeviceConfig(devName)
+	dhcpNet := devConfig.AddNetwork(evetest.DHCPNetworkConfig{
+		NetworkType: evecommon.NetworkType_V4Only,
+	})
+	devConfig.AddNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  "ethernet0",
+		PhysicalLabel: "eth0",
+		InterfaceName: "eth0",
+		NetworkUUID:   dhcpNet,
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+		SharedLabels:  []string{"newni0"},
+	})
+	devConfig.AddNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  "ethernet1",
+		PhysicalLabel: "eth1",
+		InterfaceName: "eth1",
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageDedicated,
+	})
+
+	device.ApplyConfig(devConfig, true, true)
+
+	niUUID := devConfig.AddNetworkInstance(evetest.LocalNetworkInstanceConfig{
+		DisplayName: "local-ni",
+		Port:        "ethernet0",
+		Subnet:      evetest.IPSubnet("10.11.12.0/24"),
+		DHCPRange: types.IPRange{
+			Start: evetest.IPAddress("10.11.12.2"),
+			End:   evetest.IPAddress("10.11.12.254"),
+		},
+		Gateway: evetest.IPAddress("10.11.12.1"),
+	})
+
+	one := uint32(1)
+	two := uint32(2)
+	virtualNetAdapter := evetest.VirtualNetworkAdapter{
+		LogicalLabel:        "vif0",
+		NetworkInstanceUUID: niUUID,
+		MAC:                 evetest.MACAddress("02:16:3e:00:00:01"),
+		PortFwdRules: []evetest.PortFwdRule{
+			{
+				Protocol:     evetest.NetworkProtocolTCP,
+				EdgeNodePort: 2222,
+				AppPort:      22,
+			},
+		},
+		ACLAllowRules: []evetest.ACLAllowRule{
+			{
+				Protocol:     evetest.NetworkProtocolAny,
+				RemoteSubnet: evetest.IPSubnet("0.0.0.0/0"),
+			},
+		},
+		InterfaceOrder: &one,
+	}
+	directNetAdapter := evetest.DirectlyAssignedNetworkAdapter{
+		LogicalLabel:   "ethernet1",
+		InterfaceOrder: &two,
+	}
+
+	appConfig := evetest.ApplicationInstanceConfig{
+		DisplayName: "passthrough-app",
+		Activate:    true,
+		Image: evetest.DockerContainer{
+			ImageName: "lfedge/evetest-ubuntu-ctr",
+			Tag:       "1.0",
+		},
+		VirtualizationMode: eveconfig.VmMode_HVM,
+		CPUs:               1,
+		MemoryBytes:        500 * evetest.MiB,
+		NetworkAdapters: []evetest.AppNetworkAdapter{
+			virtualNetAdapter,
+		},
+		EnforceNetIntfOrder: true,
+	}
+
+	appUUID := devConfig.AddApplication(appConfig)
+	device.ApplyConfig(devConfig, true, true)
+	device.WaitUntilAppIsRunning(appUUID, timeout)
+
+	appAuth := evetest.UsernamePasswordAuth{
+		Username: "root",
+		Password: "testpassword",
+	}
+
+	t.Eventually(func(t Gomega) {
+		log.Infof("Writing something to the disk to ensure it is not purged")
+		_, stderrOutput, err := device.RunShellScriptInsideApp(appUUID, appAuth,
+			"echo -n foo > ~/foo.txt", sshTimeout, 0)
+		t.Expect(err).ToNot(HaveOccurred())
+		t.Expect(stderrOutput).To(BeEmpty())
+	}, timeout, polling).Should(Succeed())
+
+	t.Eventually(func(t Gomega) {
+		stdout, _, err := device.RunShellScriptInsideApp(appUUID, appAuth,
+			"ip a", sshTimeout, 0)
+		t.Expect(err).ToNot(HaveOccurred())
+		log.Infof("before stdout: %s\n\n\n", stdout)
+	}, timeout, polling).Should(Succeed())
+
+	t.Eventually(func(t Gomega) {
+		stdout, _, err := device.RunShellScript(`lspci -k -d 1af4:*`, time.Minute, 0)
+		t.Expect(err).ToNot(HaveOccurred())
+		t.Expect(stdout).To(ContainSubstring("vfio-pci"))
+	}, timeout, polling).Should(Succeed())
+
+	ensureNetworkOrder(t, device, appUUID, []string{"vif0"})
+
+	appConfig.NetworkAdapters = append(appConfig.NetworkAdapters, directNetAdapter)
+
+	devConfig.UpdateApplication(appUUID, appConfig)
+	device.ApplyConfig(devConfig, true, true)
+	device.WaitUntilAppIsRunning(appUUID, timeout)
+
+	t.Eventually(func(t Gomega) {
+		stdout, _, err := device.RunShellScriptInsideApp(appUUID, appAuth,
+			"ip a", sshTimeout, 0)
+		t.Expect(err).ToNot(HaveOccurred())
+		log.Infof("after stdout: %s\n\n\n", stdout)
+	}, timeout, polling).Should(Succeed())
+
+	ensureNetworkOrder(t, device, appUUID, []string{"vif0", "ethernet1"})
+
+	// Reverse the order of the network adapters
+	directNetAdapter.InterfaceOrder = &one
+	virtualNetAdapter.InterfaceOrder = &two
+	appConfig.NetworkAdapters = []evetest.AppNetworkAdapter{
+		directNetAdapter, virtualNetAdapter,
+	}
+	devConfig.UpdateApplication(appUUID, appConfig)
+	device.ApplyConfig(devConfig, true, true)
+	device.WaitUntilAppIsRunning(appUUID, timeout)
+	t.Eventually(func(t Gomega) {
+		stdout, _, err := device.RunShellScriptInsideApp(appUUID, appAuth,
+			"ip a", sshTimeout, 0)
+		t.Expect(err).ToNot(HaveOccurred())
+		log.Infof("after reverse stdout: %s\n\n\n", stdout)
+	}, timeout, polling).Should(Succeed())
+	ensureNetworkOrder(t, device, appUUID, []string{"ethernet1", "vif0"})
+
+	t.Eventually(func(t Gomega) {
+		log.Infof("Reading from disk to check it has not been purged")
+		stdoutOutput, stderrOutput, err := device.RunShellScriptInsideApp(appUUID, appAuth,
+			"cat ~/foo.txt", sshTimeout, 0)
+		t.Expect(stderrOutput).To(BeEmpty())
+		t.Expect(stdoutOutput).To(BeEquivalentTo("foo"))
+		t.Expect(err).ToNot(HaveOccurred())
+	}, timeout, polling).Should(Succeed())
+
 }

--- a/evetest/tests/networking/testsuite_test.go
+++ b/evetest/tests/networking/testsuite_test.go
@@ -418,6 +418,9 @@ func TestApplicationConnectivitySuite(test *testing.T) {
 			Test: TestNetworkAdapterPassthrough,
 		},
 		evetest.TestCase{
+			Test: TestNetworkAdapterPassthroughChange,
+		},
+		evetest.TestCase{
 			Test: TestStagedNICChange,
 		},
 		evetest.TestCase{

--- a/pkg/pillar/cmd/zedagent/handlemetrics.go
+++ b/pkg/pillar/cmd/zedagent/handlemetrics.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -707,14 +708,21 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 			ReportAppMetric.Memory.AvailPercentage = availableMemoryPercent
 		}
 
-		appInterfaceList := aiStatus.GetAppInterfaceList()
-		log.Tracef("ReportMetrics: domainName %s ifs %v",
-			aiStatus.DomainName, appInterfaceList)
-		// Use the network metrics from zedrouter subscription
-		for _, ifName := range appInterfaceList {
+		// Use the network metrics from zedrouter subscription. Directly
+		// assigned network adapters are reported too, in their interface
+		// order position, but with zero counters -- the guest owns the NIC,
+		// so EVE cannot observe its traffic.
+		for _, entry := range orderedAppNetworkEntries(&aiStatus) {
+			networkDetails := new(metrics.NetworkMetric)
+			networkDetails.IName = entry.name
+			if entry.vifName == "" {
+				ReportAppMetric.Network = append(ReportAppMetric.Network,
+					networkDetails)
+				continue
+			}
 			var metric *types.NetworkMetric
 			for _, m := range networkMetrics.MetricList {
-				if ifName == m.IfName {
+				if entry.vifName == m.IfName {
 					metric = &m
 					break
 				}
@@ -722,17 +730,14 @@ func publishMetrics(ctx *zedagentContext, iteration int) {
 			if metric == nil {
 				continue
 			}
-			networkDetails := new(metrics.NetworkMetric)
-			name := appIfnameToName(&aiStatus, metric.IfName)
 			log.Tracef("app %s/%s localname %s name %s",
 				aiStatus.Key(), aiStatus.DisplayName,
-				metric.IfName, name)
-			networkDetails.IName = name
+				metric.IfName, entry.name)
 			networkDetails.LocalName = metric.IfName
 			// Counters not swapped on vif
-			if strings.HasPrefix(ifName, "nbn") ||
-				strings.HasPrefix(ifName, "nbu") ||
-				strings.HasPrefix(ifName, "nbo") {
+			if strings.HasPrefix(entry.vifName, "nbn") ||
+				strings.HasPrefix(entry.vifName, "nbu") ||
+				strings.HasPrefix(entry.vifName, "nbo") {
 				networkDetails.TxPkts = metric.TxPkts
 				networkDetails.RxPkts = metric.RxPkts
 				networkDetails.TxBytes = metric.TxBytes
@@ -1203,17 +1208,33 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 			ReportAppInfo.AssignedAdapters = append(ReportAppInfo.AssignedAdapters,
 				reportAA)
 		}
-		// Get vifs assigned to the application
-		// Mostly reporting the UP status
-		// We extract the appIP from the dnsmasq assignment
-		ifNames := (*aiStatus).GetAppInterfaceList()
-		log.Tracef("ReportAppInfo: domainName %s ifs %v",
-			aiStatus.DomainName, ifNames)
-		for _, ifname := range ifNames {
+		// Report the app's network adapters in their interface order --
+		// virtual ones (with the addresses extracted from the dnsmasq
+		// assignment) and directly assigned network adapters (identity
+		// only: the guest owns the NIC, so its addresses are not known
+		// here).
+		for _, entry := range orderedAppNetworkEntries(aiStatus) {
 			networkInfo := new(info.ZInfoNetwork)
-			networkInfo.LocalName = *proto.String(ifname)
+			networkInfo.DevName = *proto.String(entry.name)
+			if entry.vifName == "" {
+				for _, ib := range aa.LookupIoBundleAny(entry.name) {
+					if ib == nil {
+						continue
+					}
+					if networkInfo.LocalName == "" {
+						networkInfo.LocalName = *proto.String(ib.Ifname)
+					}
+					if networkInfo.MacAddr == "" {
+						networkInfo.MacAddr = *proto.String(ib.MacAddr)
+					}
+				}
+				ReportAppInfo.Network = append(ReportAppInfo.Network,
+					networkInfo)
+				continue
+			}
+			networkInfo.LocalName = *proto.String(entry.vifName)
 			addrs, hasIPv4Addr, macAddr, ipAddrMismatch :=
-				getAppIPs(ctx, aiStatus, ifname)
+				getAppIPs(ctx, aiStatus, entry.vifName)
 			for _, ipv4Addr := range addrs.IPv4Addrs {
 				networkInfo.IPAddrs = append(networkInfo.IPAddrs,
 					ipv4Addr.Address.String())
@@ -1225,12 +1246,10 @@ func PublishAppInfoToZedCloud(ctx *zedagentContext, uuid string,
 			networkInfo.MacAddr = *proto.String(macAddr.String())
 			networkInfo.Ipv4Up = hasIPv4Addr
 			networkInfo.IpAddrMisMatch = ipAddrMismatch
-			name := appIfnameToName(aiStatus, ifname)
 			log.Tracef("app %s/%s localName %s devName %s",
 				aiStatus.Key(), aiStatus.DisplayName,
-				ifname, name)
-			networkInfo.DevName = *proto.String(name)
-			niStatus := appIfnameToNetworkInstance(ctx, aiStatus, ifname)
+				entry.vifName, entry.name)
+			niStatus := appIfnameToNetworkInstance(ctx, aiStatus, entry.vifName)
 			if niStatus != nil {
 				networkInfo.NtpServers = utils.ToStrings(niStatus.CombinedNTPServers)
 				networkInfo.DefaultRouters = []string{niStatus.Gateway.String()}
@@ -1542,13 +1561,49 @@ func appIfnameToNetworkInstance(ctx *zedagentContext,
 	return nil
 }
 
-func appIfnameToName(aiStatus *types.AppInstanceStatus, vifname string) string {
+// appNetworkEntry identifies one network adapter of an app instance to be
+// reported to the controller: either a virtual adapter (vifName is set) or a
+// directly assigned network adapter (vifName is empty).
+type appNetworkEntry struct {
+	name      string // adapter logical name, reported as devName/iName
+	vifName   string // host-side interface name; empty for directly assigned adapters
+	intfOrder uint32
+}
+
+// orderedAppNetworkEntries returns one entry per app network adapter --
+// virtual and directly assigned (passthrough) network adapters alike. With
+// EnforceNetworkInterfaceOrder the entries are sorted by the configured
+// interface order, mirroring the order of the NICs inside the guest;
+// otherwise the virtual adapters keep their existing order and the directly
+// assigned ones, whose order is undefined in that case, are appended at the
+// end.
+func orderedAppNetworkEntries(aiStatus *types.AppInstanceStatus) []appNetworkEntry {
+	var entries []appNetworkEntry
 	for _, adapterStatus := range aiStatus.AppNetAdapters {
-		if adapterStatus.VifUsed == vifname {
-			return adapterStatus.Name
+		if adapterStatus.VifUsed == "" {
+			continue
 		}
+		entries = append(entries, appNetworkEntry{
+			name:      adapterStatus.Name,
+			vifName:   adapterStatus.VifUsed,
+			intfOrder: adapterStatus.IntfOrder,
+		})
 	}
-	return ""
+	for _, ia := range aiStatus.IoAdapterList {
+		if !ia.Type.IsNet() {
+			continue
+		}
+		entries = append(entries, appNetworkEntry{
+			name:      ia.Name,
+			intfOrder: ia.IntfOrder,
+		})
+	}
+	if aiStatus.FixedResources.EnforceNetworkInterfaceOrder {
+		sort.SliceStable(entries, func(i, j int) bool {
+			return entries[i].intfOrder < entries[j].intfOrder
+		})
+	}
+	return entries
 }
 
 // This function is called per change, hence needs to try over all management ports

--- a/pkg/pillar/cmd/zedmanager/handledomainmgr.go
+++ b/pkg/pillar/cmd/zedmanager/handledomainmgr.go
@@ -6,6 +6,7 @@ package zedmanager
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -42,6 +43,27 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 	} else {
 		log.Functionf("Domain config add for %s", key)
 	}
+	// Stage direct-attach adapter changes while domainmgr holds adapters:
+	// keep publishing the held IoAdapterList and let the new one take effect
+	// when the domain is next created by domainmgr's doActivate, which
+	// re-runs adapter reservation and assignment.
+	// This matches the staging of virtual network adapters in
+	// MaybeAddAppNetworkConfig. Staging is keyed on domainmgr still holding
+	// adapters for this app (running, or boot-failed with the old adapters
+	// still reserved — maybeRetryBoot re-runs Setup without re-reserving, so
+	// it must keep seeing the reserved list). With no DomainStatus, or its
+	// IoAdapterList nil, nothing is held and the change applies immediately.
+	// domainmgr publishes the halt and the adapter release in one message,
+	// so the restart flush needs no RestartInprogress bookkeeping: the first
+	// status showing the domain down already carries a nil list.
+	ioAdapterList := aiConfig.IoAdapterList
+	ds := lookupDomainStatus(ctx, key)
+	if ds != nil && ds.IoAdapterList != nil &&
+		!reflect.DeepEqual(ds.IoAdapterList, aiConfig.IoAdapterList) {
+		log.Noticef("MaybeAddDomainConfig(%s): I/O adapter change staged; "+
+			"will be applied when the application is restarted", key)
+		ioAdapterList = ds.IoAdapterList
+	}
 	AppNum := 0
 	if ns != nil {
 		AppNum = ns.AppNum
@@ -61,7 +83,7 @@ func MaybeAddDomainConfig(ctx *zedmanagerContext,
 		PurgeCounter:      aiConfig.PurgeCmd.Counter + aiConfig.LocalPurgeCmd.Counter,
 		RestartCounter:    aiConfig.RestartCmd.Counter + aiConfig.LocalRestartCmd.Counter,
 		VmConfig:          aiConfig.FixedResources,
-		IoAdapterList:     aiConfig.IoAdapterList,
+		IoAdapterList:     ioAdapterList,
 		CloudInitUserData: aiConfig.CloudInitUserData,
 		CipherBlockStatus: aiConfig.CipherBlockStatus,
 		GPUConfig:         "legacy",

--- a/pkg/pillar/cmd/zedmanager/zedmanager.go
+++ b/pkg/pillar/cmd/zedmanager/zedmanager.go
@@ -1671,9 +1671,7 @@ func quantifyChanges(config types.AppInstanceConfig, oldConfig types.AppInstance
 	if !cmp.Equal(config.IoAdapterList, oldConfig.IoAdapterList) {
 		str := fmt.Sprintf("IoAdapterList changed: %v",
 			cmp.Diff(oldConfig.IoAdapterList, config.IoAdapterList))
-		log.Function(str)
-		needPurge = true
-		purgeReason += str + "\n"
+		log.Functionf("%s - will be applied on next application restart", str)
 	}
 
 	// Check if FixedResources changed

--- a/pkg/pillar/docs/zedmanager.md
+++ b/pkg/pillar/docs/zedmanager.md
@@ -38,9 +38,13 @@ zedmanager can also handle two commands; a restart and a purge command.
 
 The restart means restarting/rebooting the application instance without any changes. This is fed down to domainmgr as a Activate=false followed by Activate=true sequence of operation.
 
-The purge means replacing the first volume (the "boot disk") with a copy recreated from the immutable content. As part of that it is also possible to add and drop virtual disks, network adapters, and/or I/O adapters.
+The purge means replacing the first volume (the "boot disk") with a copy recreated from the immutable content. As part of that it is also possible to add and drop virtual disks. Network adapters and I/O adapters can also be changed as part of a purge, but no longer require one (see below).
 
 The purge orchestration takes pains to minimize the downtime for the application by creating the new volume or volumes (which might involve downloading and verifying new versions or new content) while the application is running using the old volumes. After that the application instance is halted, and the I/O and network adapters are released. Then the instance is recreated and booted using the new volumes and I/O plus networking adapters.
+
+### Changing network and I/O adapters without a purge
+
+A change to the set of virtual network adapters or to the set of directly assigned (passthrough) I/O adapters of an application instance touches no volume, so it does not need a purge. zedmanager stages such a change instead: while the application instance is running it keeps publishing the old adapter set to zedrouter and domainmgr, and the new set takes effect on the next restart of the application instance, when domainmgr re-creates the domain and re-runs I/O adapter reservation and assignment.
 
 ## Communication
 


### PR DESCRIPTION
# Description

Follow-up to #6188, which allowed changing an app's virtual network
adapters with a restart instead of a purge. This PR extends the same
treatment to directly assigned (passthrough) I/O adapters and makes them
visible in the app's controller-facing reporting:

- **zedmanager: stage I/O adapter changes until app restart** — an
  `IoAdapterList` change no longer triggers a purge of the app instance. A
  directly assigned adapter change touches no volume, so a purge is not
  needed; but it must also not be applied while the guest is running.
  zedmanager keeps publishing the old adapter list while the app is
  activated and the new one takes effect on the next restart, when
  domainmgr re-creates the domain and re-runs adapter reservation and
  assignment.
- **zedagent: report passthrough NICs in app info and metrics** — the
  per-app network lists in info and metrics messages now include directly
  assigned network adapters, not only virtual ones. With
  `EnforceNetworkInterfaceOrder` the combined list is sorted by the
  configured interface order, mirroring the NIC order inside the guest.
  Since the guest owns a passthrough NIC, EVE cannot observe it: the info
  entry carries just its identity (logical name, plus interface name and
  MAC address of the underlying I/O bundle) and the metrics entry reports
  zero counters.
- **evetest: allow setting interface order** and
  **evetest: test passthrough NIC add and reorder without purge** — evetest
  support for `InterfaceOrder` on directly assigned network adapters, a new
  `TestNetworkAdapterPassthroughChange` E2E test (attach a passthrough NIC
  to a deployed app, then swap the interface order of its adapters, and
  verify the app volume is never purged), and an extension of
  `TestNetworkAdapterPassthrough` pinning the passthrough NIC's position in
  the enforced interface order.

## How to test and validate this PR

Automated (QEMU-based evetest E2E):

```sh
make evetest NAME=TestNetworkAdapterPassthroughChange
make evetest NAME=TestNetworkAdapterPassthrough
```

`TestNetworkAdapterPassthroughChange` deploys an app with one virtual NIC,
writes a file to the app volume, attaches the dedicated `eth1` as a
passthrough NIC to the deployed app, then swaps the interface order of the
two adapters. After each step it verifies the app comes back running, the
NIC is bound to vfio-pci and owned by the guest, and info/metrics report
the adapters in the requested order; finally it checks the file still
exists, i.e. no purge happened.

Manual validation against a controller:

1. Deploy an app instance with a virtual NIC on a device that has a spare
   NIC marked for dedicated use.
2. Add the dedicated adapter to the app's configuration (without a purge
   command): the app restarts instead of being purged, the guest sees the
   NIC, and the app's volumes keep their data. The same applies to
   removing the adapter or changing the interface order.
3. The app's network info and metrics on the controller now list the
   passthrough NIC at its configured interface-order position (identity
   only, zero traffic counters).

## Changelog notes

Changing the directly assigned (passthrough) I/O adapters of an application
instance no longer purges the instance: the change is applied with an app
restart and the app's volumes are preserved. Directly assigned network
adapters are now also included in the application's network info and
metrics, in the configured interface order.

## PR Backports

- 17.0-stable: No, it builds on #6188, which was not backported.
- 16.0-stable: No, it builds on #6188, which was not backported.
- 14.5-stable: No, it builds on #6188, which was not backported.
- 13.4-stable: No, it builds on #6188, which was not backported.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I
  didn't check them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

