### PR TITLE
[17.0-stable] Fix CDI file for JP7 and udev rules for NVIDIA

### DIFF
--- a/pkg/nvidia/Dockerfile
+++ b/pkg/nvidia/Dockerfile
@@ -140,6 +140,7 @@ COPY --from=build /rootfs-dist/ /opt/vendor/nvidia/dist/
 COPY --from=build /ldconfig-bin/* /opt/vendor/nvidia/bin/
 COPY --from=build /nvfanctrl/dist/* /opt/vendor/nvidia/bin/
 COPY --from=build /nvct/dist/* /opt/vendor/nvidia/bin/
+COPY --from=build /nv-dev-nodes.sh /opt/vendor/nvidia/bin/
 COPY --from=build /nv-init.sh /opt/vendor/nvidia/init.d/
 COPY --from=build /eve-platform /opt/vendor/nvidia/
 COPY --from=build /sbom-out/lib/apk/db/installed /lib/apk/db/installed

--- a/pkg/nvidia/cdi/jp7/jetson-thor.yaml
+++ b/pkg/nvidia/cdi/jp7/jetson-thor.yaml
@@ -16,9 +16,9 @@ devices:
         - path: /dev/nvidiactl
         - path: /dev/nvmap
         - path: /dev/nvsciipc
+        - path: /dev/dri/card0
         - path: /dev/dri/card1
         - path: /dev/dri/card2
-        - path: /dev/dri/card3
         - path: /dev/dri/renderD128
         - path: /dev/dri/renderD129
         - path: /dev/dri/renderD130
@@ -1869,9 +1869,9 @@ devices:
         - path: /dev/nvidiactl
         - path: /dev/nvmap
         - path: /dev/nvsciipc
+        - path: /dev/dri/card0
         - path: /dev/dri/card1
         - path: /dev/dri/card2
-        - path: /dev/dri/card3
         - path: /dev/dri/renderD128
         - path: /dev/dri/renderD129
         - path: /dev/dri/renderD130

--- a/pkg/nvidia/scripts/nv-dev-nodes.sh
+++ b/pkg/nvidia/scripts/nv-dev-nodes.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Copyright (c) 2026 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Create NVIDIA device nodes
+case "$1" in
+nvidia_uvm)
+    major=$(awk '$2 == "nvidia-uvm" {print $1}' /proc/devices)
+    [ -n "$major" ] || exit 1
+    rm -f /dev/nvidia-uvm /dev/nvidia-uvm-tools
+    mknod -m 660 /dev/nvidia-uvm c "$major" 0
+    mknod -m 660 /dev/nvidia-uvm-tools c "$major" 1
+    ;;
+esac
+

--- a/pkg/nvidia/udev/jp5/rules.d/90-eve-nvidia.rules
+++ b/pkg/nvidia/udev/jp5/rules.d/90-eve-nvidia.rules
@@ -7,7 +7,7 @@ KERNEL=="fb", RUN+="/bin/mknod -m 660 /dev/fb1 c %M 1"
 # NVIDIA modules
 KERNEL=="nvidia", RUN+="/bin/mknod -m 660 /dev/nvidiactl c 195 255"
 KERNEL=="nvidia", RUN+="/bin/mknod -m 660 /dev/nvidia0 c 195 0"
-KERNEL=="nvidia_modeset", RUN+="/bin/mknod -m 660 /dev/nvidia-modeset c %M %m"
+KERNEL=="nvidia_modeset", RUN+="/bin/mknod -m 660 /dev/nvidia-modeset c 195 254"
 DRIVER=="host1x", RUN+="/bin/mknod -m 660 /dev/tegra_dc_1 c %M 1"
 
 # Set SD card read_ahead_kb to 2048 (taken from Jetpack)

--- a/pkg/nvidia/udev/jp6/rules.d/90-eve-nvidia.rules
+++ b/pkg/nvidia/udev/jp6/rules.d/90-eve-nvidia.rules
@@ -6,9 +6,9 @@ KERNEL=="fb", RUN+="/bin/mknod -m 660 /dev/fb0 c %M 0"
 # NVIDIA modules
 KERNEL=="nvidia", RUN+="/bin/mknod -m 660 /dev/nvidiactl c 195 255"
 KERNEL=="nvidia", RUN+="/bin/mknod -m 660 /dev/nvidia0 c 195 0"
-KERNEL=="nvidia_modeset", RUN+="/bin/mknod -m 660 /dev/nvidia-modeset c %M %m"
-KERNEL=="15480000.nvdec", ACTION=="bind", RUN+="/bin/mknod -m 666 /dev/v4l2-nvdec c %M %m"
-KERNEL=="154c0000.nvenc", ACTION=="bind", RUN+="/bin/mknod -m 666 /dev/v4l2-nvenc c %M %m"
+KERNEL=="nvidia_modeset", RUN+="/bin/mknod -m 660 /dev/nvidia-modeset c 195 254"
+ACTION="bind", KERNEL=="15480000.nvdec", DRIVER=="tegra-nvdec", RUN+="/bin/mknod -m 666 /dev/v4l2-nvdec c 1 3"
+ACTION="bind", KERNEL=="154c0000.nvenc", DRIVER=="tegra-nvenc", RUN+="/bin/mknod -m 666 /dev/v4l2-nvenc c 1 3"
 
 # RTC
 KERNEL=="rtc1", SUBSYSTEM=="rtc", SYMLINK="rtc", MODE="0666"

--- a/pkg/nvidia/udev/jp7/rules.d/90-eve-nvidia.rules
+++ b/pkg/nvidia/udev/jp7/rules.d/90-eve-nvidia.rules
@@ -4,14 +4,13 @@
 KERNEL=="fb", RUN+="/bin/mknod -m 660 /dev/fb0 c %M 0"
 
 # NVIDIA modules
-KERNEL=="nvidia", RUN+="/bin/mknod -m 660 /dev/nvidiactl c 195 255"
-KERNEL=="nvidia", RUN+="/bin/mknod -m 660 /dev/nvidia0 c 195 0"
-KERNEL=="nvidia", RUN+="/bin/mknod -m 660 /dev/nvidia1 c 195 1"
-KERNEL=="nvidia_modeset", RUN+="/bin/mknod -m 660 /dev/nvidia-modeset c %M %m"
-KERNEL=="nvidia_uvm", RUN+="/bin/mknod -m 660 /dev/nvidia-uvm c %M %m"
-KERNEL=="nvidia_uvm", RUN+="/bin/mknod -m 660 /dev/nvidia-uvm-tools c %M %m"
-DRIVERS=="tegra-nvdec", ACTION=="bind", RUN+="/bin/mknod -m 666 /dev/v4l2-nvdec c %M %m"
-DRIVERS=="tegra-nvenc", ACTION=="bind", RUN+="/bin/mknod -m 666 /dev/v4l2-nvenc c %M %m"
+ACTION=="add", SUBSYSTEM=="module", KERNEL=="nvidia", RUN+="/bin/mknod -m 660 /dev/nvidiactl c 195 255"
+ACTION=="add", SUBSYSTEM=="module", KERNEL=="nvidia", RUN+="/bin/mknod -m 660 /dev/nvidia0 c 195 0"
+ACTION=="add", SUBSYSTEM=="module", KERNEL=="nvidia", RUN+="/bin/mknod -m 660 /dev/nvidia1 c 195 1"
+ACTION=="add", SUBSYSTEM=="module", KERNEL=="nvidia_modeset", RUN+="/bin/mknod -m 660 /dev/nvidia-modeset c 195 254"
+ACTION=="add", SUBSYSTEM=="module", KERNEL=="nvidia_uvm", RUN+="/opt/vendor/nvidia/bin/nv-dev-nodes.sh nvidia_uvm"
+ACTION="bind", KERNEL=="15480000.nvdec", DRIVER=="tegra-nvdec", RUN+="/bin/mknod -m 666 /dev/v4l2-nvdec c 1 3"
+ACTION="bind", KERNEL=="154c0000.nvenc", DRIVER=="tegra-nvenc", RUN+="/bin/mknod -m 666 /dev/v4l2-nvenc c 1 3"
 
 # Set SD card read_ahead_kb to 2048 (taken from Jetpack)
 KERNEL=="mmcblk[0-9]", SUBSYSTEMS=="mmc", ACTION=="add|change", ATTR{bdi/read_ahead_kb}="2048"


### PR DESCRIPTION
# Description

Backport of https://github.com/lf-edge/eve/pull/6387

## How to test and validate this PR

1. Deploy a Reduced Isolation Container with GPU access on a Jetson JP7 device
2. Ensure the container works and no CDI errors are present
3. List the following files devices and ensure they don't have 0 as major number:

```sh
ca6b61b6-aeca-46a9-8ce5-0cb7c71b272d:~# ls -l /dev/nvidia-uvm /dev/nvidia-uvm-tools /dev/nvidia-modeset 
crw-rw----    1 root     root      195, 254 Aug 21 15:07 /dev/nvidia-modeset
crw-rw----    1 root     root      487,   0 Aug 21 15:07 /dev/nvidia-uvm
crw-rw----    1 root     root      487,   1 Aug 21 15:07 /dev/nvidia-uvm-tools
```

In this case major numbers are 195, 487, and 487. The 487 mighty vary depending on the device. 

## Changelog notes

Fix CDI file and udev rules for NVIDIA devices.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [x] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.