### PR TITLE
edgeview: fix directory-denylist path-traversal bypass (CWE-22)

### DIFF
--- a/pkg/edgeview/src/system.go
+++ b/pkg/edgeview/src/system.go
@@ -39,6 +39,7 @@ const (
 	requestRemoveInfoGZFile = requestCollectInfoDir + "/edgeview-request-remove-tar-gz"
 	infoFilePatternPrefix   = "/persist/eve-info/eve-info-edgeview-"
 	infoFilePattern         = infoFilePatternPrefix + "v*.tar.gz"
+	hostFSPrefix            = "/hostfs"
 )
 
 var tarBlockDirs = []string{
@@ -271,6 +272,11 @@ func runDu(opt string) {
 
 	if !finfo.IsDir() {
 		fmt.Printf("%s is not a directory\n", opt)
+		return
+	}
+
+	if !checkBlockedDirs(dir) {
+		fmt.Printf("directory is blocked for disk usage: %s\n", dir)
 		return
 	}
 
@@ -913,6 +919,11 @@ func runLs(opt string) {
 		}
 	}
 
+	if !checkBlockedDirs(path) {
+		fmt.Printf("directory is blocked for listing: %s\n", path)
+		return
+	}
+
 	if fi.IsDir() {
 		files, err := os.ReadDir(path)
 		if err != nil {
@@ -1234,15 +1245,42 @@ func createArchive(source, archiveName string, timeRange *logSearchRange, dirSiz
 	return nil
 }
 
-// checkBlockedDirs - return false if the dirName is in blocked list
+// checkBlockedDirs - return false if dirName resolves into a blocked directory.
+// The lexically-cleaned absolute path is checked, and so is the symlink-resolved
+// real path when it exists, so neither ".." traversal, the /hostfs host-mirror
+// alias, nor a symlink pointing into a blocked directory can slip past.
 func checkBlockedDirs(dirName string) bool {
-	for _, d := range tarBlockDirs {
-		d1 := strings.TrimPrefix(d, "/") // handle without leading '/' in front
-		if strings.HasPrefix(dirName, d) || strings.HasPrefix(dirName, d1) {
+	abs, err := filepath.Abs(dirName)
+	if err != nil {
+		return false
+	}
+	if isBlockedPath(abs) {
+		return false
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil && resolved != abs {
+		if isBlockedPath(resolved) {
 			return false
 		}
 	}
 	return true
+}
+
+// isBlockedPath reports whether p, after stripping the /hostfs host-mirror alias,
+// lies inside one of tarBlockDirs.
+func isBlockedPath(p string) bool {
+	for p == hostFSPrefix || strings.HasPrefix(p, hostFSPrefix+"/") {
+		p = strings.TrimPrefix(p, hostFSPrefix)
+		if p == "" {
+			p = "/"
+			break
+		}
+	}
+	for _, d := range tarBlockDirs {
+		if p == d || strings.HasPrefix(p, d+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 // checkBlockedFileSuffix - return false if the fileName suffix in blocked list

--- a/pkg/edgeview/src/system_path_test.go
+++ b/pkg/edgeview/src/system_path_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCheckBlockedDirs is a regression test for the edgeview cat/cp/tar
+// directory-denylist bypass (CWE-22). Path traversal and the /hostfs host-mirror
+// alias must not reach a blocked directory, while legitimate paths still pass.
+// Inputs are absolute so the result is independent of the test's working
+// directory (checkBlockedDirs resolves relative paths against the CWD, matching
+// how the caller's os.Stat/read resolve them).
+func TestCheckBlockedDirs(t *testing.T) {
+	cases := []struct {
+		path    string
+		allowed bool
+	}{
+		// Legitimate paths are allowed.
+		{"/persist/status/uuid", true},
+		{"/config/device.cert.pem", true},
+		{"/run/eve.id", true},
+		{"/persist", true},
+		{"/persist/vault-backup", true}, // sibling, not inside the blocked dir
+
+		// Blocked directories (direct).
+		{"/persist/vault", false},
+		{"/persist/vault/protector/key", false},
+		{"/persist/clear/x", false},
+		{"/run/domainmgr/cloudinit/x", false},
+		{"/run/.kube/k3s/x", false},
+
+		// Traversal must not slip past the check.
+		{"/persist/status/../vault/protector.key", false},
+		{"/a/b/../../persist/vault", false},
+		{"/persist/vault/../vault/key", false},
+
+		// The /hostfs host-mirror alias must not reach blocked dirs.
+		{"/hostfs/persist/vault/protector/key", false},
+		{"/hostfs/run/.kube/k3s", false},
+		{"/hostfs/hostfs/persist/vault", false},        // nested alias
+		{"/hostfs/persist/status/../vault/key", false}, // alias + traversal
+		{"/hostfs/etc/passwd", true},                   // non-secret via mirror, allowed
+	}
+	for _, c := range cases {
+		if got := checkBlockedDirs(c.path); got != c.allowed {
+			t.Errorf("checkBlockedDirs(%q) = %v, want %v", c.path, got, c.allowed)
+		}
+	}
+}
+
+// TestCheckBlockedDirsSymlink verifies that a symlink pointing into a blocked
+// directory is caught (the lexical path alone would not reveal it). It points
+// tarBlockDirs at a temp directory so the resolved paths actually exist on the
+// test host. The temp root is symlink-resolved up front so the blocked entry is
+// itself free of symlinks and matches the resolved targets.
+func TestCheckBlockedDirsSymlink(t *testing.T) {
+	tmp, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocked := filepath.Join(tmp, "vault")
+	if err := os.MkdirAll(blocked, 0700); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(blocked, "key")
+	if err := os.WriteFile(secret, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	fileLink := filepath.Join(tmp, "file-link") // -> blocked/key
+	dirLink := filepath.Join(tmp, "dir-link")   // -> blocked
+	if err := os.Symlink(secret, fileLink); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(blocked, dirLink); err != nil {
+		t.Fatal(err)
+	}
+	allowed := filepath.Join(tmp, "ok.txt")
+	if err := os.WriteFile(allowed, []byte("y"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	old := tarBlockDirs
+	tarBlockDirs = []string{blocked}
+	defer func() { tarBlockDirs = old }()
+
+	cases := []struct {
+		path    string
+		allowed bool
+	}{
+		{blocked, false},  // direct
+		{secret, false},   // file inside blocked dir
+		{fileLink, false}, // symlink to a file inside blocked dir
+		{dirLink, false},  // symlink to the blocked dir itself
+		{allowed, true},   // unrelated file
+		{tmp, true},       // parent of the blocked dir
+	}
+	for _, c := range cases {
+		if got := checkBlockedDirs(c.path); got != c.allowed {
+			t.Errorf("checkBlockedDirs(%q) = %v, want %v", c.path, got, c.allowed)
+		}
+	}
+}


### PR DESCRIPTION
# Description

edgeview's `cat`/`cp`/`tar` (and `ls`/`du`) gate access to the sealed data
store — `/persist/vault` (device + SCEP private keys), `/persist/clear`,
`/run/domainmgr/cloudinit`, `/run/.kube/k3s` — with a directory denylist.
`checkBlockedDirs` matched the caller-supplied path as a **raw string prefix**,
without cleaning or absolutizing it and without accounting for the `/hostfs`
bind-mount (a read-only mirror of the whole host filesystem), so the denylist
was bypassable (CWE-22):

- `..` traversal: `cat//persist/status/../vault/<file>`
- `/hostfs` host-mirror alias: `cat//hostfs/persist/vault/<file>`
- a symlink from an allowed path into a blocked dir (followed by the read)

`ls` and `du` didn't call the check at all, disclosing file names and sizes of
the sealed store.

The fix hardens `checkBlockedDirs` centrally (covers all callers): resolve the
path to an absolute, cleaned form and, when it exists, to its symlink-resolved
real path; strip the `/hostfs` alias (repeatedly, for nested forms); match
containment on a path boundary. It blocks on **either** the lexical or the
resolved form, so a blocked prefix reached via a symlink is caught without
assuming the prefixes are symlink-free. `ls`/`du` now call the check too.

Reported by the 408 Security Research Collective.

## PR dependencies

None.

## How to test and validate this PR

Automated (added in this PR): `make -C pkg/edgeview/src test` — or
`go test -C pkg/edgeview/src -race -run TestCheckBlockedDirs` runs
`TestCheckBlockedDirs` (traversal / `/hostfs` / nested / boundary) and
`TestCheckBlockedDirsSymlink` (real symlink into a blocked dir).

Manual, from an edgeview session:

1. Confirm each is refused ("directory is blocked ..."):
   - `cat//persist/status/../vault/<file>`
   - `cat//hostfs/persist/vault/<file>`
   - `ls//persist/vault`, `du//hostfs/persist/vault`
2. Confirm legitimate access still works: `cat//config/device.cert.pem`,
   `ls//persist/status`, `tar//persist/agentdebug`.

## Changelog notes

Hardened EdgeView so its `cat`/`cp`/`tar`/`ls`/`du` commands can no longer be
tricked — via `..` path traversal, the `/hostfs` mount, or symlinks — into
reading or listing the device's sealed data store (private keys, etc.).

## PR Backports

Present and unfixed on all current LTS branches (`checkBlockedDirs` uses a raw
prefix match and `/hostfs` is mounted on each).

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

Label added: `stable`.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
