### PR TITLE
dpcmanager: configurable DPC test-fail interval, lower testinterval floor

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -32,6 +32,7 @@ This document mirrors the key names, types, defaults, and ranges defined there.
 | timer.port.georetry | integer in seconds | 600 (10 minutes) | 5 | 4294967295 (max uint32) | retry geolocation after failure |
 | timer.port.testduration | integer in seconds | 30 | 10 | 3600 (1 hour) | wait for DHCP to give address |
 | timer.port.testinterval | timer in seconds | 300 (5 minutes) | 60 (1 minute) | 3600 (1 hour) | retest the current port config |
+| timer.port.testfailinterval | timer in seconds | 300 (5 minutes) | 60 (1 minute) | 3600 (1 hour) | minimum time a port config must wait after a verification failure before it is eligible to be retested |
 | timer.port.timeout | timer in seconds | 15 | 0 | 3600 (1 hour) | time for each http/send |
 | timer.port.testbetterinterval | timer in seconds | 600 (10 minutes) | 0 | 4294967295 | retry the highest-priority port configuration when the current port configuration is a lower-priority fallback |
 | network.fallback.any.eth | "enabled" or "disabled" | disabled | - | - | if no connectivity try any Ethernet, WiFi, or LTE with DHCP client (enabled forcefully during onboarding if no network config) |

--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -31,7 +31,7 @@ This document mirrors the key names, types, defaults, and ranges defined there.
 | timer.port.georedo | integer in seconds | 3600 (1 hour) | 60 (1 minute) | 4294967295 (max uint32) | redo IP geolocation |
 | timer.port.georetry | integer in seconds | 600 (10 minutes) | 5 | 4294967295 (max uint32) | retry geolocation after failure |
 | timer.port.testduration | integer in seconds | 30 | 10 | 3600 (1 hour) | wait for DHCP to give address |
-| timer.port.testinterval | timer in seconds | 300 (5 minutes) | 300 (5 minutes) | 3600 (1 hour) | retest the current port config |
+| timer.port.testinterval | timer in seconds | 300 (5 minutes) | 60 (1 minute) | 3600 (1 hour) | retest the current port config |
 | timer.port.timeout | timer in seconds | 15 | 0 | 3600 (1 hour) | time for each http/send |
 | timer.port.testbetterinterval | timer in seconds | 600 (10 minutes) | 0 | 4294967295 | retry the highest-priority port configuration when the current port configuration is a lower-priority fallback |
 | network.fallback.any.eth | "enabled" or "disabled" | disabled | - | - | if no connectivity try any Ethernet, WiFi, or LTE with DHCP client (enabled forcefully during onboarding if no network config) |

--- a/pkg/pillar/dpcmanager/dpcmanager.go
+++ b/pkg/pillar/dpcmanager/dpcmanager.go
@@ -73,9 +73,10 @@ type DpcManager struct {
 
 	// Minimum time that should pass after a DPC verification failure
 	// until the DPC is eligible for another round of verification.
-	// By default it is 5 minutes.
-	// It is useful to override for unit testing purposes.
-	// XXX Should we make this a global config parameter?
+	// Driven by the NetworkTestFailInterval global config item once GCP is
+	// available (see doUpdateGCP); defaults to 5 minutes beforehand.
+	// It is useful to preset for unit testing purposes, e.g. before the
+	// first UpdateGCP call, or in tests that never call it at all.
 	DpcMinTimeSinceFailure time.Duration
 
 	// Time limit for some DPC to become available.
@@ -817,6 +818,8 @@ func (m *DpcManager) doUpdateGCP(ctx context.Context, gcp types.ConfigItemValueM
 		time.Duration(m.globalCfg.GlobalValueInt(types.NetworkTestBetterInterval))
 	testDuration := time.Second *
 		time.Duration(m.globalCfg.GlobalValueInt(types.NetworkTestDuration))
+	testFailInterval := time.Second *
+		time.Duration(m.globalCfg.GlobalValueInt(types.NetworkTestFailInterval))
 	// We refresh the gelocation information when the underlay aka public
 	// IP address(es) change, plus periodically with this interval.
 	geoRedoInterval := time.Second *
@@ -860,6 +863,7 @@ func (m *DpcManager) doUpdateGCP(ctx context.Context, gcp types.ConfigItemValueM
 		}
 		m.dpcTestDuration = testDuration
 	}
+	m.DpcMinTimeSinceFailure = testFailInterval
 	if m.geoRetryInterval != geoRetryInterval {
 		if geoRetryInterval == 0 {
 			m.Log.Warn("NOT running GeoTimer")

--- a/pkg/pillar/dpcmanager/dpcmanager_test.go
+++ b/pkg/pillar/dpcmanager/dpcmanager_test.go
@@ -455,6 +455,9 @@ func globalConfig() types.ConfigItemValueMap {
 	gcp.SetGlobalValueInt(types.NetworkTestInterval, 2)
 	gcp.SetGlobalValueInt(types.NetworkTestBetterInterval, 3)
 	gcp.SetGlobalValueInt(types.NetworkTestDuration, 1)
+	// Matches initTest's DpcMinTimeSinceFailure struct field preset (in
+	// effect only until the first UpdateGCP call, which this overrides).
+	gcp.SetGlobalValueInt(types.NetworkTestFailInterval, 3)
 	gcp.SetGlobalValueInt(types.NetworkGeoRetryTime, 1)
 	gcp.SetGlobalValueInt(types.NetworkGeoRedoTime, 3)
 	gcp.SetGlobalValueInt(types.LocationCloudInterval, 10)
@@ -1580,7 +1583,8 @@ func TestRestartVerifyParksWhenNothingCurrentlyTestable(test *testing.T) {
 	// could be masked by) the periodic dpcTestTimer/testConnectivityToController
 	// retry, which runs independently of this fix and would otherwise recover
 	// on its own within a couple of seconds either way.
-	dpcManager.DpcMinTimeSinceFailure = time.Minute
+	gcp := globalConfig()
+	gcp.SetGlobalValueInt(types.NetworkTestFailInterval, 60)
 
 	eth0 := mockEth0()
 	eth1 := mockEth1()
@@ -1588,7 +1592,7 @@ func TestRestartVerifyParksWhenNothingCurrentlyTestable(test *testing.T) {
 	networkMonitor.AddOrUpdateInterface(eth1)
 	aa := makeAA(selectedIntfs{eth0: true, eth1: true})
 	dpcManager.UpdateAA(aa)
-	dpcManager.UpdateGCP(globalConfig())
+	dpcManager.UpdateGCP(gcp)
 
 	// "override" DPC over eth0 fails; its own failure cooldown has NOT
 	// elapsed yet (and, per above, will not for the duration of this test).
@@ -1632,7 +1636,8 @@ func TestParksAtManualWhenEverythingFails(test *testing.T) {
 	t.Expect(dpcManager.GetDNS().DPCKey).To(BeEmpty())
 
 	// Avoid a previously-failed DPC becoming testable again mid-test.
-	dpcManager.DpcMinTimeSinceFailure = time.Minute
+	gcp := globalConfig()
+	gcp.SetGlobalValueInt(types.NetworkTestFailInterval, 60)
 
 	eth0 := mockEth0()
 	eth1 := mockEth1()
@@ -1640,7 +1645,7 @@ func TestParksAtManualWhenEverythingFails(test *testing.T) {
 	networkMonitor.AddOrUpdateInterface(eth1)
 	aa := makeAA(selectedIntfs{eth0: true, eth1: true})
 	dpcManager.UpdateAA(aa)
-	dpcManager.UpdateGCP(globalConfig())
+	dpcManager.UpdateGCP(gcp)
 
 	// Older "override" DPC over eth0 previously worked, then breaks.
 	overrideTimePrio := time.Now()

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -195,6 +195,10 @@ const (
 	NetworkTestDuration GlobalSettingKey = "timer.port.testduration"
 	// NetworkTestInterval global setting key
 	NetworkTestInterval GlobalSettingKey = "timer.port.testinterval"
+	// NetworkTestFailInterval global setting key: minimum time a DPC must
+	// wait after a verification failure before it is eligible to be
+	// retested again (DpcManager.DpcMinTimeSinceFailure).
+	NetworkTestFailInterval GlobalSettingKey = "timer.port.testfailinterval"
 	// NetworkTestBetterInterval global setting key
 	NetworkTestBetterInterval GlobalSettingKey = "timer.port.testbetterinterval"
 	// NetworkTestTimeout global setting key
@@ -1177,6 +1181,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(NetworkGeoRetryTime, 10*MinuteInSec, 5, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkTestDuration, 30, 10, HourInSec)
 	configItemSpecMap.AddIntItem(NetworkTestInterval, 5*MinuteInSec, MinuteInSec, HourInSec)
+	configItemSpecMap.AddIntItem(NetworkTestFailInterval, 5*MinuteInSec, MinuteInSec, HourInSec)
 	configItemSpecMap.AddIntItem(NetworkTestBetterInterval, 10*MinuteInSec, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkTestTimeout, 15, 0, HourInSec)
 	configItemSpecMap.AddIntItem(NetworkSendTimeout, 2*MinuteInSec, 0, HourInSec)

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -1176,7 +1176,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(NetworkGeoRedoTime, HourInSec, 60, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkGeoRetryTime, 10*MinuteInSec, 5, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkTestDuration, 30, 10, HourInSec)
-	configItemSpecMap.AddIntItem(NetworkTestInterval, 5*MinuteInSec, 5*MinuteInSec, HourInSec)
+	configItemSpecMap.AddIntItem(NetworkTestInterval, 5*MinuteInSec, MinuteInSec, HourInSec)
 	configItemSpecMap.AddIntItem(NetworkTestBetterInterval, 10*MinuteInSec, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkTestTimeout, 15, 0, HourInSec)
 	configItemSpecMap.AddIntItem(NetworkSendTimeout, 2*MinuteInSec, 0, HourInSec)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -209,6 +209,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		NetworkGeoRetryTime,
 		NetworkTestDuration,
 		NetworkTestInterval,
+		NetworkTestFailInterval,
 		NetworkTestBetterInterval,
 		NetworkTestTimeout,
 		NetworkSendTimeout,


### PR DESCRIPTION
# Description

Two related changes to the DPC (device port config) verification retry
timers, both driven by controller config knobs:

- `timer.port.testinterval`'s floor was accidentally set equal to its
  5-minute default, unlike every other `timer.*` item in
  `docs/CONFIG-PROPERTIES.md`, which allows a much lower minimum than its
  default. Lower the floor to 1 minute.
- `DpcManager.DpcMinTimeSinceFailure` (the minimum time a DPC must wait
  after a verification failure before it is eligible to be retested) was a
  hardcoded 5-minute constant with no controller-config override. Add a new
  `timer.port.testfailinterval` (`NetworkTestFailInterval`) global config
  item, following the same pattern already used for
  `timer.port.testduration/testinterval/testbetterinterval`, and keep
  `DpcMinTimeSinceFailure` in sync with it on every `UpdateGCP` call.

**This is mostly for testing purposes**: it lets DPC-focused evetests lower
these intervals via controller config instead of relying on long fixed
timeouts, which currently slow those tests down considerably.

## PR dependencies

None.

## How to test and validate this PR

- Unit tests in `pkg/pillar/dpcmanager/dpcmanager_test.go` and
  `pkg/pillar/types/global_test.go` cover both changes
  (`make -C pkg/pillar test`).
- On a device connected to a controller, set `timer.port.testinterval`
  and/or `timer.port.testfailinterval` below 5 minutes and confirm DPC
  retests happen at the configured cadence instead of the previous fixed
  5-minute one.

## Changelog notes

Lowered the minimum allowed value for the `timer.port.testinterval`
config setting to 1 minute, and added a new `timer.port.testfailinterval`
config setting controlling how long a device port config must wait after
a verification failure before being retested again. No behavior change at
default values.

## PR Backports

- 17.0-stable: #6528
- 16.0-stable: #6527
- 14.5-stable: #6526
- 13.4-stable: #6525

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
