### PR TITLE
kvm: honour the force flag when stopping a domain

### DIFF
--- a/evetest/tests/apps/shutdown_helpers_test.go
+++ b/evetest/tests/apps/shutdown_helpers_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package apps_test
+
+import (
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	eveinfo "github.com/lf-edge/eve-api/go/info"
+	"github.com/lf-edge/eve/evetest"
+)
+
+// haltBudget bounds how long an application may take to be reported HALTED after
+// it is deactivated. It sits between two hardcoded budgets in domainmgr's
+// doInactivate an order of magnitude apart: a stop which escalates promptly
+// costs the 60s first wait, one which does not costs the 600s second wait on
+// top. Neither is a measure of work, so this is not a stopwatch on a loaded
+// host.
+const haltBudget = 300 * time.Second
+
+// haltTiming records when an application's halt transitions were reported,
+// relative to the deactivation which caused them.
+type haltTiming struct {
+	deactivatedAt time.Time
+	haltingAt     time.Time
+	haltedAt      time.Time
+	done          chan struct{}
+}
+
+// watchHalt takes ownership of updates from the deactivation onwards and
+// timestamps the HALTING and HALTED reports as they arrive. Timing them at
+// arrival rather than at read time measures the device, not the caller.
+func watchHalt(updates <-chan *eveinfo.ZInfoApp) *haltTiming {
+	ht := &haltTiming{deactivatedAt: time.Now(), done: make(chan struct{})}
+	go func() {
+		defer close(ht.done)
+		for update := range updates {
+			switch update.GetState() {
+			case eveinfo.ZSwState_HALTING:
+				if ht.haltingAt.IsZero() {
+					ht.haltingAt = time.Now()
+				}
+			case eveinfo.ZSwState_HALTED:
+				ht.haltedAt = time.Now()
+				return
+			}
+		}
+	}()
+	return ht
+}
+
+// requireHaltedWithinBudget fails unless the application was reported HALTED
+// within haltBudget of being deactivated, and logs how long it took either way.
+func requireHaltedWithinBudget(t *WithT, ht *haltTiming) {
+	select {
+	case <-ht.done:
+	case <-time.After(haltBudget):
+		t.Expect(false).To(BeTrue(),
+			"application was not reported HALTED within %v of being deactivated; "+
+				"a stop which does not escalate costs the whole 600s budget", haltBudget)
+		return
+	}
+	took := ht.haltedAt.Sub(ht.deactivatedAt)
+	evetest.Logger().Infof("Application reported HALTED %v after being deactivated",
+		took.Round(time.Second))
+	t.Expect(took).To(BeNumerically("<", haltBudget),
+		"application took %v to be reported HALTED", took.Round(time.Second))
+}

--- a/evetest/tests/apps/shutdown_unresponsive_guest_test.go
+++ b/evetest/tests/apps/shutdown_unresponsive_guest_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package apps_test
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	eveconfig "github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve-api/go/evecommon"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/netmodels"
+)
+
+// Alpine cloud images, pinned per architecture. See https://alpinelinux.org/cloud/.
+var unresponsiveGuestImages = map[string]struct {
+	relativePath string
+	sha256       string
+	sizeBytes    uint64
+}{
+	"amd64": {
+		relativePath: "/alpine/v3.24/releases/cloud/generic_alpine-3.24.1-x86_64-bios-cloudinit-r0.qcow2",
+		sha256:       "6e2e6fe0572b6632527f268d3659e8fccebda4e1ee470fafe2c4d7b85b6a4df6",
+		sizeBytes:    183697408,
+	},
+	"arm64": {
+		relativePath: "/alpine/v3.24/releases/cloud/generic_alpine-3.24.1-aarch64-uefi-cloudinit-r0.qcow2",
+		sha256:       "3059a6280977c2122982632e0317c5ddbd39069d46ca1e60480de283091f720f",
+		sizeBytes:    239271936,
+	},
+}
+
+// How long the guest is given to finish applying its user-data before the test
+// stops it, so the guest ignores the poweroff request rather than racing
+// cloud-init for it.
+const unresponsiveGuestSettle = 90 * time.Second
+
+// TestHaltUnresponsiveGuest verifies that a guest which never acts on the ACPI
+// poweroff request is still stopped promptly.
+//
+// Nothing obliges a guest to service that request, and when it does not only
+// terminating the domain ends the stop; until then the application stays
+// reported as halting and holds its memory and any assigned PCI devices. The
+// guest here ignores it by construction -- acpid services the power button on
+// Alpine, and cloud-init stops it and removes it from the runlevel. The mode is
+// HVM, which already gets the short first wait, so what is left under test is
+// the escalation after it.
+//
+// Network model
+// -------------
+//   - netmodels.SingleEthWithDHCP -- the guest only has to reach the image
+//     datastore and then be stopped.
+//
+// Device configuration
+// --------------------
+//   - one mgmt+apps port, one local network instance
+//   - one HVM VM application from the pinned Alpine cloud image, with acpid
+//     disabled through user-data
+//
+// Phases
+// ------
+//  1. Deploy the application and wait until it is reported RUNNING.
+//  2. Let cloud-init finish disabling acpid.
+//  3. Deactivate the application.
+//  4. Require it to be reported HALTED within haltBudget.
+func TestHaltUnresponsiveGuest(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+	)
+	hypervisor := evetest.GetHypervisorParameterValue()
+
+	evetest.Setup(
+		evetest.RequireEdgeDevice{
+			Name:              devName,
+			WithHypervisor:    hypervisor,
+			DeviceReusePolicy: evetest.ResetDeviceConfig,
+		},
+		evetest.RequireNetworkModel{NetworkModel: netmodels.SingleEthWithDHCP},
+	)
+	device := evetest.GetEdgeDevice(devName)
+	evetest.Checkpoint("setup-done")
+
+	image, known := unresponsiveGuestImages[device.GetArch()]
+	if !known {
+		test.Skipf("no pinned Alpine cloud image for %s", device.GetArch())
+	}
+
+	devConfig := evetest.NewEdgeDeviceConfig(devName)
+	dhcpNet := devConfig.AddNetwork(evetest.DHCPNetworkConfig{
+		NetworkType: evecommon.NetworkType_V4Only,
+	})
+	devConfig.AddNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  "ethernet0",
+		PhysicalLabel: "eth0",
+		InterfaceName: "eth0",
+		NetworkUUID:   dhcpNet,
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+	})
+	niUUID := addLocalNI(devConfig)
+	cloudConfig := `#cloud-config
+runcmd:
+  - rc-service acpid stop
+  - rc-update del acpid default
+`
+	appUUID := devConfig.AddApplication(evetest.ApplicationInstanceConfig{
+		DisplayName: "unresponsive-app",
+		Activate:    true,
+		Image: evetest.HTTPStorage{
+			ImageFormat:       eveconfig.Format_QCOW2,
+			ImageSHA256:       image.sha256,
+			MaxDownloadBytes:  image.sizeBytes,
+			ImageRelativePath: image.relativePath,
+			ServerAddress:     "dl-cdn.alpinelinux.org",
+			UseHTTPS:          true,
+		},
+		VirtualizationMode: eveconfig.VmMode_HVM,
+		CPUs:               1,
+		MemoryBytes:        512 * evetest.MiB,
+		UserData:           base64.StdEncoding.EncodeToString([]byte(cloudConfig)),
+		NetworkAdapters:    singleVIFWithSSH(niUUID),
+	})
+
+	appUpdates, stopAppWatch := device.WatchAppInfo(appUUID)
+	defer stopAppWatch()
+	device.ApplyConfig(devConfig, true, true)
+	device.WaitUntilAppIsRunning(appUUID, 10*time.Minute)
+	evetest.Checkpoint("app-running")
+
+	time.Sleep(unresponsiveGuestSettle)
+
+	halt := watchHalt(appUpdates)
+	device.DeactivateApplication(appUUID, false, 0)
+	evetest.Checkpoint("app-deactivated")
+
+	requireHaltedWithinBudget(t, halt)
+}

--- a/evetest/tests/apps/testsuite_test.go
+++ b/evetest/tests/apps/testsuite_test.go
@@ -82,6 +82,9 @@ import (
 //   - TestAppRestart -- controller-requested restarts (restart counter
 //     bumps, no purge) bring the app back to RUNNING; regression test for
 //     a stale QMP handler quitting the re-created domain.
+//   - TestHaltUnresponsiveGuest -- a guest which never services the ACPI
+//     poweroff request still halts promptly, because the stop escalates to
+//     terminating the domain. Pulls its image from dl-cdn.alpinelinux.org.
 //   - TestVMAppPurgeReplacesVMIRS -- a plain purge of a healthy app leaves
 //     exactly one VMIRS, named for the new generation. Kubevirt only; skips
 //     on any other hypervisor.
@@ -124,6 +127,9 @@ func TestAppsSuite(test *testing.T) {
 		},
 		evetest.TestCase{
 			Test: TestAppRestart,
+		},
+		evetest.TestCase{
+			Test: TestHaltUnresponsiveGuest,
 		},
 		evetest.TestCase{
 			Test: TestVMAppPurgeReplacesVMIRS,

--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -2054,7 +2054,12 @@ func (ctx KvmContext) Start(domainName string) error {
 }
 
 // Stop stops a domain
-func (ctx KvmContext) Stop(domainName string, _ bool) error {
+func (ctx KvmContext) Stop(domainName string, force bool) error {
+	// Without force this is an ACPI poweroff request, which a guest still early
+	// in boot simply ignores; force has to make the domain go away regardless.
+	if force {
+		return terminateQemu(kvmStateDir, domainName, "Stop")
+	}
 	if err := execShutdown(GetQmpExecutorSocket(domainName)); err != nil {
 		return logError("Stop: failed to execute shutdown command %v", err)
 	}
@@ -2090,43 +2095,58 @@ func waitProcessGone(pid int, timeout time.Duration) bool {
 	}
 }
 
-// Delete deletes a domain
-func (ctx KvmContext) Delete(domainName string) (result error) {
-	// Capture the qemu pid before tearing down state, so we can guarantee the
-	// process is gone even if the QMP quit below fails or hangs.
-	pid, pidErr := procutils.GetPidFromFile(kvmStateDir + domainName + "/pid")
+// terminateQemu makes the qemu process serving domainName exit and release its
+// resources: it pauses the vCPUs, issues a QMP quit, and SIGKILLs the process if
+// that does not take, since the quit can hang when the monitor is wedged. It
+// fails if the process cannot be established to be gone; an absent pid file is
+// not a failure, as there is then no process to terminate. Removing the state
+// directory is left to Delete and Cleanup. stateDir is a parameter so tests stay
+// off the real /run path; caller only names the caller in the logs.
+func terminateQemu(stateDir string, domainName string, caller string) error {
+	// Capture the pid first, so the process can still be dealt with if the QMP
+	// quit below fails or hangs.
+	pid, pidErr := procutils.GetPidFromFile(filepath.Join(stateDir, domainName, "pid"))
 
 	// Issue a QMP `stop` command (not a process signal) to pause the vCPUs,
 	// freezing the guest before we quit it.
-	_, err := os.Stat(GetQmpExecutorSocket(domainName))
-	if err == nil {
-		execStop(GetQmpExecutorSocket(domainName))
-		if err = execQuit(GetQmpExecutorSocket(domainName)); err != nil {
+	socket := qmpExecutorSocket(stateDir, domainName)
+	if _, err := os.Stat(socket); err == nil {
+		execStop(socket)
+		if err := execQuit(socket); err != nil {
 			logError("failed to execute quit command %v", err)
 		}
 	}
 
-	// Backstop: make sure qemu has actually exited and released its resources
-	// (memory, assigned PCI devices). quit over QMP can fail or hang if the
-	// monitor is wedged; without a hard kill the caller would keep seeing the
-	// domain as present and never free its resources (the lf-edge/eve#5916
-	// stall). Wait briefly for a clean exit, then SIGKILL.
-	if pidErr == nil {
+	if pidErr != nil {
+		if errors.Is(pidErr, os.ErrNotExist) {
+			return nil
+		}
+		return logError("%s(%s): no usable pid file, qemu cannot be terminated: %v",
+			caller, domainName, pidErr)
+	}
+	if !waitProcessGone(pid, qemuExitGrace) {
+		logrus.Warnf("%s(%s): qemu pid %d still alive after quit; sending SIGKILL",
+			caller, domainName, pid)
+		_ = syscall.Kill(pid, syscall.SIGKILL)
 		if !waitProcessGone(pid, qemuExitGrace) {
-			logrus.Warnf("Delete(%s): qemu pid %d still alive after quit; sending SIGKILL",
-				domainName, pid)
-			_ = syscall.Kill(pid, syscall.SIGKILL)
-			if !waitProcessGone(pid, qemuExitGrace) {
-				logrus.Errorf("Delete(%s): qemu pid %d survived SIGKILL", domainName, pid)
-			}
+			return logError("%s(%s): qemu pid %d survived SIGKILL",
+				caller, domainName, pid)
 		}
 	}
+	return nil
+}
+
+// Delete deletes a domain
+func (ctx KvmContext) Delete(domainName string) (result error) {
+	// terminateQemu has logged any failure already; carry it to the caller so a
+	// domain whose process is still around is not reported as deleted.
+	termErr := terminateQemu(kvmStateDir, domainName, "Delete")
 
 	if err := os.RemoveAll(kvmStateDir + domainName); err != nil {
 		return logError("failed to clean up domain state directory %s (%v)", domainName, err)
 	}
 
-	return nil
+	return termErr
 }
 
 // decideKvmState maps the containerd task state and the QMP run-state into the
@@ -2243,7 +2263,13 @@ func usbBusPort(USBAddr string) (string, string) {
 
 // GetQmpExecutorSocket returns the path to the qmp socket of a domain
 func GetQmpExecutorSocket(domainName string) string {
-	return filepath.Join(kvmStateDir, domainName, "qmp")
+	return qmpExecutorSocket(kvmStateDir, domainName)
+}
+
+// qmpExecutorSocket returns the path to the qmp socket of a domain whose state
+// lives under stateDir.
+func qmpExecutorSocket(stateDir string, domainName string) string {
+	return filepath.Join(stateDir, domainName, "qmp")
 }
 
 func getQmpListenerSocket(domainName string) string {

--- a/pkg/pillar/hypervisor/kvm_force_test.go
+++ b/pkg/pillar/hypervisor/kvm_force_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package hypervisor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// startSleeper returns a live process standing in for qemu and the state
+// directory holding its pid file. Both the pid file and the monitor socket are
+// looked for there, so nothing here can reach a domain on the test host.
+func startSleeper(t *testing.T) (stateDir string, domainName string, pid int) {
+	t.Helper()
+	domainName = "forcetest"
+	stateDir = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(stateDir, domainName), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	cmd := exec.Command("sleep", "300")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start stand-in process: %v", err)
+	}
+	pid = cmd.Process.Pid
+	// A zombie still answers signal 0, which is how liveness is probed, so this
+	// child has to be reaped as soon as it dies. qemu is not a child of pillar,
+	// so this only matters here.
+	go func() { _, _ = cmd.Process.Wait() }()
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	pidFile := filepath.Join(stateDir, domainName, "pid")
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d\n", pid)), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return stateDir, domainName, pid
+}
+
+// A domain whose QMP monitor cannot be reached still has to be terminated: that
+// is the path a guest which never services the poweroff request takes.
+func TestTerminateQemuKillsWhenMonitorUnreachable(t *testing.T) {
+	stateDir, domainName, pid := startSleeper(t)
+
+	// No qmp socket under the temporary state directory, so the quit is skipped
+	// exactly as it is for a wedged or absent monitor.
+	if err := terminateQemu(stateDir, domainName, "test"); err != nil {
+		t.Errorf("terminateQemu: %v", err)
+	}
+
+	if err := syscall.Kill(pid, 0); err == nil {
+		t.Errorf("process %d survived terminateQemu", pid)
+	}
+}
+
+// The pid file is the only handle on the process, so a domain without one must
+// not wedge the caller, and has nothing left to terminate so does not fail.
+func TestTerminateQemuWithoutPidFile(t *testing.T) {
+	domainName := "forcetest"
+	stateDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(stateDir, domainName), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- terminateQemu(stateDir, domainName, "test") }()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("terminateQemu: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("terminateQemu did not return without a pid file")
+	}
+}
+
+// A pid file that is there but unusable leaves nothing to signal, so no kill is
+// attempted; the caller has to hear about that rather than being told the forced
+// stop succeeded over a domain that is still running.
+func TestTerminateQemuReportsUnusablePidFile(t *testing.T) {
+	stateDir, domainName, pid := startSleeper(t)
+	pidFile := filepath.Join(stateDir, domainName, "pid")
+	if err := os.WriteFile(pidFile, []byte("not-a-pid\n"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := terminateQemu(stateDir, domainName, "test"); err == nil {
+		t.Error("terminateQemu reported success with an unusable pid file")
+	}
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Errorf("stand-in process %d was signalled despite an unusable pid file: %v", pid, err)
+	}
+}


### PR DESCRIPTION
# Description

Fixes #6452.

A forced stop of a KVM domain was the same ACPI poweroff request as a graceful
one: `KvmContext.Stop` discarded its `force` argument and issued QMP
`system_powerdown` either way. A guest which cannot service that yet - one still
early in boot, for instance - ignores both, so nothing made the domain go away
until domainmgr gave up waiting and deleted it. An application stopped shortly
after it started therefore stayed reported as halting for as long as those waits
took, holding its memory and any assigned PCI devices meanwhile, and the
`Shutdown(force) succeeded` line domainmgr logs was not true.

A forced stop now terminates the process. That is what the interface promises
and what the xen (`xl shutdown -F`) and containerd implementations of the same
method already do. The termination path `Delete` already had - pause the vCPUs,
quit over the monitor, and a kill if that does not take - is factored out and
shared rather than duplicated, and now reports whether it worked, so
`Shutdown(force) succeeded` means what it says.

Measured on EVE-kvm amd64, an `HVM` Alpine guest with acpid stopped so it
ignores the request, deactivated once running:

| build | deactivate -> HALTED |
| --- | --- |
| master | **701s** (11m41s) |
| master + this PR | **96s** |
| master + a bounded graceful wait, without this PR | 703s |

The 605s difference is domainmgr's second wait, and 701s matches the ~11m45s
#5916 recorded for four eclient pods in one CI run. The third row is the
control: bounding the *graceful* wait cannot help, because `HVM` already gets
60s there.

Related to #6440 but deliberately not a fix for it -- see "What this does not
fix" below.

## PR dependencies

None.

## How to test and validate this PR

Covered by an evetest test and by unit tests, all validated against un-fixed
code.

`TestHaltUnresponsiveGuest`, in `evetest/tests/apps` and registered in
`TestAppsSuite`, deploys an `HVM` Alpine VM whose cloud-init stops acpid and
removes it from the runlevel, so the guest ignores the poweroff request by
construction. Against an EVE image without this change -- one carrying the
bounded graceful wait of #6453, so that only this PR is under test -- it fails
on its 300s bound; with it the application reports HALTED 1m36s after the
deactivation. It pulls its image from `dl-cdn.alpinelinux.org`, which
`tests/apps` did not previously depend on (`tests/security/vcom_test.go`
already does).

The assertion is on elapsed time because the reported state sequence is
identical either way -- RUNNING, HALTING, HALTED -- and only the time spent
halting differs. The bound separates two hardcoded budgets an order of magnitude
apart rather than an amount of work, so it is not a stopwatch on a loaded host.

The unit tests in `kvm_force_test.go` cover a domain whose monitor cannot be
reached, which is the path a guest that never services the poweroff request
takes; one with no pid file, so the absence of the only handle on the process
cannot wedge the caller; and one whose pid file is there but unreadable, where
nothing can be signalled and the caller has to be told rather than hearing that
the stop succeeded.

## Changelog notes

None. A forced stop now does what its name says, which no current caller
reaches before its effect is already moot; nothing user-facing changes yet.

## PR Backports

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

The defect has been present since the KVM driver was first written
(`ef4d38f1c`, 2020), so every stable branch carries it.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation -- no behaviour is documented that
  this changes; the method's contract is stated on the interface.
- [ ] I've tested my PR on amd64 device -- the unit tests cover the changed
  path; the end-to-end reproduction in #6440 was run before the fix, not after.
- [ ] I've tested my PR on arm64 device -- not tested; the change is
  architecture independent.
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR.

## What this does not fix

Stating it plainly, because the two look alike: this change does **not** shorten
the stall in #6440. There the application's mode is `PV` -- evetest leaves
`VirtualizationMode` unset and `VmMode_PV` is the zero value -- so the
`doInactivate` switch leaves `firstDelay` at `maxDelay` and the whole budget is
spent in the **first**, graceful `waitForDomainGone`, before the forced stop
this PR fixes is reached. Deactivating a container application in the same
second it reported RUNNING:

| build | deactivate -> HALTED |
| --- | --- |
| master | 637 / 636 / 637 s |
| master + a bounded graceful wait (#6453) | 98 / 95 / 96 s |
| master + #6453 + this PR | 99 / 97 / 99 s |

This PR adds nothing to the second row: once the graceful wait is bounded the
guest is ACPI-capable by the time the request is re-sent. #6453 is the cure for
#6440, and it is equally not a cure for #6452 -- the control row in the
Description shows it leaving that stall at 703s. The two are complementary and
neither subsumes the other: bounding the graceful wait fixes the guest which
becomes capable, and this PR fixes the guest which never does.

## Note on scope

`kubevirtContext.Stop` ignores the same argument, and there it is *named*
`force` rather than `_` so nothing flags it. That is deliberately left alone
here: it is a different mechanism and #6271 is the live conversation about that
code.

Whether `PV` should keep a 600s graceful budget before escalating - `HVM` and
`FML` get 60s, `PV` falls through to `maxDelay` - is a separate decision this PR
does not take, and it affects Xen PV guests too. Without it the graceful wait is
unchanged; this PR only makes the escalation after it real.
