### PR TITLE
Increase squashfs block size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -480,6 +480,14 @@ else
         endif
 endif
 
+# squashfs block size for the rootfs image, in bytes. Empty means the mksquashfs
+# default of 128KB. Larger blocks shrink the image but read-amplify: faulting one
+# 4KB page reads and decompresses the whole block.
+ROOTFS_SQUASHFS_BLOCK_SIZE=
+ifeq ($(ZARCH)-$(HV),amd64-kvm)
+    ROOTFS_SQUASHFS_BLOCK_SIZE=1048576
+endif
+
 PKGS_riscv64=pkg/ipxe pkg/mkconf pkg/mkimage-iso-efi pkg/grub     \
              pkg/mkimage-raw-efi pkg/uefi pkg/u-boot pkg/cross-compilers \
 	     pkg/debug pkg/dom0-ztools pkg/gpt-tools pkg/storage-init pkg/mkrootfs-squash \
@@ -894,7 +902,7 @@ $(ROOTFS_IMG_BASE)-%.img: $(ROOTFS_TAR_BASE)-%.tar | $(INSTALLER)
 endif
 	$(QUIET): $@: Begin
 	echo "Building rootfs image $@ from $(ROOTFS_TAR_BASE)-$*.tar"
-	./tools/makerootfs.sh imagefromtar -t $(ROOTFS_TAR_BASE)-$*.tar -i $@ -f $(ROOTFS_FORMAT) -a $(ZARCH)
+	./tools/makerootfs.sh imagefromtar -t $(ROOTFS_TAR_BASE)-$*.tar -i $@ -f $(ROOTFS_FORMAT) -a $(ZARCH) $(if $(ROOTFS_SQUASHFS_BLOCK_SIZE),-b $(ROOTFS_SQUASHFS_BLOCK_SIZE))
 	@echo "size of $@ is $$(wc -c < "$@")B"
 ifeq ($(ROOTFS_FORMAT),squash)
 	@[ $$(wc -c < "$@") -gt $$(( $(ROOTFS_MAXSIZE_MB) * 1024 * 1024 )) ] && \

--- a/pkg/mkrootfs-squash/make-rootfs
+++ b/pkg/mkrootfs-squash/make-rootfs
@@ -7,6 +7,7 @@
 #
 # The following env variables change the behaviour of this script
 #     DEBUG - makes this script verbose
+#     SQUASHFS_BLOCK_SIZE - mksquashfs -b value; unset means the mksquashfs default
 
 set -e
 [ -n "$DEBUG" ] && set -x
@@ -35,7 +36,13 @@ IMGFILE=/rootfs.img
   ROOTFS_PART_SIZE_KB=$(( ( ($ROOTFS_PART_SIZE + 1024) / 1024 * 1024) / 1024 ))
   ROOTFS_PART_SECTORS=$(( $ROOTFS_PART_SIZE_KB * 2 ))
 
-  mksquashfs /tmp/rootfs/ $IMGFILE -noappend -comp xz -Xbcj x86,arm -no-recovery
+  BLOCKSIZE_ARG=""
+  if [ -n "${SQUASHFS_BLOCK_SIZE:-}" ]; then
+    BLOCKSIZE_ARG="-b $SQUASHFS_BLOCK_SIZE"
+  fi
+
+  # shellcheck disable=SC2086
+  mksquashfs /tmp/rootfs/ $IMGFILE -noappend -comp xz -Xbcj x86,arm $BLOCKSIZE_ARG -no-recovery
 )
 
 $EXPORT_CMD

--- a/tools/makerootfs.sh
+++ b/tools/makerootfs.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # Usage:
 #
-#     ./makerootfs.sh mode [-y <image.yml>] [-i <output rootfs image>] [-t <tar file>] [-f <filesystem format>] [-a <arch>] [-d <directory where to execute>]
+#     ./makerootfs.sh mode [-y <image.yml>] [-i <output rootfs image>] [-t <tar file>] [-f <filesystem format>] [-a <arch>] [-b <squashfs block size>] [-d <directory where to execute>]
 # <fs> defaults to squash
 # <arch> defaults to the current machine architecture
+# <squashfs block size> defaults to the mksquashfs default, and is ignored for ext4
 
 # NOTE: this will get executed from the provided -d <dir>, or else the current directory
 # make NO assumptions about where this runs; if you can, use absolute paths
@@ -64,9 +65,13 @@ do_imagefromtar() {
     echo "must supply tarfile and imgfile and not ymlfile" >&2
     help
   fi
+  BLOCKSIZEARG=""
+  if [ -n "$blocksize" ]; then
+    BLOCKSIZEARG="-e SQUASHFS_BLOCK_SIZE=${blocksize}"
+  fi
   : > "$IMAGE"
-  # shellcheck disable=SC2002
-  cat "${tarfile}" | docker run -i --rm -v /dev:/dev --privileged -v "$IMAGE:/rootfs.img" "${MKROOTFS_TAG}"
+  # shellcheck disable=SC2002,SC2086
+  cat "${tarfile}" | docker run -i --rm -v /dev:/dev --privileged ${BLOCKSIZEARG} -v "$IMAGE:/rootfs.img" "${MKROOTFS_TAG}"
 }
 
 abspath() {
@@ -104,14 +109,14 @@ bail() {
 
 # no mode we recognize
 help() {
-  echo "Usage: $0 <mode> [-y <image.yml>] [-i <output rootfs image>] [-t <tarfile>] [-f {ext4|squash}] [-a <arch>] [-d <directory>]" >&2
+  echo "Usage: $0 <mode> [-y <image.yml>] [-i <output rootfs image>] [-t <tarfile>] [-f {ext4|squash}] [-a <arch>] [-b <squashfs block size>] [-d <directory>]" >&2
   echo "must be one of the following modes:" >&2
   echo "  generate final image from yml:" >&2
   echo "    $0 image [-y <image.yml>] [-i <output rootfs image>] [-f {ext4|squash}] [-a <arch>]" >&2
   echo "  generate tar from yml:" >&2
   echo "    $0 tar [-y <image.yml>] [-t <output tarfile>] [-a <arch>]" >&2
   echo "  generate final image from tar:" >&2
-  echo "    $0 imagefromtar [-i <output rootfs image>] [-f {ext4|squash}] [-t <input tarfile>]" >&2
+  echo "    $0 imagefromtar [-i <output rootfs image>] [-f {ext4|squash}] [-t <input tarfile>] [-b <squashfs block size>]" >&2
   echo
   echo "setting the directory via -d will change to execute in the given directory" >&2
   exit 1
@@ -125,7 +130,7 @@ mode="$1"
 shift
 
 unset tarfile imgfile arch format ymlfile execidr updatetar
-while getopts "t:i:a:f:y:d:uh" o
+while getopts "t:i:a:f:y:d:b:uh" o
 do
   case $o in
     t)
@@ -136,6 +141,9 @@ do
       ;;
     a)
       arch="$OPTARG"
+      ;;
+    b)
+      blocksize="$OPTARG"
       ;;
     f)
       format="$OPTARG"


### PR DESCRIPTION
# Description

The amd64/kvm rootfs sits 1.38MiB below `ROOTFS_MAXSIZE_MB` (290), so any
package growth now breaks the build rather than merely costing space. The Core
image additionally has to keep fitting the legacy 300MB partition.

squashfs compresses in fixed-size blocks, and `mksquashfs` was invoked with no
`-b`, leaving the tool default of 128KB. Larger blocks give the compressor more
context and shrink the image.

This PR plumbs a block size from the Makefile down into `pkg/mkrootfs-squash`
and applies it to amd64/kvm only. It is currently set to 1MB; **the value is a
one-line change to `ROOTFS_SQUASHFS_BLOCK_SIZE`**, and the measurements below
cover every option so reviewers can pick a different one.

## Measurements

Four images built from the same tree, identical except for the `mksquashfs -b`
value. Block size verified in each with `unsquashfs -s`. Measured on an
amd64 KVM guest (4 vCPU, 2048MiB RAM, ext4), three boots per variant.

| Block size | rootfs.img | Step | Headroom under 290MiB | Boot read | vs 128KB | SUnreclaim | Cached | Bytes/fault | Decompress (300 reads) | zedbox start |
|---|---|---|---|---|---|---|---|---|---|---|
| 128KB (today) | 288.62MiB | — | 1.38MiB | 142.5MB | — | — | — | 34.2kB | 0.63s | 22.67s |
| 256KB | 282.57MiB | −6.04MiB | 7.43MiB | 151.3MB | +6.1% | +0.49MB | +17MB | 53.2kB | 0.94s | 22.92s |
| 512KB | 277.17MiB | −5.40MiB | 12.83MiB | 173.9MB | +22.0% | +1.81MB | +41MB | 83.1kB | 1.48s | 23.54s |
| **1MB (this PR)** | **271.82MiB** | **−5.35MiB** | **18.18MiB** | 212.2MB | +48.9% | +3.96MB | +81MB | 107.8kB | 1.92s | 24.59s |

Measurement spread across the three boots of a variant, for scale: rootfs bytes
read 0.65%, `SUnreclaim` 0.7%, `Cached` 2.7%. `MemTotal` was identical across
variants to within 8KB.

Image size savings are close to linear (−6.04, −5.40, −5.35MiB per doubling).
Every cost is superlinear.

### What the columns mean

- **Boot read** — sectors read from the rootfs partition during boot, from
  `/proc/diskstats`. This counter resets at boot, so a single read afterwards
  gives that boot's total.
- **SUnreclaim** — non-reclaimable kernel memory. This is the permanent cost:
  the decompressor buffer plus the 3-block fragment cache
  (`CONFIG_SQUASHFS_FRAGMENT_CACHE_SIZE=3`), both sized to the block.
- **Cached** — page cache. Grows because the kernel is built with
  `CONFIG_SQUASHFS_FILE_DIRECT=y`, so a fault decompresses the whole block into
  the page cache. This memory is reclaimable and is not a footprint.
- **Bytes/fault** — device bytes read per 4KB page fault, over 300 single-page
  reads at fixed pseudo-random offsets across six large unmapped rootfs files,
  after `drop_caches`. The offsets come from a fixed seed, so every variant
  faults the same pages. This isolates read amplification: squashfs cannot
  decompress part of a block, so faulting one page reads and decompresses the
  whole block containing it.
- **Decompress** — wall clock for those 300 reads, less a measured 0.075s of
  process-spawn overhead.

### Caveats

- Measured under QEMU with the host page cache active. Boot-time deltas are the
  least transferable figures; bytes read and `SUnreclaim` should transfer.
  Guest CPU time spent decompressing is representative.
- amd64/kvm only. Not measured on physical hardware or on arm64.

## Functional validation

A full evetest run against the 1MB image: **87 pass, 14 fail, 7 skip** across 12
suites. Clean suites included Bootstrap 15/15, Apps 7/7, Telemetry 9/9,
Pciback 9/9, LPS 5/5, Security 4/4, Datastore 4/4.

Every failure was re-run against a 128KB image on the same host and harness:

| Category | Count | Basis |
|---|---|---|
| Fails identically on 128KB | 6 | present on the shipped block size |
| Requires ZFS | 1 | `fstrim: discard operation is not supported`; run was ext4 |
| Kubevirt image not built | 3 | `manifest for lfedge/eve:<version>-k-amd64 not found` |
| Passes on re-run on 1MB | 3 | failed inside its suite, passed run individually on the same image |
| Did not run | 1 | parameterised suite variant, not invocable by name |

No failure reproduced as specific to the block size.

## Scope

- Other arches and hypervisors keep the default. The Makefile variable is empty
  there, so no `-b` reaches `mksquashfs`, its command line is byte-for-byte
  unchanged, and their images are unaffected.
- The installer image is deliberately left alone: it is not bound by
  `ROOTFS_MAXSIZE_MB` and is booted once, so it would take the runtime cost
  without the benefit.
- This makes amd64/kvm the only flavour with different compression, so its
  runtime read characteristics diverge from the other arches.

## PR dependencies

None.

## How to test and validate this PR

Build for amd64/kvm and confirm the block size and the size reduction:

```sh
make ZARCH=amd64 HV=kvm rootfs
unsquashfs -s dist/amd64/current/installer/rootfs.img | grep -i "block size"
# expected: Block size 1048576
```

Confirm other flavours are untouched — the block size must stay 131072:

```sh
make ZARCH=amd64 HV=k rootfs
unsquashfs -s dist/amd64/current/installer/rootfs.img | grep -i "block size"
make ZARCH=arm64 HV=kvm rootfs
unsquashfs -s dist/arm64/current/installer/rootfs.img | grep -i "block size"
```

The second check matters more than the first: it is the regression risk.

Functional coverage is the evetest run described above.

## Changelog notes

The amd64/kvm rootfs image is roughly 17MB smaller.

## PR Backports

- 17.0-stable: No, this is a build-time size optimisation, not a fix.
- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR

Notes on unchecked boxes:

- Documentation: no user-facing behaviour changes; the rationale and the
  measured trade-off are in the commit message.
- arm64: not tested on hardware. arm64 is excluded by the condition and its
  `mksquashfs` invocation is byte-for-byte unchanged, so no arm64 image is
  affected.
- Labels: to be set after opening.
