### PR TITLE
volumemgr: don't lose work when the worker pool is saturated

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -38,6 +38,7 @@ This document mirrors the key names, types, defaults, and ranges defined there.
 | network.fallback.any.eth | "enabled" or "disabled" | disabled | - | - | if no connectivity try any Ethernet, WiFi, or LTE with DHCP client (enabled forcefully during onboarding if no network config) |
 | network.download.max.cost | 0-255 | 0 | 0 | 255 | [max port cost for download](DEVICE-CONNECTIVITY.md) to avoid e.g., LTE ports |
 | blob.download.max.retries | 1-10 | 5 | 1 | 10 | max download retries when image verification fails. |
+| volumemgr.worker.pool.size | integer | 20 | 1 | 200 | max number of concurrent volumemgr background jobs (loading images into the CAS, preparing/creating/destroying volumes). Work exceeding the limit is deferred and retried, so this bounds throughput; raise it on nodes deploying many app instances at once (doesn't need a reboot to take effect) |
 | debug.disable.dhcp.all-ones.netmask | boolean | false | - | - | deprecated; retained only to avoid reporting errors for older deployments where this option is still configured |
 | debug.enable.usb | boolean | true | - | - | allow USB e.g. keyboards on device (controller by default overrides to false) |
 | debug.enable.vga | boolean | true | - | - | allow VGA console on device (controller by default overrides to false) |

--- a/evetest/tests/apps/load_test.go
+++ b/evetest/tests/apps/load_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Application life-cycle operations tested against the EVE API:
+// controller-requested restart of an application instance.
+
+package apps_test
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	// revive:disable:dot-imports
+	. "github.com/onsi/gomega"
+	uuid "github.com/satori/go.uuid"
+
+	eveconfig "github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve-api/go/evecommon"
+	eveinfo "github.com/lf-edge/eve-api/go/info"
+	"github.com/lf-edge/eve/evetest"
+	"github.com/lf-edge/eve/evetest/matchers"
+	"github.com/lf-edge/eve/evetest/netmodels"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+)
+
+func TestLotsOfApps(test *testing.T) {
+	const countApps = 25
+
+	evetestT := evetest.Init(test)
+	t := NewGomegaWithT(evetestT)
+	defer evetest.Close()
+
+	evetest.DefineTestParameters(
+		evetest.HypervisorParameter(),
+	)
+
+	hypervisor := evetest.GetHypervisorParameterValue()
+
+	devName := "edge-dev"
+	requiredDevice := evetest.RequireEdgeDevice{
+		Name:              devName,
+		WithHypervisor:    hypervisor,
+		DeviceReusePolicy: evetest.ResetDeviceConfig,
+		MinRAMInMiB:       24576,
+	}
+	requiredNetModel := evetest.RequireNetworkModel{
+		NetworkModel: netmodels.SingleEthWithDHCP,
+	}
+	evetest.Setup(requiredDevice, requiredNetModel)
+	device := evetest.GetEdgeDevice(devName)
+	evetest.Checkpoint("setup-done")
+
+	// Build the device configuration: one mgmt+apps port, one Local NI and
+	// one container app connected to it.
+	devConfig := evetest.NewEdgeDeviceConfig(devName)
+	dhcpNet := devConfig.AddNetwork(
+		evetest.DHCPNetworkConfig{
+			NetworkType: evecommon.NetworkType_V4Only,
+		})
+	devConfig.AddNetworkAdapter(
+		evetest.NetworkAdapterConfig{
+			LogicalLabel:  "ethernet0",
+			PhysicalLabel: "eth0",
+			InterfaceName: "eth0",
+			NetworkUUID:   dhcpNet,
+			Usage:         evecommon.PhyIoMemberUsage_PhyIoUsageMgmtAndApps,
+		})
+	niUUID := devConfig.AddNetworkInstance(evetest.LocalNetworkInstanceConfig{
+		DisplayName: "local-ni",
+		Port:        "ethernet0",
+		Subnet:      evetest.IPSubnet("10.11.12.0/24"),
+		DHCPRange: types.IPRange{
+			Start: evetest.IPAddress("10.11.12.2"),
+			End:   evetest.IPAddress("10.11.12.254"),
+		},
+		Gateway: evetest.IPAddress("10.11.12.1"),
+		MTU:     1500,
+	})
+
+	appUpdatess := make([]<-chan *eveinfo.ZInfoApp, 0)
+	appUUIDs := make([]uuid.UUID, 0)
+	for i := range countApps {
+		appUUID := devConfig.AddApplication(evetest.ApplicationInstanceConfig{
+			DisplayName: fmt.Sprintf("restarted-app-%d", i),
+			Activate:    true,
+			Image: evetest.DockerContainer{
+				ImageName: "lfedge/evetest-ubuntu-ctr",
+				Tag:       "1.0",
+			},
+			VirtualizationMode: eveconfig.VmMode_HVM, // PV does not work in xen, shim VM fails to start
+			CPUs:               1,
+			MemoryBytes:        500 * evetest.MiB,
+			NetworkAdapters: []evetest.AppNetworkAdapter{
+				evetest.VirtualNetworkAdapter{
+					LogicalLabel:        fmt.Sprintf("vif%d", i),
+					NetworkInstanceUUID: niUUID,
+					PortFwdRules: []evetest.PortFwdRule{
+						{
+							Protocol:     evetest.NetworkProtocolTCP,
+							EdgeNodePort: 2222 + uint16(i),
+							AppPort:      22,
+						},
+					},
+					ACLAllowRules: []evetest.ACLAllowRule{
+						{
+							Protocol:     evetest.NetworkProtocolAny,
+							RemoteSubnet: evetest.IPSubnet("0.0.0.0/0"),
+						},
+					},
+				},
+			},
+		})
+
+		appUpdates, stopAppWatch := device.WatchAppInfo(appUUID)
+		appUpdatess = append(appUpdatess, appUpdates)
+		defer stopAppWatch()
+		appUUIDs = append(appUUIDs, appUUID)
+
+	}
+	device.ApplyConfig(devConfig, true, true)
+
+	// give it a bit more time for slow laptops
+	timeoutExcludingDownload := 15 * time.Minute
+	for _, appUUID := range appUUIDs {
+		device.WaitUntilAppIsRunning(appUUID, timeoutExcludingDownload)
+	}
+
+	evetest.Checkpoint("app-deployed")
+
+	// An app reaching RUNNING does not mean it has fully booted -- wait
+	// until its SSH daemon is reachable through the 2222->22 port-forwarding
+	// rule before considering the deployment complete.
+	appAuth := evetest.UsernamePasswordAuth{
+		Username: "root",
+		Password: "testpassword",
+	}
+	timeout := 3 * time.Minute
+	sshTimeout := 20 * time.Second
+	polling := 3 * time.Second
+	log := evetest.Logger()
+	verifyAppOverSSH := func() {
+		for _, appUUID := range appUUIDs {
+			t.Eventually(func(t Gomega) {
+				log.Infof("Waiting for app SSH daemon to start and become reachable...")
+				output, _, err := device.RunShellScriptInsideApp(appUUID, appAuth,
+					"hostname", sshTimeout, 0)
+				t.Expect(err).ToNot(HaveOccurred())
+				t.Expect(output).To(ContainSubstring(appUUID.String()))
+			}, timeout, polling).Should(Succeed())
+		}
+	}
+	verifyAppOverSSH()
+
+	for _, appUpdates := range appUpdatess {
+		t.Eventually(appUpdates, timeout).Should(Receive(matchers.SatisfyPredicate(
+			"App is RUNNING and reports its boot time",
+			func(info *eveinfo.ZInfoApp) bool {
+				return info.State == eveinfo.ZSwState_RUNNING &&
+					info.GetBootTime() != nil
+			}).StopIf(appHasError)))
+	}
+
+	t.Eventually(func(t Gomega) {
+		log.Infof("Waiting for app SSH daemon to start and become reachable...")
+		stdout, stderr, err := device.RunShellScript("pgrep -c qemu-system",
+			time.Minute, 0)
+		t.Expect(err).ToNot(HaveOccurred())
+		log.Printf("stdout: \n%s\n", stdout)
+		log.Printf("stderr: \n%s\n", stderr)
+		result, err := strconv.Atoi(strings.TrimSpace(stdout))
+		t.Expect(err).ToNot(HaveOccurred())
+		if err == nil && result >= countApps {
+			return
+		}
+		t.Expect(result).Should(BeNumerically("==", countApps))
+	}, 10*time.Minute, 20*time.Second).Should(Succeed())
+}

--- a/evetest/tests/apps/testsuite_test.go
+++ b/evetest/tests/apps/testsuite_test.go
@@ -94,6 +94,7 @@ import (
 //   - TestVMAppPurgeAfterPowerCycle -- a purge issued while the device is
 //     powered off, which is where a reboot lands in the middle of the purge
 //     deterministically rather than by chance. Meaningful on every hypervisor.
+//   - TestLotsOfApps -- starts lots of apps and checks for success
 //
 // The two purge tests come last because they are the expensive ones: they
 // assert on which generation of a workload exists, so each needs a device
@@ -142,6 +143,9 @@ func TestAppsSuite(test *testing.T) {
 		},
 		evetest.TestCase{
 			Test: TestVMAppPurgeAfterPowerCycle,
+		},
+		evetest.TestCase{
+			Test: TestLotsOfApps,
 		},
 	)
 }

--- a/pkg/pillar/cmd/baseosmgr/handledownload.go
+++ b/pkg/pillar/cmd/baseosmgr/handledownload.go
@@ -138,7 +138,14 @@ func installDownloadedObject(ctx *baseOsMgrContext, contentID uuid.UUID, finalOb
 	// Move to final installation point
 	// do this as a background task
 	// XXX called twice!
-	AddWorkInstall(ctx, contentID.String(), refID, finalObjDir)
+	if err := AddWorkInstall(ctx, contentID.String(), refID, finalObjDir); err != nil {
+		// The error lands on the BaseOsStatus (visible to the controller) and
+		// this function is re-run on the next content tree or config event,
+		// which retries the submission.
+		return changed, proceed, fmt.Errorf(
+			"installDownloadedObject(%s): install not scheduled, will retry: %w",
+			contentID, err)
+	}
 	log.Functionf("installDownloadedObject(%s) worker started", contentID)
 	return changed, proceed, nil
 }

--- a/pkg/pillar/cmd/baseosmgr/worker.go
+++ b/pkg/pillar/cmd/baseosmgr/worker.go
@@ -4,6 +4,7 @@
 package baseosmgr
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -21,23 +22,37 @@ type installWorkDescription struct {
 	target string
 }
 
-// AddWorkInstall create a Work job to install the provided image to the target path
-func AddWorkInstall(ctx *baseOsMgrContext, key, ref, target string) {
+// AddWorkInstall create a Work job to install the provided image to the target path.
+// Returns an error if the job could not be handed to the worker pool, in
+// which case no worker owns the install and the caller must arrange for a
+// retry. A job already in progress for this key counts as success, so the
+// caller stays idempotent.
+func AddWorkInstall(ctx *baseOsMgrContext, key, ref, target string) error {
 	d := installWorkDescription{
 		key:    key,
 		ref:    ref,
 		target: target,
 	}
-	// Don't fail on errors to make idempotent (Submit returns an error if
-	// the work was already submitted)
 	done, err := ctx.worker.TrySubmit(worker.Work{Key: key, Kind: workInstall,
 		Description: d})
 	if err != nil {
-		log.Errorf("TrySubmit %s failed: %s", key, err)
-	} else if !done {
-		log.Fatalf("Failed to submit work due to queue length for %s", key)
+		var inProgress *worker.JobInProgressError
+		if errors.As(err, &inProgress) {
+			log.Functionf("AddWorkInstall(%s): job already in progress", key)
+			return nil
+		}
+		log.Errorf("AddWorkInstall(%s): TrySubmit failed: %s", key, err)
+		return err
+	}
+	if !done {
+		// A pool never returns (false, nil); only a bare worker with a full
+		// queue does, and baseosmgr uses a pool.
+		err := fmt.Errorf("worker did not accept install job %s", key)
+		log.Error(err)
+		return err
 	}
 	log.Functionf("AddWorkInstall(%s) done", key)
+	return nil
 }
 
 // installWorker implementation of work.WorkFunction that installs an image to a particular location

--- a/pkg/pillar/cmd/baseosmgr/worker_test.go
+++ b/pkg/pillar/cmd/baseosmgr/worker_test.go
@@ -129,6 +129,24 @@ func TestInstallDownloadedObject_FirstCallSubmitsWork(t *testing.T) {
 	}
 }
 
+func TestInstallDownloadedObject_RefusedSubmitReturnsError(t *testing.T) {
+	tc := newTestCtx(t)
+	tc.wk.submitErr = errBoom
+	cid, _ := uuid.NewV4()
+	cts := &types.ContentTreeStatus{
+		State:       types.LOADED,
+		ContentID:   cid,
+		RelativeURL: "ref-x",
+	}
+	_, _, err := installDownloadedObject(tc.ctx, cid, "IMGB", cts)
+	if err == nil {
+		t.Fatal("expected the refused install submission to surface as an error")
+	}
+	if !strings.Contains(err.Error(), "will retry") {
+		t.Fatalf("got %q", err.Error())
+	}
+}
+
 func TestInstallDownloadedObject_ResultPresentIndicatesProceed(t *testing.T) {
 	tc := newTestCtx(t)
 	cid, _ := uuid.NewV4()
@@ -218,12 +236,24 @@ func TestAddWorkInstall_SubmitsThroughWorker(t *testing.T) {
 	}
 }
 
-func TestAddWorkInstall_TrySubmitErrorIsLoggedNotPanicking(t *testing.T) {
+func TestAddWorkInstall_TrySubmitErrorIsReturned(t *testing.T) {
 	tc := newTestCtx(t)
 	tc.wk.submitErr = errBoom
-	AddWorkInstall(tc.ctx, "k1", "ref-x", "IMGB")
+	err := AddWorkInstall(tc.ctx, "k1", "ref-x", "IMGB")
+	if err == nil {
+		t.Fatalf("expected the refused submission to be reported")
+	}
 	// No panic; submission still recorded so we can check we tried.
 	if got := len(tc.wk.submitted); got != 1 {
 		t.Fatalf("expected one attempt, got %d", got)
+	}
+}
+
+func TestAddWorkInstall_JobInProgressCountsAsSuccess(t *testing.T) {
+	tc := newTestCtx(t)
+	tc.wk.submittedDone = false
+	tc.wk.submitErr = &worker.JobInProgressError{}
+	if err := AddWorkInstall(tc.ctx, "k1", "ref-x", "IMGB"); err != nil {
+		t.Fatalf("job already in progress must count as success, got %v", err)
 	}
 }

--- a/pkg/pillar/cmd/volumemgr/acceptclustercontenttree.go
+++ b/pkg/pillar/cmd/volumemgr/acceptclustercontenttree.go
@@ -86,22 +86,26 @@ func contentTreeSatisfiedByPVCs(ctx *volumemgrContext, status *types.ContentTree
 }
 
 // reevaluatePendingContentTrees re-drives every ContentTreeStatus still below
-// VERIFIED, so a check maxFreshPVCProbesPerCheck deferred gets finished on a
-// later pass -- the same role reevaluatePendingVolumes plays for volumes.
-// Called from the periodic gc handler.
+// LOADED -- the same role reevaluatePendingVolumes plays for volumes. Two
+// things need finishing on a later pass: a check maxFreshPVCProbesPerCheck
+// deferred (EVE-k only), and a CAS ingest the worker pool refused because it
+// was at maxWorkers, which can happen on any hypervisor.
+// Called from the periodic gc handler and from every worker result handler,
+// since a completed job is what frees the slot a refused ingest needs.
 func reevaluatePendingContentTrees(ctx *volumemgrContext) {
-	if !ctx.hvTypeKube {
-		// The accept-from-PVCs path this re-drives is EVE-k only.
-		return
-	}
 	for _, s := range ctx.pubContentTreeStatus.GetAll() {
 		status := s.(types.ContentTreeStatus)
-		if status.State >= types.VERIFIED {
+		if status.State >= types.LOADED {
+			continue
+		}
+		if lookupContentTreeConfig(ctx, status.Key()) == nil {
+			// Being torn down; leave it to the delete handler.
 			continue
 		}
 		changed, _ := doUpdateContentTree(ctx, &status)
 		if changed {
 			publishContentTreeStatus(ctx, &status)
+			updateVolumeStatusFromContentID(ctx, status.ContentID)
 		}
 	}
 }

--- a/pkg/pillar/cmd/volumemgr/acceptclustercontenttree.go
+++ b/pkg/pillar/cmd/volumemgr/acceptclustercontenttree.go
@@ -85,17 +85,24 @@ func contentTreeSatisfiedByPVCs(ctx *volumemgrContext, status *types.ContentTree
 	return true
 }
 
-// reevaluatePendingContentTrees re-drives every ContentTreeStatus still below
-// LOADED -- the same role reevaluatePendingVolumes plays for volumes. Two
-// things need finishing on a later pass: a check maxFreshPVCProbesPerCheck
-// deferred (EVE-k only), and a CAS ingest the worker pool refused because it
-// was at maxWorkers, which can happen on any hypervisor.
-// Called from the periodic gc handler and from every worker result handler,
-// since a completed job is what frees the slot a refused ingest needs.
-func reevaluatePendingContentTrees(ctx *volumemgrContext) {
+// reevaluatePendingContentTrees re-drives every ContentTreeStatus with
+// minState <= State < LOADED -- the same role reevaluatePendingVolumes plays
+// for volumes.
+//
+// The periodic gc handler passes INITIAL, covering also the trees below
+// VERIFIED whose accept-from-PVCs check (EVE-k) deferred after spending its
+// live-probe budget: those probes are blocking Kubernetes calls sized for the
+// gc cadence (see maxFreshPVCProbesPerCheck). The worker result handlers pass
+// VERIFIED: a completed job is what frees the slot a refused submission
+// needs, and everything the pool can park -- an ingest deferred back to
+// VERIFIED, a LOADING tree that lost its job -- sits at VERIFIED or above.
+// Sweeping the download states from the hot result path too would spend the
+// probe budget far more often than it was sized for; those states are driven
+// by downloader/verifier/resolver events, which do not involve the pool.
+func reevaluatePendingContentTrees(ctx *volumemgrContext, minState types.SwState) {
 	for _, s := range ctx.pubContentTreeStatus.GetAll() {
 		status := s.(types.ContentTreeStatus)
-		if status.State >= types.LOADED {
+		if status.State < minState || status.State >= types.LOADED {
 			continue
 		}
 		if lookupContentTreeConfig(ctx, status.Key()) == nil {

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -323,9 +323,10 @@ func maybeDeleteVolume(ctx *volumemgrContext, status *types.VolumeStatus) {
 			// destroy that ran and failed: retryFailedVolumeDelete re-drives
 			// it off the gc tick.
 			status.SetErrorDescription(types.ErrorDescription{
-				Error:               fmt.Sprintf("volume destroy deferred: %v", err),
-				ErrorRetryCondition: "Will retry when a worker becomes available",
-				ErrorSeverity:       types.ErrorSeverityWarning,
+				Error: fmt.Sprintf("volume destroy deferred: %v", err),
+				ErrorRetryCondition: "Will retry when a worker becomes available; " +
+					"the volumemgr.worker.pool.size config item bounds the pool",
+				ErrorSeverity: types.ErrorSeverityWarning,
 			})
 			publishVolumeStatus(ctx, status)
 		}

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -318,7 +318,17 @@ func maybeDeleteVolume(ctx *volumemgrContext, status *types.VolumeStatus) {
 		status.SubState = types.VolumeSubStateDeleting
 		publishVolumeStatus(ctx, status)
 		// Asynch destruction; make sure we have a request for the work
-		AddWorkDestroy(ctx, status)
+		if err := AddWorkDestroy(ctx, status); err != nil {
+			// Park it in the Deleting sub-state with an error, exactly like a
+			// destroy that ran and failed: retryFailedVolumeDelete re-drives
+			// it off the gc tick.
+			status.SetErrorDescription(types.ErrorDescription{
+				Error:               fmt.Sprintf("volume destroy deferred: %v", err),
+				ErrorRetryCondition: "Will retry when a worker becomes available",
+				ErrorSeverity:       types.ErrorSeverityWarning,
+			})
+			publishVolumeStatus(ctx, status)
+		}
 	} else if status.SubState == types.VolumeSubStateDeleting {
 		vr := popVolumeWorkResult(ctx, status.Key())
 		if vr != nil {
@@ -362,12 +372,20 @@ func maybeDeleteVolume(ctx *volumemgrContext, status *types.VolumeStatus) {
 
 // reevaluatePendingVolumes re-drives every VolumeStatus still below
 // CREATING_VOLUME through doUpdateVol. It is called whenever something may have
-// unblocked a deferred volume -- disk space freeing up, or EVE-k cluster storage
-// (longhorn/CDI) becoming ready.
+// unblocked a deferred volume -- disk space freeing up, EVE-k cluster storage
+// (longhorn/CDI) becoming ready, or a worker-pool slot freeing up after a
+// refused submission.
 func reevaluatePendingVolumes(ctx *volumemgrContext) {
 	for _, s := range ctx.pubVolumeStatus.GetAll() {
 		status := s.(types.VolumeStatus)
-		if status.State >= types.CREATING_VOLUME {
+		// A volume in CREATING_VOLUME still in the Preparing sub-state may be
+		// waiting for a refused create submission to be retried; the Preparing
+		// branch of doUpdateVol is the only place that re-submits it.
+		// Everything else at CREATING_VOLUME or beyond is driven by its work
+		// result, so leave it alone.
+		if status.State > types.CREATING_VOLUME ||
+			(status.State == types.CREATING_VOLUME &&
+				status.SubState != types.VolumeSubStatePreparing) {
 			continue
 		}
 		if vc := ctx.LookupVolumeConfig(status.Key()); vc == nil {

--- a/pkg/pillar/cmd/volumemgr/handlework.go
+++ b/pkg/pillar/cmd/volumemgr/handlework.go
@@ -397,7 +397,7 @@ func processVolumeWorkResult(ctxPtr interface{}, res worker.WorkResult) error {
 	// This job's completion freed a slot in the shared worker pool: give any
 	// volume or content tree whose submission was refused another chance.
 	reevaluatePendingVolumes(ctx)
-	reevaluatePendingContentTrees(ctx)
+	reevaluatePendingContentTrees(ctx, types.VERIFIED)
 	return nil
 }
 
@@ -408,7 +408,7 @@ func processVolumePrepareResult(ctxPtr interface{}, res worker.WorkResult) error
 	updateVolumeStatus(ctx, d.status.VolumeID)
 	// See processVolumeWorkResult: this frees a slot in the shared pool.
 	reevaluatePendingVolumes(ctx)
-	reevaluatePendingContentTrees(ctx)
+	reevaluatePendingContentTrees(ctx, types.VERIFIED)
 	return nil
 }
 
@@ -435,7 +435,7 @@ func processCasIngestWorkResult(ctxPtr interface{}, res worker.WorkResult) error
 	updateStatusByBlob(ctx, d.status.Blobs...)
 	// See processVolumeWorkResult: this frees a slot in the shared pool.
 	reevaluatePendingVolumes(ctx)
-	reevaluatePendingContentTrees(ctx)
+	reevaluatePendingContentTrees(ctx, types.VERIFIED)
 	return nil
 }
 

--- a/pkg/pillar/cmd/volumemgr/handlework.go
+++ b/pkg/pillar/cmd/volumemgr/handlework.go
@@ -6,6 +6,8 @@ package volumemgr
 // Interface to worker to run the create and destroy in separate goroutines
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/lf-edge/eve/pkg/pillar/types"
@@ -59,57 +61,104 @@ type casIngestWorkResult struct {
 	loaded            []string
 }
 
-// AddWorkCreate adds a Work job to create a volume
-func AddWorkCreate(ctx *volumemgrContext, status *types.VolumeStatus) {
+// trySubmitWork hands one work item to the worker pool, distinguishing the
+// benign idempotent case (a job with this key is already in progress) from a
+// real refusal. Returns nil if the job is running or was accepted, and an
+// error (a worker.PoolFullError when the pool is at maxWorkers) if nothing
+// owns the work: the caller must then either retry later or not commit any
+// state that assumes the job will run.
+func trySubmitWork(ctx *volumemgrContext, w worker.Work) error {
+	done, err := ctx.worker.TrySubmit(w)
+	if err != nil {
+		var inProgress *worker.JobInProgressError
+		if errors.As(err, &inProgress) {
+			log.Functionf("trySubmitWork(%s): job already in progress", w.Key)
+			return nil
+		}
+		return err
+	}
+	if !done {
+		// A pool never returns (false, nil); only a bare worker with a full
+		// queue does, and volumemgr uses a pool.
+		return fmt.Errorf("worker did not accept job %s", w.Key)
+	}
+	return nil
+}
+
+// AddWorkCreate adds a Work job to create a volume.
+// Returns an error if the job could not be handed to the worker pool, in
+// which case no worker owns it and the caller must arrange for a retry. A job
+// already in progress for this key counts as success, so callers stay
+// idempotent.
+func AddWorkCreate(ctx *volumemgrContext, status *types.VolumeStatus) error {
 	d := volumeWorkDescription{
 		create: true,
 		status: *status,
 	}
 	w := worker.Work{Kind: workCreate, Key: status.Key(), Description: d}
-	// Don't fail on errors to make idempotent (Submit returns an error if
-	// the work was already submitted)
-	done, err := ctx.worker.TrySubmit(w)
-	if err != nil {
-		log.Errorf("TrySubmit %s failed: %s", status.Key(), err)
-	} else if !done {
-		log.Fatalf("Failed to submit work due to queue length for %s",
-			status.Key())
+	if err := trySubmitWork(ctx, w); err != nil {
+		log.Warnf("AddWorkCreate(%s): %v", status.Key(), err)
+		return err
 	}
+	return nil
 }
 
-// AddWorkLoad adds a Work job to load an image and blobs into CAS
-func AddWorkLoad(ctx *volumemgrContext, status *types.ContentTreeStatus) {
+// AddWorkLoad adds a Work job to load an image and blobs into CAS.
+// Returns an error if the job could not be handed to the worker pool, in
+// which case no worker owns the content tree and the caller must undo
+// whatever state it committed in anticipation of the load. A job that is
+// already in progress for this key counts as success, so callers stay
+// idempotent.
+func AddWorkLoad(ctx *volumemgrContext, status *types.ContentTreeStatus) error {
 	d := casIngestWorkDescription{
 		status: *status,
 	}
 	w := worker.Work{Kind: workIngest, Key: status.Key(), Description: d}
-	// Don't fail on errors to make idempotent (Submit returns an error if
-	// the work was already submitted)
-	done, err := ctx.worker.TrySubmit(w)
-	if err != nil {
-		log.Errorf("TrySubmit %s failed: %s", status.Key(), err)
-	} else if !done {
-		log.Fatalf("Failed to submit work due to queue length for %s",
-			status.Key())
+	if err := trySubmitWork(ctx, w); err != nil {
+		log.Warnf("AddWorkLoad(%s): %v", status.Key(), err)
+		return err
 	}
+	if ctx.pendingIngest == nil {
+		ctx.pendingIngest = make(map[string]bool)
+	}
+	ctx.pendingIngest[status.Key()] = true
+	return nil
 }
 
-// AddWorkPrepare adds a Work job to create a volume
-func AddWorkPrepare(ctx *volumemgrContext, status *types.VolumeStatus) {
+// ingestInFlightFor reports whether some content tree with an accepted, not
+// yet completed CAS ingest job carries this blob. A blob sitting in LOADING
+// that no in-flight job covers has lost its worker; treating such a blob as
+// busy is what turns a refused submit into a permanent stall for every other
+// content tree sharing it.
+func ingestInFlightFor(ctx *volumemgrContext, sha string) bool {
+	for key := range ctx.pendingIngest {
+		ctStatus := ctx.LookupContentTreeStatus(key)
+		if ctStatus == nil {
+			continue
+		}
+		for _, blobSha := range ctStatus.Blobs {
+			if blobSha == sha {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// AddWorkPrepare adds a Work job to prepare creation of a volume.
+// Returns an error if the job could not be handed to the worker pool (see
+// AddWorkCreate); a job already in progress for this key counts as success.
+func AddWorkPrepare(ctx *volumemgrContext, status *types.VolumeStatus) error {
 	d := volumeWorkDescription{
 		prepare: true,
 		status:  *status,
 	}
 	w := worker.Work{Kind: workPrepare, Key: status.Key(), Description: d}
-	// Don't fail on errors to make idempotent (Submit returns an error if
-	// the work was already submitted)
-	done, err := ctx.worker.TrySubmit(w)
-	if err != nil {
-		log.Errorf("TrySubmit %s failed: %s", status.Key(), err)
-	} else if !done {
-		log.Fatalf("Failed to submit work due to queue length for %s",
-			status.Key())
+	if err := trySubmitWork(ctx, w); err != nil {
+		log.Warnf("AddWorkPrepare(%s): %v", status.Key(), err)
+		return err
 	}
+	return nil
 }
 
 // DeleteWorkCreate is called by user when work is done
@@ -127,22 +176,20 @@ func DeleteWorkLoad(ctx *volumemgrContext, key string) {
 	ctx.worker.Cancel(key)
 }
 
-// AddWorkDestroy adds a Work job to destroy a volume
-func AddWorkDestroy(ctx *volumemgrContext, status *types.VolumeStatus) {
+// AddWorkDestroy adds a Work job to destroy a volume.
+// Returns an error if the job could not be handed to the worker pool (see
+// AddWorkCreate); a job already in progress for this key counts as success.
+func AddWorkDestroy(ctx *volumemgrContext, status *types.VolumeStatus) error {
 	d := volumeWorkDescription{
 		destroy: true,
 		status:  *status,
 	}
 	w := worker.Work{Kind: workCreate, Key: status.Key(), Description: d}
-	// Don't fail on errors to make idempotent (Submit returns an error if
-	// the work was already submitted)
-	done, err := ctx.worker.TrySubmit(w)
-	if err != nil {
-		log.Errorf("TrySubmit %s failed: %s", status.Key(), err)
-	} else if !done {
-		log.Fatalf("Failed to submit work due to queue length for %s",
-			status.Key())
+	if err := trySubmitWork(ctx, w); err != nil {
+		log.Warnf("AddWorkDestroy(%s): %v", status.Key(), err)
+		return err
 	}
+	return nil
 }
 
 // DeleteWorkDestroy cancels a job to destroy a volume
@@ -281,19 +328,28 @@ func processVolumeWorkResult(ctxPtr interface{}, res worker.WorkResult) error {
 			DeleteWorkCreate(ctx, &d.status)
 			d.status.FileLocation = d.FileLocation
 			d.status.SubState = types.VolumeSubStateDeleting
-			AddWorkDestroy(ctx, &d.status)
+			if err := AddWorkDestroy(ctx, &d.status); err != nil {
+				// There is no VolumeStatus left to retry from; the created
+				// file stays behind until the init-time GC. Losing this
+				// cleanup must not lose the result processing.
+				log.Errorf("processVolumeWorkResult: destroy of orphaned %s not scheduled: %v",
+					d.status.Key(), err)
+			}
 		}
 	} else {
 		status := ctx.LookupVolumeStatus(d.status.Key())
 		if status == nil {
 			log.Functionf("processVolumeWorkResult for %v, VolumeStatus not found", d.status.Key())
-			return nil
+		} else {
+			log.Functionf("processVolumeWorkResult for %v, VolumeStatus found", d.status.Key())
+			updateVolumeStatusRefCount(ctx, status)
+			maybeDeleteVolume(ctx, status)
 		}
-		log.Functionf("processVolumeWorkResult for %v, VolumeStatus found", d.status.Key())
-		updateVolumeStatusRefCount(ctx, status)
-		maybeDeleteVolume(ctx, status)
-		reevaluatePendingVolumes(ctx)
 	}
+	// This job's completion freed a slot in the shared worker pool: give any
+	// volume or content tree whose submission was refused another chance.
+	reevaluatePendingVolumes(ctx)
+	reevaluatePendingContentTrees(ctx)
 	return nil
 }
 
@@ -302,6 +358,9 @@ func processVolumePrepareResult(ctxPtr interface{}, res worker.WorkResult) error
 	ctx := ctxPtr.(*volumemgrContext)
 	d := res.Description.(volumeWorkDescription)
 	updateVolumeStatus(ctx, d.status.VolumeID)
+	// See processVolumeWorkResult: this frees a slot in the shared pool.
+	reevaluatePendingVolumes(ctx)
+	reevaluatePendingContentTrees(ctx)
 	return nil
 }
 
@@ -309,6 +368,7 @@ func processVolumePrepareResult(ctxPtr interface{}, res worker.WorkResult) error
 func processCasIngestWorkResult(ctxPtr interface{}, res worker.WorkResult) error {
 	ctx := ctxPtr.(*volumemgrContext)
 	d := res.Description.(casIngestWorkDescription)
+	delete(ctx.pendingIngest, d.status.Key())
 	// loaded has the hashes of the blobs we loaded; publicise their new states.
 	blobs := lookupBlobStatuses(ctx, d.loaded...)
 	for _, blob := range blobs {
@@ -316,16 +376,32 @@ func processCasIngestWorkResult(ctxPtr interface{}, res worker.WorkResult) error
 		publishBlobStatus(ctx, blob)
 	}
 	updateStatusByBlob(ctx, d.status.Blobs...)
+	// See processVolumeWorkResult: this frees a slot in the shared pool.
+	reevaluatePendingVolumes(ctx)
+	reevaluatePendingContentTrees(ctx)
 	return nil
 }
 
-// popasIngestWorkResult get the result exactly once
-func popCasIngestWorkResult(ctx *volumemgrContext, key string) *casIngestWorkResult {
-	res := ctx.worker.Pop(key)
+// popCasIngestWorkResult gets the result exactly once. A result whose job was
+// submitted for different content than the tree now under this key is
+// discarded: a content change makes handleContentTreeModify delete and
+// recreate the tree, but Key() is the bare ContentID, so the recreated tree
+// would otherwise consume the replaced tree's outcome -- typically a failed
+// ingest of content that no longer exists, parking the new tree with a stale
+// error. With the result discarded, the LOADING self-heal resubmits a fresh
+// load once no job is in flight.
+func popCasIngestWorkResult(ctx *volumemgrContext, status *types.ContentTreeStatus) *casIngestWorkResult {
+	res := ctx.worker.Pop(status.Key())
 	if res == nil {
 		return nil
 	}
 	d := res.Description.(casIngestWorkDescription)
+	if d.status.ContentSha256 != status.ContentSha256 ||
+		d.status.RelativeURL != status.RelativeURL {
+		log.Noticef("popCasIngestWorkResult(%s): discarding result of replaced content (sha %s url %s)",
+			status.Key(), d.status.ContentSha256, d.status.RelativeURL)
+		return nil
+	}
 	return &casIngestWorkResult{
 		WorkResult: *res,
 		loaded:     d.loaded,

--- a/pkg/pillar/cmd/volumemgr/handlework.go
+++ b/pkg/pillar/cmd/volumemgr/handlework.go
@@ -37,6 +37,10 @@ type volumeWorkDescription struct {
 // casIngestWorkDescription cas ingest work we feed into the worker go routine
 type casIngestWorkDescription struct {
 	status types.ContentTreeStatus
+	// claimedBlobs are the blob sha256s this job -- and no concurrent job --
+	// will load into the CAS, decided in the main event loop at submit time
+	// (see AddWorkLoad).
+	claimedBlobs []string
 	// used for results
 	loaded []string
 }
@@ -63,26 +67,27 @@ type casIngestWorkResult struct {
 
 // trySubmitWork hands one work item to the worker pool, distinguishing the
 // benign idempotent case (a job with this key is already in progress) from a
-// real refusal. Returns nil if the job is running or was accepted, and an
-// error (a worker.PoolFullError when the pool is at maxWorkers) if nothing
-// owns the work: the caller must then either retry later or not commit any
-// state that assumes the job will run.
-func trySubmitWork(ctx *volumemgrContext, w worker.Work) error {
+// real refusal. Returns (true, nil) if this submission was accepted,
+// (false, nil) if a job with this key is already running, and an error (a
+// worker.PoolFullError when the pool is at maxWorkers) if nothing owns the
+// work: the caller must then either retry later or not commit any state that
+// assumes the job will run.
+func trySubmitWork(ctx *volumemgrContext, w worker.Work) (bool, error) {
 	done, err := ctx.worker.TrySubmit(w)
 	if err != nil {
 		var inProgress *worker.JobInProgressError
 		if errors.As(err, &inProgress) {
 			log.Functionf("trySubmitWork(%s): job already in progress", w.Key)
-			return nil
+			return false, nil
 		}
-		return err
+		return false, err
 	}
 	if !done {
 		// A pool never returns (false, nil); only a bare worker with a full
 		// queue does, and volumemgr uses a pool.
-		return fmt.Errorf("worker did not accept job %s", w.Key)
+		return false, fmt.Errorf("worker did not accept job %s", w.Key)
 	}
-	return nil
+	return true, nil
 }
 
 // AddWorkCreate adds a Work job to create a volume.
@@ -96,7 +101,7 @@ func AddWorkCreate(ctx *volumemgrContext, status *types.VolumeStatus) error {
 		status: *status,
 	}
 	w := worker.Work{Kind: workCreate, Key: status.Key(), Description: d}
-	if err := trySubmitWork(ctx, w); err != nil {
+	if _, err := trySubmitWork(ctx, w); err != nil {
 		log.Warnf("AddWorkCreate(%s): %v", status.Key(), err)
 		return err
 	}
@@ -110,39 +115,66 @@ func AddWorkCreate(ctx *volumemgrContext, status *types.VolumeStatus) error {
 // already in progress for this key counts as success, so callers stay
 // idempotent.
 func AddWorkLoad(ctx *volumemgrContext, status *types.ContentTreeStatus) error {
-	d := casIngestWorkDescription{
-		status: *status,
-	}
-	w := worker.Work{Kind: workIngest, Key: status.Key(), Description: d}
-	if err := trySubmitWork(ctx, w); err != nil {
-		log.Warnf("AddWorkLoad(%s): %v", status.Key(), err)
-		return err
-	}
 	if ctx.pendingIngest == nil {
 		ctx.pendingIngest = make(map[string]bool)
 	}
+	if ctx.inflightBlobIngests == nil {
+		ctx.inflightBlobIngests = make(map[string]string)
+	}
+	// Decide here, where BlobStatus is authoritative, exactly which blobs
+	// this job will load: those in LOADING that no other in-flight job has
+	// claimed. The worker must not select blobs itself from the stale copy it
+	// is handed: two workers that each saw a shared blob in LOADING would
+	// both ingest it, and the one finishing last can find the verified file
+	// already deleted by the completion of the first (with the redundant
+	// multi-hundred-MB writes as a bonus).
+	var claimed []string
+	seen := map[string]bool{}
+	for _, blobSha := range status.Blobs {
+		if seen[blobSha] {
+			continue
+		}
+		seen[blobSha] = true
+		blob := ctx.LookupBlobStatus(blobSha)
+		if blob == nil || blob.State != types.LOADING {
+			continue
+		}
+		if owner, ok := ctx.inflightBlobIngests[blobSha]; ok && owner != status.Key() {
+			// Another job loads it; this tree waits on that job's result.
+			continue
+		}
+		claimed = append(claimed, blobSha)
+	}
+	d := casIngestWorkDescription{
+		status:       *status,
+		claimedBlobs: claimed,
+	}
+	w := worker.Work{Kind: workIngest, Key: status.Key(), Description: d}
+	accepted, err := trySubmitWork(ctx, w)
+	if err != nil {
+		log.Warnf("AddWorkLoad(%s): %v", status.Key(), err)
+		return err
+	}
 	ctx.pendingIngest[status.Key()] = true
+	if accepted {
+		// Only a submission that was actually handed to a worker owns its
+		// claims; when the key was already in progress, the running job keeps
+		// loading whatever it claimed at its own submit time.
+		for _, blobSha := range claimed {
+			ctx.inflightBlobIngests[blobSha] = status.Key()
+		}
+	}
 	return nil
 }
 
-// ingestInFlightFor reports whether some content tree with an accepted, not
-// yet completed CAS ingest job carries this blob. A blob sitting in LOADING
-// that no in-flight job covers has lost its worker; treating such a blob as
-// busy is what turns a refused submit into a permanent stall for every other
-// content tree sharing it.
+// ingestInFlightFor reports whether some accepted, not yet completed CAS
+// ingest job claimed this blob. A blob sitting in LOADING that no in-flight
+// job covers has lost its worker; treating such a blob as busy is what turns
+// a refused submit into a permanent stall for every other content tree
+// sharing it.
 func ingestInFlightFor(ctx *volumemgrContext, sha string) bool {
-	for key := range ctx.pendingIngest {
-		ctStatus := ctx.LookupContentTreeStatus(key)
-		if ctStatus == nil {
-			continue
-		}
-		for _, blobSha := range ctStatus.Blobs {
-			if blobSha == sha {
-				return true
-			}
-		}
-	}
-	return false
+	_, ok := ctx.inflightBlobIngests[sha]
+	return ok
 }
 
 // AddWorkPrepare adds a Work job to prepare creation of a volume.
@@ -154,7 +186,7 @@ func AddWorkPrepare(ctx *volumemgrContext, status *types.VolumeStatus) error {
 		status:  *status,
 	}
 	w := worker.Work{Kind: workPrepare, Key: status.Key(), Description: d}
-	if err := trySubmitWork(ctx, w); err != nil {
+	if _, err := trySubmitWork(ctx, w); err != nil {
 		log.Warnf("AddWorkPrepare(%s): %v", status.Key(), err)
 		return err
 	}
@@ -185,7 +217,7 @@ func AddWorkDestroy(ctx *volumemgrContext, status *types.VolumeStatus) error {
 		status:  *status,
 	}
 	w := worker.Work{Kind: workCreate, Key: status.Key(), Description: d}
-	if err := trySubmitWork(ctx, w); err != nil {
+	if _, err := trySubmitWork(ctx, w); err != nil {
 		log.Warnf("AddWorkDestroy(%s): %v", status.Key(), err)
 		return err
 	}
@@ -248,38 +280,57 @@ func volumeWorker(ctxPtr interface{}, w worker.Work) worker.WorkResult {
 	return result
 }
 
+// selectClaimedBlobs returns fresh copies of the blobs an ingest job claimed
+// at submit time and still has to load. Re-reading BlobStatus here (rather
+// than trusting the copy taken at submit time) keeps Path current; a claimed
+// blob that meanwhile disappeared (its content tree was deleted) or was
+// already loaded is skipped.
+func selectClaimedBlobs(ctx *volumemgrContext, key string, claimedBlobs []string) []types.BlobStatus {
+	loadBlobs := []types.BlobStatus{}
+	for _, blobSha := range claimedBlobs {
+		blob := ctx.LookupBlobStatus(blobSha)
+		if blob == nil {
+			log.Warnf("selectClaimedBlobs(%s): claimed blob %s disappeared, skipping",
+				key, blobSha)
+			continue
+		}
+		if blob.State == types.LOADED {
+			continue
+		}
+		loadBlobs = append(loadBlobs, *blob)
+	}
+	return loadBlobs
+}
+
 // casIngestWorker implementation of work.WorkFunction that loads blobs and an image into the CAS store
 func casIngestWorker(ctxPtr interface{}, w worker.Work) worker.WorkResult {
 	ctx := ctxPtr.(*volumemgrContext)
 	d := w.Description.(casIngestWorkDescription)
 	status := d.status
 
-	log.Functionf("casIngestWorker has blobs: %v", status.Blobs)
-	blobStatuses := lookupBlobStatuses(ctx, status.Blobs...)
+	log.Functionf("casIngestWorker has blobs: %v, claimed: %v",
+		status.Blobs, d.claimedBlobs)
+	result := worker.WorkResult{
+		Key:         w.Key,
+		Description: d,
+	}
 
-	// find the blobs we need to load and indicate that they are being loaded
-	// The order here is important. As a safety check, IngestBlobsAndCreateImage
-	// will not load any blobs that are of state LOADED or LOADING. If we set it to LOADING,
-	// we will prevent it from being loaded. But we need to indicate to the rest of the world
-	// that this blob is being loaded. So we do the following:
-	//
-	// 1. duplicate the BlobStatus to pass to IngestBlobsAndCreateImage
-	// 2. update the original BlobStatus state and publish
-	// 3. When we get the response, update the originals and publish
+	// Load exactly the blobs this job claimed at submit time (see
+	// AddWorkLoad). Blobs of this tree claimed by a concurrent job are left
+	// to that job; the tree waits for them through the per-blob states.
+	loadBlobs := selectClaimedBlobs(ctx, status.Key(), d.claimedBlobs)
 
-	// also keep track so we do not try to load duplicates
-	found := map[string]bool{}
-	loadBlobs := []types.BlobStatus{}
-	root := blobStatuses[0]
-	for _, blob := range blobStatuses {
-		// be careful not to load the same Sha256 twice
-		if _, ok := found[blob.Sha256]; ok {
-			continue
-		}
-		found[blob.Sha256] = true
-		if blob.State == types.LOADING {
-			loadBlobs = append(loadBlobs, *blob)
-		}
+	// The first blob is always the root; the image reference is created from
+	// its descriptor even when nothing is left to ingest.
+	var root *types.BlobStatus
+	if len(status.Blobs) > 0 {
+		root = ctx.LookupBlobStatus(status.Blobs[0])
+	}
+	if root == nil {
+		result.Error = fmt.Errorf("casIngestWorker(%s): root blob not found",
+			status.Key())
+		result.ErrorTime = time.Now()
+		return result
 	}
 
 	appImgName := status.ReferenceID()
@@ -290,10 +341,7 @@ func casIngestWorker(ctxPtr interface{}, w worker.Work) worker.WorkResult {
 	for _, blob := range loadedBlobs {
 		d.loaded = append(d.loaded, blob.Sha256)
 	}
-	result := worker.WorkResult{
-		Key:         w.Key,
-		Description: d,
-	}
+	result.Description = d
 	if err != nil {
 		result.Error = err
 		result.ErrorTime = time.Now()
@@ -368,7 +416,16 @@ func processVolumePrepareResult(ctxPtr interface{}, res worker.WorkResult) error
 func processCasIngestWorkResult(ctxPtr interface{}, res worker.WorkResult) error {
 	ctx := ctxPtr.(*volumemgrContext)
 	d := res.Description.(casIngestWorkDescription)
-	delete(ctx.pendingIngest, d.status.Key())
+	key := d.status.Key()
+	delete(ctx.pendingIngest, key)
+	// Release this job's blob claims, whether it succeeded or not: a blob it
+	// claimed but failed to load stays in LOADING with no owner, and the next
+	// content tree to look at it takes the load over instead of waiting.
+	for sha, owner := range ctx.inflightBlobIngests {
+		if owner == key {
+			delete(ctx.inflightBlobIngests, sha)
+		}
+	}
 	// loaded has the hashes of the blobs we loaded; publicise their new states.
 	blobs := lookupBlobStatuses(ctx, d.loaded...)
 	for _, blob := range blobs {

--- a/pkg/pillar/cmd/volumemgr/handlework_test.go
+++ b/pkg/pillar/cmd/volumemgr/handlework_test.go
@@ -74,12 +74,29 @@ func newIngestTestCtx(t *testing.T) (*volumemgrContext, *fakeWorker) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	pubVolumeStatus, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.VolumeStatus{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	subContentTreeConfig, err := ps.NewSubscription(pubsub.SubscriptionOptions{
+		AgentName: "zedagent",
+		TopicImpl: types.ContentTreeConfig{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	wk := newFakeWorker()
 	ctx := &volumemgrContext{
 		pubContentTreeStatus: pubContentTreeStatus,
 		pubBlobStatus:        pubBlobStatus,
+		pubVolumeStatus:      pubVolumeStatus,
+		subContentTreeConfig: subContentTreeConfig,
 		worker:               wk,
 		pendingIngest:        make(map[string]bool),
+		inflightBlobIngests:  make(map[string]string),
 	}
 	return ctx, wk
 }
@@ -216,5 +233,129 @@ func TestOrphanedRootBlobTakeover(t *testing.T) {
 	}
 	if len(wk.submitted) != 1 {
 		t.Errorf("expected no new submission while deferring, got %d", len(wk.submitted))
+	}
+}
+
+// TestSharedBlobIngestedOnce pins the claim protocol that stops concurrent
+// workers from ingesting the same blob: the job submitted for a content tree
+// claims the LOADING blobs no other in-flight job owns, a second tree sharing
+// the blob defers instead of submitting a duplicate load, and when the owning
+// job ends without loading the blob (here: it failed), the release of its
+// claims lets the waiting tree take the load over. Before this, every tree
+// sharing a layer re-ingested it, and the loser of that race could find the
+// verified file already deleted by the winner's completion.
+func TestSharedBlobIngestedOnce(t *testing.T) {
+	ctx, wk := newIngestTestCtx(t)
+	first := verifiedTree(ctx, "first", "sha-once", types.VERIFIED)
+
+	doUpdateContentTree(ctx, first)
+	if owner := ctx.inflightBlobIngests["sha-once"]; owner != first.Key() {
+		t.Fatalf("blob owner = %q, want %q", owner, first.Key())
+	}
+	d := wk.submitted[0].Description.(casIngestWorkDescription)
+	if len(d.claimedBlobs) != 1 || d.claimedBlobs[0] != "sha-once" {
+		t.Fatalf("claimedBlobs = %v, want [sha-once]", d.claimedBlobs)
+	}
+
+	// A second tree sharing the blob defers on the claimed root instead of
+	// submitting a duplicate ingest of the same content.
+	second := verifiedTree(ctx, "second", "sha-once", types.LOADING)
+	doUpdateContentTree(ctx, second)
+	if second.State != types.VERIFIED || len(wk.submitted) != 1 {
+		t.Fatalf("state = %s, submissions = %d; want deferred with no duplicate job",
+			second.State, len(wk.submitted))
+	}
+
+	// The owning job fails without having loaded the blob. Its result must
+	// release the claim, and the waiting tree must take the load over with a
+	// job of its own, rather than deferring forever to a load nobody owns.
+	res := worker.WorkResult{
+		Key:         first.Key(),
+		Error:       &worker.PoolFullError{}, // any error will do
+		Description: d,
+	}
+	wk.results[first.Key()] = &res
+	if err := processCasIngestWorkResult(ctx, res); err != nil {
+		t.Fatal(err)
+	}
+	// The released claim is not observable as an empty map out here: releasing
+	// it inside the handler is exactly what lets the re-drive in the same call
+	// hand the blob to the waiting tree, which claims it again. What must hold
+	// is that the failed job no longer owns it.
+	if owner := ctx.inflightBlobIngests["sha-once"]; owner == first.Key() {
+		t.Errorf("failed job still owns the blob claim")
+	}
+	failed := ctx.LookupContentTreeStatus(first.Key())
+	if !failed.HasError() || failed.State != types.LOADING {
+		t.Errorf("failed tree: state=%s error=%q; want parked in LOADING with the error",
+			failed.State, failed.Error)
+	}
+	if len(wk.submitted) != 2 {
+		t.Fatalf("submissions = %d; want the waiting tree to take the load over",
+			len(wk.submitted))
+	}
+	takeover := wk.submitted[1].Description.(casIngestWorkDescription)
+	if len(takeover.claimedBlobs) != 1 || takeover.claimedBlobs[0] != "sha-once" {
+		t.Errorf("takeover claims = %v, want [sha-once]", takeover.claimedBlobs)
+	}
+	if owner := ctx.inflightBlobIngests["sha-once"]; owner != second.Key() {
+		t.Errorf("blob owner after takeover = %q, want %q", owner, second.Key())
+	}
+}
+
+// TestSelectClaimedBlobs pins what the ingest worker will load: fresh copies
+// of exactly the claimed blobs, skipping one that disappeared (its tree was
+// deleted while the job waited) or that is already loaded.
+func TestSelectClaimedBlobs(t *testing.T) {
+	ctx, _ := newIngestTestCtx(t)
+	publishBlobStatus(ctx,
+		&types.BlobStatus{Sha256: "sha-load", State: types.LOADING, Path: "/fresh/path"},
+		&types.BlobStatus{Sha256: "sha-done", State: types.LOADED})
+
+	got := selectClaimedBlobs(ctx, "key", []string{"sha-load", "sha-done", "sha-gone"})
+	if len(got) != 1 || got[0].Sha256 != "sha-load" || got[0].Path != "/fresh/path" {
+		t.Errorf("selectClaimedBlobs = %+v, want just sha-load with its current path", got)
+	}
+}
+
+// TestLoadingWaitsOnForeignClaim pins the guard on the LOADING self-heal: a
+// content tree with no job of its own must NOT reset and resubmit while a
+// concurrent job's claim covers its missing blob -- that job's result is what
+// re-drives this tree. Without the guard the reset loops: the fresh job can
+// claim nothing (the blob is owned), completes as a no-op that still updates
+// the image reference in containerd, and its result handler re-drives the
+// tree straight back into the reset, for as long as the owning job keeps
+// loading the shared layer.
+func TestLoadingWaitsOnForeignClaim(t *testing.T) {
+	ctx, wk := newIngestTestCtx(t)
+	publishBlobStatus(ctx,
+		&types.BlobStatus{Sha256: "sha-root-l", State: types.LOADED},
+		&types.BlobStatus{Sha256: "sha-layer", State: types.LOADING, Path: "/some/path"})
+	contentID, _ := uuid.NewV4()
+	status := &types.ContentTreeStatus{
+		ContentID:   contentID,
+		DisplayName: "waiter",
+		State:       types.LOADING,
+		Blobs:       []string{"sha-root-l", "sha-layer"},
+	}
+	publishContentTreeStatus(ctx, status)
+	ctx.inflightBlobIngests["sha-layer"] = "other-tree-key"
+
+	changed, _ := doUpdateContentTree(ctx, status)
+	if changed || status.State != types.LOADING || len(wk.submitted) != 0 {
+		t.Errorf("got (changed=%v,state=%s,submissions=%d); want to keep waiting in LOADING",
+			changed, status.State, len(wk.submitted))
+	}
+
+	// Once the claim is released (the owning job finished without loading the
+	// blob), the reset fires and the resubmitted job claims the blob itself.
+	delete(ctx.inflightBlobIngests, "sha-layer")
+	doUpdateContentTree(ctx, status)
+	if status.State != types.LOADING || len(wk.submitted) != 1 {
+		t.Errorf("state=%s submissions=%d; want reset and one resubmitted job",
+			status.State, len(wk.submitted))
+	}
+	if owner := ctx.inflightBlobIngests["sha-layer"]; owner != status.Key() {
+		t.Errorf("blob owner = %q, want %q", owner, status.Key())
 	}
 }

--- a/pkg/pillar/cmd/volumemgr/handlework_test.go
+++ b/pkg/pillar/cmd/volumemgr/handlework_test.go
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package volumemgr
+
+import (
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/pubsub"
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	"github.com/lf-edge/eve/pkg/pillar/worker"
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+)
+
+// fakeWorker implements worker.Worker with scripted TrySubmit results, so the
+// submission-refused paths of doUpdateContentTree can be driven without a real
+// pool. Only the methods the code under test touches do anything.
+type fakeWorker struct {
+	submitted  []worker.Work
+	submitDone bool
+	submitErr  error
+	results    map[string]*worker.WorkResult
+}
+
+func newFakeWorker() *fakeWorker {
+	return &fakeWorker{submitDone: true, results: map[string]*worker.WorkResult{}}
+}
+
+func (w *fakeWorker) NumPending() int                  { return 0 }
+func (w *fakeWorker) NumResults() int                  { return 0 }
+func (w *fakeWorker) MsgChan() <-chan worker.Processor { return nil }
+func (w *fakeWorker) C() <-chan worker.Processor       { return nil }
+func (w *fakeWorker) Submit(work worker.Work) error {
+	_, err := w.TrySubmit(work)
+	return err
+}
+func (w *fakeWorker) TrySubmit(work worker.Work) (bool, error) {
+	w.submitted = append(w.submitted, work)
+	if w.submitErr != nil {
+		return false, w.submitErr
+	}
+	return w.submitDone, nil
+}
+func (w *fakeWorker) Cancel(key string) {}
+func (w *fakeWorker) Done()             {}
+func (w *fakeWorker) Pop(key string) *worker.WorkResult {
+	res := w.results[key]
+	delete(w.results, key)
+	return res
+}
+func (w *fakeWorker) Peek(key string) *worker.WorkResult { return w.results[key] }
+
+// newIngestTestCtx builds a volumemgrContext with in-memory pubsub topics and
+// a fakeWorker: just enough for the VERIFIED->LOADING(ingest) transitions of
+// doUpdateContentTree.
+func newIngestTestCtx(t *testing.T) (*volumemgrContext, *fakeWorker) {
+	t.Helper()
+	logger := logrus.StandardLogger()
+	log = base.NewSourceLogObject(logger, "test-volumemgr", 0)
+	ps := pubsub.New(&pubsub.EmptyDriver{}, logger, log)
+	pubContentTreeStatus, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.ContentTreeStatus{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubBlobStatus, err := ps.NewPublication(pubsub.PublicationOptions{
+		AgentName: agentName,
+		TopicType: types.BlobStatus{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wk := newFakeWorker()
+	ctx := &volumemgrContext{
+		pubContentTreeStatus: pubContentTreeStatus,
+		pubBlobStatus:        pubBlobStatus,
+		worker:               wk,
+		pendingIngest:        make(map[string]bool),
+	}
+	return ctx, wk
+}
+
+// verifiedTree publishes one BlobStatus in the given state and returns a
+// (published) ContentTreeStatus in VERIFIED that references it. Each call
+// makes a distinct content tree; trees given the same sha share the blob.
+func verifiedTree(ctx *volumemgrContext, name, sha string, blobState types.SwState) *types.ContentTreeStatus {
+	blob := &types.BlobStatus{Sha256: sha, State: blobState, Path: "/some/path"}
+	publishBlobStatus(ctx, blob)
+	contentID, _ := uuid.NewV4()
+	status := &types.ContentTreeStatus{
+		ContentID:   contentID,
+		DisplayName: name,
+		State:       types.VERIFIED,
+		Blobs:       []string{sha},
+	}
+	publishContentTreeStatus(ctx, status)
+	return status
+}
+
+// TestRefusedIngestRevertsToVerified pins the fix for the field failure where
+// a saturated worker pool made AddWorkLoad silently drop the CAS ingest after
+// doUpdateContentTree had already committed the tree and its blobs to
+// LOADING: nothing retried, no error was set, and the image was wedged until
+// reboot. A refused submit must leave the tree (and the blobs it claimed) in
+// VERIFIED so the re-evaluation paths retry it, and must surface a warning so
+// the deferral is visible to the controller.
+func TestRefusedIngestRevertsToVerified(t *testing.T) {
+	ctx, wk := newIngestTestCtx(t)
+	status := verifiedTree(ctx, "refused", "sha-refused", types.VERIFIED)
+
+	wk.submitErr = &worker.PoolFullError{}
+	changed, done := doUpdateContentTree(ctx, status)
+	if !changed || done {
+		t.Errorf("got (changed=%v,done=%v), want (true,false)", changed, done)
+	}
+	if status.State != types.VERIFIED {
+		t.Errorf("tree state = %s, want VERIFIED", status.State)
+	}
+	if blob := ctx.LookupBlobStatus("sha-refused"); blob.State != types.VERIFIED {
+		t.Errorf("blob state = %s, want VERIFIED (claim released)", blob.State)
+	}
+	if !status.HasError() || status.ErrorSeverity != types.ErrorSeverityWarning {
+		t.Errorf("expected a warning on the status, got error=%q severity=%v",
+			status.Error, status.ErrorSeverity)
+	}
+	if ctx.pendingIngest[status.Key()] {
+		t.Error("refused job must not be recorded as in flight")
+	}
+
+	// A pool slot freed up: the same call now goes through, moves the tree to
+	// LOADING, records the in-flight job and drops the deferral warning.
+	wk.submitErr = nil
+	doUpdateContentTree(ctx, status)
+	if status.State != types.LOADING {
+		t.Errorf("tree state = %s, want LOADING", status.State)
+	}
+	if blob := ctx.LookupBlobStatus("sha-refused"); blob.State != types.LOADING {
+		t.Errorf("blob state = %s, want LOADING", blob.State)
+	}
+	if status.HasError() {
+		t.Errorf("deferral warning must be cleared on submit, got %q", status.Error)
+	}
+	if !ctx.pendingIngest[status.Key()] {
+		t.Error("accepted job must be recorded as in flight")
+	}
+}
+
+// TestLoadingWithoutIngestResets pins the self-healing of a content tree
+// found in LOADING with no ingest job in flight (a refused submit from before
+// this fix, or a volumemgr restart mid-ingest): it must fall back to VERIFIED
+// and resubmit the load, instead of waiting forever for a work result that
+// cannot arrive. A tree whose ingest actually failed keeps its error and
+// stays parked, as before.
+func TestLoadingWithoutIngestResets(t *testing.T) {
+	ctx, wk := newIngestTestCtx(t)
+	status := verifiedTree(ctx, "orphaned", "sha-orphaned", types.LOADING)
+	status.State = types.LOADING
+	publishContentTreeStatus(ctx, status)
+
+	changed, _ := doUpdateContentTree(ctx, status)
+	if !changed || status.State != types.LOADING {
+		t.Errorf("got (changed=%v,state=%s), want (true,LOADING) with a fresh job",
+			changed, status.State)
+	}
+	if len(wk.submitted) != 1 {
+		t.Fatalf("expected the load to be resubmitted once, got %d", len(wk.submitted))
+	}
+	if !ctx.pendingIngest[status.Key()] {
+		t.Error("resubmitted job must be recorded as in flight")
+	}
+
+	// With the job recorded as in flight it must keep waiting in LOADING.
+	doUpdateContentTree(ctx, status)
+	if status.State != types.LOADING || len(wk.submitted) != 1 {
+		t.Errorf("state = %s, submissions = %d; want waiting in LOADING with no resubmit",
+			status.State, len(wk.submitted))
+	}
+
+	// A tree with an error is the controller's to retry; no auto-resubmit.
+	delete(ctx.pendingIngest, status.Key())
+	status.SetErrorWithSource("ingest failed", types.ContentTreeStatus{}, status.CreateTime)
+	doUpdateContentTree(ctx, status)
+	if status.State != types.LOADING || len(wk.submitted) != 1 {
+		t.Errorf("state = %s, submissions = %d; want parked in LOADING with the error",
+			status.State, len(wk.submitted))
+	}
+}
+
+// TestOrphanedRootBlobTakeover pins the shared-blob half of the stall: a
+// content tree must defer on a root blob in LOADING only while some in-flight
+// ingest actually covers that blob. An orphaned LOADING root (its tree's
+// submit was refused) is taken over instead of deferred to forever.
+func TestOrphanedRootBlobTakeover(t *testing.T) {
+	ctx, wk := newIngestTestCtx(t)
+	status := verifiedTree(ctx, "sharer", "sha-shared", types.LOADING)
+
+	// No ingest in flight covers the root: take the load over.
+	doUpdateContentTree(ctx, status)
+	if status.State != types.LOADING {
+		t.Errorf("state = %s, want LOADING (took over orphaned root)", status.State)
+	}
+	if len(wk.submitted) != 1 {
+		t.Fatalf("expected one submitted job, got %d", len(wk.submitted))
+	}
+
+	// The takeover is now the in-flight ingest covering the shared blob, so a
+	// second tree sharing it defers (and submits nothing).
+	waiting := verifiedTree(ctx, "waiter", "sha-shared", types.LOADING)
+	doUpdateContentTree(ctx, waiting)
+	if waiting.State != types.VERIFIED {
+		t.Errorf("state = %s, want VERIFIED (deferring to in-flight load)", waiting.State)
+	}
+	if len(wk.submitted) != 1 {
+		t.Errorf("expected no new submission while deferring, got %d", len(wk.submitted))
+	}
+}

--- a/pkg/pillar/cmd/volumemgr/retryclustervolume.go
+++ b/pkg/pillar/cmd/volumemgr/retryclustervolume.go
@@ -116,7 +116,13 @@ func retryFailedClusterVolumeCreate(ctx *volumemgrContext) {
 				maxClusterVolumeRetries, status.Error)
 			status.ClearErrorWithSource()
 			publishVolumeStatus(ctx, &status)
-			AddWorkCreate(ctx, &status)
+			if err := AddWorkCreate(ctx, &status); err != nil {
+				// Pool full; put the error back so the volume stays a retry
+				// candidate for the next gc tick.
+				status.SetErrorWithSource(err.Error(), types.VolumeStatus{},
+					time.Now())
+				publishVolumeStatus(ctx, &status)
+			}
 		}
 	}
 }

--- a/pkg/pillar/cmd/volumemgr/retryvolumedelete.go
+++ b/pkg/pillar/cmd/volumemgr/retryvolumedelete.go
@@ -94,7 +94,12 @@ func retryFailedVolumeDelete(ctx *volumemgrContext) {
 				"(attempt %d/%d): %s",
 				key, status.DisplayName, ctx.volumeDeleteRetryCount[key],
 				maxVolumeDeleteRetries, status.Error)
-			AddWorkDestroy(ctx, &status)
+			if err := AddWorkDestroy(ctx, &status); err != nil {
+				// Pool full; the volume keeps its error, so the next gc tick
+				// re-drives it (spending one more unit of the retry budget).
+				log.Warnf("retryFailedVolumeDelete: destroy of %s not scheduled: %v",
+					key, err)
+			}
 		}
 	}
 }

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -481,16 +481,22 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			// whose ingest failed keeps its error and is not re-driven here;
 			// retrying that is the controller's call, as before.
 			for _, blob := range lookupBlobStatuses(ctx, status.Blobs...) {
-				if blob.State != types.LOADED {
-					log.Noticef("doUpdateContentTree(%s): in LOADING with no ingest "+
-						"in flight; resetting to VERIFIED to retry", status.Key())
-					status.State = types.VERIFIED
-					publishContentTreeStatus(ctx, status)
-					// Rerun so the VERIFIED branch resubmits the load right
-					// away rather than on some later event.
-					_, done := doUpdateContentTree(ctx, status)
-					return true, done
+				if blob.State == types.LOADED || ingestInFlightFor(ctx, blob.Sha256) {
+					// Loaded, or a concurrent job's claim covers it: that
+					// job's result re-drives this tree, so there is nothing
+					// to resubmit. Resetting anyway would loop: the fresh
+					// job could claim nothing, complete as a no-op, and its
+					// result would land us right back here.
+					continue
 				}
+				log.Noticef("doUpdateContentTree(%s): in LOADING with no ingest "+
+					"in flight; resetting to VERIFIED to retry", status.Key())
+				status.State = types.VERIFIED
+				publishContentTreeStatus(ctx, status)
+				// Rerun so the VERIFIED branch resubmits the load right
+				// away rather than on some later event.
+				_, done := doUpdateContentTree(ctx, status)
+				return true, done
 			}
 		}
 		if wres != nil {

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -401,13 +401,28 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 		blobStatuses := lookupBlobStatuses(ctx, status.Blobs...)
 		root := blobStatuses[0]
 		if root.State == types.LOADING {
-			log.Functionf("Found root blob %s in LOADING; defer", root.Key())
-			return changed, false
+			// Only defer if that load is really running. An orphaned LOADING
+			// flag -- left behind by a refused submit or a volumemgr restart
+			// -- would otherwise park us here forever.
+			if ingestInFlightFor(ctx, root.Sha256) {
+				log.Functionf("Found root blob %s in LOADING; defer", root.Key())
+				return changed, false
+			}
+			log.Noticef("doUpdateContentTree(%s): root blob %s in LOADING with no "+
+				"ingest in flight; taking it over", status.Key(), root.Sha256)
 		}
+		// casIngestWorker picks the blobs to ingest by filtering on
+		// State == LOADING, so the transition has to happen before the work
+		// is submitted. Remember exactly which blobs we moved, so that a
+		// refused submit can put them back: a blob that was already LOADING
+		// belongs to another content tree's live worker and must not be
+		// touched.
+		claimed := []*types.BlobStatus{}
 		for _, b := range blobStatuses {
 			if b.State == types.VERIFIED {
 				b.State = types.LOADING
 				publishBlobStatus(ctx, b)
+				claimed = append(claimed, b)
 			}
 		}
 
@@ -417,9 +432,38 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 		// it is a bit silly to publish twice, but it is important that we keep the audit
 		// trail that the image was verified, and now is loading
 		status.State = types.LOADING
-		publishContentTreeStatus(ctx, status)
 
-		AddWorkLoad(ctx, status)
+		if err := AddWorkLoad(ctx, status); err != nil {
+			// Nothing owns these blobs and no work result will ever arrive.
+			// Leaving them in LOADING would also park every other content
+			// tree sharing them on the root-blob check above, so release the
+			// claim and drop back to VERIFIED; the reevaluates run by the
+			// work result handlers retry once a pool slot frees up. Surface
+			// the deferral so the controller sees why the tree does not
+			// progress if the pool stays saturated for long.
+			for _, b := range claimed {
+				b.State = types.VERIFIED
+				publishBlobStatus(ctx, b)
+			}
+			status.State = types.VERIFIED
+			description := types.ErrorDescription{
+				Error:               fmt.Sprintf("CAS ingest deferred: %v", err),
+				ErrorRetryCondition: "Will retry when a worker becomes available",
+				ErrorSeverity:       types.ErrorSeverityWarning,
+			}
+			// do not touch time of the error with the same content
+			if status.Error != description.Error {
+				status.SetErrorWithSourceAndDescription(description,
+					types.ContentTreeStatus{})
+			}
+			changed = true
+		} else if status.IsErrorSource(types.ContentTreeStatus{}) {
+			// A fresh ingest is owned by a worker now; drop a stale deferral
+			// warning (or a previous attempt's error) while it runs.
+			status.ClearErrorWithSource()
+			changed = true
+		}
+		publishContentTreeStatus(ctx, status)
 
 		return changed, false
 	}
@@ -428,7 +472,27 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 	if status.State == types.LOADING {
 		log.Functionf("doUpdateContentTree(%s): ContentTree status is LOADING", status.Key())
 		// get the work result - see if it succeeded
-		wres := popCasIngestWorkResult(ctx, status.Key())
+		wres := popCasIngestWorkResult(ctx, status)
+		if wres == nil && !ctx.pendingIngest[status.Key()] && !status.HasError() {
+			// No result and no job: the ingest was never queued, or volumemgr
+			// restarted while it was running. Unless the blobs happen to have
+			// been loaded by someone else, nothing will ever advance this, so
+			// go back to VERIFIED and let the branch above resubmit. A tree
+			// whose ingest failed keeps its error and is not re-driven here;
+			// retrying that is the controller's call, as before.
+			for _, blob := range lookupBlobStatuses(ctx, status.Blobs...) {
+				if blob.State != types.LOADED {
+					log.Noticef("doUpdateContentTree(%s): in LOADING with no ingest "+
+						"in flight; resetting to VERIFIED to retry", status.Key())
+					status.State = types.VERIFIED
+					publishContentTreeStatus(ctx, status)
+					// Rerun so the VERIFIED branch resubmits the load right
+					// away rather than on some later event.
+					_, done := doUpdateContentTree(ctx, status)
+					return true, done
+				}
+			}
+		}
 		if wres != nil {
 			log.Functionf("doUpdateContentTree(%s): IngestWorkResult found", status.Key())
 			if wres.Error != nil {
@@ -489,6 +553,23 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 	}
 
 	return changed, status.State == types.LOADED
+}
+
+// deferVolumeWork records on the VolumeStatus that a worker-pool submission
+// was refused, as a warning with a retry condition so the controller sees why
+// the volume does not progress while the pool stays saturated. The callers
+// put the state machine back so the re-evaluation run by the work result
+// handlers retries the submission once a pool slot frees up.
+func deferVolumeWork(status *types.VolumeStatus, what string, err error) {
+	description := types.ErrorDescription{
+		Error:               fmt.Sprintf("volume %s deferred: %v", what, err),
+		ErrorRetryCondition: "Will retry when a worker becomes available",
+		ErrorSeverity:       types.ErrorSeverityWarning,
+	}
+	// do not touch time of the error with the same content
+	if status.Error != description.Error {
+		status.SetErrorWithSourceAndDescription(description, types.VolumeStatus{})
+	}
 }
 
 // Returns changed
@@ -607,6 +688,7 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 				log.Noticef("doUpdateVol(%s): deferring blank volume create until cluster storage (longhorn/CDI) ready", status.Key())
 				return changed, false
 			}
+			prevState := status.State
 			status.State = types.CREATING_VOLUME
 			status.ReferenceName = "" //set empty for blank volume
 			status.ContentFormat = blankVolumeFormat
@@ -615,7 +697,12 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 			changed = true
 			log.Noticef("doUpdateVol(%s): creating blank volume with format %s", status.Key(), status.ContentFormat)
 			// Asynch preparation; ensure we have requested it
-			AddWorkPrepare(ctx, status)
+			if err := AddWorkPrepare(ctx, status); err != nil {
+				// Nothing owns the prepare; stay below CREATING_VOLUME so
+				// reevaluatePendingVolumes re-drives this branch.
+				status.State = prevState
+				deferVolumeWork(status, "prepare", err)
+			}
 			return changed, false
 		}
 	case zconfig.VolumeContentOriginType_VCOT_DOWNLOAD:
@@ -639,11 +726,17 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 						status.Key())
 					return changed, false
 				}
+				prevState := status.State
 				status.State = types.CREATING_VOLUME
 				changed = true
 				log.Noticef("doUpdateVol(%s): adopting existing cluster PVC, bypassing ContentTree wait", status.Key())
 				// Asynch preparation; ensure we have requested it
-				AddWorkPrepare(ctx, status)
+				if err := AddWorkPrepare(ctx, status); err != nil {
+					// Nothing owns the prepare; stay below CREATING_VOLUME so
+					// reevaluatePendingVolumes re-drives this branch.
+					status.State = prevState
+					deferVolumeWork(status, "prepare", err)
+				}
 				return changed, false
 			case kubeapi.PVCStateAbsent:
 				if ctStatus != nil && ctStatus.State == types.REMOTELOADED {
@@ -744,6 +837,7 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 				log.Noticef("doUpdateVol(%s): deferring volume create until cluster storage (longhorn/CDI) ready", status.Key())
 				return changed, false
 			}
+			prevState := status.State
 			status.State = types.CREATING_VOLUME
 			// first blob is always the root
 			if len(ctStatus.Blobs) < 1 {
@@ -756,7 +850,12 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 			log.Noticef("doUpdateVol(%s): setting VolumeStatus.ContentFormat by ContentTree to %s", status.Key(), status.ContentFormat)
 			changed = true
 			// Asynch preparation; ensure we have requested it
-			AddWorkPrepare(ctx, status)
+			if err := AddWorkPrepare(ctx, status); err != nil {
+				// Nothing owns the prepare; stay below CREATING_VOLUME so
+				// reevaluatePendingVolumes re-drives this branch.
+				status.State = prevState
+				deferVolumeWork(status, "prepare", err)
+			}
 			return changed, false
 		}
 		if status.IsErrorSource(types.ContentTreeStatus{}) {
@@ -807,12 +906,19 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 		if !prepared {
 			return changed, false
 		}
-		status.SubState = types.VolumeSubStatePrepareDone
-		changed = true
 		//prepare work done
 		DeleteWorkPrepare(ctx, status)
-		// Asynch creation; ensure we have requested it
-		AddWorkCreate(ctx, status)
+		// Asynch creation; ensure we have requested it. Only advance out of
+		// Preparing once a worker owns the create: nothing consuming a work
+		// result re-submits from PrepareDone, so a refused submit leaves the
+		// sub-state as is and reevaluatePendingVolumes re-drives this branch.
+		if err := AddWorkCreate(ctx, status); err != nil {
+			deferVolumeWork(status, "create", err)
+			changed = true
+			return changed, false
+		}
+		status.SubState = types.VolumeSubStatePrepareDone
+		changed = true
 		return changed, false
 	}
 	if status.State == types.CREATING_VOLUME && status.SubState == types.VolumeSubStatePrepareDone {

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -447,9 +447,10 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 			}
 			status.State = types.VERIFIED
 			description := types.ErrorDescription{
-				Error:               fmt.Sprintf("CAS ingest deferred: %v", err),
-				ErrorRetryCondition: "Will retry when a worker becomes available",
-				ErrorSeverity:       types.ErrorSeverityWarning,
+				Error: fmt.Sprintf("CAS ingest deferred: %v", err),
+				ErrorRetryCondition: "Will retry when a worker becomes available; " +
+					"the volumemgr.worker.pool.size config item bounds the pool",
+				ErrorSeverity: types.ErrorSeverityWarning,
 			}
 			// do not touch time of the error with the same content
 			if status.Error != description.Error {
@@ -568,9 +569,10 @@ func doUpdateContentTree(ctx *volumemgrContext, status *types.ContentTreeStatus)
 // handlers retries the submission once a pool slot frees up.
 func deferVolumeWork(status *types.VolumeStatus, what string, err error) {
 	description := types.ErrorDescription{
-		Error:               fmt.Sprintf("volume %s deferred: %v", what, err),
-		ErrorRetryCondition: "Will retry when a worker becomes available",
-		ErrorSeverity:       types.ErrorSeverityWarning,
+		Error: fmt.Sprintf("volume %s deferred: %v", what, err),
+		ErrorRetryCondition: "Will retry when a worker becomes available; " +
+			"the volumemgr.worker.pool.size config item bounds the pool",
+		ErrorSeverity: types.ErrorSeverityWarning,
 	}
 	// do not touch time of the error with the same content
 	if status.Error != description.Error {

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -94,6 +94,12 @@ type volumemgrContext struct {
 	worker worker.Worker // For background work
 
 	signalledRestartedStatus bool
+	// pendingIngest tracks ContentTreeStatus keys for which a CAS ingest job
+	// has been accepted by the worker pool but has not yet returned a result.
+	// A content tree in LOADING without an entry here has lost its worker and
+	// must be re-driven; see doUpdateContentTree. Only touched from the main
+	// event loop goroutine.
+	pendingIngest map[string]bool
 
 	verifierRestarted    bool // Wait for verifier to restart
 	contentTreeRestarted bool // Wait to receive all contentTree after restart
@@ -195,6 +201,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		// storage is usable as soon as volumemgr is up.
 		storageReady:  !base.IsHVTypeKube(),
 		statusTrigger: make(chan struct{}, 1),
+		pendingIngest: make(map[string]bool),
 	}
 	if ctx.hvTypeKube {
 		ctx.storageUnmet = storageWaitPending

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -458,8 +458,14 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 	populateExistingVolumesFormatObjects(&ctx, volumeEncryptedDirName)
 	populateExistingVolumesFormatObjects(&ctx, volumeClearDirName)
 
-	// Create the background worker
-	ctx.worker = worker.NewPool(log, &ctx, 20, map[string]worker.Handler{
+	// Create the background worker. Global config has already been received
+	// at this point, so size the pool from it; later changes to the setting
+	// are applied by handleGlobalConfigImpl without recreating the pool.
+	poolSize := int(ctx.globalConfig.GlobalValueInt(types.VolumemgrWorkerPoolSize))
+	if poolSize <= 0 {
+		poolSize = types.DefaultVolumemgrWorkerPoolSize
+	}
+	ctx.worker = worker.NewPool(log, &ctx, poolSize, map[string]worker.Handler{
 		workCreate:  {Request: volumeWorker, Response: processVolumeWorkResult},
 		workIngest:  {Request: casIngestWorker, Response: processCasIngestWorkResult},
 		workPrepare: {Request: volumePrepareWorker, Response: processVolumePrepareResult},
@@ -955,6 +961,15 @@ func handleGlobalConfigImpl(ctxArg interface{}, key string,
 		// Set max retries for blob download from global config
 		if gcp.GlobalValueInt(types.BlobDownloadMaxRetries) != 0 {
 			blobDownloadMaxRetries = gcp.GlobalValueInt(types.BlobDownloadMaxRetries)
+		}
+		// Resize the background worker pool. The pool does not exist yet when
+		// the first global config arrives (it is created right after the
+		// GCInitialized wait, sized from the config), and SetMaxWorkers is
+		// pool-only, so a plain worker would be left alone.
+		if n := gcp.GlobalValueInt(types.VolumemgrWorkerPoolSize); n != 0 {
+			if pool, ok := ctx.worker.(*worker.Pool); ok {
+				pool.SetMaxWorkers(int(n))
+			}
 		}
 		maybeUpdateConfigItems(ctx, gcp)
 		ctx.globalConfig = gcp

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -900,7 +900,7 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 			// (contentTreeSatisfiedByPVCs) deferred after spending its
 			// per-call live-probe budget; nothing else re-evaluates a
 			// content tree sitting idle on that check.
-			reevaluatePendingContentTrees(&ctx)
+			reevaluatePendingContentTrees(&ctx, types.INITIAL)
 			ps.CheckMaxTimeTopic(agentName, "gc", start,
 				warningTime, errorTime)
 

--- a/pkg/pillar/cmd/volumemgr/volumemgr.go
+++ b/pkg/pillar/cmd/volumemgr/volumemgr.go
@@ -100,6 +100,13 @@ type volumemgrContext struct {
 	// must be re-driven; see doUpdateContentTree. Only touched from the main
 	// event loop goroutine.
 	pendingIngest map[string]bool
+	// inflightBlobIngests maps a blob sha256 to the ContentTreeStatus key of
+	// the accepted-but-not-completed ingest job that will load it into the
+	// CAS. Claims are made in AddWorkLoad and released when the job's result
+	// is consumed; casIngestWorker loads exactly the blobs its job claimed,
+	// so a blob shared by many content trees is ingested once instead of once
+	// per tree. Only touched from the main event loop goroutine.
+	inflightBlobIngests map[string]string
 
 	verifierRestarted    bool // Wait for verifier to restart
 	contentTreeRestarted bool // Wait to receive all contentTree after restart
@@ -199,9 +206,10 @@ func Run(ps *pubsub.PubSub, loggerArg *logrus.Logger, logArg *base.LogObject, ar
 		hvTypeKube:         base.IsHVTypeKube(),
 		// Only an EVE-k node has cluster storage to wait for; everywhere else
 		// storage is usable as soon as volumemgr is up.
-		storageReady:  !base.IsHVTypeKube(),
-		statusTrigger: make(chan struct{}, 1),
-		pendingIngest: make(map[string]bool),
+		storageReady:        !base.IsHVTypeKube(),
+		statusTrigger:       make(chan struct{}, 1),
+		pendingIngest:       make(map[string]bool),
+		inflightBlobIngests: make(map[string]string),
 	}
 	if ctx.hvTypeKube {
 		ctx.storageUnmet = storageWaitPending

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -151,6 +151,11 @@ func (gs *GlobalStatus) UpdateItemValuesFromGlobalConfig(gc ConfigItemValueMap) 
 // A value of zero means we should use the default
 // All times are in seconds.
 
+// DefaultVolumemgrWorkerPoolSize is the default for VolumemgrWorkerPoolSize.
+// It matches the previously hardcoded pool size, so the setting is
+// behaviour-neutral until an operator raises it.
+const DefaultVolumemgrWorkerPoolSize = 20
+
 // GlobalSettingKey - Constants of all global setting keys
 type GlobalSettingKey string
 
@@ -256,6 +261,16 @@ const (
 	// BlobDownloadMaxRetries global setting key
 	// how many times EVE will retry to download a blob if its checksum is not verified
 	BlobDownloadMaxRetries GlobalSettingKey = "blob.download.max.retries"
+
+	// VolumemgrWorkerPoolSize global setting key
+	// maximum number of concurrent volumemgr background jobs: loading images
+	// into the CAS, and preparing, creating and destroying volumes all draw
+	// on this single pool. Work that cannot be submitted is deferred and
+	// retried, so this bounds throughput rather than correctness. Raise it on
+	// nodes running many app instances; each concurrent CAS ingest streams a
+	// layer through pillar, so the practical ceiling is pillar's memory
+	// cgroup and the disk.
+	VolumemgrWorkerPoolSize GlobalSettingKey = "volumemgr.worker.pool.size"
 
 	// Bool Items
 	// UsbAccess global setting key
@@ -1228,6 +1243,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(LogRemainToSendMBytes, 2048, 10, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(DownloadMaxPortCost, 0, 0, 255)
 	configItemSpecMap.AddIntItem(BlobDownloadMaxRetries, 5, 1, 10)
+	configItemSpecMap.AddIntItem(VolumemgrWorkerPoolSize, DefaultVolumemgrWorkerPoolSize, 1, 200)
 
 	// Goroutine Leak Detection section
 	configItemSpecMap.AddIntItem(GoroutineLeakDetectionThreshold, 5000, 1, 0xFFFFFFFF)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -226,6 +226,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		LogRemainToSendMBytes,
 		DownloadMaxPortCost,
 		BlobDownloadMaxRetries,
+		VolumemgrWorkerPoolSize,
 		KubernetesDrainTimeout,
 		DrainSkipK8sAPINotReachableTimeout,
 		KubernetesDrainAllNodesConfigMultiple,

--- a/pkg/pillar/worker/errors.go
+++ b/pkg/pillar/worker/errors.go
@@ -3,6 +3,8 @@
 
 package worker
 
+import "fmt"
+
 // JobInProgressError indicates a job in progress
 type JobInProgressError struct {
 	s string
@@ -10,4 +12,17 @@ type JobInProgressError struct {
 
 func (e *JobInProgressError) Error() string {
 	return e.s
+}
+
+// PoolFullError indicates that a Pool refused a submission because it already
+// runs maxWorkers concurrent jobs. Unlike JobInProgressError this is not
+// benign: nothing owns the refused work, so the caller must keep enough state
+// to submit it again later (or must not commit state that assumes the job
+// will run).
+type PoolFullError struct {
+	maxWorkers int
+}
+
+func (e *PoolFullError) Error() string {
+	return fmt.Sprintf("Would exceed maxWorkers of %d", e.maxWorkers)
 }

--- a/pkg/pillar/worker/workerpool.go
+++ b/pkg/pillar/worker/workerpool.go
@@ -7,7 +7,6 @@
 package worker
 
 import (
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -197,7 +196,7 @@ func (wp *Pool) TrySubmit(work Work) (bool, error) {
 		return true, nil
 	}
 	wp.log.Tracef("Would exceed maxWorkers of %d", wp.maxWorkers)
-	return false, fmt.Errorf("Would exceed maxWorkers of %d", wp.maxWorkers)
+	return false, &PoolFullError{maxWorkers: wp.maxWorkers}
 }
 
 // MsgChan returns a channel to be used in a select loop.

--- a/pkg/pillar/worker/workerpool.go
+++ b/pkg/pillar/worker/workerpool.go
@@ -134,6 +134,22 @@ func (wp *Pool) NumWorkers() int {
 	return len(wp.workers)
 }
 
+// SetMaxWorkers adjusts the ceiling on concurrent workers. Zero means
+// unlimited. Existing workers are left alone: lowering the ceiling only
+// prevents new ones from being created, and purgeOld reaps the idle surplus.
+// The result channel keeps the capacity it was constructed with, so raising
+// the ceiling a long way makes mergeResult apply backpressure rather than
+// buffer without bound -- which is the behaviour we want.
+func (wp *Pool) SetMaxWorkers(maxWorkers int) {
+	wp.workersLock.Lock()
+	defer wp.workersLock.Unlock()
+	if maxWorkers == wp.maxWorkers {
+		return
+	}
+	wp.log.Tracef("SetMaxWorkers: %d -> %d", wp.maxWorkers, maxWorkers)
+	wp.maxWorkers = maxWorkers
+}
+
 // Submit submits jobs to the WorkerPool. If it cannot find a worker in the pool
 // that can service it - i.e. both the number of workers is at the maximum and the
 // queues of all workers are full - then it waits one second and tries all available

--- a/pkg/pillar/worker/workerpool_test.go
+++ b/pkg/pillar/worker/workerpool_test.go
@@ -586,3 +586,40 @@ func getStacks(all bool) string {
 	buf = buf[:stackSize]
 	return string(buf)
 }
+
+// TestTrySubmitDistinguishesPoolFull pins the error contract callers rely on
+// when they defer and retry a refused job: a pool at maxWorkers refuses with a
+// PoolFullError, which is distinguishable from the benign JobInProgressError.
+// A caller that cannot tell the two apart either drops refused work on the
+// floor (the field failure that left app instances stuck in LOADING forever)
+// or double-submits running work.
+func TestTrySubmitDistinguishesPoolFull(t *testing.T) {
+	ctx, wp, _ := setupPool(1)
+	testname := "testpoolfull"
+
+	// Fill the single slot with a job that is still running afterwards.
+	w1 := worker.Work{Kind: "test", Key: testname + "1", Description: sleep4}
+	done, err := wp.TrySubmit(w1)
+	assert.True(t, done)
+	assert.Nil(t, err)
+
+	// The same key again while it runs: the benign idempotent case.
+	done, err = wp.TrySubmit(w1)
+	assert.False(t, done)
+	var inProgress *worker.JobInProgressError
+	assert.True(t, errors.As(err, &inProgress))
+
+	// A different job at the ceiling: a real refusal the caller must handle.
+	w2 := worker.Work{Kind: "test", Key: testname + "2", Description: sleep1}
+	done, err = wp.TrySubmit(w2)
+	assert.False(t, done)
+	var full *worker.PoolFullError
+	assert.True(t, errors.As(err, &full))
+	assert.Contains(t, err.Error(), "maxWorkers")
+
+	// Drain the one result so the pool shuts down cleanly.
+	proc := <-wp.MsgChan()
+	proc.Process(ctx, true)
+	assert.Equal(t, 0, wp.NumPending())
+	wp.Done()
+}

--- a/pkg/pillar/worker/workerpool_test.go
+++ b/pkg/pillar/worker/workerpool_test.go
@@ -623,3 +623,47 @@ func TestTrySubmitDistinguishesPoolFull(t *testing.T) {
 	assert.Equal(t, 0, wp.NumPending())
 	wp.Done()
 }
+
+// TestSetMaxWorkers verifies the ceiling can be adjusted on a live pool: at
+// the ceiling TrySubmit refuses (with the error contract pinned by
+// TestTrySubmitDistinguishesPoolFull), and raising the ceiling admits the
+// same job without recreating the pool. Lowering it never disturbs workers
+// that are already running.
+func TestSetMaxWorkers(t *testing.T) {
+	ctx, wp, _ := setupPool(1)
+	testname := "testsetmaxworkers"
+
+	// Fill the single slot with a job that is still running afterwards.
+	w1 := worker.Work{Kind: "test", Key: testname + "1", Description: sleep4}
+	done, err := wp.TrySubmit(w1)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, wp.NumWorkers())
+
+	// At the ceiling the next job is refused.
+	w2 := worker.Work{Kind: "test", Key: testname + "2", Description: sleep1}
+	done, err = wp.TrySubmit(w2)
+	assert.False(t, done)
+	assert.NotNil(t, err)
+
+	// Raising the ceiling admits the very same job.
+	wp.SetMaxWorkers(2)
+	done, err = wp.TrySubmit(w2)
+	assert.True(t, done)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, wp.NumWorkers())
+
+	// Setting the same value again is a no-op, and lowering the ceiling does
+	// not disturb workers that are already running.
+	wp.SetMaxWorkers(2)
+	wp.SetMaxWorkers(1)
+	assert.Equal(t, 2, wp.NumWorkers())
+
+	// Drain both results so the pool shuts down cleanly.
+	for i := 0; i < 2; i++ {
+		proc := <-wp.MsgChan()
+		proc.Process(ctx, true)
+	}
+	assert.Equal(t, 0, wp.NumPending())
+	wp.Done()
+}


### PR DESCRIPTION
# Description

On a node deploying many app instances at once, volumemgr's background
worker pool (hardcoded to 20) saturates: a single CAS ingest of a
multi-hundred-MB layer can hold a worker for minutes. Every submission
wrapper swallowed the pool's refusal, so `doUpdateContentTree` - which
commits the content tree and all of its blobs to LOADING *before*
submitting the load - left the tree parked in LOADING with no worker, no
retry, no timeout and no error reported to the controller. Since
BlobStatus is keyed by sha256 and shared, every other content tree
referencing the same image then deferred on the orphaned LOADING root
blob, waiting for a load that did not exist. On one production node,
five refusals inside a two-minute burst permanently wedged 11 of 39 app
instances (empty Error field, stuck until reboot). The volume
prepare/create/destroy and base OS install paths swallowed refusals the
same way, and concurrent workers each re-ingested the same shared blobs
from stale BlobStatus copies (234 ingests for 191 distinct blobs in a
ten-minute window on that node).

Three commits, one per problem:

1. **volumemgr,baseosmgr: don't drop work refused by a full pool** - the
   pool refuses with a typed `worker.PoolFullError`; all submission
   wrappers return it; a refused ingest rolls the LOADING transition
   back and surfaces a warning (with retry condition) on the status;
   every work-result handler re-drives pending content trees and
   volumes; a tree found in LOADING with no ingest in flight and no
   error heals itself (also recovers already-wedged nodes after
   upgrading to this fix, without a reboot); refused volume
   prepare/create/destroy and base OS install submissions are reported
   and retried instead of lost.
2. **volumemgr: load each shared blob from exactly one worker** - the
   main event loop claims, per ingest job, the LOADING blobs no other
   in-flight job owns; the worker loads exactly its claimed set
   (re-reading BlobStatus for a current verified-file path instead of
   using a stale snapshot); claims are released when the result is
   consumed, so a failed job's blobs are taken over by the next tree
   that needs them. Complements a4b7e5b8ea ("pkg/pillar/cas: make
   IngestBlob idempotent when the verified file is gone"), which keeps
   the delete-under-reader race from failing sibling trees but does not
   remove the duplicate ingests.
3. **volumemgr: make the worker pool ceiling configurable** - new config
   item `volumemgr.worker.pool.size` (default 20, i.e.
   behaviour-neutral; range 1-200), applied at startup and resizable at
   runtime via `Pool.SetMaxWorkers` without a reboot. With commit 1 in
   place, reaching the limit only defers work, so this is a throughput
   knob rather than a correctness cliff.

## How to test and validate this PR

Automated (run with `make -C pkg/pillar test`, or `go test ./worker/
./cmd/volumemgr/ ./cmd/baseosmgr/` inside `make shell`):

- `pkg/pillar/cmd/volumemgr`: `TestRefusedIngestRevertsToVerified`,
  `TestLoadingWithoutIngestResets`, `TestOrphanedRootBlobTakeover`,
  `TestSharedBlobIngestedOnce`, `TestSelectClaimedBlobs` pin the
  refusal/rollback, self-healing, takeover and claim/release behaviour.
- `pkg/pillar/worker`: `TestTrySubmitDistinguishesPoolFull`,
  `TestSetMaxWorkers` pin the pool error contract and live resize.
- `pkg/pillar/cmd/baseosmgr`: `TestAddWorkInstall_TrySubmitErrorIsReturned`,
  `TestAddWorkInstall_JobInProgressCountsAsSuccess`,
  `TestInstallDownloadedObject_RefusedSubmitReturnsError`.

QA scenarios (single node, EVE with this PR):

1. **Pool saturation does not wedge apps**: deploy 30+ app instances at
   once whose images have large layers (>100 MB each; more content
   trees than the pool size of 20). Before this PR, some content trees
   could stay in LOADING forever and their app instances never start,
   with an empty error. With this PR, all app instances eventually reach
   RUNNING. While the pool is saturated, `pillar.log` shows
   `Would exceed maxWorkers of 20` followed by later resubmission, and
   the affected content tree / volume may transiently report the warning
   "CAS ingest deferred ... Will retry when a worker becomes available".
2. **Already-wedged node recovers on upgrade**: on a node wedged by the
   old bug (content trees parked in LOADING with no `casIngestWorker`
   active, e.g. reproduced by step 1 on the previous release), update
   the base OS to an image with this PR. Within one gc interval the
   parked trees reset to VERIFIED, reload, and the stuck app instances
   start - no purge or reboot needed.
3. **Shared layers are ingested once**: deploy several app instances
   whose images share base layers at the same time. In `pillar.log`,
   each `IngestBlob(<sha>): Attempting to load blob` now appears once
   per distinct sha, not once per content tree referencing it.
4. **Pool size knob**: raise `volumemgr.worker.pool.size` (e.g. to 40)
   from the controller without rebooting, redeploy the step-1 workload,
   and verify more than 20 concurrent ingests run and no
   `Would exceed maxWorkers` refusals are logged. Values outside 1-200
   must be rejected by config item validation (error reported in
   ZInfoDevice config item status, value not applied).

## Changelog notes

Fixed app instances getting permanently stuck (never starting, with no
error reported) when many app instances are deployed to a node at once
and volumemgr's background worker pool saturates; work that cannot be
scheduled immediately is now deferred, retried and reported as a
warning. Image layers shared by several app instances are now loaded
into the content store once instead of once per instance. New
configuration property `volumemgr.worker.pool.size` (default 20) allows
raising the number of concurrent volumemgr background jobs on nodes
running many app instances, without a reboot.

## PR Backports

The buggy code path is identical on all four LTS branches (verified):

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

Note for the backports: the second commit pairs with a4b7e5b8ea
("pkg/pillar/cas: make IngestBlob idempotent when the verified file is
gone"), which is already on 16.0-stable (b80143eee2) and 14.5-stable
(d4da1421c6) but not yet on 17.0-stable or 13.4-stable; it should be
backported to those two alongside this PR.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them: device testing is still pending, which is why this PR is a draft;
  unit tests are included and `go vet`/`gofmt` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
