### PR TITLE
evetest: widen TestFlowLog's flow-log wait to cover conntrack's extra timeout

### DIFF
--- a/evetest/tests/networking/netinst_test.go
+++ b/evetest/tests/networking/netinst_test.go
@@ -2417,11 +2417,19 @@ func TestFlowLog(test *testing.T) {
 	t.Expect(appInfo.GetNetwork()[0].GetIPAddrs()).ToNot(BeEmpty())
 	appIP := appInfo.GetNetwork()[0].GetIPAddrs()[0]
 
-	// pkg/pillar/nistate/linux.go's flowCollectInterval (~108-120s, randomized,
-	// hardcoded -- no controller-config override) governs how often the
-	// conntrack table is swept and a connection's flow record published, so
-	// give it comfortable room for at least one full cycle plus margin.
-	flowLogTimeout := 3 * time.Minute
+	// A closed TCP connection's flow record isn't reported as soon as it
+	// closes: pkg/pillar/nistate/linux_flow.go's conntrackFlowExtraTimeout
+	// (150s) only makes a conntrack entry eligible for collection once its
+	// remaining protocol timeout (e.g. nf_conntrack_tcp_timeout_time_wait /
+	// _syn_sent = 270s, see pkg/dom0-ztools/rootfs/etc/sysctl.d/02-eve.conf)
+	// drops below that threshold -- a ~120s floor after the connection
+	// closes. On top of that, pkg/pillar/nistate/linux.go's
+	// flowCollectInterval (108-120s, randomized, hardcoded -- no
+	// controller-config override) governs how often the conntrack table is
+	// actually swept, adding up to another full cycle. Worst case is
+	// therefore ~240s after the connection closes, so give it comfortable
+	// room beyond that.
+	flowLogTimeout := 5 * time.Minute
 	t.Eventually(func(g Gomega) {
 		outbound := device.GetAppFlowLogs(appUUID, evetest.FlowLogMatch{
 			VirtualNetAdapter: "vif0",


### PR DESCRIPTION
# Description

`TestFlowLog` (part of `evetest`'s `TestApplicationConnectivitySuite`) waits
up to `flowLogTimeout` (3 minutes) for flow log records to be reported for
traffic it just generated. This has been failing intermittently but very
frequently in the nightly `evetest` CI run (on my fork) with:

```
Timed out after 180.000s.
The function passed to Eventually failed at .../netinst_test.go:2437 with:
expected an outbound flow record for the allowed HTTP ACE (2) from 10.50.0.2 to 10.17.17.25:80
```

The 3-minute budget only accounted for one `flowCollectInterval` cycle
(`pkg/pillar/nistate/linux.go`, 108-120s randomized) -- the interval at
which EVE sweeps the conntrack table and publishes flow records. It
missed a second, larger delay: a closed TCP connection's flow record
isn't even *eligible* for collection until `conntrackFlowExtraTimeout`
(`pkg/pillar/nistate/linux_flow.go`, 150s) worth of its protocol timeout
has elapsed. The relevant protocol timeouts
(`nf_conntrack_tcp_timeout_time_wait` / `_syn_sent`, both 270s in
`pkg/dom0-ztools/rootfs/etc/sysctl.d/02-eve.conf`) mean that floor alone
is ~120s after the connection closes -- before the collection cycle even
applies. Worst case is therefore ~240s after the connection closes,
comfortably exceeding the old 180s test budget.

This is purely a test-timing bug (confirmed by directly reading the
pillar source and sysctl defaults referenced above) -- not a
functional/regression bug in EVE's flow logging.

## PR dependencies

None.

## How to test and validate this PR

**Affected test:** `evetest/tests/networking/netinst_test.go`,
`TestFlowLog` (part of `TestApplicationConnectivitySuite`). Prior to this
fix it failed very frequently (multiple times across every night for the
past several days) with the timeout above; this change widens
`flowLogTimeout` from 3 to 5 minutes, which comfortably covers the ~240s
worst case derived above, and updates the explanatory comment to describe
both delay sources.

## Changelog notes

None (test-only change, no user-facing impact).

## PR Backports

No backport needed via the usual per-PR process: `evetest` is not yet
wired into the stable-branch CI, and its accumulated changes (including
this one) will be backported to each stable branch together in a
separate batch pass.

- 17.0-stable: No, evetest backports handled separately in bulk.
- 16.0-stable: No, evetest backports handled separately in bulk.
- 14.5-stable: No, evetest backports handled separately in bulk.
- 13.4-stable: No, evetest backports handled separately in bulk.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.