### PR TITLE
[14.5-stable] dpcmanager: configurable DPC test-fail interval, lower testinterval floor

### DIFF
--- a/docs/CONFIG-PROPERTIES.md
+++ b/docs/CONFIG-PROPERTIES.md
@@ -26,6 +26,7 @@
 | timer.port.georetry | integer in seconds | 600 | retry geolocation after failure |
 | timer.port.testduration | integer in seconds | 30 | wait for DHCP to give address |
 | timer.port.testinterval | timer in seconds | 300 | retest the current port config |
+| timer.port.testfailinterval | timer in seconds | 300 | minimum time a port config must wait after a verification failure before it is eligible to be retested |
 | timer.port.timeout | timer in seconds | 15 | time for each http/send |
 | timer.port.testbetterinterval | timer in seconds | 600 | test a higher prio port config |
 | network.fallback.any.eth | "enabled" or "disabled" | disabled (enabled forcefully during onboarding if no network config) | if no connectivity try any Ethernet, WiFi, or LTE with DHCP client |

--- a/pkg/pillar/dpcmanager/dpcmanager.go
+++ b/pkg/pillar/dpcmanager/dpcmanager.go
@@ -69,9 +69,10 @@ type DpcManager struct {
 
 	// Minimum time that should pass after a DPC verification failure
 	// until the DPC is eligible for another round of verification.
-	// By default it is 5 minutes.
-	// It is useful to override for unit testing purposes.
-	// XXX Should we make this a global config parameter?
+	// Driven by the NetworkTestFailInterval global config item once GCP is
+	// available (see doUpdateGCP); defaults to 5 minutes beforehand.
+	// It is useful to preset for unit testing purposes, e.g. before the
+	// first UpdateGCP call, or in tests that never call it at all.
 	DpcMinTimeSinceFailure time.Duration
 
 	// Time limit for some DPC to become available.
@@ -566,6 +567,8 @@ func (m *DpcManager) doUpdateGCP(ctx context.Context, gcp types.ConfigItemValueM
 		time.Duration(m.globalCfg.GlobalValueInt(types.NetworkTestBetterInterval))
 	testDuration := time.Second *
 		time.Duration(m.globalCfg.GlobalValueInt(types.NetworkTestDuration))
+	testFailInterval := time.Second *
+		time.Duration(m.globalCfg.GlobalValueInt(types.NetworkTestFailInterval))
 	// We refresh the gelocation information when the underlay aka public
 	// IP address(es) change, plus periodically with this interval.
 	geoRedoInterval := time.Second *
@@ -600,6 +603,7 @@ func (m *DpcManager) doUpdateGCP(ctx context.Context, gcp types.ConfigItemValueM
 		}
 		m.dpcTestDuration = testDuration
 	}
+	m.DpcMinTimeSinceFailure = testFailInterval
 	if m.geoRetryInterval != geoRetryInterval {
 		if geoRetryInterval == 0 {
 			m.Log.Warn("NOT running GeoTimer")

--- a/pkg/pillar/dpcmanager/dpcmanager_test.go
+++ b/pkg/pillar/dpcmanager/dpcmanager_test.go
@@ -282,6 +282,9 @@ func globalConfig() types.ConfigItemValueMap {
 	gcp.SetGlobalValueInt(types.NetworkTestInterval, 2)
 	gcp.SetGlobalValueInt(types.NetworkTestBetterInterval, 3)
 	gcp.SetGlobalValueInt(types.NetworkTestDuration, 1)
+	// Matches initTest's DpcMinTimeSinceFailure struct field preset (in
+	// effect only until the first UpdateGCP call, which this overrides).
+	gcp.SetGlobalValueInt(types.NetworkTestFailInterval, 3)
 	gcp.SetGlobalValueInt(types.NetworkGeoRetryTime, 1)
 	gcp.SetGlobalValueInt(types.NetworkGeoRedoTime, 3)
 	gcp.SetGlobalValueInt(types.LocationCloudInterval, 10)

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -189,6 +189,10 @@ const (
 	NetworkTestDuration GlobalSettingKey = "timer.port.testduration"
 	// NetworkTestInterval global setting key
 	NetworkTestInterval GlobalSettingKey = "timer.port.testinterval"
+	// NetworkTestFailInterval global setting key: minimum time a DPC must
+	// wait after a verification failure before it is eligible to be
+	// retested again (DpcManager.DpcMinTimeSinceFailure).
+	NetworkTestFailInterval GlobalSettingKey = "timer.port.testfailinterval"
 	// NetworkTestBetterInterval global setting key
 	NetworkTestBetterInterval GlobalSettingKey = "timer.port.testbetterinterval"
 	// NetworkTestTimeout global setting key
@@ -973,6 +977,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(NetworkGeoRetryTime, 600, 5, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkTestDuration, 30, 10, 3600)
 	configItemSpecMap.AddIntItem(NetworkTestInterval, 300, 60, 3600)
+	configItemSpecMap.AddIntItem(NetworkTestFailInterval, 300, 60, 3600)
 	configItemSpecMap.AddIntItem(NetworkTestBetterInterval, 600, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkTestTimeout, 15, 0, 3600)
 	configItemSpecMap.AddIntItem(NetworkSendTimeout, 120, 0, 3600)

--- a/pkg/pillar/types/global.go
+++ b/pkg/pillar/types/global.go
@@ -972,7 +972,7 @@ func NewConfigItemSpecMap() ConfigItemSpecMap {
 	configItemSpecMap.AddIntItem(NetworkGeoRedoTime, 3600, 60, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkGeoRetryTime, 600, 5, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkTestDuration, 30, 10, 3600)
-	configItemSpecMap.AddIntItem(NetworkTestInterval, 300, 300, 3600)
+	configItemSpecMap.AddIntItem(NetworkTestInterval, 300, 60, 3600)
 	configItemSpecMap.AddIntItem(NetworkTestBetterInterval, 600, 0, 0xFFFFFFFF)
 	configItemSpecMap.AddIntItem(NetworkTestTimeout, 15, 0, 3600)
 	configItemSpecMap.AddIntItem(NetworkSendTimeout, 120, 0, 3600)

--- a/pkg/pillar/types/global_test.go
+++ b/pkg/pillar/types/global_test.go
@@ -166,6 +166,7 @@ func TestNewConfigItemSpecMap(t *testing.T) {
 		NetworkGeoRetryTime,
 		NetworkTestDuration,
 		NetworkTestInterval,
+		NetworkTestFailInterval,
 		NetworkTestBetterInterval,
 		NetworkTestTimeout,
 		NetworkSendTimeout,


### PR DESCRIPTION
# Description

Backport of #6464

## PR dependencies

None.

## How to test and validate this PR

See #6464.

## Changelog notes

Lowered the minimum allowed value for the `timer.port.testinterval`
config setting to 1 minute, and added a new `timer.port.testfailinterval`
config setting controlling how long a device port config must wait after
a verification failure before being retested again. No behavior change at
default values.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [ ] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [ ] I've written the test verification instructions
- [x] I've set the proper labels to this PR

For backport PRs:

- [x] I've added a reference link to the original PR
- [x] PR's title follows the template

And the last but not least:

- [x] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)