### PR TITLE
Track NIM interface/bridge identity via IfInstanceID

### DIFF
--- a/evetest/netmodels/multi-eth.go
+++ b/evetest/netmodels/multi-eth.go
@@ -2163,3 +2163,111 @@ var SeparateClusterPort = &api.NetworkModel{
 		},
 	},
 }
+
+// MultiPortSwitchAndVLANTrunk is a network model with four ethernet ports combining a
+// multi-port L2 segment with a VLAN trunk:
+//   - eth0 -> bridge0 -> its own DHCP management network (10.53.10.0/24), with
+//     controller access.
+//   - eth1, eth2 -> bridge1 -> a single STP-enabled SDN bridge shared by both ports
+//     (WithStp=true, mirroring FourPortsWithSTPBridge's bridge1: EVE bridging these
+//     two ports together and this SDN bridge together form a loop that STP must
+//     resolve). An SDN router serves DHCP for an untagged application network
+//     (10.53.20.0/24).
+//   - eth3 -> bridge2 -> trunk port carrying VLAN-tagged traffic. An SDN router
+//     serves DHCP for a VLAN 100 application network (10.53.100.0/24).
+var MultiPortSwitchAndVLANTrunk = &api.NetworkModel{
+	Ports: []*api.Port{
+		{LogicalLabel: "eth0", AdminUp: true},
+		{LogicalLabel: "eth1", AdminUp: true},
+		{LogicalLabel: "eth2", AdminUp: true},
+		{LogicalLabel: "eth3", AdminUp: true},
+	},
+	Bridges: []*api.Bridge{
+		{LogicalLabel: "bridge0", Ports: []string{"eth0"}},
+		{LogicalLabel: "bridge1", Ports: []string{"eth1", "eth2"}, WithStp: true},
+		{LogicalLabel: "bridge2", Ports: []string{"eth3"}},
+	},
+	Networks: []*api.Network{
+		{
+			LogicalLabel: "mgmt-network",
+			Bridge:       "bridge0",
+			Ipv4: &api.NetworkIPConfig{
+				Subnet: "10.53.10.0/24",
+				GwIp:   "10.53.10.1",
+				Dhcp: &api.DHCP{
+					Enable:     true,
+					DomainName: "test",
+					Dns: &api.DNSClientConfig{
+						PrivateDns: []string{"dns-server"},
+					},
+				},
+			},
+		},
+		{
+			LogicalLabel: "multiport-network",
+			Bridge:       "bridge1",
+			Ipv4: &api.NetworkIPConfig{
+				Subnet: "10.53.20.0/24",
+				GwIp:   "10.53.20.1",
+				Dhcp: &api.DHCP{
+					Enable:     true,
+					DomainName: "test",
+					// Pool leaves .2-.9 free for statically-assigned addresses.
+					IpRange: &api.IPRange{
+						FromIp: "10.53.20.10",
+						ToIp:   "10.53.20.200",
+					},
+					Dns: &api.DNSClientConfig{
+						PrivateDns: []string{"dns-server"},
+					},
+				},
+			},
+		},
+		{
+			LogicalLabel: "vlan100-network",
+			Bridge:       "bridge2",
+			VlanId:       100,
+			Ipv4: &api.NetworkIPConfig{
+				Subnet: "10.53.100.0/24",
+				GwIp:   "10.53.100.1",
+				Dhcp: &api.DHCP{
+					Enable:     true,
+					DomainName: "test",
+					// Pool leaves .2-.9 free for statically-assigned addresses.
+					IpRange: &api.IPRange{
+						FromIp: "10.53.100.10",
+						ToIp:   "10.53.100.200",
+					},
+					Dns: &api.DNSClientConfig{
+						PrivateDns: []string{"dns-server"},
+					},
+				},
+			},
+		},
+	},
+	Endpoints: &api.Endpoints{
+		DnsServers: []*api.DNSServer{
+			{
+				Endpoint: &api.Endpoint{
+					LogicalLabel: "dns-server",
+					Fqdn:         "dns-server.test",
+					Ipv4: &api.EndpointIPConfig{
+						Subnet: "10.16.16.0/24",
+						Ip:     "10.16.16.25",
+					},
+				},
+				StaticEntries: []*api.DNSEntry{
+					{
+						FqdnSource: &api.DNSEntry_FqdnLiteral{
+							FqdnLiteral: evetest.GetControllerHostname(),
+						},
+						IpSource: &api.DNSEntry_IpLiteral{
+							IpLiteral: evetest.GetControllerIPv4().String(),
+						},
+					},
+				},
+				UpstreamServers: []string{"8.8.8.8", "1.1.1.1"},
+			},
+		},
+	},
+}

--- a/evetest/tests/networking/helpers_test.go
+++ b/evetest/tests/networking/helpers_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package networking_test
+
+import (
+	"strings"
+	"time"
+
+	eveinfo "github.com/lf-edge/eve-api/go/info"
+	"github.com/lf-edge/eve/evetest"
+)
+
+// readBpduGuard reads the BPDU guard sysfs flag for a named bridge port.
+// Returns "0", "1", or "" if the path cannot be read.
+func readBpduGuard(device *evetest.EdgeDevice, bridgeName, portName string,
+	sshTimeout time.Duration) string {
+	path := "/sys/class/net/" + bridgeName + "/brif/" + portName + "/bpdu_guard"
+	output, _, err := device.RunShellScript("cat "+path, sshTimeout, 0)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(output)
+}
+
+// niHasError is a matchers.SatisfyPredicate StopIf callback: it stops an
+// Eventually early if the network instance has reached the ERROR state,
+// instead of waiting out the full timeout.
+func niHasError(info *eveinfo.ZInfoNetworkInstance) (string, bool) {
+	stop := info.State == eveinfo.ZNetworkInstanceState_ZNETINST_STATE_ERROR
+	if stop {
+		return "Network instance is in error state", true
+	}
+	return "", false
+}
+
+// appHasError is a matchers.SatisfyPredicate StopIf callback: it stops an
+// Eventually early if the application instance has reached the ERROR state,
+// instead of waiting out the full timeout.
+func appHasError(info *eveinfo.ZInfoApp) (string, bool) {
+	stop := info.State == eveinfo.ZSwState_ERROR
+	if stop {
+		return "Application instance is in error state", true
+	}
+	return "", false
+}

--- a/evetest/tests/networking/netinst_test.go
+++ b/evetest/tests/networking/netinst_test.go
@@ -2585,19 +2585,3 @@ func findDNSRequest(records []*eveflowlog.DnsRequest, hostname string) *eveflowl
 	}
 	return nil
 }
-
-func niHasError(info *eveinfo.ZInfoNetworkInstance) (string, bool) {
-	stop := info.State == eveinfo.ZNetworkInstanceState_ZNETINST_STATE_ERROR
-	if stop {
-		return "Network instance is in error state", true
-	}
-	return "", false
-}
-
-func appHasError(info *eveinfo.ZInfoApp) (string, bool) {
-	stop := info.State == eveinfo.ZSwState_ERROR
-	if stop {
-		return "Application instance is in error state", true
-	}
-	return "", false
-}

--- a/evetest/tests/networking/stp_test.go
+++ b/evetest/tests/networking/stp_test.go
@@ -301,17 +301,6 @@ func TestSwitchNIWithMultiplePorts(test *testing.T) {
 	t.Expect(niInfo.Vifs[0].MacAddress).To(Equal(appMACAddr))
 	t.Expect(niInfo.Vifs[0].AppID).To(Equal(appUUID.String()))
 
-	// readBpduGuard reads the BPDU guard sysfs flag for a named bridge port.
-	// Returns "0", "1", or "" if the path cannot be read.
-	readBpduGuard := func(portName string) string {
-		path := "/sys/class/net/" + bridgeName + "/brif/" + portName + "/bpdu_guard"
-		output, _, err := device.RunShellScript("cat "+path, sshTimeout, 0)
-		if err != nil {
-			return ""
-		}
-		return strings.TrimSpace(output)
-	}
-
 	// -----------------------------------------------------------------------
 	// Phase 1: STP convergence
 	// -----------------------------------------------------------------------
@@ -339,13 +328,13 @@ func TestSwitchNIWithMultiplePorts(test *testing.T) {
 
 	// BPDU guard: app VIF and eth3 ("edge-port") have it on; eth1/eth2 are
 	// active STP participants and must have it off.
-	t.Expect(readBpduGuard(vifName)).To(Equal("1"),
+	t.Expect(readBpduGuard(device, bridgeName, vifName, sshTimeout)).To(Equal("1"),
 		"BPDU guard must be on for app VIF")
-	t.Expect(readBpduGuard("eth1")).To(Equal("0"),
+	t.Expect(readBpduGuard(device, bridgeName, "eth1", sshTimeout)).To(Equal("0"),
 		"BPDU guard must be off for eth1")
-	t.Expect(readBpduGuard("eth2")).To(Equal("0"),
+	t.Expect(readBpduGuard(device, bridgeName, "eth2", sshTimeout)).To(Equal("0"),
 		"BPDU guard must be off for eth2")
-	t.Expect(readBpduGuard("eth3")).To(Equal("1"),
+	t.Expect(readBpduGuard(device, bridgeName, "eth3", sshTimeout)).To(Equal("1"),
 		"BPDU guard must be on for eth3 (edge-port)")
 
 	// App connectivity: curl through whichever port STP chose as forwarding.

--- a/evetest/tests/networking/switch_config_race_test.go
+++ b/evetest/tests/networking/switch_config_race_test.go
@@ -1,0 +1,663 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package networking_test
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+
+	eveconfig "github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve-api/go/evecommon"
+	eveinfo "github.com/lf-edge/eve-api/go/info"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/matchers"
+	"github.com/lf-edge/eve/evetest/netmodels"
+	pillartypes "github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+)
+
+// TestSwitchNIPortConfigRace is a regression test for a class of races
+// between NIM (device-port reconciler) and zedrouter (network-instance
+// reconciler), fixed by IfInstanceID (see pkg/pillar/types/dns.go,
+// nireconciler and dpcreconciler). NIM renames a physical or VLAN interface
+// to "k<ifname>" and creates a bridge "<ifname>" over it whenever the port
+// becomes a DHCP client, static, or a VLAN parent
+// (isAdapterBridgedByNIM in dpcreconciler/linuxitems/adapter.go). Switching a
+// port's config so that this bridging decision is recreated -- even when the
+// end result is unchanged -- previously could: leave a stale tc-ingress
+// qdisc behind after a rename ("Exclusivity flag on, cannot modify"),
+// silently miss reapplying VLAN filtering after a same-named bridge was torn
+// down and recreated, or leave the application VIF un-re-enslaved.
+//
+// Topology
+// --------
+//
+//	                    +------------------+              +--------+
+//	                    | eth0 (EVE mgmt)  |--------------| switch |----(router, controller reachable)
+//	                    |      (DHCP)      |              +--------+
+//	                    +------------------+
+//
+//	+-----+  +----------------+  +-------------------+
+//	| app |->| multiswitch-ni |->| eth1 (app-shared) |    +--------+
+//	|     |  +----------------+  | (no IP, L2-only)  |----| switch |----(router)
+//	|     |                 |    +-------------------+    | (STP)  |
+//	|     |                 |    +-------------------+    +--------+
+//	|     |                 ---->| eth2 (app-shared) |         |
+//	|     |                      | (no IP, L2-only)  |---------+
+//	|     |                      +-------------------+
+//	|     |
+//	|     |  +----------------+  +-------------------+    +--------+
+//	+-----+->| vlan-switch-ni |->| vlan100 on eth3   |----| switch |----(router, VLAN 100)
+//	         +----------------+  | (VLAN sub-if)     |    +--------+
+//	                             +-------------------+
+//
+// eth3 itself carries no traffic of its own -- it exists only as the VLAN
+// parent of vlan100.
+//
+// Network model
+// -------------
+//   - netmodels.MultiPortSwitchAndVLANTrunk: eth0 is on its own DHCP
+//     management bridge. eth1 and eth2 share a single STP-enabled SDN bridge
+//     with a router serving an untagged application network (10.53.20.0/24).
+//     eth3 is a VLAN trunk toward a router serving a VLAN 100 application
+//     network (10.53.100.0/24).
+//
+// Device configuration
+// --------------------
+//   - ethernet0: DHCP, mgmt only. Never changed for the rest of the test.
+//   - ethernet1, ethernet2: initially no IP, L2-only, shared label
+//     "multiswitch-ports". Both ports of the multi-port Switch NI
+//     "multiswitch-ni" (STP is mandatory for any multi-port Switch NI, hence
+//     the SDN-side loop above). A port cannot be individually bridged by NIM
+//     while still a raw member of this multi-port bridge -- it cannot be a
+//     member of two different bridges at once -- so ethernet1 never changes
+//     for the rest of the test, and its continued reachability confirms
+//     that churning the *other* ports (ethernet2, vlan100) never disrupts
+//     it. ethernet2 is itself churned in Phase E below: it leaves
+//     multiswitch-ports' membership and becomes an individually
+//     NIM-bridged DHCP client, then rejoins -- BPDU guard is enabled on it
+//     (rather than on ethernet1) so that Phase E's rejoin actually exercises
+//     the BPDUGuard fix, since it forces the guard to be deleted and
+//     reapplied, not just set once and left alone.
+//   - ethernet3: VLAN parent, no IP of its own, through Phase E. vlan100:
+//     VLAN 100 sub-interface of ethernet3, initially a DHCP client. Sole
+//     port of the single-port Switch NI "vlan-switch-ni" through Phase E --
+//     the port the race scenarios in Phases A-D are applied to. Phase F
+//     deletes vlan100 and moves vlan-switch-ni directly onto ethernet3
+//     instead, with VLAN filtering enabled (see Phases F-G).
+//   - One container app (lfedge/evetest-ubuntu-ctr:1.0) with two VIFs: vif0
+//     on multiswitch-ni, vif1 on vlan-switch-ni. Phase F gives vif1 an
+//     access VLAN, which restarts the app.
+//
+// Phases
+// ------
+//
+//  1. NI and app creation: both Switch NIs reach ZNETINST_STATE_ONLINE with
+//     their expected port count (AssignedAdapters for multiswitch-ni's
+//     physical ports; Ports for vlan-switch-ni's VLAN sub-interface, which
+//     is not a physical IO bundle), and the app receives a DHCP address on
+//     each VIF from its respective SDN router.
+//
+//  2. Baseline connectivity: from inside the app, ping the gateway of each
+//     of the two application networks (10.53.20.1 via vif0, 10.53.100.1 via
+//     vif1).
+//
+//  3. A sequence of live vlan100 config changes previously prone to the
+//     NIM/zedrouter races described above, each followed by re-verifying
+//     step 2's connectivity check (wrapped in Eventually, to allow for the
+//     brief reconciliation that a genuine config change causes):
+//     a. DHCP client -> static IP. vlan100 stays bridged by NIM throughout
+//     (Static, like DHCP client, satisfies isAdapterBridgedByNIM), so this
+//     recreates the *same* bridge without ever changing whether it's
+//     bridged -- the case that needed the VLANBridge/BridgePort recreate
+//     fix, in addition to the original Port/Bridge/TCIngress fix.
+//     b. Static IP -> DHCP client (same, other direction).
+//     c. DHCP client -> no IP: this flips vlan100 from bridged-by-NIM to
+//     not bridged at all -- NIM releases it and zedrouter's own switch-NI
+//     bridging takes over the same interface directly.
+//     d. No IP -> DHCP client: the reverse transition, bridged-by-NIM again.
+//
+//  4. ethernet2's membership in multiswitch-ni is itself churned, again
+//     followed each time by re-verifying step 2's connectivity check:
+//     a. ethernet2 leaves the "multiswitch-ports" label and becomes an
+//     individually NIM-bridged DHCP client -- multiswitch-ni shrinks to
+//     ethernet1 alone (and drops out of STP, being down to one port).
+//     b. ethernet2 rejoins "multiswitch-ports" as a no-IP member again --
+//     multiswitch-ni recovers its second port (and STP re-engages), and
+//     BPDU guard must read back "1" on ethernet2 (sysfs), confirming it was
+//     correctly reapplied rather than lost.
+//
+//  5. vlan-switch-ni's port is switched from vlan100 (deleted) directly to
+//     ethernet3, its former VLAN parent. vif1 is given an access VLAN
+//     (which restarts the app), enabling VLAN filtering on the NI --
+//     exercising VLANPort, which none of the scenarios above ever
+//     construct. ethernet3 itself is left as an (automatic) trunk port,
+//     matching its physical link, which genuinely carries 802.1Q-tagged
+//     traffic for the SDN's VLAN 100 router.
+//
+//  6. With VLAN filtering active, ethernet3's own IP config is churned
+//     between no IP and static IP and back, again followed each time by
+//     re-verifying step 2's connectivity check: the same NIM/zedrouter
+//     bridge-ownership race as step 3c/3d, now exercised through a
+//     VLANPort (trunk config) instead of a plain BridgePort.
+//
+// Test params
+// -----------
+//   - HYPERVISOR (defaults to KVM).
+func TestSwitchNIPortConfigRace(test *testing.T) {
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+	)
+	hypervisor := evetest.GetHypervisorParameterValue()
+
+	devName := "edge-dev"
+	evetest.Setup(
+		evetest.RequireEdgeDevice{
+			Name:              devName,
+			WithHypervisor:    hypervisor,
+			DeviceReusePolicy: evetest.ResetDeviceConfig,
+		},
+		evetest.RequireNetworkModel{
+			NetworkModel: netmodels.MultiPortSwitchAndVLANTrunk,
+		},
+	)
+	device := evetest.GetEdgeDevice(devName)
+	evetest.Checkpoint("setup-done")
+
+	devConfig := evetest.NewEdgeDeviceConfig(devName)
+
+	// eth0: management port, DHCP. Never touched again.
+	mgmtNet := devConfig.AddNetwork(evetest.DHCPNetworkConfig{
+		NetworkType: evecommon.NetworkType_V4Only,
+	})
+	devConfig.AddNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  "ethernet0",
+		PhysicalLabel: "eth0",
+		InterfaceName: "eth0",
+		NetworkUUID:   mgmtNet,
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtOnly,
+	})
+
+	// eth1, eth2: no-IP, L2-only members of multiswitch-ni. ethernet1 never
+	// changes, so it shares the same no-IP network config as eth3. ethernet2
+	// gets its own dedicated network, since Phase E below mutates it
+	// independently.
+	noIPNet := devConfig.AddNetwork(evetest.NoIPNetworkConfig{})
+	devConfig.AddNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  "ethernet1",
+		PhysicalLabel: "eth1",
+		InterfaceName: "eth1",
+		NetworkUUID:   noIPNet,
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+		SharedLabels:  []string{"multiswitch-ports"},
+	})
+	eth2Net := devConfig.AddNetwork(evetest.NoIPNetworkConfig{})
+	devConfig.AddNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  "ethernet2",
+		PhysicalLabel: "eth2",
+		InterfaceName: "eth2",
+		NetworkUUID:   eth2Net,
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+		SharedLabels:  []string{"multiswitch-ports"},
+	})
+
+	// eth3: VLAN parent, no IP of its own; not used directly by any NI.
+	devConfig.AddNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  "ethernet3",
+		PhysicalLabel: "eth3",
+		InterfaceName: "eth3",
+		NetworkUUID:   noIPNet,
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+	})
+
+	// vlan100: VLAN 100 sub-interface of eth3, DHCP client. Sole port of
+	// vlan-switch-ni, and the subject of every race scenario below.
+	vlan100Net := devConfig.AddNetwork(evetest.DHCPNetworkConfig{
+		NetworkType: evecommon.NetworkType_V4Only,
+	})
+	devConfig.AddVLANSubinterface(evetest.VLANSubinterfaceConfig{
+		LogicalLabel:       "vlan100",
+		InterfaceName:      "vlan100",
+		ParentLogicalLabel: "ethernet3",
+		VlanID:             100,
+		NetworkUUID:        vlan100Net,
+		Usage:              evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+	})
+
+	device.ApplyConfig(devConfig, true, true)
+	if hypervisor == evetest.HypervisorKubevirt {
+		device.WaitForClusterNodeIsReady(20 * time.Minute)
+	}
+	evetest.Checkpoint("port-config-applied")
+
+	// multiswitch-ni: Switch NI spanning ethernet1 + ethernet2. STP is
+	// mandatory for any multi-port Switch NI. BPDU guard is enabled on
+	// ethernet2 rather than the never-changing ethernet1: ethernet2's
+	// BridgePort (and therefore its BPDUGuard) is deleted and recreated by
+	// Phase E below, which is what actually exercises the BPDUGuard fix --
+	// on a port that never changes, BPDU guard would only ever be applied
+	// once and never need to be reapplied.
+	multiNIUUID := devConfig.AddNetworkInstance(evetest.SwitchNetworkInstanceConfig{
+		DisplayName: "multiswitch-ni",
+		Port:        "multiswitch-ports",
+		STPConfig:   pillartypes.STPConfig{PortsWithBpduGuard: "ethernet2"},
+	})
+
+	// vlan-switch-ni: single-port Switch NI directly on the vlan100
+	// sub-interface.
+	vlanNIUUID := devConfig.AddNetworkInstance(evetest.SwitchNetworkInstanceConfig{
+		DisplayName: "vlan-switch-ni",
+		Port:        "vlan100",
+	})
+
+	const appMultiMAC = "02:16:3e:00:00:01"
+	const appVlanMAC = "02:16:3e:00:00:02"
+	appUUID := devConfig.AddApplication(evetest.ApplicationInstanceConfig{
+		DisplayName: "container-app",
+		Activate:    true,
+		Image: evetest.DockerContainer{
+			ImageName: "lfedge/evetest-ubuntu-ctr",
+			Tag:       "1.0",
+		},
+		VirtualizationMode: eveconfig.VmMode_HVM, // PV does not work in xen
+		CPUs:               1,
+		MemoryBytes:        500 * evetest.MiB,
+		NetworkAdapters: []evetest.AppNetworkAdapter{
+			evetest.VirtualNetworkAdapter{
+				LogicalLabel:        "vif0",
+				NetworkInstanceUUID: multiNIUUID,
+				MAC:                 evetest.MACAddress(appMultiMAC),
+				ACLAllowRules: []evetest.ACLAllowRule{
+					{
+						Protocol:     evetest.NetworkProtocolAny,
+						RemoteSubnet: evetest.IPSubnet("0.0.0.0/0"),
+					},
+				},
+			},
+			evetest.VirtualNetworkAdapter{
+				LogicalLabel:        "vif1",
+				NetworkInstanceUUID: vlanNIUUID,
+				MAC:                 evetest.MACAddress(appVlanMAC),
+				ACLAllowRules: []evetest.ACLAllowRule{
+					{
+						Protocol:     evetest.NetworkProtocolAny,
+						RemoteSubnet: evetest.IPSubnet("0.0.0.0/0"),
+					},
+				},
+			},
+		},
+	})
+
+	multiNIUpdates, stopMultiNIWatch := device.WatchNetworkInstanceInfo(multiNIUUID)
+	defer stopMultiNIWatch()
+	vlanNIUpdates, stopVlanNIWatch := device.WatchNetworkInstanceInfo(vlanNIUUID)
+	defer stopVlanNIWatch()
+	appUpdates, stopAppWatch := device.WatchAppInfo(appUUID)
+	defer stopAppWatch()
+	device.ApplyConfig(devConfig, false, false)
+
+	// STP convergence for multiswitch-ni can take up to ~2 minutes (standard
+	// STP, not RSTP); every timeout below is sized with enough margin for
+	// both that and the ordinary Switch NI bring-up delay.
+	timeout := 3 * time.Minute
+	sshTimeout := 20 * time.Second
+	polling := 5 * time.Second
+	log := evetest.Logger()
+
+	var multiNIInfo *eveinfo.ZInfoNetworkInstance
+	t.Eventually(multiNIUpdates, timeout).Should(Receive(matchers.SatisfyPredicate(
+		"multiswitch-ni is ONLINE with 2 assigned adapters",
+		func(info *eveinfo.ZInfoNetworkInstance) bool {
+			multiNIInfo = info
+			return info.State == eveinfo.ZNetworkInstanceState_ZNETINST_STATE_ONLINE &&
+				len(info.AssignedAdapters) == 2
+		}).StopIf(niHasError)))
+	multiBridgeName := multiNIInfo.BridgeName
+	t.Expect(multiBridgeName).ToNot(BeEmpty())
+	t.Eventually(vlanNIUpdates, timeout).Should(Receive(matchers.SatisfyPredicate(
+		"vlan-switch-ni is ONLINE with 1 port",
+		func(info *eveinfo.ZInfoNetworkInstance) bool {
+			// AssignedAdapters ([]*ZioBundle) reports assigned physical IO
+			// bundles only -- vlan100 is a VLAN sub-interface, not a distinct
+			// physical IO bundle (its underlying ethernet3 is never itself
+			// assigned to any NI), so AssignedAdapters is always empty here.
+			// Ports (logical port names) is the field that's actually
+			// populated for it.
+			return info.State == eveinfo.ZNetworkInstanceState_ZNETINST_STATE_ONLINE &&
+				len(info.Ports) == 1
+		}).StopIf(niHasError)))
+	evetest.Checkpoint("nis-online")
+
+	device.WaitUntilAppIsRunning(appUUID, 5*time.Minute)
+	evetest.Checkpoint("app-running")
+
+	multiSubnet := evetest.IPSubnet("10.53.20.0/24")
+	vlanSubnet := evetest.IPSubnet("10.53.100.0/24")
+	t.Eventually(appUpdates, timeout).Should(Receive(matchers.SatisfyPredicate(
+		"app has IPs from both application subnets",
+		func(info *eveinfo.ZInfoApp) bool {
+			if len(info.Network) != 2 {
+				return false
+			}
+			var hasMulti, hasVlan bool
+			for _, vif := range info.Network {
+				for _, ipAddr := range vif.IPAddrs {
+					ip := evetest.IPAddress(ipAddr)
+					if multiSubnet.Contains(ip) {
+						hasMulti = true
+					}
+					if vlanSubnet.Contains(ip) {
+						hasVlan = true
+					}
+				}
+			}
+			return hasMulti && hasVlan
+		}).StopIf(appHasError)))
+	evetest.Checkpoint("app-connected")
+
+	appAuth := evetest.UsernamePasswordAuth{
+		Username: "root",
+		Password: "testpassword",
+	}
+	const multiGwIP = "10.53.20.1"
+	const vlanGwIP = "10.53.100.1"
+
+	// pingGateways verifies that the app can still reach both Switch NI
+	// gateways. Called after every config change below; Eventually allows
+	// for the brief reconciliation delay a genuine config change causes
+	// (and, for multiswitch-ni, for STP to reconverge if disturbed).
+	// checkNINotInError aborts the enclosing Eventually immediately, via
+	// gomega.StopTrying, if the NI's last recorded info reports the ERROR
+	// state -- instead of letting it blindly retry ping/SSH for the full
+	// timeout. Reads GetNetworkInstanceInfo (the device's own last-recorded
+	// state) rather than the watch channel, so it doesn't compete with
+	// waitForMultiNIAdapterCount (or anything else) for the same messages.
+	checkNINotInError := func(name string, niUUID uuid.UUID) {
+		info := device.GetNetworkInstanceInfo(niUUID)
+		if info == nil {
+			return
+		}
+		if reason, isErr := niHasError(info); isErr {
+			StopTrying(fmt.Sprintf("%s: %s\n%s", name, reason, info.String())).Now()
+		}
+	}
+
+	pingGateways := func(reason string) {
+		log.Infof("Pinging gateways (%s)...", reason)
+		t.Eventually(func(g Gomega) {
+			checkNINotInError("multiswitch-ni", multiNIUUID)
+			_, _, err := device.RunShellScriptInsideApp(appUUID, appAuth,
+				"ping -c 3 -W 2 "+multiGwIP, sshTimeout, 0)
+			g.Expect(err).ToNot(HaveOccurred(), "ping to multiswitch-ni gateway")
+		}, timeout, polling).Should(Succeed())
+		t.Eventually(func(g Gomega) {
+			checkNINotInError("vlan-switch-ni", vlanNIUUID)
+			_, _, err := device.RunShellScriptInsideApp(appUUID, appAuth,
+				"ping -c 3 -W 2 "+vlanGwIP, sshTimeout, 0)
+			g.Expect(err).ToNot(HaveOccurred(), "ping to vlan-switch-ni gateway")
+		}, timeout, polling).Should(Succeed())
+	}
+
+	pingGateways("baseline")
+	evetest.Checkpoint("baseline-connectivity-ok")
+
+	dnsServerIP := evetest.IPAddress("10.16.16.25")
+
+	// -----------------------------------------------------------------------
+	// Phase A: vlan100, DHCP client -> static IP. Stays bridged by NIM
+	// throughout (Static also satisfies isAdapterBridgedByNIM), so this
+	// recreates the same bridge without ever changing whether it's bridged.
+	// -----------------------------------------------------------------------
+	log.Infof("Phase A: vlan100 DHCP -> static")
+	devConfig.UpdateNetwork(vlan100Net, evetest.StaticNetworkConfig{
+		NetworkType: evecommon.NetworkType_V4Only,
+		Subnet:      vlanSubnet,
+		Gateway:     evetest.IPAddress(vlanGwIP),
+		DNSServers:  []net.IP{dnsServerIP},
+	})
+	devConfig.UpdateVLANSubinterface(evetest.VLANSubinterfaceConfig{
+		LogicalLabel:       "vlan100",
+		InterfaceName:      "vlan100",
+		ParentLogicalLabel: "ethernet3",
+		VlanID:             100,
+		NetworkUUID:        vlan100Net,
+		Usage:              evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+		StaticIP:           evetest.IPAddress("10.53.100.5"),
+	})
+	device.ApplyConfig(devConfig, true, true)
+	pingGateways("vlan100 switched to static IP")
+	evetest.Checkpoint("vlan100-static")
+
+	// -----------------------------------------------------------------------
+	// Phase B: vlan100, static IP -> DHCP client (Phase A, reversed).
+	// -----------------------------------------------------------------------
+	log.Infof("Phase B: vlan100 static -> DHCP")
+	devConfig.UpdateNetwork(vlan100Net, evetest.DHCPNetworkConfig{
+		NetworkType: evecommon.NetworkType_V4Only,
+	})
+	devConfig.UpdateVLANSubinterface(evetest.VLANSubinterfaceConfig{
+		LogicalLabel:       "vlan100",
+		InterfaceName:      "vlan100",
+		ParentLogicalLabel: "ethernet3",
+		VlanID:             100,
+		NetworkUUID:        vlan100Net,
+		Usage:              evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+	})
+	device.ApplyConfig(devConfig, true, true)
+	pingGateways("vlan100 switched back to DHCP")
+	evetest.Checkpoint("vlan100-dhcp-restored")
+
+	// -----------------------------------------------------------------------
+	// Phase C: vlan100, DHCP client -> no IP. Flips vlan100 from bridged by
+	// NIM to not bridged at all: NIM releases it and zedrouter's own
+	// switch-NI bridging takes over the same interface directly.
+	// -----------------------------------------------------------------------
+	log.Infof("Phase C: vlan100 DHCP -> no IP (un-bridging)")
+	devConfig.UpdateNetwork(vlan100Net, evetest.NoIPNetworkConfig{})
+	devConfig.UpdateVLANSubinterface(evetest.VLANSubinterfaceConfig{
+		LogicalLabel:       "vlan100",
+		InterfaceName:      "vlan100",
+		ParentLogicalLabel: "ethernet3",
+		VlanID:             100,
+		NetworkUUID:        vlan100Net,
+		Usage:              evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+	})
+	device.ApplyConfig(devConfig, true, true)
+	pingGateways("vlan100 un-bridged (no IP)")
+	evetest.Checkpoint("vlan100-unbridged")
+
+	// -----------------------------------------------------------------------
+	// Phase D: vlan100, no IP -> DHCP client (Phase C, reversed: bridged by
+	// NIM again).
+	// -----------------------------------------------------------------------
+	log.Infof("Phase D: vlan100 no IP -> DHCP (re-bridging)")
+	devConfig.UpdateNetwork(vlan100Net, evetest.DHCPNetworkConfig{
+		NetworkType: evecommon.NetworkType_V4Only,
+	})
+	devConfig.UpdateVLANSubinterface(evetest.VLANSubinterfaceConfig{
+		LogicalLabel:       "vlan100",
+		InterfaceName:      "vlan100",
+		ParentLogicalLabel: "ethernet3",
+		VlanID:             100,
+		NetworkUUID:        vlan100Net,
+		Usage:              evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+	})
+	device.ApplyConfig(devConfig, true, true)
+	pingGateways("vlan100 re-bridged (DHCP)")
+	evetest.Checkpoint("vlan100-rebridged")
+
+	// waitForMultiNIAdapterCount waits for multiswitch-ni to report the given
+	// number of AssignedAdapters, used by Phase E below to confirm ethernet2
+	// actually left/rejoined the NI (not just that traffic still flows).
+	waitForMultiNIAdapterCount := func(count int, reason string) {
+		t.Eventually(multiNIUpdates, timeout).Should(Receive(matchers.SatisfyPredicate(
+			fmt.Sprintf("multiswitch-ni has %d assigned adapter(s) (%s)", count, reason),
+			func(info *eveinfo.ZInfoNetworkInstance) bool {
+				return info.State == eveinfo.ZNetworkInstanceState_ZNETINST_STATE_ONLINE &&
+					len(info.AssignedAdapters) == count
+			}).StopIf(niHasError)))
+	}
+
+	// -----------------------------------------------------------------------
+	// Phase E: ethernet2 leaves multiswitch-ports (becoming an individually
+	// NIM-bridged DHCP client) and rejoins. Exercises a port transitioning
+	// out of a zedrouter-owned multi-port bridge and into a NIM-owned one
+	// (and back), rather than a NIM-owned bridge's own DHCP/static config
+	// changing as in Phases A-D.
+	// -----------------------------------------------------------------------
+	log.Infof("Phase E: ethernet2 leaves multiswitch-ports, becomes a DHCP client")
+	devConfig.UpdateNetwork(eth2Net, evetest.DHCPNetworkConfig{
+		NetworkType: evecommon.NetworkType_V4Only,
+	})
+	devConfig.UpdateNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  "ethernet2",
+		PhysicalLabel: "eth2",
+		InterfaceName: "eth2",
+		NetworkUUID:   eth2Net,
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+	})
+	device.ApplyConfig(devConfig, true, true)
+	waitForMultiNIAdapterCount(1, "ethernet2 left")
+	pingGateways("ethernet2 left multiswitch-ni and became an independent DHCP client")
+	evetest.Checkpoint("ethernet2-left")
+
+	log.Infof("Phase E: ethernet2 rejoins multiswitch-ports as a no-IP member")
+	devConfig.UpdateNetwork(eth2Net, evetest.NoIPNetworkConfig{})
+	devConfig.UpdateNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  "ethernet2",
+		PhysicalLabel: "eth2",
+		InterfaceName: "eth2",
+		NetworkUUID:   eth2Net,
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+		SharedLabels:  []string{"multiswitch-ports"},
+	})
+	device.ApplyConfig(devConfig, true, true)
+	waitForMultiNIAdapterCount(2, "ethernet2 rejoined")
+	pingGateways("ethernet2 rejoined multiswitch-ni")
+
+	// Ping alone would not catch a lost BPDU guard -- it doesn't gate
+	// ordinary traffic. This is the actual regression check for the
+	// BPDUGuard fix: ethernet2's BridgePort (and BPDUGuard along with it)
+	// was deleted when it left the NI and must be correctly recreated now
+	// that it rejoined, not silently left off.
+	t.Eventually(func(g Gomega) {
+		bpduGuardFlag := readBpduGuard(device, multiBridgeName, "eth2", sshTimeout)
+		g.Expect(bpduGuardFlag).To(Equal("1"))
+	}, timeout, polling).Should(
+		Succeed(), "BPDU guard must be back on for ethernet2 after rejoining")
+	evetest.Checkpoint("ethernet2-rejoined")
+
+	// -----------------------------------------------------------------------
+	// Phase F: vlan-switch-ni's port switches from vlan100 (deleted) to its
+	// former VLAN parent ethernet3, with VLAN filtering enabled -- the
+	// first scenario to exercise VLANPort. ethernet3's link genuinely
+	// carries 802.1Q-tagged traffic, so it stays a trunk port; vif1 is made
+	// the VID 100 access port instead, which is what actually turns VLAN
+	// filtering on for the NI. Changing vif1 restarts the app.
+	// -----------------------------------------------------------------------
+	log.Infof("Phase F: vlan-switch-ni switches from vlan100 to ethernet3 (VLAN filtering)")
+	devConfig.DeleteVLANSubinterface("vlan100")
+	devConfig.DeleteNetwork(vlan100Net)
+	// ethernet3 shared noIPNet with ethernet1 as a passive VLAN parent; give
+	// it its own network now that Phase G below churns it independently.
+	eth3Net := devConfig.AddNetwork(evetest.NoIPNetworkConfig{})
+	devConfig.UpdateNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  "ethernet3",
+		PhysicalLabel: "eth3",
+		InterfaceName: "eth3",
+		NetworkUUID:   eth3Net,
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+	})
+	devConfig.UpdateNetworkInstance(vlanNIUUID, evetest.SwitchNetworkInstanceConfig{
+		DisplayName: "vlan-switch-ni",
+		Port:        "ethernet3",
+	})
+	devConfig.UpdateApplication(appUUID, evetest.ApplicationInstanceConfig{
+		DisplayName: "container-app",
+		Activate:    true,
+		Image: evetest.DockerContainer{
+			ImageName: "lfedge/evetest-ubuntu-ctr",
+			Tag:       "1.0",
+		},
+		VirtualizationMode: eveconfig.VmMode_HVM,
+		CPUs:               1,
+		MemoryBytes:        500 * evetest.MiB,
+		NetworkAdapters: []evetest.AppNetworkAdapter{
+			evetest.VirtualNetworkAdapter{
+				LogicalLabel:        "vif0",
+				NetworkInstanceUUID: multiNIUUID,
+				MAC:                 evetest.MACAddress(appMultiMAC),
+				ACLAllowRules: []evetest.ACLAllowRule{
+					{
+						Protocol:     evetest.NetworkProtocolAny,
+						RemoteSubnet: evetest.IPSubnet("0.0.0.0/0"),
+					},
+				},
+			},
+			evetest.VirtualNetworkAdapter{
+				LogicalLabel:        "vif1",
+				NetworkInstanceUUID: vlanNIUUID,
+				MAC:                 evetest.MACAddress(appVlanMAC),
+				AccessVLAN:          100,
+				ACLAllowRules: []evetest.ACLAllowRule{
+					{
+						Protocol:     evetest.NetworkProtocolAny,
+						RemoteSubnet: evetest.IPSubnet("0.0.0.0/0"),
+					},
+				},
+			},
+		},
+	})
+	device.ApplyConfig(devConfig, true, true)
+	device.WaitUntilAppIsRunning(appUUID, 5*time.Minute)
+	pingGateways("vlan-switch-ni switched to ethernet3 with VLAN filtering")
+	evetest.Checkpoint("vlan-switch-ni-on-ethernet3")
+
+	// -----------------------------------------------------------------------
+	// Phase G: with VLAN filtering active, churn ethernet3 between no IP
+	// (bridged by zedrouter) and static IP (bridged by NIM) and back --
+	// the same race as Phases C/D, now with a VLANPort in play. The static
+	// subnet is deliberately unreachable (TEST-NET-1); it only needs to
+	// make NIM bridge the port.
+	// -----------------------------------------------------------------------
+	log.Infof("Phase G: ethernet3 no IP -> static IP (re-bridging under VLAN filtering)")
+	devConfig.UpdateNetwork(eth3Net, evetest.StaticNetworkConfig{
+		NetworkType: evecommon.NetworkType_V4Only,
+		Subnet:      evetest.IPSubnet("192.0.2.0/24"),
+		Gateway:     evetest.IPAddress("192.0.2.1"),
+	})
+	devConfig.UpdateNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  "ethernet3",
+		PhysicalLabel: "eth3",
+		InterfaceName: "eth3",
+		NetworkUUID:   eth3Net,
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+		StaticIP:      evetest.IPAddress("192.0.2.5"),
+	})
+	device.ApplyConfig(devConfig, true, true)
+	pingGateways("ethernet3 bridged by NIM under VLAN filtering (static IP)")
+	evetest.Checkpoint("ethernet3-vlan-static")
+
+	log.Infof("Phase G: ethernet3 static IP -> no IP (un-bridging under VLAN filtering)")
+	devConfig.UpdateNetwork(eth3Net, evetest.NoIPNetworkConfig{})
+	devConfig.UpdateNetworkAdapter(evetest.NetworkAdapterConfig{
+		LogicalLabel:  "ethernet3",
+		PhysicalLabel: "eth3",
+		InterfaceName: "eth3",
+		NetworkUUID:   eth3Net,
+		Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageShared,
+	})
+	device.ApplyConfig(devConfig, true, true)
+	pingGateways("ethernet3 un-bridged by NIM under VLAN filtering (no IP)")
+	evetest.Checkpoint("ethernet3-vlan-noip")
+}

--- a/evetest/tests/networking/testsuite_test.go
+++ b/evetest/tests/networking/testsuite_test.go
@@ -1,6 +1,11 @@
 // Copyright (c) 2026 Zededa, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package networking_test holds the EVE networking tests.
+//
+// helpers_test.go holds helpers shared across multiple tests in this
+// package. New shared helpers belong there too, not alongside the test
+// that first needed them.
 package networking_test
 
 import (
@@ -325,6 +330,10 @@ func TestDeviceConnectivitySuite(test *testing.T) {
 //   - TestNICCountChangeOrderedInterface -- the same no-purge NIC addition
 //     with explicitly pinned interface orders: the added adapter must be
 //     enumerated by the guest at the position its order dictates.
+//   - TestSwitchNIPortConfigRace -- regression test for NIM/zedrouter races
+//     around IfInstanceID: a multi-port Switch NI plus a single-port Switch NI
+//     on a VLAN sub-interface, with ports live-switched between DHCP/static/no-IP;
+//     app connectivity through both NIs must survive every change.
 func TestApplicationConnectivitySuite(test *testing.T) {
 	evetest.Init(test)
 	defer evetest.Close()
@@ -428,6 +437,9 @@ func TestApplicationConnectivitySuite(test *testing.T) {
 		},
 		evetest.TestCase{
 			Test: TestNICCountChangeOrderedInterface,
+		},
+		evetest.TestCase{
+			Test: TestSwitchNIPortConfigRace,
 		},
 	)
 }

--- a/pkg/pillar/cmd/zedrouter/networkinstance.go
+++ b/pkg/pillar/cmd/zedrouter/networkinstance.go
@@ -141,20 +141,23 @@ func (z *zedrouter) getNIPortConfig(
 					IfName:       port2.IfName,
 					VLAN:         port2.VLAN.ID,
 					MTU:          port2.MTU,
+					InstanceID:   port2.UnderlyingIfInstanceID,
 				})
 			}
 		}
 		portConfigs = append(portConfigs, nireconciler.Port{
-			LogicalLabel:      port.Logicallabel,
-			SharedLabels:      port.SharedLabels,
-			IfName:            port.IfName,
-			IsMgmt:            port.IsMgmt,
-			MTU:               port.MTU,
-			DhcpType:          port.Dhcp,
-			DNSServers:        types.GetDNSServers(*z.deviceNetworkStatus, port.IfName),
-			StaticIP:          netutils.NewIPNet(port.ConfiguredIP, port.ConfiguredSubnet),
-			IgnoreDhcpIPs:     port.IgnoredDhcpIPs,
-			VLANSubinterfaces: vlanSubIfs,
+			LogicalLabel:           port.Logicallabel,
+			SharedLabels:           port.SharedLabels,
+			IfName:                 port.IfName,
+			IsMgmt:                 port.IsMgmt,
+			MTU:                    port.MTU,
+			DhcpType:               port.Dhcp,
+			DNSServers:             types.GetDNSServers(*z.deviceNetworkStatus, port.IfName),
+			StaticIP:               netutils.NewIPNet(port.ConfiguredIP, port.ConfiguredSubnet),
+			IgnoreDhcpIPs:          port.IgnoredDhcpIPs,
+			VLANSubinterfaces:      vlanSubIfs,
+			UnderlyingIfInstanceID: port.UnderlyingIfInstanceID,
+			BridgeIfInstanceID:     port.BridgeIfInstanceID,
 		})
 	}
 	return portConfigs

--- a/pkg/pillar/dpcmanager/dns.go
+++ b/pkg/pillar/dpcmanager/dns.go
@@ -148,6 +148,23 @@ func (m *DpcManager) updateDNS() {
 		} else {
 			m.deviceNetStatus.Ports[ix].Up = ifAttrs.LowerUp
 			m.deviceNetStatus.Ports[ix].MTU = ifAttrs.MTU
+			// If NIM has bridged this port, port.IfName is the bridge and
+			// "k"+port.IfName is the underlying interface (see
+			// AdapterConfigurator in dpcreconciler/linuxitems/adapter.go).
+			m.deviceNetStatus.Ports[ix].UnderlyingIfInstanceID = ifAttrs.InstanceID
+			m.deviceNetStatus.Ports[ix].BridgeIfInstanceID = 0
+			kernIfName := "k" + port.IfName
+			if kernIfIndex, kernExists, kernErr :=
+				m.NetworkMonitor.GetInterfaceIndex(kernIfName); kernErr == nil && kernExists {
+				if kernAttrs, kernErr := m.NetworkMonitor.GetInterfaceAttrs(kernIfIndex); kernErr == nil {
+					m.deviceNetStatus.Ports[ix].BridgeIfInstanceID = ifAttrs.InstanceID
+					m.deviceNetStatus.Ports[ix].UnderlyingIfInstanceID = kernAttrs.InstanceID
+				} else {
+					m.Log.Warnf(
+						"updateDNS: failed to get attrs for interface %s: %v",
+						kernIfName, kernErr)
+				}
+			}
 		}
 		ipAddrs, macAddr, err := m.NetworkMonitor.GetInterfaceAddrs(ifindex)
 		if err != nil {

--- a/pkg/pillar/dpcreconciler/linux.go
+++ b/pkg/pillar/dpcreconciler/linux.go
@@ -800,7 +800,7 @@ func (r *LinuxDpcReconciler) updateCurrentNetworkIO(
 			// entries in AssignableAdapters should not be ignored.
 			continue
 		}
-		_, found, err := r.NetworkMonitor.GetInterfaceIndex(port.IfName)
+		ifIndex, found, err := r.NetworkMonitor.GetInterfaceIndex(port.IfName)
 		if err != nil {
 			r.Log.Errorf("updateCurrentNetworkIO: failed to get ifIndex for %s: %v",
 				port.IfName, err)
@@ -808,6 +808,19 @@ func (r *LinuxDpcReconciler) updateCurrentNetworkIO(
 		}
 		if !found {
 			continue
+		}
+		// Tag the NIC with a fresh IfInstanceID the first time it's seen here
+		// (not in PhysIf.Create: that doesn't run for every physical port,
+		// and NeedsRecreate can fire for reasons unrelated to the hardware
+		// actually changing). Guarded on InstanceID == 0 to never reassign.
+		if ifAttrs, err := r.NetworkMonitor.GetInterfaceAttrs(ifIndex); err != nil {
+			r.Log.Errorf("updateCurrentNetworkIO: failed to get attrs for %s: %v",
+				port.IfName, err)
+		} else if ifAttrs.InstanceID == 0 {
+			if _, err := r.NetworkMonitor.AssignNewInstanceID(ifIndex); err != nil {
+				r.Log.Errorf("updateCurrentNetworkIO: failed to assign IfInstanceID for %s: %v",
+					port.IfName, err)
+			}
 		}
 		currentIO.PutItem(generic.NetIO{
 			LogicalLabel: port.Logicallabel,

--- a/pkg/pillar/dpcreconciler/linuxitems/adapter.go
+++ b/pkg/pillar/dpcreconciler/linuxitems/adapter.go
@@ -216,6 +216,14 @@ func (c *AdapterConfigurator) Create(ctx context.Context, item depgraph.Item) er
 		c.Log.Error(err)
 		return err
 	}
+	// Fresh IfInstanceID, distinct from any prior bridge under this name.
+	// kernIfname keeps its own ID -- it was only renamed, not destroyed.
+	if _, err := c.NetworkMonitor.AssignNewInstanceID(bridge.Attrs().Index); err != nil {
+		err = fmt.Errorf("failed to assign IfInstanceID for bridge %s: %v",
+			adapter.IfName, err)
+		c.Log.Error(err)
+		return err
+	}
 	// Look up again after rename
 	kernLink, err := netlink.LinkByName(kernIfname)
 	if err != nil {

--- a/pkg/pillar/dpcreconciler/linuxitems/bond.go
+++ b/pkg/pillar/dpcreconciler/linuxitems/bond.go
@@ -182,6 +182,13 @@ func (c *BondConfigurator) Create(ctx context.Context, item depgraph.Item) error
 		c.Log.Error(err)
 		return err
 	}
+	// Tag with a fresh IfInstanceID so it survives a rename and isn't
+	// confused with a future bond that reuses this name.
+	if _, err = c.NetworkMonitor.AssignNewInstanceID(bond.Attrs().Index); err != nil {
+		err = fmt.Errorf("failed to assign IfInstanceID for bond %s: %v", bondCfg.IfName, err)
+		c.Log.Error(err)
+		return err
+	}
 	err = netlink.LinkSetUp(bond)
 	if err != nil {
 		err = fmt.Errorf("failed to set bond %s UP: %v", bondCfg.IfName, err)

--- a/pkg/pillar/dpcreconciler/linuxitems/vlan.go
+++ b/pkg/pillar/dpcreconciler/linuxitems/vlan.go
@@ -124,6 +124,14 @@ func (c *VlanConfigurator) Create(ctx context.Context, item depgraph.Item) error
 		c.Log.Error(err)
 		return err
 	}
+	// Tag with a fresh IfInstanceID so it survives a rename and isn't
+	// confused with a future sub-interface that reuses this name.
+	if _, err = c.NetworkMonitor.AssignNewInstanceID(vlan.Attrs().Index); err != nil {
+		err = fmt.Errorf("failed to assign IfInstanceID for VLAN sub-interface %s: %v",
+			vlanCfg.IfName, err)
+		c.Log.Error(err)
+		return err
+	}
 	// Ensure the parent interface is set to UP before bringing up the VLAN subinterface.
 	// Otherwise, netlink.LinkSetUp(vlan) will return a "network is down" error.
 	err = netlink.LinkSetUp(parentLink)

--- a/pkg/pillar/netmonitor/linux.go
+++ b/pkg/pillar/netmonitor/linux.go
@@ -5,6 +5,7 @@ package netmonitor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -62,6 +64,10 @@ type LinuxNetworkMonitor struct {
 	ifIndexToDNS   map[int][]DNSInfo
 	ifIndexToDHCP  map[int]DHCPInfo
 	ifIndexToGWs   map[int][]net.IP
+
+	// nextIfInstanceID backs AssignNewInstanceID. Zero is reserved for
+	// "undefined", so the first allocated ID is 1.
+	nextIfInstanceID atomic.Uint64
 }
 
 type ifAddrs struct {
@@ -167,12 +173,90 @@ func (m *LinuxNetworkMonitor) ifAttrsFromLink(link netlink.Link) IfAttrs {
 		Enslaved:      link.Attrs().MasterIndex != 0,
 		MasterIfIndex: link.Attrs().MasterIndex,
 		MTU:           uint16(link.Attrs().MTU),
+		InstanceID:    parseIfInstanceID(link.Attrs().Alias),
 	}
 	if vlan, ok := link.(*netlink.Vlan); ok {
 		attrs.VlanID = uint16(vlan.VlanId)
 		attrs.VlanParentIfIndex = vlan.ParentIndex
 	}
 	return attrs
+}
+
+// ifInstanceIDAliasPrefix distinguishes an IfInstanceID stored in a Linux
+// interface alias (IFLA_IFALIAS) from an alias set for any other purpose.
+const ifInstanceIDAliasPrefix = "eve-nim-id:"
+
+func formatIfInstanceID(id types.IfInstanceID) string {
+	return ifInstanceIDAliasPrefix + strconv.FormatUint(uint64(id), 10)
+}
+
+// parseIfInstanceID returns zero for an alias not set (by NIM) in this format.
+func parseIfInstanceID(alias string) types.IfInstanceID {
+	suffix, ok := strings.CutPrefix(alias, ifInstanceIDAliasPrefix)
+	if !ok {
+		return 0
+	}
+	id, err := strconv.ParseUint(suffix, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return types.IfInstanceID(id)
+}
+
+// GetInterfaceByInstanceID always enumerates live kernel state rather than
+// the name/index cache, since the interface may have been renamed since it
+// was last cached by name.
+func (m *LinuxNetworkMonitor) GetInterfaceByInstanceID(
+	id types.IfInstanceID) (attrs IfAttrs, exists bool, err error) {
+	if id == 0 {
+		return IfAttrs{}, false, nil
+	}
+	// The kernel can interrupt a link dump if the link table changes while
+	// it is in progress (ErrDumpInterrupted) -- expected under exactly the
+	// kind of concurrent NIM/zedrouter interface churn this ID lookup is
+	// used to resolve. LinkList still returns whatever it received before
+	// being interrupted, so a match found in it is trusted regardless; only
+	// a "not found" against an interrupted (possibly incomplete) dump is
+	// ambiguous and worth a bounded retry, instead of risking a false
+	// negative that a caller might treat as "genuinely gone".
+	const maxAttempts = 3
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		links, listErr := netlink.LinkList()
+		if listErr != nil && !errors.Is(listErr, netlink.ErrDumpInterrupted) {
+			return IfAttrs{}, false, listErr
+		}
+		for _, link := range links {
+			if parseIfInstanceID(link.Attrs().Alias) == id {
+				return m.ifAttrsFromLink(link), true, nil
+			}
+		}
+		if listErr == nil {
+			return IfAttrs{}, false, nil
+		}
+		if attempt == maxAttempts {
+			return IfAttrs{}, false, fmt.Errorf(
+				"interface list repeatedly interrupted while looking up IfInstanceID %d: %w",
+				id, listErr)
+		}
+	}
+	return IfAttrs{}, false, nil
+}
+
+// AssignNewInstanceID allocates a fresh IfInstanceID and writes it into the
+// interface's kernel alias.
+func (m *LinuxNetworkMonitor) AssignNewInstanceID(ifIndex int) (types.IfInstanceID, error) {
+	link, err := netlink.LinkByIndex(ifIndex)
+	if err != nil {
+		return 0, err
+	}
+	id := types.IfInstanceID(m.nextIfInstanceID.Add(1))
+	if err := netlink.LinkSetAlias(link, formatIfInstanceID(id)); err != nil {
+		return 0, err
+	}
+	m.cacheLock.Lock()
+	defer m.cacheLock.Unlock()
+	delete(m.ifIndexToAttrs, ifIndex) // stale now, force a re-read
+	return id, nil
 }
 
 // GetInterfaceAddrs returns IP addresses and the HW address assigned

--- a/pkg/pillar/netmonitor/mock.go
+++ b/pkg/pillar/netmonitor/mock.go
@@ -22,9 +22,10 @@ type MockNetworkMonitor struct {
 	Log    *base.LogObject
 	MainRT int // inject syscall.RT_TABLE_MAIN for Linux network stack
 
-	eventSubs  []subscriber
-	interfaces map[int]MockInterface // key = ifIndex
-	routes     []Route
+	eventSubs        []subscriber
+	interfaces       map[int]MockInterface // key = ifIndex
+	routes           []Route
+	nextIfInstanceID uint64 // backs AssignNewInstanceID; 0 reserved for "undefined"
 }
 
 // MockInterface : a simulated network interface and its state.
@@ -296,6 +297,39 @@ func (m *MockNetworkMonitor) GetBondMetrics(ifIndex int) (types.BondMetrics, err
 		return types.BondMetrics{}, fmt.Errorf("interface %s is not a bond", mockIf.Attrs.IfName)
 	}
 	return types.BondMetrics{}, nil
+}
+
+// GetInterfaceByInstanceID finds the mock interface currently carrying the
+// given IfInstanceID, regardless of its current name.
+func (m *MockNetworkMonitor) GetInterfaceByInstanceID(id types.IfInstanceID) (
+	attrs IfAttrs, exists bool, err error) {
+	m.Lock()
+	defer m.Unlock()
+	if id == 0 {
+		return IfAttrs{}, false, nil
+	}
+	for _, mockIf := range m.interfaces {
+		if mockIf.Attrs.InstanceID == id {
+			return mockIf.Attrs, true, nil
+		}
+	}
+	return IfAttrs{}, false, nil
+}
+
+// AssignNewInstanceID allocates a fresh IfInstanceID and tags the mock
+// interface with it.
+func (m *MockNetworkMonitor) AssignNewInstanceID(ifIndex int) (types.IfInstanceID, error) {
+	m.Lock()
+	defer m.Unlock()
+	mockIf, exists := m.interfaces[ifIndex]
+	if !exists {
+		return 0, m.ifNotFoundErr(ifIndex)
+	}
+	m.nextIfInstanceID++
+	id := types.IfInstanceID(m.nextIfInstanceID)
+	mockIf.Attrs.InstanceID = id
+	m.interfaces[ifIndex] = mockIf
+	return id, nil
 }
 
 // ListRoutes lists all mock routes.

--- a/pkg/pillar/netmonitor/netmonitor.go
+++ b/pkg/pillar/netmonitor/netmonitor.go
@@ -66,6 +66,15 @@ type NetworkMonitor interface {
 	// Note: BondMetrics.LogicalLabel and BondMemberMetrics.LogicalLabel are
 	// returned unset (NetworkMonitor does not work with logical labels).
 	GetBondMetrics(ifIndex int) (types.BondMetrics, error)
+	// GetInterfaceByInstanceID : find the interface currently carrying the given
+	// IfInstanceID, regardless of its current name. exists=false, err=nil means
+	// the interface was genuinely removed, not just renamed.
+	GetInterfaceByInstanceID(id types.IfInstanceID) (attrs IfAttrs, exists bool, err error)
+	// AssignNewInstanceID allocates a fresh IfInstanceID (unique for the
+	// process lifetime; no persistence needed, since a restart implies a
+	// reboot) and writes it into the interface's kernel alias. NIM is the
+	// sole caller.
+	AssignNewInstanceID(ifIndex int) (types.IfInstanceID, error)
 	// ClearCache : clear cached mappings between interface names, interface indexes,
 	// attributes, assigned addresses, DNS info, DHCP info and default GWs.
 	// It is reasonable to do this once in a while because the monitor can miss some
@@ -184,6 +193,9 @@ type IfAttrs struct {
 	VlanParentIfIndex int
 	// VLAN ID assigned to this subinterface (only set for VLAN sub-interfaces).
 	VlanID uint16
+	// InstanceID is the types.IfInstanceID NIM assigned, read from the
+	// interface's kernel alias. Zero if not (yet) assigned.
+	InstanceID types.IfInstanceID
 }
 
 // Equal allows to compare two sets of interface attributes for equality.
@@ -199,7 +211,8 @@ func (a IfAttrs) Equal(a2 IfAttrs) bool {
 		a.MasterIfIndex == a2.MasterIfIndex &&
 		a.MTU == a2.MTU &&
 		a.VlanParentIfIndex == a2.VlanParentIfIndex &&
-		a.VlanID == a2.VlanID
+		a.VlanID == a2.VlanID &&
+		a.InstanceID == a2.InstanceID
 }
 
 // DNSInfo : DNS information associated with an interface.

--- a/pkg/pillar/nireconciler/genericitems/items_test.go
+++ b/pkg/pillar/nireconciler/genericitems/items_test.go
@@ -375,6 +375,8 @@ func TestPortEqual(t *testing.T) {
 	p3DiffName := Port{IfName: "eth1", LogicalLabel: "uplink", AdminUp: true, IPAddresses: []*net.IPNet{ip1}}
 	p4DiffIPs := Port{IfName: "eth0", LogicalLabel: "uplink", AdminUp: true, IPAddresses: []*net.IPNet{ip2}}
 	p5WrongType := IPReserve{AddrWithMask: ip1}
+	p6DiffInstanceID := Port{IfName: "eth0", LogicalLabel: "uplink", AdminUp: true,
+		IPAddresses: []*net.IPNet{ip1}, InstanceID: 42}
 	tests := []struct {
 		name  string
 		other dg.Item
@@ -384,6 +386,7 @@ func TestPortEqual(t *testing.T) {
 		{"different IfName", p3DiffName, false},
 		{"different IPs", p4DiffIPs, false},
 		{"wrong type", p5WrongType, false},
+		{"different InstanceID", p6DiffInstanceID, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/pillar/nireconciler/genericitems/port.go
+++ b/pkg/pillar/nireconciler/genericitems/port.go
@@ -8,6 +8,7 @@ import (
 	"net"
 
 	dg "github.com/lf-edge/eve-libs/depgraph"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
 	"github.com/lf-edge/eve/pkg/pillar/utils/netutils"
 )
@@ -25,6 +26,14 @@ type Port struct {
 	AdminUp bool
 	// IPAddresses : IP addresses assigned to the port.
 	IPAddresses []*net.IPNet
+	// InstanceID distinguishes this concrete kernel object from any other
+	// interface that may come to carry the same IfName after a NIM rename
+	// or recreation. See types.IfInstanceID.
+	InstanceID types.IfInstanceID
+	// IsBridge is true if the interface is itself a Linux bridge master.
+	// NIM may still be tearing down its own bridge over this port; enslaving
+	// a bridge into another bridge is rejected by the kernel (ELOOP).
+	IsBridge bool
 }
 
 // Name returns the physical interface name.
@@ -52,6 +61,8 @@ func (p Port) Equal(other dg.Item) bool {
 		p.LogicalLabel == p2.LogicalLabel &&
 		p.MasterIfName == p2.MasterIfName &&
 		p.AdminUp == p2.AdminUp &&
+		p.InstanceID == p2.InstanceID &&
+		p.IsBridge == p2.IsBridge &&
 		generics.EqualSetsFn(p.IPAddresses, p2.IPAddresses, netutils.EqualIPNets)
 }
 
@@ -64,8 +75,8 @@ func (p Port) External() bool {
 // String describes Port.
 func (p Port) String() string {
 	return fmt.Sprintf("Port: {ifName: %s, logicalLabel: %s, "+
-		"masterIfName: %s, adminUP: %t, ipAddresses: %v}", p.IfName, p.LogicalLabel,
-		p.MasterIfName, p.AdminUp, p.IPAddresses)
+		"masterIfName: %s, adminUP: %t, ipAddresses: %v, instanceID: %d, isBridge: %t}",
+		p.IfName, p.LogicalLabel, p.MasterIfName, p.AdminUp, p.IPAddresses, p.InstanceID, p.IsBridge)
 }
 
 // Dependencies returns nothing (external item).

--- a/pkg/pillar/nireconciler/linux_config.go
+++ b/pkg/pillar/nireconciler/linux_config.go
@@ -453,6 +453,7 @@ func (r *LinuxNIReconciler) getIntendedPorts() dg.Graph {
 				LogicalLabel: port.LogicalLabel,
 				MasterIfName: masterIfName,
 				AdminUp:      true,
+				InstanceID:   port.UnderlyingIfInstanceID,
 			}, nil)
 		}
 	}
@@ -630,13 +631,20 @@ func (r *LinuxNIReconciler) getIntendedNIL2Cfg(niID uuid.UUID) dg.Graph {
 	bridgeIPs, _, bridgeMAC, _, _ := r.getBridgeAddrs(niID)
 	withSTP := ni.config.Type == types.NetworkInstanceTypeSwitch &&
 		len(ni.bridge.Ports) > 1
+	createdByNIM := r.niBridgeIsCreatedByNIM(ni.config, ni.bridge)
+	var bridgeInstanceID types.IfInstanceID
+	if createdByNIM {
+		// createdByNIM implies len(ni.bridge.Ports) == 1.
+		bridgeInstanceID = ni.bridge.Ports[0].BridgeIfInstanceID
+	}
 	intendedL2Cfg.PutItem(linux.Bridge{
 		IfName:       ni.brIfName,
-		CreatedByNIM: r.niBridgeIsCreatedByNIM(ni.config, ni.bridge),
+		CreatedByNIM: createdByNIM,
 		MACAddress:   bridgeMAC,
 		IPAddresses:  bridgeIPs,
 		MTU:          ni.bridge.MTU,
 		WithSTP:      withSTP,
+		InstanceID:   bridgeInstanceID,
 	}, nil)
 	intendedL2Cfg.PutItem(linux.BridgeFwdMask{
 		BridgeIfName: ni.brIfName,
@@ -652,6 +660,7 @@ func (r *LinuxNIReconciler) getIntendedNIL2Cfg(niID uuid.UUID) dg.Graph {
 	intendedL2Cfg.PutItem(linux.VLANBridge{
 		BridgeIfName:        ni.brIfName,
 		EnableVLANFiltering: enableVLANFiltering,
+		ExpectedBridgeID:    bridgeInstanceID,
 	}, nil)
 	if len(ni.bridge.Ports) == 0 {
 		// Air-gapped, no port to configure as VLAN trunk or access.
@@ -663,17 +672,20 @@ func (r *LinuxNIReconciler) getIntendedNIL2Cfg(niID uuid.UUID) dg.Graph {
 			Variant: linux.BridgePortVariant{
 				PortIfName: portPhysIfName(port),
 			},
-			ExternallyBridged: r.niBridgeIsCreatedByNIM(ni.config, ni.bridge),
+			ExternallyBridged: createdByNIM,
 			MTU:               port.MTU,
+			ExpectedPortID:    port.UnderlyingIfInstanceID,
+			ExpectedBridgeID:  port.BridgeIfInstanceID,
 		}, nil)
 		portsWithBpduGuard := ni.config.STPConfig.PortsWithBpduGuard
 		if withSTP && portsWithBpduGuard != "" {
 			if portsWithBpduGuard == port.LogicalLabel ||
 				generics.ContainsItem(port.SharedLabels, portsWithBpduGuard) {
 				intendedL2Cfg.PutItem(linux.BPDUGuard{
-					BridgeIfName: ni.brIfName,
-					PortIfName:   portPhysIfName(port),
-					ForVIF:       false,
+					BridgeIfName:     ni.brIfName,
+					PortIfName:       portPhysIfName(port),
+					ForVIF:           false,
+					ExpectedBridgeID: bridgeInstanceID,
 				}, nil)
 			}
 		}
@@ -684,6 +696,7 @@ func (r *LinuxNIReconciler) getIntendedNIL2Cfg(niID uuid.UUID) dg.Graph {
 				ParentLL:     port.LogicalLabel,
 				ParentIfName: port.IfName,
 				ID:           vlanSubIf.VLAN,
+				InstanceID:   vlanSubIf.InstanceID,
 			}, nil)
 			intendedL2Cfg.PutItem(linux.BridgePort{
 				BridgeIfName: ni.brIfName,
@@ -695,6 +708,8 @@ func (r *LinuxNIReconciler) getIntendedNIL2Cfg(niID uuid.UUID) dg.Graph {
 				},
 				ExternallyBridged: true,
 				MTU:               vlanSubIf.MTU,
+				ExpectedBridgeID:  port.BridgeIfInstanceID,
+				ExpectedPortID:    vlanSubIf.InstanceID,
 			}, nil)
 		}
 		if !enableVLANFiltering {
@@ -714,6 +729,8 @@ func (r *LinuxNIReconciler) getIntendedNIL2Cfg(niID uuid.UUID) dg.Graph {
 							VID: vlanAccessPort.VlanID,
 						},
 					},
+					ExpectedBridgeID: bridgeInstanceID,
+					ExpectedPortID:   port.UnderlyingIfInstanceID,
 				}, nil)
 				break
 			}
@@ -726,6 +743,8 @@ func (r *LinuxNIReconciler) getIntendedNIL2Cfg(niID uuid.UUID) dg.Graph {
 				VLANConfig: linux.VLANConfig{
 					TrunkPort: &trunkPort,
 				},
+				ExpectedBridgeID: bridgeInstanceID,
+				ExpectedPortID:   port.UnderlyingIfInstanceID,
 			}, nil)
 		}
 		for _, vlanSubIf := range port.VLANSubinterfaces {
@@ -739,6 +758,8 @@ func (r *LinuxNIReconciler) getIntendedNIL2Cfg(niID uuid.UUID) dg.Graph {
 						IfName: vlanSubIf.IfName,
 					},
 				},
+				ExpectedBridgeID: bridgeInstanceID,
+				ExpectedPortID:   vlanSubIf.InstanceID,
 			}, nil)
 		}
 	}
@@ -1008,8 +1029,12 @@ func (r *LinuxNIReconciler) getIntendedNIMirroring(niID uuid.UUID) dg.Graph {
 			IfName:  ifName,
 			ItemRef: dg.Reference(generic.Port{IfName: ifName}),
 		}
-		intendedNIMirroring.PutItem(linux.TCIngress{NetIf: portIfRef}, nil)
-		for _, mirrorRule := range r.getIntendedNIMirrorRules(niID, portIfRef) {
+		intendedNIMirroring.PutItem(linux.TCIngress{
+			NetIf:          portIfRef,
+			ExpectedPortID: port.UnderlyingIfInstanceID,
+		}, nil)
+		for _, mirrorRule := range r.getIntendedNIMirrorRules(
+			niID, portIfRef, port.UnderlyingIfInstanceID) {
 			intendedNIMirroring.PutItem(mirrorRule, nil)
 		}
 	}
@@ -1017,7 +1042,7 @@ func (r *LinuxNIReconciler) getIntendedNIMirroring(niID uuid.UUID) dg.Graph {
 }
 
 func (r *LinuxNIReconciler) getIntendedNIMirrorRules(niID uuid.UUID,
-	fromNetIf generic.NetworkIf) []linux.TCMirror {
+	fromNetIf generic.NetworkIf, expectedPortID types.IfInstanceID) []linux.TCMirror {
 	var rules []linux.TCMirror
 	ni := r.nis[niID]
 	mirrorIfRef := generic.NetworkIf{
@@ -1099,6 +1124,9 @@ func (r *LinuxNIReconciler) getIntendedNIMirrorRules(niID uuid.UUID,
 		TransportProtocol: &icmpv6,
 		ICMPType:          &neighSolicitation,
 	})
+	for i := range rules {
+		rules[i].ExpectedPortID = expectedPortID
+	}
 	return rules
 }
 
@@ -1481,6 +1509,11 @@ func (r *LinuxNIReconciler) getIntendedAppConnCfg(niID uuid.UUID,
 	ni := r.nis[vif.NI]
 	enableVLANFiltering, _ := r.getVLANConfigForNI(ni)
 	app := r.apps[vif.App]
+	var bridgeInstanceID types.IfInstanceID
+	if r.niBridgeIsCreatedByNIM(ni.config, ni.bridge) {
+		// createdByNIM implies len(ni.bridge.Ports) == 1.
+		bridgeInstanceID = ni.bridge.Ports[0].BridgeIfInstanceID
+	}
 	graphArgs := dg.InitArgs{
 		Name:        AppConnSGName(vif.App, vif.NetAdapterName),
 		Description: "Connection between application and network instance",
@@ -1596,7 +1629,8 @@ func (r *LinuxNIReconciler) getIntendedAppConnCfg(niID uuid.UUID,
 		Variant: linux.BridgePortVariant{
 			VIFIfName: vif.hostIfName,
 		},
-		MTU: ni.bridge.MTU,
+		MTU:              ni.bridge.MTU,
+		ExpectedBridgeID: bridgeInstanceID,
 	}, nil)
 	if ni.config.Type == types.NetworkInstanceTypeSwitch {
 		if len(ni.bridge.Ports) > 1 {
@@ -1617,10 +1651,11 @@ func (r *LinuxNIReconciler) getIntendedAppConnCfg(niID uuid.UUID,
 				vlanConfig.AccessPort = &linux.AccessPort{VID: uint16(ul.AccessVlanID)}
 			}
 			intendedAppConnCfg.PutItem(linux.VLANPort{
-				BridgeIfName: ni.brIfName,
-				PortIfName:   vif.hostIfName,
-				ForVIF:       true,
-				VLANConfig:   vlanConfig,
+				BridgeIfName:     ni.brIfName,
+				PortIfName:       vif.hostIfName,
+				ForVIF:           true,
+				VLANConfig:       vlanConfig,
+				ExpectedBridgeID: bridgeInstanceID,
 			}, nil)
 		}
 		// Mirror small portion of the traffic for monitoring
@@ -1630,7 +1665,7 @@ func (r *LinuxNIReconciler) getIntendedAppConnCfg(niID uuid.UUID,
 			ItemRef: dg.Reference(linux.VIF{HostIfName: vif.hostIfName}),
 		}
 		intendedAppConnCfg.PutItem(linux.TCIngress{NetIf: vifRef}, nil)
-		for _, mirrorRule := range r.getIntendedNIMirrorRules(niID, vifRef) {
+		for _, mirrorRule := range r.getIntendedNIMirrorRules(niID, vifRef, 0) {
 			intendedAppConnCfg.PutItem(mirrorRule, nil)
 		}
 	}

--- a/pkg/pillar/nireconciler/linux_currentstate.go
+++ b/pkg/pillar/nireconciler/linux_currentstate.go
@@ -97,6 +97,8 @@ func (r *LinuxNIReconciler) updateCurrentGlobalState(onlyPortsChanged bool) (cha
 				MasterIfName: masterIfName,
 				AdminUp:      ifAttrs.AdminUp,
 				IPAddresses:  ips,
+				InstanceID:   ifAttrs.InstanceID,
+				IsBridge:     ifAttrs.IfType == "bridge",
 			}, &reconciler.ItemStateData{
 				State:         reconciler.ItemStateCreated,
 				LastOperation: reconciler.OperationCreate,
@@ -196,6 +198,12 @@ func (r *LinuxNIReconciler) updateCurrentNIBridge(niID uuid.UUID) (changed bool)
 			LogAndErrPrefix, niID, err)
 		return r.updateSingleItem(prevExtBridge, nil, l2SG)
 	}
+	var instanceID types.IfInstanceID
+	if brIfIndex, brFound, err := r.netMonitor.GetInterfaceIndex(ni.brIfName); err == nil && brFound {
+		if brAttrs, err := r.netMonitor.GetInterfaceAttrs(brIfIndex); err == nil {
+			instanceID = brAttrs.InstanceID
+		}
+	}
 	bridge := linux.Bridge{
 		IfName:       ni.brIfName,
 		CreatedByNIM: true,
@@ -203,6 +211,7 @@ func (r *LinuxNIReconciler) updateCurrentNIBridge(niID uuid.UUID) (changed bool)
 		IPAddresses:  ips,
 		MTU:          mtu,
 		WithSTP:      false,
+		InstanceID:   instanceID,
 	}
 	return r.updateSingleItem(prevExtBridge, bridge, l2SG)
 }
@@ -303,6 +312,7 @@ func (r *LinuxNIReconciler) updateCurrentVLANSubIfs(niID uuid.UUID) (changed boo
 				ParentLL:     port.LogicalLabel,
 				ParentIfName: parentIfAttrs.IfName,
 				ID:           ifAttrs.VlanID,
+				InstanceID:   ifAttrs.InstanceID,
 			}
 			subIfRef := dg.Reference(subIf)
 			prevSubIf := prevSubIfs[subIfRef]

--- a/pkg/pillar/nireconciler/linux_test.go
+++ b/pkg/pillar/nireconciler/linux_test.go
@@ -3320,7 +3320,7 @@ func TestSwitchNIWithMultiplePorts(test *testing.T) {
 		linuxitems.BridgePort{BridgeIfName: "bn1", Variant: linuxitems.BridgePortVariant{PortIfName: "eth3"}}))).
 		To(BeTrue())
 	t.Expect(itemDescription(dg.Reference(linuxitems.VLANPort{BridgeIfName: "bn1", PortIfName: "eth1"}))).
-		To(ContainSubstring("trunkPort: {allVIDs: false, vids: [100 200]}}"))
+		To(ContainSubstring("trunkPort: {allVIDs: false, vids: [100 200]}"))
 	t.Expect(itemDescription(dg.Reference(linuxitems.VLANPort{BridgeIfName: "bn1", PortIfName: "eth2"}))).
 		To(ContainSubstring("accessPort: {vid: 100}"))
 	t.Expect(itemDescription(dg.Reference(linuxitems.VLANPort{BridgeIfName: "bn1", PortIfName: "eth3"}))).
@@ -4179,7 +4179,7 @@ func TestSwitchNICombinedWithVLANSubinterfaces(test *testing.T) {
 		linuxitems.BridgePort{BridgeIfName: "eth0", Variant: linuxitems.BridgePortVariant{VIFIfName: "nbu1x3"}}))).
 		To(BeTrue())
 	t.Expect(itemDescription(dg.Reference(linuxitems.VLANPort{BridgeIfName: "eth0", PortIfName: "nbu1x3"}))).
-		To(ContainSubstring("trunkPort: {allVIDs: true, vids: []}}"))
+		To(ContainSubstring("trunkPort: {allVIDs: true, vids: []}"))
 
 	// Connect "app4"
 	app4UUID := makeUUID("29c3bf99-665e-46dc-837c-30453c64ca2b")

--- a/pkg/pillar/nireconciler/linuxitems/bpduguard.go
+++ b/pkg/pillar/nireconciler/linuxitems/bpduguard.go
@@ -12,6 +12,7 @@ import (
 	dg "github.com/lf-edge/eve-libs/depgraph"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/netmonitor"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
 // BPDUGuard : item representing BPDU guard enabled on a Linux bridge port.
@@ -27,6 +28,9 @@ type BPDUGuard struct {
 	// ForVIF : true if this is BPDU guard applied to application VIF
 	// (and not to device network port).
 	ForVIF bool
+	// ExpectedBridgeID: IfInstanceID BridgeIfName is expected to carry. Zero
+	// if the bridge is not NIM-managed.
+	ExpectedBridgeID types.IfInstanceID
 }
 
 // Name returns the interface name of the bridged port
@@ -52,7 +56,8 @@ func (g BPDUGuard) Equal(other dg.Item) bool {
 	if !isBPDUGuard {
 		return false
 	}
-	return g.BridgeIfName == g2.BridgeIfName && g.ForVIF == g2.ForVIF
+	return g.BridgeIfName == g2.BridgeIfName && g.ForVIF == g2.ForVIF &&
+		g.ExpectedBridgeID == g2.ExpectedBridgeID
 }
 
 // External returns false.
@@ -62,8 +67,9 @@ func (g BPDUGuard) External() bool {
 
 // String describes BPDUGuard.
 func (g BPDUGuard) String() string {
-	return fmt.Sprintf("BPDUGuard: {bridgeIfName: %s, portIfName: %s, forVIF: %t}",
-		g.BridgeIfName, g.PortIfName, g.ForVIF)
+	return fmt.Sprintf("BPDUGuard: {bridgeIfName: %s, portIfName: %s, forVIF: %t, "+
+		"expectedBridgeID: %d}",
+		g.BridgeIfName, g.PortIfName, g.ForVIF, g.ExpectedBridgeID)
 }
 
 // Dependencies returns the bridge and the port as the dependencies.
@@ -72,6 +78,20 @@ func (g BPDUGuard) Dependencies() (deps []dg.Dependency) {
 		RequiredItem: dg.ItemRef{
 			ItemType: BridgeTypename,
 			ItemName: g.BridgeIfName,
+		},
+		MustSatisfy: func(item dg.Item) bool {
+			if g.ExpectedBridgeID == 0 {
+				return true
+			}
+			bridge, isBridge := item.(Bridge)
+			if !isBridge {
+				// unreachable
+				return false
+			}
+			// BPDU guard lives in the bridge's brif sysfs directory, so it is
+			// genuinely gone when the bridge is torn down (AutoDeletedByExternal
+			// below) -- reject a same-named bridge NIM has since recreated.
+			return bridge.InstanceID == g.ExpectedBridgeID
 		},
 		Description: "Bridge must exist",
 		Attributes: dg.DependencyAttributes{
@@ -107,12 +127,29 @@ func (c *BPDUGuardConfigurator) createOrDelete(item dg.Item, del bool) (err erro
 	}
 	sysOptVal := "1"
 	action := "enable"
+	bridgeIfName := bpduGuard.BridgeIfName
 	if del {
 		sysOptVal = "0"
 		action = "disable"
+		if bpduGuard.ExpectedBridgeID != 0 {
+			// NIM may have since reused this name for a bridge of its own;
+			// resolve by IfInstanceID rather than risk touching that instead.
+			attrs, exists, err := c.NetworkMonitor.GetInterfaceByInstanceID(
+				bpduGuard.ExpectedBridgeID)
+			if err != nil {
+				err = fmt.Errorf("failed to look up interface with IfInstanceID %d: %v",
+					bpduGuard.ExpectedBridgeID, err)
+				return err
+			}
+			if !exists {
+				// Genuinely gone; nothing left to clean up.
+				return nil
+			}
+			bridgeIfName = attrs.IfName
+		}
 	}
 	sysOptPath := fmt.Sprintf("/sys/class/net/%s/brif/%s/bpdu_guard",
-		bpduGuard.BridgeIfName, bpduGuard.PortIfName)
+		bridgeIfName, bpduGuard.PortIfName)
 	err = os.WriteFile(sysOptPath, []byte(sysOptVal), 0644)
 	if err != nil {
 		if del && errors.Is(err, os.ErrNotExist) {
@@ -122,7 +159,7 @@ func (c *BPDUGuardConfigurator) createOrDelete(item dg.Item, del bool) (err erro
 			return nil
 		}
 		err = fmt.Errorf("failed to %s BPDU guard for port %s on bridge %s: %w",
-			action, bpduGuard.PortIfName, bpduGuard.BridgeIfName, err)
+			action, bpduGuard.PortIfName, bridgeIfName, err)
 		return err
 	}
 	return nil

--- a/pkg/pillar/nireconciler/linuxitems/bridge.go
+++ b/pkg/pillar/nireconciler/linuxitems/bridge.go
@@ -35,6 +35,10 @@ type Bridge struct {
 	MTU uint16
 	// WithSTP: enable to run the Spanning Tree Protocol (STP).
 	WithSTP bool
+	// InstanceID is meaningful only when CreatedByNIM is true; it changes
+	// whenever NIM destroys and recreates the bridge, even under the same
+	// name and MAC. See types.IfInstanceID.
+	InstanceID types.IfInstanceID
 }
 
 // Name returns the physical interface name.
@@ -62,7 +66,8 @@ func (b Bridge) Equal(other dg.Item) bool {
 		b.CreatedByNIM == b2.CreatedByNIM &&
 		bytes.Equal(b.MACAddress, b2.MACAddress) &&
 		generics.EqualSetsFn(b.IPAddresses, b2.IPAddresses, netutils.EqualIPNets) &&
-		b.MTU == b2.MTU && b.WithSTP == b2.WithSTP
+		b.MTU == b2.MTU && b.WithSTP == b2.WithSTP &&
+		b.InstanceID == b2.InstanceID
 }
 
 // External returns true if it was created by NIM and not be zedrouter.
@@ -73,8 +78,8 @@ func (b Bridge) External() bool {
 // String describes Bridge.
 func (b Bridge) String() string {
 	return fmt.Sprintf("Bridge: {ifName: %s, createdByNIM: %t, "+
-		"macAddress: %s, ipAddresses: %v, MTU: %d, withSTP: %t}", b.IfName,
-		b.CreatedByNIM, b.MACAddress, b.IPAddresses, b.MTU, b.WithSTP)
+		"macAddress: %s, ipAddresses: %v, MTU: %d, withSTP: %t, instanceID: %d}", b.IfName,
+		b.CreatedByNIM, b.MACAddress, b.IPAddresses, b.MTU, b.WithSTP, b.InstanceID)
 }
 
 // Dependencies returns reservations of IPs that bridge should have assigned.

--- a/pkg/pillar/nireconciler/linuxitems/bridgeport.go
+++ b/pkg/pillar/nireconciler/linuxitems/bridgeport.go
@@ -26,6 +26,13 @@ type BridgePort struct {
 	ExternallyBridged bool
 	// MTU : Maximum transmission unit size.
 	MTU uint16
+	// ExpectedBridgeID: IfInstanceID BridgeIfName is expected to carry. Zero
+	// if the bridge is not NIM-managed.
+	ExpectedBridgeID types.IfInstanceID
+	// ExpectedPortID: IfInstanceID the bridged port is expected to carry --
+	// Variant.PortIfName or Variant.VLANSubinterface, whichever is set. Zero
+	// for the VIF variant (not NIM-managed).
+	ExpectedPortID types.IfInstanceID
 }
 
 // BridgePortVariant is like union, only one option should have non-zero value.
@@ -76,8 +83,9 @@ func (p BridgePort) External() bool {
 // String describes BridgePort.
 func (p BridgePort) String() string {
 	return fmt.Sprintf("BridgePort: {bridgeIfName: %s, portIfName: %s, "+
-		"externallyBridged: %t, MTU: %d}",
-		p.BridgeIfName, p.portIfName(), p.ExternallyBridged, p.MTU)
+		"externallyBridged: %t, MTU: %d, expectedBridgeID: %d, expectedPortID: %d}",
+		p.BridgeIfName, p.portIfName(), p.ExternallyBridged, p.MTU,
+		p.ExpectedBridgeID, p.ExpectedPortID)
 }
 
 // Dependencies returns the bridge and the port as the dependencies.
@@ -87,7 +95,19 @@ func (p BridgePort) Dependencies() (deps []dg.Dependency) {
 			ItemType: BridgeTypename,
 			ItemName: p.BridgeIfName,
 		},
-		Description: "Bridge must exist",
+		MustSatisfy: func(item dg.Item) bool {
+			if p.ExpectedBridgeID == 0 {
+				return true
+			}
+			bridge, isBridge := item.(Bridge)
+			if !isBridge {
+				// unreachable
+				return false
+			}
+			// Reject a same-named bridge NIM has since torn down and recreated.
+			return bridge.InstanceID == p.ExpectedBridgeID
+		},
+		Description: "Bridge must exist, with the expected IfInstanceID if NIM-managed",
 	})
 	switch {
 	case p.Variant.VIFIfName != "":
@@ -113,7 +133,25 @@ func (p BridgePort) Dependencies() (deps []dg.Dependency) {
 					// unreachable
 					return false
 				}
+				if p.ExpectedPortID != 0 &&
+					port.InstanceID != p.ExpectedPortID {
+					return false
+				}
 				return port.MasterIfName == p.BridgeIfName
+			}
+		} else {
+			// zedrouter enslaves the port into its own bridge below. NIM may
+			// still be in the process of un-bridging this same port (tearing
+			// down its own bridge over it); the kernel rejects enslaving a
+			// bridge master into another bridge (ELOOP), so wait for NIM to
+			// finish rather than attempt it.
+			mustSatisfy = func(item dg.Item) bool {
+				port, isPort := item.(generic.Port)
+				if !isPort {
+					// unreachable
+					return false
+				}
+				return !port.IsBridge
 			}
 		}
 		deps = append(deps, dg.Dependency{
@@ -123,7 +161,7 @@ func (p BridgePort) Dependencies() (deps []dg.Dependency) {
 			},
 			MustSatisfy: mustSatisfy,
 			Description: "Port must exist, and if it is managed by NIM, " +
-				"it must already be bridged",
+				"it must already be bridged, or otherwise not itself a bridge",
 			Attributes: dg.DependencyAttributes{
 				AutoDeletedByExternal: true,
 			},
@@ -138,6 +176,10 @@ func (p BridgePort) Dependencies() (deps []dg.Dependency) {
 			vlanSubIf, isVLANSubIf := item.(VLANSubIf)
 			if !isVLANSubIf {
 				// unreachable
+				return false
+			}
+			if p.ExpectedPortID != 0 &&
+				vlanSubIf.InstanceID != p.ExpectedPortID {
 				return false
 			}
 			return vlanSubIf.ParentIfName == p.BridgeIfName &&
@@ -286,17 +328,45 @@ func (c *BridgePortConfigurator) Delete(ctx context.Context, item dg.Item) (err 
 		// Port bridging is done outside zedrouter, NOOP here.
 		return nil
 	}
-	link, err := netlink.LinkByName(bridgePort.portIfName())
+	// Resolve by IfInstanceID rather than by name when available: NIM may have
+	// since renamed this interface away, or even reused its old name for a
+	// bridge of its own -- operating on the name as recorded at Create time
+	// could silently hit (and modify) an unrelated, NIM-owned interface.
+	ifName := bridgePort.portIfName()
+	if bridgePort.ExpectedPortID != 0 {
+		attrs, exists, err := c.NetworkMonitor.GetInterfaceByInstanceID(
+			bridgePort.ExpectedPortID)
+		if err != nil {
+			err = fmt.Errorf("failed to look up interface with IfInstanceID %d: %v",
+				bridgePort.ExpectedPortID, err)
+			c.Log.Error(err)
+			return err
+		}
+		if !exists {
+			// Genuinely gone; nothing left to detach.
+			return nil
+		}
+		ifName = attrs.IfName
+	}
+	link, err := netlink.LinkByName(ifName)
 	if err != nil {
 		err = fmt.Errorf("failed to get link for interface %s: %w",
-			bridgePort.portIfName(), err)
+			ifName, err)
 		c.Log.Error(err)
 		return err
+	}
+	if !stillEnslavedIn(
+		c.NetworkMonitor, link, bridgePort.BridgeIfName, bridgePort.ExpectedBridgeID) {
+		// The interface has since been repurposed (e.g. re-enslaved by NIM
+		// into a bridge of its own): our own enslavement into BridgeIfName is
+		// already gone, so there is nothing left for us to detach. Touching
+		// it now would rip it out of whatever it is actually attached to.
+		return nil
 	}
 	err = netlink.LinkSetNoMaster(link)
 	if err != nil {
 		err = fmt.Errorf("failed to detach interface %s from bridge %s: %w",
-			bridgePort.portIfName(), bridgePort.BridgeIfName, err)
+			ifName, bridgePort.BridgeIfName, err)
 		c.Log.Error(err)
 		return err
 	}
@@ -304,7 +374,7 @@ func (c *BridgePortConfigurator) Delete(ctx context.Context, item dg.Item) (err 
 		err = netlink.LinkSetMTU(link, types.DefaultMTU)
 		if err != nil {
 			err = fmt.Errorf("failed to set default MTU %d for interface %s: %w",
-				types.DefaultMTU, bridgePort.portIfName(), err)
+				types.DefaultMTU, ifName, err)
 			c.Log.Error(err)
 			return err
 		}
@@ -312,11 +382,32 @@ func (c *BridgePortConfigurator) Delete(ctx context.Context, item dg.Item) (err 
 	err = netlink.LinkSetDown(link)
 	if err != nil {
 		err = fmt.Errorf("failed to set interface %s DOWN: %w",
-			bridgePort.portIfName(), err)
+			ifName, err)
 		c.Log.Error(err)
 		return err
 	}
 	return nil
+}
+
+// stillEnslavedIn returns true if link is currently a slave of the bridge
+// identified by bridgeIfName/expectedBridgeID. Used before detaching or
+// otherwise mutating bridge-scoped state (e.g. per-port VLAN membership) of
+// an interface resolved by IfInstanceID, to avoid acting on a bridge it was
+// re-enslaved into (by NIM) after this item's own claim on it was
+// superseded.
+func stillEnslavedIn(netMonitor netmonitor.NetworkMonitor, link netlink.Link,
+	bridgeIfName string, expectedBridgeID types.IfInstanceID) bool {
+	if link.Attrs().MasterIndex == 0 {
+		return false
+	}
+	masterAttrs, err := netMonitor.GetInterfaceAttrs(link.Attrs().MasterIndex)
+	if err != nil {
+		return false
+	}
+	if expectedBridgeID != 0 {
+		return masterAttrs.InstanceID == expectedBridgeID
+	}
+	return masterAttrs.InstanceID == 0 && masterAttrs.IfName == bridgeIfName
 }
 
 // NeedsRecreate returns false if only MTU changed.

--- a/pkg/pillar/nireconciler/linuxitems/items_test.go
+++ b/pkg/pillar/nireconciler/linuxitems/items_test.go
@@ -95,15 +95,28 @@ func TestBPDUGuardEqual(t *testing.T) {
 	if g1.Equal(DummyIf{}) {
 		t.Error("wrong type should be unequal")
 	}
+	g5DiffInstanceID := BPDUGuard{BridgeIfName: "br0", PortIfName: "eth0", ExpectedBridgeID: 42}
+	if g1.Equal(g5DiffInstanceID) {
+		t.Error("different ExpectedBridgeID should be unequal")
+	}
 }
 
 func TestBPDUGuardDependencies(t *testing.T) {
-	g := BPDUGuard{BridgeIfName: "br0", PortIfName: "eth0"}
+	g := BPDUGuard{BridgeIfName: "br0", PortIfName: "eth0", ExpectedBridgeID: 42}
 	deps := g.Dependencies()
 	if len(deps) != 2 {
 		t.Fatalf("expected 2 deps, got %d", len(deps))
 	}
-	depByType(t, deps, BridgeTypename)
+	bridgeDep := depByType(t, deps, BridgeTypename)
+	if bridgeDep.MustSatisfy == nil {
+		t.Fatal("Bridge dep should have MustSatisfy when ExpectedBridgeID is set")
+	}
+	if !bridgeDep.MustSatisfy(Bridge{IfName: "br0", InstanceID: 42}) {
+		t.Error("MustSatisfy should accept a Bridge with the expected InstanceID")
+	}
+	if bridgeDep.MustSatisfy(Bridge{IfName: "br0", InstanceID: 43}) {
+		t.Error("MustSatisfy should reject a Bridge with a different InstanceID")
+	}
 	bpDep := depByType(t, deps, BridgePortTypename)
 	wantBPName := BridgePortName("br0", "eth0")
 	if bpDep.RequiredItem.ItemName != wantBPName {
@@ -188,6 +201,11 @@ func TestBridgeEqual(t *testing.T) {
 	}
 	if b1.Equal(DummyIf{}) {
 		t.Error("wrong type should be unequal")
+	}
+	b5DiffInstanceID := Bridge{IfName: "br0", MACAddress: mac1, MTU: 1500, InstanceID: 7}
+	if b1.Equal(b5DiffInstanceID) {
+		t.Error("different InstanceID should be unequal -- this is what lets a " +
+			"NIM-recreated bridge (same name, same MAC) be detected as changed")
 	}
 }
 
@@ -302,20 +320,33 @@ func TestBridgePortDependenciesVIF(t *testing.T) {
 }
 
 func TestBridgePortDependenciesPort(t *testing.T) {
-	// ExternallyBridged=false: no MustSatisfy
+	// ExternallyBridged=false: MustSatisfy rejects a Port that is itself
+	// currently a bridge (NIM may still be un-bridging it; enslaving a
+	// bridge into another bridge is rejected by the kernel with ELOOP).
 	p := BridgePort{BridgeIfName: "br0", Variant: BridgePortVariant{PortIfName: "eth0"}}
 	deps := p.Dependencies()
 	if len(deps) != 2 {
 		t.Fatalf("expected 2 deps, got %d", len(deps))
 	}
 	portDep := depByType(t, deps, generic.PortTypename)
-	if portDep.MustSatisfy != nil {
-		t.Error("non-externally bridged port dep should not have MustSatisfy")
+	if portDep.MustSatisfy == nil {
+		t.Fatal("non-externally bridged port dep should have MustSatisfy")
+	}
+	if !portDep.MustSatisfy(generic.Port{IsBridge: false}) {
+		t.Error("MustSatisfy should be true for a Port that is not itself a bridge")
+	}
+	if portDep.MustSatisfy(generic.Port{IsBridge: true}) {
+		t.Error("MustSatisfy should be false for a Port that is itself a bridge")
 	}
 }
 
 func TestBridgePortDependenciesPortExternallyBridged(t *testing.T) {
-	p := BridgePort{BridgeIfName: "br0", Variant: BridgePortVariant{PortIfName: "eth0"}, ExternallyBridged: true}
+	p := BridgePort{
+		BridgeIfName:      "br0",
+		Variant:           BridgePortVariant{PortIfName: "eth0"},
+		ExternallyBridged: true,
+		ExpectedPortID:    42,
+	}
 	deps := p.Dependencies()
 	if len(deps) != 2 {
 		t.Fatalf("expected 2 deps, got %d", len(deps))
@@ -324,20 +355,56 @@ func TestBridgePortDependenciesPortExternallyBridged(t *testing.T) {
 	if portDep.MustSatisfy == nil {
 		t.Fatal("externally bridged port dep should have MustSatisfy")
 	}
-	// Port with matching MasterIfName → true
-	portMatch := generic.Port{MasterIfName: "br0"}
+	portMatch := generic.Port{MasterIfName: "br0", InstanceID: 42}
 	if !portDep.MustSatisfy(portMatch) {
-		t.Error("MustSatisfy should be true for matching MasterIfName")
+		t.Error("MustSatisfy should be true for matching MasterIfName and InstanceID")
 	}
-	portNoMatch := generic.Port{MasterIfName: "br1"}
+	portNoMatch := generic.Port{MasterIfName: "br1", InstanceID: 42}
 	if portDep.MustSatisfy(portNoMatch) {
 		t.Error("MustSatisfy should be false for non-matching MasterIfName")
+	}
+	portWrongID := generic.Port{MasterIfName: "br0", InstanceID: 43}
+	if portDep.MustSatisfy(portWrongID) {
+		t.Error("MustSatisfy should be false for a Port with a different InstanceID " +
+			"even if MasterIfName matches -- it may be a different incarnation " +
+			"of the port that NIM has since renamed or recreated")
+	}
+}
+
+func TestBridgePortDependenciesBridgeID(t *testing.T) {
+	p := BridgePort{
+		BridgeIfName:     "br0",
+		Variant:          BridgePortVariant{PortIfName: "eth0"},
+		ExpectedBridgeID: 42,
+	}
+	bridgeDep := depByType(t, p.Dependencies(), BridgeTypename)
+	if bridgeDep.MustSatisfy == nil {
+		t.Fatal("Bridge dep should have MustSatisfy when ExpectedBridgeID is set")
+	}
+	if !bridgeDep.MustSatisfy(Bridge{IfName: "br0", InstanceID: 42}) {
+		t.Error("MustSatisfy should accept a Bridge with the expected InstanceID")
+	}
+	if bridgeDep.MustSatisfy(Bridge{IfName: "br0", InstanceID: 43}) {
+		t.Error("MustSatisfy should reject a Bridge with a different InstanceID " +
+			"(a same-named bridge NIM has since torn down and recreated -- this " +
+			"is what makes a silently-recreated bridge visible again, so " +
+			"orphaned VIFs get re-enslaved instead of staying disconnected)")
+	}
+	pNotNIM := BridgePort{BridgeIfName: "br0", Variant: BridgePortVariant{PortIfName: "eth0"}}
+	noIDDep := depByType(t, pNotNIM.Dependencies(), BridgeTypename)
+	if !noIDDep.MustSatisfy(Bridge{IfName: "br0", InstanceID: 99}) {
+		t.Error("MustSatisfy should accept any InstanceID when ExpectedBridgeID is zero")
 	}
 }
 
 func TestBridgePortDependenciesVLANSubinterface(t *testing.T) {
 	subIf := &VLANSubinterface{IfName: "eth0.100", VID: 100}
-	p := BridgePort{BridgeIfName: "br0", Variant: BridgePortVariant{VLANSubinterface: subIf}, ExternallyBridged: true}
+	p := BridgePort{
+		BridgeIfName:      "br0",
+		Variant:           BridgePortVariant{VLANSubinterface: subIf},
+		ExternallyBridged: true,
+		ExpectedPortID:    42,
+	}
 	deps := p.Dependencies()
 	if len(deps) != 2 {
 		t.Fatalf("expected 2 deps, got %d", len(deps))
@@ -346,14 +413,19 @@ func TestBridgePortDependenciesVLANSubinterface(t *testing.T) {
 	if subIfDep.MustSatisfy == nil {
 		t.Fatal("VLANSubinterface dep should have MustSatisfy")
 	}
-	// VLANSubIf with matching ParentIfName and ID → true
-	match := VLANSubIf{ParentIfName: "br0", ID: 100}
+	// VLANSubIf with matching ParentIfName, ID and InstanceID → true
+	match := VLANSubIf{ParentIfName: "br0", ID: 100, InstanceID: 42}
 	if !subIfDep.MustSatisfy(match) {
 		t.Error("MustSatisfy should be true for matching VLANSubIf")
 	}
-	noMatch := VLANSubIf{ParentIfName: "br0", ID: 200}
+	noMatch := VLANSubIf{ParentIfName: "br0", ID: 200, InstanceID: 42}
 	if subIfDep.MustSatisfy(noMatch) {
 		t.Error("MustSatisfy should be false for wrong VID")
+	}
+	wrongID := VLANSubIf{ParentIfName: "br0", ID: 100, InstanceID: 43}
+	if subIfDep.MustSatisfy(wrongID) {
+		t.Error("MustSatisfy should be false for a VLANSubIf with a different InstanceID " +
+			"even if ParentIfName and VID match -- NIM may have torn it down and recreated it")
 	}
 }
 
@@ -496,7 +568,10 @@ func TestTCIngressEqual(t *testing.T) {
 
 func TestTCIngressDependencies(t *testing.T) {
 	ref := dg.ItemRef{ItemType: "Port", ItemName: "eth0"}
-	tc := TCIngress{NetIf: generic.NetworkIf{IfName: "eth0", ItemRef: ref}}
+	tc := TCIngress{
+		NetIf:          generic.NetworkIf{IfName: "eth0", ItemRef: ref},
+		ExpectedPortID: 42,
+	}
 	deps := tc.Dependencies()
 	if len(deps) != 1 {
 		t.Fatalf("expected 1 dep, got %d", len(deps))
@@ -504,8 +579,24 @@ func TestTCIngressDependencies(t *testing.T) {
 	if deps[0].RequiredItem != ref {
 		t.Errorf("dep should be NetIf")
 	}
-	if !deps[0].Attributes.AutoDeletedByExternal {
-		t.Error("dep should be AutoDeletedByExternal")
+	if deps[0].Attributes.AutoDeletedByExternal {
+		t.Error("dep should not be AutoDeletedByExternal -- an IfInstanceID " +
+			"mismatch is now a genuine Equal() diff on TCIngress itself, so a " +
+			"real Delete runs instead of silently skipping straight to Create")
+	}
+	if deps[0].MustSatisfy == nil {
+		t.Fatal("dep should have MustSatisfy to check the Port's IfInstanceID")
+	}
+	if !deps[0].MustSatisfy(generic.Port{IfName: "eth0", InstanceID: 42}) {
+		t.Error("MustSatisfy should accept a Port with the expected InstanceID")
+	}
+	if deps[0].MustSatisfy(generic.Port{IfName: "eth0", InstanceID: 43}) {
+		t.Error("MustSatisfy should reject a Port with a different InstanceID " +
+			"(a same-named Port that NIM has since torn down and recreated)")
+	}
+	tcNoID := TCIngress{NetIf: generic.NetworkIf{IfName: "eth0", ItemRef: ref}}
+	if !tcNoID.Dependencies()[0].MustSatisfy(generic.Port{IfName: "eth0", InstanceID: 99}) {
+		t.Error("MustSatisfy should accept any InstanceID when ExpectedPortID is zero")
 	}
 }
 
@@ -630,16 +721,29 @@ func TestVLANBridgeEqual(t *testing.T) {
 	if v1.Equal(DummyIf{}) {
 		t.Error("wrong type should be unequal")
 	}
+	v4DiffInstanceID := VLANBridge{BridgeIfName: "br0", EnableVLANFiltering: true, ExpectedBridgeID: 42}
+	if v1.Equal(v4DiffInstanceID) {
+		t.Error("different ExpectedBridgeID should be unequal")
+	}
 }
 
 func TestVLANBridgeDependencies(t *testing.T) {
-	v := VLANBridge{BridgeIfName: "br0"}
+	v := VLANBridge{BridgeIfName: "br0", ExpectedBridgeID: 42}
 	deps := v.Dependencies()
 	if len(deps) != 1 {
 		t.Fatalf("expected 1 dep, got %d", len(deps))
 	}
 	if deps[0].RequiredItem.ItemType != BridgeTypename || deps[0].RequiredItem.ItemName != "br0" {
 		t.Errorf("dep should be Bridge br0, got %+v", deps[0].RequiredItem)
+	}
+	if deps[0].MustSatisfy == nil {
+		t.Fatal("Bridge dep should have MustSatisfy when ExpectedBridgeID is set")
+	}
+	if !deps[0].MustSatisfy(Bridge{IfName: "br0", InstanceID: 42}) {
+		t.Error("MustSatisfy should accept a Bridge with the expected InstanceID")
+	}
+	if deps[0].MustSatisfy(Bridge{IfName: "br0", InstanceID: 43}) {
+		t.Error("MustSatisfy should reject a Bridge with a different InstanceID")
 	}
 }
 
@@ -722,6 +826,10 @@ func TestVLANSubIfEqual(t *testing.T) {
 	}
 	if v1.Equal(v4DiffParent) {
 		t.Error("different ParentIfName should be unequal")
+	}
+	v5DiffInstanceID := VLANSubIf{IfName: "eth0.100", ParentIfName: "eth0", ID: 100, InstanceID: 42}
+	if v1.Equal(v5DiffInstanceID) {
+		t.Error("different InstanceID should be unequal")
 	}
 }
 

--- a/pkg/pillar/nireconciler/linuxitems/registry.go
+++ b/pkg/pillar/nireconciler/linuxitems/registry.go
@@ -20,7 +20,7 @@ func RegisterItems(log *base.LogObject, registry *reconciler.DefaultRegistry,
 	configurators := []configurator{
 		{c: &BridgeConfigurator{Log: log}, t: BridgeTypename},
 		{c: &BridgeFwdMaskConfigurator{Log: log}, t: BridgeFwdMaskTypename},
-		{c: &BridgePortConfigurator{Log: log}, t: BridgePortTypename},
+		{c: &BridgePortConfigurator{Log: log, NetworkMonitor: monitor}, t: BridgePortTypename},
 		{c: &DummyIfConfigurator{Log: log}, t: DummyIfTypename},
 		{c: &IPRuleConfigurator{Log: log}, t: IPRuleTypename},
 		{c: &IPSetConfigurator{Log: log}, t: generic.IPSetTypename},
@@ -30,9 +30,9 @@ func RegisterItems(log *base.LogObject, registry *reconciler.DefaultRegistry,
 		{c: &VLANPortConfigurator{Log: log, NetworkMonitor: monitor}, t: VLANPortTypename},
 		{c: &SysctlConfigurator{Log: log}, t: SysctlTypename},
 		{c: &VIFConfigurator{Log: log}, t: VIFTypename},
-		{c: &BPDUGuardConfigurator{Log: log}, t: BPDUGuardTypename},
-		{c: &TCIngressConfigurator{Log: log}, t: TCIngressTypename},
-		{c: &TCMirrorConfigurator{Log: log}, t: TCMirrorTypename},
+		{c: &BPDUGuardConfigurator{Log: log, NetworkMonitor: monitor}, t: BPDUGuardTypename},
+		{c: &TCIngressConfigurator{Log: log, NetworkMonitor: monitor}, t: TCIngressTypename},
+		{c: &TCMirrorConfigurator{Log: log, NetworkMonitor: monitor}, t: TCMirrorTypename},
 	}
 	for _, configurator := range configurators {
 		err := registry.Register(configurator.c, configurator.t)

--- a/pkg/pillar/nireconciler/linuxitems/tcingress.go
+++ b/pkg/pillar/nireconciler/linuxitems/tcingress.go
@@ -12,7 +12,9 @@ import (
 
 	dg "github.com/lf-edge/eve-libs/depgraph"
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/netmonitor"
 	"github.com/lf-edge/eve/pkg/pillar/nireconciler/genericitems"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
 // TCIngress : enable ingress traffic control (tc) qdisc for a network interface.
@@ -20,6 +22,9 @@ import (
 type TCIngress struct {
 	// NetIf : network interface which will have ingress qdisc enabled.
 	NetIf genericitems.NetworkIf
+	// ExpectedPortID: IfInstanceID NetIf is expected to carry, when it
+	// refers to a NIM-managed Port. Zero (unchecked) otherwise, e.g. for a VIF.
+	ExpectedPortID types.IfInstanceID
 }
 
 // Name returns the interface name on which tc-ingress qdisc is enabled.
@@ -55,17 +60,28 @@ func (tc TCIngress) External() bool {
 
 // String describes TCIngress.
 func (tc TCIngress) String() string {
-	return fmt.Sprintf("TC-Ingress qdisc for interface: %s", tc.NetIf.IfName)
+	return fmt.Sprintf("TC-Ingress qdisc for interface: %s, expectedPortID: %d",
+		tc.NetIf.IfName, tc.ExpectedPortID)
 }
 
 // Dependencies returns the interface on which the tc-ingress qdisc should be enabled.
 func (tc TCIngress) Dependencies() (deps []dg.Dependency) {
 	deps = append(deps, dg.Dependency{
 		RequiredItem: tc.NetIf.ItemRef,
-		Description:  "interface on which tc-ingress should be enabled must exist",
-		Attributes: dg.DependencyAttributes{
-			AutoDeletedByExternal: true,
+		MustSatisfy: func(item dg.Item) bool {
+			if tc.ExpectedPortID == 0 {
+				return true
+			}
+			port, isPort := item.(genericitems.Port)
+			if !isPort {
+				return true
+			}
+			// Reject a same-named Port that NIM has since torn down and
+			// recreated -- its old qdisc may still be attached.
+			return port.InstanceID == tc.ExpectedPortID
 		},
+		Description: "interface on which tc-ingress should be enabled must exist " +
+			"with the expected IfInstanceID",
 	})
 	return deps
 }
@@ -73,7 +89,8 @@ func (tc TCIngress) Dependencies() (deps []dg.Dependency) {
 // TCIngressConfigurator implements Configurator interface (libs/reconciler)
 // for enabling TC-Ingress qdisc.
 type TCIngressConfigurator struct {
-	Log *base.LogObject
+	Log            *base.LogObject
+	NetworkMonitor netmonitor.NetworkMonitor
 }
 
 // Create enables tc-ingress qdisc on an interface.
@@ -105,12 +122,28 @@ func (c *TCIngressConfigurator) Delete(ctx context.Context, item dg.Item) error 
 	if !isTCIngress {
 		return fmt.Errorf("invalid item type %T, expected TCIngress", item)
 	}
+	ifName := tcIngress.NetIf.IfName
+	if tcIngress.ExpectedPortID != 0 {
+		attrs, exists, err := c.NetworkMonitor.GetInterfaceByInstanceID(
+			tcIngress.ExpectedPortID)
+		if err != nil {
+			err = fmt.Errorf("failed to look up interface with IfInstanceID %d: %v",
+				tcIngress.ExpectedPortID, err)
+			c.Log.Error(err)
+			return err
+		}
+		if !exists {
+			// Genuinely gone (not just renamed); kernel already cleaned up.
+			return nil
+		}
+		ifName = attrs.IfName // may have been renamed since this item was created
+	}
 	var args []string
-	args = append(args, "qdisc", "delete", "dev", tcIngress.NetIf.IfName, "ingress")
+	args = append(args, "qdisc", "delete", "dev", ifName, "ingress")
 	output, err := exec.Command("tc", args...).CombinedOutput()
 	if err != nil {
 		isDevNotFound := strings.Contains(string(output),
-			fmt.Sprintf("Cannot find device \"%s\"", tcIngress.NetIf.IfName))
+			fmt.Sprintf("Cannot find device \"%s\"", ifName))
 		if isDevNotFound {
 			// Ignore if interface was already deleted and therefore Linux has
 			// automatically removed the tc-filter rule.
@@ -118,7 +151,7 @@ func (c *TCIngressConfigurator) Delete(ctx context.Context, item dg.Item) error 
 			err = nil
 		} else {
 			err = fmt.Errorf("failed to delete tc-ingress qdisc from interface %s: %s (%w)",
-				tcIngress.NetIf.IfName, output, err)
+				ifName, output, err)
 			c.Log.Error(err)
 			return err
 		}

--- a/pkg/pillar/nireconciler/linuxitems/tcmirror.go
+++ b/pkg/pillar/nireconciler/linuxitems/tcmirror.go
@@ -13,7 +13,9 @@ import (
 
 	dg "github.com/lf-edge/eve-libs/depgraph"
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/netmonitor"
 	"github.com/lf-edge/eve/pkg/pillar/nireconciler/genericitems"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
 // TCMirror : tc-filter rule mirroring matching packets (using tc-u32) from ingress qdisc
@@ -47,6 +49,9 @@ type TCMirror struct {
 	// Use zero to disable matching by the transport protocol destination port.
 	// Only valid if Protocol is either IPv4 or IPv6.
 	TransportDstPort uint16
+	// ExpectedPortID: IfInstanceID FromNetIf is expected to carry, when it
+	// refers to a NIM-managed Port. Zero (unchecked) otherwise, e.g. for a VIF.
+	ExpectedPortID types.IfInstanceID
 }
 
 // TCMatchProtocol : protocol to match by TCMirror rule.
@@ -105,7 +110,8 @@ func (tc TCMirror) Equal(other dg.Item) bool {
 		equalUint8Ptr(tc.TransportProtocol, tc2.TransportProtocol) &&
 		equalUint8Ptr(tc.ICMPType, tc2.ICMPType) &&
 		tc.TransportSrcPort == tc2.TransportSrcPort &&
-		tc.TransportDstPort == tc2.TransportDstPort
+		tc.TransportDstPort == tc2.TransportDstPort &&
+		tc.ExpectedPortID == tc2.ExpectedPortID
 }
 
 // External returns false.
@@ -134,8 +140,8 @@ func (tc TCMirror) String() string {
 			fmt.Sprintf("transport-dst-port=%d", tc.TransportDstPort))
 	}
 	return fmt.Sprintf("TC-Mirror rule from interface %s to interface %s priority %d, "+
-		"matching: %v", tc.FromNetIf.IfName, tc.ToNetIf.IfName, tc.RulePriority,
-		strings.Join(matchRules, ", "))
+		"matching: %v, expectedPortID: %d", tc.FromNetIf.IfName, tc.ToNetIf.IfName,
+		tc.RulePriority, strings.Join(matchRules, ", "), tc.ExpectedPortID)
 }
 
 // Dependencies returns the source interface with ingress qdisc enabled and the destination
@@ -169,7 +175,8 @@ func equalUint8Ptr(value1, value2 *uint8) bool {
 // TCMirrorConfigurator implements Configurator interface (libs/reconciler)
 // for configuring tc-filter rules mirroring selected packets.
 type TCMirrorConfigurator struct {
-	Log *base.LogObject
+	Log            *base.LogObject
+	NetworkMonitor netmonitor.NetworkMonitor
 }
 
 // Create adds tc-filter rule mirroring selected packets.
@@ -252,24 +259,44 @@ func (c *TCMirrorConfigurator) Delete(ctx context.Context, item dg.Item) error {
 	if !isTCMirror {
 		return fmt.Errorf("invalid item type %T, expected TCMirror", item)
 	}
+	ifName := tcMirror.FromNetIf.IfName
+	if tcMirror.ExpectedPortID != 0 {
+		attrs, exists, err := c.NetworkMonitor.GetInterfaceByInstanceID(
+			tcMirror.ExpectedPortID)
+		if err != nil {
+			err = fmt.Errorf("failed to look up interface with IfInstanceID %d: %v",
+				tcMirror.ExpectedPortID, err)
+			c.Log.Error(err)
+			return err
+		}
+		if !exists {
+			// Genuinely gone (not just renamed); kernel already cleaned up.
+			return nil
+		}
+		// May have been renamed since this item was created, or the old name
+		// may have been reused for a different interface (e.g. NIM-created
+		// bridge takes over the adapter's logical name once it starts bridging).
+		ifName = attrs.IfName
+	}
 	var args []string
 	args = append(args, "filter", "delete")
-	args = append(args, "dev", tcMirror.FromNetIf.IfName)
+	args = append(args, "dev", ifName)
 	args = append(args, "parent", "ffff:") // ingress qdisc
 	args = append(args, "prio", strconv.Itoa(int(tcMirror.RulePriority)))
 	output, err := exec.Command("tc", args...).CombinedOutput()
 	if err != nil {
 		isDevNotFound := strings.Contains(string(output),
-			fmt.Sprintf("Cannot find device \"%s\"", tcMirror.FromNetIf.IfName))
-		if isDevNotFound {
-			// Ignore if interface was already deleted and therefore Linux has
-			// automatically removed the tc-filter rule.
+			fmt.Sprintf("Cannot find device \"%s\"", ifName))
+		isQdiscGone := strings.Contains(string(output), "Parent Qdisc doesn't exists")
+		if isDevNotFound || isQdiscGone {
+			// Ignore if the interface, or its ingress qdisc, was already removed
+			// (e.g. by TCIngress's own Delete) -- the filter is implicitly gone too.
 			c.Log.Warn(err)
 			err = nil
 		} else {
 			err = fmt.Errorf(
 				"failed to delete tc-rule mirroring traffic from %s to %s: %s (%w)",
-				tcMirror.FromNetIf.IfName, tcMirror.ToNetIf.IfName, output, err)
+				ifName, tcMirror.ToNetIf.IfName, output, err)
 			c.Log.Error(err)
 			return err
 		}

--- a/pkg/pillar/nireconciler/linuxitems/vlanbridge.go
+++ b/pkg/pillar/nireconciler/linuxitems/vlanbridge.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lf-edge/eve-libs/reconciler"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/netmonitor"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/vishvananda/netlink"
 )
 
@@ -25,6 +26,9 @@ type VLANBridge struct {
 	// EnableVLANFiltering : drop packet if it belongs to a VLAN which is not enabled
 	// on the input bridge port (using VLANPort config item).
 	EnableVLANFiltering bool
+	// ExpectedBridgeID: IfInstanceID BridgeIfName is expected to carry. Zero
+	// if the bridge is not NIM-managed.
+	ExpectedBridgeID types.IfInstanceID
 }
 
 // Name returns the interface name of the bridge.
@@ -58,8 +62,9 @@ func (v VLANBridge) External() bool {
 
 // String describes VLANBridge.
 func (v VLANBridge) String() string {
-	return fmt.Sprintf("VLANBridge: {bridgeIfName: %s, enableVlanFiltering: %t}",
-		v.BridgeIfName, v.EnableVLANFiltering)
+	return fmt.Sprintf("VLANBridge: {bridgeIfName: %s, enableVlanFiltering: %t, "+
+		"expectedBridgeID: %d}",
+		v.BridgeIfName, v.EnableVLANFiltering, v.ExpectedBridgeID)
 }
 
 // Dependencies returns the bridge as the only dependency.
@@ -68,6 +73,21 @@ func (v VLANBridge) Dependencies() (deps []dg.Dependency) {
 		RequiredItem: dg.ItemRef{
 			ItemType: BridgeTypename,
 			ItemName: v.BridgeIfName,
+		},
+		MustSatisfy: func(item dg.Item) bool {
+			if v.ExpectedBridgeID == 0 {
+				return true
+			}
+			bridge, isBridge := item.(Bridge)
+			if !isBridge {
+				// unreachable
+				return false
+			}
+			// Reject a same-named bridge NIM has since torn down and
+			// recreated -- VLAN filtering config lives on the bridge itself,
+			// so it is genuinely gone with it (hence AutoDeletedByExternal
+			// below), and must be reapplied to the new incarnation.
+			return bridge.InstanceID == v.ExpectedBridgeID
 		},
 		Attributes: dg.DependencyAttributes{
 			AutoDeletedByExternal: true,
@@ -183,6 +203,23 @@ func (c *VLANBridgeConfigurator) Delete(ctx context.Context, item dg.Item) error
 	}
 	const enableVlanFiltering = false // default value
 	brIfName := vlanBridge.BridgeIfName
+	if vlanBridge.ExpectedBridgeID != 0 {
+		// NIM may have since reused this name for a bridge of its own;
+		// resolve by IfInstanceID rather than risk touching that instead.
+		attrs, exists, err := c.NetworkMonitor.GetInterfaceByInstanceID(
+			vlanBridge.ExpectedBridgeID)
+		if err != nil {
+			err = fmt.Errorf("failed to look up interface with IfInstanceID %d: %v",
+				vlanBridge.ExpectedBridgeID, err)
+			c.Log.Error(err)
+			return err
+		}
+		if !exists {
+			// Genuinely gone; nothing left to clean up.
+			return nil
+		}
+		brIfName = attrs.IfName
+	}
 	brIsBusy, err := c.setVlanFiltering(brIfName, enableVlanFiltering)
 	if err != nil && !brIsBusy {
 		c.Log.Error(err)

--- a/pkg/pillar/nireconciler/linuxitems/vlanport.go
+++ b/pkg/pillar/nireconciler/linuxitems/vlanport.go
@@ -10,6 +10,7 @@ import (
 	dg "github.com/lf-edge/eve-libs/depgraph"
 	"github.com/lf-edge/eve/pkg/pillar/base"
 	"github.com/lf-edge/eve/pkg/pillar/netmonitor"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 	"github.com/lf-edge/eve/pkg/pillar/utils/generics"
 	"github.com/vishvananda/netlink"
 )
@@ -30,6 +31,12 @@ type VLANPort struct {
 	ForVIF bool
 	// VLANConfig : VLAN configuration to apply on the bridged interface.
 	VLANConfig VLANConfig
+	// ExpectedBridgeID: IfInstanceID BridgeIfName is expected to carry. Zero
+	// if the bridge is not NIM-managed.
+	ExpectedBridgeID types.IfInstanceID
+	// ExpectedPortID: IfInstanceID PortIfName is expected to carry.
+	// Zero if the port is not NIM-managed (e.g. VIF).
+	ExpectedPortID types.IfInstanceID
 }
 
 // VLANConfig : VLAN configuration to apply either on a bridge port or as a VLAN sub-interface.
@@ -113,7 +120,9 @@ func (v VLANPort) Equal(other dg.Item) bool {
 	// Compare common fields
 	return v.BridgeIfName == v2.BridgeIfName &&
 		v.PortIfName == v2.PortIfName &&
-		v.ForVIF == v2.ForVIF
+		v.ForVIF == v2.ForVIF &&
+		v.ExpectedBridgeID == v2.ExpectedBridgeID &&
+		v.ExpectedPortID == v2.ExpectedPortID
 }
 
 // External returns false.
@@ -138,8 +147,10 @@ func (v VLANPort) String() string {
 		vlanConfig = "vlanConfig: none"
 	}
 	return fmt.Sprintf(
-		"VLANPort: {bridgeIfName: %s, portIfName: %s, forVIF: %t, %s}",
+		"VLANPort: {bridgeIfName: %s, portIfName: %s, forVIF: %t, %s, "+
+			"expectedBridgeID: %d, expectedPortID: %d}",
 		v.BridgeIfName, v.PortIfName, v.ForVIF, vlanConfig,
+		v.ExpectedBridgeID, v.ExpectedPortID,
 	)
 }
 
@@ -172,6 +183,18 @@ func (v VLANPort) Dependencies() (deps []dg.Dependency) {
 				if bpSubIf == nil || bpSubIf.VID != v.VLANConfig.VLANSubinterface.VID {
 					return false
 				}
+			}
+			// Reject a BridgePort built from a different (older or newer)
+			// snapshot of the underlying port/bridge instances -- applying
+			// our VLAN config against it could otherwise target a port or
+			// bridge that NIM has since renamed or recreated.
+			if v.ExpectedPortID != 0 &&
+				bridgePort.ExpectedPortID != v.ExpectedPortID {
+				return false
+			}
+			if v.ExpectedBridgeID != 0 &&
+				bridgePort.ExpectedBridgeID != v.ExpectedBridgeID {
+				return false
 			}
 			return true
 		},
@@ -211,22 +234,70 @@ func (c *VLANPortConfigurator) createOrDelete(item dg.Item, del bool) (err error
 		return fmt.Errorf("invalid item type %T, expected VLANPort", item)
 	}
 
-	link, err := netlink.LinkByName(vlanPort.PortIfName)
+	portIfName := vlanPort.PortIfName
+	bridgeIfName := vlanPort.BridgeIfName
+	if del {
+		// Resolve by IfInstanceID rather than by name when available: NIM
+		// may have since renamed these interfaces away, or even reused
+		// their old names for a bridge of its own -- operating on the
+		// names as recorded at Create time could silently hit (and
+		// modify) unrelated, NIM-owned interfaces.
+		if vlanPort.ExpectedPortID != 0 {
+			attrs, exists, err := c.NetworkMonitor.GetInterfaceByInstanceID(
+				vlanPort.ExpectedPortID)
+			if err != nil {
+				err = fmt.Errorf("failed to look up interface with IfInstanceID %d: %v",
+					vlanPort.ExpectedPortID, err)
+				c.Log.Error(err)
+				return err
+			}
+			if !exists {
+				// Genuinely gone; nothing left to clean up.
+				return nil
+			}
+			portIfName = attrs.IfName
+		}
+		if vlanPort.ExpectedBridgeID != 0 {
+			attrs, exists, err := c.NetworkMonitor.GetInterfaceByInstanceID(
+				vlanPort.ExpectedBridgeID)
+			if err != nil {
+				err = fmt.Errorf("failed to look up interface with IfInstanceID %d: %v",
+					vlanPort.ExpectedBridgeID, err)
+				c.Log.Error(err)
+				return err
+			}
+			if !exists {
+				return nil
+			}
+			bridgeIfName = attrs.IfName
+		}
+	}
+
+	link, err := netlink.LinkByName(portIfName)
 	if err != nil {
 		err = fmt.Errorf("failed to get link for bridge port %s: %w",
-			vlanPort.PortIfName, err)
+			portIfName, err)
 		c.Log.Error(err)
 		// Dependencies should prevent this.
 		return err
 	}
 
-	brLink, err := netlink.LinkByName(vlanPort.BridgeIfName)
+	brLink, err := netlink.LinkByName(bridgeIfName)
 	if err != nil {
 		err = fmt.Errorf("failed to get link for bridge %s: %w",
-			vlanPort.BridgeIfName, err)
+			bridgeIfName, err)
 		c.Log.Error(err)
 		// Dependencies should prevent this.
 		return err
+	}
+
+	if del && vlanPort.VLANConfig.VLANSubinterface == nil &&
+		!stillEnslavedIn(c.NetworkMonitor, link, bridgeIfName, vlanPort.ExpectedBridgeID) {
+		// The port has since been repurposed (e.g. re-enslaved by NIM into a
+		// bridge of its own): our own VLAN config for it under this bridge
+		// is already gone. Touching it now could instead disrupt whatever
+		// it is actually attached to.
+		return nil
 	}
 
 	switch {

--- a/pkg/pillar/nireconciler/linuxitems/vlansubif.go
+++ b/pkg/pillar/nireconciler/linuxitems/vlansubif.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	dg "github.com/lf-edge/eve-libs/depgraph"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
 // VLANSubIf : VLAN sub-interface.
@@ -22,6 +23,8 @@ type VLANSubIf struct {
 	ParentIfName string
 	// VLAN ID.
 	ID uint16
+	// InstanceID: IfInstanceID NIM assigned. See types.IfInstanceID.
+	InstanceID types.IfInstanceID
 }
 
 // Name returns the physical name of the VLAN sub-interface.
@@ -43,7 +46,8 @@ func (v VLANSubIf) Type() string {
 func (v VLANSubIf) Equal(other dg.Item) bool {
 	v2 := other.(VLANSubIf)
 	return v.ParentIfName == v2.ParentIfName &&
-		v.ID == v2.ID
+		v.ID == v2.ID &&
+		v.InstanceID == v2.InstanceID
 }
 
 // External returns true -- VLAN sub-interfaces are created by NIM, not by zedrouter.

--- a/pkg/pillar/nireconciler/nireconciler.go
+++ b/pkg/pillar/nireconciler/nireconciler.go
@@ -147,6 +147,10 @@ type Port struct {
 	StaticIP          *net.IPNet
 	IgnoreDhcpIPs     bool
 	VLANSubinterfaces []VLANSubinterface
+	// From types.NetworkPortStatus; BridgeIfInstanceID is zero unless NIM
+	// currently bridges this port.
+	UnderlyingIfInstanceID types.IfInstanceID
+	BridgeIfInstanceID     types.IfInstanceID
 }
 
 // Equal compares two ports for equality.
@@ -161,7 +165,9 @@ func (p Port) Equal(p2 Port) bool {
 		generics.EqualSetsFn(p.NTPServers, p2.NTPServers, netutils.EqualIPs) &&
 		netutils.EqualIPNets(p.StaticIP, p2.StaticIP) &&
 		p.IgnoreDhcpIPs == p2.IgnoreDhcpIPs &&
-		generics.EqualSets(p.VLANSubinterfaces, p2.VLANSubinterfaces)
+		generics.EqualSets(p.VLANSubinterfaces, p2.VLANSubinterfaces) &&
+		p.UnderlyingIfInstanceID == p2.UnderlyingIfInstanceID &&
+		p.BridgeIfInstanceID == p2.BridgeIfInstanceID
 }
 
 // UsedWithIP returns true if the port is (potentially) used with an IP address.
@@ -175,6 +181,9 @@ type VLANSubinterface struct {
 	IfName       string
 	VLAN         uint16
 	MTU          uint16
+	// InstanceID: IfInstanceID this sub-interface's own port row carries in
+	// DeviceNetworkStatus. See types.IfInstanceID.
+	InstanceID types.IfInstanceID
 }
 
 // IPRoute is a static IP route configured inside the NI routing table.

--- a/pkg/pillar/types/dns.go
+++ b/pkg/pillar/types/dns.go
@@ -39,6 +39,13 @@ type NetworkPortStatus struct {
 	// can differ from the model (e.g. ethN vs enpNsN) or change across driver
 	// re-binds. Empty for ports not backed by a PCI device (e.g. USB NICs).
 	PciLong string
+	// UnderlyingIfInstanceID identifies the interface NIM enslaves under a
+	// bridge when bridging this port (a physical NIC, VLAN sub-interface, or
+	// bond) -- always defined, whether or not the port is currently bridged.
+	UnderlyingIfInstanceID IfInstanceID
+	// BridgeIfInstanceID identifies the bridge NIM creates over
+	// UnderlyingIfInstanceID. Zero when this port isn't bridged by NIM.
+	BridgeIfInstanceID IfInstanceID
 	// Unlike the logicallabel, which is defined in the device model and unique
 	// for each port, these user-configurable "shared" labels are potentially
 	// assigned to multiple ports so that they can be used all together with
@@ -83,6 +90,13 @@ type NetworkPortStatus struct {
 	// Server (LPS). Reported only back to LPS and never sent to the controller.
 	LpsConfigError string
 }
+
+// IfInstanceID uniquely identifies one concrete network-interface object
+// (NIC, bridge, VLAN sub-interface, or bond) managed by NIM, system-wide.
+// Unlike ifindex (reused by the kernel) or ifname (renamed by NIM), it
+// changes only when NIM actually destroys and recreates the object. Zero
+// means undefined.
+type IfInstanceID uint64
 
 type AddrInfo struct {
 	Addr             net.IP
@@ -250,7 +264,9 @@ func (status DeviceNetworkStatus) MostlyEqual(status2 DeviceNetworkStatus) bool 
 			p1.InvalidConfig != p2.InvalidConfig ||
 			p1.Cost != p2.Cost ||
 			p1.MTU != p2.MTU ||
-			p1.ConfigSource.Origin != p2.ConfigSource.Origin {
+			p1.ConfigSource.Origin != p2.ConfigSource.Origin ||
+			p1.UnderlyingIfInstanceID != p2.UnderlyingIfInstanceID ||
+			p1.BridgeIfInstanceID != p2.BridgeIfInstanceID {
 			return false
 		}
 		if p1.Dhcp != p2.Dhcp ||

--- a/pkg/pillar/types/dns_test.go
+++ b/pkg/pillar/types/dns_test.go
@@ -513,6 +513,24 @@ func TestDeviceNetworkStatusMostlyEqualPortContent(t *testing.T) {
 		},
 	}
 	assert.False(t, s1.MostlyEqual(s4))
+
+	// Different UnderlyingIfInstanceID: NIM re-created the underlying interface
+	// (e.g. after a rename cycle), zedrouter must not treat this as a no-op.
+	s5 := DeviceNetworkStatus{
+		Ports: []NetworkPortStatus{
+			{IfName: "eth0", IsMgmt: true, IPv4Subnet: subnet, UnderlyingIfInstanceID: 1},
+		},
+	}
+	assert.False(t, s1.MostlyEqual(s5))
+
+	// Different BridgeIfInstanceID: NIM stopped/started bridging the port,
+	// zedrouter must not treat this as a no-op.
+	s6 := DeviceNetworkStatus{
+		Ports: []NetworkPortStatus{
+			{IfName: "eth0", IsMgmt: true, IPv4Subnet: subnet, BridgeIfInstanceID: 1},
+		},
+	}
+	assert.False(t, s1.MostlyEqual(s6))
 }
 
 // DeviceNetworkStatus.MostlyEqual — remaining branches


### PR DESCRIPTION
# Description

NIM (`dpcreconciler`) and zedrouter (`nireconciler`) both manage and sometimes
collide over Linux network interfaces: whenever a port becomes a DHCP client, static,
or a VLAN parent, NIM renames the physical/VLAN interface to `k<ifname>` and creates
a bridge `<ifname>` over it (`isAdapterBridgedByNIM` in `dpcreconciler/linuxitems/adapter.go`).
zedrouter treats that bridge and the interface underneath it as external, name-keyed
items, with no notion of object identity distinct from the name. On the other hand,
no-IP port is not bridged by NIM and is instead left for zedrouter to use as part of a single
or a multi-port switch NI.

That microservice split is the root cause of a whole class of races: a controller-pushed DPC
change that flips a port's `DhcpType` and as a result switches a port's bridge ownership
between NIM and zedrouter, can rename/tear down/recreate the same kernel
object under the same name within under a second. NIM acts independently (not aware
of / not dependent on zedrouter), while zedrouter answers to NIM changes re-actively
based on NIM publications and kernel notifications.
Depending on which item and in which direction has changed, this previously showed up as:

- A stale `tc-ingress` qdisc surviving a NIM-executed interface rename, colliding with a later
  zedrouter executed `TCIngressConfigurator.Create` (`Exclusivity flag on, cannot modify`).
- A same-named bridge silently torn down and recreated with a new identity by NIM,
  invisible to zedrouter's `Bridge.Equal()`, so VIFs, VLAN filtering config, and BPDU guard never
  get reapplied to the new instance.
- A stale item's `Delete` resolving purely by name after NIM has already
  renamed the object away or reused its name for a bridge of its own,
  wrongly bringing down or detaching an object that has since been
  legitimately taken over by NIM.
- zedrouter attempting to enslave a port into its own bridge while NIM is
  still mid-teardown of its own bridge over that same port, which the kernel
  rejects outright (`ELOOP`, "too many levels of symbolic links" -- the
  kernel's "no bridging of bridges" check).

**This PR addresses every currently known race in this class between NIM and
zedrouter.** It is specific to **Switch network instances** -- Local network
instances always own their own bridge and are not affected.

The fix: NIM assigns every interface/bridge/VLAN-sub-interface/bond it manages
a **process-lifetime-unique `IfInstanceID`**, stored in the interface's kernel
alias (survives renames) and published via `DeviceNetworkStatus`
(`UnderlyingIfInstanceID` / `BridgeIfInstanceID`). zedrouter's `nireconciler`
items (`TCIngress`, `TCMirror`, `BridgePort`, `VLANPort`, `VLANBridge`,
`BPDUGuard`) carry the corresponding expected IDs (`ExpectedPortID`,
`ExpectedBridgeID`) and use them in both:

- dependency `MustSatisfy` checks, so a same-named-but-different-instance
  object is correctly treated as not-yet-ready instead of silently accepted, and
- `Delete` handlers, which now resolve the target by `IfInstanceID` rather
  than by name, and verify the resolved interface is still actually attached
  where this item expects before mutating it.

## PR dependencies

None.

## How to test and validate this PR

Covered by a new automated regression test:
`evetest/tests/networking/nim_port_config_race_test.go`
(`TestSwitchNIPortConfigRace`), added in this PR. It exercises, on a single
device, two Switch NIs (a multi-port one and a single-port one) through the
full set of previously-racy transitions while continuously verifying app
connectivity through both:

- A port's config flipping DHCP client <-> static IP <-> no IP (bridged by
  NIM throughout, then un-bridged, then re-bridged).
- A port leaving/rejoining a multi-port Switch NI's shared bridge while
  individually gaining/losing NIM bridging, including an explicit BPDU guard
  reapplication check.
- A Switch NI's port switching from a VLAN sub-interface to a plain physical
  port with VLAN filtering enabled on the NI, then churning that port's own IP
  config the same way.

Run with:

```sh
make evetest NAME=TestSwitchNIPortConfigRace
```

Manual reproduction of the original incident: on a device with a Switch NI
bound to a port, push a DPC change that flips that port's `DhcpType` (e.g.
DHCP client -> static IP, or DHCP client -> no IP) and check for any
switch NI errors or application connectivity loss.

## Changelog notes

Fixes intermittent, sometimes silent, connectivity loss on Switch network
instances when the underlying device port's configuration changes (e.g.
switching between DHCP, static IP, and no-IP, or a port moving in/out of a
NIM-managed bridge).
Local network instances were not affected.

## PR Backports

- 17.0-stable: #6576
- 16.0-stable: #6577
- 14.5-stable: Not backported -- diverged too far from master (missing several
  prerequisite features this commit touches in passing for a clean, low-risk backport).
- 13.4-stable: Not backported, same reason as 14.5-stable.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

