### PR TITLE
fix : pillar: bound unbounded HTTP response reads

### DIFF
--- a/pkg/pillar/cmd/zedkube/clusterstatus.go
+++ b/pkg/pillar/cmd/zedkube/clusterstatus.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -27,6 +27,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
+
+// maxClusterAppInfoSize bounds the per-app info response read from another
+// cluster node.
+const maxClusterAppInfoSize = 10 << 20 // 10 MiB
 
 func handleDNSCreate(ctxArg interface{}, _ string, statusArg interface{}) {
 	z := ctxArg.(*zedkube)
@@ -594,10 +598,15 @@ func (z *zedkube) clusterAppIDHandler(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 
-			remoteAppInfoJSON, err := ioutil.ReadAll(resp.Body)
+			remoteAppInfoJSON, err := io.ReadAll(io.LimitReader(resp.Body, maxClusterAppInfoSize+1))
 			resp.Body.Close()
 			if err != nil {
 				log.Errorf("clusterAppIDHandler: error reading response from %s: %v", host, err)
+				continue
+			}
+			if int64(len(remoteAppInfoJSON)) > maxClusterAppInfoSize {
+				log.Errorf("clusterAppIDHandler: response from %s exceeds max size %d bytes",
+					host, maxClusterAppInfoSize)
 				continue
 			}
 			combinedJSON = combinedJSON + "," + strings.TrimSuffix(string(remoteAppInfoJSON), "\n")

--- a/pkg/pillar/cmd/zedrouter/appcontainer.go
+++ b/pkg/pillar/cmd/zedrouter/appcontainer.go
@@ -48,7 +48,56 @@ const (
 	nestedAppDomainAppMetricsURL = "/api/v1/metrics/nested-app-id/"
 	// nestedAppRuntimeDiskMetricURL - URL to get the runtime level storage metrics
 	nestedAppRuntimeDiskMetricURL = "/api/v1/storagemetrics/runtime"
+	// maxDockerResponseSize bounds a single response body from the app Docker API.
+	maxDockerResponseSize = 10 << 20 // 10 MiB
+	// dockerAPITimeout bounds each Docker API call.
+	dockerAPITimeout = 30 * time.Second
+	// maxNestedAppResponseSize bounds a nested-app runtime metrics HTTP response.
+	maxNestedAppResponseSize = 10 << 20 // 10 MiB
+	// nestedAppHTTPTimeout bounds each nested-app runtime metrics HTTP request.
+	nestedAppHTTPTimeout = 30 * time.Second
 )
+
+// limitedResponseTransport caps the size of response bodies returned by the
+// app-provided Docker endpoint.
+type limitedResponseTransport struct {
+	base  http.RoundTripper
+	limit int64
+}
+
+// limitedReadCloser returns an error once more than the configured number of
+// bytes has been read.
+type limitedReadCloser struct {
+	inner     io.ReadCloser
+	remaining int64
+}
+
+func (t *limitedResponseTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	// Bound the body the Docker client will read. remaining is limit+1 so a body
+	// of exactly limit bytes is still delivered in full, while a larger one trips
+	// the error in limitedReadCloser.Read instead of being silently truncated.
+	// The cutoff is approximate to within a byte, which is immaterial at this cap.
+	resp.Body = &limitedReadCloser{inner: resp.Body, remaining: t.limit + 1}
+	return resp, nil
+}
+
+func (l *limitedReadCloser) Read(p []byte) (int, error) {
+	if l.remaining <= 0 {
+		return 0, fmt.Errorf("response body exceeds maximum allowed size")
+	}
+	if int64(len(p)) > l.remaining {
+		p = p[:l.remaining]
+	}
+	n, err := l.inner.Read(p)
+	l.remaining -= int64(n)
+	return n, err
+}
+
+func (l *limitedReadCloser) Close() error { return l.inner.Close() }
 
 // check if we need to launch the goroutine to collect App container stats
 func (z *zedrouter) checkAppContainerStatsCollecting(config *types.AppNetworkConfig,
@@ -330,14 +379,21 @@ func (z *zedrouter) getAppContainers(status types.AppNetworkStatus) (
 	cli, err := client.NewClientWithOpts(
 		client.WithHost(containerEndpoint),
 		client.WithVersion(dockerAPIVersion),
-		client.WithHTTPClient(&http.Client{}))
+		client.WithHTTPClient(&http.Client{
+			Timeout: dockerAPITimeout,
+			Transport: &limitedResponseTransport{
+				base:  http.DefaultTransport,
+				limit: maxDockerResponseSize,
+			},
+		}))
 	if err != nil {
 		z.log.Errorf("getAppContainers: client create failed, error %v", err)
 		return nil, nil, err
 	}
 
-	containers, err := cli.ContainerList(
-		context.Background(), containertypes.ListOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), dockerAPITimeout)
+	defer cancel()
+	containers, err := cli.ContainerList(ctx, containertypes.ListOptions{})
 	if err != nil {
 		z.log.Errorf("getAppContainers: Container list error %v", err)
 		return nil, nil, err
@@ -511,7 +567,8 @@ func (z *zedrouter) getNestedDomainAppList(status types.AppNetworkStatus) ([]typ
 
 // fetchHTTPData fetches data from the given URL
 func fetchHTTPData(url string) ([]byte, error) {
-	resp, err := http.Get(url)
+	httpClient := &http.Client{Timeout: nestedAppHTTPTimeout}
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch data from %s: %w", url, err)
 	}
@@ -521,9 +578,12 @@ func fetchHTTPData(url string) ([]byte, error) {
 		return nil, fmt.Errorf("unexpected status code %d from %s", resp.StatusCode, url)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxNestedAppResponseSize+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body from %s: %w", url, err)
+	}
+	if int64(len(data)) > maxNestedAppResponseSize {
+		return nil, fmt.Errorf("response from %s exceeds max size %d bytes", url, maxNestedAppResponseSize)
 	}
 
 	return data, nil

--- a/pkg/pillar/cmd/zedrouter/appcontainer_test.go
+++ b/pkg/pillar/cmd/zedrouter/appcontainer_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package zedrouter
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+)
+
+// TestLimitedReadCloser is a regression test for the response-body cap applied
+// to the untrusted app Docker endpoint (CWE-400). Reads must stay bounded and
+// return an error once the stream reaches the configured size instead of
+// allocating without limit.
+func TestLimitedReadCloser(t *testing.T) {
+	g := NewWithT(t)
+
+	newReader := func(n int) *limitedReadCloser {
+		body := io.NopCloser(bytes.NewReader(bytes.Repeat([]byte("a"), n)))
+		// remaining is the number of bytes that may be consumed before the next
+		// read is rejected; getAppContainers sets it to limit+1.
+		return &limitedReadCloser{inner: body, remaining: 10}
+	}
+
+	// Under the limit: the whole body is returned, no error.
+	out, err := io.ReadAll(newReader(9))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out).To(HaveLen(9))
+
+	// At the limit: rejected.
+	_, err = io.ReadAll(newReader(10))
+	g.Expect(err).To(HaveOccurred())
+
+	// Well over the limit: rejected, and no more than the cap is ever read.
+	_, err = io.ReadAll(newReader(1000))
+	g.Expect(err).To(HaveOccurred())
+}
+
+// TestLimitedResponseTransport verifies the transport wrapper caps the response
+// body seen by a client (as used by the Docker client in getAppContainers): a
+// body larger than the limit fails to read, a smaller one reads cleanly.
+func TestLimitedResponseTransport(t *testing.T) {
+	g := NewWithT(t)
+
+	serve := func(size int) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, _ *http.Request) {
+				w.Write(bytes.Repeat([]byte("x"), size))
+			}))
+	}
+	client := func() *http.Client {
+		return &http.Client{Transport: &limitedResponseTransport{
+			base: http.DefaultTransport, limit: 512}}
+	}
+
+	// Body within the cap: reads fine.
+	srv := serve(400)
+	defer srv.Close()
+	resp, err := client().Get(srv.URL)
+	g.Expect(err).ToNot(HaveOccurred())
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(body).To(HaveLen(400))
+
+	// Body over the cap: the read fails instead of allocating without limit.
+	bigSrv := serve(4096)
+	defer bigSrv.Close()
+	resp, err = client().Get(bigSrv.URL)
+	g.Expect(err).ToNot(HaveOccurred())
+	_, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	g.Expect(err).To(HaveOccurred())
+}
+
+// TestFetchHTTPData covers the happy path and the non-200 rejection of the
+// nested-app runtime metrics fetch.
+func TestFetchHTTPData(t *testing.T) {
+	g := NewWithT(t)
+
+	okSrv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte("payload"))
+		}))
+	defer okSrv.Close()
+	data, err := fetchHTTPData(okSrv.URL)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(data)).To(Equal("payload"))
+
+	errSrv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+	defer errSrv.Close()
+	_, err = fetchHTTPData(errSrv.URL)
+	g.Expect(err).To(HaveOccurred())
+}

--- a/pkg/pillar/controllerconn/send.go
+++ b/pkg/pillar/controllerconn/send.go
@@ -51,6 +51,9 @@ const MaxWaitForRequests = 4 * time.Minute
 // is not very often (e.g. once per day).
 const pcapDelay = 250 * time.Millisecond
 
+// maxLocalResponseSize bounds how much we read from a local endpoint response.
+const maxLocalResponseSize = 1 << 20 // 1 MiB
+
 // Client allows to establish connection to the controller/LOC/LPS
 // and perform some HTTP(S) request or just check if connectivity is working.
 // It takes care of proxy handling, TLS configuration, and network interface
@@ -1360,7 +1363,7 @@ func (c *Client) SendLocal(destURL string, intf string, ipSrc net.IP,
 		return nil, nil, errors.New(errStr)
 	}
 
-	contents, err := io.ReadAll(resp.Body)
+	contents, err := io.ReadAll(io.LimitReader(resp.Body, maxLocalResponseSize+1))
 	if err != nil {
 		resp.Body.Close()
 		resp.Body = nil
@@ -1370,8 +1373,15 @@ func (c *Client) SendLocal(destURL string, intf string, ipSrc net.IP,
 		return nil, nil, fmt.Errorf("ReadAll failed: %v", err)
 	}
 	resp.Body.Close()
-	resplen := int64(len(contents))
 	resp.Body = nil
+	if int64(len(contents)) > maxLocalResponseSize {
+		if c.AgentMetrics != nil {
+			c.AgentMetrics.RecordFailure(c.log, intf, reqURL, reqlen, 0, false)
+		}
+		return nil, nil, fmt.Errorf("SendLocal response from %s exceeds max size %d bytes",
+			reqURL, maxLocalResponseSize)
+	}
+	resplen := int64(len(contents))
 
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusNotModified, http.StatusNoContent:

--- a/pkg/pillar/controllerconn/send_local_test.go
+++ b/pkg/pillar/controllerconn/send_local_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllerconn_test
+
+import (
+	"bytes"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	"github.com/lf-edge/eve/pkg/pillar/controllerconn"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// TestSendLocalRejectsOversizeResponse is a regression test for the response
+// cap on SendLocal (CWE-400). A local endpoint is served by an application on
+// the device, which is untrusted; an oversized body must be rejected rather
+// than read into memory without limit.
+func TestSendLocalRejectsOversizeResponse(test *testing.T) {
+	t := NewGomegaWithT(test)
+
+	// maxLocalResponseSize is 1 MiB (unexported); answer with more than that.
+	overCap := (1 << 20) + 1024
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Write(bytes.Repeat([]byte("z"), overCap))
+		}))
+	defer server.Close()
+
+	var dns types.DeviceNetworkStatus
+	client := makeControllerClient(test, &dns, controllerconn.NewAgentMetrics())
+
+	_, contents, err := client.SendLocal(
+		server.URL, "lo", net.ParseIP("127.0.0.1"), nil, "")
+	t.Expect(err).To(HaveOccurred())
+	t.Expect(err.Error()).To(ContainSubstring("exceeds max size"))
+	t.Expect(contents).To(BeNil())
+}
+
+// TestSendLocalAcceptsSmallResponse makes sure the cap does not break the normal
+// case: a small body is returned to the caller unchanged.
+func TestSendLocalAcceptsSmallResponse(test *testing.T) {
+	t := NewGomegaWithT(test)
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte("hello-local"))
+		}))
+	defer server.Close()
+
+	var dns types.DeviceNetworkStatus
+	client := makeControllerClient(test, &dns, controllerconn.NewAgentMetrics())
+
+	resp, contents, err := client.SendLocal(
+		server.URL, "lo", net.ParseIP("127.0.0.1"), nil, "")
+	t.Expect(err).ToNot(HaveOccurred())
+	t.Expect(resp).ToNot(BeNil())
+	t.Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	t.Expect(string(contents)).To(Equal("hello-local"))
+}

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -56,6 +56,11 @@ const (
 	waitForPodCheckTime    = 15 // Check every 15 seconds, don't wait for too long to cause watchdog
 	tolerateSec            = 15 // Pod/VMI reschedule delay after node unreachable seconds
 	unknownToHaltMinutes   = 30 // If VMI is unknown for 30 minutes, return halt state
+	// virtHandlerHTTPTimeout bounds the metrics request to the KubeVirt
+	// virt-handler.
+	virtHandlerHTTPTimeout = 30 * time.Second
+	// maxVirtHandlerMetricsSize bounds the virt-handler metrics.
+	maxVirtHandlerMetricsSize = 16 << 20 // 16 MiB
 )
 
 // newKubevirtClient and newK8sClient wrap the kubevirt/k8s client
@@ -1938,6 +1943,7 @@ func (ctx kubevirtContext) GetDomsCPUMem() (map[string]types.DomainMetric, error
 
 	url := "https://" + virtIP + ":8443/metrics"
 	httpClient := &http.Client{
+		Timeout: virtHandlerHTTPTimeout,
 		Transport: &http.Transport{
 			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
 			DisableKeepAlives: true,
@@ -1960,11 +1966,14 @@ func (ctx kubevirtContext) GetDomsCPUMem() (map[string]types.DomainMetric, error
 		return nil, err
 	}
 
-	// Read the response body
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxVirtHandlerMetricsSize+1))
 	if err != nil {
 		logrus.Infof("GetDomsCPUMem: Error reading response body %v", err)
 		return nil, err
+	}
+	if int64(len(body)) > maxVirtHandlerMetricsSize {
+		return nil, fmt.Errorf("GetDomsCPUMem: metrics response from %s exceeds max size %d bytes",
+			url, maxVirtHandlerMetricsSize)
 	}
 
 	// domainAvailMB temporarily tracks kubevirt_vmi_memory_available_bytes per domain


### PR DESCRIPTION
# Description

This PR hardens pillar against unbounded HTTP response reads (CWE-400). Several
call sites read a response body with `io.ReadAll` and no size limit, and some
use an HTTP client with no timeout. Because every pillar agent runs as a
goroutine in the shared `zedbox` process, an untrusted or semi-trusted peer
that returns an arbitrarily large (or slow) body can exhaust memory and take
down all of pillar (and trigger a watchdog reboot).

Each fix wraps the read in an `io.LimitReader` with a generous cap and rejects
an oversized body, adding an HTTP client timeout where one was missing. Four
independent sites, one commit each:

- **controllerconn: bound SendLocal response size** - local LOC/LPS and
  app-provided endpoints are untrusted; cap at 1 MiB (these return small proto
  control messages).
- **zedrouter: bound and time-limit untrusted app metric reads** - the app
  Docker API client gets a timeout and a body-size-limiting transport (covers
  `ContainerList`/`Inspect`/`Stats`/`Logs`), and the nested-app metrics fetch
  gets a timeout plus a 10 MiB cap.
- **hypervisor/kubevirt: bound and time-limit virt-handler metrics read** -
  the virt-handler `/metrics` scrape (over the cluster network, TLS verification
  disabled) gets a timeout and a 16 MiB cap.
- **zedkube: bound cluster-peer app-info read** - responses from other cluster
  nodes (not fully trusted) get a 10 MiB cap.

The first two were reported externally (see the `Reported-by` trailers); the
kubevirt and zedkube fixes are variants found while auditing for the same
pattern. 

## How to test and validate this PR

Automated (added in this PR, run with `make -C pkg/pillar test`):

- `controllerconn`: `TestSendLocalRejectsOversizeResponse`,
  `TestSendLocalAcceptsSmallResponse`.
- `zedrouter`: `TestLimitedReadCloser`, `TestLimitedResponseTransport`,
  `TestFetchHTTPData`.

Manual:

1. Deploy an app with container stats collection enabled (`GetStatsIPAddr` set).
2. Have the app's Docker API / nested-app metrics endpoint return a multi-GB
   body (or a never-ending stream).
3. Confirm pillar logs an "exceeds max size" error for that cycle and does
   **not** grow unbounded / OOM / restart; a well-behaved app still reports
   metrics normally.

For the eve-k (kubevirt) variants, the equivalent is a virt-handler or a peer
cluster node returning an oversized `/metrics` or app-info response.

## Changelog notes

Hardened the edge device against denial-of-service from oversized HTTP responses
returned by applications or cluster peers: such responses are now rejected
instead of being read into memory without limit.

## PR Backports

All four fixes are security hardening and should be backported where the
affected code exists.

- 17.0-stable: To be backported (all four fixes; affected code present).
- 16.0-stable: To be backported (all four fixes; affected code present).
- 14.5-stable: To be backported (all four fixes; affected code present).
- 13.4-stable: To be backported, partially :
  - controllerconn/SendLocal: applies.
  - zedrouter/appcontainer: only the Docker-client cap/timeout applies; the
    nested-app `fetchHTTPData` path does not exist on 13.4.
  - hypervisor/kubevirt: applies.
  - zedkube cluster-peer read: N/A - the multi-node cluster status feature
    (`clusterAppIDHandler`) is not present on 13.4.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
