### PR TITLE
nireconciler: track bridge identity for BridgeFwdMask like other bridge-dependent items

### DIFF
--- a/pkg/pillar/nireconciler/linux_config.go
+++ b/pkg/pillar/nireconciler/linux_config.go
@@ -647,8 +647,9 @@ func (r *LinuxNIReconciler) getIntendedNIL2Cfg(niID uuid.UUID) dg.Graph {
 		InstanceID:   bridgeInstanceID,
 	}, nil)
 	intendedL2Cfg.PutItem(linux.BridgeFwdMask{
-		BridgeIfName: ni.brIfName,
-		ForwardLLDP:  ni.config.ForwardLLDP,
+		BridgeIfName:     ni.brIfName,
+		ForwardLLDP:      ni.config.ForwardLLDP,
+		ExpectedBridgeID: bridgeInstanceID,
 	}, nil)
 	// For Switch NI also add the intended VLAN configuration.
 	// Here we put VLAN config only for the bridge itself and the port interface,

--- a/pkg/pillar/nireconciler/linuxitems/bridgefwdmask.go
+++ b/pkg/pillar/nireconciler/linuxitems/bridgefwdmask.go
@@ -11,6 +11,7 @@ import (
 
 	dg "github.com/lf-edge/eve-libs/depgraph"
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/types"
 )
 
 const (
@@ -43,6 +44,9 @@ type BridgeFwdMask struct {
 	// frames (destination MAC 01-80-C2-00-00-0D).
 	// Note: currently not configurable via EVE API (i.e. always disabled).
 	ForwardMVRP bool
+	// ExpectedBridgeID: IfInstanceID BridgeIfName is expected to carry. Zero
+	// if the bridge is not NIM-managed.
+	ExpectedBridgeID types.IfInstanceID
 }
 
 // Name returns the interface name of the bridge
@@ -78,8 +82,8 @@ func (m BridgeFwdMask) External() bool {
 // String describes BridgeFwdMask.
 func (m BridgeFwdMask) String() string {
 	return fmt.Sprintf("BridgeFwdMask: {bridgeIfName: %s, forwardLLDP: %t, "+
-		"forwardEAPOL: %t, forwardMVRP: %t}",
-		m.BridgeIfName, m.ForwardLLDP, m.ForwardEAPOL, m.ForwardMVRP)
+		"forwardEAPOL: %t, forwardMVRP: %t, expectedBridgeID: %d}",
+		m.BridgeIfName, m.ForwardLLDP, m.ForwardEAPOL, m.ForwardMVRP, m.ExpectedBridgeID)
 }
 
 // Dependencies returns the bridge as the only dependency.
@@ -89,6 +93,21 @@ func (m BridgeFwdMask) Dependencies() (deps []dg.Dependency) {
 			RequiredItem: dg.ItemRef{
 				ItemType: BridgeTypename,
 				ItemName: m.BridgeIfName,
+			},
+			MustSatisfy: func(item dg.Item) bool {
+				if m.ExpectedBridgeID == 0 {
+					return true
+				}
+				bridge, isBridge := item.(Bridge)
+				if !isBridge {
+					// unreachable
+					return false
+				}
+				// Reject a same-named bridge NIM has since torn down and
+				// recreated -- the forwarding mask lives on the bridge itself,
+				// so it is genuinely gone with it (hence AutoDeletedByExternal
+				// below), and must be reapplied to the new incarnation.
+				return bridge.InstanceID == m.ExpectedBridgeID
 			},
 			Description: "Bridge must exist",
 			Attributes: dg.DependencyAttributes{
@@ -148,6 +167,14 @@ func (c *BridgeFwdMaskConfigurator) Delete(ctx context.Context, item dg.Item) er
 	fwdMaskVal := "0x0"
 	fwdMaskPath := fmt.Sprintf(groupFwdMaskPathTemplate, fwdMask.BridgeIfName)
 	if err := os.WriteFile(fwdMaskPath, []byte(fwdMaskVal), 0644); err != nil {
+		if os.IsNotExist(err) {
+			// Ignore if the bridge was already removed (e.g. NIM tore it down
+			// and is recreating it under the same name) -- the forwarding
+			// mask is implicitly gone too.
+			c.Log.Warnf("Bridge %s is already gone, nothing to zero-out: %v",
+				fwdMask.BridgeIfName, err)
+			return nil
+		}
 		return fmt.Errorf("failed to zero-out forwarding mask for bridge %s: %w",
 			fwdMask.BridgeIfName, err)
 	}

--- a/pkg/pillar/nireconciler/linuxitems/items_test.go
+++ b/pkg/pillar/nireconciler/linuxitems/items_test.go
@@ -139,16 +139,32 @@ func TestBridgeFwdMaskEqual(t *testing.T) {
 	if m1.Equal(DummyIf{}) {
 		t.Error("wrong type should be unequal")
 	}
+	m4DiffInstanceID := BridgeFwdMask{BridgeIfName: "br0", ForwardLLDP: true, ExpectedBridgeID: 42}
+	if m1.Equal(m4DiffInstanceID) {
+		t.Error("different ExpectedBridgeID should be unequal")
+	}
 }
 
 func TestBridgeFwdMaskDependencies(t *testing.T) {
-	m := BridgeFwdMask{BridgeIfName: "br0"}
+	m := BridgeFwdMask{BridgeIfName: "br0", ExpectedBridgeID: 42}
 	deps := m.Dependencies()
 	if len(deps) != 1 {
 		t.Fatalf("expected 1 dep, got %d", len(deps))
 	}
 	if deps[0].RequiredItem.ItemType != BridgeTypename || deps[0].RequiredItem.ItemName != "br0" {
 		t.Errorf("dep should be Bridge br0, got %+v", deps[0].RequiredItem)
+	}
+	if deps[0].MustSatisfy == nil {
+		t.Fatal("Bridge dep should have MustSatisfy when ExpectedBridgeID is set")
+	}
+	if !deps[0].MustSatisfy(Bridge{IfName: "br0", InstanceID: 42}) {
+		t.Error("MustSatisfy should accept a Bridge with the expected InstanceID")
+	}
+	if deps[0].MustSatisfy(Bridge{IfName: "br0", InstanceID: 43}) {
+		t.Error("MustSatisfy should reject a Bridge with a different InstanceID -- this is " +
+			"what lets a NIM-recreated bridge (same name) be detected as changed, so a stale " +
+			"BridgeFwdMask is auto-deleted instead of Delete() being called against the " +
+			"already-gone old bridge")
 	}
 }
 


### PR DESCRIPTION
# Description

`TestSwitchNIPortConfigRace` (evetest, `TestApplicationConnectivitySuite`)
has been failing intermittently but very frequently in the nightly evetest
CI run (on my EVE fork), putting a switch network instance into `ZNETINST_STATE_ERROR`:

```
failed items: BridgeFwdMask/vlan100 (failed to zero-out forwarding mask
for bridge vlan100: open /sys/class/net/vlan100/bridge/group_fwd_mask:
no such file or directory)
```

even though the bridge and its forwarding mask are healthy again moments
later -- the test deliberately churns a switch NI's port config, which
makes NIM tear down and recreate the underlying bridge under the same
name.

This is a direct gap left by commit 8f277c37b ("Track NIM
interface/bridge identity via IfInstanceID"), which added an
`ExpectedBridgeID`/`ExpectedPortID` field plus a `MustSatisfy` dependency
check to every other bridge-dependent reconciler item (`VLANBridge`,
`VLANPort`, `BridgePort`, `TCMirror`, `TCIngress`, `BPDUGuard`) so that
when NIM recreates a bridge under the same name, the reconciler detects
the identity change and skips calling `Delete()` on stale dependents
(`AutoDeletedByExternal`) instead of running it for real against a bridge
that no longer exists. `BridgeFwdMask` was missed: it already declared
`AutoDeletedByExternal` on its "Bridge must exist" dependency, but
without an identity check the dependency stayed "satisfied" across a
bridge recreation, so the reconciler kept invoking a real `Delete()` (and
then `Create()`) against the old, already torn-down bridge, hitting the
sysfs `ENOENT` above.

## PR dependencies

None.

## How to test and validate this PR

Covered by `evetest`'s `TestSwitchNIPortConfigRace`
(`tests/networking/netinst_test.go`), which churns a switch NI's port
config to force NIM to tear down and recreate the underlying bridge.
Before this fix it failed intermittently with a `BridgeFwdMask`
`ZNETINST_STATE_ERROR`; with the fix it passes reliably.

To reproduce in production: use a switch network instance whose sole
port is a NIM-managed adapter/bridge, then change the device's port
config in a way that makes NIM recreate that bridge under the same name
(e.g. toggle the adapter between DHCP and static). Occasionally this
races the NI into a spurious `ZNETINST_STATE_ERROR` that clears itself a
moment later.

## Changelog notes

Fixed an intermittent, spurious network-instance error that could occur
when NIM tears down and recreates a bridge (e.g. due to a port
reconfiguration) while a switch network instance is using it -- the
bridge's forwarding-mask cleanup could race the bridge's own removal and
be wrongly reported as a failure.

## PR Backports

This bug only exists starting from commit 8f277c37b ("Track NIM
interface/bridge identity via IfInstanceID", #6460), which has not yet
been backported to any current LTS branch (confirmed: not an ancestor of
17.0-stable, 16.0-stable, 14.5-stable, or 13.4-stable). This PR should be
backported together with #6460, to whichever stable branch(es) #6460
itself ends up being backported to -- it doesn't apply on its own to a
branch that doesn't have #6460.

- 17.0-stable: #6576 (combined with #6460's backport)
- 16.0-stable: #6577 (combined with #6460's backport)
- 14.5-stable: Not backported -- #6460 was not backported here (too diverged), and the `BridgeFwdMask` reconciler item this PR fixes does not exist on this branch at all, so there is nothing for this fix to apply to.
- 13.4-stable: Not backported, same reason as 14.5-stable.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [ ] I've set the proper labels to this PR
- [x] I've checked the boxes above, or I've provided a good reason why I didn't check them.



