### PR TITLE
[16.0-stable] domainmgr: bound the graceful stop wait for default-mode guests

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -67,6 +67,10 @@ const (
 	warningTime         = 40 * time.Second
 	casClientType       = "containerd"
 	unknownStateRetries = 10
+
+	// gracefulShutdownWait bounds how long a guest is given to act on the
+	// poweroff request before the stop is escalated to a forced one.
+	gracefulShutdownWait = 60 * time.Second
 )
 
 // Really a constant
@@ -1933,6 +1937,33 @@ func doActivateTail(ctx *domainContext, status *types.DomainStatus,
 }
 
 // shutdown and wait for the domain to go away; if that fails destroy and wait
+// shutdownBudget decides how a domain in the given virtualization mode is asked
+// to stop: whether a poweroff request is sent at all, and how long that request
+// is given to take effect before the caller escalates to a forced stop. hvName
+// is the hypervisor backend in use, and maxDelay the budget for a mode that
+// warrants waiting the whole way.
+func shutdownBudget(mode types.VmMode, hvName string,
+	maxDelay time.Duration) (doShutdown bool, firstDelay time.Duration) {
+
+	switch mode {
+	case types.HVM, types.FML:
+		// Do a short shutdown wait, just in case there are
+		// PV tools in guest, then a shutdown -F
+		return true, gracefulShutdownWait
+	case types.PV:
+		// PV is the zero value of VmMode, so it is also what an application
+		// whose config leaves the mode unset lands on. Only xen acts on the
+		// mode; under any other hypervisor such a guest is no more likely to
+		// service the poweroff request than an HVM one, so it gets the same
+		// short wait rather than the whole budget.
+		if hvName == hypervisor.XenHypervisorName {
+			return true, maxDelay
+		}
+		return true, gracefulShutdownWait
+	}
+	return false, maxDelay
+}
+
 func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool) {
 
 	log.Functionf("doInactivate(%v) for %s domainId %d",
@@ -1953,19 +1984,8 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 		maxDelay /= 10
 	}
 
-	firstDelay := maxDelay
-	doShutdown := false // shutdown for particular VirtualizationModes
-
-	switch status.VirtualizationMode {
-	case types.HVM, types.FML:
-		doShutdown = true
-
-		// Do a short shutdown wait, just in case there are
-		// PV tools in guest, then a shutdown -F
-		firstDelay = time.Second * 60
-	case types.PV:
-		doShutdown = true
-	}
+	doShutdown, firstDelay := shutdownBudget(status.VirtualizationMode,
+		hyper.Name(), maxDelay)
 
 	if status.DomainId != 0 {
 		status.State = types.HALTING

--- a/pkg/pillar/cmd/domainmgr/shutdownbudget_test.go
+++ b/pkg/pillar/cmd/domainmgr/shutdownbudget_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package domainmgr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lf-edge/eve/pkg/pillar/hypervisor"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+// The budget the poweroff request gets decides how long an application stays
+// reported as halting when its guest cannot service that request. A guest whose
+// mode carries no meaning for the hypervisor running it must not hold the whole
+// budget before the stop is escalated.
+func TestShutdownBudget(t *testing.T) {
+	const maxDelay = 600 * time.Second
+
+	tests := []struct {
+		name           string
+		mode           types.VmMode
+		hvName         string
+		maxDelay       time.Duration
+		wantShutdown   bool
+		wantFirstDelay time.Duration
+	}{
+		{
+			name:           "PV under kvm is the unset default and waits briefly",
+			mode:           types.PV,
+			hvName:         hypervisor.KVMHypervisorName,
+			maxDelay:       maxDelay,
+			wantShutdown:   true,
+			wantFirstDelay: gracefulShutdownWait,
+		},
+		{
+			name:           "PV under kubevirt waits briefly too",
+			mode:           types.PV,
+			hvName:         hypervisor.KubevirtHypervisorName,
+			maxDelay:       maxDelay,
+			wantShutdown:   true,
+			wantFirstDelay: gracefulShutdownWait,
+		},
+		{
+			name:           "PV under xen is a real PV guest and keeps the budget",
+			mode:           types.PV,
+			hvName:         hypervisor.XenHypervisorName,
+			maxDelay:       maxDelay,
+			wantShutdown:   true,
+			wantFirstDelay: maxDelay,
+		},
+		{
+			name:           "an impatient xen PV guest gets only the reduced budget",
+			mode:           types.PV,
+			hvName:         hypervisor.XenHypervisorName,
+			maxDelay:       maxDelay / 10,
+			wantShutdown:   true,
+			wantFirstDelay: maxDelay / 10,
+		},
+		{
+			name:           "HVM waits briefly",
+			mode:           types.HVM,
+			hvName:         hypervisor.KVMHypervisorName,
+			maxDelay:       maxDelay,
+			wantShutdown:   true,
+			wantFirstDelay: gracefulShutdownWait,
+		},
+		{
+			name:           "FML waits briefly",
+			mode:           types.FML,
+			hvName:         hypervisor.KVMHypervisorName,
+			maxDelay:       maxDelay,
+			wantShutdown:   true,
+			wantFirstDelay: gracefulShutdownWait,
+		},
+		{
+			name:         "NOHYPER is never asked to power off",
+			mode:         types.NOHYPER,
+			hvName:       hypervisor.KVMHypervisorName,
+			maxDelay:     maxDelay,
+			wantShutdown: false,
+		},
+		{
+			name:         "LEGACY is never asked to power off",
+			mode:         types.LEGACY,
+			hvName:       hypervisor.XenHypervisorName,
+			maxDelay:     maxDelay,
+			wantShutdown: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doShutdown, firstDelay := shutdownBudget(tt.mode, tt.hvName, tt.maxDelay)
+			if doShutdown != tt.wantShutdown {
+				t.Fatalf("doShutdown = %v, want %v", doShutdown, tt.wantShutdown)
+			}
+			if doShutdown && firstDelay != tt.wantFirstDelay {
+				t.Errorf("firstDelay = %v, want %v", firstDelay, tt.wantFirstDelay)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Backport of #6453 to `16.0-stable`.

An application whose configuration leaves the virtualization mode unset gets
`PV`, the zero value of the mode enum. Only xen acts on that mode; under kvm or
kubevirt such a guest is an ordinary one which happens to have defaulted. Yet
deactivating it granted the ACPI poweroff request the entire ten-minute budget
before anything else was tried, because the `PV` case in `doInactivate` sets
`doShutdown` without lowering `firstDelay` from `maxDelay` the way `HVM` and
`FML` do. A guest which cannot service the request yet -- one still early in
boot, for instance -- therefore stayed reported as halting for that whole
period, holding its memory and any assigned devices.

Such a guest now gets the same one-minute wait an `HVM` or `FML` guest already
gets, after which the stop escalates exactly as before. A xen `PV` guest keeps
the full budget, where the mode names a real paravirtualized guest whose tools
are inherent.

Cherry-picked with `-x` from `b66b0040c`, no adaptations: the pick applied
clean, and every added and removed line is identical to the master commit's --
the only difference against it is hunk-header line numbers. The buggy `switch`
block on this branch was character-identical to master's before the fix.

**The second commit of #6453 is not backported.** It adds an evetest test, and
`evetest/` does not exist on this branch, so backporting it would mean
backporting the harness. The regression stays guarded here by the unit test
that ships in the cherry-picked commit.

## PR dependencies

None.

## How to test and validate this PR

`TestShutdownBudget` in `pkg/pillar/cmd/domainmgr` covers all eight
mode/hypervisor combinations. On this branch `go build ./...`,
`go vet ./cmd/domainmgr/` and the full `domainmgr` test suite pass, and
`gofmt -l` is clean.

Validated against un-fixed code on 13.4-stable, the most divergent of the four
targets: reverting the `PV` arm to `return true, maxDelay` fails exactly the
two rows this change affects, `PV under kvm` and `PV under kubevirt`, with
`firstDelay = 10m0s, want 1m0s`, while both xen rows and the `HVM`, `FML`,
`NOHYPER` and `LEGACY` rows still pass.

End-to-end device measurements are in #6453: 637/636/637 s from deactivation to
HALTED before the fix against 98/95/96 s after, and 85 runs over 8 hours with
no outlier.

## Changelog notes

An application which is stopped very shortly after it starts is no longer held
for ten minutes before it is reported as stopped.

## PR Backports

- 17.0-stable: #6472
- 16.0-stable: this PR.
- 14.5-stable: #6474
- 13.4-stable: #6475

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation -- no documented behaviour changes;
  the budgets are internal to `doInactivate`.
- [x] I've tested my PR on amd64 device -- the measurements in #6453.
- [ ] I've tested my PR on arm64 device -- not tested; the change is
  architecture independent.
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs:

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.
