### PR TITLE
kube-init: fix eve-k VNC proxy regressions from the bash rewrite

### DIFF
--- a/pkg/kube/kube-init/vnc/vnc.go
+++ b/pkg/kube/kube-init/vnc/vnc.go
@@ -12,12 +12,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net"
 	"os"
 	"os/exec"
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/lf-edge/eve/pkg/kube/kube-init/state"
+	"github.com/lf-edge/eve/pkg/pillar/utils/netutils"
 )
 
 // Paths and process knobs. Vars so tests can route them onto tmp
@@ -185,6 +187,7 @@ func (m *Manager) startVirtctl(cfg *vncConfig) error {
 		"--port", fmt.Sprintf("%d", cfg.VNCPort),
 		"--proxy-only",
 	)
+	cmd.Env = virtctlEnv()
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	if err := cmd.Start(); err != nil {
@@ -206,7 +209,11 @@ func (m *Manager) startVirtctl(cfg *vncConfig) error {
 			_ = logFile.Close()
 			return fmt.Errorf("virtctl exited before port was ready")
 		case <-tick.C:
-			if portListening(cfg.VNCPort) {
+			// Must not Dial: virtctl --proxy-only treats any TCP
+			// connection as the one VNC session and exits once it
+			// closes, so a connect-and-close readiness probe kills
+			// the proxy right after "confirming" it's up.
+			if netutils.IsLocalPortListening(uint32(cfg.VNCPort)) {
 				m.mu.Lock()
 				m.virtctlCmd = cmd
 				m.logFile = logFile
@@ -273,16 +280,12 @@ func (m *Manager) callerPIDWatchdog(ctx context.Context, pid int) {
 	}
 }
 
-// portListening dials 127.0.0.1:<port> with a 1-second budget and
-// returns true if anything answered.
-func portListening(port int) bool {
-	conn, err := net.DialTimeout("tcp",
-		fmt.Sprintf("127.0.0.1:%d", port), time.Second)
-	if err != nil {
-		return false
-	}
-	_ = conn.Close()
-	return true
+// virtctlEnv builds the environment for the virtctl subprocess.
+// virtctl needs KUBECONFIG to reach the k3s API server; without it,
+// client-go falls back to the legacy insecure default address
+// ([::1]:8080) and every call fails.
+func virtctlEnv() []string {
+	return append(os.Environ(), "KUBECONFIG="+state.K3sKubeconfig)
 }
 
 // processAlive reports whether the given PID exists. Signal 0 is a

--- a/pkg/kube/kube-init/vnc/vnc_test.go
+++ b/pkg/kube/kube-init/vnc/vnc_test.go
@@ -7,7 +7,10 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
+
+	"github.com/lf-edge/eve/pkg/kube/kube-init/state"
 )
 
 func TestIsRegularFile(t *testing.T) {
@@ -91,6 +94,18 @@ func TestVncConfigParsing(t *testing.T) {
 					cfg, c.wantVMI, c.wantPort, c.wantPID)
 			}
 		})
+	}
+}
+
+// TestVirtctlEnvIncludesKubeconfig guards against the regression
+// where virtctl was spawned with no KUBECONFIG in its environment,
+// causing client-go to fall back to the insecure [::1]:8080 default
+// API server address instead of reaching the real k3s server.
+func TestVirtctlEnvIncludesKubeconfig(t *testing.T) {
+	want := "KUBECONFIG=" + state.K3sKubeconfig
+	env := virtctlEnv()
+	if !slices.Contains(env, want) {
+		t.Errorf("virtctlEnv() = %v, want it to contain %q", env, want)
 	}
 }
 


### PR DESCRIPTION
# Description

The Go kube-init VNC proxy (replacing the retired cluster-init.sh / vnc-proxy.sh) had two regressions that together made VNC access never work, only visible once both were fixed:

1. startVirtctl spawned virtctl vnc --proxy-only with no KUBECONFIG in its environment and no --kubeconfig/--server flag. With nothing to load, client-go fell back to the legacy insecure default API server address ([::1]:8080), so every call failed ("virtctl exited before port was ready"). The old shell script avoided this by exporting KUBECONFIG once at the top, which every backgrounded virtctl call inherited; the Go rewrite dropped that for this one subprocess, even though update/cluster.go already sets KUBECONFIG explicitly on its own exec.Command calls.

2. Once KUBECONFIG was fixed, the readiness probe still broke things: it polled with net.DialTimeout, connecting and immediately closing. virtctl --proxy-only treats any TCP connection as the one VNC client session, so the probe's own connect-then-close made virtctl consider the session finished and exit right after "confirming" it had started. The manager saw the process die, restarted it, and repeated forever every ~1s - the real VNC client from edgeview/noVNC never got a stable proxy to connect through.

Fix both: extract env construction into virtctlEnv() and set KUBECONFIG there, and replace the Dial-based probe with netutils.IsLocalPortListening, which reads /proc/net/tcp for LISTEN state without opening a connection. zedkube/vnc.go and edgeview/network.go already use that helper for the same reason; vnc.go was the one prober that still dialed.

Add a regression test for the KUBECONFIG env setup.

## PR dependencies

## How to test and validate this PR

Run eve-k image w/ this patch, and launch VM apps. In the UI, remote-access,
run the VNC to the apps. Make sure it is working.

## Changelog notes

kube-init: fix eve-k VNC proxy regressions from the bash rewrite

## PR Backports

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [ ] I've added a reference link to the original PR
- [ ] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
