### PR TITLE
[17.0-stable] kvm: honour the force flag when stopping a domain

### DIFF
--- a/pkg/pillar/hypervisor/kvm.go
+++ b/pkg/pillar/hypervisor/kvm.go
@@ -2054,7 +2054,12 @@ func (ctx KvmContext) Start(domainName string) error {
 }
 
 // Stop stops a domain
-func (ctx KvmContext) Stop(domainName string, _ bool) error {
+func (ctx KvmContext) Stop(domainName string, force bool) error {
+	// Without force this is an ACPI poweroff request, which a guest still early
+	// in boot simply ignores; force has to make the domain go away regardless.
+	if force {
+		return terminateQemu(kvmStateDir, domainName, "Stop")
+	}
 	if err := execShutdown(GetQmpExecutorSocket(domainName)); err != nil {
 		return logError("Stop: failed to execute shutdown command %v", err)
 	}
@@ -2090,43 +2095,58 @@ func waitProcessGone(pid int, timeout time.Duration) bool {
 	}
 }
 
-// Delete deletes a domain
-func (ctx KvmContext) Delete(domainName string) (result error) {
-	// Capture the qemu pid before tearing down state, so we can guarantee the
-	// process is gone even if the QMP quit below fails or hangs.
-	pid, pidErr := procutils.GetPidFromFile(kvmStateDir + domainName + "/pid")
+// terminateQemu makes the qemu process serving domainName exit and release its
+// resources: it pauses the vCPUs, issues a QMP quit, and SIGKILLs the process if
+// that does not take, since the quit can hang when the monitor is wedged. It
+// fails if the process cannot be established to be gone; an absent pid file is
+// not a failure, as there is then no process to terminate. Removing the state
+// directory is left to Delete and Cleanup. stateDir is a parameter so tests stay
+// off the real /run path; caller only names the caller in the logs.
+func terminateQemu(stateDir string, domainName string, caller string) error {
+	// Capture the pid first, so the process can still be dealt with if the QMP
+	// quit below fails or hangs.
+	pid, pidErr := procutils.GetPidFromFile(filepath.Join(stateDir, domainName, "pid"))
 
 	// Issue a QMP `stop` command (not a process signal) to pause the vCPUs,
 	// freezing the guest before we quit it.
-	_, err := os.Stat(GetQmpExecutorSocket(domainName))
-	if err == nil {
-		execStop(GetQmpExecutorSocket(domainName))
-		if err = execQuit(GetQmpExecutorSocket(domainName)); err != nil {
+	socket := qmpExecutorSocket(stateDir, domainName)
+	if _, err := os.Stat(socket); err == nil {
+		execStop(socket)
+		if err := execQuit(socket); err != nil {
 			logError("failed to execute quit command %v", err)
 		}
 	}
 
-	// Backstop: make sure qemu has actually exited and released its resources
-	// (memory, assigned PCI devices). quit over QMP can fail or hang if the
-	// monitor is wedged; without a hard kill the caller would keep seeing the
-	// domain as present and never free its resources (the lf-edge/eve#5916
-	// stall). Wait briefly for a clean exit, then SIGKILL.
-	if pidErr == nil {
+	if pidErr != nil {
+		if errors.Is(pidErr, os.ErrNotExist) {
+			return nil
+		}
+		return logError("%s(%s): no usable pid file, qemu cannot be terminated: %v",
+			caller, domainName, pidErr)
+	}
+	if !waitProcessGone(pid, qemuExitGrace) {
+		logrus.Warnf("%s(%s): qemu pid %d still alive after quit; sending SIGKILL",
+			caller, domainName, pid)
+		_ = syscall.Kill(pid, syscall.SIGKILL)
 		if !waitProcessGone(pid, qemuExitGrace) {
-			logrus.Warnf("Delete(%s): qemu pid %d still alive after quit; sending SIGKILL",
-				domainName, pid)
-			_ = syscall.Kill(pid, syscall.SIGKILL)
-			if !waitProcessGone(pid, qemuExitGrace) {
-				logrus.Errorf("Delete(%s): qemu pid %d survived SIGKILL", domainName, pid)
-			}
+			return logError("%s(%s): qemu pid %d survived SIGKILL",
+				caller, domainName, pid)
 		}
 	}
+	return nil
+}
+
+// Delete deletes a domain
+func (ctx KvmContext) Delete(domainName string) (result error) {
+	// terminateQemu has logged any failure already; carry it to the caller so a
+	// domain whose process is still around is not reported as deleted.
+	termErr := terminateQemu(kvmStateDir, domainName, "Delete")
 
 	if err := os.RemoveAll(kvmStateDir + domainName); err != nil {
 		return logError("failed to clean up domain state directory %s (%v)", domainName, err)
 	}
 
-	return nil
+	return termErr
 }
 
 // decideKvmState maps the containerd task state and the QMP run-state into the
@@ -2243,7 +2263,13 @@ func usbBusPort(USBAddr string) (string, string) {
 
 // GetQmpExecutorSocket returns the path to the qmp socket of a domain
 func GetQmpExecutorSocket(domainName string) string {
-	return filepath.Join(kvmStateDir, domainName, "qmp")
+	return qmpExecutorSocket(kvmStateDir, domainName)
+}
+
+// qmpExecutorSocket returns the path to the qmp socket of a domain whose state
+// lives under stateDir.
+func qmpExecutorSocket(stateDir string, domainName string) string {
+	return filepath.Join(stateDir, domainName, "qmp")
 }
 
 func getQmpListenerSocket(domainName string) string {

--- a/pkg/pillar/hypervisor/kvm_force_test.go
+++ b/pkg/pillar/hypervisor/kvm_force_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package hypervisor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// startSleeper returns a live process standing in for qemu and the state
+// directory holding its pid file. Both the pid file and the monitor socket are
+// looked for there, so nothing here can reach a domain on the test host.
+func startSleeper(t *testing.T) (stateDir string, domainName string, pid int) {
+	t.Helper()
+	domainName = "forcetest"
+	stateDir = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(stateDir, domainName), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	cmd := exec.Command("sleep", "300")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start stand-in process: %v", err)
+	}
+	pid = cmd.Process.Pid
+	// A zombie still answers signal 0, which is how liveness is probed, so this
+	// child has to be reaped as soon as it dies. qemu is not a child of pillar,
+	// so this only matters here.
+	go func() { _, _ = cmd.Process.Wait() }()
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	pidFile := filepath.Join(stateDir, domainName, "pid")
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d\n", pid)), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return stateDir, domainName, pid
+}
+
+// A domain whose QMP monitor cannot be reached still has to be terminated: that
+// is the path a guest which never services the poweroff request takes.
+func TestTerminateQemuKillsWhenMonitorUnreachable(t *testing.T) {
+	stateDir, domainName, pid := startSleeper(t)
+
+	// No qmp socket under the temporary state directory, so the quit is skipped
+	// exactly as it is for a wedged or absent monitor.
+	if err := terminateQemu(stateDir, domainName, "test"); err != nil {
+		t.Errorf("terminateQemu: %v", err)
+	}
+
+	if err := syscall.Kill(pid, 0); err == nil {
+		t.Errorf("process %d survived terminateQemu", pid)
+	}
+}
+
+// The pid file is the only handle on the process, so a domain without one must
+// not wedge the caller, and has nothing left to terminate so does not fail.
+func TestTerminateQemuWithoutPidFile(t *testing.T) {
+	domainName := "forcetest"
+	stateDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(stateDir, domainName), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- terminateQemu(stateDir, domainName, "test") }()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("terminateQemu: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("terminateQemu did not return without a pid file")
+	}
+}
+
+// A pid file that is there but unusable leaves nothing to signal, so no kill is
+// attempted; the caller has to hear about that rather than being told the forced
+// stop succeeded over a domain that is still running.
+func TestTerminateQemuReportsUnusablePidFile(t *testing.T) {
+	stateDir, domainName, pid := startSleeper(t)
+	pidFile := filepath.Join(stateDir, domainName, "pid")
+	if err := os.WriteFile(pidFile, []byte("not-a-pid\n"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := terminateQemu(stateDir, domainName, "test"); err == nil {
+		t.Error("terminateQemu reported success with an unusable pid file")
+	}
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Errorf("stand-in process %d was signalled despite an unusable pid file: %v", pid, err)
+	}
+}


### PR DESCRIPTION
# Description

Backport of #6441 to `17.0-stable`.

A forced stop was the same ACPI poweroff request as a graceful one, which a guest
that cannot service it yet — one still early in boot, for instance — simply
ignores. Nothing then made the domain go away until domainmgr gave up waiting and
deleted it, so an application stopped shortly after it started stayed reported as
halting for as long as those waits took, and its memory and any assigned devices
stayed held. A forced stop now terminates the process, as the xen and containerd
implementations of the same method already do, and reports whether that worked so
a process that outlives the SIGKILL reaches the caller rather than only the log.

The pillar commit is cherry-picked with `-x` and applied cleanly. The source PR's
second commit, `evetest: halt a guest which ignores ACPI`, is not carried:
`evetest/tests/apps` does not exist on this branch, so the test has no suite to
join.

## How to test and validate this PR

`go test ./hypervisor/` in `pkg/pillar` — `kvm_force_test.go` covers the forced
path, including the pid-file and surviving-process failures. `go build ./...` and
`go vet ./hypervisor/` are clean on this branch.

On a device, stop an application a few seconds after starting it, while the guest
is still early in boot and ignoring ACPI. The domain goes away promptly instead of
staying in halting until domainmgr's wait expires, and its memory and any assigned
PCI devices are released at that point.

## Changelog notes

An application stopped while its guest is still booting now halts promptly
instead of staying in a halting state until the shutdown wait expires.

## PR Backports

- 17.0-stable: This PR.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device (via #6441)
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've added a reference link to the original PR
- [x] PR's title follows the template
