### PR TITLE
github/workflows: keep credentials for tag fetch

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -85,12 +85,13 @@ jobs:
             platform: "nvidia-jp7"
             hv: "k"
     steps:
+      # The tag fetch below runs against github.com, so the GITHUB_TOKEN must
+      # stay in .git/config; anonymous git is subject to GitHub's rate limits.
       - name: checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2 # zizmor: ignore[artipacked]
         with:
           ref: ${{ inputs.tag_ref }}
           fetch-depth: 0
-          persist-credentials: false
       - name: Force fetch annotated tags (workaround)
         # Workaround for https://github.com/actions/checkout/issues/290
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,10 +38,11 @@ jobs:
           df -h
           echo Memory
           free -m
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      # The tag fetch below runs against github.com, so the GITHUB_TOKEN must
+      # stay in .git/config; anonymous git is subject to GitHub's rate limits.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
-          persist-credentials: false
       - name: Force fetch annotated tags (workaround)
         run: |
           git fetch --force --tags
@@ -91,10 +92,11 @@ jobs:
           df -h
           echo Memory
           free -m
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      # The tag fetch below runs against github.com, so the GITHUB_TOKEN must
+      # stay in .git/config; anonymous git is subject to GitHub's rate limits.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
-          persist-credentials: false
       - name: Force fetch annotated tags (workaround)
         run: |
           git fetch --force --tags
@@ -205,11 +207,12 @@ jobs:
             os: zededa-ubuntu-2204
 
     steps:
+      # run-make fetches tags from github.com, so the GITHUB_TOKEN must stay
+      # in .git/config; anonymous git is subject to GitHub's rate limits.
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
-          persist-credentials: false
       - name: Install qemu for cross-arch build
         if: matrix.arch == 'riscv64'
         run: |
@@ -254,10 +257,11 @@ jobs:
     needs: eve
     runs-on: zededa-ubuntu-2204
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      # run-make fetches tags from github.com, so the GITHUB_TOKEN must stay
+      # in .git/config; anonymous git is subject to GitHub's rate limits.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
-          persist-credentials: false
       - uses: ./.github/actions/run-make
         with:
           command: "V=1 LINUXKIT_PKG_TARGET=manifest pkgs"


### PR DESCRIPTION
# Description

The publish and release-asset jobs fetch annotated tags from github.com after
their checkout — in `pkgs-amd64`/`pkgs-arm64`, in `assets.yml`, and inside the
`run-make` action used by `eve` and `manifest`. `actions/checkout` authenticates
its own clone and then strips the credential from `.git/config` unless
`persist-credentials` is set, so those later fetches run anonymously and are
subject to GitHub's unauthenticated rate limits. Introduced by Claude in #5966.

Keep the credential on those five checkouts, each with an inline
`# zizmor: ignore[artipacked]` and a comment naming the dependency, as
`build-alpine-base.yml` already does. The `coverage` job keeps
`persist-credentials: false`; it only runs `make test`.

## How to test and validate this PR

Neither workflow runs on a pull request, so validation is post-merge: the tag
fetches should keep succeeding under load. Locally, yamllint is clean and
`zizmor --offline` reports the same severity counts as before, with the five new
`artipacked` findings suppressed by the inline ignores.

## Changelog notes

None — CI-only change.

## PR Backports

- 17.0-stable: No — `publish.yml` there never set `persist-credentials`.
- 16.0-stable: No — same.
- 14.5-stable: No — same.
- 13.4-stable: No — same.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — n/a, no docs affected
- [ ] I've tested my PR on amd64 device — n/a, no device-visible change
- [ ] I've tested my PR on arm64 device — n/a, no device-visible change
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
