### PR TITLE
eve-k: reduce idle logging in csihandler status path

### DIFF
--- a/pkg/pillar/volumehandlers/csihandler.go
+++ b/pkg/pillar/volumehandlers/csihandler.go
@@ -40,7 +40,7 @@ func NewCSIHandler(common commonVolumeHandler, useVHost bool) VolumeHandler {
 
 func (handler *volumeHandlerCSI) GetVolumeDetails() (uint64, uint64, string, bool, error) {
 	pvcName := handler.status.GetPVCName()
-	handler.log.Noticef("GetVolumeDetails called for PVC %s", pvcName)
+	handler.log.Tracef("GetVolumeDetails called for PVC %s", pvcName)
 	imgInfo, err := kubeapi.GetPVCInfo(pvcName, handler.log)
 	if err != nil {
 		return 0, 0, "", false, fmt.Errorf("GetPVCInfo failed for %s: %v", pvcName, err)
@@ -52,11 +52,11 @@ func (handler *volumeHandlerCSI) GetVolumeDetails() (uint64, uint64, string, boo
 func (handler *volumeHandlerCSI) UsageFromStatus() uint64 {
 	cfg := handler.volumeManager.LookupVolumeConfig(handler.status.Key())
 	if handler.status.ReadOnly || cfg == nil || cfg.HasNoAppReferences {
-		handler.log.Noticef("UsageFromStatus: Volume %s use CurrentSize (ReadOnly=%v cfg==nil:%v)",
+		handler.log.Tracef("UsageFromStatus: Volume %s use CurrentSize (ReadOnly=%v cfg==nil:%v)",
 			handler.status.GetPVCName(), handler.status.ReadOnly, cfg == nil)
 		return uint64(handler.status.CurrentSize)
 	}
-	handler.log.Noticef("UsageFromStatus: Use MaxVolSize for PVC %s",
+	handler.log.Tracef("UsageFromStatus: Use MaxVolSize for PVC %s",
 		handler.status.GetPVCName())
 	return handler.status.MaxVolSize
 }


### PR DESCRIPTION
## Description

In total these were logging around 8800 lines/day for 3 PVCs

Found while debugging #6442 

## PR dependencies

None

## How to test and validate this PR

No tests, verify manually by searching newlog/keepSentQueue on a system where volumemgr logging level is not trace level.

## Changelog notes

No user visible changes

## PR Backports

- 17.0-stable: To be backported.
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
