### PR TITLE
edgeview: fix client-side untar Zip-Slip

### DIFF
--- a/pkg/edgeview/src/copyfile.go
+++ b/pkg/edgeview/src/copyfile.go
@@ -4,11 +4,12 @@
 package main
 
 import (
+	"archive/tar"
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -444,6 +445,63 @@ func sendCopyDone(context string, err error) {
 	}
 }
 
+// extractTarContained extracts the tar archive at tarPath into destDir. Every
+// member path is validated to stay within destDir, and only regular files and
+// directories are extracted; symlinks, hardlinks and other special members are
+// skipped.
+func extractTarContained(tarPath, destDir string) error {
+	f, err := os.Open(tarPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	destDir = filepath.Clean(destDir)
+	tr := tar.NewReader(f)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		// filepath.Join cleans the result, so a ".." or absolute member name
+		// cannot land outside destDir without tripping this boundary check.
+		target := filepath.Join(destDir, hdr.Name)
+		if target != destDir && !strings.HasPrefix(target, destDir+string(os.PathSeparator)) {
+			return fmt.Errorf("tar member %q escapes %s", hdr.Name, destDir)
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return err
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				out.Close()
+				return err
+			}
+			out.Close()
+		default:
+			// Skip symlinks/hardlinks/devices: a device-supplied archive must
+			// not create links that could redirect a later member's write.
+			fmt.Printf("untarLogfile: skipping unsupported tar member %q (type %d)\n",
+				hdr.Name, hdr.Typeflag)
+		}
+	}
+	return nil
+}
+
 // untarLogfile - unzip and make into a single .txt
 // with sequential log entries for dev and each of the apps
 // this is done only if the tar file size is not too large
@@ -466,10 +524,7 @@ func untarLogfile(downloadedFile string, filesize int64) {
 		fmt.Printf("untarLogfile: unexpected path %s\n", tarfile)
 		return
 	}
-	cmdArgs := []string{"xvf", tarfile, "-C", fileCopyDir}
-	untarCmd := exec.Command("tar", cmdArgs[:]...)
-
-	err := untarCmd.Run()
+	err := extractTarContained(tarfile, fileCopyDir)
 	if err != nil {
 		fmt.Printf("untar error: %v\n", err)
 	} else {

--- a/pkg/edgeview/src/copyfile_zipslip_test.go
+++ b/pkg/edgeview/src/copyfile_zipslip_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"archive/tar"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type tarEntry struct {
+	hdr  tar.Header
+	data []byte
+}
+
+func writeTestTar(t *testing.T, path string, entries []tarEntry) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	tw := tar.NewWriter(f)
+	for _, e := range entries {
+		h := e.hdr
+		if h.Typeflag == tar.TypeReg {
+			h.Size = int64(len(e.data))
+		}
+		if err := tw.WriteHeader(&h); err != nil {
+			t.Fatal(err)
+		}
+		if h.Typeflag == tar.TypeReg {
+			if _, err := tw.Write(e.data); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestExtractTarContained is a regression test for the edgeview client-side untar
+// Zip-Slip (CWE-22): a device-supplied archive must not write outside the
+// destination directory via ".." members or a symlink a later member is written
+// through, while a benign archive still extracts.
+func TestExtractTarContained(t *testing.T) {
+	// Benign archive extracts.
+	t.Run("benign", func(t *testing.T) {
+		dest := t.TempDir()
+		tarPath := filepath.Join(t.TempDir(), "ok.tar")
+		writeTestTar(t, tarPath, []tarEntry{
+			{hdr: tar.Header{Name: "newlog", Typeflag: tar.TypeDir, Mode: 0755}},
+			{hdr: tar.Header{Name: "newlog/dev.log.gz", Typeflag: tar.TypeReg, Mode: 0644}, data: []byte("hello")},
+		})
+		if err := extractTarContained(tarPath, dest); err != nil {
+			t.Fatalf("benign extract failed: %v", err)
+		}
+		got, err := os.ReadFile(filepath.Join(dest, "newlog", "dev.log.gz"))
+		if err != nil || string(got) != "hello" {
+			t.Fatalf("benign member not extracted: %v (%q)", err, got)
+		}
+	})
+
+	// A ".." member is rejected and nothing is written outside dest.
+	t.Run("traversal", func(t *testing.T) {
+		dest := t.TempDir()
+		tarPath := filepath.Join(t.TempDir(), "trav.tar")
+		writeTestTar(t, tarPath, []tarEntry{
+			{hdr: tar.Header{Name: "../evil.txt", Typeflag: tar.TypeReg, Mode: 0644}, data: []byte("pwned")},
+		})
+		if err := extractTarContained(tarPath, dest); err == nil {
+			t.Fatal("expected error for traversal member, got nil")
+		}
+		if _, err := os.Stat(filepath.Join(filepath.Dir(dest), "evil.txt")); err == nil {
+			t.Fatal("traversal member escaped the destination")
+		}
+	})
+
+	// A symlink member pointing outside is skipped, so a later member written
+	// "through" it stays contained and does not reach the outside target.
+	t.Run("symlink-escape", func(t *testing.T) {
+		dest := t.TempDir()
+		outside := t.TempDir()
+		tarPath := filepath.Join(t.TempDir(), "link.tar")
+		writeTestTar(t, tarPath, []tarEntry{
+			{hdr: tar.Header{Name: "link", Typeflag: tar.TypeSymlink, Linkname: outside, Mode: 0777}},
+			{hdr: tar.Header{Name: "link/pwned.txt", Typeflag: tar.TypeReg, Mode: 0644}, data: []byte("pwned")},
+		})
+		// Skipping the symlink and writing a contained "link" dir is fine; the
+		// escape (writing into the outside target) must not happen.
+		_ = extractTarContained(tarPath, dest)
+		if _, err := os.Stat(filepath.Join(outside, "pwned.txt")); err == nil {
+			t.Fatal("symlink member allowed a write outside the destination")
+		}
+	})
+}


### PR DESCRIPTION
# Description

The edgeview client extracts a device-supplied tar in `untarLogfile`
(`pkg/edgeview/src/copyfile.go`) with `tar xvf` and no validation of member
paths. A malicious or compromised device the operator connects to could write
outside the download directory via `..` members or a symlink that a later member
is written through (Zip-Slip, CWE-22). In the documented deployment the client
runs in a disposable `docker run --rm` container, which bounds the blast radius;
an operator running the client directly on their host would take the write
there.

Replace the `tar xvf` shell-out with in-process `archive/tar` extraction that
rejects any member escaping the destination and skips symlink/hardlink/special
members. The device-side archive (`createArchive`) already contains only
directories and regular files and omits symlinks, so the newlog workflow is
unaffected. Adds a regression test.

Reported by 408 Security Research Collective.

## PR dependencies

None.

## How to test and validate this PR

Automated (added in this PR): `go test -C pkg/edgeview/src -race -run
TestExtractTarContained` covers the benign, `..`-traversal, and symlink-escape
cases. During development the extractor was also checked against real tarballs
(Go source trees, docs with binary images, a newlog-shaped `.gz` archive):
extracted content matched the source and `tar xf` byte-for-byte (283 regular
files), with symlink members skipped by design.

Manual:

1. On an EVE-K / cluster or standard device, run the edgeview `log/copy-logfiles`
   workflow and confirm logs are downloaded and extracted normally into the
   client download directory.
2. Negative check (requires a crafted archive): a device-supplied tar containing
   a `..` member or a symlink-then-write-through pair must not create any file
   outside the download directory; extraction reports an error / skips the
   member instead.

## Changelog notes

Hardened the EdgeView client so a malicious device cannot use a crafted log
archive to write files outside the client's download directory during log
extraction.

## PR Backports

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [ ] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
