### PR TITLE
hypervisor/kubevirt: base halted state on the whole workload

### DIFF
--- a/pkg/pillar/cmd/domainmgr/domainmgr.go
+++ b/pkg/pillar/cmd/domainmgr/domainmgr.go
@@ -1135,6 +1135,29 @@ func runHandler(ctx *domainContext, key string, configChannel <-chan Notify, cpu
 	log.Functionf("runHandler(%s) DONE", key)
 }
 
+// kubevirtStillReaping reports whether Info's HALTING means the VMIRS is
+// gone but Kubernetes is still reaping its VMI and pod -- not a teardown
+// yet, unlike HALTING's qemu -no-shutdown meaning on other hypervisors.
+func kubevirtStillReaping(ctx *domainContext, domainStatus types.SwState, err error) bool {
+	return ctx.hvTypeKube && err == nil && domainStatus == types.HALTING
+}
+
+// kubevirtDeactivateComplete reports whether an async kubevirt deactivate
+// (asyncKubevirtDeactivate) has finished: the workload is absent, this is
+// not a delete, and the app has not been re-activated since.
+func kubevirtDeactivateComplete(ctx *domainContext, status *types.DomainStatus,
+	configActivate bool, domainStatus types.SwState) bool {
+	return ctx.hvTypeKube && status.Activated && !configActivate &&
+		!status.PendingDelete && domainStatus == types.HALTED
+}
+
+// asyncKubevirtDeactivate reports whether doInactivate should hand this
+// teardown to Kubernetes and return rather than block: a live kubevirt
+// deactivate, not a delete -- handleDelete always passes impatient=true.
+func asyncKubevirtDeactivate(ctx *domainContext, status *types.DomainStatus, impatient bool) bool {
+	return ctx.hvTypeKube && !impatient && status.DomainId != 0
+}
+
 // Check if it is still running
 func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 	// Never reconcile a domain whose crash is being handled: a dump may be in
@@ -1155,8 +1178,11 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 	// process is still paused holding resources (qemu -no-shutdown); treat it
 	// like HALTED so we tear it down and free the resources rather than leaving
 	// it parked. (Info only reports HALTING once the guest has actually powered
-	// off, so an in-progress shutdown is not cut short.)
-	if err != nil || domainStatus == types.HALTED || domainStatus == types.HALTING {
+	// off, so an in-progress shutdown is not cut short.) Under kubevirt this
+	// same state means the opposite thing, so kubevirtStillReaping is checked
+	// first and holds instead.
+	if !kubevirtStillReaping(ctx, domainStatus, err) &&
+		(err != nil || domainStatus == types.HALTED || domainStatus == types.HALTING) {
 		if status.Activated && configActivate {
 			if err == nil {
 				err = fmt.Errorf("unexpected state %s", domainStatus.String())
@@ -1211,6 +1237,15 @@ func verifyStatus(ctx *domainContext, status *types.DomainStatus) {
 					log.Errorf("failed to cleanup domain: %s (%v)", status.DomainName, err)
 				}
 			}
+		} else if kubevirtDeactivateComplete(ctx, status, configActivate, domainStatus) {
+			// doInactivate handed this teardown to Kubernetes and returned.
+			// The workload is absent now, so release the resources and
+			// settle the state here. DomainId has to be cleared first, or
+			// doCleanup reads a live domain and records a failure instead.
+			log.Noticef("verifyStatus(%s): deactivate complete, workload absent",
+				status.Key())
+			status.DomainId = 0
+			doCleanup(ctx, status)
 		}
 		status.DomainId = 0
 		publishDomainStatus(ctx, status)
@@ -2260,6 +2295,21 @@ func doInactivate(ctx *domainContext, status *types.DomainStatus, impatient bool
 	doShutdown, firstDelay := shutdownBudget(status.VirtualizationMode,
 		hyper.Name(), maxDelay)
 
+	// A kubevirt deactivate hands the teardown to Kubernetes and returns:
+	// deleting the VMIRS is the whole of EVE's part, and reaping the VMI and
+	// its pod can outlast any budget worth blocking a config apply for.
+	// verifyStatus settles the state once Info reports all three absent.
+	// handleDelete (impatient) stays synchronous, because it unpublishes
+	// DomainStatus as soon as this returns.
+	if asyncKubevirtDeactivate(ctx, status, impatient) {
+		status.State = types.HALTING
+		publishDomainStatus(ctx, status)
+		if err := DomainShutdown(ctx, *status, false); err != nil {
+			log.Errorf("doInactivate(%s) Shutdown failed: %s", status.Key(), err)
+		}
+		return
+	}
+
 	if status.DomainId != 0 {
 		status.State = types.HALTING
 		publishDomainStatus(ctx, status)
@@ -2961,7 +3011,11 @@ func waitForDomainGone(status types.DomainStatus, maxDelay time.Duration) bool {
 				state.String())
 			return true
 		}
-		if state == types.HALTING {
+		// Under kubevirt HALTING means the reverse of the case below: the
+		// VMIRS is gone and Kubernetes is still reaping the VMI and its
+		// pod. Nothing is parked for the caller to reap, so keep polling
+		// until the workload is really absent.
+		if state == types.HALTING && !base.IsHVTypeKube() {
 			// The guest has powered off but the hypervisor process is still
 			// paused holding its resources (e.g. qemu -no-shutdown). Stop
 			// waiting and let the caller reap it (Delete) now rather than

--- a/pkg/pillar/hypervisor/kubevirt.go
+++ b/pkg/pillar/hypervisor/kubevirt.go
@@ -941,6 +941,64 @@ func confirmPodReplicaSetGone(kubeconfig *rest.Config, name string) error {
 	}
 }
 
+// dependentsPresent reports whether this domain's VMI or virt-launcher pod
+// still exists after its VMIRS is gone. A pod holds the RWO disk until it
+// is deleted, so an absent VMIRS alone does not mean the domain is down.
+//
+// Single pass, not a retry loop: the caller polls again.
+func (t kubevirtTask) dependentsPresent(domainName string) (bool, error) {
+	if t.metaType() == IsMetaReplicaPod {
+		// A NOHYPER app has no VMI; its pods carry "app=<kubeName>",
+		// which is already generation-specific.
+		clientset, err := newK8sClient(t.kubeConfig)
+		if err != nil {
+			return false, err
+		}
+		listCtx, listCancel := apiCtx()
+		defer listCancel()
+		pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).
+			List(listCtx, metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("app=%s", t.kubeName()),
+			})
+		if err != nil {
+			return false, err
+		}
+		return len(pods.Items) > 0, nil
+	}
+
+	virtClient, err := newKubevirtClient(t.kubeConfig)
+	if err != nil {
+		return false, err
+	}
+	vmiCtx, vmiCancel := apiCtx()
+	defer vmiCancel()
+	vmis, err := virtClient.VirtualMachineInstance(kubeapi.EVEKubeNameSpace).
+		List(vmiCtx, metav1.ListOptions{
+			LabelSelector: eveLabelKey + "=" + domainName,
+		})
+	if err != nil {
+		return false, err
+	}
+	if len(vmis.Items) > 0 {
+		return true, nil
+	}
+
+	clientset, err := newK8sClient(t.kubeConfig)
+	if err != nil {
+		return false, err
+	}
+	podCtx, podCancel := apiCtx()
+	defer podCancel()
+	pods, err := clientset.CoreV1().Pods(kubeapi.EVEKubeNameSpace).
+		List(podCtx, metav1.ListOptions{
+			LabelSelector: "kubevirt.io=virt-launcher," + eveLabelKey + "=" + domainName,
+		})
+	if err != nil {
+		return false, err
+	}
+	return len(pods.Items) > 0, nil
+}
+
 // sweepStaleGenerations deletes every VMIRS/ReplicaSet belonging to this
 // app whose purge counter is strictly less than desiredCounter, and
 // confirms each one is actually gone - object and pods - before returning.
@@ -1576,12 +1634,32 @@ func (t kubevirtTask) replicaSetUID(kubeName string) (uid string, err error) {
 	return string(vmirs.UID), nil
 }
 
-// Info's contract: DomainId is zero if and only if the VMIRS (or plain
-// ReplicaSet, for a NOHYPER app) is confirmed absent (Get -> NotFound).
-// Every other outcome - found, found-but-unattributed, found-with-an-
-// unmapped-phase, or the existence check itself failing - returns a
-// non-zero id, because a zero id is what tells domainmgr's doInactivate/
-// doCleanup that a teardown already happened.
+// confirmedAbsent is the only place Info may report a workload as gone: it
+// checks dependentsPresent before returning HALTED, so a caller never sees
+// the domain reported down while its VMI or pod is still up. where names
+// the call site, for the log line only.
+func (t kubevirtTask) confirmedAbsent(domainName, kubeName, where string) (int, types.SwState, error) {
+	present, err := t.dependentsPresent(domainName)
+	if err != nil {
+		// Absence not established: hold the caller's id rather than
+		// emitting the confirmed-absent token.
+		logrus.Infof("Info(%s): %s absent (%s) but the dependent check failed: %v",
+			domainName, kubeName, where, err)
+		return t.status.DomainId, types.UNKNOWN, err
+	}
+	if present {
+		logrus.Infof("Info(%s): %s absent (%s), a VMI or pod is still present",
+			domainName, kubeName, where)
+		return t.status.DomainId, types.HALTING, nil
+	}
+	logrus.Infof("Info(%s): %s confirmed absent (%s)", domainName, kubeName, where)
+	return 0, types.HALTED, nil
+}
+
+// Info's contract: DomainId is zero only when the VMIRS (or ReplicaSet, for
+// NOHYPER), its VMI, and its pod are all confirmed absent. Every other
+// outcome keeps a non-zero id, since zero tells domainmgr's
+// doInactivate/doCleanup that a teardown already happened.
 func (t kubevirtTask) Info(domainName string) (int, types.SwState, error) {
 	logrus.Debugf("Info called for Domain: %s", domainName)
 	nodeName, ok := t.nodeNameMap["nodename"]
@@ -1602,8 +1680,7 @@ func (t kubevirtTask) Info(domainName string) (int, types.SwState, error) {
 	uid, err := t.replicaSetUID(kubeName)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			logrus.Infof("Info(%s): %s confirmed absent", domainName, kubeName)
-			return 0, types.HALTED, nil
+			return t.confirmedAbsent(domainName, kubeName, "existence check")
 		}
 		// Existence could not be confirmed one way or the other (API
 		// unreachable, or some other error): never produce the "confirmed
@@ -1654,9 +1731,7 @@ func (t kubevirtTask) Info(domainName string) (int, types.SwState, error) {
 				// so this is the same confirmed-absent answer arriving one
 				// call later. Returning here also skips the fall-through's
 				// own Get, which can only reach the same conclusion.
-				logrus.Infof("Info(%s): %s confirmed absent after the existence check",
-					domainName, kubeName)
-				return 0, types.HALTED, nil
+				return t.confirmedAbsent(domainName, kubeName, "existence check race")
 			}
 			if isK3sUnreachable(rerr) {
 				// Unknown, not absent: hold the caller's id rather than
@@ -1688,9 +1763,7 @@ func (t kubevirtTask) Info(domainName string) (int, types.SwState, error) {
 			// Backstop for the lookups that do their own Get: the NOHYPER
 			// dispatch and the fall-through above. Absence is absence
 			// wherever it is observed.
-			logrus.Infof("Info(%s): %s confirmed absent during the scheduling lookup",
-				domainName, kubeName)
-			return 0, types.HALTED, nil
+			return t.confirmedAbsent(domainName, kubeName, "scheduling lookup")
 		}
 		if isK3sUnreachable(err) {
 			logrus.Infof("Info(%s): k3s unreachable while determining scheduled node: %v",

--- a/pkg/pillar/hypervisor/kubevirt_dependents_test.go
+++ b/pkg/pillar/hypervisor/kubevirt_dependents_test.go
@@ -1,0 +1,449 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build k
+
+package hypervisor
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/lf-edge/eve/pkg/pillar/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	k8sv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"github.com/lf-edge/eve/pkg/pillar/kubeapi"
+)
+
+// swapK8sClientWithObjects is swapK8sClientNoPods with a seeded cluster,
+// for the rows where a pod outlives its VMIRS.
+func swapK8sClientWithObjects(t *testing.T, objs ...runtime.Object) {
+	t.Helper()
+	orig := newK8sClient
+	fakeClientset := fake.NewSimpleClientset(objs...)
+	newK8sClient = func(cfg *rest.Config) (kubernetes.Interface, error) {
+		if cfg == nil {
+			t.Errorf("newK8sClient called with a nil *rest.Config: " +
+				"the caller did not populate kubeConfig")
+		}
+		return fakeClientset, nil
+	}
+	t.Cleanup(func() { newK8sClient = orig })
+}
+
+// mkVirtLauncherPod builds the pod KubeVirt runs a VMI in, carrying the
+// labels a real one carries: "kubevirt.io=virt-launcher" plus the
+// App-Domain-Name that CreateReplicaVMIConfig's template sets.
+func mkVirtLauncherPod(name, domainNameLabel string) *k8sv1.Pod {
+	return &k8sv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: kubeapi.EVEKubeNameSpace,
+			Labels: map[string]string{
+				"kubevirt.io": "virt-launcher",
+				eveLabelKey:   domainNameLabel,
+			},
+		},
+	}
+}
+
+// mkAppPod builds a NOHYPER app's container pod, labeled "app=<kubeName>".
+func mkAppPod(name, appLabel string) *k8sv1.Pod {
+	return &k8sv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: kubeapi.EVEKubeNameSpace,
+			Labels:    map[string]string{"app": appLabel},
+		},
+	}
+}
+
+// mkVMI builds a VMI carrying the App-Domain-Name label its VMIRS
+// template sets, which is how dependentsPresent finds it.
+func mkVMI(name, domainNameLabel string) v1.VirtualMachineInstance {
+	return v1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: kubeapi.EVEKubeNameSpace,
+			Labels:    map[string]string{eveLabelKey: domainNameLabel},
+		},
+	}
+}
+
+// expectVMIList adds a VirtualMachineInstance().List() expectation to
+// mockClient that honors the label selector rather than returning the
+// fixtures blindly, so a test using it covers the selector dependentsPresent
+// builds and not just the mock -- the fake clientset already does this for
+// pods. Returns how many times that List was consulted.
+//
+// Shared rather than folded into dependentMocks below: a caller with its own
+// ReplicaSet expectations (e.g. one asserting a specific sequence of Get
+// answers) still needs this same VMI side wired in.
+func expectVMIList(t *testing.T, ctrl *gomock.Controller,
+	mockClient *kubecli.MockKubevirtClient, vmis []v1.VirtualMachineInstance) *int {
+	t.Helper()
+	vmiCalls := 0
+	mockVMI := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
+	mockClient.EXPECT().VirtualMachineInstance(gomock.Any()).
+		Return(mockVMI).AnyTimes()
+	mockVMI.EXPECT().List(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ interface{}, opts interface{}) (*v1.VirtualMachineInstanceList, error) {
+			vmiCalls++
+			var raw string
+			switch o := opts.(type) {
+			case metav1.ListOptions:
+				raw = o.LabelSelector
+			case *metav1.ListOptions:
+				raw = o.LabelSelector
+			default:
+				t.Fatalf("unexpected ListOptions type %T", opts)
+			}
+			selector, err := labels.Parse(raw)
+			if err != nil {
+				return nil, err
+			}
+			matched := &v1.VirtualMachineInstanceList{}
+			for _, vmi := range vmis {
+				if selector.Matches(labels.Set(vmi.Labels)) {
+					matched.Items = append(matched.Items, vmi)
+				}
+			}
+			return matched, nil
+		}).AnyTimes()
+	return &vmiCalls
+}
+
+// dependentMocks wires a kubevirt client whose VMI List returns the given
+// VMIs, and reports how many times that List was consulted.
+func dependentMocks(t *testing.T, vmirs *v1.VirtualMachineInstanceReplicaSet,
+	kubeName string, vmis []v1.VirtualMachineInstance) *int {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	mockClient := kubecli.NewMockKubevirtClient(ctrl)
+
+	mockRS := kubecli.NewMockReplicaSetInterface(ctrl)
+	mockClient.EXPECT().ReplicaSet(gomock.Any()).Return(mockRS).AnyTimes()
+	if vmirs == nil {
+		mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			nil, apierrors.NewNotFound(
+				schema.GroupResource{
+					Group:    "kubevirt.io",
+					Resource: "virtualmachineinstancereplicasets",
+				}, kubeName)).AnyTimes()
+	} else {
+		mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(vmirs, nil).AnyTimes()
+	}
+
+	vmiCalls := expectVMIList(t, ctrl, mockClient, vmis)
+	swapKubevirtClient(t, mockClient)
+	return vmiCalls
+}
+
+// TestDependentsPresent is the truth table for the two objects that can
+// outlive a deleted VMIRS. Either one alone means the workload is still
+// there, because the pod holds the RWO disk until it is gone.
+func TestDependentsPresent(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		vmi  bool
+		pod  bool
+		want bool
+	}{
+		{name: "vmi absent, pod absent", want: false},
+		{name: "vmi absent, pod present", pod: true, want: true},
+		{name: "vmi present, pod absent", vmi: true, want: true},
+		{name: "vmi present, pod present", vmi: true, pod: true, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			task, _ := newInfoTestTask(t, 918273645)
+			domainName := task.status.DomainName
+
+			var vmis []v1.VirtualMachineInstance
+			if tc.vmi {
+				vmis = append(vmis, mkVMI("vmi-0", domainName))
+			}
+			var pods []runtime.Object
+			if tc.pod {
+				pods = append(pods, mkVirtLauncherPod("virt-launcher-vmi-0", domainName))
+			}
+			dependentMocks(t, nil, task.kubeName(), vmis)
+			swapK8sClientWithObjects(t, pods...)
+
+			task.kubeConfig = &rest.Config{}
+			got, err := task.dependentsPresent(domainName)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestDependentsAreScopedToTheDomain: the labels are per-domainName,
+// so another app's - or an older generation's - leftovers must not make
+// this domain look alive.
+func TestDependentsAreScopedToTheDomain(t *testing.T) {
+	task, _ := newInfoTestTask(t, 1)
+	dependentMocks(t, nil, task.kubeName(),
+		[]v1.VirtualMachineInstance{mkVMI("vmi-other", "someone-else.1.1")})
+	swapK8sClientWithObjects(t,
+		mkVirtLauncherPod("virt-launcher-other", "someone-else.1.1"))
+
+	task.kubeConfig = &rest.Config{}
+	got, err := task.dependentsPresent(task.status.DomainName)
+	assert.NoError(t, err)
+	assert.False(t, got, "another domain's objects are not this domain's dependents")
+}
+
+// TestDependentsPresentNoHyper covers the NOHYPER app, which has no VMI at
+// all: its pods carry "app=<kubeName>", already generation-specific.
+func TestDependentsPresentNoHyper(t *testing.T) {
+	for _, pod := range []bool{false, true} {
+		t.Run(fmt.Sprintf("pod present %v", pod), func(t *testing.T) {
+			task, _ := newInfoTestTask(t, 1)
+			task.status.VirtualizationMode = types.NOHYPER
+			task.kubeConfig = &rest.Config{}
+
+			var objs []runtime.Object
+			if pod {
+				objs = append(objs, mkAppPod("myapp-pod", task.kubeName()))
+			}
+			swapK8sClientWithObjects(t, objs...)
+
+			got, err := task.dependentsPresent(task.status.DomainName)
+			assert.NoError(t, err)
+			assert.Equal(t, pod, got)
+		})
+	}
+}
+
+// TestInfoStateFromWorkloadObjects is the truth table for the rule that a
+// domain's state follows the existence of its VMIRS, VMI, and pod: HALTED
+// with a zero DomainId requires all three absent, and a surviving VMIRS is
+// never reported as HALTED regardless of the other two.
+//
+// The VMIRS-present rows leave vmiList empty, the shortest path through
+// Info once existence is confirmed.
+func TestInfoStateFromWorkloadObjects(t *testing.T) {
+	const lastKnownID = 918273645
+
+	for _, tc := range []struct {
+		name         string
+		vmirs        bool
+		vmi          bool
+		pod          bool
+		wantState    types.SwState
+		wantZeroID   bool
+		wantDepCheck bool // are the dependents worth looking up?
+	}{{
+		name:         "all three absent is the only halted case",
+		wantState:    types.HALTED,
+		wantZeroID:   true,
+		wantDepCheck: true,
+	}, {
+		name:         "pod outlives the vmirs",
+		pod:          true,
+		wantState:    types.HALTING,
+		wantDepCheck: true,
+	}, {
+		name:         "vmi outlives the vmirs",
+		vmi:          true,
+		wantState:    types.HALTING,
+		wantDepCheck: true,
+	}, {
+		name:         "vmi and pod both outlive the vmirs",
+		vmi:          true,
+		pod:          true,
+		wantState:    types.HALTING,
+		wantDepCheck: true,
+	}, {
+		// A live VMIRS settles it on its own, so no dependent lookup runs -
+		// keeping a steady-state poll cheap.
+		name:      "vmirs present, nothing else",
+		vmirs:     true,
+		wantState: types.SCHEDULING,
+	}, {
+		name:      "vmirs and pod present",
+		vmirs:     true,
+		pod:       true,
+		wantState: types.SCHEDULING,
+	}, {
+		name:      "vmirs and vmi present",
+		vmirs:     true,
+		vmi:       true,
+		wantState: types.SCHEDULING,
+	}, {
+		name:      "all three present",
+		vmirs:     true,
+		vmi:       true,
+		pod:       true,
+		wantState: types.SCHEDULING,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			task, _ := newInfoTestTask(t, lastKnownID)
+			domainName := task.status.DomainName
+
+			var live *v1.VirtualMachineInstanceReplicaSet
+			if tc.vmirs {
+				live = &v1.VirtualMachineInstanceReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: task.kubeName(),
+						UID:  "live-vmirs-uid",
+					},
+				}
+			}
+			var vmis []v1.VirtualMachineInstance
+			if tc.vmi {
+				vmis = append(vmis, mkVMI("vmi-0", domainName))
+			}
+			var pods []runtime.Object
+			if tc.pod {
+				pods = append(pods, mkVirtLauncherPod("virt-launcher-vmi-0", domainName))
+			}
+
+			vmiCalls := dependentMocks(t, live, task.kubeName(), vmis)
+			swapK8sClientWithObjects(t, pods...)
+
+			id, state, err := task.Info(domainName)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantState, state)
+
+			if tc.wantZeroID {
+				assert.Zero(t, id, "all three absent, so the workload is confirmed gone")
+			} else {
+				assert.NotZero(t, id,
+					"a zero id would falsely tell domainmgr the workload is gone")
+			}
+			assert.Equal(t, tc.wantDepCheck, *vmiCalls > 0,
+				"dependents must be looked up only when the VMIRS is absent")
+		})
+	}
+}
+
+// TestInfoUnresolvedDependentsKeepLastID: an unresolved dependent lookup
+// must not emit the confirmed-absent token either, the same rule the
+// existence check itself follows.
+func TestInfoUnresolvedDependentsKeepLastID(t *testing.T) {
+	const lastKnownID = 918273645
+	task, _ := newInfoTestTask(t, lastKnownID)
+
+	ctrl := gomock.NewController(t)
+	mockClient := kubecli.NewMockKubevirtClient(ctrl)
+	mockRS := kubecli.NewMockReplicaSetInterface(ctrl)
+	mockClient.EXPECT().ReplicaSet(gomock.Any()).Return(mockRS).AnyTimes()
+	mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil, apierrors.NewNotFound(
+			schema.GroupResource{
+				Group:    "kubevirt.io",
+				Resource: "virtualmachineinstancereplicasets",
+			}, task.kubeName())).AnyTimes()
+	mockVMI := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
+	mockClient.EXPECT().VirtualMachineInstance(gomock.Any()).
+		Return(mockVMI).AnyTimes()
+	mockVMI.EXPECT().List(gomock.Any(), gomock.Any()).
+		Return(nil, assert.AnError).AnyTimes()
+	swapKubevirtClient(t, mockClient)
+	swapK8sClientWithObjects(t)
+
+	id, state, err := task.Info(task.status.DomainName)
+	assert.Error(t, err)
+	assert.Equal(t, types.UNKNOWN, state)
+	assert.Equal(t, lastKnownID, id)
+}
+
+// TestNoHyperPodLabelsMatchTheSelector ties the label CreateReplicaPodConfig
+// stamps on a NOHYPER app's pods to the selector dependentsPresent looks
+// them up with. The two are written in different places and could drift; a
+// selector matching nothing would report every domain as gone.
+//
+// The pod here is labeled by the production code rather than by the test, so
+// the two sides cannot agree merely by construction.
+func TestNoHyperPodLabelsMatchTheSelector(t *testing.T) {
+	appUUID := uuid.Must(uuid.FromString("11111111-1111-1111-1111-111111111111"))
+	domainName := appUUID.String() + ".1.1"
+
+	config := types.DomainConfig{
+		UUIDandVersion: types.UUIDandVersion{UUID: appUUID},
+		DisplayName:    "myapp",
+		PurgeCounter:   1,
+		KubeImageName:  "docker.io/library/alpine:3.24",
+	}
+	domainStatus := types.DomainStatus{
+		UUIDandVersion: types.UUIDandVersion{UUID: appUUID},
+		DisplayName:    config.DisplayName,
+		DomainName:     domainName,
+		PurgeCounter:   config.PurgeCounter,
+	}
+	// Promoted from an embedded struct, so not settable in the literals above.
+	config.VirtualizationMode = types.NOHYPER
+	domainStatus.VirtualizationMode = types.NOHYPER
+
+	// One VIF, because CreateReplicaPodConfig refuses a pod with no network
+	// selections. IoAdapterList stays empty: an IoNetEth entry there would
+	// go check for a NAD in a live cluster.
+	mac, err := net.ParseMAC("00:16:3e:00:00:01")
+	require.NoError(t, err)
+	config.VifList = []types.VifConfig{{Mac: mac}}
+
+	file, err := os.CreateTemp(t.TempDir(), "replicaset")
+	require.NoError(t, err)
+	defer file.Close()
+
+	var ctx kubevirtContext
+	ctx.nodeNameMap = map[string]string{"nodename": "node1"}
+	ctx.vmiList = make(map[string]*vmiMetaData)
+	ctx.prevDomainMetric = make(map[string]types.DomainMetric)
+
+	require.NoError(t, ctx.CreateReplicaPodConfig(domainName, config,
+		domainStatus, nil, nil, file))
+
+	meta := ctx.vmiList[domainName]
+	require.NotNil(t, meta)
+	require.NotNil(t, meta.repPod)
+	podLabels := meta.repPod.Spec.Template.Labels
+	require.NotEmpty(t, podLabels, "pods with no labels could never be found")
+
+	// The asymmetry that makes this branch differ from the VMI one:
+	// App-Domain-Name is stamped on the ReplicaSet object, and is not
+	// propagated to its pods, so the pod lookup cannot use it.
+	assert.Contains(t, meta.repPod.ObjectMeta.Labels, eveLabelKey,
+		"the ReplicaSet object carries the domain-name label")
+	assert.NotContains(t, podLabels, eveLabelKey,
+		"a NOHYPER app's pods do not carry the domain-name label")
+
+	// dependentsPresent derives the selector from DomainStatus, while the
+	// ReplicaSet was named from DomainConfig. Drift between the two would
+	// point the lookup at another generation.
+	task := ctx.Task(&domainStatus).(kubevirtTask)
+	assert.Equal(t, meta.repPod.ObjectMeta.Name, task.kubeName(),
+		"kubeName from status must name the ReplicaSet built from config")
+
+	task.kubeConfig = &rest.Config{}
+	swapK8sClientWithObjects(t, &k8sv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myapp-pod",
+			Namespace: kubeapi.EVEKubeNameSpace,
+			Labels:    podLabels,
+		},
+	})
+
+	present, err := task.dependentsPresent(domainName)
+	assert.NoError(t, err)
+	assert.True(t, present,
+		"a pod labeled by CreateReplicaPodConfig must match the selector")
+}

--- a/pkg/pillar/hypervisor/kubevirt_info_test.go
+++ b/pkg/pillar/hypervisor/kubevirt_info_test.go
@@ -47,8 +47,9 @@ func newInfoTestTask(t *testing.T, lastKnownID int) (kubevirtTask, *types.Domain
 }
 
 // TestInfoContract pins the main invariant in Info's contract (see its doc
-// comment in kubevirt.go): a zero DomainId means the VMIRS is confirmed
-// absent, and nothing else. Every other outcome must return a non-zero id.
+// comment in kubevirt.go): a zero DomainId means the whole workload -
+// VMIRS, VMI and pod - is confirmed absent, and nothing else. Every other
+// outcome must return a non-zero id.
 //
 // It covers the two rows the existence check decides alone (NotFound, and
 // unreachable) plus the stranded-VMIRS row. The remaining "found" rows need
@@ -56,7 +57,7 @@ func newInfoTestTask(t *testing.T, lastKnownID int) (kubevirtTask, *types.Domain
 func TestInfoContract(t *testing.T) {
 	const lastKnownID = 918273645
 
-	t.Run("NotFound is the only case that returns zero", func(t *testing.T) {
+	t.Run("a wholly absent workload is the only case that returns zero", func(t *testing.T) {
 		task, _ := newInfoTestTask(t, lastKnownID)
 
 		ctrl := gomock.NewController(t)
@@ -67,7 +68,16 @@ func TestInfoContract(t *testing.T) {
 			nil, apierrors.NewNotFound(
 				schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineinstancereplicasets"},
 				task.kubeName()))
+		// An absent VMIRS is necessary but not sufficient, so Info also
+		// looks for a surviving VMI and pod. Both are absent here;
+		// TestInfoHaltedRequiresWholeWorkloadGone covers the rest.
+		mockVMI := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
+		mockClient.EXPECT().VirtualMachineInstance(gomock.Any()).
+			Return(mockVMI).AnyTimes()
+		mockVMI.EXPECT().List(gomock.Any(), gomock.Any()).
+			Return(&v1.VirtualMachineInstanceList{}, nil).AnyTimes()
 		swapKubevirtClient(t, mockClient)
+		swapK8sClientWithObjects(t)
 
 		id, state, err := task.Info(task.status.DomainName)
 		assert.NoError(t, err)
@@ -125,47 +135,148 @@ func TestInfoContract(t *testing.T) {
 	})
 }
 
-// TestInfoVmirsDeletedMidCall covers a VMIRS that is present for Info's
-// existence check and deleted before the Get that follows it. Absence
-// observed at the second Get must produce the same answer as absence
-// observed at the first - HALTED, zero id, no error - rather than the
-// SCHEDULING-with-an-error that a NotFound would otherwise fall through to.
-// That error matters beyond the state it carries: waitForDomainGone treats
-// any error from Info as "the domain is gone" and stops waiting.
+// TestInfoVmirsDeletedMidCall covers a VMIRS present at the existence check
+// and gone by the next Get. Both rows race the same way; only the
+// dependents differ, so a surviving VMI or pod must produce HALTING, not
+// HALTED, the same as confirmedAbsent's other callers.
 func TestInfoVmirsDeletedMidCall(t *testing.T) {
 	const lastKnownID = 918273645
-	task, status := newInfoTestTask(t, lastKnownID)
-	status.DomainName = "11111111-1111-1111-1111-111111111111.1.1"
-	task.vmiList = map[string]*vmiMetaData{
-		status.DomainName: {mtype: IsMetaReplicaVMI, name: task.kubeName()},
+
+	for _, tc := range []struct {
+		name      string
+		vmis      []v1.VirtualMachineInstance
+		wantState types.SwState
+		wantZero  bool
+	}{{
+		name:      "no dependents left behind",
+		wantState: types.HALTED,
+		wantZero:  true,
+	}, {
+		name:      "a VMI outlived the VMIRS",
+		vmis:      []v1.VirtualMachineInstance{{ObjectMeta: metav1.ObjectMeta{Name: "vmi-0"}}},
+		wantState: types.HALTING,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			task, status := newInfoTestTask(t, lastKnownID)
+			status.DomainName = "11111111-1111-1111-1111-111111111111.1.1"
+			task.vmiList = map[string]*vmiMetaData{
+				status.DomainName: {mtype: IsMetaReplicaVMI, name: task.kubeName()},
+			}
+
+			vmis := tc.vmis
+			for i := range vmis {
+				vmis[i].Labels = map[string]string{eveLabelKey: status.DomainName}
+			}
+
+			ctrl := gomock.NewController(t)
+			mockClient := kubecli.NewMockKubevirtClient(ctrl)
+			mockRS := kubecli.NewMockReplicaSetInterface(ctrl)
+			mockClient.EXPECT().ReplicaSet(gomock.Any()).Return(mockRS).AnyTimes()
+
+			notFound := apierrors.NewNotFound(
+				schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineinstancereplicasets"},
+				task.kubeName())
+			gomock.InOrder(
+				// The existence check finds it...
+				mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&v1.VirtualMachineInstanceReplicaSet{
+						ObjectMeta: metav1.ObjectMeta{Name: task.kubeName(), UID: "some-uid"},
+					}, nil),
+				// ...and it is gone from here on. Left unbounded rather than
+				// pinned to a single call so this asserts the answer Info
+				// returns, not how many times it asks.
+				mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, notFound).AnyTimes(),
+			)
+			expectVMIList(t, ctrl, mockClient, vmis)
+			swapKubevirtClient(t, mockClient)
+			swapK8sClientNoPods(t)
+
+			id, state, err := task.Info(status.DomainName)
+			assert.NoError(t, err, "a confirmed answer, either way, is not an error")
+			assert.Equal(t, tc.wantState, state)
+			if tc.wantZero {
+				assert.Zero(t, id)
+			} else {
+				assert.NotZero(t, id,
+					"a zero id would falsely tell domainmgr the workload is gone")
+			}
+		})
 	}
+}
 
-	ctrl := gomock.NewController(t)
-	mockClient := kubecli.NewMockKubevirtClient(ctrl)
-	mockRS := kubecli.NewMockReplicaSetInterface(ctrl)
-	mockClient.EXPECT().ReplicaSet(gomock.Any()).Return(mockRS).AnyTimes()
+// TestInfoSchedulingLookupNotFoundIsAbsent covers the scheduling-lookup
+// backstop: the VMIRS is present at the existence check, the direct
+// re-fetch hits a transient error, and scheduledOnMe's own Get is what
+// finally observes NotFound. That NotFound must still go through
+// confirmedAbsent's dependents check.
+func TestInfoSchedulingLookupNotFoundIsAbsent(t *testing.T) {
+	const lastKnownID = 918273645
 
-	notFound := apierrors.NewNotFound(
-		schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineinstancereplicasets"},
-		task.kubeName())
-	gomock.InOrder(
-		// The existence check finds it...
-		mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-			&v1.VirtualMachineInstanceReplicaSet{
-				ObjectMeta: metav1.ObjectMeta{Name: task.kubeName(), UID: "some-uid"},
-			}, nil),
-		// ...and it is gone from here on. Left unbounded rather than pinned
-		// to a single call so this asserts the answer Info returns, not how
-		// many times it asks.
-		mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(nil, notFound).AnyTimes(),
-	)
-	swapKubevirtClient(t, mockClient)
+	for _, tc := range []struct {
+		name      string
+		vmis      []v1.VirtualMachineInstance
+		wantState types.SwState
+		wantZero  bool
+	}{{
+		name:      "no dependents left behind",
+		wantState: types.HALTED,
+		wantZero:  true,
+	}, {
+		name:      "a VMI outlived the VMIRS",
+		vmis:      []v1.VirtualMachineInstance{{ObjectMeta: metav1.ObjectMeta{Name: "vmi-0"}}},
+		wantState: types.HALTING,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			task, status := newInfoTestTask(t, lastKnownID)
+			status.DomainName = "11111111-1111-1111-1111-111111111111.1.1"
+			task.vmiList = map[string]*vmiMetaData{
+				status.DomainName: {mtype: IsMetaReplicaVMI, name: task.kubeName()},
+			}
 
-	id, state, err := task.Info(status.DomainName)
-	assert.NoError(t, err, "a confirmed-absent domain is not an error")
-	assert.Equal(t, types.HALTED, state)
-	assert.Zero(t, id)
+			vmis := tc.vmis
+			for i := range vmis {
+				vmis[i].Labels = map[string]string{eveLabelKey: status.DomainName}
+			}
+
+			ctrl := gomock.NewController(t)
+			mockClient := kubecli.NewMockKubevirtClient(ctrl)
+			mockRS := kubecli.NewMockReplicaSetInterface(ctrl)
+			mockClient.EXPECT().ReplicaSet(gomock.Any()).Return(mockRS).AnyTimes()
+
+			notFound := apierrors.NewNotFound(
+				schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineinstancereplicasets"},
+				task.kubeName())
+			gomock.InOrder(
+				// The existence check finds it...
+				mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&v1.VirtualMachineInstanceReplicaSet{
+						ObjectMeta: metav1.ObjectMeta{Name: task.kubeName(), UID: "some-uid"},
+					}, nil),
+				// The direct re-fetch hits some other, non-NotFound failure,
+				// which falls through to scheduledOnMe's own Get instead of
+				// answering here.
+				mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, assert.AnError),
+				// ...and that Get is the one that observes it gone.
+				mockRS.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, notFound).AnyTimes(),
+			)
+			expectVMIList(t, ctrl, mockClient, vmis)
+			swapKubevirtClient(t, mockClient)
+			swapK8sClientNoPods(t)
+
+			id, state, err := task.Info(status.DomainName)
+			assert.NoError(t, err, "a confirmed answer, either way, is not an error")
+			assert.Equal(t, tc.wantState, state)
+			if tc.wantZero {
+				assert.Zero(t, id)
+			} else {
+				assert.NotZero(t, id,
+					"a zero id would falsely tell domainmgr the workload is gone")
+			}
+		})
+	}
 }
 
 // TestInfoUnreachableKeepsLastID is a focused restatement of the second


### PR DESCRIPTION
## Description

Info() reported HALTED as soon as the VMIRS Get returned NotFound. The three objects form an ownership chain: the VMIRS owns the VMI, and the VMI owns the virt-launcher pod. EVE deletes only the VMIRS, so it is the first to go, and Kubernetes then collects its dependents in the background. The pod holds the RWO disk until it goes away.

A domain was therefore reported as halted while its workload still ran. A peer that stands in for a downed node reads that state to decide if an app is really down, and a controller reads it to decide the app can move. Both can act too early.

Info() now takes the state from the existence of the VMIRS, the VMI and the pod, each found by its App-Domain-Name label. An absent VMIRS with a surviving dependent gives HALTING and keeps a non-zero DomainId, because a zero DomainId is the confirmed-absent token. HALTED with a zero DomainId needs all three to be absent. The dependent lookup runs only on the absent-VMIRS branch, so a steady-state poll makes no more API calls than it did before.

A config apply must not wait for this. A kubevirt deactivate now publishes HALTING, deletes the VMIRS, and returns. verifyStatus settles the state and releases the resources when Info reports all three objects absent. Kubernetes owns how long that takes, and on a node that is off it has no end, so no budget on the config path is the correct one.

The paths that must finish before they return keep their behavior, because impatient is already true for them: handleDelete unpublishes DomainStatus as soon as it returns, and a purge or a restart advances its counter only after the teardown clears status.Activated.

Two other reads of HALTING had to be separated from this one. waitForDomainGone took it for a guest that powered off while its hypervisor process stayed parked and held resources, a qemu -no-shutdown condition, so it stopped waiting and let the caller reap the domain. verifyStatus took it for a teardown to finish now. Under kubevirt HALTING is the reverse of both: nothing is parked, and Kubernetes is still at work. Both short circuits now apply to the other hypervisors only.

Start() already waits for a stale generation to disappear, object and pods, before it creates the next one, because generations share the disk and the veth names. That is what keeps an asynchronous deactivate safe beside a create.

## PR dependencies

None

## How to test and validate this PR

### pillar go-test:

```
make -C pkg/pillar TESTPKGS='./hypervisor/... ./cmd/domainmgr/...' test
```

Covers the VMIRS/VMI/pod state combinations, the async-deactivate hand-off, and the resulting HALTED/HALTING transitions without a live cluster.

### evetest

Coming in PR #6505 

## Changelog notes

EVE could report an application halted before Kubernetes had actually torn it down (its VM instance or pod could still be running). App halted/running status now reflects the real state of the workload, and deactivating an app no longer blocks device configuration while Kubernetes finishes the teardown in the background.

## PR Backports

- 17.0-stable: To be backported.
- 16.0-stable: No, as the feature is not available there.
- 14.5-stable: No, as the feature is not available there.
- 13.4-stable: No, as the feature is not available there.

## Checklist

- [x] I've provided a proper description
- [ ] I've added the proper documentation
- [x] I've tested my PR on amd64 device
- [ ] I've tested my PR on arm64 device
- [x] I've written the test verification instructions
- [x] I've set the proper labels to this PR

And the last but not least:

- [ ] I've checked the boxes above, or I've provided a good reason why I didn't
  check them.

Please, check the boxes above after submitting the PR in interactive mode.
