### PR TITLE
[16.0-stable] Ask pubsub whether the metrics fit

### DIFF
--- a/pkg/pillar/controllerconn/agentmetrics.go
+++ b/pkg/pillar/controllerconn/agentmetrics.go
@@ -8,6 +8,7 @@
 package controllerconn
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 	"sync"
@@ -121,6 +122,40 @@ func (am *AgentMetrics) RecordSuccess(log *base.LogObject, ifname, url string,
 	am.metrics[ifname] = m
 }
 
+// evictOldestURLs drops up to count least recently used URLMetrics entries,
+// combined across all interfaces, counting each one in URLCounterRedactedCount.
+// It returns how many it dropped, which is short of count once nothing is left
+// to drop. Caller must hold the AgentMetrics lock.
+func (am *AgentMetrics) evictOldestURLs(count int) int {
+	type urlEntry struct {
+		ifname, url string
+		lastUpdated time.Time
+	}
+	var entries []urlEntry
+	for ifname, m := range am.metrics {
+		for url, u := range m.URLCounters {
+			entries = append(entries, urlEntry{ifname, url, u.LastUpdated})
+		}
+	}
+	if count > len(entries) {
+		count = len(entries)
+	}
+	if count <= 0 {
+		return 0
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].lastUpdated.Before(entries[j].lastUpdated)
+	})
+
+	for _, e := range entries[:count] {
+		m := am.metrics[e.ifname]
+		delete(m.URLCounters, e.url)
+		m.URLCounterRedactedCount++
+		am.metrics[e.ifname] = m
+	}
+	return count
+}
+
 // makeRoomForNewURL evicts urlCountersWiggle least recently used
 // URLMetrics entries, combined across all interfaces, once the high
 // watermark is reached. Caller must hold the AgentMetrics lock.
@@ -132,37 +167,40 @@ func (am *AgentMetrics) makeRoomForNewURL(log *base.LogObject) {
 	if total < types.MaxURLCounters+urlCountersWiggle {
 		return
 	}
-
-	type urlEntry struct {
-		ifname, url string
-		lastUpdated time.Time
-	}
-	entries := make([]urlEntry, 0, total)
-	for ifname, m := range am.metrics {
-		for url, u := range m.URLCounters {
-			entries = append(entries, urlEntry{ifname, url, u.LastUpdated})
-		}
-	}
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].lastUpdated.Before(entries[j].lastUpdated)
-	})
-
-	for _, e := range entries[:urlCountersWiggle] {
-		m := am.metrics[e.ifname]
-		delete(m.URLCounters, e.url)
-		m.URLCounterRedactedCount++
-		am.metrics[e.ifname] = m
-	}
 	log.Warnf("AgentMetrics: URLCounters limit of %d reached; "+
 		"evicted %d least recently used entries",
-		types.MaxURLCounters, urlCountersWiggle)
+		types.MaxURLCounters, am.evictOldestURLs(urlCountersWiggle))
 }
 
 // Publish the recorded metrics through the given publisher.
+//
+// makeRoomForNewURL caps how many URLCounters entries are kept, but what pubsub
+// limits is the encoded size of the whole map, which the length of the URL keys
+// dominates. Ask whether the value fits before handing it over -- publishing an
+// oversized one is a fatal in this agent rather than an error -- and give up the
+// least recently used entries until what is left does fit.
 func (am *AgentMetrics) Publish(
 	log *base.LogObject, publication pubsub.Publication, key string) error {
 	release := am.acquire(log)
 	defer release()
+
+	var evicted int
+	for {
+		err := publication.CheckMaxSize(key, am.metrics)
+		if err == nil {
+			break
+		}
+		dropped := am.evictOldestURLs(urlCountersWiggle)
+		if dropped == 0 {
+			return fmt.Errorf("metrics do not fit in a pubsub message and no "+
+				"URLCounters entry is left to drop: %w", err)
+		}
+		evicted += dropped
+	}
+	if evicted > 0 {
+		log.Warnf("AgentMetrics: metrics did not fit in a pubsub message; "+
+			"dropped %d least recently used URLCounters entries", evicted)
+	}
 	return publication.Publish(key, am.metrics)
 }
 

--- a/pkg/pillar/controllerconn/agentmetrics_test.go
+++ b/pkg/pillar/controllerconn/agentmetrics_test.go
@@ -4,6 +4,8 @@
 package controllerconn_test
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -120,4 +122,120 @@ func TestAgentMetricsURLCountersLimitAcrossInterfaces(t *testing.T) {
 	g.Expect(toMap["eth0"].URLCounters).NotTo(HaveKey("/eth0/0"))
 	g.Expect(toMap["eth1"].URLCounters).To(HaveKey("/eth1/new"))
 	g.Expect(toMap["eth0"].URLCounterRedactedCount).To(Equal(uint64(urlCountersWiggle)))
+}
+
+// pubsubMaxsize mirrors the maxsize constant of pubsub/socketdriver: the
+// largest socket message a publisher may write, measured after the value has
+// been base64-encoded.
+const pubsubMaxsize = 65535
+
+// fakePublication applies the size limit the way the socket driver does, so
+// that AgentMetrics.Publish is exercised against the real framing rather than
+// against the raw JSON length.
+type fakePublication struct {
+	maxsize      int
+	publishCount int
+	published    types.MetricsMap
+}
+
+func (p *fakePublication) encodedSize(key string, item interface{}) int {
+	b, err := json.Marshal(item)
+	if err != nil {
+		panic(err)
+	}
+	return len(fmt.Sprintf("update MetricsMap %s %s",
+		base64.StdEncoding.EncodeToString([]byte(key)),
+		base64.StdEncoding.EncodeToString(b)))
+}
+
+func (p *fakePublication) CheckMaxSize(key string, item interface{}) error {
+	if size := p.encodedSize(key, item); size >= p.maxsize {
+		return fmt.Errorf("key %s serialized to size %d exceeds max %d",
+			key, size, p.maxsize)
+	}
+	return nil
+}
+
+func (p *fakePublication) Publish(key string, item interface{}) error {
+	p.publishCount++
+	p.published = item.(types.MetricsMap)
+	return nil
+}
+
+func (p *fakePublication) Unpublish(string) error          { return nil }
+func (p *fakePublication) SignalRestarted() error          { return nil }
+func (p *fakePublication) ClearRestarted() error           { return nil }
+func (p *fakePublication) Get(string) (interface{}, error) { return nil, nil }
+func (p *fakePublication) GetAll() map[string]interface{}  { return nil }
+func (p *fakePublication) Iterate(base.StrMapFunc)         {}
+func (p *fakePublication) Close() error                    { return nil }
+
+// blobURL returns a URL of the given length shaped like the registry blob URLs
+// downloader records one of per image layer.
+func blobURL(i, length int) string {
+	u := fmt.Sprintf("https://registry.example.com/v2/org/repo/blobs/sha256:%064x", i)
+	for len(u) < length {
+		u += "x"
+	}
+	return u[:length-8] + fmt.Sprintf("%08d", i)
+}
+
+func TestAgentMetricsPublishThatFits(t *testing.T) {
+	g := NewGomegaWithT(t)
+	log := testLogObject()
+	am := controllerconn.NewAgentMetrics()
+
+	for i := 0; i < types.MaxURLCounters; i++ {
+		am.RecordSuccess(log, "eth0", blobURL(i, 64), 10, 10, 1, false)
+	}
+
+	pub := &fakePublication{maxsize: pubsubMaxsize}
+	g.Expect(am.Publish(log, pub, "global")).To(Succeed())
+	g.Expect(pub.publishCount).To(Equal(1))
+	g.Expect(len(pub.published["eth0"].URLCounters)).To(Equal(types.MaxURLCounters))
+	g.Expect(pub.published["eth0"].URLCounterRedactedCount).To(Equal(uint64(0)))
+}
+
+func TestAgentMetricsPublishEvictsUntilItFits(t *testing.T) {
+	g := NewGomegaWithT(t)
+	log := testLogObject()
+	am := controllerconn.NewAgentMetrics()
+
+	// Peak occupancy, with URLs long enough that the entry cap on its own
+	// leaves the map over the size limit.
+	highWatermark := types.MaxURLCounters + urlCountersWiggle
+	for i := 0; i < highWatermark; i++ {
+		am.RecordSuccess(log, "eth0", blobURL(i, 400), 10, 10, 1, false)
+	}
+	newest := blobURL(highWatermark-1, 400)
+
+	toMap := types.MetricsMap{}
+	am.AddInto(log, toMap)
+	pub := &fakePublication{maxsize: pubsubMaxsize}
+	g.Expect(pub.CheckMaxSize("global", toMap)).NotTo(Succeed())
+
+	g.Expect(am.Publish(log, pub, "global")).To(Succeed())
+	g.Expect(pub.publishCount).To(Equal(1))
+
+	cm := pub.published["eth0"]
+	g.Expect(len(cm.URLCounters)).To(BeNumerically("<", highWatermark))
+	g.Expect(cm.URLCounterRedactedCount).To(BeNumerically(">", 0))
+	// What is given up is the least recently used, so the newest survives.
+	g.Expect(cm.URLCounters).To(HaveKey(newest))
+	g.Expect(pub.encodedSize("global", pub.published)).
+		To(BeNumerically("<", pubsubMaxsize))
+}
+
+func TestAgentMetricsPublishGivesUpWhenNothingLeftToDrop(t *testing.T) {
+	g := NewGomegaWithT(t)
+	log := testLogObject()
+	am := controllerconn.NewAgentMetrics()
+
+	am.RecordSuccess(log, "eth0", blobURL(0, 64), 10, 10, 1, false)
+
+	// Small enough that not even an empty URLCounters fits: publishing anyway
+	// would be fatal, so Publish must report instead.
+	pub := &fakePublication{maxsize: 10}
+	g.Expect(am.Publish(log, pub, "global")).NotTo(Succeed())
+	g.Expect(pub.publishCount).To(Equal(0))
 }


### PR DESCRIPTION
# Description

Backport of #6434 to `16.0-stable`, of the single commit
b5da0e04fb75f9ada6d32254a9d9d74a1560047c, as requested there: a customer on
this branch is hitting the pubsub fatal that large URL metrics cause.

`makeRoomForNewURL` caps how many `URLCounters` entries are kept, but what
pubsub limits is the encoded size of the published map, which the length of the
URL keys dominates. A run of long URLs -- a registry blob URL, or a datastore
URL carrying a query string -- puts the map over the limit at an entry count the
cap still allows, and pubsub answers an oversized value with a fatal rather than
an error, taking down an agent that was only reporting on itself. `Publish` now
asks whether the value fits, gives up the least recently used entries until what
is left does, and reports rather than publishes if even an empty set does not.

The commit sits on top of the rest of #6434, which is not being backported, so
it was first rebased onto master and then cherry-picked here. Dropped in the
rebase: the `net/http` import and the two `RecordAnswer` hunks git offered
alongside, which belong to an earlier commit of #6434. Nothing the fix does was
changed, and the pick onto this branch was clean -- both touched files are
identical between master and `16.0-stable`.

## PR dependencies

Builds on the `URLCounters` entry cap from #6410, already merged here.

#6434 has not merged, so the commit carries no `(cherry picked from commit
...)` trailer -- there is no master SHA to reference yet, and the fork-branch
SHA is not the one that will land. This PR stays in draft until then; the commit
will be re-created with `git cherry-pick -x <landed sha>` and force-pushed once
#6434 merges.

## How to test and validate this PR

Covered by automated unit tests, `make -C pkg/pillar test`: three new cases in
`controllerconn` -- a map that fits publishes untouched, one that does not is
trimmed least recently used first until it does, and one that cannot fit at all
is reported rather than published. `fakePublication` applies the limit the way
the socket driver does, base64-encoding the value before measuring it, so the
tests exercise the real framing rather than the raw JSON length.

Validated against un-fixed code on this branch: removing the `CheckMaxSize`
loop from `Publish` makes `TestAgentMetricsPublishEvictsUntilItFits` and
`TestAgentMetricsPublishGivesUpWhenNothingLeftToDrop` fail on their assertions,
and both pass again once restored.

Per-branch verification: `gofmt -l controllerconn/`, `go build ./...`,
`go vet ./controllerconn/ ./types/` and `go test ./controllerconn/ ./types/` all
exit 0.

## Changelog notes

An agent reporting many distinct URLs -- most often the downloader, pulling
image blobs -- no longer dies when its metrics grow past the size a pubsub
message can carry. The oldest per-URL entries are given up instead, and counted
as redacted.

## PR Backports

- 17.0-stable: Yes -- see #6476.
- 16.0-stable: This PR.
- 14.5-stable: No, the `URLCounters` cap this builds on is not present there.
- 13.4-stable: No, the `URLCounters` cap this builds on is not present there,
  and the code still lives in the pre-rename `pkg/pillar/zedcloud` package.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation -- none needed; no user-visible
  interface changes.
- [x] I've tested my PR on amd64 device -- unit tests only, as above.
- [ ] I've tested my PR on arm64 device -- not tested; the change is
  architecture independent.
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs:

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
