### PR TITLE
pkg/xen-tools: fix cleanup rm missing the /out prefix

### DIFF
--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -185,7 +185,7 @@ RUN register-sbom-pkg.sh -n xen -v "${XEN_VERSION}" -l GPL-2.0-only -u https://x
 RUN register-sbom-pkg.sh -n seabios -v "${SEABIOS_UPSTREAM_REVISION}" -l LGPL-2.1-only -u https://www.seabios.org
 
 # Filter out a few things that we don't currently need
-RUN rm -rf /out/usr/share/qemu-xen/qemu/edk2-* /out/var/run /usr/include /usr/lib/*.a
+RUN rm -rf /out/usr/share/qemu-xen/qemu/edk2-* /out/var/run /out/usr/include
 # FIXME: this is a workaround for Xen on ARM still requiring qemu-system-i386
 #   https://wiki.xenproject.org/wiki/Xen_ARM_with_Virtualization_Extensions#Use_of_qemu-system-i386_on_ARM
 WORKDIR /out/usr/lib/xen/bin/
@@ -199,7 +199,9 @@ RUN mkdir -p /out/usr/lib/xen/boot && cp /uefi/OVMF.fd /out/usr/lib/xen/boot/ovm
     { [ -f /uefi/igd.rom ] && cp /uefi/igd.rom /out/usr/lib/xen/boot/igd.rom || :; }
 
 # We need to keep a slim profile, which means removing things we don't need
-RUN rm -rf /out/usr/lib/libxen*.a /out/usr/lib/libxl*.a /out/usr/lib/debug /out/usr/lib/python*
+RUN rm -rf /out/usr/lib/debug /out/usr/lib/python*
+# Static libraries are build-time only; some live in subdirectories (e.g. xen/lib/libfdt.a).
+RUN find /out -type f -name '*.a' -exec rm -f {} +
 RUN rm -rf /out/usr/share/man
 RUN rm -rf /out/usr/share/qemu-xen/qemu/openbios-*
 RUN rm -rf /out/usr/lib/xen/bin/qemu-storage-daemon


### PR DESCRIPTION
# Description

`pkg/xen-tools/Dockerfile` intends to strip C headers and static libraries out
of the package it stages, but two of the four paths in the `rm` are missing the
`/out` prefix:

```dockerfile
RUN rm -rf /out/usr/share/qemu-xen/qemu/edk2-* /out/var/run /usr/include /usr/lib/*.a
```

The final stage is `FROM scratch` + `COPY --from=build /out/ /`, so only what
lives under `/out` matters. `/usr/include` and `/usr/lib/*.a` delete the build
stage's own copies *after* the build has already finished — a no-op that reads
like cleanup. The files ship in every EVE image today, on `kvm`, `k` and `xen`
alike. The surrounding `rm` lines do carry the prefix, which is what makes
these two easy to miss.

Simply prefixing the glob is not enough: `/out/usr/lib/*.a` does not match
`usr/lib/xen/lib/libfdt.a`, the largest of the static libs, because the glob
does not descend. So this PR replaces both `.a` globs with a `find` over all of
`/out`, which also makes the narrower `libxen*.a` / `libxl*.a` globs below
redundant. `-exec rm` rather than `-delete`, because the build stage's `find`
is busybox's.

The headers are the Xen public API (`xenctrl.h`, `libxl.h`, `libxl_event.h`,
`xen/domctl.h`, `xen/sysctl.h`, the `xen/io/*.h` protocol headers) — build-time
artifacts with no runtime consumer in EVE. Nothing in-tree builds against them,
and `pkg/external-boot-image` — the only in-tree consumer of this package —
takes just `runx-initrd` from it.

Found while auditing Xen's footprint, but it has nothing to do with Xen: it is
a build fix that shrinks every image now.

## Note for reviewers of the backports

**Corrected after merge.** This section previously claimed that `16.0-stable`,
`14.5-stable` and `13.4-stable` additionally ship `usr/lib/debug` and
`usr/lib/python*`. That was wrong. On those branches the second cleanup line

```dockerfile
RUN rm -rf /usr/lib/libxen*.a /usr/lib/libxl*.a /usr/lib/debug /usr/lib/python*
```

sits *after* `FROM scratch`, so it runs in the final stage against `/` and its
unprefixed paths are correct there. Master and `17.0-stable` had already
consolidated all cleanup into the build stage against `/out`, which is why the
lines look alike but mean different things. I compared the line text across
branches without checking which stage each one lived in.

What each branch actually ships, measured by flattening the published amd64
package (whiteouts applied):

| branch | `usr/include/` | static libs | saving |
| --- | --- | --- | --- |
| master | 122 files, 1.40 MiB | `liburing.a`, `xen/lib/libfdt.a` (0.27 MiB) | 1.67 MiB |
| 17.0-stable | 122 files, 1.40 MiB | `liburing.a`, `xen/lib/libfdt.a` (0.27 MiB) | ~1.67 MiB |
| 16.0-stable | 119 files, 1.38 MiB | `liburing.a` (8.6 KiB) | ~1.39 MiB |
| 14.5-stable | 119 files, 1.38 MiB | `liburing.a` (8.6 KiB) | ~1.39 MiB |
| 13.4-stable | 119 files, 1.38 MiB | `liburing.a` (8.6 KiB) | ~1.39 MiB |

`usr/lib/debug` and `usr/lib/python*` ship on **none** of them. The older
branches carry less because their Xen version does not produce
`xen/lib/libfdt.a` and their `usr/include/` is three files smaller.

So the bug on the three older branches is confined to the build-stage line, and
the only static lib their final-stage `rm` misses is `liburing.a`. Their
backports still need adapting — the `find` goes in the build stage, and the
final stage's now-dead `libxen*.a` / `libxl*.a` globs are dropped — but they
remove *less* than this PR, not more.

## How to test and validate this PR

Build the package and confirm neither headers nor static libs are present in
the staged output:

```sh
make pkg/xen-tools
# then, for the resulting amd64 image layer:
tar tzf <layer>.tar.gz | grep -E '^usr/include/|\.a$'
```

should return nothing.

Verified by building this branch and diffing the amd64 layers against the same
tree without the change:

| | before | after |
|---|---|---|
| entries | 1272 | 1133 |
| size | 102.64 MiB | 100.97 MiB |
| `usr/include/` | 122 files, 1.40 MiB | gone |
| `usr/lib/liburing.a` | 8.6 KiB | gone |
| `usr/lib/xen/lib/libfdt.a` | 269.7 KiB | gone |

139 entries removed, all of them under `usr/include/` or `*.a`; no file added,
and no other file resized. Total saving 1.67 MiB per image.

Beyond that, any normal boot exercises this: the package is in the `kvm`, `k`
and `xen` rootfs, so a device that boots and starts domains confirms nothing
needed was removed.

## Changelog notes

Every EVE image shrinks by ~1.7 MiB — build-time C headers and static
libraries were being shipped in the xen-tools package by mistake. No
functional change.

## PR Backports

- 17.0-stable: To be backported.
- 16.0-stable: To be backported. Needs adaptation — see the note above.
- 14.5-stable: To be backported. Needs adaptation — see the note above.
- 13.4-stable: To be backported. Needs adaptation — see the note above.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — not applicable, no documented
  behaviour changes.
- [x] I've tested my PR on amd64 device — package built and layer contents
  diffed, see above.
- [ ] I've tested my PR on arm64 device — not built for arm64. The paths are
  arch-independent and the change is confined to the staging cleanup, so the
  risk is limited to arm64 shipping a static lib under a path the `find` would
  catch anyway.
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
