### PR TITLE
domainmgr: bound the graceful stop wait for default-mode guests

### DIFF
--- a/evetest/tests/apps/shutdown_immediate_deactivate_test.go
+++ b/evetest/tests/apps/shutdown_immediate_deactivate_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package apps_test
+
+import (
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	"github.com/lf-edge/eve-api/go/evecommon"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/netmodels"
+)
+
+// TestHaltAfterImmediateDeactivate verifies that an application deactivated in
+// the same second it first reports RUNNING is still stopped promptly.
+//
+// A guest that early in its boot cannot service the ACPI poweroff request, so
+// the request is lost and the stop has to escalate for the application to go
+// away at all. The budget before that escalation depends on the virtualization
+// mode, and an application whose configuration leaves the mode unset gets PV,
+// the zero value -- which is the case this test covers, and which used to be
+// granted the whole ten-minute budget rather than the minute HVM and FML get.
+// The application then stayed reported as halting for that whole period,
+// holding its memory and any assigned devices.
+//
+// Network model
+// -------------
+//   - netmodels.SingleEthWithDHCP -- nothing here depends on the topology; the
+//     application only has to run and then stop.
+//
+// Device configuration
+// --------------------
+//   - one mgmt+apps port, one local network instance
+//   - one container application on it, with the virtualization mode left unset
+//     so that it defaults, which is what puts it on the path under test
+//
+// Phases
+// ------
+//  1. Deploy the application and wait until it is reported RUNNING.
+//  2. Deactivate it immediately, with nothing in between -- anything which
+//     samples state first lets the guest become able to service the request,
+//     and the case stops being the one under test.
+//  3. Require it to be reported HALTED within haltBudget.
+func TestHaltAfterImmediateDeactivate(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+	)
+	hypervisor := evetest.GetHypervisorParameterValue()
+
+	evetest.Setup(
+		evetest.RequireEdgeDevice{
+			Name:              devName,
+			WithHypervisor:    hypervisor,
+			DeviceReusePolicy: evetest.ResetDeviceConfig,
+		},
+		evetest.RequireNetworkModel{NetworkModel: netmodels.SingleEthWithDHCP},
+	)
+	device := evetest.GetEdgeDevice(devName)
+	evetest.Checkpoint("setup-done")
+
+	devConfig := evetest.NewEdgeDeviceConfig(devName)
+	dhcpNet := devConfig.AddNetwork(evetest.DHCPNetworkConfig{
+		NetworkType: evecommon.NetworkType_V4Only,
+	})
+	devConfig.AddNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  "ethernet0",
+		PhysicalLabel: "eth0",
+		InterfaceName: "eth0",
+		NetworkUUID:   dhcpNet,
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+	})
+	niUUID := addLocalNI(devConfig)
+	appUUID := devConfig.AddApplication(evetest.ApplicationInstanceConfig{
+		DisplayName: "halted-app",
+		Activate:    true,
+		Image: evetest.DockerContainer{
+			ImageName: ubuntuCtrImage,
+			Tag:       ubuntuCtrTag,
+		},
+		// VirtualizationMode is deliberately left unset: defaulting is what
+		// puts the application on the path under test.
+		CPUs:            1,
+		MemoryBytes:     500 * evetest.MiB,
+		NetworkAdapters: singleVIFWithSSH(niUUID),
+	})
+
+	appUpdates, stopAppWatch := device.WatchAppInfo(appUUID)
+	defer stopAppWatch()
+	device.ApplyConfig(devConfig, true, true)
+	device.WaitUntilAppIsRunning(appUUID, 5*time.Minute)
+	evetest.Checkpoint("app-running")
+
+	halt := watchHalt(appUpdates)
+	device.DeactivateApplication(appUUID, false, 0)
+	evetest.Checkpoint("app-deactivated")
+
+	requireHaltedWithinBudget(t, halt)
+}

--- a/evetest/tests/apps/testsuite_test.go
+++ b/evetest/tests/apps/testsuite_test.go
@@ -82,6 +82,9 @@ import (
 //   - TestAppRestart -- controller-requested restarts (restart counter
 //     bumps, no purge) bring the app back to RUNNING; regression test for
 //     a stale QMP handler quitting the re-created domain.
+//   - TestHaltAfterImmediateDeactivate -- an app stopped in the same second
+//     it reports RUNNING still halts promptly; regression test for the
+//     graceful budget an unset virtualization mode used to be granted.
 //   - TestHaltUnresponsiveGuest -- a guest which never services the ACPI
 //     poweroff request still halts promptly, because the stop escalates to
 //     terminating the domain. Pulls its image from dl-cdn.alpinelinux.org.
@@ -127,6 +130,9 @@ func TestAppsSuite(test *testing.T) {
 		},
 		evetest.TestCase{
 			Test: TestAppRestart,
+		},
+		evetest.TestCase{
+			Test: TestHaltAfterImmediateDeactivate,
 		},
 		evetest.TestCase{
 			Test: TestHaltUnresponsiveGuest,

--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -87,6 +87,10 @@ const (
 	warningTime         = 40 * time.Second
 	casClientType       = "containerd"
 	unknownStateRetries = 10
+
+	// gracefulShutdownWait bounds how long a guest is given to act on the
+	// poweroff request before the stop is escalated to a forced one.
+	gracefulShutdownWait = 60 * time.Second
 )
 
 // Really a constant
@@ -2185,6 +2189,33 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 }
 
 // shutdown and wait for the domain to go away; if that fails destroy and wait
+// shutdownBudget decides how a domain in the given virtualization mode is asked
+// to stop: whether a poweroff request is sent at all, and how long that request
+// is given to take effect before the caller escalates to a forced stop. hvName
+// is the hypervisor backend in use, and maxDelay the budget for a mode that
+// warrants waiting the whole way.
+func shutdownBudget(mode types.VmMode, hvName string,
+	maxDelay time.Duration) (doShutdown bool, firstDelay time.Duration) {
+
+	switch mode {
+	case types.HVM, types.FML:
+		// Do a short shutdown wait, just in case there are
+		// PV tools in guest, then a shutdown -F
+		return true, gracefulShutdownWait
+	case types.PV:
+		// PV is the zero value of VmMode, so it is also what an application
+		// whose config leaves the mode unset lands on. Only xen acts on the
+		// mode; under any other hypervisor such a guest is no more likely to
+		// service the poweroff request than an HVM one, so it gets the same
+		// short wait rather than the whole budget.
+		if hvName == hypervisor.XenHypervisorName {
+			return true, maxDelay
+		}
+		return true, gracefulShutdownWait
+	}
+	return false, maxDelay
+}
+
 func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool) {
 
 	log.Functionf("doInactivate(%v) for %s domainId %d",
@@ -2226,19 +2257,8 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 		maxDelay /= 10
 	}
 
-	firstDelay := maxDelay
-	doShutdown := false // shutdown for particular VirtualizationModes
-
-	switch status.VirtualizationMode {
-	case types.HVM, types.FML:
-		doShutdown = true
-
-		// Do a short shutdown wait, just in case there are
-		// PV tools in guest, then a shutdown -F
-		firstDelay = time.Second * 60
-	case types.PV:
-		doShutdown = true
-	}
+	doShutdown, firstDelay := shutdownBudget(status.VirtualizationMode,
+		hyper.Name(), maxDelay)
 
 	if status.DomainId != 0 {
 		status.State = types.HALTING

--- a/pkg/pillar/cmd/domainmgr/shutdownbudget_test.go
+++ b/pkg/pillar/cmd/domainmgr/shutdownbudget_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package domainmgr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/hypervisor"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// The budget the poweroff request gets decides how long an application stays
+// reported as halting when its guest cannot service that request. A guest whose
+// mode carries no meaning for the hypervisor running it must not hold the whole
+// budget before the stop is escalated.
+func TestShutdownBudget(t *testing.T) {
+	const maxDelay = 600 * time.Second
+
+	tests := []struct {
+		name           string
+		mode           types.VmMode
+		hvName         string
+		maxDelay       time.Duration
+		wantShutdown   bool
+		wantFirstDelay time.Duration
+	}{
+		{
+			name:           "PV under kvm is the unset default and waits briefly",
+			mode:           types.PV,
+			hvName:         hypervisor.KVMHypervisorName,
+			maxDelay:       maxDelay,
+			wantShutdown:   true,
+			wantFirstDelay: gracefulShutdownWait,
+		},
+		{
+			name:           "PV under kubevirt waits briefly too",
+			mode:           types.PV,
+			hvName:         hypervisor.KubevirtHypervisorName,
+			maxDelay:       maxDelay,
+			wantShutdown:   true,
+			wantFirstDelay: gracefulShutdownWait,
+		},
+		{
+			name:           "PV under xen is a real PV guest and keeps the budget",
+			mode:           types.PV,
+			hvName:         hypervisor.XenHypervisorName,
+			maxDelay:       maxDelay,
+			wantShutdown:   true,
+			wantFirstDelay: maxDelay,
+		},
+		{
+			name:           "an impatient xen PV guest gets only the reduced budget",
+			mode:           types.PV,
+			hvName:         hypervisor.XenHypervisorName,
+			maxDelay:       maxDelay / 10,
+			wantShutdown:   true,
+			wantFirstDelay: maxDelay / 10,
+		},
+		{
+			name:           "HVM waits briefly",
+			mode:           types.HVM,
+			hvName:         hypervisor.KVMHypervisorName,
+			maxDelay:       maxDelay,
+			wantShutdown:   true,
+			wantFirstDelay: gracefulShutdownWait,
+		},
+		{
+			name:           "FML waits briefly",
+			mode:           types.FML,
+			hvName:         hypervisor.KVMHypervisorName,
+			maxDelay:       maxDelay,
+			wantShutdown:   true,
+			wantFirstDelay: gracefulShutdownWait,
+		},
+		{
+			name:         "NOHYPER is never asked to power off",
+			mode:         types.NOHYPER,
+			hvName:       hypervisor.KVMHypervisorName,
+			maxDelay:     maxDelay,
+			wantShutdown: false,
+		},
+		{
+			name:         "LEGACY is never asked to power off",
+			mode:         types.LEGACY,
+			hvName:       hypervisor.XenHypervisorName,
+			maxDelay:     maxDelay,
+			wantShutdown: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doShutdown, firstDelay := shutdownBudget(tt.mode, tt.hvName, tt.maxDelay)
+			if doShutdown != tt.wantShutdown {
+				t.Fatalf("doShutdown = %v, want %v", doShutdown, tt.wantShutdown)
+			}
+			if doShutdown && firstDelay != tt.wantFirstDelay {
+				t.Errorf("firstDelay = %v, want %v", firstDelay, tt.wantFirstDelay)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Fixes #6440.

An application whose configuration leaves the virtualization mode unset gets
`PV`, the zero value of the mode enum. Only xen acts on that mode; under kvm or
kubevirt such a guest is an ordinary one which happens to have defaulted. Yet
deactivating it granted the ACPI poweroff request the entire ten-minute budget
before anything else was tried, because the `PV` case in `doInactivate` sets
`doShutdown` without lowering `firstDelay` from `maxDelay` the way `HVM` and
`FML` do. A guest which cannot service the request yet -- one still early in
boot, for instance -- therefore stayed reported as halting for that whole
period, holding its memory and any assigned devices, even though the steps
which follow would have freed it in seconds.

Such a guest now gets the same one-minute wait an `HVM` or `FML` guest already
gets, after which the stop escalates exactly as before. **A xen `PV` guest keeps
the full budget:** there the mode names a real paravirtualized guest whose tools
are inherent, so a slow but cooperative shutdown is worth waiting out, and
shortening it would be a behaviour change for those guests that this PR does not
want to make.

The decision moves into `shutdownBudget`, which reports whether a poweroff
request is sent at all and how long it is given, so it can be exercised without
a running domainmgr.

## PR dependencies

None. In particular this is **independent of #6441** -- see below.

## How to test and validate this PR

Covered by a unit test and an evetest test, both validated against un-fixed
code.

`TestShutdownBudget` covers all eight mode/hypervisor combinations. Reverting
the `PV` arm to `return true, maxDelay` fails exactly the two rows this PR
changes (`firstDelay = 10m0s, want 1m0s`) while the xen, `HVM`, `FML`,
`NOHYPER` and `LEGACY` rows still pass.

`TestHaltAfterImmediateDeactivate`, in `evetest/tests/apps` and registered in
`TestAppsSuite`, deploys a container application, waits until it is reported
RUNNING and deactivates it immediately -- nothing in between, because anything
which samples state first lets the guest become able to service the request and
the case stops being the one under test. Against an EVE image without this
change it **fails**:

```text
shutdown_helpers_test.go:68: TEST FAILURE:
  application was not reported HALTED within 5m0s of being deactivated;
  a stop which does not escalate costs the whole 600s budget
```

and passes with it, reporting HALTED 1m37s after the deactivation.

The assertion is on elapsed time because the reported state sequence is
identical either way -- RUNNING, HALTING, HALTED -- and only the time spent
halting differs; there is nothing qualitative to assert on through the EVE API.
The 300s bound separates two hardcoded budgets an order of magnitude apart
rather than an amount of work, so it is not a stopwatch on a loaded host: the
prompt path measured 95-100s across ~90 runs under contention, against 636s and
701s for the two ways of losing the budget.

Measured end to end on EVE-kvm amd64 under evetest, deactivating a container
application in the same second it first reports RUNNING, which is the #6440
trigger. Three EVE images off one common base, differing only in the fix, with
every run's achieved RUNNING->deactivate gap confirmed to be 0s:

| build | deactivate -> HALTED |
| --- | --- |
| base | 637 / 636 / 637 s |
| base + this PR | 98 / 95 / 96 s |
| base + this PR + #6441 | 99 / 97 / 99 s |

Soaked for 8 hours on the middle build: **85 runs, all at a 0s gap, 95-100s,
no outliers**, bookended by runs of the un-fixed build which still produced
636s and 637s -- so "never stalled" reflects the change and not a trigger which
quietly stopped firing.

The third row is why this PR does not depend on #6441: with the graceful wait
bounded, the guest is ACPI-capable by the time the request is re-sent, so
making the escalation terminate the domain saves nothing *here*. #6441 is
needed for a different failure, #6452, where the guest never becomes capable at
all -- there this PR is the one that changes nothing. The two are complementary
and neither subsumes the other.

## Changelog notes

An application which is stopped very shortly after it starts is no longer held
for ten minutes before it is reported as stopped.

## PR Backports

- 17.0-stable: #6472
- 16.0-stable: #6473
- 14.5-stable: #6474
- 13.4-stable: #6475

The `PV` case has left `firstDelay` at `maxDelay` since the switch was written,
so every stable branch carries it.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation -- no documented behaviour changes;
  the budgets are internal to `doInactivate`.
- [x] I've tested my PR on amd64 device -- the measurements above.
- [ ] I've tested my PR on arm64 device -- not tested; the change is
  architecture independent.
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR


