### PR TITLE
edgeview: prevent argument injection in tcpdump and traceroute

### DIFF
--- a/pkg/edgeview/src/basics.go
+++ b/pkg/edgeview/src/basics.go
@@ -423,6 +423,19 @@ func addPackage(pathName, pkgName string) error {
 	return nil
 }
 
+// validateExecArg guards an attacker-controlled operand before it is passed to
+// an external command via exec (no shell). If the token begins with '-' a
+// getopt-style option parser treats it as an option instead of an operand
+// (argument injection, CWE-88), e.g. a tcpdump filter of "-w<path>" becoming a
+// file-write option. Returns an error if unsafe. The caller must reject
+// the command on error rather than run it.
+func validateExecArg(name, val string) error {
+	if strings.HasPrefix(strings.TrimSpace(val), "-") {
+		return fmt.Errorf("%s %q must not start with '-'", name, val)
+	}
+	return nil
+}
+
 func runCmd(prog string, args []string, isPrint bool) (string, error) {
 	var retStr string
 	var retBytes []byte

--- a/pkg/edgeview/src/network.go
+++ b/pkg/edgeview/src/network.go
@@ -1052,10 +1052,18 @@ func runTrace(substring, server string) {
 	prog := "traceroute"
 	var args []string
 	if substring != "" {
+		if err := validateExecArg("traceroute target", substring); err != nil {
+			fmt.Printf("%v\n", err)
+			return
+		}
 		// limit to 10 hops, 2 queries per hop, and wait 1 second
 		baseargs := []string{"-4", "-m", "10", "-q", "2", "-w", "1", substring}
 		args = baseargs
 		if cmdTimeout != "" {
+			if err := validateExecArg("timeout value", cmdTimeout); err != nil {
+				fmt.Printf("%v\n", err)
+				return
+			}
 			prog = "timeout"
 			args = []string{cmdTimeout, "traceroute"}
 			args = append(args, baseargs...)
@@ -1451,6 +1459,10 @@ func runTCPDump(intfStat []intfIP, subStr string) {
 			fmt.Printf("interface name %s, does not match any 'UP' interfaces on device: %v\n", intf, upintfs)
 			return
 		}
+	}
+	if err := validateExecArg("tcpdump filter", subs[1]); err != nil {
+		fmt.Printf("%v\n", err)
+		return
 	}
 	if !rePattern.MatchString(subs[1]) {
 		fmt.Printf("tcpdump command has invalid option\n")

--- a/pkg/edgeview/src/network_test.go
+++ b/pkg/edgeview/src/network_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+)
+
+// TestValidateExecArg is a regression test for argument injection (CWE-88):
+// an attacker-controlled operand passed to an external command must not be
+// allowed to act as an option (a leading '-'). This is the guard applied to the
+// tcpdump filter and the traceroute target/timeout.
+func TestValidateExecArg(t *testing.T) {
+	g := NewWithT(t)
+
+	// Must be rejected: these would be parsed as options by getopt.
+	for _, bad := range []string{
+		"-w/hostfs/tmp/pwn", // tcpdump -w file write (the reported injection)
+		"-i",                // traceroute -i interface
+		"-sKILL",            // timeout -s signal
+		"--",                // end-of-options marker
+		"  -w/x",            // leading spaces then a dash
+		"\t-x",              // leading tab then a dash
+		"\n-w/x",            // leading newline then a dash
+	} {
+		g.Expect(validateExecArg("arg", bad)).To(HaveOccurred(), "input %q", bad)
+	}
+
+	// Must pass: legitimate operands (filters, hosts, timeouts) never lead with
+	// '-', and embedded dashes are harmless in a single argv token.
+	for _, ok := range []string{
+		"port 80", "host 1.2.3.4", "tcp", "8.8.8.8", "1.2.3.4",
+		"example.com", "a-b-c", "1.2.3.4:80", "60", "",
+		"60; rm", // non-option junk is harmless: no shell, one argv token
+	} {
+		g.Expect(validateExecArg("arg", ok)).ToNot(HaveOccurred(), "input %q", ok)
+	}
+}


### PR DESCRIPTION
# Description

Attacker-controlled operands from an edgeview session were placed into an
external command's argv validated only by a permissive regex that allows a
leading `-`. Because edgeview runs commands through exec (no shell), each
element is one argv token, so a leading `-` is parsed by the program's getopt as
an option (argument injection, CWE-88): a tcpdump filter of `-w<path>` becomes a
capture-file write to an attacker-chosen path, and the traceroute target and the
`timeout` duration can inject options too.

This adds a general guard, `validateExecArg`, that rejects any attacker-controlled
operand which would be parsed as an option, and applies it to every edgeview
command that passes user input into exec: the tcpdump filter and the traceroute
target and timeout value. The remaining edgeview exec sites use only fixed or
system-derived argv (verified by an audit of all exec call sites).

This is the remediation for an external private security report (408 Security Research Collective).

## PR dependencies

None.

## How to test and validate this PR

Automated (added in this PR):

- `pkg/edgeview/src/network_test.go`: `TestValidateExecArg` asserts that
  option-shaped operands (including the reported `-w/hostfs/tmp/pwn`, and
  `-i` / `-sKILL` / `--` / leading-whitespace-then-dash variants) are rejected,
  and that legitimate filters, hosts and numeric timeouts pass.
- Run: `go test ./src/ -run TestValidateExecArg` (in `pkg/edgeview`).

Manual (from an edgeview session):

1. `tcpdump` with a filter of `<intf>/-w/hostfs/tmp/pwn`. Pre-fix, tcpdump
   writes a capture file to that path. Post-fix, the command is rejected with
   `tcpdump filter "-w/hostfs/tmp/pwn" must not start with '-'` and nothing runs.
2. `trace` with a target starting with `-`, and the time option set to a value
   starting with `-`: both are now rejected instead of reaching traceroute /
   timeout as options.

## Changelog notes

Hardened edgeview: a tcpdump filter or a traceroute target/timeout supplied
through an edgeview session can no longer inject command-line options (for
example, using tcpdump's `-w` to write a file).

## PR Backports

The vulnerable code is present in and should be backported to every current LTS
branch:

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation (N/A: no doc changes)
- [ ] I've tested my PR on amd64 device (see note below)
- [ ] I've tested my PR on arm64 device (see note below)
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR (add `stable`)

For backport PRs (remove it if it's not a backport): N/A, this is the original PR.

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them. Device testing not performed: this is arch-independent Go logic
  covered by a unit test that exercises the injection strings; validated on
  amd64 via `go test`.
