### PR TITLE
[16.0-stable] fix(agentlog): use proper file permissions when appending logs

### DIFF
--- a/pkg/pillar/agentlog/agentlog.go
+++ b/pkg/pillar/agentlog/agentlog.go
@@ -397,8 +397,7 @@ func GetRebootImage(log *base.LogObject) string {
 
 // Append if file exists.
 func printToFile(filename string, str string) error {
-	f, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE,
-		os.ModeAppend)
+	f, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}

--- a/tests/semgrep-rules/os-openfile-non-perm-mode.yaml
+++ b/tests/semgrep-rules/os-openfile-non-perm-mode.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2025 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+rules:
+  - id: os-openfile-non-perm-mode
+    message: "os.OpenFile called with os.O_CREATE but invalid permission mode ($MODE). Use an octal permission like 0o644 or 0644."
+    severity: ERROR
+    languages:
+      - go
+    options:
+      constant_propagation: true
+    patterns:
+      - pattern: os.OpenFile($FILENAME, $FLAGS, $MODE)
+      - metavariable-pattern:
+          metavariable: $FLAGS
+          patterns:
+            - pattern-regex: '.*O_CREATE.*'
+      - metavariable-pattern:
+          metavariable: $MODE
+          patterns:
+            - pattern-not-regex: '^0[oO]?[0-7]{3,4}$'

--- a/tests/semgrep-rules/os-openfile-non-perm-mode.yaml
+++ b/tests/semgrep-rules/os-openfile-non-perm-mode.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Zededa, Inc.
+# Copyright (c) 2025-2026 Zededa, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 ---


### PR DESCRIPTION
# Description

Backport of #5487.

The `RebootReason` function in EdgeView creates `/persist/log/reboot-reason.log`
via `printToFile`, which incorrectly passed `os.ModeAppend` as the permission
argument to `os.OpenFile`. This resulted in Unix permissions `000` on the
created file, so the EdgeView "Reboot reason" command later failed with:

```
reboot-reason.log
open /persist/log/reboot-reason.log: permission denied
```

The fix replaces `os.ModeAppend` with `0644` in `OpenFile` to correctly set
Unix `rw-r--r--` permissions when creating or appending to log files, and adds
a semgrep rule that guards against passing non-permission modes to
`os.OpenFile`.

Cherry-picked with `git cherry-pick -x` from
319babc383d4f46eaeee1dede5b716f11c2c82ea (#5487 as merged on `master`); it
applied cleanly to `16.0-stable` with no conflicts.

A follow-up commit extends the semgrep rule's copyright notice to
2025-2026, since the `spdx-check` CI on the stable branches requires
the current year in newly added files.

## PR dependencies

None.

## How to test and validate this PR

Apply the fix, or use an image with the fix in place, and run the
"Reboot reason" command from EdgeView: it should succeed. Additionally,
`/persist/log/reboot-reason.log` should be created with `rw-r--r--` (0644)
permissions instead of `000`.

## Changelog notes

Fix "Reboot reason" command in EdgeView failing due to log file permission
errors.

## PR Backports

This PR is itself a backport of #5487 to `16.0-stable`. Status across the
current LTS branches:

- 17.0-stable: Not needed, the branch already contains the original fix.
- 16.0-stable: This PR.
- 14.5-stable: #6514
- 13.4-stable: #6513

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation — no documentation changes needed
- [ ] I've tested my PR on amd64 device — not retested here; the fix was verified on `master` in #5487
- [ ] I've tested my PR on arm64 device — not retested here; the fix was verified on `master` in #5487
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs (remove it if it's not a backport):

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
