### PR TITLE
downloader: don't abort download when declared size is unknown (0)

### DIFF
--- a/pkg/pillar/cmd/downloader/download.go
+++ b/pkg/pillar/cmd/downloader/download.go
@@ -322,7 +322,9 @@ func download(ctx *downloaderContext, trType zedUpload.SyncTransportType,
 			// sometime, the download goes to an infinite loop,
 			// showing it has downloaded, more than it is supposed to
 			// aborting download, marking it as an error
-			if currentSize > totalSize {
+			// totalSize of 0 means no size hint was provided, not that
+			// the image is empty, so it must not trip this check.
+			if totalSize > 0 && currentSize > totalSize {
 				errStr := fmt.Sprintf("Size '%v' provided in image config of '%s' is incorrect.\nDownload status (%v / %v). Aborting the download",
 					totalSize, resp.GetLocalName(), currentSize, totalSize)
 				log.Errorln(errStr)


### PR DESCRIPTION
# Description

`downloader`'s progress-monitoring loop aborts an in-progress download as
soon as it sees `currentSize > totalSize`, treating that as "the download
is looping / exceeded the declared image size". But `totalSize` (the
content tree's declared `MaxSizeBytes`/`MaxDownloadSize`) legitimately can
be `0`, meaning "no size hint was provided in the config" -- not "the image is 0 bytes".
In that case the very first progress tick that observes any downloaded
bytes (`currentSize > 0`) trips the check and the download is aborted with
a misleading error:

```
Size '0' provided in image config of '<file>' is incorrect.
Download status (<n> / 0). Aborting the download
```

even though the download was proceeding correctly. This was found via a
recurring failure in EVE's nightly `evetest` CI (`TestStorageSuite` /
`TestVolumes`; running on my EVE fork), reproducing identically for several
consecutive nights.

The fix guards the check with `totalSize > 0`, so an unknown/unset size no
longer triggers a false abort.

## PR dependencies

None.

## How to test and validate this PR

**Affected automated test:** `evetest/tests/storage/volumes_test.go`,
`TestVolumes` (part of `TestStorageSuite`). It creates 5 volumes from
different image formats (docker, qcow2, qcow, vmdk, vhdx) over an HTTP
datastore without setting a size hint (`MaxDownloadBytes` unset ->
`ContentTree.MaxSizeBytes = 0`). Normally all 5 downloads finish inside a
single ~1s progress tick and never hit the buggy code path, but the vhdx
image is the largest of the five (a "blank" vhdx preallocates a multi-MB
log region even at 0 logical content), so its download reliably straddles
a progress tick while `totalSize` is still 0, tripping the abort. With
this fix, `TestVolumes` no longer fails on the vhdx volume.

**How to reproduce in production:** any EVE ContentTree/Image whose config
does not set a size hint (`MaxSizeBytes`/`MaxDownloadSize` left at `0`) and
whose download takes long enough to cross more than one progress-report
tick will trigger this (at least couple of MBs). This happens whenever the controller
(or a directly-authored device config) publishes an image/content-tree without
a known size in advance -- e.g. a custom HTTP/SFTP/S3 datastore pointing
at an externally hosted image where the controller has no prior knowledge
of the file size, or any workflow that omits the size field rather than
probing it. The larger the image (the more likely the download crosses a
progress tick before completing), the more reliably this reproduces; on a
real device this can be seen as downloads failing/erroring on the first
progress update.

## Changelog notes

Fixed a downloader bug where a content tree published without a declared
image size could have its download incorrectly aborted with a
"Size '0' provided in image config ... is incorrect" error, even though
the download was healthy.

## PR Backports

This bug (the unguarded `currentSize > totalSize` check) is present on all
current LTS branches:

- 17.0-stable: #6571
- 16.0-stable: #6572
- 14.5-stable: #6573
- 13.4-stable: #6574

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.

