### PR TITLE
zedmanager: do not let a domain-held stale volume ref block a purge

### DIFF
--- a/pkg/pillar/cmd/zedmanager/updatestatus.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus.go
@@ -500,9 +500,21 @@ func doInstall(ctx *zedmanagerContext,
 			}
 		}
 	}
-	// Determine minimum state and errors across all of VolumeRefStatus
+	// Determine minimum state and errors across all of VolumeRefStatus.
+	// While purging, a VolumeRefStatus dropped from the current config is kept
+	// around above (not removed) as long as the running domain still uses it,
+	// solely so its release can be ordered after the domain is torn down. Such
+	// an entry must not otherwise count here: a stale volume's error (e.g. a
+	// pre-existing upload failure) would otherwise block doInstall from ever
+	// returning done, which blocks the domain teardown that is the only thing
+	// that lets this stale entry go away — deadlocking the purge on the exact
+	// state it needs to get past.
 	minState := types.MAXSTATE
 	for _, vrs := range status.VolumeRefStatusList {
+		if status.PurgeInprogress == types.DownloadAndVerify &&
+			getVolumeRefConfigFromAIConfig(&config, vrs) == nil {
+			continue
+		}
 		if vrs.State < minState {
 			minState = vrs.State
 		}

--- a/pkg/pillar/cmd/zedmanager/updatestatus_test.go
+++ b/pkg/pillar/cmd/zedmanager/updatestatus_test.go
@@ -158,3 +158,82 @@ func TestDoInstallWaitsForStaleVolumeRefWithLiveStatus(t *testing.T) {
 			"must be marked pending removal while waiting for volumemgr's delete")
 	}
 }
+
+// TestDoInstallErroredStaleVolumeRefHeldByDomainDoesNotBlock is the
+// regression test for a second purge wedge, distinct from the two above: a
+// VolumeRefStatus dropped from the current config but still used by the
+// running domain is correctly kept (not dropped, not marked PendingAdd) so
+// its release can be ordered after the domain is torn down. But if that
+// stale entry also carries an error - e.g. a pre-existing volume failure
+// unrelated to the purge - that error must not propagate into doInstall's
+// aggregate error/done computation. Doing so would make doInstall return
+// done=false forever, which prevents doUpdate from ever reaching the domain
+// teardown that is the only thing that lets this stale entry go away -
+// deadlocking the purge on exactly the state it needs to get past.
+func TestDoInstallErroredStaleVolumeRefHeldByDomainDoesNotBlock(t *testing.T) {
+	appUUID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
+	staleVolumeID := uuid.Must(uuid.FromString("22222222-2222-2222-2222-222222222222"))
+	newVolumeID := uuid.Must(uuid.FromString("33333333-3333-3333-3333-333333333333"))
+
+	staleVrs := types.VolumeRefStatus{
+		VolumeID:   staleVolumeID,
+		AppUUID:    appUUID,
+		State:      types.CREATING_VOLUME,
+		VerifyOnly: false,
+		ErrorAndTimeWithSource: types.ErrorAndTimeWithSource{
+			ErrorDescription: types.ErrorDescription{
+				Error:         "PVC upload failed, no upload pod annotation",
+				ErrorSeverity: types.ErrorSeverityError,
+			},
+		},
+	}
+	// volumemgr still reports this volume as live (matches reality: the
+	// volume genuinely exists, it is just stuck in a terminal error).
+	ctx := newDoInstallTestContext(t, []types.VolumeRefStatus{staleVrs})
+
+	// The running domain still has a disk pointing at the stale volume - this
+	// is what makes doInstall keep the stale VolumeRefStatus around instead
+	// of dropping or PendingAdd-ing it.
+	domainConfig := types.DomainConfig{
+		UUIDandVersion: types.UUIDandVersion{UUID: appUUID, Version: "1"},
+		DiskConfigList: []types.DiskConfig{
+			{VolumeKey: staleVrs.VolumeKey()},
+		},
+	}
+	assert.NoError(t, ctx.pubDomainConfig.Publish(domainConfig.Key(), domainConfig))
+
+	newVrc := types.VolumeRefConfig{VolumeID: newVolumeID, AppUUID: appUUID, VerifyOnly: true}
+	config := types.AppInstanceConfig{
+		UUIDandVersion:      types.UUIDandVersion{UUID: appUUID, Version: "2"},
+		VolumeRefConfigList: []types.VolumeRefConfig{newVrc},
+	}
+	newVrs := types.VolumeRefStatus{
+		VolumeID:   newVolumeID,
+		AppUUID:    appUUID,
+		State:      types.LOADED,
+		VerifyOnly: true,
+	}
+	status := &types.AppInstanceStatus{
+		UUIDandVersion:      config.UUIDandVersion,
+		PurgeInprogress:     types.DownloadAndVerify,
+		VolumeRefStatusList: []types.VolumeRefStatus{staleVrs, newVrs},
+	}
+
+	_, done := doInstall(ctx, config, status)
+
+	assert.True(t, done,
+		"the new volume is LOADED; doInstall must not stay blocked by the stale, "+
+			"domain-held volume's unrelated error")
+	assert.False(t, status.HasError(),
+		"the stale volume's error must not become the app's own error")
+
+	foundStale := false
+	for _, vrs := range status.VolumeRefStatusList {
+		if vrs.VolumeID == staleVolumeID {
+			foundStale = true
+			assert.False(t, vrs.PendingAdd,
+				"the domain still uses it, so it must not be marked pending removal")
+		}
+	}
+	assert.True(t, foundStale, "the domain-held stale volume ref must still be present")
+}


### PR DESCRIPTION
# Description

`doInstall` keeps a `VolumeRefStatus` that the current `AppInstanceConfig`
no longer references around, unremoved, for as long as the running domain
still uses it — so its release can be ordered *after* the domain is torn
down rather than yanking storage out from under a live app. That part is
correct.

But `doInstall`'s aggregate error computation still folded that stale
entry's error into the app's own blocking error, so `doInstall` never
returned `done=true` while the stale volume was in an error state. That
deadlocks the purge: `doUpdate` bails out on `!done` before ever reaching
the code that tears down the domain — which is the only thing that lets
the stale volume actually go away. A volume that failed once (independent
of any purge) and then had a purge move the app to a new generation would
wedge that purge forever, with no automatic path out.

Fix: skip a stale, domain-held `VolumeRefStatus`'s error (and state) when
computing `doInstall`'s aggregate result during the `DownloadAndVerify`
phase — only errors on volume refs still present in the current config
should be able to block progress.

Found while debugging two apps on an eve-k dev cluster stuck indefinitely
in `DownloadAndVerify` after an unrelated volume-creation failure (a
separate CDI-upload-completeness bug) left one volume permanently errored
right as a purge tried to move the app to a new generation.

## PR dependencies

None

## How to test and validate this PR

Covered by an automated regression test:

    make TESTPKGS=./pkg/pillar/cmd/zedmanager/... TESTRUN=TestDoInstall test
Covered by an automated regression test:

    make TESTPKGS=./pkg/pillar/cmd/zedmanager/... TESTRUN=TestDoInstall test

`TestDoInstallErroredStaleVolumeRefHeldByDomainDoesNotBlock` reproduces the
exact shape: a domain still attached to an errored old-generation volume,
plus a new-generation volume already `LOADED` and waiting on `VerifyOnly`
to clear. Before the fix, `doInstall` returns `done=false` forever; after
it, `done=true` and the stale volume's error is not folded into the app's.

## Changelog notes

Fixed a bug where an application purge on eve-k could hang indefinitely
if the app's currently-active volume was in a permanent error state when
the purge was issued — the purge would never tear down the old app
generation or start the new one. No other user-facing changes.

## PR Backports

- 17.0-stable: To be backported.
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
