### PR TITLE
Split security policy into three documents

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -4,4 +4,4 @@
 
 [codespell]
 skip = ./.git/*,*/vendor/*,./conf/v2tlsbaseroot-certificates.pem,./pkg/gpt-tools/patches/*,./pkg/new-kernel/*,./pkg/kernel/*,./pkg/fw/*,./evetest/cert/eve_rsa*,./evetest/constants/eve.go
-ignore-words-list = uptodate,synopsys,crate,UE,ratatui,archtype,nd,witht
+ignore-words-list = uptodate,synopsys,crate,UE,ratatui,archtype,nd,witht,cna

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,17 +27,17 @@ hear about an issue twice than not at all.
 
 ## CRA Stewardship
 
-This project is supported under the Linux Foundation CRA stewardship framework. Our project
-CRA steward is **TBD(TSC)**, the Linux Foundation legal entity that hosts LF Edge; it is
-recorded as the "Legal Parent" in LFX PCC under Operations, Project Definition, Legal
-Details, and `support@linuxfoundation.org` can confirm it. The steward's policy is published
-at <https://www.linuxfoundation.org/security>. Report vulnerabilities through the channels
-above, and the security team coordinates the report with the steward.
+EVE is a project of LF Edge, and is supported under the Linux Foundation CRA stewardship
+framework. Our project CRA steward is **TBD(TSC)**, the Linux Foundation legal entity that
+hosts LF Edge; it is recorded as the "Legal Parent" in LFX PCC under Operations, Project
+Definition, Legal Details, and `support@linuxfoundation.org` can confirm it. The steward's
+policy is published at <https://www.linuxfoundation.org/security>. Report vulnerabilities
+through the channels above, and the security team coordinates the report with the steward.
 
 If you believe a vulnerability is being **actively exploited**, say so explicitly and put it
-in the subject line. Active exploitation starts a 24-hour regulatory clock for the steward,
-so the security team escalates such a report immediately instead of waiting for triage to
-finish.
+in the subject line. Active exploitation obliges the steward to file an early warning within
+24 hours and a formal notification within 72 hours, so the security team escalates such a
+report immediately instead of waiting for triage to finish.
 
 EVE is published for use in commercial products, which is what brings it within the steward
 obligations in Regulation (EU) 2024/2847 Art 24.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,27 @@ You may also report a vulnerability to a national CSIRT or to ENISA independentl
 policy. Doing so does not replace reporting it here, and the EVE security team would rather
 hear about an issue twice than not at all.
 
+## CRA Stewardship
+
+This project is supported under the Linux Foundation CRA stewardship framework. Our project
+CRA steward is **TBD(TSC)**, the Linux Foundation legal entity that hosts LF Edge; it is
+recorded as the "Legal Parent" in LFX PCC under Operations, Project Definition, Legal
+Details, and `support@linuxfoundation.org` can confirm it. The steward's policy is published
+at <https://www.linuxfoundation.org/security>. Report vulnerabilities through the channels
+above, and the security team coordinates the report with the steward.
+
+If you believe a vulnerability is being **actively exploited**, say so explicitly and put it
+in the subject line. Active exploitation starts a 24-hour regulatory clock for the steward,
+so the security team escalates such a report immediately instead of waiting for triage to
+finish.
+
+EVE is published for use in commercial products, which is what brings it within the steward
+obligations in Regulation (EU) 2024/2847 Art 24.
+
+<!-- TBD(TSC): the Linux Foundation template offers a separate emergency reporting mechanism
+     for CRA escalation. EVE has no channel distinct from the two above. Decide whether to
+     add one, or keep the single intake and rely on the subject-line convention. -->
+
 ## Safe Harbor
 
 The EVE project will not initiate or support legal action against anyone who discovers or

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,24 +27,22 @@ hear about an issue twice than not at all.
 
 ## CRA Stewardship
 
-EVE is a project of LF Edge, and is supported under the Linux Foundation CRA stewardship
-framework. Our project CRA steward is **TBD(TSC)**, the Linux Foundation legal entity that
-hosts LF Edge; it is recorded as the "Legal Parent" in LFX PCC under Operations, Project
-Definition, Legal Details, and `support@linuxfoundation.org` can confirm it. The steward's
-policy is published at <https://www.linuxfoundation.org/security>. Report vulnerabilities
-through the channels above, and the security team coordinates the report with the steward.
+This project is supported under the Linux Foundation CRA stewardship framework, as described
+at <https://www.linuxfoundation.org/security>. Security vulnerabilities should be reported
+through the mechanisms described below, which we will coordinate with our CRA steward. For
+actively exploited vulnerabilities and severe incidents that may require CRA escalation,
+please use the project’s emergency security reporting mechanisms as appropriate.
 
-If you believe a vulnerability is being **actively exploited**, say so explicitly and put it
-in the subject line. Active exploitation obliges the steward to file an early warning within
-24 hours and a formal notification within 72 hours, so the security team escalates such a
-report immediately instead of waiting for triage to finish.
+EVE's emergency reporting mechanism is the intake above, escalated on the strength of what
+you tell us: if you believe a vulnerability is being **actively exploited**, or that the
+project's own release or build infrastructure has been compromised, say so explicitly and put
+it in the subject line. Active exploitation obliges the steward to file an early warning
+within 24 hours and a formal notification within 72 hours, so the security team escalates
+such a report to the steward immediately instead of waiting for triage to finish. There is no
+separate address to remember under time pressure.
 
 EVE is published for use in commercial products, which is what brings it within the steward
 obligations in Regulation (EU) 2024/2847 Art 24.
-
-<!-- TBD(TSC): the Linux Foundation template offers a separate emergency reporting mechanism
-     for CRA escalation. EVE has no channel distinct from the two above. Decide whether to
-     add one, or keep the single intake and rely on the subject-line convention. -->
 
 ## Safe Harbor
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,12 +11,17 @@ Please include a description of the issue, the steps to reproduce it, the EVE ve
 believe are affected, your assessment of the impact, and a patch or proof of concept if you
 have one. Report in English.
 
-The security team acknowledges a report within **24 hours**. This is an acknowledgment of
-receipt, not a commitment to a fix; remediation time depends on severity. EVE follows a
-**90-day** coordinated disclosure timeline: if no fix has shipped 90 days after the report is
-acknowledged, the reporter is free to disclose publicly, and the security team will publish
-what it knows rather than let the issue go unrecorded. An earlier or later date can be agreed
-with the reporter where a fix is imminent or a coordinated multi-vendor release requires it.
+The security team acknowledges and analyzes a report within **3 business days** — you get
+confirmation that a human has it, and an initial assessment of what it affects and how
+severe it looks. That is not a commitment to a fix; remediation time depends on severity. A
+report you flag as actively exploited is taken up when it arrives rather than waiting out
+that window.
+
+EVE follows a **90-day** coordinated disclosure timeline: if no fix has shipped 90 days after
+the report arrives, the reporter is free to disclose publicly, and the security team will
+publish what it knows rather than let the issue go unrecorded. An earlier or later date can
+be agreed with the reporter where a fix is imminent or a coordinated multi-vendor release
+requires it.
 
 How reports are triaged, patched, embargoed, and published is described in
 [docs/VULNERABILITY-HANDLING.md](docs/VULNERABILITY-HANDLING.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,65 +1,92 @@
 # Security Policy
 
-## Supported Versions
-
-The EVE project maintains security support for the following versions:
-
-| Version | Supported          |
-| ------- | ------------------ |
-| master  | ✅ |
-| 17.0.x | ✅ |
-| 16.0.x. | ✅ |
-| 14.5.x  | ✅ |
-| 13.4.x  | ✅ |
-| 12.0.x  | ✅ |
-| 11.0.x  | ✅ |
-| 10.4.x  | ✅ |
-
 ## Reporting a Vulnerability
 
-### For Security Vulnerabilities
+If you discover a security issue in EVE, report it privately. **Do not open a public GitHub issue.**
 
-If you discover a security vulnerability in EVE, please report it privately to maintain the security of all users. **Do not create a public GitHub issue.**
+- Email [eve-security@lists.lfedge.org](mailto:eve-security@lists.lfedge.org), or
+- use GitHub [private vulnerability reporting](https://github.com/lf-edge/eve/security/advisories/new).
 
-#### Preferred Reporting Methods
+Please include a description of the issue, the steps to reproduce it, the EVE versions you
+believe are affected, your assessment of the impact, and a patch or proof of concept if you
+have one. Report in English.
 
-1. **Email**: Send details to [eve-security@lists.lfedge.org](mailto:eve-security@lists.lfedge.org).
-2. **GitHub Security Advisory**: Use the [private vulnerability reporting](https://github.com/lf-edge/eve/security/advisories/new) feature.
+The security team acknowledges a report within **24 hours**. This is an acknowledgment of
+receipt, not a commitment to a fix; remediation time depends on severity. EVE follows a
+**90-day** coordinated disclosure timeline: if no fix has shipped 90 days after the report is
+acknowledged, the reporter is free to disclose publicly, and the security team will publish
+what it knows rather than let the issue go unrecorded. An earlier or later date can be agreed
+with the reporter where a fix is imminent or a coordinated multi-vendor release requires it.
 
-#### What to Include
+How reports are triaged, patched, embargoed, and published is described in
+[docs/VULNERABILITY-HANDLING.md](docs/VULNERABILITY-HANDLING.md).
 
-Please include the following information in your report:
+You may also report a vulnerability to a national CSIRT or to ENISA independently of this
+policy. Doing so does not replace reporting it here, and the EVE security team would rather
+hear about an issue twice than not at all.
 
-- **Description**: Clear description of the vulnerability
-- **Steps to Reproduce**: Detailed steps to reproduce the issue
-- **Impact Assessment**: Your assessment of the potential impact
-- **Affected Versions**: Which versions of EVE are affected
-- **Proof of Concept**: If available, a proof-of-concept or exploit code
-- **Suggested Fix**: A patch to fix the vulnerability
+## Safe Harbor
 
-### Response Timeline
+The EVE project will not initiate or support legal action against anyone who discovers or
+reports a vulnerability in good faith under this policy, and will treat such research as
+authorized conduct. Good faith means: you report promptly, you give the project a reasonable
+opportunity to fix the issue before disclosing it, and you do not exploit the issue beyond
+what is needed to demonstrate it.
 
-We are committed to responding to security vulnerability reports within 24 hours of receipt. The time required to develop a fix may vary depending on the severity. Any public disclosure will be coordinated with the reporter.
+Testing must stay within your own systems. Do not test against deployments, devices, or
+controllers you do not own or have written permission to test, do not run denial-of-service
+or resource-exhaustion tests against shared infrastructure, do not access or exfiltrate
+another party's data, and do not use social engineering against project members or users.
 
-### Security Advisory Publication
+The project does not operate a paid bounty program.
 
-Security advisories will be published:
+## Supported Versions
 
-- On the [EVE Security Advisories](https://github.com/lf-edge/eve/security/advisories) page.
-- Through the [LF Edge EVE mailing lists](https://lists.lfedge.org/g/eve).
+Which release lines receive security fixes, and until when, is maintained in
+[docs/RELEASE-SUPPORT.md](docs/RELEASE-SUPPORT.md). That document is the authoritative
+statement of security support; the GitHub releases page records what was published but
+carries no support status.
 
-### Acknowledgments
+## Scope
 
-We recognize and appreciate the efforts of the security research community in helping make EVE more secure. Security researchers who responsibly disclose vulnerabilities will be acknowledged.
+This policy covers the EVE edge operating system as published by the project: the
+`lf-edge/eve` repository, the official EVE releases and installer images, the official
+`lfedge/eve*` container images, and the repositories that build or ship code into a released
+EVE image, currently `eve-api`, `eve-libs`, `eve-kernel`, `eve-monitor-rs`, `eve-rust`,
+`eve-tpmea`, `edge-containers` and `runx`.
 
-### Scope
+The build and test repositories `eden`, `adam`, `eve-build-tools`, `eve-tools` and `rol` are
+in scope for reports, but a finding there normally affects developer and CI systems rather
+than a deployed edge device. Say so in the report if you believe otherwise.
 
-This security policy applies to:
+**Out of scope:** EVE is controller-agnostic. A vulnerability in a particular controller, or
+in a controller's API surface as that controller implements it, belongs to that controller's
+vendor, not to this project. Report it to them. Where a controller vulnerability is only
+exploitable because of how EVE behaves, report it here as well.
 
-- The main EVE repository (lf-edge/eve)
-- Official EVE container images
-- Official EVE releases and distributions
+Vulnerabilities in third-party components that EVE packages are in scope for triage: the
+security team will assess the impact on EVE, coordinate with the upstream project, and ship
+the fix. The upstream project owns the fix itself.
 
-### Security Resources
+## Published Advisories
 
-Additional information about our security model can be found in the [EVE Security Architecture](docs/SECURITY-ARCHITECTURE.md) document.
+Advisories are published on the [EVE security advisories](https://github.com/lf-edge/eve/security/advisories)
+page and announced on the [EVE mailing list](https://lists.lfedge.org/g/eve). Each advisory
+identifies the affected versions, the fixed versions, the impact, and the mitigation
+available to operators who cannot upgrade immediately.
+
+## For Downstream Vendors
+
+A vendor shipping an EVE-based product is a manufacturer under Regulation (EU) 2024/2847 and
+carries reporting and disclosure obligations that this project cannot discharge on the
+vendor's behalf. [docs/RELEASE-SUPPORT.md](docs/RELEASE-SUPPORT.md) describes the support
+information a vendor needs from the project, and how to join the pre-notification list that
+carries embargoed advisories ahead of publication.
+
+## Further Reading
+
+- [docs/VULNERABILITY-HANDLING.md](docs/VULNERABILITY-HANDLING.md) — how the security team handles a report.
+- [docs/SECURITY-ARCHITECTURE.md](docs/SECURITY-ARCHITECTURE.md) — EVE's security model and threat model.
+- [docs/SECURITY-HARDWARE.md](docs/SECURITY-HARDWARE.md) — hardware security recommendations.
+- [docs/SBOM-AND-SOURCES.md](docs/SBOM-AND-SOURCES.md) — where to find the SBoM and corresponding sources for a release.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — contribution guidelines, including the stable-branch backport process.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -92,9 +92,13 @@ the fix. The upstream project owns the fix itself.
 ## Published Advisories
 
 Advisories are published on the [EVE security advisories](https://github.com/lf-edge/eve/security/advisories)
-page and announced on the [EVE mailing list](https://lists.lfedge.org/g/eve). Each advisory
-identifies the affected versions, the fixed versions, the impact, and the mitigation
-available to operators who cannot upgrade immediately.
+page and announced on `eve-security-announce@lists.lfedge.org`. Each advisory identifies the
+affected versions, the fixed versions, the impact, and the mitigation available to operators
+who cannot upgrade immediately.
+
+<!-- TBD(TSC): eve-security-announce@lists.lfedge.org does not exist yet and has to be
+     requested from LF Edge. Until it does, advisories are announced on the general EVE
+     mailing list at https://lists.lfedge.org/g/eve. -->
 
 ## For Downstream Vendors
 

--- a/docs/RELEASE-SUPPORT.md
+++ b/docs/RELEASE-SUPPORT.md
@@ -100,4 +100,11 @@ commercially, carrying embargoed advisory information ahead of public publicatio
 can prepare its own advisory and update. Membership requires a named security contact who
 agrees to hold embargoed information until the disclosure date.
 
+For an actively exploited vulnerability the list is notified on the clock Regulation (EU)
+2024/2847 Art 14 sets — an early warning inside 24 hours, a fuller notification inside 72 —
+in step with the CRA steward rather than on the lead time a planned disclosure gets. This is
+the part of membership that matters most to a vendor with its own Art 14 deadlines: those run
+from the vendor's own awareness, and being on the list is what makes the project's awareness
+and the vendor's arrive close together.
+
 To request membership, contact [eve-security@lists.lfedge.org](mailto:eve-security@lists.lfedge.org).

--- a/docs/RELEASE-SUPPORT.md
+++ b/docs/RELEASE-SUPPORT.md
@@ -23,28 +23,43 @@ the LTS is behind.
 The consequence for security support is that the releases page cannot answer "is this line
 still supported". It records what was published, not what is maintained. Use the table below.
 
+## How long a line is supported
+
+An LTS line receives security fixes for **36 months** from the date its first
+`<major>.<minor>.0-lts` release was published, in two phases:
+
+- **Active**, for the first 24 months — security fixes and new LTS point releases.
+- **Backports only**, for the following 12 months — security fixes land on the stable
+  branch, but no further release is cut; consumers build from the branch or move to an
+  active line.
+
+After that the line is **end of life** and receives no fixes. Existing artifacts remain
+downloadable.
+
+The clock starts at the first `.0-lts` release rather than at the branch cut or the first
+release candidate, so every date below is derived from a published release a downstream
+vendor can check.
+
 ## Support status by line
 
-Status values:
+| Line | First `.0-lts` | Status | Active until | Backports until |
+| --- | --- | --- | --- | --- |
+| `master` | n/a | Development. Not for production, no security support. | n/a | n/a |
+| 17.0.x | 2026-07-27 | Active | 2028-07-27 | 2029-07-27 |
+| 16.0.x | 2026-01-07 | Active | 2028-01-07 | 2029-01-07 |
+| 14.5.x | 2025-06-18 | Active | 2027-06-18 | 2028-06-18 |
+| 13.4.x | 2024-12-28 | Active | 2026-12-28 | 2027-12-28 |
 
-- **Active** — receives security fixes and new LTS point releases.
-- **Backports only** — receives security fixes on the stable branch, but no new release is
-  being cut; consumers build from the branch or move to an active line.
-- **End of life** — receives no fixes. Existing artifacts remain downloadable.
+<!-- TBD(TSC): 13.4.x is Active under this policy until 2026-12-28, and the Active phase
+     promises new LTS point releases, but none has been cut since 13.4.3-lts on
+     2025-07-11. Either cut them, or move the line to Backports only ahead of the date and
+     record that here. -->
 
-<!-- TBD(TSC): the end dates below are unset. Each needs a decision before this document
-     is accurate. A line marked Active with no end date states an open-ended commitment. -->
-
-| Line | Status | Security fixes until |
-| --- | --- | --- |
-| `master` | Development. Not for production, no security support. | n/a |
-| 17.0.x | Active | TBD(TSC) |
-| 16.0.x | Active | TBD(TSC) |
-| 14.5.x | Active | TBD(TSC) |
-| 13.4.x | Backports only | TBD(TSC) |
-| 12.0.x | TBD(TSC) — no commit on `12.0-stable` since June 2025 | TBD(TSC) |
-| 11.0.x | TBD(TSC) | TBD(TSC) |
-| 10.4.x | TBD(TSC) — no commit on `10.4-stable` since July 2024 | TBD(TSC) |
+<!-- TBD(TSC): confirm that 12.0.x, 11.0.x, 10.4.x and everything older are end of life.
+     The 8.12, 9.4, 10.4, 11.0 and 12.0 lines were promoted to LTS partway through the
+     line and have no `.0-lts` release at all, so this policy sets no start date for them.
+     Their stable branches are dormant: last commit on `12.0-stable` June 2025, on
+     `10.4-stable` July 2024. -->
 
 A line absent from this table is end of life.
 

--- a/docs/RELEASE-SUPPORT.md
+++ b/docs/RELEASE-SUPPORT.md
@@ -55,22 +55,6 @@ surprising.
 | 11.0.x | `11.0.2-lts`, 2023-12-15 | 2023-11-30 | Backports only | 2025-11-30 | 2026-11-30 |
 | 10.4.x | `10.4.5-lts`, 2023-10-27 | 2023-09-30 | Backports only | 2025-09-30 | 2026-09-30 |
 
-<!-- TBD(TSC): the support-start dates for 11.0.x and 10.4.x precede the first `-lts` tag
-     on those lines and are not derivable from the releases page, so record where they come
-     from or replace them with a date that is. Every other line's date is the publication
-     date of its first `-lts` release. -->
-
-<!-- TBD(TSC): 13.4.x is Active under this policy until 2026-12-28, and the Active phase
-     promises new LTS point releases, but none has been cut since 13.4.3-lts on
-     2025-07-11. Either cut them, or move the line to Backports only ahead of the date and
-     record that here. -->
-
-<!-- TBD(TSC): 12.0.x, 11.0.x and 10.4.x are in their backport phase under this policy, but
-     the branches are not receiving backports: last commit on `12.0-stable` June 2025, on
-     `11.0-stable` January 2026, on `10.4-stable` July 2024. Either resume backporting to
-     them for the remainder of the window, or shorten the window and say so. 10.4.x runs out
-     on 2026-09-30 either way, so that one decides itself shortly. -->
-
 A line absent from this table is end of life.
 
 Fixes reach a stable branch through the backport process in
@@ -113,9 +97,5 @@ The project maintains `eve-distributors-announce@lists.lfedge.org` for vendors w
 commercially, carrying embargoed advisory information ahead of public publication so a vendor
 can prepare its own advisory and update. Membership requires a named security contact who
 agrees to hold embargoed information until the disclosure date.
-
-<!-- TBD(TSC): the list does not exist yet and has to be requested from LF Edge. Decide the
-     membership criteria and approver, the embargo agreement text, and what a member
-     receives and when. See docs/VULNERABILITY-HANDLING.md, "Vendor pre-notification". -->
 
 To request membership, contact [eve-security@lists.lfedge.org](mailto:eve-security@lists.lfedge.org).

--- a/docs/RELEASE-SUPPORT.md
+++ b/docs/RELEASE-SUPPORT.md
@@ -1,0 +1,96 @@
+# Release Lines and Security Support
+
+This document states which EVE release lines receive security fixes and for how long. It is
+the authoritative source for that question, referenced from [SECURITY.md](../SECURITY.md).
+
+## How EVE releases
+
+EVE releases on a bi-weekly cadence from `master`. Each release is tagged and published on
+the GitHub releases page.
+
+Two kinds of release exist, and the GitHub prerelease flag is what distinguishes them:
+
+- **LTS releases** carry an `-lts` suffix and are published as full releases. They are cut
+  from a `<major>.<minor>-stable` branch.
+- **Agile releases** carry no suffix and are published as prereleases, as are release
+  candidates.
+
+The flag is load-bearing rather than cosmetic: because only `-lts` tags are full releases,
+`https://github.com/lf-edge/eve/releases/latest` always resolves to the current LTS, which is
+what the README points production users at. A newer agile release is normal and does not mean
+the LTS is behind.
+
+The consequence for security support is that the releases page cannot answer "is this line
+still supported". It records what was published, not what is maintained. Use the table below.
+
+## Support status by line
+
+Status values:
+
+- **Active** — receives security fixes and new LTS point releases.
+- **Backports only** — receives security fixes on the stable branch, but no new release is
+  being cut; consumers build from the branch or move to an active line.
+- **End of life** — receives no fixes. Existing artifacts remain downloadable.
+
+<!-- TBD(TSC): the end dates below are unset. Each needs a decision before this document
+     is accurate. A line marked Active with no end date states an open-ended commitment. -->
+
+| Line | Status | Security fixes until |
+| --- | --- | --- |
+| `master` | Development. Not for production, no security support. | n/a |
+| 17.0.x | Active | TBD(TSC) |
+| 16.0.x | Active | TBD(TSC) |
+| 14.5.x | Active | TBD(TSC) |
+| 13.4.x | Backports only | TBD(TSC) |
+| 12.0.x | TBD(TSC) — no commit on `12.0-stable` since June 2025 | TBD(TSC) |
+| 11.0.x | TBD(TSC) | TBD(TSC) |
+| 10.4.x | TBD(TSC) — no commit on `10.4-stable` since July 2024 | TBD(TSC) |
+
+A line absent from this table is end of life.
+
+Fixes reach a stable branch through the backport process in
+[CONTRIBUTING.md](../CONTRIBUTING.md#backporting).
+
+## Artifact and update availability
+
+Release artifacts published to the GitHub releases page are not deleted when a line reaches
+end of life, so an operator can still obtain the last build of an unsupported line. Continued
+availability is not security support: no further fixes are issued for that line.
+
+The SBoM and the corresponding sources for a release are described in
+[SBOM-AND-SOURCES.md](SBOM-AND-SOURCES.md).
+
+## For downstream vendors
+
+A vendor shipping an EVE-based product is a manufacturer under Regulation (EU) 2024/2847 and
+owes its own users a support period, a vulnerability-reporting contact, and security updates.
+Those obligations sit with the vendor. This project supplies the inputs a vendor needs to
+meet them, and nothing here is a commitment made to the vendor's customers.
+
+Three points are worth stating explicitly, because vendors have read the project's own table
+as if it were their support commitment:
+
+- **The support end dates above are the project's, not yours.** A vendor's support period is
+  set by the vendor, based on how long its product is expected to be in use. It may be longer
+  than the upstream line's, in which case the vendor carries the fixes itself once the
+  upstream line ends.
+- **Keeping issued updates available is a separate duty from maintaining a line.** A vendor
+  must keep each security update it has shipped retrievable by its users well after the
+  update was issued, whether or not the corresponding EVE line is still maintained.
+- **Reporting deadlines run from the vendor's own awareness.** An actively exploited
+  vulnerability obliges the vendor to notify its national CSIRT and ENISA on a short clock.
+  The project's acknowledgment SLA in [SECURITY.md](../SECURITY.md) is a different and
+  unrelated commitment, and meeting it does not discharge the vendor's deadline.
+
+### Pre-notification list
+
+The project maintains a list for vendors who ship EVE commercially, carrying embargoed
+advisory information ahead of public publication so a vendor can prepare its own advisory and
+update. Membership requires a named security contact who agrees to hold embargoed information
+until the disclosure date.
+
+<!-- TBD(TSC): the list does not exist yet. Decide the intake address, the membership
+     criteria and approver, the embargo agreement text, and what a member receives and when.
+     See docs/VULNERABILITY-HANDLING.md, "Vendor pre-notification". -->
+
+To request membership, contact [eve-security@lists.lfedge.org](mailto:eve-security@lists.lfedge.org).

--- a/docs/RELEASE-SUPPORT.md
+++ b/docs/RELEASE-SUPPORT.md
@@ -25,8 +25,8 @@ still supported". It records what was published, not what is maintained. Use the
 
 ## How long a line is supported
 
-An LTS line receives security fixes for **36 months** from the date its first
-`<major>.<minor>.0-lts` release was published, in two phases:
+An LTS line receives security fixes for **36 months** from the date its first `-lts`
+release was published, in two phases:
 
 - **Active**, for the first 24 months — security fixes and new LTS point releases.
 - **Backports only**, for the following 12 months — security fixes land on the stable
@@ -36,30 +36,40 @@ An LTS line receives security fixes for **36 months** from the date its first
 After that the line is **end of life** and receives no fixes. Existing artifacts remain
 downloadable.
 
-The clock starts at the first `.0-lts` release rather than at the branch cut or the first
-release candidate, so every date below is derived from a published release a downstream
-vendor can check.
+The clock starts at a published release rather than at the branch cut or the first release
+candidate, so a downstream vendor can check every date below against the releases page. From
+13.4 onward a line's first `-lts` release is its `<major>.<minor>.0-lts`; the older lines
+were promoted to LTS partway through and start at the first `-lts` tag they carry.
 
 ## Support status by line
 
-| Line | First `.0-lts` | Status | Active until | Backports until |
+| Line | First `-lts` release | Status | Active until | Backports until |
 | --- | --- | --- | --- | --- |
 | `master` | n/a | Development. Not for production, no security support. | n/a | n/a |
-| 17.0.x | 2026-07-27 | Active | 2028-07-27 | 2029-07-27 |
-| 16.0.x | 2026-01-07 | Active | 2028-01-07 | 2029-01-07 |
-| 14.5.x | 2025-06-18 | Active | 2027-06-18 | 2028-06-18 |
-| 13.4.x | 2024-12-28 | Active | 2026-12-28 | 2027-12-28 |
+| 17.0.x | `17.0.0-lts`, 2026-07-27 | Active | 2028-07-27 | 2029-07-27 |
+| 16.0.x | `16.0.0-lts`, 2026-01-07 | Active | 2028-01-07 | 2029-01-07 |
+| 14.5.x | `14.5.0-lts`, 2025-06-18 | Active | 2027-06-18 | 2028-06-18 |
+| 13.4.x | `13.4.0-lts`, 2024-12-28 | Active | 2026-12-28 | 2027-12-28 |
+| 12.0.x | `12.0.2-lts`, 2024-06-12 | Backports only | 2026-06-12 | 2027-06-12 |
+| 11.0.x | `11.0.2-lts`, 2023-12-15 | Backports only | 2025-12-15 | 2026-12-15 |
+| 10.4.x | `10.4.6-lts`, 2023-10-27 | Backports only | 2025-10-27 | 2026-10-27 |
 
 <!-- TBD(TSC): 13.4.x is Active under this policy until 2026-12-28, and the Active phase
      promises new LTS point releases, but none has been cut since 13.4.3-lts on
      2025-07-11. Either cut them, or move the line to Backports only ahead of the date and
      record that here. -->
 
-<!-- TBD(TSC): confirm that 12.0.x, 11.0.x, 10.4.x and everything older are end of life.
-     The 8.12, 9.4, 10.4, 11.0 and 12.0 lines were promoted to LTS partway through the
-     line and have no `.0-lts` release at all, so this policy sets no start date for them.
-     Their stable branches are dormant: last commit on `12.0-stable` June 2025, on
-     `10.4-stable` July 2024. -->
+<!-- TBD(TSC): 12.0.x, 11.0.x and 10.4.x are in their backport phase under this policy, but
+     the branches are not receiving backports: last commit on `12.0-stable` June 2025, on
+     `11.0-stable` January 2026, on `10.4-stable` July 2024. Either resume backporting to
+     them for the remainder of the window, or shorten the window and say so. Declaring them
+     end of life is not free: ZEDEDA publishes limited support for all three, to 2027-06-12,
+     2026-11-30 and 2026-09-30 respectively. -->
+
+<!-- TBD(TSC): the dates above are derived from the lf-edge/eve releases page. ZEDEDA's
+     published LTS matrix agrees exactly for 12.0.x through 16.0.x, but dates 17.0.x one day
+     later (2026-07-28) and uses GA dates for 11.0.x (2023-11-30) and 10.4.x (2023-09-30)
+     that no EVE release carries. Decide whether to align the two tables. -->
 
 A line absent from this table is end of life.
 

--- a/docs/RELEASE-SUPPORT.md
+++ b/docs/RELEASE-SUPPORT.md
@@ -99,13 +99,13 @@ as if it were their support commitment:
 
 ### Pre-notification list
 
-The project maintains a list for vendors who ship EVE commercially, carrying embargoed
-advisory information ahead of public publication so a vendor can prepare its own advisory and
-update. Membership requires a named security contact who agrees to hold embargoed information
-until the disclosure date.
+The project maintains `eve-distributors-announce@lists.lfedge.org` for vendors who ship EVE
+commercially, carrying embargoed advisory information ahead of public publication so a vendor
+can prepare its own advisory and update. Membership requires a named security contact who
+agrees to hold embargoed information until the disclosure date.
 
-<!-- TBD(TSC): the list does not exist yet. Decide the intake address, the membership
-     criteria and approver, the embargo agreement text, and what a member receives and when.
-     See docs/VULNERABILITY-HANDLING.md, "Vendor pre-notification". -->
+<!-- TBD(TSC): the list does not exist yet and has to be requested from LF Edge. Decide the
+     membership criteria and approver, the embargo agreement text, and what a member
+     receives and when. See docs/VULNERABILITY-HANDLING.md, "Vendor pre-notification". -->
 
 To request membership, contact [eve-security@lists.lfedge.org](mailto:eve-security@lists.lfedge.org).

--- a/docs/RELEASE-SUPPORT.md
+++ b/docs/RELEASE-SUPPORT.md
@@ -25,8 +25,8 @@ still supported". It records what was published, not what is maintained. Use the
 
 ## How long a line is supported
 
-An LTS line receives security fixes for **36 months** from the date its first `-lts`
-release was published, in two phases:
+An LTS line receives security fixes for **36 months** from the date the line became
+generally available, in two phases:
 
 - **Active**, for the first 24 months — security fixes and new LTS point releases.
 - **Backports only**, for the following 12 months — security fixes land on the stable
@@ -36,23 +36,28 @@ release was published, in two phases:
 After that the line is **end of life** and receives no fixes. Existing artifacts remain
 downloadable.
 
-The clock starts at a published release rather than at the branch cut or the first release
-candidate, so a downstream vendor can check every date below against the releases page. From
-13.4 onward a line's first `-lts` release is its `<major>.<minor>.0-lts`; the older lines
-were promoted to LTS partway through and start at the first `-lts` tag they carry.
+The support-start dates below are the general-availability dates of the LTS lines, which for
+12.0 onward are the dates the line's first `-lts` release was published. The 11.0 and 10.4
+lines were promoted to LTS partway through, and became generally available before the first
+`-lts` tag they carry; both dates are given so the difference is visible rather than
+surprising.
 
 ## Support status by line
 
-| Line | First `-lts` release | Status | Active until | Backports until |
-| --- | --- | --- | --- | --- |
-| `master` | n/a | Development. Not for production, no security support. | n/a | n/a |
-| 17.0.x | `17.0.0-lts`, 2026-07-27 | Active | 2028-07-27 | 2029-07-27 |
-| 16.0.x | `16.0.0-lts`, 2026-01-07 | Active | 2028-01-07 | 2029-01-07 |
-| 14.5.x | `14.5.0-lts`, 2025-06-18 | Active | 2027-06-18 | 2028-06-18 |
-| 13.4.x | `13.4.0-lts`, 2024-12-28 | Active | 2026-12-28 | 2027-12-28 |
-| 12.0.x | `12.0.2-lts`, 2024-06-12 | Backports only | 2026-06-12 | 2027-06-12 |
-| 11.0.x | `11.0.2-lts`, 2023-12-15 | Backports only | 2025-12-15 | 2026-12-15 |
-| 10.4.x | `10.4.6-lts`, 2023-10-27 | Backports only | 2025-10-27 | 2026-10-27 |
+| Line | First `-lts` release | Support start | Status | Active until | Backports until |
+| --- | --- | --- | --- | --- | --- |
+| `master` | n/a | n/a | Development. Not for production, no security support. | n/a | n/a |
+| 17.0.x | `17.0.0-lts`, 2026-07-27 | 2026-07-28 | Active | 2028-07-28 | 2029-07-28 |
+| 16.0.x | `16.0.0-lts`, 2026-01-07 | 2026-01-07 | Active | 2028-01-07 | 2029-01-07 |
+| 14.5.x | `14.5.0-lts`, 2025-06-18 | 2025-06-18 | Active | 2027-06-18 | 2028-06-18 |
+| 13.4.x | `13.4.0-lts`, 2024-12-28 | 2024-12-28 | Active | 2026-12-28 | 2027-12-28 |
+| 12.0.x | `12.0.2-lts`, 2024-06-12 | 2024-06-12 | Backports only | 2026-06-12 | 2027-06-12 |
+| 11.0.x | `11.0.2-lts`, 2023-12-15 | 2023-11-30 | Backports only | 2025-11-30 | 2026-11-30 |
+| 10.4.x | `10.4.5-lts`, 2023-10-27 | 2023-09-30 | Backports only | 2025-09-30 | 2026-09-30 |
+
+<!-- These dates match the EVE-OS LTS supportability matrix ZEDEDA publishes to its
+     customers, deliberately, so that the project's table and the one vendors already read
+     cannot drift apart. Anything that changes a date here has to change there too. -->
 
 <!-- TBD(TSC): 13.4.x is Active under this policy until 2026-12-28, and the Active phase
      promises new LTS point releases, but none has been cut since 13.4.3-lts on
@@ -62,14 +67,8 @@ were promoted to LTS partway through and start at the first `-lts` tag they carr
 <!-- TBD(TSC): 12.0.x, 11.0.x and 10.4.x are in their backport phase under this policy, but
      the branches are not receiving backports: last commit on `12.0-stable` June 2025, on
      `11.0-stable` January 2026, on `10.4-stable` July 2024. Either resume backporting to
-     them for the remainder of the window, or shorten the window and say so. Declaring them
-     end of life is not free: ZEDEDA publishes limited support for all three, to 2027-06-12,
-     2026-11-30 and 2026-09-30 respectively. -->
-
-<!-- TBD(TSC): the dates above are derived from the lf-edge/eve releases page. ZEDEDA's
-     published LTS matrix agrees exactly for 12.0.x through 16.0.x, but dates 17.0.x one day
-     later (2026-07-28) and uses GA dates for 11.0.x (2023-11-30) and 10.4.x (2023-09-30)
-     that no EVE release carries. Decide whether to align the two tables. -->
+     them for the remainder of the window, or shorten the window and say so. 10.4.x runs out
+     on 2026-09-30 either way, so that one decides itself shortly. -->
 
 A line absent from this table is end of life.
 

--- a/docs/RELEASE-SUPPORT.md
+++ b/docs/RELEASE-SUPPORT.md
@@ -96,9 +96,10 @@ as if it were their support commitment:
 ### Pre-notification list
 
 The project maintains `eve-distributors-announce@lists.lfedge.org` for vendors who ship EVE
-commercially, carrying embargoed advisory information ahead of public publication so a vendor
-can prepare its own advisory and update. Membership requires a named security contact who
-agrees to hold embargoed information until the disclosure date.
+commercially. Members receive the advisory and the patch **two weeks** before publication, so
+they can have their own advisory and update ready on the day. Membership requires a named
+security contact who agrees to hold embargoed information — including the patch and anything
+built from it — until the disclosure date.
 
 For an actively exploited vulnerability the list is notified on the clock Regulation (EU)
 2024/2847 Art 14 sets — an early warning inside 24 hours, a fuller notification inside 72 —

--- a/docs/RELEASE-SUPPORT.md
+++ b/docs/RELEASE-SUPPORT.md
@@ -88,8 +88,10 @@ as if it were their support commitment:
   update was issued, whether or not the corresponding EVE line is still maintained.
 - **Reporting deadlines run from the vendor's own awareness.** An actively exploited
   vulnerability obliges the vendor to notify its national CSIRT and ENISA on a short clock.
-  The project's acknowledgment SLA in [SECURITY.md](../SECURITY.md) is a different and
-  unrelated commitment, and meeting it does not discharge the vendor's deadline.
+  The project's triage window in [SECURITY.md](../SECURITY.md) is a separate commitment and
+  meeting it does not discharge the vendor's deadline. Note that the window is longer than
+  the clock: a vendor that waits for the project to confirm a report before filing its own
+  early warning will miss the deadline.
 
 ### Pre-notification list
 

--- a/docs/RELEASE-SUPPORT.md
+++ b/docs/RELEASE-SUPPORT.md
@@ -55,9 +55,10 @@ surprising.
 | 11.0.x | `11.0.2-lts`, 2023-12-15 | 2023-11-30 | Backports only | 2025-11-30 | 2026-11-30 |
 | 10.4.x | `10.4.5-lts`, 2023-10-27 | 2023-09-30 | Backports only | 2025-09-30 | 2026-09-30 |
 
-<!-- These dates match the EVE-OS LTS supportability matrix ZEDEDA publishes to its
-     customers, deliberately, so that the project's table and the one vendors already read
-     cannot drift apart. Anything that changes a date here has to change there too. -->
+<!-- TBD(TSC): the support-start dates for 11.0.x and 10.4.x precede the first `-lts` tag
+     on those lines and are not derivable from the releases page, so record where they come
+     from or replace them with a date that is. Every other line's date is the publication
+     date of its first `-lts` release. -->
 
 <!-- TBD(TSC): 13.4.x is Active under this policy until 2026-12-28, and the Active phase
      promises new LTS point releases, but none has been cut since 13.4.3-lts on

--- a/docs/VULNERABILITY-HANDLING.md
+++ b/docs/VULNERABILITY-HANDLING.md
@@ -1,0 +1,180 @@
+# Vulnerability Handling Policy
+
+How the EVE security team handles a vulnerability report, from intake to published advisory.
+[SECURITY.md](../SECURITY.md) tells a reporter what to do; this document tells the project
+what it does in response, so that a reporter, a downstream vendor, or a regulator can see the
+process rather than infer it.
+
+This is a process document. It does not add reporting channels: report vulnerabilities as
+described in [SECURITY.md](../SECURITY.md).
+
+## Security team
+
+Reports arrive at `eve-security@lists.lfedge.org` and at GitHub private vulnerability
+reporting on `lf-edge/eve`. Both are read by the security team.
+
+<!-- TBD(TSC): name the team. The guidance the project is following recommends 3-7 members
+     with a mix of security, engineering and release experience, at least two of whom hold
+     the GitHub permission needed to create and publish a repository security advisory.
+     Record members by role and GitHub handle here, and keep a separate internal alias for
+     team coordination distinct from the reporter-facing intake address. -->
+
+Members are listed with their affiliation so a reporter can see who receives an embargoed
+report before sending one. Membership changes are announced on the
+[EVE mailing list](https://lists.lfedge.org/g/eve).
+
+The team is reachable during business days across at least two time zones so that a report
+does not wait on one person's availability.
+
+## Intake and acknowledgment
+
+Every report is acknowledged within 24 hours, with a tracking reference. Acknowledgment
+confirms a human has the report; it carries no assessment yet.
+
+A report that turns out not to be a vulnerability is closed with a written reason sent to the
+reporter. A report that describes a bug without security impact is redirected to the public
+issue tracker, with the reporter's agreement.
+
+## Triage
+
+Within <!-- TBD(TSC) --> working days of acknowledgment the team determines:
+
+- whether the issue is a vulnerability in EVE, in a packaged third-party component, or in a
+  controller;
+- which release lines are affected, per [RELEASE-SUPPORT.md](RELEASE-SUPPORT.md);
+- a severity, using CVSS v3.1 base metrics plus a statement of the exploitation conditions,
+  because a base score alone tends to misrepresent an edge appliance whose attack surface
+  depends heavily on deployment;
+- whether the vulnerability is being actively exploited, which changes the handling path (see
+  "Actively exploited vulnerabilities").
+
+A GitHub repository security advisory is opened in draft at triage, and becomes the record
+for the issue. Every report gets one, including reports that are ultimately rejected, so the
+queue reflects the full set of things the project was told.
+
+## Remediation targets
+
+Measured from triage, for supported lines:
+
+<!-- TBD(TSC): set these. They are the project's commitment and the thing a downstream vendor
+     plans against, so unset targets make the rest of this document unenforceable. -->
+
+| Severity | Fix on `master` | Backport to supported lines |
+| --- | --- | --- |
+| Critical | TBD(TSC) | TBD(TSC) |
+| High | TBD(TSC) | TBD(TSC) |
+| Medium | TBD(TSC) | TBD(TSC) |
+| Low | TBD(TSC) | TBD(TSC) |
+
+A target the team expects to miss is communicated to the reporter, and to the
+pre-notification list, before it is missed rather than after.
+
+## Patch development
+
+Work on an unpublished vulnerability happens in the private fork GitHub creates for the draft
+advisory, not in a branch on `lf-edge/eve` and not in a contributor's public fork. A commit
+pushed to a public branch ends the embargo whether or not an advisory has been published.
+
+Fixes land on `master` first, then reach supported lines through the backport process in
+[CONTRIBUTING.md](../CONTRIBUTING.md#backporting). Where possible a security fix is a separate
+commit from any functional change, so that a vendor maintaining its own line can take the fix
+alone.
+
+Tests that demonstrate the vulnerability are merged with the fix. Where publishing the test
+would function as an exploit before operators have upgraded, it is held with the advisory and
+merged at disclosure.
+
+## CVE assignment
+
+A CVE identifier is requested for any vulnerability in released EVE code rated medium or
+above, and for any vulnerability at any severity where a downstream vendor needs an
+identifier to reference in its own advisory. Requesting one for a low-severity issue is never
+wrong.
+
+<!-- TBD(TSC): record the CNA path. Either the project requests IDs through GitHub as a CNA
+     for advisories it publishes on lf-edge/eve, or it establishes a CNA of last resort
+     contact. Name which, so the team does not rediscover it under time pressure. -->
+
+The identifier is attached to the advisory before publication so that the advisory, the
+release notes, and the vendor advisories all reference the same ID.
+
+## Embargo and vendor pre-notification
+
+The default embargo runs until a fix is available on all supported lines, and in any case no
+longer than the 90-day disclosure timeline in [SECURITY.md](../SECURITY.md).
+
+During embargo, information is shared with: the reporter; the security team; the maintainers
+needed to develop and review the fix; the upstream project, where the vulnerability is in a
+packaged component; and the vendor pre-notification list.
+
+### Vendor pre-notification
+
+Vendors on the pre-notification list receive the advisory content, the affected and fixed
+versions, and the planned publication date, ahead of publication, so they can prepare their
+own advisory and update.
+
+<!-- TBD(TSC): decide the lead time. It has to be long enough for a vendor to build, test and
+     stage an update, and short enough that the exposure window does not grow. Decide also
+     whether the pre-notification carries the patch or only the description. -->
+
+Adding a vendor to the list widens the set of people holding an embargoed vulnerability, so
+membership is approved individually and carries a named contact who has agreed in writing to
+hold the information. Membership criteria are in
+[RELEASE-SUPPORT.md](RELEASE-SUPPORT.md#pre-notification-list).
+
+## Disclosure and publication
+
+At disclosure the team publishes the GitHub advisory, announces it on the
+[EVE mailing list](https://lists.lfedge.org/g/eve), and references it from the release notes
+of every release that carries the fix.
+
+The advisory states the description, the affected versions, the fixed versions, the severity
+and its basis, the impact, the mitigation available to operators who cannot upgrade
+immediately, and credit to the reporter unless the reporter asked to stay anonymous.
+
+Publication is not deferred past the availability of a fix. Where the team judges that
+publishing detail would put operators at more risk than it removes, the advisory is published
+with the description and affected versions on schedule and the exploitation detail follows
+once operators have had the opportunity to upgrade. The advisory says that detail is being
+held and when it is expected.
+
+Every draft advisory reaches one of three end states: published, or closed with a written
+reason, or explicitly embargoed with a date recorded on it. A draft left in neither state is
+a defect in this process, not a neutral holding position, because it makes the queue useless
+as a record of what the project knew and when.
+
+## Actively exploited vulnerabilities
+
+A vulnerability under active exploitation is handled ahead of the queue regardless of
+severity, and the team:
+
+1. notifies the pre-notification list immediately, with whatever is known, rather than
+   waiting for a complete assessment;
+2. publishes an advisory as soon as operators have an action to take, which may be a
+   mitigation rather than a fix;
+3. records when the project became aware, and of what, because downstream vendors have
+   reporting deadlines that run from their own awareness and will need to establish it.
+
+Downstream vendors, not this project, notify national CSIRTs and ENISA about vulnerabilities
+in their products. The project's obligation is to give vendors what they need, fast enough
+to be useful.
+
+<!-- TBD(TSC/LF counsel): whether the Linux Foundation is an open-source software steward for
+     EVE under Regulation (EU) 2024/2847 Art 3(14), and if so what the steward itself must
+     report under Art 24(3), is a legal question and not settled here. This document is
+     written so that the process works either way. -->
+
+## Records
+
+The team keeps, for each report: when it arrived, when it was acknowledged, the triage
+outcome and severity basis, the fix commits and the releases carrying them, who held
+embargoed information, the publication date, and the reason for any missed target. The GitHub
+advisory holds most of this; anything it cannot hold is recorded alongside it.
+
+These records are what the project can produce if a market surveillance authority asks how
+vulnerabilities in EVE are handled, and they are worth keeping for that reason alone.
+
+## Reviewing this policy
+
+The security team reviews this document annually, and after any incident that the process
+handled badly. Changes go through the normal pull request process so the history is public.

--- a/docs/VULNERABILITY-HANDLING.md
+++ b/docs/VULNERABILITY-HANDLING.md
@@ -109,13 +109,18 @@ packaged component; and the vendor pre-notification list.
 
 ### Vendor pre-notification
 
-Vendors on the pre-notification list receive the advisory content, the affected and fixed
-versions, and the planned publication date, ahead of publication, so they can prepare their
-own advisory and update.
+Vendors on the pre-notification list, `eve-distributors-announce@lists.lfedge.org`, receive
+the advisory content, the affected and fixed versions, and the planned publication date,
+ahead of publication, so they can prepare their own advisory and update.
 
 <!-- TBD(TSC): decide the lead time. It has to be long enough for a vendor to build, test and
      stage an update, and short enough that the exposure window does not grow. Decide also
      whether the pre-notification carries the patch or only the description. -->
+
+<!-- TBD(TSC): neither eve-distributors-announce@lists.lfedge.org nor
+     eve-security-announce@lists.lfedge.org exists yet; both have to be requested from LF
+     Edge. Until they do, the general EVE mailing list at https://lists.lfedge.org/g/eve is
+     the only announcement channel and there is no embargoed vendor channel at all. -->
 
 Adding a vendor to the list widens the set of people holding an embargoed vulnerability, so
 membership is approved individually and carries a named contact who has agreed in writing to
@@ -124,9 +129,9 @@ hold the information. Membership criteria are in
 
 ## Disclosure and publication
 
-At disclosure the team publishes the GitHub advisory, announces it on the
-[EVE mailing list](https://lists.lfedge.org/g/eve), and references it from the release notes
-of every release that carries the fix.
+At disclosure the team publishes the GitHub advisory, announces it on
+`eve-security-announce@lists.lfedge.org`, and references it from the release notes of every
+release that carries the fix.
 
 The advisory states the description, the affected versions, the fixed versions, the severity
 and its basis, the impact, the mitigation available to operators who cannot upgrade

--- a/docs/VULNERABILITY-HANDLING.md
+++ b/docs/VULNERABILITY-HANDLING.md
@@ -140,6 +140,10 @@ Vendors on the pre-notification list, `eve-distributors-announce@lists.lfedge.or
 the advisory content, the affected and fixed versions, and the planned publication date,
 ahead of publication, so they can prepare their own advisory and update.
 
+That applies to a planned disclosure. An actively exploited vulnerability displaces it: the
+list is notified on the CRA clock, in step with the steward, because the vendors on it carry
+their own reporting deadlines. See "Actively exploited vulnerabilities".
+
 <!-- TBD(TSC): decide the lead time. It has to be long enough for a vendor to build, test and
      stage an update, and short enough that the exposure window does not grow. Decide also
      whether the pre-notification carries the patch or only the description. -->
@@ -177,17 +181,29 @@ as a record of what the project knew and when.
 
 ## Actively exploited vulnerabilities
 
-A vulnerability under active exploitation is handled ahead of the queue regardless of
-severity, and the team:
+A vulnerability under active exploitation does not follow the severity path above. It is
+handled ahead of the queue regardless of severity, and the process follows the reporting
+requirements of Regulation (EU) 2024/2847 Art 14 rather than any timetable of the project's
+own: an early warning within 24 hours of awareness, a fuller notification within 72, and a
+final report once a fix or mitigation is available. The steward files those reports; what the
+project owes is the information they need, early enough to be filed on time.
+
+On that basis the team:
 
 1. notifies the CRA steward at `steward@linuxfoundation.org` immediately, before triage is
    complete and with whatever is known at the time;
-2. notifies the pre-notification list immediately, with whatever is known, rather than
-   waiting for a complete assessment;
+2. notifies the pre-notification list on the same clock, and with the same cascade — the
+   early warning inside 24 hours and the fuller picture inside 72 — rather than the lead time
+   a planned disclosure gets. A vendor shipping EVE has its own Art 14 deadlines running from
+   its own awareness, and it cannot meet them on information the project is still sitting on;
 3. publishes an advisory as soon as operators have an action to take, which may be a
    mitigation rather than a fix;
 4. records when the project became aware, and of what, because both the steward's and the
    vendors' reporting deadlines run from an awareness that has to be established.
+
+Each of those notifications goes out on what is known at the time. Waiting for a complete
+assessment is how a 24-hour deadline is missed; an early warning that says only what is
+confirmed and what is still unknown discharges it.
 
 The same escalation applies to a severe incident affecting the project's own development
 infrastructure, a compromise of the release process being the case to watch for. Escalate

--- a/docs/VULNERABILITY-HANDLING.md
+++ b/docs/VULNERABILITY-HANDLING.md
@@ -56,33 +56,43 @@ A GitHub repository security advisory is opened in draft at triage, and becomes 
 for the issue. Every report gets one, including reports that are ultimately rejected, so the
 queue reflects the full set of things the project was told.
 
-## Remediation targets
+## What each severity commits the project to
 
-Measured from triage, for supported lines:
+EVE is developed in the open and `master` is built every two weeks, so a fix that lands on
+`master` is disclosed whether or not an advisory has been published. Severity therefore
+decides two things: whether the fix is developed under embargo or in public, and which
+release carries it.
 
-<!-- TBD(TSC): set these. They are the project's commitment and the thing a downstream vendor
-     plans against, so unset targets make the rest of this document unenforceable. -->
-
-| Severity | Fix on `master` | Backport to supported lines |
+| Severity | Fix developed | Release |
 | --- | --- | --- |
-| Critical | TBD(TSC) | TBD(TSC) |
-| High | TBD(TSC) | TBD(TSC) |
-| Medium | TBD(TSC) | TBD(TSC) |
-| Low | TBD(TSC) | TBD(TSC) |
+| Critical | Under embargo, in the advisory's private fork | Triggers a point release on every supported line. Addressed as soon as possible. |
+| High | Under embargo, in the advisory's private fork | Triggers a point release on every supported line. The embargo is kept to a minimum; the aim is no longer than a month. |
+| Moderate | Under embargo, in the advisory's private fork | The fix and the advisory are published together; the backport rides the next scheduled point release on each supported line rather than triggering one. |
+| Low | In public on `master`, reviewed as an ordinary change | Reaches users on the ordinary release cadence, and supported lines through the normal backport process. |
 
-A target the team expects to miss is communicated to the reporter, and to the
+Severity is the starting point, not a rule that overrides judgment. A Moderate issue that is
+trivially exploitable in a common deployment is handled as High, and the reasoning is recorded
+on the advisory.
+
+Nothing is held back waiting for a release to roll several fixes together. Holding a fix out
+of a public `master` costs the embargo the moment anyone notices the gap, and with a two-week
+cadence there is nothing to gain by it.
+
+A commitment the team expects to miss is communicated to the reporter, and to the
 pre-notification list, before it is missed rather than after.
 
 ## Patch development
 
-Work on an unpublished vulnerability happens in the private fork GitHub creates for the draft
+Work on an embargoed vulnerability happens in the private fork GitHub creates for the draft
 advisory, not in a branch on `lf-edge/eve` and not in a contributor's public fork. A commit
-pushed to a public branch ends the embargo whether or not an advisory has been published.
+pushed to a public branch ends the embargo whether or not an advisory has been published. A
+low-severity fix is developed in public instead, as an ordinary change, because an embargo it
+does not need costs review attention it would otherwise get.
 
-Fixes land on `master` first, then reach supported lines through the backport process in
-[CONTRIBUTING.md](../CONTRIBUTING.md#backporting). Where possible a security fix is a separate
-commit from any functional change, so that a vendor maintaining its own line can take the fix
-alone.
+`master` carries the canonical fix and supported lines follow through the backport process in
+[CONTRIBUTING.md](../CONTRIBUTING.md#backporting); for an embargoed fix the two land together
+at disclosure rather than in sequence. Where possible a security fix is a separate commit from
+any functional change, so that a vendor maintaining its own line can take the fix alone.
 
 Tests that demonstrate the vulnerability are merged with the fix. Where publishing the test
 would function as an exploit before operators have upgraded, it is held with the advisory and
@@ -114,8 +124,11 @@ release notes, and the vendor advisories all reference the same ID.
 
 ## Embargo and vendor pre-notification
 
-The default embargo runs until a fix is available on all supported lines, and in any case no
-longer than the 90-day disclosure timeline in [SECURITY.md](../SECURITY.md).
+The default embargo runs until the release that carries the fix is available, and in any case
+no longer than the 90-day disclosure timeline in [SECURITY.md](../SECURITY.md). For a
+Critical or High issue that means a point release on every supported line; for a Moderate one
+it means the fix on `master`, with the stable backports following on the ordinary cadence, so
+the advisory has to give operators of those lines a mitigation they can apply meanwhile.
 
 During embargo, information is shared with: the reporter; the security team; the maintainers
 needed to develop and review the fix; the upstream project, where the vulnerability is in a

--- a/docs/VULNERABILITY-HANDLING.md
+++ b/docs/VULNERABILITY-HANDLING.md
@@ -138,15 +138,20 @@ packaged component; and the vendor pre-notification list.
 
 Vendors on the pre-notification list, `eve-distributors-announce@lists.lfedge.org`, receive
 the advisory content, the affected and fixed versions, and the planned publication date,
-ahead of publication, so they can prepare their own advisory and update.
+**two weeks** before that date, so they can prepare their own advisory and update.
 
-That applies to a planned disclosure. An actively exploited vulnerability displaces it: the
-list is notified on the CRA clock, in step with the steward, because the vendors on it carry
-their own reporting deadlines. See "Actively exploited vulnerabilities".
+The two weeks run from patch availability, not from triage. A lead time measured from triage
+would be spent waiting for a fix that does not exist yet, which is no use to a vendor who
+needs to build and test one.
 
-<!-- TBD(TSC): decide the lead time. It has to be long enough for a vendor to build, test and
-     stage an update, and short enough that the exposure window does not grow. Decide also
-     whether the pre-notification carries the patch or only the description. -->
+The pre-notification carries the patch, not only a description. A vendor that has to
+reconstruct a fix from prose cannot have an update ready on disclosure day, which is the
+whole point of the list. The patch and any binaries built from it are inside the embargo:
+shipping a build before the publication date breaks it as surely as pushing the commit does.
+
+All of that describes a planned disclosure. An actively exploited vulnerability displaces it:
+the list is notified on the CRA clock, in step with the steward, because the vendors on it
+carry their own reporting deadlines. See "Actively exploited vulnerabilities".
 
 <!-- TBD(TSC): neither eve-distributors-announce@lists.lfedge.org nor
      eve-security-announce@lists.lfedge.org exists yet; both have to be requested from LF

--- a/docs/VULNERABILITY-HANDLING.md
+++ b/docs/VULNERABILITY-HANDLING.md
@@ -28,8 +28,12 @@ does not wait on one person's availability.
 
 ## Intake and acknowledgment
 
-Every report is acknowledged within 24 hours, with a tracking reference. Acknowledgment
-confirms a human has the report; it carries no assessment yet.
+Every report is acknowledged within 3 business days of arrival, with a tracking reference,
+and the triage below is completed in the same window.
+
+That window is a ceiling for the ordinary case, not a queue to wait in. A report flagged as
+actively exploited is taken up when it arrives, because the steward's reporting clock starts
+at the project's awareness and not at its convenience.
 
 A report that turns out not to be a vulnerability is closed with a written reason sent to the
 reporter. A report that describes a bug without security impact is redirected to the public
@@ -37,7 +41,7 @@ issue tracker, with the reporter's agreement.
 
 ## Triage
 
-Within <!-- TBD(TSC) --> working days of acknowledgment the team determines:
+Within the same 3 business days the team determines:
 
 - whether the issue is a vulnerability in EVE, in a packaged third-party component, or in a
   controller;

--- a/docs/VULNERABILITY-HANDLING.md
+++ b/docs/VULNERABILITY-HANDLING.md
@@ -148,21 +148,36 @@ as a record of what the project knew and when.
 A vulnerability under active exploitation is handled ahead of the queue regardless of
 severity, and the team:
 
-1. notifies the pre-notification list immediately, with whatever is known, rather than
+1. notifies the CRA steward's contact immediately, before triage is complete and with
+   whatever is known at the time;
+2. notifies the pre-notification list immediately, with whatever is known, rather than
    waiting for a complete assessment;
-2. publishes an advisory as soon as operators have an action to take, which may be a
+3. publishes an advisory as soon as operators have an action to take, which may be a
    mitigation rather than a fix;
-3. records when the project became aware, and of what, because downstream vendors have
-   reporting deadlines that run from their own awareness and will need to establish it.
+4. records when the project became aware, and of what, because both the steward's and the
+   vendors' reporting deadlines run from an awareness that has to be established.
 
-Downstream vendors, not this project, notify national CSIRTs and ENISA about vulnerabilities
-in their products. The project's obligation is to give vendors what they need, fast enough
-to be useful.
+The same escalation applies to a severe incident affecting the project's own development
+infrastructure, a compromise of the release process being the case to watch for. Escalate
+while fixing the problem, never instead of fixing it.
 
-<!-- TBD(TSC/LF counsel): whether the Linux Foundation is an open-source software steward for
-     EVE under Regulation (EU) 2024/2847 Art 3(14), and if so what the steward itself must
-     report under Art 24(3), is a legal question and not settled here. This document is
-     written so that the process works either way. -->
+## Who reports to the authorities
+
+Two separate tracks, neither of which the security team runs itself:
+
+- The Linux Foundation legal entity that hosts LF Edge is EVE's CRA steward under
+  Regulation (EU) 2024/2847 Art 24. It is registered on the ENISA single reporting platform
+  and files the steward reports, so the security team's duty is to reach the steward's CRA
+  contact fast, not to file with a CSIRT or ENISA directly.
+  [SECURITY.md](../SECURITY.md) identifies the steward entity and its policy.
+- Downstream vendors notify their own national CSIRT and ENISA about vulnerabilities in
+  their products, on deadlines that run from each vendor's own awareness. The project does
+  not report on a vendor's behalf; its obligation is to give vendors what they need, fast
+  enough to be useful.
+
+<!-- TBD(TSC): record the steward's CRA escalation contact here, and who on the security team
+     holds it. A contact nobody can find at 02:00 is not a contact. Obtain it from the
+     steward named in SECURITY.md, or via support@linuxfoundation.org. -->
 
 ## Records
 

--- a/docs/VULNERABILITY-HANDLING.md
+++ b/docs/VULNERABILITY-HANDLING.md
@@ -153,8 +153,8 @@ as a record of what the project knew and when.
 A vulnerability under active exploitation is handled ahead of the queue regardless of
 severity, and the team:
 
-1. notifies the CRA steward's contact immediately, before triage is complete and with
-   whatever is known at the time;
+1. notifies the CRA steward at `steward@linuxfoundation.org` immediately, before triage is
+   complete and with whatever is known at the time;
 2. notifies the pre-notification list immediately, with whatever is known, rather than
    waiting for a complete assessment;
 3. publishes an advisory as soon as operators have an action to take, which may be a
@@ -170,19 +170,22 @@ while fixing the problem, never instead of fixing it.
 
 Two separate tracks, neither of which the security team runs itself:
 
-- The Linux Foundation legal entity that hosts LF Edge is EVE's CRA steward under
-  Regulation (EU) 2024/2847 Art 24. It is registered on the ENISA single reporting platform
-  and files the steward reports, so the security team's duty is to reach the steward's CRA
-  contact fast, not to file with a CSIRT or ENISA directly.
-  [SECURITY.md](../SECURITY.md) identifies the steward entity and its policy.
-- Downstream vendors notify their own national CSIRT and ENISA about vulnerabilities in
-  their products, on deadlines that run from each vendor's own awareness. The project does
-  not report on a vendor's behalf; its obligation is to give vendors what they need, fast
-  enough to be useful.
+- The Linux Foundation is EVE's CRA steward under Regulation (EU) 2024/2847 Art 24. It is
+  registered on the ENISA single reporting platform and files the steward reports, so the
+  security team's duty is to reach the steward fast, not to file with a CSIRT or ENISA
+  directly. **The project reports to `steward@linuxfoundation.org`.** The stewardship
+  framework is described at <https://www.linuxfoundation.org/security>.
+- Downstream vendors report vulnerabilities in their own products through the ENISA single
+  reporting platform, to the CSIRT designated as coordinator for them, on deadlines that run
+  from each vendor's own awareness. The project does not report on a vendor's behalf; its
+  obligation is to give vendors what they need, fast enough to be useful.
 
-<!-- TBD(TSC): record the steward's CRA escalation contact here, and who on the security team
-     holds it. A contact nobody can find at 02:00 is not a contact. Obtain it from the
-     steward named in SECURITY.md, or via support@linuxfoundation.org. -->
+<!-- TBD(TSC): name who on the security team is responsible for sending the steward report,
+     and their deputy. A 24-hour clock with no named owner is not staffed. -->
+
+<!-- TBD(TSC): confirm with the steward whether steward@linuxfoundation.org is monitored
+     outside EU business hours. Art 14 states its deadlines in hours and days with no
+     business-day qualification, so they run across weekends. -->
 
 ## Records
 

--- a/docs/VULNERABILITY-HANDLING.md
+++ b/docs/VULNERABILITY-HANDLING.md
@@ -91,9 +91,19 @@ above, and for any vulnerability at any severity where a downstream vendor needs
 identifier to reference in its own advisory. Requesting one for a low-severity issue is never
 wrong.
 
-<!-- TBD(TSC): record the CNA path. Either the project requests IDs through GitHub as a CNA
-     for advisories it publishes on lf-edge/eve, or it establishes a CNA of last resort
-     contact. Name which, so the team does not rediscover it under time pressure. -->
+Identifiers come from GitHub, which is a CVE Numbering Authority. The request is made from
+the draft advisory the team already opens at triage — `Request CVE` at the bottom of the
+advisory form — so there is no separate form, address or queue to find under time pressure.
+It needs admin permission on the advisory, and GitHub reviews the request within about 72
+hours.
+
+Requesting an identifier publishes nothing. The details reach the public CVE record only when
+the advisory itself is published, so the request is made early rather than held to the end of
+an embargo.
+
+Where the vulnerability is in a packaged third-party component, the identifier belongs to
+that component's own CNA and the advisory references it instead of requesting a second one.
+GitHub does not assign for a project another CNA already covers.
 
 The identifier is attached to the advisory before publication so that the advisory, the
 release notes, and the vendor advisories all reference the same ID.


### PR DESCRIPTION
# Description

**Draft: the values marked `TBD(TSC)` need project decisions before this is mergeable. See "Open decisions" below.**

The security policy answered three unrelated questions in one file, and the one it answered worst was which releases still get security fixes. A hand-maintained table in a file nobody opens during a release had drifted into marking 10.4.x and 12.0.x supported — `10.4-stable` has had no commit since July 2024 and `12.0-stable` none since June 2025. That matters beyond tidiness: a vendor shipping an EVE-based product reads that table as the upstream commitment sitting behind the support period it promises its own customers.

This splits the file three ways:

- **`SECURITY.md`** keeps only what a reporter needs: where to report, what to include, when to expect an acknowledgment, the disclosure timeline, safe harbor and testing boundaries, what is in scope, and where advisories appear.
- **`docs/RELEASE-SUPPORT.md`** becomes the authoritative statement of which lines receive security fixes, under a stated policy rather than a curated list: 24 months of active support with point releases from the date a line became generally available, then 12 months of backports on the stable branch. The dates are the LTS general-availability dates, which for 12.0 onward are the publication dates of each line's first `-lts` release. It also writes down what the GitHub prerelease flag encodes, which is currently folklore: only `-lts` tags are published as full releases, and that is what makes the `releases/latest` link in the README resolve to the current LTS rather than to the newest agile release.
- **`docs/VULNERABILITY-HANDLING.md`** describes what happens after a report arrives — triage, severity, patch development in the advisory private fork, CVE assignment, embargo and vendor pre-notification, publication, and the separate path for a vulnerability already under active exploitation. Severity decides whether a fix is developed under embargo or in public, and which release carries it, in the shape OpenSSL uses — but not OpenSSL's "kept private until the next release", which EVE cannot honour because `master` is public and built every two weeks, so a fix landing there is disclosed. Active exploitation leaves that path entirely and runs on the Art 14 clock, which the pre-notification list is now on as well. Identifiers come from GitHub as the CNA, requested from the draft advisory the team opens at triage, which is also where the advisory record lives — so the numbering authority, the embargo and the eventual publication are all one artifact rather than three systems to reconcile.

Moving the version list out of `SECURITY.md` follows what projects that keep their policy current do. Kubernetes, Istio and Moby all keep a "Supported Versions" heading and delegate the list to a living document; the canonical OpenSSF security-policy templates carry no supported-version content at all. The GitHub releases page is not a candidate for that pointer, because it has no support-status field and cannot express a line that receives backports without a release being cut, which is 13.4.x today.

`SECURITY.md` also carries the CRA stewardship statement the Linux Foundation asked its hosted projects to add, in the wording LF Edge supplied. The Linux Foundation is registered on the ENISA single reporting platform and files the regulatory reports, so the project's job is to reach the steward immediately when a vulnerability turns out to be actively exploited — not to build a reporting function. The handling policy records `steward@linuxfoundation.org` as the address it reports to. Both halves of the clock are stated, since the steward owes an early warning at 24 hours and a formal notification at 72. This also corrects the handling policy, which claimed downstream vendors alone notify CSIRTs and ENISA; the steward files as well, and those are two separate tracks.

The statement refers reporters to the project's emergency reporting mechanism, so `SECURITY.md` says what that is: the same intake, escalated on the reporter's own say-so when they flag active exploitation or a compromise of the release pipeline in the subject line. A second address to remember while a 24-hour clock runs would make escalation slower, not faster.

Advisory announcement and embargoed vendor pre-notification are separate audiences with different embargo rules, so they get separate addresses — `eve-security-announce@lists.lfedge.org` and `eve-distributors-announce@lists.lfedge.org`. Both names follow the convention Kubernetes, containerd, Envoy and Harbor use, so a vendor already subscribed to those recognizes what each one carries.

Three smaller changes ride along. Scope now names the repositories that build or ship code into a released image separately from the build and test repositories, and states that a vulnerability in a particular controller belongs to that controller's vendor — EVE is controller-agnostic. `docs/SBOM-AND-SOURCES.md` was reachable from no other page in the tree and is now linked, which matters for anyone doing component due diligence on an EVE-based product. And the reporter-facing triage window is stated as a window on the project, so it is not mistaken for a regulatory reporting deadline — `RELEASE-SUPPORT.md` warns vendors explicitly that the project's window is longer than their own early-warning clock.

## Open decisions

Every marker is greppable as `TBD(TSC)`.

| Where | Decision needed |
| --- | --- |
| `SECURITY.md`, `VULNERABILITY-HANDLING.md` | Neither `eve-security-announce@lists.lfedge.org` nor `eve-distributors-announce@lists.lfedge.org` exists. Both have to be requested from LF Edge |
| `VULNERABILITY-HANDLING.md` security team | The roster, by role and GitHub handle, plus the internal coordination alias |
| `VULNERABILITY-HANDLING.md` escalation | Who on the security team owns sending the steward report, and their deputy |
| `VULNERABILITY-HANDLING.md` escalation | Whether `steward@linuxfoundation.org` is monitored outside EU business hours, which Art 14's deadlines require since they run across weekends |

The first row is the only one that depends on anyone outside the project.

`RELEASE-SUPPORT.md` carries no markers: its dates are settled. Three things about it are worth a reviewer's attention even so, none of them a defect in the document. 13.4.x is in its Active phase until 2026-12-28, which promises point releases, and none has been cut since `13.4.3-lts` in July 2025. 12.0.x, 11.0.x and 10.4.x are inside their backport window while their branches sit idle — last commit on `12.0-stable` June 2025, on `11.0-stable` January 2026, on `10.4-stable` July 2024 — and 10.4.x reaches the end of its window on 2026-09-30 regardless. And the support-start dates for 11.0.x and 10.4.x precede the first `-lts` tag on those lines, so unlike every other row they cannot be checked against the releases page.

Four values are filled in rather than marked, and all are published commitments worth confirming:

- **Acknowledged and analyzed within 3 business days** replaces the current `SECURITY.md`'s bare 24-hour acknowledgment. The old promise bought a reporter a receipt and then an unbounded wait; this one commits to an actual assessment, matching what Kubernetes and CRI-O publish. It is a relaxation of a published number, so it is called out rather than buried: a report flagged as actively exploited is taken up on arrival, since the steward's 24-hour clock runs from the project's awareness.
- **90-day disclosure timeline** is new, and now runs from the report's arrival rather than its acknowledgment. The current policy states no disclosure deadline, and Annex I Part II(5) of Regulation (EU) 2024/2847 requires a coordinated-disclosure policy that is enforced, which needs a date. 90 days is both the OpenSSF template default and Envoy's published fix-or-disclose deadline.
- **A two-week vendor pre-notification lead time**, carrying the patch, is new. Two weeks is what Xen and OpenSSL give their own pre-disclosure lists; Envoy gives three, Kubernetes about one. It runs from patch availability rather than triage, and the patch plus anything built from it sits inside the embargo.
- **A 36-month support window** is new; the current policy commits to no period at all. A vendor whose product stays in the field longer than three years carries EVE fixes itself once the line ends, which `RELEASE-SUPPORT.md` states is the vendor's obligation rather than the project's — but it is the kind of thing better agreed now than discovered by a vendor later.

## How to test and validate this PR

Documentation only; no build or runtime change, and nothing to test on device.

- `markdownlint` under the repository's own `.markdownlint.yaml` reports no findings on the three files.
- `codespell` under the repository's own `.codespellrc` reports no findings on the three files.
- All relative links and heading anchors in the three files resolve, including `RELEASE-SUPPORT.md#pre-notification-list` and `CONTRIBUTING.md#backporting`.
- `./tools/spdx-check.sh upstream/master` passes.
- Every row of the support table is internally consistent: the Active and Backports columns are the support-start date plus 24 and 36 months. For 12.0.x and later, the support-start date is the `published_at` of that line's first `-lts` release; 11.0.x and 10.4.x are the two exceptions flagged above.

For review, the substantive questions are whether the scope section draws the repository boundary correctly, whether 24+12 months is the right support window, and whether the handling policy matches how the security team actually wants to work — it is written as a proposal, not a description of existing practice.

## Changelog notes

The security policy is reorganized. `SECURITY.md` now covers reporting and disclosure only; security support per release line moves to `docs/RELEASE-SUPPORT.md`, and the vulnerability handling process is documented in `docs/VULNERABILITY-HANDLING.md`. Supported lines now carry stated end dates: 24 months of active support from a line's general-availability date, followed by 12 months of backports. The previously published support table listed release lines that no longer receive fixes.

## PR Backports

- 17.0-stable: No.
- 16.0-stable: No.
- 14.5-stable: No.
- 13.4-stable: No.

GitHub surfaces `SECURITY.md` from the default branch only, so a backport would not change what a reporter sees. The documents describe the project as a whole rather than a branch, and per-branch copies would diverge.

## Checklist

- [x] I've provided a proper description
- [x] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.

Device testing does not apply: the PR changes three Markdown files and no build input. No `stable` label, since nothing is proposed for backport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhfowfL6NxSopWpQh2T4mD
