### PR TITLE
Makefile: lower the non-k rootfs ceiling to 290MB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -463,7 +463,7 @@ endif
 # Before 10.2.0 it was 300MB. We must maintain compatibility with older versions so rootfs size cannot exceed 300MB.
 # 'k' and nvidia are not affected by this limitation because there no installation of kubevirt/k3s prior to 10.2.0
 # Even though the partition layout is now unified, let's still check for ROOTFS_MAXSIZE_MB not exceeding 10GB for 'k'
-# and NVIDIA based platforms, and 291MB for x86_64 and other arm64 platforms. That helps in catching image size
+# and NVIDIA based platforms, and 290MB for x86_64 and other arm64 platforms. That helps in catching image size
 # increases earlier than at later stage.
 # We are currently filtering out a few packages from bulk builds since they are not getting published in Docker HUB
 ifeq ($(HV),k)
@@ -474,7 +474,7 @@ else
         PKGS_$(ZARCH)=$(shell find pkg -maxdepth 1 -type d | grep -Ev "eve|alpine|sources|kube|external-boot-image$$")
         # nvidia platform requires more space
         ifeq (, $(findstring nvidia,$(PLATFORM)))
-            ROOTFS_MAXSIZE_MB=291
+            ROOTFS_MAXSIZE_MB=290
         else
             ROOTFS_MAXSIZE_MB=10240
         endif


### PR DESCRIPTION
# Description

One of my PRs I merged today had the non-k rootfs size guard sits at 291MB since that was needed last week.
Reverting that change since it is no longer needed.

## How to test and validate this PR

N/A

## Changelog notes

No user-facing changes.

## PR Backports

- 17.0-stable: No — this only tightens a build-time size guard on master.
- 16.0-stable: No, same reason.
- 14.5-stable: No, same reason.
- 13.4-stable: No, same reason.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — the Makefile comment carrying the
  number is updated in the same hunk; there is no separate doc for this guard.
- [x] I've tested my PR on amd64 device — built `make rootfs` on amd64.
- [ ] I've tested my PR on arm64 device — no arm64 hardware here; the change is
  a build-time size assertion, so CI's arm64 rootfs build covers it.
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR — no `stable` label, since no
  backport is requested.
