### PR TITLE
get-deps: assert build args linuxkit still emits

### DIFF
--- a/tools/get-deps/lktargs_test.go
+++ b/tools/get-deps/lktargs_test.go
@@ -5,30 +5,31 @@ package main
 
 import "testing"
 
+// Test_lktBuildArgs checks that pkglib's build args for a package are
+// harvested. PKG_IMAGE is asserted exactly, since it is composed from
+// build.yml's org and image keys and so pins that the right file was read;
+// PKG_HASH is content-derived and only checked for presence.
 func Test_lktBuildArgs(t *testing.T) {
 	tests := []struct {
 		name string // description of this test case
 		// Named input parameters for target function.
-		ymlPath string
-		want    map[string]struct{}
+		ymlPath   string
+		wantImage string
 	}{
 		{
-			name:    "pillar",
-			ymlPath: "../../pkg/pillar/build.yml",
-			want: map[string]struct{}{
-				"REL_HASH_LFEDGE_EVE_GRUB":                {},
-				"REL_HASH_LFEDGE_EVE_EXTERNAL_BOOT_IMAGE": {},
-			},
+			name:      "pillar",
+			ymlPath:   "../../pkg/pillar/build.yml",
+			wantImage: "lfedge/eve-pillar",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buildArgs := lktBuildArgs(tt.ymlPath)
-			for buildArg := range tt.want {
-				_, found := buildArgs[buildArg]
-				if !found {
-					t.Errorf("lktBuildArgs() = %v, want %v", buildArgs, tt.want)
-				}
+			if got := buildArgs["PKG_IMAGE"]; got != tt.wantImage {
+				t.Errorf("lktBuildArgs() PKG_IMAGE = %q, want %q", got, tt.wantImage)
+			}
+			if buildArgs["PKG_HASH"] == "" {
+				t.Errorf("lktBuildArgs() returned no PKG_HASH: %v", buildArgs)
 			}
 		})
 	}


### PR DESCRIPTION
# Description

`Test_lktBuildArgs` in `tools/get-deps` asserts that linuxkit's pkglib hands the
package two build args, `REL_HASH_LFEDGE_EVE_GRUB` and
`REL_HASH_LFEDGE_EVE_EXTERNAL_BOOT_IMAGE`. Nothing generates those any more, so
the test fails on a clean checkout of master.

They came from a pkglib feature switched on by one line in
`pkg/pillar/build.yml`:

```yaml
buildArgs:
  - REL_HASH_%=@lkt:pkgs:../*
```

`%` expanded per sibling package under `pkg/`, so linuxkit generated one
`REL_HASH_LFEDGE_EVE_*` arg per package carrying that package's pinned image
reference, and `pkg/pillar/Dockerfile` consumed them as
`FROM ${REL_HASH_LFEDGE_EVE_UEFI}` in place of hardcoded hashes. That landed in
 #5190 and was reverted by #5554 because of linuxkit/linuxkit#4180, which is
still open; #5557 carried the same revert to 16.0-stable. The revert dropped the
`build.yml` line and the Dockerfile use but left the test asserting the args, so
it has failed since. `REL_HASH` now appears nowhere else in the tree.

Rather than delete the test — `lktargs_test.go` contains nothing else, so
`lktBuildArgs` would be left with no coverage at all — this asserts what pkglib
does still provide: `PKG_IMAGE` exactly, because it is composed from
`build.yml`'s `org` and `image` keys and therefore proves the intended file was
parsed, and `PKG_HASH` for presence only, being content-derived and so not
stable to pin.

Worth knowing for review: this is developer-facing only. `make test` covers
pillar, dnstest, debug, vtpm, newlog, edgeview and kube-init, but not `tools/`,
so CI never ran this test and no CI check changes colour here. The failure bites
anyone running `go test ./...` under `tools/get-deps`.

## How to test and validate this PR

Covered by the unit test itself:

```sh
cd tools/get-deps && go test -count=1 ./...
```

- On master: `--- FAIL: Test_lktBuildArgs/pillar`, reporting the args actually
  returned (`GOPKGVERSION`, `PKG_HASH`, `PKG_IMAGE`, `REVISION`, `SOURCE`)
  against the wanted `REL_HASH_*` pair.
- With this change: `ok get-deps`.

Both new assertions were positive-controlled, so neither is vacuous:

- Expecting `lfedge/eve-WRONG` fails on the `PKG_IMAGE` line, not on a compile
  error.
- Inverting the `PKG_HASH` emptiness check fails on the `PKG_HASH` line.

`gofmt -l` is clean and `go vet ./...` passes in the module.

## Changelog notes

No user-facing changes.

## PR Backports

Not backported — this is a test-only cleanup with no runtime effect, and CI does
not run `tools/` tests on any branch, so the stale assertion costs nothing where
it sits.

- 17.0-stable: No — test-only cleanup.
- 16.0-stable: No — test-only cleanup.
- 14.5-stable: No — `tools/get-deps/lktargs_test.go` does not exist on that
  branch.
- 13.4-stable: No — same.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — n/a, no documented interface changes
- [ ] I've tested my PR on amd64 device — n/a, a build-host unit test; nothing
  ships in the image
- [ ] I've tested my PR on arm64 device — n/a, same reason
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR — n/a, no `stable` label as this
  is not backported
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them
