### PR TITLE
pillar/cloudconfig: resolve write_files paths with RESOLVE_IN_ROOT

### DIFF
--- a/pkg/pillar/utils/cloudconfig/cloudconfig.go
+++ b/pkg/pillar/utils/cloudconfig/cloudconfig.go
@@ -4,16 +4,13 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/lf-edge/eve/pkg/pillar/base"
-	fileutils "github.com/lf-edge/eve/pkg/pillar/utils/file"
 	"gopkg.in/yaml.v2"
 )
 
@@ -81,15 +78,6 @@ func WriteFile(log *base.LogObject, file WritableFile, rootPath string) error {
 	}
 	mode := os.FileMode(perm)
 
-	writePath := filepath.Join(rootPath, file.Path)
-	// Reject any write that escapes rootPath. filepath.Rel expresses the
-	// resolved writePath relative to rootPath: a contained path yields a
-	// normal subpath, while an escape yields ".." or a "../"-prefixed result.
-	rel, err := filepath.Rel(rootPath, writePath)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-		return fmt.Errorf("detected possible attempt to write file outside of root path. invalid path %s", file.Path)
-	}
-
 	var contentBytes []byte
 	switch file.Encoding {
 	case "b64", "base64":
@@ -112,23 +100,8 @@ func WriteFile(log *base.LogObject, file WritableFile, rootPath string) error {
 		return err
 	}
 
-	// check if the parent directory exists
-	parentDir := filepath.Dir(writePath)
-	if _, err := os.Stat(parentDir); os.IsNotExist(err) {
-		// create parent directory
-		err = os.MkdirAll(parentDir, 0755)
-		if err != nil {
-			return err
-		}
-	}
-
 	log.Tracef("Creating file %s with mode %s in %s\n", file.Path, mode, rootPath)
-	err = fileutils.WriteRename(writePath, contentBytes)
-	if err != nil {
-		return err
-	}
-	err = os.Chmod(writePath, mode)
-	if err != nil {
+	if err := writeFileInRoot(rootPath, file.Path, contentBytes, mode); err != nil {
 		return err
 	}
 	if file.Owner != "" {

--- a/pkg/pillar/utils/cloudconfig/helpers_test.go
+++ b/pkg/pillar/utils/cloudconfig/helpers_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudconfig_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/utils/cloudconfig"
+	"github.com/sirupsen/logrus"
+)
+
+// Fixtures and assertions shared by the WriteFile tests.
+
+func testLog() *base.LogObject {
+	return base.NewSourceLogObject(logrus.StandardLogger(), "cloudconfig", 0)
+}
+
+// newRoot returns an empty application rootfs.
+func newRoot(t *testing.T) string {
+	t.Helper()
+	rootPath := filepath.Join(t.TempDir(), "rootfs")
+	if err := os.MkdirAll(rootPath, 0755); err != nil {
+		t.Fatalf("failed to create rootfs: %v", err)
+	}
+	return rootPath
+}
+
+func write(rootPath, filePath, content, permissions string) error {
+	return cloudconfig.WriteFile(testLog(), cloudconfig.WritableFile{
+		Path:        filePath,
+		Content:     content,
+		Permissions: permissions,
+	}, rootPath)
+}
+
+// findFile returns the paths of the regular files under dir whose base name is
+// name. Symlinks are excluded: a symlink named the same is not a written file.
+func findFile(t *testing.T, dir, name string) []string {
+	t.Helper()
+	var found []string
+	err := filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type().IsRegular() && d.Name() == name {
+			found = append(found, p)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to walk %s: %v", dir, err)
+	}
+	return found
+}
+
+// assertAbsent fails unless path does not exist. Lstat, so a symlink counts as
+// present, and only a not-exist error counts as absence -- any other error
+// means the question was not answered.
+func assertAbsent(t *testing.T, path, why string) {
+	t.Helper()
+	_, err := os.Lstat(path)
+	if err == nil {
+		t.Errorf("%s: %s exists", why, path)
+		return
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("could not determine whether %s exists: %v", path, err)
+	}
+}
+
+// tempFiles returns the leftover temporary files in dir.
+func tempFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", dir, err)
+	}
+	var left []string
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".cloudinit-tmp") {
+			left = append(left, entry.Name())
+		}
+	}
+	return left
+}

--- a/pkg/pillar/utils/cloudconfig/path_test.go
+++ b/pkg/pillar/utils/cloudconfig/path_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudconfig_test
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/utils/cloudconfig"
+)
+
+// How a requested path is turned into a destination: normalization, relative
+// paths, parent creation, and the paths that are refused outright. Symlink
+// resolution is in symlink_test.go.
+
+// TestWriteFilePathNormalization asserts a requested path is normalized before
+// it is split into a parent and a file name. path.Base and path.Dir disagree
+// about a trailing separator, so without normalizing, "/foo/" would create a
+// directory foo and write foo/foo inside it, and "/foo/." would be rejected --
+// where both name the file "/foo".
+func TestWriteFilePathNormalization(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct{ requested, want string }{
+		{requested: "/foo", want: "foo"},
+		{requested: "/foo/", want: "foo"},
+		{requested: "/foo/.", want: "foo"},
+		{requested: "//a//b", want: "a/b"},
+		{requested: "/a/./b", want: "a/b"},
+		{requested: "/a/c/../b", want: "a/b"},
+	} {
+		t.Run(tc.requested, func(t *testing.T) {
+			t.Parallel()
+
+			rootPath := filepath.Join(t.TempDir(), "rootfs")
+			if err := os.MkdirAll(rootPath, 0755); err != nil {
+				t.Fatalf("failed to create rootfs: %v", err)
+			}
+			if err := cloudconfig.WriteFile(testLog(), cloudconfig.WritableFile{
+				Path:        tc.requested,
+				Content:     "normalized",
+				Permissions: "0644",
+			}, rootPath); err != nil {
+				t.Fatalf("write of %q failed: %v", tc.requested, err)
+			}
+
+			want := filepath.Join(rootPath, tc.want)
+			content, err := os.ReadFile(want)
+			if err != nil {
+				t.Fatalf("expected %q to be written to %s: %v", tc.requested, want, err)
+			}
+			if string(content) != "normalized" {
+				t.Errorf("content of %s = %q, want %q", want, content, "normalized")
+			}
+		})
+	}
+}
+
+// TestWriteFileRelativePath asserts a path without a leading separator is
+// still resolved against the rootfs rather than the writing process's cwd.
+// The controller is not required to send an absolute path.
+func TestWriteFileRelativePath(t *testing.T) {
+	t.Parallel()
+
+	for _, requested := range []string{"etc/foo", "foo"} {
+		t.Run(requested, func(t *testing.T) {
+			t.Parallel()
+
+			rootPath := newRoot(t)
+			if err := write(rootPath, requested, "relative", "0644"); err != nil {
+				t.Fatalf("write of %q failed: %v", requested, err)
+			}
+			want := filepath.Join(rootPath, requested)
+			if content, err := os.ReadFile(want); err != nil {
+				t.Fatalf("expected the file at %s: %v", want, err)
+			} else if string(content) != "relative" {
+				t.Errorf("content = %q, want %q", content, "relative")
+			}
+		})
+	}
+}
+
+// TestWriteFileRejectsClimbOutOfRoot asserts a path whose ".." climbs above
+// the root is rejected, including one that climbs out and re-enters through a
+// component that happens to match the root's own name. Deciding containment by
+// joining onto rootPath and comparing strings accepts that second form,
+// because rootPath's trailing component absorbs the "..", and then writes it
+// somewhere other than where the check looked.
+func TestWriteFileRejectsClimbOutOfRoot(t *testing.T) {
+	t.Parallel()
+
+	for _, requested := range []string{
+		"../../etc/passwd",
+		"/../rootfs/foo",
+		"/a/../../escape",
+		"/",
+		"/..",
+	} {
+		t.Run(requested, func(t *testing.T) {
+			t.Parallel()
+
+			baseDir := t.TempDir()
+			// Named "rootfs" so "/../rootfs/foo" can re-enter through it.
+			rootPath := filepath.Join(baseDir, "rootfs")
+			if err := os.MkdirAll(rootPath, 0755); err != nil {
+				t.Fatalf("failed to create rootfs: %v", err)
+			}
+
+			err := cloudconfig.WriteFile(testLog(), cloudconfig.WritableFile{
+				Path:        requested,
+				Content:     "escaped",
+				Permissions: "0644",
+			}, rootPath)
+			if err == nil {
+				t.Errorf("expected %q to be rejected", requested)
+			}
+			// The name this entry would have written, had it been accepted.
+			if got := findFile(t, baseDir, path.Base(requested)); len(got) != 0 {
+				t.Errorf("%q was written to %v", requested, got)
+			}
+		})
+	}
+}
+
+// TestWriteFileCreatesMissingParents asserts every missing directory on the
+// way to the file is created, not just the immediate parent.
+func TestWriteFileCreatesMissingParents(t *testing.T) {
+	t.Parallel()
+
+	rootPath := newRoot(t)
+	if err := write(rootPath, "/deep/ly/nested/secret", "s3cret", "0640"); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(rootPath, "deep", "ly", "nested", "secret"))
+	if err != nil {
+		t.Fatalf("expected the file: %v", err)
+	}
+	if string(content) != "s3cret" {
+		t.Errorf("content = %q, want %q", content, "s3cret")
+	}
+}

--- a/pkg/pillar/utils/cloudconfig/rootedwrite.go
+++ b/pkg/pillar/utils/cloudconfig/rootedwrite.go
@@ -1,0 +1,425 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudconfig
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"sync/atomic"
+
+	"golang.org/x/sys/unix"
+)
+
+// Not os.Root: it refuses an absolute symlink outright ("Symbolic links must
+// not be absolute"), so /var/run -> /run would fail rather than resolve to the
+// application's own /run. It is the right tool only if refusing such a path
+// ever becomes the wanted behaviour.
+
+// maxSymlinkDepth caps how many symlinks-to-missing-directories ensureDirPath
+// will follow. Serves the same purpose as the kernel's ELOOP limit, on the one
+// case the kernel cannot resolve for us: a directory that has to be created
+// through a symlink whose target does not exist yet.
+const maxSymlinkDepth = 8
+
+// maxResolveRetries bounds the retries of a lookup the kernel declined to
+// answer. It expects a retry to succeed promptly, so a tree being mutated hard
+// enough to exhaust this fails rather than spinning.
+const maxResolveRetries = 16
+
+// tmpCounter distinguishes the temporary files of successive writes, so a
+// leftover from an interrupted write cannot make the next one fail on O_EXCL.
+var tmpCounter atomic.Uint64
+
+// writeFileInRoot writes content at filePath with the given mode, resolving
+// filePath as though rootPath were the filesystem root, and creates the parent
+// directories that do not exist yet.
+//
+// filePath comes from a cloud-config write_files entry and is resolved against
+// the rootfs of the application's own container image, so every symlink along
+// the way is chosen by whoever built that image. openat2(2) with
+// RESOLVE_IN_ROOT has the kernel resolve the path with rootPath as "/":
+// absolute symlink targets are re-rooted at rootPath and ".." cannot climb
+// above it. Those are chroot(2) semantics without chroot's process-wide
+// effect, and unlike resolving the path in userspace there is no window
+// between deciding a path is safe and writing to it.
+//
+// Re-rooting rather than rejecting is what the guest itself means by such a
+// path: in a Debian-based image /var/lock is a symlink to /run/lock, and a
+// write there belongs in the container's own /run/lock.
+//
+// Containment does not rest on this function being the only writer, nor on it
+// never creating a symlink: every call re-resolves from its own root
+// descriptor, so it tolerates whatever symlinks it finds. A container-format
+// volume may in fact be shared writable with an already-running application
+// (see checkReferences in volumemgr), so a concurrent writer must be assumed.
+//
+// It does rest on two properties of the caller's namespace:
+//   - No directory is moved out of rootPath mid-write, since a descriptor
+//     follows its directory. The mount boundary is what gives this: a guest
+//     sees such a volume only as a bind mount of that tree, and rename(2)
+//     cannot cross mounts. A rename within the root stays contained.
+//   - No outside inode is exposed beneath rootPath by a mount pillar can see.
+//     RESOLVE_IN_ROOT confines path resolution to the tree, not to one
+//     filesystem, so an interior mount would be followed (RESOLVE_NO_XDEV
+//     would forbid that, at the cost of any legitimate interior mount).
+//
+// Needs Linux 5.6 for openat2.
+func writeFileInRoot(rootPath, filePath string, content []byte, mode os.FileMode) error {
+	dir, name, err := normalizeInRoot(filePath)
+	if err != nil {
+		return err
+	}
+
+	rootFd, err := retryOnEINTR2(func() (int, error) {
+		return unix.Open(rootPath, unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to open root path %s: %w", rootPath, err)
+	}
+	defer unix.Close(rootFd)
+
+	if err := ensureDirPath(rootFd, dir, 0); err != nil {
+		return err
+	}
+	// Opened read-only rather than O_PATH so the directory can be fsynced
+	// after the rename.
+	dirFd, err := openInRoot(rootFd, dir, unix.O_RDONLY|unix.O_DIRECTORY)
+	if err != nil {
+		return fmt.Errorf("failed to open directory %s under %s: %w", dir, rootPath, err)
+	}
+	defer unix.Close(dirFd)
+
+	return writeRenameAt(dirFd, name, content, mode)
+}
+
+// normalizeInRoot splits a requested path into the directory to resolve and
+// the name to write inside it, and rejects a path that climbs above the root.
+//
+// The split is not a containment measure -- RESOLVE_IN_ROOT already makes an
+// escape impossible whatever this returns. It exists because rename(2) is what
+// makes the write atomic, and renameat takes a directory descriptor plus a
+// plain name, with no resolve-flag variant. path.Dir and path.Base alone would
+// not do, as they disagree about a trailing separator: "/foo/" would name the
+// file "foo" inside a directory "/foo".
+//
+// ".." is left in dir for the kernel to resolve. Collapsing it here would
+// apply it before symlinks rather than after, naming a different directory:
+// with "/alias" a symlink to "real/deep", "/alias/../f" is "/real/f", not
+// "/f".
+//
+// The climb-out rejection is a lexical sanity check on the config, not a
+// containment mechanism, and it is deliberately approximate in both
+// directions: with "/a" a symlink to "/", "/a/../f" is accepted although the
+// traversal does climb to the root, and with "/a" a symlink to "real/deep",
+// "/a/../../f" is rejected although it resolves to a contained path. It earns
+// its place only by turning a plainly malformed entry into an error instead of
+// a file written somewhere its author did not name; the kernel is what keeps
+// either outcome inside the root.
+func normalizeInRoot(filePath string) (dir, name string, err error) {
+	invalid := fmt.Errorf(
+		"detected possible attempt to write file outside of root path. invalid path %s",
+		filePath)
+
+	var components []string
+	for _, component := range strings.Split(filePath, "/") {
+		// Dropping "." changes no meaning; ".." is kept for the kernel.
+		if component != "" && component != "." {
+			components = append(components, component)
+		}
+	}
+	if len(components) == 0 {
+		// Names the root directory itself, not a file in it.
+		return "", "", invalid
+	}
+	if components[len(components)-1] == ".." {
+		return "", "", invalid
+	}
+	// Whether the path climbs out, counted lexically. A symlink can make the
+	// kernel disagree about which directory a ".." lands in, but not about
+	// whether the path stays inside the root.
+	depth := 0
+	for _, component := range components {
+		if component == ".." {
+			if depth == 0 {
+				return "", "", invalid
+			}
+			depth--
+			continue
+		}
+		depth++
+	}
+
+	last := len(components) - 1
+	return "/" + strings.Join(components[:last], "/"), components[last], nil
+}
+
+// openInRoot opens path with rootFd standing in for the filesystem root.
+//
+// A ".." under RESOLVE_IN_ROOT is only safe if the kernel can confirm it did
+// not escape, which it cannot always do while the tree is changing underneath;
+// it then reports EAGAIN and leaves retrying to the caller (openat2(2)). So
+// EAGAIN here says nothing about the path -- treating it as a failure makes a
+// perfectly good entry fail whenever something else touches the filesystem at
+// the wrong moment.
+func openInRoot(rootFd int, path string, flags int) (int, error) {
+	var fd int
+	var err error
+	for attempt := 0; attempt <= maxResolveRetries; attempt++ {
+		fd, err = retryOnEINTR2(func() (int, error) {
+			return unix.Openat2(rootFd, path, &unix.OpenHow{
+				Flags:   uint64(flags | unix.O_CLOEXEC),
+				Resolve: unix.RESOLVE_IN_ROOT,
+			})
+		})
+		if !errors.Is(err, unix.EAGAIN) {
+			return fd, err
+		}
+	}
+	return fd, err
+}
+
+// ensureDirPath creates every component of dir that does not exist yet, each
+// one below a parent the kernel has already resolved inside the root.
+//
+// Prefixes are built by concatenation rather than by path.Join, because a
+// symlink target may contain "..": cleaning it would name an ancestor of the
+// link's own lexical path instead of an ancestor of what the link points at.
+// Left intact, every prefix is resolved by the kernel, which follows the real
+// symlinks before applying the "..".
+func ensureDirPath(rootFd int, dir string, depth int) error {
+	if depth > maxSymlinkDepth {
+		return fmt.Errorf("too many symbolic links while creating %s", dir)
+	}
+	parent, full := "/", ""
+	for _, name := range strings.Split(dir, "/") {
+		if name == "" || name == "." {
+			continue
+		}
+		if full != "" {
+			parent = full
+		}
+		full += "/" + name
+		// ".." always exists, and only the kernel can say what it refers to
+		// once symlinks are in play.
+		if name == ".." {
+			continue
+		}
+		if err := ensureDir(rootFd, parent, full, name, depth); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ensureDir makes sure name, whose full path within the root is full and whose
+// parent is parent, exists as a directory. A name that is a symlink to a
+// directory which does not exist yet is not created itself -- mkdir would fail
+// on the symlink -- its target is created instead, which RESOLVE_IN_ROOT keeps
+// inside the root.
+func ensureDir(rootFd int, parent, full, name string, depth int) error {
+	fd, err := openInRoot(rootFd, full, unix.O_PATH|unix.O_DIRECTORY)
+	if err == nil {
+		unix.Close(fd)
+		return nil
+	}
+	// Anything but "not there" (ENOTDIR for a file in the way, ELOOP, EACCES)
+	// is the useful error and must not be masked by the EEXIST below.
+	if !errors.Is(err, unix.ENOENT) {
+		return fmt.Errorf("failed to open %s: %w", full, err)
+	}
+
+	parentFd, err := openInRoot(rootFd, parent, unix.O_PATH|unix.O_DIRECTORY)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", parent, err)
+	}
+	defer unix.Close(parentFd)
+
+	mkErr := retryOnEINTR(func() error { return unix.Mkdirat(parentFd, name, 0755) })
+	if mkErr == nil {
+		return nil
+	}
+	if !errors.Is(mkErr, unix.EEXIST) {
+		return fmt.Errorf("failed to create %s: %w", full, mkErr)
+	}
+
+	// The name exists yet did not resolve to a directory: either a symlink
+	// whose target is missing, whose target is created below, or a directory
+	// that appeared between the lookup and the mkdir.
+	target, err := readlinkAt(parentFd, name)
+	if err != nil {
+		if fd, openErr := openInRoot(rootFd, full, unix.O_PATH|unix.O_DIRECTORY); openErr == nil {
+			unix.Close(fd)
+			return nil
+		}
+		return fmt.Errorf("failed to create %s: exists but is not a usable directory: %w",
+			full, err)
+	}
+	if !path.IsAbs(target) {
+		// Concatenated rather than joined, for the reason in ensureDirPath.
+		target = parent + "/" + target
+	}
+	return ensureDirPath(rootFd, target, depth+1)
+}
+
+func readlinkAt(dirFd int, name string) (string, error) {
+	for size := 256; size <= unix.PathMax; size *= 2 {
+		buf := make([]byte, size)
+		n, err := retryOnEINTR2(func() (int, error) {
+			return unix.Readlinkat(dirFd, name, buf)
+		})
+		if err != nil {
+			return "", err
+		}
+		if n < size {
+			return string(buf[:n]), nil
+		}
+	}
+	return "", fmt.Errorf("symbolic link target of %s is too long", name)
+}
+
+// writeRenameAt writes content to name inside dirFd via a temporary file and
+// rename(2), so nothing observes a partially written file. Mirrors
+// fileutils.WriteRename, except that every step is relative to dirFd: the
+// directory was resolved once, under RESOLVE_IN_ROOT, and no step here walks a
+// path a symlink could redirect.
+func writeRenameAt(dirFd int, name string, content []byte, mode os.FileMode) error {
+	tmp, fd, err := createTempAt(dirFd)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if tmp != "" {
+			unix.Unlinkat(dirFd, tmp, 0) //nolint:errcheck // cleanup of a failed write
+		}
+	}()
+
+	// Mode before the sync, so the file's permissions are part of the state
+	// that reaches the disk, and before the rename, so the file is never
+	// visible under its final name with the temporary's mode.
+	if err := writeAndSync(fd, content, mode); err != nil {
+		unix.Close(fd) //nolint:errcheck // the write already failed
+		return fmt.Errorf("failed to write %s: %w", name, err)
+	}
+	// Not retried on EINTR: on Linux the descriptor is released regardless,
+	// so a retry could close an unrelated file.
+	if err := unix.Close(fd); err != nil {
+		return fmt.Errorf("failed to close %s: %w", name, err)
+	}
+
+	if err := retryOnEINTR(func() error {
+		return unix.Renameat(dirFd, tmp, dirFd, name)
+	}); err != nil {
+		return fmt.Errorf("failed to rename %s into place: %w", name, err)
+	}
+	tmp = ""
+	if err := retryOnEINTR(func() error { return unix.Fsync(dirFd) }); err != nil {
+		return fmt.Errorf("failed to sync directory of %s: %w", name, err)
+	}
+	return nil
+}
+
+func writeAndSync(fd int, content []byte, mode os.FileMode) error {
+	if err := writeAll(fd, content); err != nil {
+		return err
+	}
+	if err := retryOnEINTR(func() error { return unix.Fchmod(fd, unixMode(mode)) }); err != nil {
+		return err
+	}
+	return retryOnEINTR(func() error { return unix.Fsync(fd) })
+}
+
+// createTempAt creates a uniquely named file inside dirFd. O_NOFOLLOW because
+// the name may already exist as a symlink planted in the image; with O_EXCL
+// that is refused rather than followed.
+//
+// O_EXCL authenticates the inode it returns, not the name for the rest of the
+// operation. A concurrent writer sharing the volume can replace the name
+// afterwards, in which case the rename below publishes what that writer put
+// there and the deferred cleanup unlinks it rather than our own file. Both stay
+// inside the root, and such a writer can already write this tree, so this
+// costs integrity of the published file and no more.
+func createTempAt(dirFd int) (string, int, error) {
+	flags := unix.O_CREAT | unix.O_EXCL | unix.O_WRONLY | unix.O_CLOEXEC | unix.O_NOFOLLOW
+	var lastErr error
+	for i := 0; i < 100; i++ {
+		name := fmt.Sprintf(".cloudinit-tmp-%d-%d", os.Getpid(), tmpCounter.Add(1))
+		fd, err := retryOnEINTR2(func() (int, error) {
+			return unix.Openat(dirFd, name, flags, 0600)
+		})
+		if err == nil {
+			return name, fd, nil
+		}
+		if !errors.Is(err, unix.EEXIST) {
+			return "", -1, fmt.Errorf("failed to create temporary file: %w", err)
+		}
+		lastErr = err
+	}
+	return "", -1, fmt.Errorf("failed to create temporary file: %w", lastErr)
+}
+
+func writeAll(fd int, content []byte) error {
+	for len(content) > 0 {
+		n, err := unix.Write(fd, content)
+		if err != nil {
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
+			return err
+		}
+		if n <= 0 {
+			return io.ErrShortWrite
+		}
+		content = content[n:]
+	}
+	return nil
+}
+
+// unixMode converts mode the way os.Chmod does, so a permissions string keeps
+// meaning exactly what it meant before the write moved to a descriptor.
+func unixMode(mode os.FileMode) uint32 {
+	m := uint32(mode.Perm())
+	if mode&os.ModeSetuid != 0 {
+		m |= unix.S_ISUID
+	}
+	if mode&os.ModeSetgid != 0 {
+		m |= unix.S_ISGID
+	}
+	if mode&os.ModeSticky != 0 {
+		m |= unix.S_ISVTX
+	}
+	return m
+}
+
+// retryOnEINTR repeats f while a signal interrupts it.
+//
+// Applied wherever the os-package call this write path replaced retried: open,
+// mkdir, readlink, chmod, fsync, write and rename all loop inside os (see
+// ignoringEINTR there). The runtime preempts goroutines with SIGURG, and while
+// its own handlers carry SA_RESTART, anything else in the process may install
+// one without it -- pillar is a single process running every agent -- so the
+// guarantee is not ours to make.
+//
+// close(2) is deliberately excluded: on Linux the descriptor is released even
+// when it reports EINTR, so retrying could close an unrelated file.
+func retryOnEINTR(f func() error) error {
+	for {
+		if err := f(); !errors.Is(err, unix.EINTR) {
+			return err
+		}
+	}
+}
+
+// retryOnEINTR2 is retryOnEINTR for a call that also returns a value.
+func retryOnEINTR2[T any](f func() (T, error)) (T, error) {
+	for {
+		v, err := f()
+		if !errors.Is(err, unix.EINTR) {
+			return v, err
+		}
+	}
+}

--- a/pkg/pillar/utils/cloudconfig/rootedwrite_test.go
+++ b/pkg/pillar/utils/cloudconfig/rootedwrite_test.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudconfig_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// The write itself: what happens to whatever already occupies the destination,
+// how a blocked path component is reported, how a permissions string is
+// converted, and that no temporary file is left behind.
+
+// TestWriteFileFinalComponent asserts what happens when the final component
+// already exists. rename(2) replaces a symlink at its destination rather than
+// following it, which is why only intermediate components need resolving; a
+// directory cannot be replaced and must fail cleanly.
+func TestWriteFileFinalComponent(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		// setup prepares "target" inside rootPath and returns the path whose
+		// content must be left alone, if any.
+		setup     func(t *testing.T, rootPath string) (untouched string)
+		wantError bool
+	}{
+		{
+			name: "regular file",
+			setup: func(t *testing.T, rootPath string) string {
+				if err := os.WriteFile(filepath.Join(rootPath, "target"),
+					[]byte("stale and longer than the new content"), 0600); err != nil {
+					t.Fatal(err)
+				}
+				return ""
+			},
+		},
+		{
+			name: "symlink to a file",
+			setup: func(t *testing.T, rootPath string) string {
+				pointee := filepath.Join(rootPath, "pointee")
+				if err := os.WriteFile(pointee, []byte("pointee"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink("pointee", filepath.Join(rootPath, "target")); err != nil {
+					t.Fatal(err)
+				}
+				return pointee
+			},
+		},
+		{
+			name: "symlink to a directory",
+			setup: func(t *testing.T, rootPath string) string {
+				if err := os.MkdirAll(filepath.Join(rootPath, "pointee"), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink("/pointee", filepath.Join(rootPath, "target")); err != nil {
+					t.Fatal(err)
+				}
+				return ""
+			},
+		},
+		{
+			name: "dangling symlink",
+			setup: func(t *testing.T, rootPath string) string {
+				if err := os.Symlink("/nowhere", filepath.Join(rootPath, "target")); err != nil {
+					t.Fatal(err)
+				}
+				return ""
+			},
+		},
+		{
+			name: "directory",
+			setup: func(t *testing.T, rootPath string) string {
+				if err := os.MkdirAll(filepath.Join(rootPath, "target"), 0755); err != nil {
+					t.Fatal(err)
+				}
+				return ""
+			},
+			wantError: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rootPath := newRoot(t)
+			untouched := tc.setup(t, rootPath)
+			target := filepath.Join(rootPath, "target")
+
+			err := write(rootPath, "/target", "fresh", "0640")
+			if tc.wantError {
+				if err == nil {
+					t.Fatalf("expected an error writing over a %s", tc.name)
+				}
+				if fi, statErr := os.Lstat(target); statErr != nil || !fi.IsDir() {
+					t.Errorf("the existing directory did not survive: %v", statErr)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("write over a %s failed: %v", tc.name, err)
+				}
+				fi, statErr := os.Lstat(target)
+				if statErr != nil {
+					t.Fatalf("expected the file at %s: %v", target, statErr)
+				}
+				if !fi.Mode().IsRegular() {
+					t.Errorf("%s is a %v, want a regular file", target, fi.Mode().Type())
+				}
+				if content, readErr := os.ReadFile(target); readErr != nil {
+					t.Fatalf("failed to read %s: %v", target, readErr)
+				} else if string(content) != "fresh" {
+					t.Errorf("content = %q, want %q", content, "fresh")
+				}
+				if fi.Mode().Perm() != 0640 {
+					t.Errorf("mode = %v, want %v", fi.Mode().Perm(), os.FileMode(0640))
+				}
+			}
+			// A symlink is replaced, so whatever it pointed at is untouched.
+			if untouched != "" {
+				if content, readErr := os.ReadFile(untouched); readErr != nil {
+					t.Errorf("the symlink's target was disturbed: %v", readErr)
+				} else if string(content) != "pointee" {
+					t.Errorf("the symlink's target was overwritten with %q", content)
+				}
+			}
+			if left := tempFiles(t, rootPath); len(left) != 0 {
+				t.Errorf("temporary files left behind: %v", left)
+			}
+		})
+	}
+}
+
+// TestWriteFileBlockedComponent asserts a lookup failure that is not "the
+// directory is missing" is reported as itself. Only ENOENT may fall through to
+// directory creation: treating every failure as absence turns a blocking
+// regular file into a bare "file exists" from mkdir.
+func TestWriteFileBlockedComponent(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		setup   func(t *testing.T, rootPath string)
+		wantErr error
+	}{
+		{
+			name: "regular file in the way",
+			setup: func(t *testing.T, rootPath string) {
+				if err := os.WriteFile(filepath.Join(rootPath, "blocked"),
+					[]byte("x"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: unix.ENOTDIR,
+		},
+		{
+			name: "symlink loop",
+			setup: func(t *testing.T, rootPath string) {
+				if err := os.Symlink("blocked2", filepath.Join(rootPath, "blocked")); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink("blocked", filepath.Join(rootPath, "blocked2")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: unix.ELOOP,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rootPath := newRoot(t)
+			tc.setup(t, rootPath)
+
+			err := write(rootPath, "/blocked/sub/file", "x", "0644")
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("error = %v, want one wrapping %v", err, tc.wantErr)
+			}
+			if got := findFile(t, rootPath, "file"); len(got) != 0 {
+				t.Errorf("wrote the file anyway, at %v", got)
+			}
+		})
+	}
+}
+
+// TestWriteFileSpecialModeBits pins how a permissions string is converted,
+// which has to match what os.Chmod did before the write moved to a descriptor.
+// Go's FileMode carries setuid/setgid/sticky in high bits of its own, not at
+// octal 04000/02000/01000, so the two notations do not mean the same thing.
+func TestWriteFileSpecialModeBits(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		permissions string
+		wantPerm    os.FileMode
+		wantSetuid  bool
+	}{
+		{permissions: "0640", wantPerm: 0640},
+		// Go's own ModeSetuid bit, which os.Chmod mapped to S_ISUID.
+		{
+			permissions: strconv.FormatUint(uint64(os.ModeSetuid|0640), 8),
+			wantPerm:    0640,
+			wantSetuid:  true,
+		},
+		// Unix notation for setuid, which neither this code nor os.Chmod has
+		// ever honoured: 04000 is not Go's ModeSetuid. Pinned so a change is
+		// a deliberate one.
+		{permissions: "4755", wantPerm: 0755},
+	} {
+		t.Run(tc.permissions, func(t *testing.T) {
+			t.Parallel()
+
+			rootPath := newRoot(t)
+			if err := write(rootPath, "/f", "x", tc.permissions); err != nil {
+				t.Fatalf("write with permissions %q failed: %v", tc.permissions, err)
+			}
+			fi, err := os.Stat(filepath.Join(rootPath, "f"))
+			if err != nil {
+				t.Fatalf("expected the file: %v", err)
+			}
+			if fi.Mode().Perm() != tc.wantPerm {
+				t.Errorf("mode = %v, want %v", fi.Mode().Perm(), tc.wantPerm)
+			}
+			if setuid := fi.Mode()&os.ModeSetuid != 0; setuid != tc.wantSetuid {
+				t.Errorf("setuid = %v, want %v", setuid, tc.wantSetuid)
+			}
+		})
+	}
+}
+
+// TestWriteFileLeavesNoTemporaryFiles asserts the temporary file is cleaned up
+// whether the write completes or not. Without it a failed entry would leave
+// the content it could not publish sitting in the application's filesystem.
+func TestWriteFileLeavesNoTemporaryFiles(t *testing.T) {
+	t.Parallel()
+
+	rootPath := newRoot(t)
+	if err := write(rootPath, "/ok", "x", "0644"); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	// A directory at the destination fails at the rename, which is the latest
+	// failure point that still has a temporary file to remove.
+	if err := os.MkdirAll(filepath.Join(rootPath, "blocked"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := write(rootPath, "/blocked", "x", "0644"); err == nil {
+		t.Fatal("expected writing over a directory to fail")
+	}
+	if left := tempFiles(t, rootPath); len(left) != 0 {
+		t.Errorf("temporary files left behind: %v", left)
+	}
+}

--- a/pkg/pillar/utils/cloudconfig/symlink_test.go
+++ b/pkg/pillar/utils/cloudconfig/symlink_test.go
@@ -1,0 +1,326 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudconfig_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/utils/cloudconfig"
+)
+
+// Symlink resolution. WriteFile resolves a write_files path as though rootPath
+// were the filesystem root (openat2 with RESOLVE_IN_ROOT), so these cover both
+// halves of that contract: a symlink can never carry the write out of
+// rootPath, and one that stays inside is still followed.
+//
+// For a container application rootPath is the rootfs of the application's own
+// container image, so every symlink here is content an image author chose.
+
+// TestWriteFileSymlinkEscapeIsContained asserts that a symlinked directory
+// component pointing out of rootPath cannot carry the write with it. Such a
+// path is not rejected: the target is re-rooted at rootPath, so the write
+// lands inside the application's own filesystem, which is what the path means
+// from the guest's point of view.
+//
+// Both shapes of escape are covered, because they fail differently: an
+// absolute target would otherwise be resolved against the writing process's
+// root, while a relative one climbs out with "..".
+func TestWriteFileSymlinkEscapeIsContained(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		// target of the "home/a" symlink planted inside the rootfs
+		linkTarget func(rootPath, outside string) string
+	}{
+		{
+			name:       "absolute symlink",
+			linkTarget: func(_, outside string) string { return outside },
+		},
+		{
+			name: "relative symlink",
+			linkTarget: func(rootPath, outside string) string {
+				rel, err := filepath.Rel(filepath.Join(rootPath, "home"), outside)
+				if err != nil {
+					t.Fatalf("failed to build relative link target: %v", err)
+				}
+				return rel
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			baseDir := t.TempDir()
+			rootPath := filepath.Join(baseDir, "rootfs")
+			outside := filepath.Join(baseDir, "outside")
+			for _, dir := range []string{filepath.Join(rootPath, "home"), outside} {
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					t.Fatalf("failed to create %s: %v", dir, err)
+				}
+			}
+			link := filepath.Join(rootPath, "home", "a")
+			target := tc.linkTarget(rootPath, outside)
+			if err := os.Symlink(target, link); err != nil {
+				t.Fatalf("failed to create symlink: %v", err)
+			}
+
+			err := cloudconfig.WriteFile(testLog(), cloudconfig.WritableFile{
+				Path:        "/home/a/b",
+				Content:     "contained",
+				Permissions: "0644",
+			}, rootPath)
+			if err != nil {
+				t.Fatalf("write through a symlink out of rootPath failed: %v", err)
+			}
+
+			// The assertion that matters.
+			if len(findFile(t, outside, "b")) != 0 {
+				t.Errorf("containment escape: write to /home/a/b landed outside "+
+					"rootPath (link %q -> %q)", link, target)
+			}
+			// Landing anywhere inside the root is containment; landing at the
+			// re-rooted target with the right bytes is the intended behaviour.
+			want := filepath.Join(rootPath, strings.TrimPrefix(outside, "/"), "b")
+			if !filepath.IsAbs(target) {
+				want = filepath.Join(rootPath, "outside", "b")
+			}
+			content, err := os.ReadFile(want)
+			if err != nil {
+				t.Fatalf("expected the write at %s: %v (files inside root: %v)",
+					want, err, findFile(t, rootPath, "b"))
+			}
+			if string(content) != "contained" {
+				t.Errorf("content of %s = %q, want %q", want, content, "contained")
+			}
+		})
+	}
+}
+
+// TestWriteFileSymlinkedDirInsideRoot asserts a symlinked directory component
+// that stays inside rootPath is still followed. Distro images use such links
+// routinely (/etc -> usr/etc, /lib -> usr/lib), so refusing them would break
+// legitimate write_files targets.
+func TestWriteFileSymlinkedDirInsideRoot(t *testing.T) {
+	t.Parallel()
+
+	rootPath := filepath.Join(t.TempDir(), "rootfs")
+	targetDir := filepath.Join(rootPath, "usr", "etc")
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		t.Fatalf("failed to create %s: %v", targetDir, err)
+	}
+	if err := os.Symlink("usr/etc", filepath.Join(rootPath, "etc")); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	if err := cloudconfig.WriteFile(testLog(), cloudconfig.WritableFile{
+		Path:        "/etc/contained.txt",
+		Content:     "contained",
+		Permissions: "0644",
+	}, rootPath); err != nil {
+		t.Fatalf("write through a symlink contained in rootPath was rejected: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(targetDir, "contained.txt"))
+	if err != nil {
+		t.Fatalf("expected the file under %s: %v", targetDir, err)
+	}
+	if string(content) != "contained" {
+		t.Errorf("content = %q, want %q", content, "contained")
+	}
+}
+
+// TestWriteFileAbsoluteSymlinkIsReRooted covers the shape every Debian-based
+// image ships: /var/lock is an absolute symlink to /run/lock. The write
+// belongs in the container's own /run/lock, so the target must be resolved
+// against rootPath and not against the root of the process doing the write.
+func TestWriteFileAbsoluteSymlinkIsReRooted(t *testing.T) {
+	t.Parallel()
+
+	rootPath := filepath.Join(t.TempDir(), "rootfs")
+	for _, dir := range []string{
+		filepath.Join(rootPath, "run", "lock"),
+		filepath.Join(rootPath, "var"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("failed to create %s: %v", dir, err)
+		}
+	}
+	if err := os.Symlink("/run/lock", filepath.Join(rootPath, "var", "lock")); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	if err := cloudconfig.WriteFile(testLog(), cloudconfig.WritableFile{
+		Path:        "/var/lock/app.lock",
+		Content:     "locked",
+		Permissions: "0644",
+	}, rootPath); err != nil {
+		t.Fatalf("write through /var/lock was rejected: %v", err)
+	}
+
+	written := filepath.Join(rootPath, "run", "lock", "app.lock")
+	if content, err := os.ReadFile(written); err != nil {
+		t.Fatalf("expected the file at %s: %v", written, err)
+	} else if string(content) != "locked" {
+		t.Errorf("content = %q, want %q", content, "locked")
+	}
+}
+
+// TestWriteFileCreatesDirThroughDanglingSymlink covers the same shape when the
+// symlink's target does not exist in the image yet. The directory cannot be
+// created under the symlink's own name -- mkdir would fail on the link -- so
+// its target has to be created instead. Before this was handled, such a path
+// failed app activation with a bare "file exists".
+func TestWriteFileCreatesDirThroughDanglingSymlink(t *testing.T) {
+	t.Parallel()
+
+	rootPath := filepath.Join(t.TempDir(), "rootfs")
+	if err := os.MkdirAll(filepath.Join(rootPath, "var"), 0755); err != nil {
+		t.Fatalf("failed to create rootfs: %v", err)
+	}
+	// Neither /run nor /run/lock exists inside the rootfs.
+	if err := os.Symlink("/run/lock", filepath.Join(rootPath, "var", "lock")); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	if err := cloudconfig.WriteFile(testLog(), cloudconfig.WritableFile{
+		Path:        "/var/lock/app.lock",
+		Content:     "locked",
+		Permissions: "0644",
+	}, rootPath); err != nil {
+		t.Fatalf("write through a dangling /var/lock was rejected: %v", err)
+	}
+
+	written := filepath.Join(rootPath, "run", "lock", "app.lock")
+	content, err := os.ReadFile(written)
+	if err != nil {
+		t.Fatalf("expected the file at %s: %v", written, err)
+	}
+	if string(content) != "locked" {
+		t.Errorf("content of %s = %q, want %q", written, content, "locked")
+	}
+}
+
+// TestWriteFileDanglingSymlinkWithDotDot covers a dangling symlink whose target
+// is relative and climbs with "..", reached through a symlinked parent. The
+// target has to be resolved against where the link actually points, not
+// against the link's own lexical path: cleaning "/alias/../missing" would name
+// /missing, which is the wrong directory and is not where the kernel then
+// looks.
+func TestWriteFileDanglingSymlinkWithDotDot(t *testing.T) {
+	t.Parallel()
+
+	rootPath := filepath.Join(t.TempDir(), "rootfs")
+	if err := os.MkdirAll(filepath.Join(rootPath, "real", "deep"), 0755); err != nil {
+		t.Fatalf("failed to create rootfs: %v", err)
+	}
+	if err := os.Symlink("real/deep", filepath.Join(rootPath, "alias")); err != nil {
+		t.Fatalf("failed to create alias symlink: %v", err)
+	}
+	if err := os.Symlink("../missing",
+		filepath.Join(rootPath, "real", "deep", "link")); err != nil {
+		t.Fatalf("failed to create dangling symlink: %v", err)
+	}
+
+	if err := cloudconfig.WriteFile(testLog(), cloudconfig.WritableFile{
+		Path:        "/alias/link/file",
+		Content:     "resolved",
+		Permissions: "0644",
+	}, rootPath); err != nil {
+		t.Fatalf("write through a dangling relative symlink was rejected: %v", err)
+	}
+
+	written := filepath.Join(rootPath, "real", "missing", "file")
+	if content, err := os.ReadFile(written); err != nil {
+		t.Fatalf("expected the file at %s: %v", written, err)
+	} else if string(content) != "resolved" {
+		t.Errorf("content = %q, want %q", content, "resolved")
+	}
+	// The lexically-cleaned target, which must not have been created.
+	assertAbsent(t, filepath.Join(rootPath, "missing"),
+		"created the lexical join of the link's path and target instead of "+
+			"resolving the link first")
+}
+
+// TestWriteFileDotDotResolvedAfterSymlink asserts ".." is applied to where a
+// preceding symlink actually points, not to the link's own lexical parent.
+// With /alias a symlink to real/deep, "/alias/../file" names /real/file.
+// Collapsing the ".." before resolving the symlink would name /file instead --
+// still inside the root, but not the directory the path denotes.
+func TestWriteFileDotDotResolvedAfterSymlink(t *testing.T) {
+	t.Parallel()
+
+	rootPath := filepath.Join(t.TempDir(), "rootfs")
+	if err := os.MkdirAll(filepath.Join(rootPath, "real", "deep"), 0755); err != nil {
+		t.Fatalf("failed to create rootfs: %v", err)
+	}
+	if err := os.Symlink("real/deep", filepath.Join(rootPath, "alias")); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	if err := cloudconfig.WriteFile(testLog(), cloudconfig.WritableFile{
+		Path:        "/alias/../file",
+		Content:     "resolved",
+		Permissions: "0644",
+	}, rootPath); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	want := filepath.Join(rootPath, "real", "file")
+	if content, err := os.ReadFile(want); err != nil {
+		t.Fatalf("expected the file at %s: %v", want, err)
+	} else if string(content) != "resolved" {
+		t.Errorf("content = %q, want %q", content, "resolved")
+	}
+	assertAbsent(t, filepath.Join(rootPath, "file"),
+		"the \"..\" was collapsed before the symlink was resolved")
+}
+
+// TestWriteFileSymlinkDepthCap asserts the bound on following symlinks whose
+// target directory does not exist yet. That recursion is the one place
+// resolution happens outside the kernel, so it needs its own limit: eight
+// links are followed, a ninth is refused.
+func TestWriteFileSymlinkDepthCap(t *testing.T) {
+	t.Parallel()
+
+	// chain builds l0 -> /l1/sub, l1 -> /l2/sub, ... with the last target
+	// missing, so writing through l0 must follow every link in turn.
+	chain := func(t *testing.T, links int) string {
+		rootPath := newRoot(t)
+		for i := 0; i < links; i++ {
+			if err := os.Symlink(fmt.Sprintf("/l%d/sub", i+1),
+				filepath.Join(rootPath, fmt.Sprintf("l%d", i))); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return rootPath
+	}
+
+	t.Run("at the limit", func(t *testing.T) {
+		t.Parallel()
+		rootPath := chain(t, 8)
+		if err := write(rootPath, "/l0/f", "deep", "0644"); err != nil {
+			t.Fatalf("a chain of 8 links was refused: %v", err)
+		}
+		if got := findFile(t, rootPath, "f"); len(got) != 1 {
+			t.Errorf("expected exactly one file named f, got %v", got)
+		}
+	})
+
+	t.Run("past the limit", func(t *testing.T) {
+		t.Parallel()
+		rootPath := chain(t, 9)
+		err := write(rootPath, "/l0/f", "deep", "0644")
+		if err == nil {
+			t.Fatal("a chain of 9 links was followed")
+		}
+		if !strings.Contains(err.Error(), "too many symbolic links") {
+			t.Errorf("error = %v, want one about too many symbolic links", err)
+		}
+	})
+}


### PR DESCRIPTION
# Description

`cloudconfig.WriteFile()` decided containment lexically, with `filepath.Join`
and `filepath.Rel`, and then wrote to the unresolved path. Those answer
different questions — whether a path string sits under `rootPath`, and where
that path actually resolves to — and they diverge at the first symlinked
directory component.

For a container application `rootPath` is the mounted rootfs of the
application's own image, so every symlink on a requested path comes from
whoever built that image. A path that was lexically contained could therefore
redirect the write out of the application's filesystem.

The same mismatch also broke legitimate writes. `os.Stat` followed the symlink
while `os.MkdirAll` operated on the unresolved path, so a `write_files` entry
under `/var/lock` (a symlink to `/run/lock` in any Debian-based image), or
under `/etc/ssl/certs` on a Fedora-based image, failed application activation
with a bare `mkdir ...: file exists`.

This resolves the path with `openat2(2)` and `RESOLVE_IN_ROOT` instead, so the
kernel treats `rootPath` as `/`: absolute symlink targets are re-rooted there
and `..` cannot climb above it. Those are `chroot(2)` semantics without
chroot's process-wide effect, and the decision is the kernel's own, so nothing
sits between judging a path safe and writing to it. The write then runs
relative to the resolved directory descriptor, so no step re-walks a path a
symlink could redirect.

Re-rooting rather than refusing is what the guest means by such a path, and it
is what fixes the two activation failures above as well as the containment
gap. `os.Root` would refuse them: it rejects absolute symlinks outright.

Note one deliberate behaviour change: an entry naming a path through an
absolute symlink now writes inside the application, where before it followed
that symlink in pillar's own mount namespace. Anything that depended on the
old behaviour changes by design.

## How to test and validate this PR

Automated, in `pkg/pillar/utils/cloudconfig` (53 cases):

```sh
go test -C pkg/pillar ./utils/cloudconfig/ -v
```

- `symlink_test.go` — a symlink cannot carry the write out of `rootPath`
  (absolute and relative forms), a contained symlink is still followed, an
  absolute target is re-rooted, a dangling target is created, `..` is applied
  after symlink resolution, and the depth cap on following dangling links.
- `path_test.go` — normalization (trailing separator, `.`, repeated
  separators, contained `..`), relative and bare names, parent creation, and
  the paths that are refused.
- `rootedwrite_test.go` — replacing whatever already occupies the destination
  (file, directory, symlink to either, dangling symlink), a blocked path
  component reported as `ENOTDIR`/`ELOOP`, permission-string conversion, and
  that no temporary file is left behind on success or failure.

Manual, on a device: deploy a container application whose image contains
`/var/lock -> /run/lock` (any Debian/Ubuntu base) with a `write_files` entry
under `/var/lock`. Before this change the application fails to activate with
`mkdir ...: file exists`; after it, the application starts and the file is
present inside the container at `/run/lock`.

This was validated end to end on an amd64 QEMU device with an
`lfedge/evetest-ubuntu-ctr` based application: the writes land inside the
application's own filesystem and nothing appears in the corresponding
directories on the device.

## Changelog notes

Fixed handling of `write_files` paths in application cloud-init: a path that
traverses a symlinked directory is now resolved inside the application's own
filesystem. This also fixes application activation failing for entries under
paths such as `/var/lock` or `/etc/ssl/certs`.

## PR Backports

- 17.0-stable: To be backported.
- 16.0-stable: To be backported.
- 14.5-stable: To be backported.
- 13.4-stable: To be backported.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

No documentation change: this corrects the behaviour of an existing field
rather than adding or changing an interface. Not tested on arm64 — the change
is architecture independent and the code path is exercised by the unit tests,
which run on every supported architecture in CI.