### PR TITLE
[16.0-stable] pkg/xen-tools: fix cleanup rm missing the /out prefix

### DIFF
--- a/pkg/xen-tools/Dockerfile
+++ b/pkg/xen-tools/Dockerfile
@@ -105,7 +105,9 @@ RUN make -j "$(getconf _NPROCESSORS_ONLN)" && make dist
 RUN dist/install.sh /out
 
 # Filter out a few things that we don't currently need
-RUN rm -rf /out/usr/share/qemu-xen/qemu/edk2-* /out/var/run /usr/include /usr/lib/*.a
+RUN rm -rf /out/usr/share/qemu-xen/qemu/edk2-* /out/var/run /out/usr/include
+# Static libraries are build-time only; some live in subdirectories (e.g. xen/lib/libfdt.a).
+RUN find /out -type f -name '*.a' -exec rm -f {} +
 # FIXME: this is a workaround for Xen on ARM still requiring qemu-system-i386
 #   https://wiki.xenproject.org/wiki/Xen_ARM_with_Virtualization_Extensions#Use_of_qemu-system-i386_on_ARM
 WORKDIR /out/usr/lib/xen/bin/
@@ -124,7 +126,7 @@ COPY init.sh /
 COPY qemu-ifup xen-start /etc/xen/scripts/
 
 # We need to keep a slim profile, which means removing things we don't need
-RUN rm -rf /usr/lib/libxen*.a /usr/lib/libxl*.a /usr/lib/debug /usr/lib/python*
+RUN rm -rf /usr/lib/debug /usr/lib/python*
 
 RUN rm -rf /usr/share/man \
     /usr/share/qemu-xen/qemu/openbios-* \


### PR DESCRIPTION
Backport of #6463

- #6463 — pkg/xen-tools: fix cleanup rm missing the /out prefix

# Description

Adapted cherry-pick. On master all cleanup happens in the build stage against
`/out`, so the original commit fixed two build-stage lines. On `16.0-stable`
the cleanup is split: the build-stage line, and a second block that runs
*after* `FROM scratch` against `/`. Only the build-stage line was wrong here
— the unprefixed paths in the final-stage block are correct for that stage.

The adaptation:

- Build stage: add the missing `/out` prefix to `/usr/include`, and put the
  `find` for static libraries here, over `/out`.
- Final stage: drop `/usr/lib/libxen*.a` and `/usr/lib/libxl*.a`, which the
  build-stage `find` now makes dead. `/usr/lib/debug` and `/usr/lib/python*`
  are kept — they were never broken and are correct for that stage.

Measured on the published `16.0-stable` package (`ca7d4ac`, amd64) by
flattening the layers with whiteouts applied, this drops `usr/include/`
(119 files, 1.38 MiB) plus `usr/lib/liburing.a` (8.6 KiB) — about 1.39 MiB.
That is less than master's 1.67 MiB: this branch's Xen version does not produce
`xen/lib/libfdt.a`, and its `usr/include/` is three files smaller.

Note that `usr/lib/debug` and `usr/lib/python*` do **not** ship on this branch
today — the final-stage `rm` already removes them correctly. An earlier version
of #6463's description claimed otherwise; it has been corrected.

## How to test and validate this PR

See original PR.

## Changelog notes

See original PR.

## Checklist

For backport PRs:

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.